### PR TITLE
Improve Package Spec cloning 

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -284,7 +284,6 @@ namespace NuGet.SolutionRestoreManager
                 var pathContext = NuGetPathContext.Create(_settings);
 
                 // Get full dg spec
-                // TODO: pass this down instead of creating it twice.
                 var dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(_solutionManager, cacheContext);
 
                 // Avoid restoring solutions with zero potential PackageReference projects.

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -131,9 +131,9 @@ namespace NuGet.Commands
             var packageSourceProvider = new PackageSourceProvider(settings);
             var packageSourcesFromProvider = packageSourceProvider.LoadPackageSources();
             var sourceObjects = new Dictionary<string, PackageSource>();
-            foreach(var source in dgSpecSources)
+            for(var i = 0; i < dgSpecSources.Count; i++)
             {
-                sourceObjects[source.Source] = source;
+                sourceObjects[dgSpecSources[i].Source] = dgSpecSources[i];
             }
 
             foreach (var sourceUri in Sources)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -128,9 +128,13 @@ namespace NuGet.Commands
 
         private List<SourceRepository> GetEffectiveSourcesCore(ISettings settings, IList<PackageSource> dgSpecSources)
         {
-            var sourceObjects = dgSpecSources.ToDictionary(k => k.Source, v => v, StringComparer.Ordinal);
             var packageSourceProvider = new PackageSourceProvider(settings);
             var packageSourcesFromProvider = packageSourceProvider.LoadPackageSources();
+            var sourceObjects = new Dictionary<string, PackageSource>();
+            foreach(var source in dgSpecSources)
+            {
+                sourceObjects[source.Source] = source;
+            }
 
             foreach (var sourceUri in Sources)
             {

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkRuntimePair.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkRuntimePair.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -64,6 +64,11 @@ namespace NuGet.Frameworks
                 "{0}~{1}",
                 Framework.GetShortFolderName(),
                 RuntimeIdentifier);
+        }
+
+        public FrameworkRuntimePair Clone()
+        {
+            return new FrameworkRuntimePair(Framework, RuntimeIdentifier);
         }
 
         public int CompareTo(FrameworkRuntimePair other)

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
@@ -349,7 +349,7 @@ namespace NuGet.ProjectManagement.Projects
             // Update the internal target framework with TPMinV from csproj
             await UpdateInternalTargetFrameworkAsync();
 
