### PR TITLE
Dispose PackageArchiveReader

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -81,7 +81,7 @@ namespace NuGet.Commands
 
         public void BuildPackage()
         {
-            PackageArchiveReader package = BuildPackage(Path.GetFullPath(Path.Combine(_packArgs.CurrentDirectory, _packArgs.Path)));
+            BuildPackage(Path.GetFullPath(Path.Combine(_packArgs.CurrentDirectory, _packArgs.Path)))?.Dispose();
         }
 
         private PackageArchiveReader BuildPackage(string path)


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6165
Regression: No  

## Fix
Details: Dispose ```PackageArchiveReader``` deterministically, instead of waiting for GC to do so.

## Testing/Validation
Tests Added: Yes  
Reason for not adding tests:  
Validation done: Unit tests.