### PR TITLE
Improving restore failure text to point to error list for cps projects

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
@@ -144,7 +144,7 @@ namespace NuGet.SolutionRestoreManager {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to NuGet Package restore failed for project {0}: {1}..
+        ///   Looks up a localized string similar to NuGet Package restore failed for project {0}: {1}. Please see Error List window for detailed warnings and errors..
         /// </summary>
         internal static string PackageRestoreFailedForProject {
             get {
@@ -171,7 +171,7 @@ namespace NuGet.SolutionRestoreManager {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to NuGet package restore failed..
+        ///   Looks up a localized string similar to NuGet package restore failed. Please see Error List window for detailed warnings and errors..
         /// </summary>
         internal static string PackageRestoreFinishedWithError {
             get {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
@@ -147,7 +147,7 @@ Missing packages: {0}</value>
     <value>NuGet package restore canceled.</value>
   </data>
   <data name="PackageRestoreFailedForProject" xml:space="preserve">
-    <value>NuGet Package restore failed for project {0}: {1}.</value>
+    <value>NuGet Package restore failed for project {0}: {1}. Please see Error List window for detailed warnings and errors.</value>
   </data>
   <data name="PackageRestoreFinished" xml:space="preserve">
     <value>NuGet package restore finished.</value>
@@ -156,7 +156,7 @@ Missing packages: {0}</value>
     <value>NuGet Package restore finished for project '{0}'.</value>
   </data>
   <data name="PackageRestoreFinishedWithError" xml:space="preserve">
-    <value>NuGet package restore failed.</value>
+    <value>NuGet package restore failed. Please see Error List window for detailed warnings and errors.</value>
   </data>
   <data name="PackageRestoreOptOutMessage" xml:space="preserve">
     <value>Restoring NuGet packages...


### PR DESCRIPTION
## Bug
Improves: https://github.com/NuGet/Home/issues/6047
Regression: Yes, introduced in 15.3.

## Fix
Details: In cps package reference projects, we rely on net core sdk to log restore error and warnings to the error list. In that process, we stopped logging them onto the output window. This PR improves that by pointing the user to the Error List. In future, we might improve this by actually displaying the errors in the output window.  

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  UI fix for VS only.
Validation done:  Local machine testing.