-            if (TryGetInternalFramework(out object newTargetFrameworkObject))
+            if (TryGetInternalFramework(out var newTargetFrameworkObject))
             {
                 var frameworks = JsonConfigUtility.GetFrameworks(json);
                 var newTargetFramework = newTargetFrameworkObject as NuGetFramework;

--- a/src/NuGet.Core/NuGet.Packaging.Core/PackageType.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/PackageType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,6 +6,9 @@ using NuGet.Shared;
 
 namespace NuGet.Packaging.Core
 {
+    /**
+     * It is important that this type remains immutable due to the cloning of package specs
+     **/
     public class PackageType : IEquatable<PackageType>
     {
         public static readonly Version EmptyVersion = new Version(0, 0);

--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/CompatibilityProfile.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/CompatibilityProfile.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -49,6 +49,11 @@ namespace NuGet.RuntimeModel
             return other != null &&
                 string.Equals(Name, other.Name, StringComparison.Ordinal) &&
                 RestoreContexts.OrderedEquals(other.RestoreContexts, r => r);
+        }
+
+        public CompatibilityProfile Clone()
+        {
+            return new CompatibilityProfile(Name, RestoreContexts.Select(e => e.Clone()));
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeGraph.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeGraph.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeGraph.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeGraph.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeGraph.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeGraph.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -50,7 +50,7 @@ namespace NuGet.RuntimeModel
 
         public RuntimeGraph Clone()
         {
-            return new RuntimeGraph(Runtimes.Values.Select(r => r.Clone()));
+            return new RuntimeGraph(Runtimes.Values.Select(r => r.Clone()), Supports.Values.Select( s => s.Clone()));
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.ProjectModel/BuildOptions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/BuildOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -37,6 +37,13 @@ namespace NuGet.ProjectModel
             }
 
             return OutputName == other.OutputName;
+        }
+
+        public BuildOptions Clone()
+        {
+            var options = new BuildOptions();
+            options.OutputName = OutputName;
+            return options;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/BuildOptions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/BuildOptions.cs
@@ -41,9 +41,9 @@ namespace NuGet.ProjectModel
 
         public BuildOptions Clone()
         {
-            var options = new BuildOptions();
-            options.OutputName = OutputName;
-            return options;
+            var clone = new BuildOptions();
+            clone.OutputName = OutputName;
+            return clone;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/IncludeExcludeFiles.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/IncludeExcludeFiles.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -85,6 +85,16 @@ namespace NuGet.ProjectModel
                    Exclude.SequenceEqualWithNullCheck(Exclude) &&
                    IncludeFiles.SequenceEqualWithNullCheck(IncludeFiles) &&
                    ExcludeFiles.SequenceEqualWithNullCheck(ExcludeFiles);
+        }
+
+        public IncludeExcludeFiles Clone()
+        {
+            var clonedObject = new IncludeExcludeFiles();
+            clonedObject.Include = Include;
+            clonedObject.Exclude = Exclude;
+            clonedObject.IncludeFiles = IncludeFiles;
+            clonedObject.ExcludeFiles = ExcludeFiles;
+            return clonedObject;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/IncludeExcludeFiles.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/IncludeExcludeFiles.cs
@@ -90,10 +90,10 @@ namespace NuGet.ProjectModel
         public IncludeExcludeFiles Clone()
         {
             var clonedObject = new IncludeExcludeFiles();
-            clonedObject.Include = Include;
-            clonedObject.Exclude = Exclude;
-            clonedObject.IncludeFiles = IncludeFiles;
-            clonedObject.ExcludeFiles = ExcludeFiles;
+            clonedObject.Include = Include.ToList();
+            clonedObject.Exclude = Exclude.ToList();
+            clonedObject.IncludeFiles = IncludeFiles.ToList();
+            clonedObject.ExcludeFiles = ExcludeFiles.ToList();
             return clonedObject;
         }
     }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackOptions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -45,6 +45,18 @@ namespace NuGet.ProjectModel
             return PackageType.SequenceEqualWithNullCheck(other.PackageType) &&
                    Mappings.SequenceEqualWithNullCheck(other.Mappings) &&
                    EqualityUtility.EqualsWithNullCheck(IncludeExcludeFiles, other.IncludeExcludeFiles);
+        }
+        public PackOptions Clone()
+        {
+            var clonedObject = new PackOptions();
+            clonedObject.PackageType = PackageType;
+            clonedObject.IncludeExcludeFiles = IncludeExcludeFiles.Clone();
+            clonedObject.Mappings = new Dictionary<string, IncludeExcludeFiles>();
+            foreach(var kvp in Mappings)
+            {
+                clonedObject.Mappings.Add(kvp.Key, kvp.Value.Clone());
+            }
+        return clonedObject;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackOptions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackOptions.cs
@@ -49,14 +49,17 @@ namespace NuGet.ProjectModel
         public PackOptions Clone()
         {
             var clonedObject = new PackOptions();
-            clonedObject.PackageType = PackageType;
+            clonedObject.PackageType = new List<PackageType>(PackageType);
             clonedObject.IncludeExcludeFiles = IncludeExcludeFiles?.Clone();
-            clonedObject.Mappings = new Dictionary<string, IncludeExcludeFiles>();
-            foreach(var kvp in Mappings)
+            if (Mappings != null)
             {
-                clonedObject.Mappings.Add(kvp.Key, kvp.Value.Clone());
+                clonedObject.Mappings = new Dictionary<string, IncludeExcludeFiles>();
+                foreach (var kvp in Mappings)
+                {
+                    clonedObject.Mappings.Add(kvp.Key, kvp.Value.Clone());
+                }
             }
-        return clonedObject;
+            return clonedObject;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackOptions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackOptions.cs
@@ -50,7 +50,7 @@ namespace NuGet.ProjectModel
         {
             var clonedObject = new PackOptions();
             clonedObject.PackageType = PackageType;
-            clonedObject.IncludeExcludeFiles = IncludeExcludeFiles.Clone();
+            clonedObject.IncludeExcludeFiles = IncludeExcludeFiles?.Clone();
             clonedObject.Mappings = new Dictionary<string, IncludeExcludeFiles>();
             foreach(var kvp in Mappings)
             {

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -212,8 +212,8 @@ namespace NuGet.ProjectModel
             spec.Description = Description;
             spec.Summary = Summary;
             spec.ReleaseNotes = ReleaseNotes;
-            spec.Authors = (string[]) Authors.Clone();
-            spec.Owners = (string[]) Owners.Clone();
+            spec.Authors = (string[]) Authors?.Clone();
+            spec.Owners = (string[]) Owners?.Clone();
             spec.ProjectUrl = ProjectUrl;
 
             spec.IconUrl = IconUrl;
@@ -225,7 +225,7 @@ namespace NuGet.ProjectModel
             spec.Version = Version; 
 
 
-            spec.BuildOptions = BuildOptions.Clone();
+            spec.BuildOptions = BuildOptions?.Clone();
             spec.Tags = (string[])Tags.Clone();
             
             spec.ContentFiles = new List<string>(ContentFiles);
@@ -234,9 +234,9 @@ namespace NuGet.ProjectModel
             spec.PackInclude = new Dictionary<string, string>(PackInclude);
 
             spec.PackOptions = PackOptions.Clone();
-            spec.TargetFrameworks = TargetFrameworks.Select(item => (TargetFrameworkInformation)item.Clone()).ToList(); ;
-            spec.RuntimeGraph = RuntimeGraph; // This needs cloned as well
-            spec.RestoreSettings = RestoreSettings; // clone this
+            spec.TargetFrameworks = TargetFrameworks.Select(item => (TargetFrameworkInformation)item.Clone()).ToList();
+            spec.RuntimeGraph = RuntimeGraph?.Clone(); // TODO - Double check this
+            spec.RestoreSettings = RestoreSettings.Clone();
             spec.RestoreMetadata = RestoreMetadata; // The monster that'd be hardest to deal with
             return spec;
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -209,17 +209,31 @@ namespace NuGet.ProjectModel
             spec.Copyright = Copyright;
             spec.Version = Version; 
             spec.BuildOptions = BuildOptions?.Clone();
-            spec.Tags = (string[])Tags.Clone();    
-            spec.ContentFiles = new List<string>(ContentFiles);
-            spec.Dependencies = Dependencies.Select(item => (LibraryDependency)item.Clone()).ToList();
-            spec.Scripts = new Dictionary<string, IEnumerable<string>>(Scripts); ;  // This actually needs cloned;
-            spec.PackInclude = new Dictionary<string, string>(PackInclude);
+            spec.Tags = (string[]) Tags?.Clone();    
+            spec.ContentFiles = ContentFiles != null ? new List<string>(ContentFiles) : null;
+            spec.Dependencies = Dependencies?.Select(item => item.Clone()).ToList();
+            spec.Scripts = CloneScripts(Scripts);
+            spec.PackInclude = PackInclude != null ? new Dictionary<string, string>(PackInclude) : null;
             spec.PackOptions = PackOptions?.Clone();
-            spec.TargetFrameworks = TargetFrameworks != null ? TargetFrameworks.Select(item => (TargetFrameworkInformation)item.Clone()).ToList() : null;
-            spec.RuntimeGraph = RuntimeGraph?.Clone(); // TODO - Double check this
+            spec.TargetFrameworks = TargetFrameworks?.Select(item => item.Clone()).ToList();
+            spec.RuntimeGraph = RuntimeGraph?.Clone();
             spec.RestoreSettings = RestoreSettings?.Clone();
-            spec.RestoreMetadata = RestoreMetadata?.Clone(); // The monster that'd be hardest to deal with
+            spec.RestoreMetadata = RestoreMetadata?.Clone();
             return spec;
         }
+
+        private IDictionary<string, IEnumerable<string>> CloneScripts(IDictionary<string, IEnumerable<string>> toBeCloned)
+        {
+            if(toBeCloned != null)
+            {
+                var clone = new Dictionary<string, IEnumerable<string>>();
+                foreach(var kvp in toBeCloned)
+                {
+                    clone.Add(kvp.Key, new List<string>(kvp.Value));
+                }
+            }
+            return null;
+        }
+
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using NuGet.Configuration;
 using NuGet.LibraryModel;
 using NuGet.RuntimeModel;
@@ -187,7 +188,7 @@ namespace NuGet.ProjectModel
         /// <summary>
         /// Clone a PackageSpec and underlying JObject.
         /// </summary>
-        public PackageSpec Clone()
+        public PackageSpec CloneOld()
         {
             var writer = new JsonObjectWriter();
             PackageSpecWriter.Write(this, writer);
@@ -197,6 +198,46 @@ namespace NuGet.ProjectModel
             spec.Name = Name;
             spec.FilePath = FilePath;
 
+            return spec;
+        }
+
+        public PackageSpec Clone()
+        {
+            var spec = new PackageSpec();
+            spec.Name = Name;
+            spec.FilePath = FilePath;
+            spec.Title = Title;
+            spec.IsDefaultVersion = IsDefaultVersion;
+            spec.HasVersionSnapshot = HasVersionSnapshot;
+            spec.Description = Description;
+            spec.Summary = Summary;
+            spec.ReleaseNotes = ReleaseNotes;
+            spec.Authors = (string[]) Authors.Clone();
+            spec.Owners = (string[]) Owners.Clone();
+            spec.ProjectUrl = ProjectUrl;
+
+            spec.IconUrl = IconUrl;
+            spec.LicenseUrl = LicenseUrl;
+            spec.RequireLicenseAcceptance = RequireLicenseAcceptance;
+            spec.Language = Language;
+
+            spec.Copyright = Copyright;
+            spec.Version = Version; 
+
+
+            spec.BuildOptions = BuildOptions.Clone();
+            spec.Tags = (string[])Tags.Clone();
+            
+            spec.ContentFiles = new List<string>(ContentFiles);
+            spec.Dependencies = Dependencies.Select(item => (LibraryDependency)item.Clone()).ToList();
+            spec.Scripts = new Dictionary<string, IEnumerable<string>>(Scripts); ;  // This actually needs cloned;
+            spec.PackInclude = new Dictionary<string, string>(PackInclude);
+
+            spec.PackOptions = PackOptions.Clone();
+            spec.TargetFrameworks = TargetFrameworks.Select(item => (TargetFrameworkInformation)item.Clone()).ToList(); ;
+            spec.RuntimeGraph = RuntimeGraph; // This needs cloned as well
+            spec.RestoreSettings = RestoreSettings; // clone this
+            spec.RestoreMetadata = RestoreMetadata; // The monster that'd be hardest to deal with
             return spec;
         }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -202,35 +202,24 @@ namespace NuGet.ProjectModel
             spec.Authors = (string[]) Authors?.Clone();
             spec.Owners = (string[]) Owners?.Clone();
             spec.ProjectUrl = ProjectUrl;
-
             spec.IconUrl = IconUrl;
             spec.LicenseUrl = LicenseUrl;
             spec.RequireLicenseAcceptance = RequireLicenseAcceptance;
             spec.Language = Language;
-
             spec.Copyright = Copyright;
             spec.Version = Version; 
-
-
             spec.BuildOptions = BuildOptions?.Clone();
-            spec.Tags = (string[])Tags.Clone();
-            
+            spec.Tags = (string[])Tags.Clone();    
             spec.ContentFiles = new List<string>(ContentFiles);
             spec.Dependencies = Dependencies.Select(item => (LibraryDependency)item.Clone()).ToList();
             spec.Scripts = new Dictionary<string, IEnumerable<string>>(Scripts); ;  // This actually needs cloned;
             spec.PackInclude = new Dictionary<string, string>(PackInclude);
-
-            spec.PackOptions = PackOptions.Clone();
+            spec.PackOptions = PackOptions?.Clone();
             spec.TargetFrameworks = TargetFrameworks != null ? TargetFrameworks.Select(item => (TargetFrameworkInformation)item.Clone()).ToList() : null;
             spec.RuntimeGraph = RuntimeGraph?.Clone(); // TODO - Double check this
-            spec.RestoreSettings = RestoreSettings.Clone();
-            spec.RestoreMetadata = RestoreMetadata.Clone(); // The monster that'd be hardest to deal with
+            spec.RestoreSettings = RestoreSettings?.Clone();
+            spec.RestoreMetadata = RestoreMetadata?.Clone(); // The monster that'd be hardest to deal with
             return spec;
-        }
-
-        public PackageSpec WithSettings(ISettings settings)
-        {
-            return null;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -231,6 +231,7 @@ namespace NuGet.ProjectModel
                 {
                     clone.Add(kvp.Key, new List<string>(kvp.Value));
                 }
+                return clone;
             }
             return null;
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -186,21 +186,8 @@ namespace NuGet.ProjectModel
         }
 
         /// <summary>
-        /// Clone a PackageSpec and underlying JObject.
+        /// Clone a PackageSpec
         /// </summary>
-        public PackageSpec CloneOld()
-        {
-            var writer = new JsonObjectWriter();
-            PackageSpecWriter.Write(this, writer);
-            var json = writer.GetJObject();
-
-            var spec = JsonPackageSpecReader.GetPackageSpec(json);
-            spec.Name = Name;
-            spec.FilePath = FilePath;
-
-            return spec;
-        }
-
         public PackageSpec Clone()
         {
             var spec = new PackageSpec();
@@ -237,7 +224,7 @@ namespace NuGet.ProjectModel
             spec.TargetFrameworks = TargetFrameworks.Select(item => (TargetFrameworkInformation)item.Clone()).ToList();
             spec.RuntimeGraph = RuntimeGraph?.Clone(); // TODO - Double check this
             spec.RestoreSettings = RestoreSettings.Clone();
-            spec.RestoreMetadata = RestoreMetadata; // The monster that'd be hardest to deal with
+            spec.RestoreMetadata = RestoreMetadata.Clone(); // The monster that'd be hardest to deal with
             return spec;
         }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -221,7 +221,7 @@ namespace NuGet.ProjectModel
             spec.PackInclude = new Dictionary<string, string>(PackInclude);
 
             spec.PackOptions = PackOptions.Clone();
-            spec.TargetFrameworks = TargetFrameworks.Select(item => (TargetFrameworkInformation)item.Clone()).ToList();
+            spec.TargetFrameworks = TargetFrameworks?.Select(item => (TargetFrameworkInformation)item.Clone()).ToList();
             spec.RuntimeGraph = RuntimeGraph?.Clone(); // TODO - Double check this
             spec.RestoreSettings = RestoreSettings.Clone();
             spec.RestoreMetadata = RestoreMetadata.Clone(); // The monster that'd be hardest to deal with

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -221,7 +221,7 @@ namespace NuGet.ProjectModel
             spec.PackInclude = new Dictionary<string, string>(PackInclude);
 
             spec.PackOptions = PackOptions.Clone();
-            spec.TargetFrameworks = TargetFrameworks?.Select(item => (TargetFrameworkInformation)item.Clone()).ToList();
+            spec.TargetFrameworks = TargetFrameworks != null ? TargetFrameworks.Select(item => (TargetFrameworkInformation)item.Clone()).ToList() : null;
             spec.RuntimeGraph = RuntimeGraph?.Clone(); // TODO - Double check this
             spec.RestoreSettings = RestoreSettings.Clone();
             spec.RestoreMetadata = RestoreMetadata.Clone(); // The monster that'd be hardest to deal with

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -235,6 +235,5 @@ namespace NuGet.ProjectModel
             }
             return null;
         }
-
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -224,10 +224,10 @@ namespace NuGet.ProjectModel
 
         private IDictionary<string, IEnumerable<string>> CloneScripts(IDictionary<string, IEnumerable<string>> toBeCloned)
         {
-            if(toBeCloned != null)
+            if (toBeCloned != null)
             {
                 var clone = new Dictionary<string, IEnumerable<string>>();
-                foreach(var kvp in toBeCloned)
+                foreach (var kvp in toBeCloned)
                 {
                     clone.Add(kvp.Key, new List<string>(kvp.Value));
                 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -190,13 +190,13 @@ namespace NuGet.ProjectModel
             clonedObject.LegacyPackagesDirectory = LegacyPackagesDirectory;
             clonedObject.SkipContentFileWrite = SkipContentFileWrite;
             clonedObject.ValidateRuntimeAssets = ValidateRuntimeAssets;
-            clonedObject.FallbackFolders = new List<string>(FallbackFolders);
-            clonedObject.ConfigFilePaths = new List<string>(ConfigFilePaths);
-            clonedObject.OriginalTargetFrameworks = new List<string>(ConfigFilePaths);
+            clonedObject.FallbackFolders = FallbackFolders != null ? new List<string>(FallbackFolders) : null;
+            clonedObject.ConfigFilePaths = ConfigFilePaths != null ? new List<string>(ConfigFilePaths) : null;
+            clonedObject.OriginalTargetFrameworks = OriginalTargetFrameworks != null ? new List<string>(OriginalTargetFrameworks) : null;
             clonedObject.Sources = Sources?.Select(c => c.Clone()).ToList();
             clonedObject.TargetFrameworks = TargetFrameworks?.Select( c => c.Clone()).ToList();
-            clonedObject.Files = Files.Select(c => c.Clone()).ToList();
-            clonedObject.ProjectWideWarningProperties = ProjectWideWarningProperties.Clone();
+            clonedObject.Files = Files?.Select(c => c.Clone()).ToList();
+            clonedObject.ProjectWideWarningProperties = ProjectWideWarningProperties?.Clone();
             return clonedObject;
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
@@ -173,5 +174,30 @@ namespace NuGet.ProjectModel
                    EqualityUtility.SequenceEqualWithNullCheck(Files, other.Files) &&
                    EqualityUtility.EqualsWithNullCheck(ProjectWideWarningProperties, other.ProjectWideWarningProperties);
         }
+
+        public ProjectRestoreMetadata Clone()
+        {
+            var clonedObject = new ProjectRestoreMetadata();
+            clonedObject.ProjectStyle = ProjectStyle;
+            clonedObject.ProjectPath = ProjectPath;
+            clonedObject.ProjectJsonPath = ProjectJsonPath;
+            clonedObject.OutputPath = OutputPath;
+            clonedObject.ProjectName = ProjectName;
+            clonedObject.ProjectUniqueName = ProjectUniqueName;
+            clonedObject.PackagesPath = PackagesPath;
+            clonedObject.CacheFilePath = CacheFilePath;
+            clonedObject.CrossTargeting = CrossTargeting;
+            clonedObject.LegacyPackagesDirectory = LegacyPackagesDirectory;
+            clonedObject.SkipContentFileWrite = SkipContentFileWrite;
+            clonedObject.ValidateRuntimeAssets = ValidateRuntimeAssets;
+            clonedObject.FallbackFolders = new List<string>(FallbackFolders);
+            clonedObject.ConfigFilePaths = new List<string>(ConfigFilePaths);
+            clonedObject.OriginalTargetFrameworks = new List<string>(ConfigFilePaths);
+            clonedObject.Sources = Sources?.Select(c => c.Clone()).ToList();
+            clonedObject.TargetFrameworks = TargetFrameworks?.Select( c => c.Clone()).ToList();
+            clonedObject.Files = Files.Select(c => c.Clone()).ToList();
+            clonedObject.ProjectWideWarningProperties = ProjectWideWarningProperties.Clone();
+            return clonedObject;
     }
+}
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFile.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFile.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -76,5 +76,11 @@ namespace NuGet.ProjectModel
         {
             return StringComparer.Ordinal.Compare(PackagePath, other.PackagePath);
         }
+
+        public ProjectRestoreMetadataFile Clone()
+        {
+            return new ProjectRestoreMetadataFile(PackagePath, AbsolutePath);
+        }
+
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFrameworkInfo.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFrameworkInfo.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NuGet.Frameworks;
 using NuGet.Shared;
 
@@ -19,7 +20,7 @@ namespace NuGet.ProjectModel
         /// The original string before parsing the framework name. In some cases, it is important to keep this around
         /// because MSBuild framework conditions require the framework name to be the original string (non-normalized).
         /// </summary>
-        public string OriginalFrameworkName { get; set; }
+        public string OriginalFrameworkName { get; set; } // TODO NK - Remove this? Or maybe clean everything up so it shows up correctly!
 
         /// <summary>
         /// Project references
@@ -71,6 +72,15 @@ namespace NuGet.ProjectModel
             return EqualityUtility.EqualsWithNullCheck(FrameworkName, other.FrameworkName) &&
                    OriginalFrameworkName == other.OriginalFrameworkName &&
                    EqualityUtility.SequenceEqualWithNullCheck(ProjectReferences, other.ProjectReferences);
+        }
+
+        public ProjectRestoreMetadataFrameworkInfo Clone()
+        {
+            var clonedObject = new ProjectRestoreMetadataFrameworkInfo();
+            clonedObject.FrameworkName = FrameworkName;
+            clonedObject.OriginalFrameworkName = OriginalFrameworkName;
+            clonedObject.ProjectReferences = ProjectReferences?.Select(c => c.Clone()).ToList();
+            return clonedObject;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFrameworkInfo.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFrameworkInfo.cs
@@ -17,12 +17,6 @@ namespace NuGet.ProjectModel
         public NuGetFramework FrameworkName { get; set; }
 
         /// <summary>
-        /// The original string before parsing the framework name. In some cases, it is important to keep this around
-        /// because MSBuild framework conditions require the framework name to be the original string (non-normalized).
-        /// </summary>
-        public string OriginalFrameworkName { get; set; } // TODO NK - Remove this? Or maybe clean everything up so it shows up correctly!
-
-        /// <summary>
         /// Project references
         /// </summary>
         public IList<ProjectRestoreReference> ProjectReferences { get; set; } = new List<ProjectRestoreReference>();
@@ -46,7 +40,6 @@ namespace NuGet.ProjectModel
             var hashCode = new HashCodeCombiner();
 
             hashCode.AddObject(FrameworkName);
-            hashCode.AddObject(OriginalFrameworkName);
             hashCode.AddSequence(ProjectReferences);
 
             return hashCode.CombinedHash;
@@ -70,7 +63,6 @@ namespace NuGet.ProjectModel
             }
 
             return EqualityUtility.EqualsWithNullCheck(FrameworkName, other.FrameworkName) &&
-                   OriginalFrameworkName == other.OriginalFrameworkName &&
                    EqualityUtility.SequenceEqualWithNullCheck(ProjectReferences, other.ProjectReferences);
         }
 
