### PR TITLE
Fix plugin issues

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
@@ -452,11 +452,11 @@ namespace NuGet.Protocol.Plugins
 
                     try
                     {
-                        await connection.SendAsync(message, cancellationToken);
+                        await connection.SendAsync(message, requestContext.CancellationToken);
 
                         return await requestContext.CompletionTask;
                     }
-                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    catch (OperationCanceledException) when (requestContext.CancellationToken.IsCancellationRequested)
                     {
                         // Keep the request context around if cancellation was requested.
                         // A race condition exists where after sending a cancellation request,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 
 namespace NuGet.Protocol.Plugins
 {
@@ -10,6 +11,11 @@ namespace NuGet.Protocol.Plugins
     /// </summary>
     public abstract class OutboundRequestContext : IDisposable
     {
+        /// <summary>
+        /// Gets the <see cref="CancellationToken" />.
+        /// </summary>
+        public CancellationToken CancellationToken { get; protected set; }
+
         /// <summary>
         /// Gets the request ID.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext`1.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext`1.cs
@@ -15,7 +15,6 @@ namespace NuGet.Protocol.Plugins
     /// <typeparam name="TResult">The response payload type.</typeparam>
     public sealed class OutboundRequestContext<TResult> : OutboundRequestContext
     {
-        private readonly CancellationToken _cancellationToken;
         private readonly CancellationTokenSource _cancellationTokenSource;
         private readonly IConnection _connection;
         private int _isCancellationRequested; // int for Interlocked.CompareExchange(...).  0 == false, 1 == true.
@@ -66,7 +65,7 @@ namespace NuGet.Protocol.Plugins
 
             _connection = connection;
             _request = request;
-            _taskCompletionSource = new TaskCompletionSource<TResult>();
+            _taskCompletionSource = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
             _timeout = timeout;
             _isKeepAlive = isKeepAlive;
             RequestId = request.RequestId;
@@ -86,7 +85,7 @@ namespace NuGet.Protocol.Plugins
 
             // Capture the cancellation token now because if the cancellation token source
             // is disposed race conditions may cause an exception acccessing its Token property.
-            _cancellationToken = _cancellationTokenSource.Token;
+            CancellationToken = _cancellationTokenSource.Token;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/SymmetricHandshake.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/SymmetricHandshake.cs
@@ -69,7 +69,7 @@ namespace NuGet.Protocol.Plugins
             _protocolVersion = protocolVersion;
             _minimumProtocolVersion = minimumProtocolVersion;
             _handshakeFailedResponse = new HandshakeResponse(MessageResponseCode.Error, protocolVersion: null);
-            _responseSentTaskCompletionSource = new TaskCompletionSource<int>();
+            _responseSentTaskCompletionSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
             _timeoutCancellationTokenSource = new CancellationTokenSource(handshakeTimeout);
 
             _timeoutCancellationTokenSource.Token.Register(() =>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/TimeoutUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/TimeoutUtilities.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -10,6 +10,44 @@ namespace NuGet.Protocol.Plugins
     /// </summary>
     public static class TimeoutUtilities
     {
+        /// <summary>
+        /// Attempts to parse a legal timeout and returns a default timeout as a fallback.
+        /// </summary>
+        /// <param name="timeoutInSeconds">The requested timeout in seconds.</param>
+        /// <param name="fallbackTimeout">A fallback timeout.</param>
+        /// <returns>A <see cref="TimeSpan" /> object that represents a timeout interval.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="fallbackTimeout" /> is an invalid
+        /// timeout.</exception>
+        public static TimeSpan GetTimeout(string timeoutInSeconds, TimeSpan fallbackTimeout)
+        {
+            if (!IsValid(fallbackTimeout))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(fallbackTimeout),
+                    fallbackTimeout,
+                    Strings.Plugin_TimeoutOutOfRange);
+            }
+
+            int seconds;
+            if (int.TryParse(timeoutInSeconds, out seconds))
+            {
+                try
+                {
+                    var timeout = TimeSpan.FromSeconds(seconds);
+
+                    if (IsValid(timeout))
+                    {
+                        return timeout;
+                    }
+                }
+                catch (Exception)
+                {
+                }
+            }
+
+            return fallbackTimeout;
+        }
+
         /// <summary>
         /// Determines if a timeout is valid.
         /// </summary>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/OutboundRequestContextTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/OutboundRequestContextTests.cs
@@ -89,6 +89,32 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
         [Fact]
+        public void CancellationToken_LinksOriginalCancellationToken()
+        {
+            using (var test = new OutboundRequestContextTest())
+            {
+                Assert.False(test.Context.CancellationToken.IsCancellationRequested);
+
+                test.CancellationTokenSource.Cancel();
+
+                Assert.True(test.Context.CancellationToken.IsCancellationRequested);
+            }
+        }
+
+        [Fact]
+        public void CancellationToken_CancelledWhenDisposed()
+        {
+            using (var test = new OutboundRequestContextTest())
+            {
+                Assert.False(test.Context.CancellationToken.IsCancellationRequested);
+
+                test.Context.Dispose();
+
+                Assert.True(test.Context.CancellationToken.IsCancellationRequested);
+            }
+        }
+
+        [Fact]
         public void Dispose_DoesNotDisposeConnection()
         {
             using (var test = new OutboundRequestContextTest())

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/TimeoutUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/TimeoutUtilitiesTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -8,6 +8,58 @@ namespace NuGet.Protocol.Plugins.Tests
 {
     public class TimeoutUtilitiesTests
     {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("a")]
+        [InlineData("0")]
+        [InlineData("-1")]
+        [InlineData("4294967295")]
+        public void GetTimeout_ReturnsFallbackForInvalidValues(string timeoutInSeconds)
+        {
+            var fallbackTimeout = new TimeSpan(days: 0, hours: 1, minutes: 2, seconds: 3, milliseconds: 4);
+
+            var actualTimeout = TimeoutUtilities.GetTimeout(timeoutInSeconds, fallbackTimeout);
+
+            Assert.Equal(fallbackTimeout, actualTimeout);
+        }
+
+        [Fact]
+        public void GetTimeout_ThrowsForZeroFallback()
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(
+                () => TimeoutUtilities.GetTimeout("1", TimeSpan.Zero));
+
+            Assert.Equal("fallbackTimeout", exception.ParamName);
+        }
+
+        [Fact]
+        public void GetTimeout_ThrowsForNegativeFallback()
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(
+                () => TimeoutUtilities.GetTimeout("1", TimeSpan.MinValue));
+
+            Assert.Equal("fallbackTimeout", exception.ParamName);
+        }
+
+        [Fact]
+        public void GetTimeout_ThrowsForTooLargeFallback()
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(
+                () => TimeoutUtilities.GetTimeout("1", TimeSpan.MaxValue));
+
+            Assert.Equal("fallbackTimeout", exception.ParamName);
+        }
+
+        [Fact]
+        public void GetTimeout_ReturnsTimeout()
+        {
+            var actualTimeout = TimeoutUtilities.GetTimeout("123", ProtocolConstants.MaxTimeout);
+
+            Assert.Equal(TimeSpan.FromSeconds(123), actualTimeout);
+        }
+
         [Fact]
         public void IsValid_ReturnsFalseForTimeSpanZero()
         {


### PR DESCRIPTION
Resolve NuGet/Home#6149.

1.  Use the proper (linked) `CancellationToken` in `OutboundRequestContext<T>`.
2.  Use `TaskCreationOptions.RunContinuationsAsynchronously` in `TaskCompletionSource<T>` constructors to prevent the signaling thread from executing continuations.  This keeps the signaling thread free to handle incoming messages.
3.  Escape hatch:  make handshake and idle timeouts overridable.