### PR TITLE
Package install noop check

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -550,7 +550,6 @@ namespace NuGet.Commands
             };
 
             // Resolve dependency graphs
-            var allInstalledPackages = new HashSet<LibraryIdentity>();
             var allGraphs = new List<RestoreTargetGraph>();
             var runtimeIds = RequestRuntimeUtility.GetRestoreRuntimes(_request);
             var projectFrameworkRuntimePairs = CreateFrameworkRuntimePairs(_request.Project, runtimeIds);
@@ -569,7 +568,6 @@ namespace NuGet.Commands
             var result = await projectRestoreCommand.TryRestoreAsync(
                 projectRange,
                 projectFrameworkRuntimePairs,
-                allInstalledPackages,
                 userPackageFolder,
                 fallbackPackageFolders,
                 remoteWalker,
@@ -616,7 +614,6 @@ namespace NuGet.Commands
                 var compatibilityResult = await projectRestoreCommand.TryRestoreAsync(
                     projectRange,
                     _request.CompatibilityProfiles,
-                    allInstalledPackages,
                     userPackageFolder,
                     fallbackPackageFolders,
                     remoteWalker,

--- a/src/NuGet.Core/NuGet.Protocol/PackagesFolder/NuGetv3LocalRepository.cs
+++ b/src/NuGet.Core/NuGet.Protocol/PackagesFolder/NuGetv3LocalRepository.cs
@@ -50,21 +50,17 @@ namespace NuGet.Repositories
             _packageFileCache = packageFileCache ?? new LocalPackageFileCache();
         }
 
+        /// <summary>
+        /// True if the package exists.
+        /// </summary>
+        public bool Exists(string packageId, NuGetVersion version)
+        {
+            return FindPackageImpl(packageId, version) != null;
+        }
+
         public LocalPackageInfo FindPackage(string packageId, NuGetVersion version)
         {
-            LocalPackageInfo package = null;
-
-            var packages = FindPackagesByIdImpl(packageId);
-            var count = packages.Count;
-            for (var i = 0; i < count; i++)
-            {
-                var candidatePackage = packages[i];
-                if (candidatePackage.Version == version)
-                {
-                    package = candidatePackage;
-                    break;
-                }
-            }
+            var package = FindPackageImpl(packageId, version);
 
             if (package == null)
             {
@@ -118,6 +114,22 @@ namespace NuGet.Repositories
                     return GetPackages(id);
                 });
             }
+        }
+
+        private LocalPackageInfo FindPackageImpl(string packageId, NuGetVersion version)
+        {
+            var packages = FindPackagesByIdImpl(packageId);
+            var count = packages.Count;
+            for (var i = 0; i < count; i++)
+            {
+                var candidatePackage = packages[i];
+                if (candidatePackage.Version == version)
+                {
+                    return candidatePackage;
+                }
+            }
+
+            return null;
         }
 
         private List<LocalPackageInfo> GetPackages(string id)

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGetv3LocalRepositoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGetv3LocalRepositoryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Concurrent;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Test.Utility;
@@ -143,6 +144,39 @@ namespace NuGet.Repositories.Test
 
                 // Assert
                 Assert.Empty(packages);
+            }
+        }
+
+        [Theory]
+        [InlineData("foo")]
+        [InlineData("Foo")]
+        public async Task NuGetv3LocalRepository_Exists_WorksForAllCases(string id)
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                var target = new NuGetv3LocalRepository(workingDir);
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    workingDir,
+                    PackageSaveMode.Defaultv3,
+                    new SimpleTestPackageContext("foo", "1.0.0"));
+
+                target.Exists(id, NuGetVersion.Parse("1.0.0")).Should().BeTrue();
+            }
+        }
+
+        [Fact]
+        public async Task NuGetv3LocalRepository_Exists_DoesNotExist()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                var target = new NuGetv3LocalRepository(workingDir);
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    workingDir,
+                    PackageSaveMode.Defaultv3,
+                    new SimpleTestPackageContext("foo", "1.0.0"));
+
+                target.Exists("foo", NuGetVersion.Parse("2.0.0")).Should().BeFalse();
+                target.Exists("bar", NuGetVersion.Parse("1.0.0")).Should().BeFalse();
             }
         }
 


### PR DESCRIPTION
* Skip package installs for packages that have already been installed.
* Avoid clearing the package info cache for packages that were installed by other projects.

When running parallel restores multiple projects will attempt to install the same package. This change adds an extra in memory check to avoid hitting the disk and acquiring file locks around packages that have already been installed.

Previously the cache was being cleared after each install, even if the install was a noop. This was causing the global packages folder to be reloaded more than needed.
