### PR TITLE
FullPath should not do a getpotentialfullpathOrNull check

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/EnvDTEProjectInfoUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/EnvDTEProjectInfoUtility.cs
@@ -108,9 +108,9 @@ namespace NuGet.VisualStudio
             }
 
             // FullPath
-            var fullPath = GetPotentialFullPathOrNull(GetPropertyValue<string>(envDTEProject, FullPath));
+            var fullPath = GetPropertyValue<string>(envDTEProject, FullPath);
 
-            if (!String.IsNullOrEmpty(fullPath))
+            if (!string.IsNullOrEmpty(fullPath))
             {
                 // Some Project System implementations (JS metro app) return the project 
                 // file as FullPath. We only need the parent directory


### PR DESCRIPTION
## Bug
Fixes: Only partially addresses internal issue 504715
Related issue here: NuGet/Home#6120
Regression: No
If Regression then when did it last work:
If Regression then how are we preventing it in future:

## Fix
Details: Introduced in https://github.com/NuGet/NuGet.Client/pull/1777. 

In 1777 I switched the order of the checks for the fullPath in hopes to improve perf in CPS scenarios. 
There the GetPotentialFullPathOrNull check was added, but since the returned value by FullPath is the project folder in that situation, the above method would set it to null. 

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  Existing E2E tests
Validation done:  Manual, waiting on tests. 
