### PR TITLE
Call DTE.Project.FullName instead of DTE.Project.Properties item

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/EnvDTEProjectInfoUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/EnvDTEProjectInfoUtility.cs
@@ -48,20 +48,20 @@ namespace NuGet.VisualStudio
                 return Path.Combine(solutionDirectory, envDTEProject.UniqueName);
             }
 
-            // FullPath
-            var fullPath = GetPotentialFullPathOrNull(GetPropertyValue<string>(envDTEProject, FullPath));
-
-            if (fullPath != null)
-            {
-                return fullPath;
-            }
-
             // FullName
             var fullName = GetPotentialFullPathOrNull(envDTEProject.FullName);
 
-            if (fullName != null)
+            if (!string.IsNullOrEmpty(fullName))
             {
                 return fullName;
+            }
+
+            // FullPath
+            var fullPath = GetPotentialFullPathOrNull(GetPropertyValue<string>(envDTEProject, FullPath));
+
+            if (!string.IsNullOrEmpty(fullPath))
+            {
+                return fullPath;
             }
 
             return null;
@@ -91,33 +91,28 @@ namespace NuGet.VisualStudio
             // for start up scenarios such as VS Templates. In these cases we need to fallback 
             // until we can find one containing the full path.
 
-            // FullPath
-            string fullPath = GetPropertyValue<string>(envDTEProject, FullPath);
-
-            if (!String.IsNullOrEmpty(fullPath))
+            // FullName
+            if (!string.IsNullOrEmpty(envDTEProject.FullName))
             {
-                // Some Project System implementations (JS metro app) return the project 
-                // file as FullPath. We only need the parent directory
-                if (File.Exists(fullPath))
-                {
-                    return Path.GetDirectoryName(fullPath);
-                }
-
-                return fullPath;
+                return Path.GetDirectoryName(envDTEProject.FullName);
             }
 
             // C++ projects do not have FullPath property, but do have ProjectDirectory one.
-            string projectDirectory = GetPropertyValue<string>(envDTEProject, ProjectDirectory);
+            var projectDirectory = GetPropertyValue<string>(envDTEProject, ProjectDirectory);
 
-            if (!String.IsNullOrEmpty(projectDirectory))
+            if (!string.IsNullOrEmpty(projectDirectory))
             {
                 return projectDirectory;
             }
 
-            // FullName
-            if (!String.IsNullOrEmpty(envDTEProject.FullName))
+            // FullPath
+            var fullPath = GetPropertyValue<string>(envDTEProject, FullPath);
+
+            if (!string.IsNullOrEmpty(fullPath))
             {
-                return Path.GetDirectoryName(envDTEProject.FullName);
+                // Some Project System implementations (JS metro app) return the project 
+                // file as FullPath. We only need the parent directory
+                return Path.GetDirectoryName(fullPath);
             }
 
             Debug.Fail("Unable to find the project path");


### PR DESCRIPTION
Extended from Nikolche's PR: https://github.com/NuGet/NuGet.Client/pull/1777 

Per @lifengl's suggestion in an e-mail thread.

```
But instead of calling DTE.Project.Properties.Item(“FullPath”), which maps to a msbuild property, maybe you can try to use DTE.Project.FullName, which is the full path of the project file.  FullName is implemented directly inside CPS, and will return a value immediately, instead of accessing the msbuild model.
```

Earlier we had the properties call, then the project.fullName call. 

Those 2 calls' ordering has been switched. 

The delay is in GetFullProjectPath but since GetFullPath has the same call order I have changed it there as well. 

Fixes https://github.com/NuGet/Home/issues/6183 