@@ -78,7 +70,6 @@ namespace NuGet.ProjectModel
         {
             var clonedObject = new ProjectRestoreMetadataFrameworkInfo();
             clonedObject.FrameworkName = FrameworkName;
-            clonedObject.OriginalFrameworkName = OriginalFrameworkName;
             clonedObject.ProjectReferences = ProjectReferences?.Select(c => c.Clone()).ToList();
             return clonedObject;
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreReference.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreReference.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -68,6 +68,17 @@ namespace NuGet.ProjectModel
                 && IncludeAssets == other.IncludeAssets
                 && ExcludeAssets == other.ExcludeAssets
                 && PrivateAssets == other.PrivateAssets;
+        }
+
+        public ProjectRestoreReference Clone()
+        {
+            var clonedObject = new ProjectRestoreReference();
+            clonedObject.ProjectPath = ProjectPath;
+            clonedObject.ProjectUniqueName = ProjectUniqueName;
+            clonedObject.ExcludeAssets = ExcludeAssets;
+            clonedObject.IncludeAssets = IncludeAssets;
+            clonedObject.PrivateAssets = PrivateAssets;
+            return clonedObject;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreSettings.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -17,5 +17,12 @@ namespace NuGet.ProjectModel
         /// Currently this is only being used for net core based projects on nomination.
         /// </summary>
         public bool HideWarningsAndErrors { get; set; } = false;
+
+        public ProjectRestoreSettings Clone()
+        {
+            var clonedObject = new ProjectRestoreSettings();
+            clonedObject.HideWarningsAndErrors = HideWarningsAndErrors;
+            return clonedObject;
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreSettings.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreSettings.cs
@@ -24,5 +24,30 @@ namespace NuGet.ProjectModel
             clonedObject.HideWarningsAndErrors = HideWarningsAndErrors;
             return clonedObject;
         }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ProjectRestoreSettings);
