### PR TITLE
Fix PMC default project selection

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -235,9 +235,9 @@ namespace NuGet.PackageManagement.VisualStudio
             return await Task.WhenAll((await GetNuGetProjectsAsync()).Select(GetNuGetProjectSafeNameAsync));
         }
 
-        public async IEnumerable<Task<Tuple<string,string>>> GetAllNuGetProjectSafeAndDisplayNameAsync()
+        public IEnumerable<Task<Tuple<string,string>>> GetAllNuGetProjectSafeAndDisplayNameAsync(IEnumerable<NuGetProject> nuGetProjects)
         {
-            return (await GetNuGetProjectsAsync()).Select(GetNuGetProjectSafeAndDisplayNameAsync);
+            return nuGetProjects.Select(GetNuGetProjectSafeAndDisplayNameAsync);
         }
 
         private async Task<Tuple<string, string>> GetNuGetProjectSafeAndDisplayNameAsync(NuGetProject nuGetProject)
@@ -256,11 +256,11 @@ namespace NuGet.PackageManagement.VisualStudio
                 safeName = NuGetProject.GetUniqueNameOrName(nuGetProject);
             }
 
-            var displayNameTask = Task.Run(async () => await GetDisplayNameAsync(nuGetProject));
+            var displayNameTask = await GetDisplayNameAsync(nuGetProject);
 
-            return new Tuple<string,string>(safeName,displayNameTask);
+            return new Tuple<string,string>(safeName, displayNameTask);
         }
-    }
+
 
         private async Task<string> GetDisplayNameAsync(NuGetProject nuGetProject)
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -235,6 +235,52 @@ namespace NuGet.PackageManagement.VisualStudio
             return await Task.WhenAll((await GetNuGetProjectsAsync()).Select(GetNuGetProjectSafeNameAsync));
         }
 
+        public async IEnumerable<Task<Tuple<string,string>>> GetAllNuGetProjectSafeAndDisplayNameAsync()
+        {
+            return (await GetNuGetProjectsAsync()).Select(GetNuGetProjectSafeAndDisplayNameAsync);
+        }
+
+        private async Task<Tuple<string, string>> GetNuGetProjectSafeAndDisplayNameAsync(NuGetProject nuGetProject)
+        {
+            if (nuGetProject == null)
+            {
+                throw new ArgumentNullException("nuGetProject");
+            }
+
+            await EnsureInitializeAsync();
+
+            // Try searching for simple names first
+            var safeName = nuGetProject.GetMetadata<string>(NuGetProjectMetadataKeys.Name);
+            if ((await GetNuGetProjectAsync(safeName)) != nuGetProject)
+            {
+                safeName = NuGetProject.GetUniqueNameOrName(nuGetProject);
+            }
+
+            var displayNameTask = Task.Run(async () => await GetDisplayNameAsync(nuGetProject));
+
+            return new Tuple<string,string>(safeName,displayNameTask);
+        }
+    }
+
+        private async Task<string> GetDisplayNameAsync(NuGetProject nuGetProject)
+        {
+            var vsProjectAdapter = await GetVsProjectAdapterAsync(nuGetProject);
+
+            var name = vsProjectAdapter.CustomUniqueName;
+            if (await IsWebSiteAsync(vsProjectAdapter))
+            {
+                name = PathHelper.SmartTruncate(name, 40);
+            }
+            return name;
+        }
+
+        private async Task<bool> IsWebSiteAsync(IVsProjectAdapter project)
+        {
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            return (await project.GetProjectTypeGuidsAsync()).Contains(VsProjectTypes.WebSiteProjectTypeGuid);
+        }
+
         public async Task<IEnumerable<NuGetProject>> GetNuGetProjectsAsync()
         {
             InitializationTask = EnsureInitializeAsync();

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -230,57 +230,6 @@ namespace NuGet.PackageManagement.VisualStudio
             return NuGetProject.GetUniqueNameOrName(nuGetProject);
         }
 
