### PR TITLE
Ignore line/column info when loading asset files and v3 feeds

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/JsonRuntimeFormat.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/JsonRuntimeFormat.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -32,9 +32,15 @@ namespace NuGet.RuntimeModel
 
         public static RuntimeGraph ReadRuntimeGraph(TextReader textReader)
         {
+            var loadSettings = new JsonLoadSettings()
+            {
+                LineInfoHandling = LineInfoHandling.Ignore,
+                CommentHandling = CommentHandling.Ignore
+            };
+
             using (var jsonReader = new JsonTextReader(textReader))
             {
-                return ReadRuntimeGraph(JToken.Load(jsonReader));
+                return ReadRuntimeGraph(JToken.Load(jsonReader, loadSettings));
             }
         }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/CacheFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/CacheFileFormat.cs
@@ -28,19 +28,9 @@ namespace NuGet.ProjectModel
         {
             try
             {
-                using (var jsonReader = new JsonTextReader(reader))
-                {
-                    while (jsonReader.TokenType != JsonToken.StartObject)
-                    {
-                        if (!jsonReader.Read())
-                        {
-                            throw new InvalidDataException();
-                        }
-                    }
-                    var token = JToken.Load(jsonReader);
-                    var cacheFile = ReadCacheFile(token as JObject);
-                    return cacheFile;
-                }
+                var json = JsonUtility.LoadJson(reader);
+                var cacheFile = ReadCacheFile(json);
+                return cacheFile;
             }
             catch (Exception ex)
             {

--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -267,11 +267,11 @@ namespace NuGet.ProjectModel
             JObject json;
 
             using (var stream = new FileStream(packageSpecPath, FileMode.Open, FileAccess.Read, FileShare.Read))
-            using (var reader = new JsonTextReader(new StreamReader(stream)))
+            using (var reader = new StreamReader(stream))
             {
                 try
                 {
-                    json = JObject.Load(reader);
+                    json = JsonUtility.LoadJson(reader);
                 }
                 catch (JsonReaderException ex)
                 {

--- a/src/NuGet.Core/NuGet.ProjectModel/FileFormatException.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/FileFormatException.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonUtility.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.ProjectModel
+{
+    internal static class JsonUtility
+    {
+        /// <summary>
+        /// JsonLoadSettings with line info and comments ignored.
+        /// </summary>
+        internal static readonly JsonLoadSettings DefaultLoadSettings = new JsonLoadSettings()
+        {
+            LineInfoHandling = LineInfoHandling.Ignore,
+            CommentHandling = CommentHandling.Ignore
+        };
+
+        /// <summary>
+        /// Load json from a file to a JObject using the default load settings.
+        /// </summary>
+        internal static JObject LoadJson(TextReader reader)
+        {
+            using (var jsonReader = new JsonTextReader(reader))
+            {
+                while (jsonReader.TokenType != JsonToken.StartObject)
+                {
+                    if (!jsonReader.Read())
+                    {
+                        throw new InvalidDataException();
+                    }
+                }
+
+                return JObject.Load(jsonReader, DefaultLoadSettings);
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -104,20 +104,10 @@ namespace NuGet.ProjectModel
         {
             try
             {
-                using (var jsonReader = new JsonTextReader(reader))
-                {
-                    while (jsonReader.TokenType != JsonToken.StartObject)
-                    {
-                        if (!jsonReader.Read())
-                        {
-                            throw new InvalidDataException();
-                        }
-                    }
-                    var token = JToken.Load(jsonReader);
-                    var lockFile = ReadLockFile(token as JObject);
-                    lockFile.Path = path;
-                    return lockFile;
-                }
+                var json = JsonUtility.LoadJson(reader);
+                var lockFile = ReadLockFile(json);
+                lockFile.Path = path;
+                return lockFile;
             }
             catch (Exception ex)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Converters/PackageDependencyGroupConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/PackageDependencyGroupConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -19,7 +19,7 @@ namespace NuGet.Protocol
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            var set = JObject.Load(reader);
+            var set = JsonUtility.LoadJson(reader);
 
             var fxName = set.Value<string>(JsonProperties.TargetFramework);
 

--- a/src/NuGet.Core/NuGet.Protocol/Converters/VersionInfoConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/VersionInfoConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -17,7 +17,7 @@ namespace NuGet.Protocol
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            var v = JObject.Load(reader);
+            var v = JsonUtility.LoadJson(reader);
             var nugetVersion = NuGetVersion.Parse(v.Value<string>("version"));
             var count = v.Value<int?>("downloads");
             return new VersionInfo(nugetVersion, count);

--- a/src/NuGet.Core/NuGet.Protocol/Utility/JsonUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/JsonUtility.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.Protocol
+{
+    internal static class JsonUtility
+    {
+        /// <summary>
+        /// JsonLoadSettings with line info and comments ignored.
+        /// </summary>
+        internal static readonly JsonLoadSettings DefaultLoadSettings = new JsonLoadSettings()
+        {
+            LineInfoHandling = LineInfoHandling.Ignore,
+            CommentHandling = CommentHandling.Ignore
+        };
+
+        /// <summary>
+        /// Load json from a file to a JObject using the default load settings.
+        /// </summary>
+        internal static JObject LoadJson(TextReader reader)
+        {
+            using (var jsonReader = new JsonTextReader(reader))
+            {
+                return LoadJson(jsonReader);
+            }
+        }
+
+        /// <summary>
+        /// Load json from a file to a JObject using the default load settings.
+        /// </summary>
+        internal static JObject LoadJson(JsonReader jsonReader)
+        {
+            return JObject.Load(jsonReader, DefaultLoadSettings);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Utility/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/StreamExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
@@ -27,7 +27,7 @@ namespace NuGet.Protocol
 
             using (var reader = new StreamReader(await stream.AsSeekableStreamAsync()))
             {
-                return JObject.Load(new JsonTextReader(reader));
+                return JsonUtility.LoadJson(reader);
             }
         }
 


### PR DESCRIPTION
Use JsonLoadSettings to ignore line/column info when loading files. This info is not needed for machine generated files, but will still be used for project.json files that are modified by users.

I've kept the implementations the same, and made JsonUtility internal to avoid other users depending on this.

Fixes https://github.com/NuGet/Home/issues/6139
