### PR TITLE
Install command exit code fix for noop packages.config restore

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -208,7 +208,8 @@ namespace NuGet.CommandLine
                     GetDownloadResultUtility.CleanUpDirectDownloads(downloadContext);
                 }
 
-                if (!result.Restored || failedEvents.Count > 0)
+                // Use failure count to determine errors. result.Restored will be false for noop restores.
+                if (failedEvents.Count > 0)
                 {
                     // Log errors if they exist
                     foreach (var message in failedEvents.Select(e => new RestoreLogMessage(LogLevel.Error, NuGetLogCode.Undefined, e.Exception.Message)))


### PR DESCRIPTION
Install command exit code fix for noop packages.config restore

The bug here is that Install was using `RestoreResult.Restored` to decide if the restore was successful, however this flag is used to indicate if a restore was actually done or not. It does not indicate errors, those are logged in the failure events which was also being checked already.

NuGet.exe install will return 0 for scenarios where all packages in a packages.config file have already been restored.

Fixes https://github.com/NuGet/Home/issues/6144