+        }
+
+        public bool Equals(ProjectRestoreSettings other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return HideWarningsAndErrors == other.HideWarningsAndErrors;
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreSettings.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreSettings.cs
@@ -47,7 +47,7 @@ namespace NuGet.ProjectModel
 
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            return 318094734 + HideWarningsAndErrors.GetHashCode();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreSettings.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreSettings.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using NuGet.Shared;
 
 namespace NuGet.ProjectModel
 {
@@ -47,7 +48,9 @@ namespace NuGet.ProjectModel
 
         public override int GetHashCode()
         {
-            return 318094734 + HideWarningsAndErrors.GetHashCode();
+            var hashCode = new HashCodeCombiner();
+            hashCode.AddObject(HideWarningsAndErrors);
+            return hashCode.CombinedHash;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Shared;
@@ -69,6 +70,17 @@ namespace NuGet.ProjectModel
                    Dependencies.SequenceEqualWithNullCheck(other.Dependencies) &&
                    Imports.SequenceEqualWithNullCheck(other.Imports) &&
                    AssetTargetFallback == other.AssetTargetFallback;
+        }
+
+        public TargetFrameworkInformation Clone()
+        {
+            var clonedObject = new TargetFrameworkInformation();
+            clonedObject.FrameworkName = FrameworkName;
+            clonedObject.Dependencies = Dependencies.Select(item => (LibraryDependency)item.Clone()).ToList();
+            clonedObject.Imports = new List<NuGetFramework>(Imports);
+            clonedObject.AssetTargetFallback = AssetTargetFallback;
+            clonedObject.Warn = Warn;
+            return clonedObject;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/WarningProperties.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/WarningProperties.cs
@@ -74,5 +74,10 @@ namespace NuGet.ProjectModel
                 EqualityUtility.SetEqualsWithNullCheck(WarningsAsErrors, other.WarningsAsErrors) &&
                 EqualityUtility.SetEqualsWithNullCheck(NoWarn, other.NoWarn);
         }
+
+        public WarningProperties Clone()
+        {
+            return new WarningProperties(warningsAsErrors: new HashSet<NuGetLogCode>(WarningsAsErrors), noWarn: new HashSet<NuGetLogCode>(WarningsAsErrors), allWarningsAsErrors: AllWarningsAsErrors);
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/WarningProperties.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/WarningProperties.cs
@@ -77,7 +77,7 @@ namespace NuGet.ProjectModel
 
         public WarningProperties Clone()
         {
-            return new WarningProperties(warningsAsErrors: new HashSet<NuGetLogCode>(WarningsAsErrors), noWarn: new HashSet<NuGetLogCode>(WarningsAsErrors), allWarningsAsErrors: AllWarningsAsErrors);
+            return new WarningProperties(warningsAsErrors: new HashSet<NuGetLogCode>(WarningsAsErrors), noWarn: new HashSet<NuGetLogCode>(NoWarn), allWarningsAsErrors: AllWarningsAsErrors);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -99,7 +99,7 @@ namespace NuGet.Test
                     var buildIntegratedProjects = new List<TestProjectJsonBuildIntegratedNuGetProject>();
 
                     // Create projects
-                    for (int i = 0; i < 4; i++)
+                    for (var i = 0; i < 4; i++)
                     {
                         var folder = TestDirectory.Create();
                         projectFolderPaths.Add(folder);
@@ -175,7 +175,7 @@ namespace NuGet.Test
                     buildIntegratedProjects[2].ProjectReferences.Add(reference3);
                     buildIntegratedProjects[2].ProjectReferences.Add(normalReference);
 
-                    string message = string.Empty;
+                    var message = string.Empty;
 
                     var format = new LockFileFormat();
 
@@ -185,7 +185,7 @@ namespace NuGet.Test
 
                     var parsedLockFiles = new List<LockFile>();
 
-                    for (int i = 0; i < 3; i++)
+                    for (var i = 0; i < 3; i++)
                     {
                         var lockFile = format.Read(lockFiles[i]);
                         parsedLockFiles.Add(lockFile);
@@ -241,7 +241,7 @@ namespace NuGet.Test
                     var buildIntegratedProjects = new List<TestProjectJsonBuildIntegratedNuGetProject>();
 
                     // Create projects
-                    for (int i = 0; i < 4; i++)
+                    for (var i = 0; i < 4; i++)
                     {
                         var folder = TestDirectory.Create();
                         projectFolderPaths.Add(folder);
@@ -318,7 +318,7 @@ namespace NuGet.Test
                     buildIntegratedProjects[2].ProjectReferences.Add(reference3);
                     buildIntegratedProjects[2].ProjectReferences.Add(normalReference);
 
-                    string message = string.Empty;
+                    var message = string.Empty;
 
                     var format = new LockFileFormat();
 
@@ -335,7 +335,7 @@ namespace NuGet.Test
 
                     var parsedLockFiles = new List<LockFile>();
 
-                    for (int i = 0; i < 3; i++)
+                    for (var i = 0; i < 3; i++)
                     {
                         var lockFile = format.Read(lockFiles[i]);
                         parsedLockFiles.Add(lockFile);
@@ -386,7 +386,7 @@ namespace NuGet.Test
                 var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
                 var buildIntegratedProject = new ProjectJsonNuGetProject(randomConfig, projectFilePath);
 
-                string message = string.Empty;
+                var message = string.Empty;
 
                 // Act
                 // Set the direct install on the execution context of INuGetProjectContext before installing a package
@@ -435,7 +435,7 @@ namespace NuGet.Test
                 var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
                 var buildIntegratedProject = new ProjectJsonNuGetProject(randomConfig, projectFilePath);
 
-                string message = string.Empty;
+                var message = string.Empty;
 
                 // Act
                 await nuGetPackageManager.InstallPackageAsync(buildIntegratedProject, packageIdentity, new ResolutionContext(), new TestNuGetProjectContext(),
@@ -633,7 +633,7 @@ namespace NuGet.Test
                 var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
                 var buildIntegratedProject = new ProjectJsonNuGetProject(randomConfig, projectFilePath);
 
-                string message = string.Empty;
+                var message = string.Empty;
 
                 await nuGetPackageManager.InstallPackageAsync(buildIntegratedProject, packageIdentity, new ResolutionContext(), new TestNuGetProjectContext(),
                     sourceRepositoryProvider.GetRepositories(), sourceRepositoryProvider.GetRepositories(), CancellationToken.None);
@@ -686,7 +686,7 @@ namespace NuGet.Test
                 var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
                 var buildIntegratedProject = new ProjectJsonNuGetProject(randomConfig, projectFilePath);
 
-                string message = string.Empty;
+                var message = string.Empty;
 
                 await nuGetPackageManager.InstallPackageAsync(buildIntegratedProject, versioning105, new ResolutionContext(), new TestNuGetProjectContext(),
                         sourceRepositoryProvider.GetRepositories(), sourceRepositoryProvider.GetRepositories(), CancellationToken.None);
@@ -734,7 +734,7 @@ namespace NuGet.Test
                 var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
                 var buildIntegratedProject = new ProjectJsonNuGetProject(randomConfig, projectFilePath);
 
-                string message = string.Empty;
+                var message = string.Empty;
 
                 await nuGetPackageManager.InstallPackageAsync(buildIntegratedProject, oldJson, new ResolutionContext(), new TestNuGetProjectContext(),
                         sourceRepositoryProvider.GetRepositories(), sourceRepositoryProvider.GetRepositories(), CancellationToken.None);
@@ -885,7 +885,7 @@ namespace NuGet.Test
                 var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
                 var buildIntegratedProject = new ProjectJsonNuGetProject(randomConfig, projectFilePath);
 
-                string message = string.Empty;
+                var message = string.Empty;
 
                 using (var cacheContext = new SourceCacheContext())
                 {
@@ -979,7 +979,7 @@ namespace NuGet.Test
                 var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
                 var buildIntegratedProject = new ProjectJsonNuGetProject(randomConfig, projectFilePath);
 
-                string message = string.Empty;
+                var message = string.Empty;
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var downloadContext = new PackageDownloadContext(cacheContext);
@@ -1074,7 +1074,7 @@ namespace NuGet.Test
                 var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
                 var buildIntegratedProject = new ProjectJsonNuGetProject(randomConfig, projectFilePath);
 
-                string message = string.Empty;
+                var message = string.Empty;
 
                 await nuGetPackageManager.InstallPackageAsync(buildIntegratedProject, versioning105, new ResolutionContext(), new TestNuGetProjectContext(),
                         sourceRepositoryProvider.GetRepositories(), sourceRepositoryProvider.GetRepositories(), CancellationToken.None);
@@ -1143,7 +1143,7 @@ namespace NuGet.Test
                 var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
                 var buildIntegratedProject = new ProjectJsonNuGetProject(randomConfig, projectFilePath);
 
-                string message = string.Empty;
+                var message = string.Empty;
 
                 await nuGetPackageManager.InstallPackageAsync(
                     buildIntegratedProject,
@@ -1250,7 +1250,7 @@ namespace NuGet.Test
                 var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
                 var buildIntegratedProject = new ProjectJsonNuGetProject(randomConfig, projectFilePath);
 
-                string message = string.Empty;
+                var message = string.Empty;
 
                 await nuGetPackageManager.InstallPackageAsync(buildIntegratedProject, versioning105, new ResolutionContext(), new TestNuGetProjectContext(),
                         sourceRepositoryProvider.GetRepositories(), sourceRepositoryProvider.GetRepositories(), CancellationToken.None);
@@ -1312,7 +1312,7 @@ namespace NuGet.Test
                 var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
                 var buildIntegratedProject = new ProjectJsonNuGetProject(randomConfig, projectFilePath);
 
-                string message = string.Empty;
+                var message = string.Empty;
 
                 // Act
                 try
@@ -1543,7 +1543,7 @@ namespace NuGet.Test
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
                 var buildIntegratedProject = new TestProjectJsonBuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
 
-                string message = string.Empty;
+                var message = string.Empty;
 
                 // Act
                 await nuGetPackageManager.InstallPackageAsync(buildIntegratedProject, packageIdentity, new ResolutionContext(), new TestNuGetProjectContext(),
@@ -1582,7 +1582,7 @@ namespace NuGet.Test
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
                 var buildIntegratedProject = new TestProjectJsonBuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
 
-                string message = string.Empty;
+                var message = string.Empty;
 
                 await nuGetPackageManager.InstallPackageAsync(buildIntegratedProject, packageIdentity, new ResolutionContext(), new TestNuGetProjectContext(),
                         sourceRepositoryProvider.GetRepositories(), sourceRepositoryProvider.GetRepositories(), CancellationToken.None);
@@ -1624,7 +1624,7 @@ namespace NuGet.Test
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
                 var buildIntegratedProject = new TestProjectJsonBuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
 
-                string message = string.Empty;
+                var message = string.Empty;
 
                 await nuGetPackageManager.InstallPackageAsync(buildIntegratedProject, packageIdentity, new ResolutionContext(), new TestNuGetProjectContext(),
                     sourceRepositoryProvider.GetRepositories(), sourceRepositoryProvider.GetRepositories(), CancellationToken.None);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -1038,8 +1038,10 @@ namespace NuGet.Test
         private ISettings PopulateSettingsWithSources(SourceRepositoryProvider sourceRepositoryProvider, TestDirectory settingsDirectory)
         {
             var Settings = new Settings(settingsDirectory);
+
             foreach (var source in sourceRepositoryProvider.GetRepositories())
-                Settings.SetValue(ConfigurationConstants.PackageSources, ConfigurationConstants.PackageSources, source.PackageSource.Source);
+                if (source.PackageSource.Source != NuGetConstants.V3FeedUrl) 
+                    Settings.SetValue(ConfigurationConstants.PackageSources, ConfigurationConstants.PackageSources, source.PackageSource.Source);
 
             return Settings;
         }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -1038,10 +1038,8 @@ namespace NuGet.Test
         private ISettings PopulateSettingsWithSources(SourceRepositoryProvider sourceRepositoryProvider, TestDirectory settingsDirectory)
         {
             var Settings = new Settings(settingsDirectory);
-
             foreach (var source in sourceRepositoryProvider.GetRepositories())
-                if (source.PackageSource.Source != NuGetConstants.V3FeedUrl) 
-                    Settings.SetValue(ConfigurationConstants.PackageSources, ConfigurationConstants.PackageSources, source.PackageSource.Source);
+                Settings.SetValue(ConfigurationConstants.PackageSources, ConfigurationConstants.PackageSources, source.PackageSource.Source);
 
             return Settings;
         }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using Xunit;
@@ -112,13 +113,189 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void PackageSpecCloneTest()
         {
-            // TODO NK
+            // Set up
+            var PackageSpec = new PackageSpec();
+            PackageSpec.RestoreMetadata = CreateProjectRestoreMetadata();
+
+            // Act
+            var clonedPackageSpec = PackageSpec.Clone();
+
+            // TODO NK - Add more tests
+            //Assert
+            Assert.Equal(PackageSpec, clonedPackageSpec);
+            Assert.False(object.ReferenceEquals(PackageSpec, clonedPackageSpec));
+        }
+
+        private ProjectRestoreMetadata CreateProjectRestoreMetadata()
+        {
+            var projectReference = new ProjectRestoreReference();
+            projectReference.ProjectPath = "Path";
+            projectReference.ProjectUniqueName = "ProjectUniqueName";
+            projectReference.IncludeAssets = LibraryIncludeFlags.All;
+            projectReference.ExcludeAssets = LibraryIncludeFlags.Analyzers;
+            projectReference.PrivateAssets = LibraryIncludeFlags.Build;
+            var nugetFramework = NuGetFramework.Parse("net461");
+            var originalFrameworkName = "net461";
+            var originalPRMFI = new ProjectRestoreMetadataFrameworkInfo(nugetFramework);
+            originalPRMFI.OriginalFrameworkName = originalFrameworkName;
+            originalPRMFI.ProjectReferences = new List<ProjectRestoreReference>() { projectReference };
+            var targetframeworks = new List<ProjectRestoreMetadataFrameworkInfo>() { originalPRMFI };
+
+            var allWarningsAsErrors = true;
+            var noWarn = new HashSet<NuGetLogCode>() { NuGetLogCode.NU1000, NuGetLogCode.NU1500 };
+            var warningsAsErrors = new HashSet<NuGetLogCode>() { NuGetLogCode.NU1001, NuGetLogCode.NU1501 };
+            var warningProperties = new WarningProperties(allWarningsAsErrors: allWarningsAsErrors, warningsAsErrors: warningsAsErrors, noWarn: noWarn);
+
+            var originalProjectRestoreMetadata = new ProjectRestoreMetadata();
+            originalProjectRestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
+            originalProjectRestoreMetadata.ProjectPath = "ProjectPath";
+            originalProjectRestoreMetadata.ProjectJsonPath = "ProjectJsonPath";
+            originalProjectRestoreMetadata.OutputPath = "OutputPath";
+            originalProjectRestoreMetadata.ProjectName = "ProjectName";
+            originalProjectRestoreMetadata.ProjectUniqueName = "ProjectUniqueName";
+            originalProjectRestoreMetadata.PackagesPath = "PackagesPath";
+            originalProjectRestoreMetadata.CacheFilePath = "CacheFilePath";
+            originalProjectRestoreMetadata.CrossTargeting = true;
+            originalProjectRestoreMetadata.LegacyPackagesDirectory = true;
+            originalProjectRestoreMetadata.ValidateRuntimeAssets = true;
+            originalProjectRestoreMetadata.SkipContentFileWrite = true;
+            originalProjectRestoreMetadata.TargetFrameworks = targetframeworks;
+            originalProjectRestoreMetadata.Sources = new List<PackageSource>() { new PackageSource("http://api.nuget.org/v3/index.json") }; ;
+            originalProjectRestoreMetadata.FallbackFolders = new List<string>() { "fallback1" };
+            originalProjectRestoreMetadata.ConfigFilePaths = new List<string>() { "config1" };
+            originalProjectRestoreMetadata.OriginalTargetFrameworks = new List<string>() { "net45" };
+            originalProjectRestoreMetadata.Files = new List<ProjectRestoreMetadataFile>() { new ProjectRestoreMetadataFile("packagePath", "absolutePath") };
+            originalProjectRestoreMetadata.ProjectWideWarningProperties = warningProperties;
+
+            return originalProjectRestoreMetadata;
         }
 
         [Fact]
         public void ProjectRestoreMetadataCloneTest()
         {
-            // TODO NK
+            // Set up
+            var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
+            // Act
+
+            var happyClone = originalProjectRestoreMetadata.Clone();
+
+            // Assert
+            Assert.Equal(originalProjectRestoreMetadata, happyClone);
+            Assert.False(object.ReferenceEquals(originalProjectRestoreMetadata, happyClone));
+        }
+
+        [Fact]
+        public void ProjectRestoreMetadataCloneChangeSourcesTest()
+        {
+            // Set up
+            var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
+
+            // Preconditions
+            var happyClone = originalProjectRestoreMetadata.Clone();
+            Assert.Equal(originalProjectRestoreMetadata, happyClone);
+            Assert.False(object.ReferenceEquals(originalProjectRestoreMetadata, happyClone));
+
+            // Act
+            originalProjectRestoreMetadata.Sources.Clear();
+
+            // Assert
+            Assert.NotEqual(originalProjectRestoreMetadata, happyClone);
+            Assert.Equal(1, happyClone.Sources.Count);
+        }
+
+        [Fact]
+        public void ProjectRestoreMetadataCloneChangeFallbackFoldersTest()
+        {
+            // Set up
+            var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
+
+            // Preconditions
+            var happyClone = originalProjectRestoreMetadata.Clone();
+            Assert.Equal(originalProjectRestoreMetadata, happyClone);
+            Assert.False(object.ReferenceEquals(originalProjectRestoreMetadata, happyClone));
+
+            // Act
+            originalProjectRestoreMetadata.FallbackFolders.Clear();
+
+            // Assert
+            Assert.NotEqual(originalProjectRestoreMetadata, happyClone);
+            Assert.Equal(1, happyClone.FallbackFolders.Count);
+        }
+
+        [Fact]
+        public void ProjectRestoreMetadataCloneChangeConfigFilePathsTest()
+        {
+            // Set up
+            var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
+
+            // Preconditions
+            var happyClone = originalProjectRestoreMetadata.Clone();
+            Assert.Equal(originalProjectRestoreMetadata, happyClone);
+            Assert.False(object.ReferenceEquals(originalProjectRestoreMetadata, happyClone));
+
+            // Act
+            originalProjectRestoreMetadata.ConfigFilePaths.Clear();
+
+            // Assert
+            Assert.NotEqual(originalProjectRestoreMetadata, happyClone);
+            Assert.Equal(1, happyClone.ConfigFilePaths.Count);
+        }
+
+        [Fact]
+        public void ProjectRestoreMetadataCloneChangeOriginalTargetFrameworksTest()
+        {
+            // Set up
+            var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
+
+            // Preconditions
+            var happyClone = originalProjectRestoreMetadata.Clone();
+            Assert.Equal(originalProjectRestoreMetadata, happyClone);
+            Assert.False(object.ReferenceEquals(originalProjectRestoreMetadata, happyClone));
+
+            // Act
+            originalProjectRestoreMetadata.OriginalTargetFrameworks.Clear();
+
+            // Assert
+            Assert.NotEqual(originalProjectRestoreMetadata, happyClone);
+            Assert.Equal(1, happyClone.OriginalTargetFrameworks.Count);
+        }
+
+        [Fact]
+        public void ProjectRestoreMetadataCloneChangeFilesTest()
+        {
+            // Set up
+            var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
+
+            // Preconditions
+            var happyClone = originalProjectRestoreMetadata.Clone();
+            Assert.Equal(originalProjectRestoreMetadata, happyClone);
+            Assert.False(object.ReferenceEquals(originalProjectRestoreMetadata, happyClone));
+
+            // Act
+            originalProjectRestoreMetadata.Files.Clear();
+
+            // Assert
+            Assert.NotEqual(originalProjectRestoreMetadata, happyClone);
+            Assert.Equal(1, happyClone.Files.Count);
+        }
+
+        [Fact]
+        public void ProjectRestoreMetadataCloneChangeProjectWideWarningPropertiesTest()
+        {
+            // Set up
+            var originalProjectRestoreMetadata = CreateProjectRestoreMetadata();
+
+            // Preconditions
+            var happyClone = originalProjectRestoreMetadata.Clone();
+            Assert.Equal(originalProjectRestoreMetadata, happyClone);
+            Assert.False(object.ReferenceEquals(originalProjectRestoreMetadata, happyClone));
+
+            // Act
+            originalProjectRestoreMetadata.ProjectWideWarningProperties.AllWarningsAsErrors = false; ;
+
+            // Assert
+            Assert.NotEqual(originalProjectRestoreMetadata, happyClone);
+            Assert.Equal(true, happyClone.ProjectWideWarningProperties.AllWarningsAsErrors);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -30,6 +30,7 @@ namespace NuGet.ProjectModel.Test
 
             // Act
             var clonedBuildOptions = originalBuildOptions.Clone();
+
             //Assert
             Assert.Equal(originalBuildOptions.OutputName, clonedBuildOptions.OutputName);
         }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -1,0 +1,212 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using FluentAssertions;
+using NuGet.Common;
+using NuGet.Frameworks;
+using Xunit;
+namespace NuGet.ProjectModel.Test
+{
+    public class PackageSpecCloningTests
+    {
+        [Fact]
+        public void BuildOptionsCloneTest()
+        {
+            //Set up
+            var outputName = "OutputName";
+            var originalBuildOptions = new BuildOptions();
+            originalBuildOptions.OutputName = outputName;
+
+            // Act
+            var clonedBuildOptions = originalBuildOptions.Clone();
+            //Assert
+            Assert.Equal(originalBuildOptions.OutputName, clonedBuildOptions.OutputName);
+        }
+
+        [Fact]
+        public void IncludeExcludeFilesCloneTest()
+        {
+            //Set up
+            var exclude = new List<string>() { "Exlclude0" };
+            var include = new List<string>() { "Include0" };
+            var includeFiles = new List<string>() { "IncludeFiles0" };
+            var excludeFiles = new List<string>() { "ExlcludeFiles0" };
+
+            var files = new IncludeExcludeFiles();
+            files.Exclude = exclude;
+            files.Include = include;
+            files.IncludeFiles = includeFiles;
+            files.ExcludeFiles = excludeFiles;
+
+            // Act
+            var clone = files.Clone();
+            //Assert
+
+            Assert.Equal(files.Exclude, clone.Exclude);
+            Assert.Equal(files.Include, clone.Include);
+            Assert.Equal(files.IncludeFiles, clone.IncludeFiles);
+            Assert.Equal(files.ExcludeFiles, clone.ExcludeFiles);
+
+            // Act again
+            exclude.Add("Extra Exclude");
+
+            //Assert
+            Assert.Equal(2, files.Exclude.Count);
+            Assert.NotEqual(files.Exclude, clone.Exclude);
+        }
+
+        [Fact]
+        public void PackOptionsCloneTest()
+        {
+            //Set up
+            var originalPackOptions = new PackOptions();
+            var originalPackageName = "PackageA";
+            var packageTypes = new List<NuGet.Packaging.Core.PackageType>() { new Packaging.Core.PackageType(originalPackageName, new System.Version("1.0.0")) };
+
+            var exclude = new List<string>() { "Exlclude0" };
+            var include = new List<string>() { "Include0" };
+            var includeFiles = new List<string>() { "IncludeFiles0" };
+            var excludeFiles = new List<string>() { "ExlcludeFiles0" };
+
+            var files = new IncludeExcludeFiles();
+            files.Exclude = exclude;
+            files.Include = include;
+            files.IncludeFiles = includeFiles;
+            files.ExcludeFiles = excludeFiles;
+
+            originalPackOptions.PackageType = packageTypes;
+            originalPackOptions.IncludeExcludeFiles = files;
+
+            // Act
+            var clone = originalPackOptions.Clone();
+
+            // Assert
+            Assert.Equal(originalPackOptions, clone);
+
+            // Act again
+            packageTypes.Clear();
+
+            // Assert
+            Assert.NotEqual(originalPackOptions, clone);
+            Assert.Equal(originalPackageName, clone.PackageType[0].Name);
+
+            // Set Up again
+            originalPackOptions.Mappings.Add("randomString", files);
+
+            // Act again
+            var cloneWithMappings = originalPackOptions.Clone();
+
+            // Assert
+            Assert.Equal(originalPackOptions, cloneWithMappings);
+
+            // Act again
+            originalPackOptions.Mappings.Clear();
+
+            // Assert
+            Assert.NotEqual(originalPackOptions, cloneWithMappings);
+            Assert.Equal(1, cloneWithMappings.Mappings.Count);
+        }
+
+        [Fact]
+        public void PackageSpecCloneTest()
+        {
+            // TODO NK
+        }
+
+        [Fact]
+        public void ProjectRestoreMetadataCloneTest()
+        {
+            // TODO NK
+        }
+
+        [Fact]
+        public void ProjectRestoreMetadataFileCloneTest()
+        {
+            // Set up
+            var originalProjectRestoreMetadataFile = new ProjectRestoreMetadataFile("packagePath", "absolutePath");
+
+            // Act
+            var clone = originalProjectRestoreMetadataFile.Clone();
+
+            // Assert
+            Assert.Equal(originalProjectRestoreMetadataFile, clone);
+            Assert.False(object.ReferenceEquals(originalProjectRestoreMetadataFile, clone));
+        }
+
+        [Fact]
+        public void ProjectRestoreMetadataFrameworkInfoCloneTest()
+        {
+            // TODO NK
+        }
+
+        [Fact]
+        public void ProjectRestoreReferenceCloneTest()
+        {
+            // Set up
+            var originalProjectRestoreReference = new ProjectRestoreReference();
+            originalProjectRestoreReference.ProjectPath = "Path";
+            originalProjectRestoreReference.ProjectUniqueName = "ProjectUniqueName";
+            originalProjectRestoreReference.IncludeAssets = LibraryModel.LibraryIncludeFlags.All;
+            originalProjectRestoreReference.ExcludeAssets = LibraryModel.LibraryIncludeFlags.Analyzers;
+            originalProjectRestoreReference.PrivateAssets = LibraryModel.LibraryIncludeFlags.Build;
+
+            // Act
+            var clone = originalProjectRestoreReference.Clone();
+
+            // Assert
+            Assert.Equal(originalProjectRestoreReference, clone);
+            Assert.False(object.ReferenceEquals(originalProjectRestoreReference, clone));
+        }
+
+        [Fact]
+        public void ProjectRestoreSettingsCloneTest()
+        {
+            // Set up
+            var originalProjectRestoreSettings = new ProjectRestoreSettings();
+            originalProjectRestoreSettings.HideWarningsAndErrors = false;
+
+            // Act
+            var clone = originalProjectRestoreSettings.Clone();
+
+            // Assert
+            Assert.Equal(originalProjectRestoreSettings, clone);
+            Assert.False(object.ReferenceEquals(originalProjectRestoreSettings, clone));
+        }
+
+        [Fact]
+        public void TargetFrameworkInformationCloneTest()
+        {
+            // TODO Nk
+        }
+
+        [Fact]
+        public void WarningPropertiesCloneTest()
+        {
+            // Set up
+            var allWarningsAsErrors = false;
+            var noWarn = new HashSet<NuGetLogCode>() { NuGetLogCode.NU1000, NuGetLogCode.NU1500 };
+            var warningsAsErrors = new HashSet<NuGetLogCode>() { NuGetLogCode.NU1001, NuGetLogCode.NU1501 };
+            var originalWarningProperties = new WarningProperties(allWarningsAsErrors: allWarningsAsErrors, warningsAsErrors: warningsAsErrors, noWarn: noWarn);
+
+            //Act
+            var clone = originalWarningProperties.Clone();
+
+            // Assert
+            Assert.Equal(originalWarningProperties, clone);
+            Assert.False(object.ReferenceEquals(originalWarningProperties, clone));
+            //Assert.True(EqualityUtility.SetEqualsWithNullCheck(noWarn, clone.NoWarn)); TODO get the equality utility here
+            Assert.False(object.ReferenceEquals(noWarn, clone.NoWarn));
+
+            // Act again
+            noWarn.Clear();
+
+            //Assert again
+            Assert.NotEqual(originalWarningProperties, clone);
+            Assert.Equal(2, clone.NoWarn.Count);
+
+
+        }
+
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -204,8 +204,6 @@ namespace NuGet.ProjectModel.Test
             //Assert again
             Assert.NotEqual(originalWarningProperties, clone);
             Assert.Equal(2, clone.NoWarn.Count);
-
-
         }
 
     }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using NuGet.Common;
 using NuGet.Frameworks;
+using NuGet.LibraryModel;
 using Xunit;
 namespace NuGet.ProjectModel.Test
 {
@@ -137,7 +138,33 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void ProjectRestoreMetadataFrameworkInfoCloneTest()
         {
-            // TODO NK
+            //Set up
+            var projectReference = new ProjectRestoreReference();
+            projectReference.ProjectPath = "Path";
+            projectReference.ProjectUniqueName = "ProjectUniqueName";
+            projectReference.IncludeAssets = LibraryModel.LibraryIncludeFlags.All;
+            projectReference.ExcludeAssets = LibraryModel.LibraryIncludeFlags.Analyzers;
+            projectReference.PrivateAssets = LibraryModel.LibraryIncludeFlags.Build;
+
+            var nugetFramework = NuGetFramework.Parse("net461");
+            var originalFrameworkName = "net461";
+
+            var originalPRMFI = new ProjectRestoreMetadataFrameworkInfo(nugetFramework);
+            originalPRMFI.OriginalFrameworkName = originalFrameworkName;
+            originalPRMFI.ProjectReferences = new List<ProjectRestoreReference>() { projectReference };
+
+            // Act
+            var clone = originalPRMFI.Clone();
+
+            // Assert
+            Assert.Equal(clone, originalPRMFI);
+            Assert.False(object.ReferenceEquals(originalPRMFI, clone));
+
+            // Act
+            projectReference.ProjectPath = "NewPath";
+            
+            // Assert
+            Assert.NotEqual(clone, originalPRMFI);
         }
 
         [Fact]
@@ -177,7 +204,48 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void TargetFrameworkInformationCloneTest()
         {
-            // TODO Nk
+            // Set up
+            var framework = NuGetFramework.Parse("net461");
+            var dependency = new LibraryDependency();
+            dependency.LibraryRange = new LibraryRange("Dependency", LibraryDependencyTarget.Package);
+            dependency.Type = LibraryDependencyType.Default;
+            dependency.IncludeType = LibraryIncludeFlags.None;
+            dependency.SuppressParent = LibraryIncludeFlags.ContentFiles;
+            var imports = NuGetFramework.Parse("net45"); // This makes no sense in the context of fallback, just for testing :)
+
+            var originalTargetFrameworkInformation = new TargetFrameworkInformation();
+            originalTargetFrameworkInformation.FrameworkName = framework;
+            originalTargetFrameworkInformation.Dependencies = new List<LibraryDependency>() { dependency };
+            originalTargetFrameworkInformation.AssetTargetFallback = false;
+            originalTargetFrameworkInformation.Imports = new List<NuGetFramework>() { imports };
+
+            // Act
+            var clone = originalTargetFrameworkInformation.Clone();
+
+            // Assert
+            Assert.Equal(originalTargetFrameworkInformation, clone);
+            Assert.False(object.ReferenceEquals(originalTargetFrameworkInformation, clone));
+
+            // Act
+            originalTargetFrameworkInformation.Imports.Clear();
+
+            // Assert
+            Assert.NotEqual(originalTargetFrameworkInformation, clone);
+            Assert.Equal(1, clone.Imports.Count);
+
+            //Act
+            var cloneToTestDependencies = originalTargetFrameworkInformation.Clone();
+
+            // Assert
+            Assert.Equal(originalTargetFrameworkInformation, cloneToTestDependencies);
+            Assert.False(object.ReferenceEquals(originalTargetFrameworkInformation, cloneToTestDependencies));
+
+            // Act
+            originalTargetFrameworkInformation.Dependencies.Clear();
+
+            // Assert
+            Assert.NotEqual(originalTargetFrameworkInformation, cloneToTestDependencies);
+            Assert.Equal(1, cloneToTestDependencies.Dependencies.Count);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -195,22 +195,6 @@ namespace NuGet.ProjectModel.Test
             //Assert
             Assert.Equal(PackageSpec, clonedPackageSpec);
             Assert.False(object.ReferenceEquals(PackageSpec, clonedPackageSpec));
-
-            // Act
-            var oldClone = OldClone(PackageSpec);
-        }
-
-        private PackageSpec OldClone(PackageSpec packageSpec)
-        {
-
-            var writer = new JsonObjectWriter();
-            PackageSpecWriter.Write(packageSpec, writer);
-            var json = writer.GetJObject();
-
-            var spec = JsonPackageSpecReader.GetPackageSpec(json);
-            spec.Name = packageSpec.Name;
-            spec.FilePath = packageSpec.FilePath;
-            return spec;
         }
 
         private ProjectRestoreMetadata CreateProjectRestoreMetadata()

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using NuGet.Common;
@@ -12,13 +13,19 @@ namespace NuGet.ProjectModel.Test
 {
     public class PackageSpecCloningTests
     {
+        private BuildOptions CreateBuildOptions()
+        {
+            var outputName = "OutputName";
+            var originalBuildOptions = new BuildOptions();
+            originalBuildOptions.OutputName = outputName;
+            return originalBuildOptions;
+        }
+
         [Fact]
         public void BuildOptionsCloneTest()
         {
             //Set up
-            var outputName = "OutputName";
-            var originalBuildOptions = new BuildOptions();
-            originalBuildOptions.OutputName = outputName;
+            var originalBuildOptions = CreateBuildOptions();
 
             // Act
             var clonedBuildOptions = originalBuildOptions.Clone();
@@ -110,6 +117,33 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(1, cloneWithMappings.Mappings.Count);
         }
 
+        private LibraryDependency CreateLibraryDependency()
+        {
+            var dependency = new LibraryDependency();
+            dependency.LibraryRange = new LibraryRange(Guid.NewGuid().ToString(), LibraryDependencyTarget.Package);
+            dependency.Type = LibraryDependencyType.Default;
+            dependency.IncludeType = LibraryIncludeFlags.None;
+            dependency.SuppressParent = LibraryIncludeFlags.ContentFiles;
+            return dependency;
+        }
+
+        private IncludeExcludeFiles CreateIncludeExcludeFiles()
+        {
+            var files = new IncludeExcludeFiles();
+            files.Exclude = new List<string>() { "Exlclude0" };
+            files.Include = new List<string>() { "Include0" };
+            files.IncludeFiles = new List<string>() { "IncludeFiles0" };
+            files.ExcludeFiles = new List<string>() { "ExlcludeFiles0" };
+            return files;
+        }
+        private PackOptions CreatePackOptions()
+        {
+            var originalPackOptions = new PackOptions();
+            originalPackOptions.PackageType = new List<NuGet.Packaging.Core.PackageType>() { new Packaging.Core.PackageType("PackageA", new System.Version("1.0.0")) };
+            originalPackOptions.IncludeExcludeFiles = CreateIncludeExcludeFiles();
+            return originalPackOptions;
+        }
+
         [Fact]
         public void PackageSpecCloneTest()
         {
@@ -121,6 +155,33 @@ namespace NuGet.ProjectModel.Test
             PackageSpec.Name = "Name";
             PackageSpec.Title = "Title";
             PackageSpec.Version = new Versioning.NuGetVersion("1.0.0");
+            PackageSpec.HasVersionSnapshot = true;
+            PackageSpec.Description = "Description";
+            PackageSpec.Summary = "Summary";
+            PackageSpec.ReleaseNotes = "ReleaseNotes";
+            PackageSpec.Authors = new string[] { "Author1" };
+            PackageSpec.Owners = new string[] { "Owner1" };
+            PackageSpec.ProjectUrl = "ProjectUrl";
+            PackageSpec.IconUrl = "IconUrl";
+            PackageSpec.LicenseUrl = "LicenseUrl";
+            PackageSpec.Copyright = "Copyright";
+            PackageSpec.Language = "Language";
+            PackageSpec.RequireLicenseAcceptance = true;
+            PackageSpec.Tags = new string[] { "Tags" };
+            PackageSpec.BuildOptions = CreateBuildOptions();
+            PackageSpec.ContentFiles = new List<string>() { "contentFile1", "contentFile2" };
+            PackageSpec.Dependencies = new List<LibraryDependency>() { CreateLibraryDependency(), CreateLibraryDependency() };
+
+            PackageSpec.Scripts.Add(Guid.NewGuid().ToString(), new List<string>() { Guid.NewGuid().ToString() }); // Test this changing
+            PackageSpec.Scripts.Add(Guid.NewGuid().ToString(), new List<string>() { Guid.NewGuid().ToString() });
+
+            PackageSpec.PackInclude.Add(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+
+            PackageSpec.PackOptions = CreatePackOptions();
+
+            PackageSpec.RuntimeGraph = new RuntimeModel.RuntimeGraph(); // TODO - Add logic
+            PackageSpec.RestoreSettings = CreateProjectRestoreSettings();
+
             // Act
             var clonedPackageSpec = PackageSpec.Clone();
 
@@ -367,12 +428,18 @@ namespace NuGet.ProjectModel.Test
             Assert.False(object.ReferenceEquals(originalProjectRestoreReference, clone));
         }
 
+        private ProjectRestoreSettings CreateProjectRestoreSettings()
+        {
+            var prs =  new ProjectRestoreSettings();
+            prs.HideWarningsAndErrors = true;
+            return prs;
+        }
+
         [Fact]
         public void ProjectRestoreSettingsCloneTest()
         {
             // Set up
-            var originalProjectRestoreSettings = new ProjectRestoreSettings();
-            originalProjectRestoreSettings.HideWarningsAndErrors = false;
+            var originalProjectRestoreSettings = CreateProjectRestoreSettings();
 
             // Act
             var clone = originalProjectRestoreSettings.Clone();

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -114,9 +114,13 @@ namespace NuGet.ProjectModel.Test
         public void PackageSpecCloneTest()
         {
             // Set up
-            var PackageSpec = new PackageSpec();
+            var originalTargetFrameworkInformation = CreateTargetFrameworkInformation();
+            var PackageSpec = new PackageSpec(new List<TargetFrameworkInformation>() { originalTargetFrameworkInformation });
             PackageSpec.RestoreMetadata = CreateProjectRestoreMetadata();
-
+            PackageSpec.FilePath = "FilePath";
+            PackageSpec.Name = "Name";
+            PackageSpec.Title = "Title";
+            PackageSpec.Version = new Versioning.NuGetVersion("1.0.0");
             // Act
             var clonedPackageSpec = PackageSpec.Clone();
 
@@ -378,10 +382,8 @@ namespace NuGet.ProjectModel.Test
             Assert.False(object.ReferenceEquals(originalProjectRestoreSettings, clone));
         }
 
-        [Fact]
-        public void TargetFrameworkInformationCloneTest()
+        private TargetFrameworkInformation CreateTargetFrameworkInformation()
         {
-            // Set up
             var framework = NuGetFramework.Parse("net461");
             var dependency = new LibraryDependency();
             dependency.LibraryRange = new LibraryRange("Dependency", LibraryDependencyTarget.Package);
@@ -395,6 +397,14 @@ namespace NuGet.ProjectModel.Test
             originalTargetFrameworkInformation.Dependencies = new List<LibraryDependency>() { dependency };
             originalTargetFrameworkInformation.AssetTargetFallback = false;
             originalTargetFrameworkInformation.Imports = new List<NuGetFramework>() { imports };
+            return originalTargetFrameworkInformation;
+        }
+
+        [Fact]
+        public void TargetFrameworkInformationCloneTest()
+        {
+            // Set up
+            var originalTargetFrameworkInformation = CreateTargetFrameworkInformation();
 
             // Act
             var clone = originalTargetFrameworkInformation.Clone();

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -173,10 +173,10 @@ namespace NuGet.ProjectModel.Test
             PackageSpec.ContentFiles = new List<string>() { "contentFile1", "contentFile2" };
             PackageSpec.Dependencies = new List<LibraryDependency>() { CreateLibraryDependency(), CreateLibraryDependency() };
 
-            PackageSpec.Scripts.Add(Guid.NewGuid().ToString(), new List<string>() { Guid.NewGuid().ToString() }); // Test this changing
+            PackageSpec.Scripts.Add(Guid.NewGuid().ToString(), new List<string>() { Guid.NewGuid().ToString() });
             PackageSpec.Scripts.Add(Guid.NewGuid().ToString(), new List<string>() { Guid.NewGuid().ToString() });
 
-            PackageSpec.PackInclude.Add(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+            PackageSpec.PackInclude.Add(Guid.NewGuid().ToString(), Guid.NewGuid().ToString()); // Continue from here
 
             PackageSpec.PackOptions = CreatePackOptions();
 
@@ -196,6 +196,8 @@ namespace NuGet.ProjectModel.Test
         [InlineData("ModifyBuildOptions")]
         [InlineData("ModifyContentFiles")]
         [InlineData("ModifyDependencies")]
+        [InlineData("ModifyScriptsAdd")]
+        [InlineData("ModifyScriptsEdit")]
         public void PackageSpecCloneTest(string methodName)
         {
             // Set up
@@ -265,6 +267,17 @@ namespace NuGet.ProjectModel.Test
             public static void ModifyDependencies(PackageSpec packageSpec)
             {
                 packageSpec.Dependencies.Add(CreateLibraryDependency());
+            }
+
+            public static void ModifyScriptsAdd(PackageSpec packageSpec)
+            {
+                packageSpec.Scripts.Add(Guid.NewGuid().ToString(), new List<string>() { Guid.NewGuid().ToString() });
+            }
+
+            public static void ModifyScriptsEdit(PackageSpec packageSpec)
+            {
+                var key = packageSpec.Scripts.Keys.GetEnumerator().Current;
+                ((List<string>)packageSpec.Scripts[key]).Add(Guid.NewGuid().ToString());
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -35,6 +35,8 @@ namespace NuGet.ProjectModel.Test
 
             //Assert
             Assert.Equal(originalBuildOptions.OutputName, clonedBuildOptions.OutputName);
+            Assert.False(object.ReferenceEquals(originalBuildOptions, clonedBuildOptions));
+
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -120,7 +120,7 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(1, cloneWithMappings.Mappings.Count);
         }
 
-        private LibraryDependency CreateLibraryDependency()
+        internal static LibraryDependency CreateLibraryDependency()
         {
             var dependency = new LibraryDependency();
             dependency.LibraryRange = new LibraryRange(Guid.NewGuid().ToString(), LibraryDependencyTarget.Package);
@@ -190,6 +190,12 @@ namespace NuGet.ProjectModel.Test
         [InlineData("ModifyOriginalTargetFrameworkInformationAdd")]
         [InlineData("ModifyOriginalTargetFrameworkInformationEdit")]
         [InlineData("ModifyRestoreMetadata")]
+        [InlineData("ModifyVersion")]
+        [InlineData("ModifyOwners")]
+        [InlineData("ModifyTags")]
+        [InlineData("ModifyBuildOptions")]
+        [InlineData("ModifyContentFiles")]
+        [InlineData("ModifyDependencies")]
         public void PackageSpecCloneTest(string methodName)
         {
             // Set up
@@ -213,7 +219,7 @@ namespace NuGet.ProjectModel.Test
 
             public static void ModifyAuthors(PackageSpec packageSpec)
             {
-                packageSpec.Authors = new string[] { "NewAuthor" };
+                packageSpec.Authors[0] = "NewAuthor";
             }
 
             public static void ModifyOriginalTargetFrameworkInformationAdd(PackageSpec packageSpec)
@@ -230,9 +236,37 @@ namespace NuGet.ProjectModel.Test
             {
                 packageSpec.TargetFrameworks[0].Imports.Add(NuGetFramework.Parse("net461"));
             }
-        }
 
- 
+            public static void ModifyVersion(PackageSpec packageSpec)
+            {
+                packageSpec.Version = new Versioning.NuGetVersion("2.0.0");
+            }
+
+            public static void ModifyOwners(PackageSpec packageSpec)
+            {
+                packageSpec.Owners[0] = "BetterOwner";
+            }
+
+            public static void ModifyTags(PackageSpec packageSpec)
+            {
+                packageSpec.Tags[0] = "better tag!";
+            }
+
+            public static void ModifyBuildOptions(PackageSpec packageSpec)
+            {
+                packageSpec.BuildOptions.OutputName = Guid.NewGuid().ToString();
+            }
+
+            public static void ModifyContentFiles(PackageSpec packageSpec)
+            {
+                packageSpec.ContentFiles.Add("New fnacy content file");
+            }
+
+            public static void ModifyDependencies(PackageSpec packageSpec)
+            {
+                packageSpec.Dependencies.Add(CreateLibraryDependency());
+            }
+        }
 
         private ProjectRestoreMetadata CreateProjectRestoreMetadata()
         {


### PR DESCRIPTION
## Bug
Fixes: None, but being done as part of https://github.com/NuGet/Home/issues/6065
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
The Package Spec is cloned 2 times per project during one no-op restore. In VS that's done 3x.   
Each call takes 8-9ms. 
This change cuts it to ~1ms per call.

As mentioned in the comments earlier, I did not want to use existing APIs, because they did not imply deep cloning, while it's very important that the package spec is deep cloned. 

Some types like NuGetFramework and similar are immutable so those are/will not be cloned. 

The test subject is new MVC no-op, MVC clones 4x times, 2x2 for the tool and project restore each (tool clone takes way less ofc)

### With JIT baseline:
|Name | Inc % | Inc | Exc % | Exc |
|-- | -- | -- | -- | -- |
|nuget.projectmodel!DependencyGraphSpec.WithProjectClosure | 6.1 | 65 | 0.0 | 0 |
|+ nuget.projectmodel!NuGet.ProjectModel.PackageSpec.Clone() | 6.1 | 65 | 0.0 | 0 |
|+ nuget.projectmodel!JsonPackageSpecReader.GetPackageSpec | 3.0 | 32 | 0.0 | 0 |
|+ nuget.projectmodel!PackageSpecWriter.Write | 2.8 | 30 | 0.0 | 0 |
|+ clr!? | 0.3 | 3 | 0.0 | 0|

###  With JIT improved spec:

|Name | Inc % | Inc | Exc % | Exc|
|-- | -- | -- | -- | --|
|nuget.projectmodel!DependencyGraphSpec.WithProjectClosure | 0.8 | 8 | 0.0 | 0|
|+ nuget.projectmodel!NuGet.ProjectModel.PackageSpec.Clone() | 0.6 | 6 | 0.0 | 0|
|+ clr!? | 0.2 | 2 | 0.0 | 0|

### Without JIT baseline:

|Name | Inc % | Inc | Exc % | Exc|
|-- | -- | -- | -- | --|
|nuget.projectmodel!DependencyGraphSpec.WithProjectClosure | 1.5 | 9 | 0.0 | 0|
|+ nuget.projectmodel!NuGet.ProjectModel.PackageSpec.Clone() | 1.5 | 9 | 0.0 | 0|
|+ nuget.projectmodel!PackageSpecWriter.Write | 0.8 | 5 | 0.0 | 0|
|+ nuget.projectmodel!JsonPackageSpecReader.GetPackageSpec | 0.6 | 4 | 0.0 | 0|

###  WIthout JIT improved spec:

|Name | Inc % | Inc | Exc % | Exc|
|-- | -- | -- | -- | --|
|nuget.projectmodel!DependencyGraphSpec.WithProjectClosure | 0.2 | 1 | 0.0 | 0|
|+ nuget.projectmodel!NuGet.ProjectModel.PackageSpec.Clone() | 0.2 | 1 | 0.0 | 0|


Fixed an issue where RestoreArgs didn't work well with duplicate sources, because before this change the deduplication was totally accidentally done in the dg spec cloning [here](https://github.com/NuGet/NuGet.Client/blob/2c4e39c5c5cd52c7a2739fdcfd6bd2b212212cd1/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs#L256-L270)
More specifically the code change is this [one](https://github.com/NuGet/NuGet.Client/pull/1796/files#diff-4dc98f9946385b4b19fd5d9223d01fc0)

## Testing/Validation
Tests Added: Yes
Reason for not adding tests:  
Validation done:  Added new tests, existing automation tests, some manual validation
