### PR TITLE
Dispose the opened stream when creating a PackageArchiveReader from a path to an invalid .zip

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -95,8 +95,21 @@ namespace NuGet.Packaging
             {
                 throw new ArgumentNullException(nameof(filePath));
             }
-
-            _zipArchive = new ZipArchive(File.OpenRead(filePath), ZipArchiveMode.Read);
+            
+            // Since this constructor owns the stream, the responsibility falls here to dispose the stream of an
+            // invalid .zip archive. If this constructor succeeds, the disposal of the stream is handled by the
+            // disposal of this instance.
+            Stream stream = null;
+            try
+            {
+                stream = File.OpenRead(filePath);
+                _zipArchive = new ZipArchive(stream, ZipArchiveMode.Read);
+            }
+            catch
+            {
+                stream?.Dispose();
+                throw;
+            }
         }
 
         public override IEnumerable<string> GetFiles()

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -18,6 +18,42 @@ namespace NuGet.Packaging.Test
     public class PackageArchiveReaderTests
     {
         [Fact]
+        public void Constructor_WithStringPathParameter_DisposesInvalidStream()
+        {
+            // Arrange
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var path = Path.Combine(testDirectory, "invalid.nupkg");
+                File.WriteAllText(path, "This is not a valid .zip archive.");
+
+                // Act & Assert
+                Assert.Throws<InvalidDataException>(() =>
+                    new PackageArchiveReader(path).Dispose());
+                
+                File.Delete(path);
+                Assert.False(File.Exists(path), "The invalid .zip archive should not exist.");
+            }
+        }
+
+        [Fact]
+        public void Dispose_WithStringPathConstructorParameter_DisposesStream()
+        {
+            // Arrange
+            using (var test = TestPackagesCore.GetPackageContentReaderTestPackage())
+            {
+                var packageArchiveReader = new PackageArchiveReader(test);
+                var identity = packageArchiveReader.GetIdentity();
+
+                // Act
+                packageArchiveReader.Dispose();
+
+                // Assert
+                File.Delete(test);
+                Assert.False(File.Exists(test), "The .zip archive should not exist.");
+            }
+        }
+
+        [Fact]
         public void GetReferenceItems_RespectsReferencesAccordingToDifferentFrameworks()
         {
             // Copy of the InstallPackageRespectReferencesAccordingToDifferentFrameworks functional test


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/6028

Issue repro'd in 4.4.0.