-        public async Task<IEnumerable<string>> GetAllNuGetProjectSafeNameAsync()
-        {
-            return await Task.WhenAll((await GetNuGetProjectsAsync()).Select(GetNuGetProjectSafeNameAsync));
-        }
-
-        public IEnumerable<Task<Tuple<string,string>>> GetAllNuGetProjectSafeAndDisplayNameAsync(IEnumerable<NuGetProject> nuGetProjects)
-        {
-            return nuGetProjects.Select(GetNuGetProjectSafeAndDisplayNameAsync);
-        }
-
-        private async Task<Tuple<string, string>> GetNuGetProjectSafeAndDisplayNameAsync(NuGetProject nuGetProject)
-        {
-            if (nuGetProject == null)
-            {
-                throw new ArgumentNullException("nuGetProject");
-            }
-
-            await EnsureInitializeAsync();
-
-            // Try searching for simple names first
-            var safeName = nuGetProject.GetMetadata<string>(NuGetProjectMetadataKeys.Name);
-            if ((await GetNuGetProjectAsync(safeName)) != nuGetProject)
-            {
-                safeName = NuGetProject.GetUniqueNameOrName(nuGetProject);
-            }
-
-            var displayNameTask = await GetDisplayNameAsync(nuGetProject);
-
-            return new Tuple<string,string>(safeName, displayNameTask);
-        }
-
-
-        private async Task<string> GetDisplayNameAsync(NuGetProject nuGetProject)
-        {
-            var vsProjectAdapter = await GetVsProjectAdapterAsync(nuGetProject);
-
-            var name = vsProjectAdapter.CustomUniqueName;
-            if (await IsWebSiteAsync(vsProjectAdapter))
-            {
-                name = PathHelper.SmartTruncate(name, 40);
-            }
-            return name;
-        }
-
-        private async Task<bool> IsWebSiteAsync(IVsProjectAdapter project)
-        {
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-            return (await project.GetProjectTypeGuidsAsync()).Contains(VsProjectTypes.WebSiteProjectTypeGuid);
-        }
-
         public async Task<IEnumerable<NuGetProject>> GetNuGetProjectsAsync()
         {
             InitializationTask = EnsureInitializeAsync();

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
@@ -80,12 +80,5 @@ namespace NuGet.PackageManagement.VisualStudio
         /// Return true if all the .net core projects are nominated.
         /// </summary>
         Task<bool> IsAllProjectsNominatedAsync();
-
-        /// <summary>
-        /// Return collection of safe name for all supported projects in solution.
-        /// </summary>
-        Task<IEnumerable<string>> GetAllNuGetProjectSafeNameAsync();
-
-        IEnumerable<Task<Tuple<string, string>>> GetAllNuGetProjectSafeAndDisplayNameAsync(IEnumerable<NuGetProject> nuGetProjects);
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
@@ -86,6 +86,6 @@ namespace NuGet.PackageManagement.VisualStudio
         /// </summary>
         Task<IEnumerable<string>> GetAllNuGetProjectSafeNameAsync();
 
-        IEnumerable<Task<Tuple<string, string>>> GetAllNuGetProjectSafeAndDisplayNameAsync();
+        IEnumerable<Task<Tuple<string, string>>> GetAllNuGetProjectSafeAndDisplayNameAsync(IEnumerable<NuGetProject> nuGetProjects);
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
@@ -85,5 +85,7 @@ namespace NuGet.PackageManagement.VisualStudio
         /// Return collection of safe name for all supported projects in solution.
         /// </summary>
         Task<IEnumerable<string>> GetAllNuGetProjectSafeNameAsync();
+
+        IEnumerable<Task<Tuple<string, string>>> GetAllNuGetProjectSafeAndDisplayNameAsync();
     }
 }

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -731,15 +731,18 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
             return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                var displayNames = new List< Tuple<string, string> > ();
+                var displayNames = new List<Tuple<string, string>>();
                 var displayNameTasks = new List<Task<Tuple<string, string>>>();
 
                 var allProjects = await _solutionManager.Value.GetNuGetProjectsAsync();
 
-                var tasks = allProjects.Select(async e => { var safeName = await _solutionManager.Value.GetNuGetProjectSafeNameAsync(e);
-                    var displayName = await GetDisplayNameAsync(e);
-                    return new Tuple<string, string>(safeName, displayName);
-                });
+                var tasks = allProjects.Select(
+                    async e =>
+                    {
+                        var safeName = await _solutionManager.Value.GetNuGetProjectSafeNameAsync(e);
+                        var displayName = await GetDisplayNameAsync(e);
+                        return new Tuple<string, string>(safeName, displayName);
+                    });
 
                 foreach (var task in tasks)
                 {
@@ -761,9 +764,9 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                     displayNames.Add(displayName);
                 }
 
-                _projectSafeNames = displayNames.Select(e => e.Item1).ToArray();
+                var sortedDisplayNames = displayNames.OrderBy(i => i.Item1, StringComparer.CurrentCultureIgnoreCase).ToArray();
 
-                Array.Sort(displayNames.Select(e => e.Item2).ToArray(), _projectSafeNames, StringComparer.CurrentCultureIgnoreCase);
+                _projectSafeNames = sortedDisplayNames.Select(e => e.Item1).ToArray();
                 return _projectSafeNames;
             });
         }

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -264,6 +264,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                     {
                         return null;
                     }
+
                     return await GetDisplayNameAsync(defaultProject);
                 });
             }


### PR DESCRIPTION
## Bug
Fixes: 513587, feedback here https://developercommunity.visualstudio.com/content/problem/134981/package-manager-conole-default-project-dropdown-no.html
Regression: Yes  
If Regression then when did it last work:   15.3
If Regression then how are we preventing it in future:   Manual tests from vendors

## Fix
Details: 
From the dev community issue:
```
In the Package Manger Console, when attempting to select the Default Project a different project is instead selected.

I have a project list of 4 projects :
CoreUI
SamuraiAppCore.Data
SamuraiAppCore.Domain
SamuraiWebApi
```
As part of some LSL improvements https://github.com/NuGet/NuGet.Client/pull/1619, the calls to get the safe name and display name were made async. 
This complicated things because the ordering of these was not preserved so we had no way to cross-matching the safeName and DisplayName values when sorting which lead to this discrepancy. https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs#764

## Testing/Validation
Tests Added: No  
Reason for not adding tests: It's mouse action tests for which we don't have infrstracture  
Validation done:  Manual 

//cc 
@rrelyea 
