### PR TITLE
Apex test shouldn't fail if output window is not present

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/VisualStudioHostExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/VisualStudioHostExtension.cs
@@ -14,9 +14,18 @@ namespace NuGet.Tests.Apex
 
         public static bool HasNoErrorsInOutputWindows(this VisualStudioHost host)
         {
-            var outputPane = host.ObjectModel.Shell.ToolWindows.OutputWindow.GetOutputPane(_nugetOutputWindowGuid);
+            try
+            {
+                var outputPane = host.ObjectModel.Shell.ToolWindows.OutputWindow.GetOutputPane(_nugetOutputWindowGuid);
 
-            return !outputPane.Text.ToLowerInvariant().Contains("failed");
+                return !outputPane.Text.ToLowerInvariant().Contains("failed");
+            }
+            catch(ArgumentException)
+            {
+                // If no output has been printed into the nuget output window then the output pane will not be initialized
+                // If no output has been printed we know there is no error in the output window.
+                return true;
+            }
         }
 
         public static void SelectProjectInSolutionExplorer(this VisualStudioHost host, string project)

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/VisualStudioHostExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/VisualStudioHostExtension.cs
@@ -5,7 +5,7 @@ namespace NuGet.Tests.Apex
 {
     public static class VisualStudioHostExtension
     {
-        static private readonly Guid _nugetOutputWindowGuid = new Guid("CEC55EC8-CC51-40E7-9243-57B87A6F6BEB"); 
+        static private readonly Guid _nugetOutputWindowGuid = new Guid("CEC55EC8-CC51-40E7-9243-57B87A6F6BEB");
 
         public static bool HasNoErrorsInErrorList(this VisualStudioHost host)
         {
@@ -20,7 +20,7 @@ namespace NuGet.Tests.Apex
 
                 return !outputPane.Text.ToLowerInvariant().Contains("failed");
             }
-            catch(ArgumentException)
+            catch (ArgumentException)
             {
                 // If no output has been printed into the nuget output window then the output pane will not be initialized
                 // If no output has been printed we know there is no error in the output window.
@@ -42,7 +42,7 @@ namespace NuGet.Tests.Apex
                 var outputPane = host.ObjectModel.Shell.ToolWindows.OutputWindow.GetOutputPane(_nugetOutputWindowGuid);
                 outputPane.Clear();
             }
-            catch(ArgumentException)
+            catch (ArgumentException)
             {
                 //if outputPane doesn't exist, ignore it
             }


### PR DESCRIPTION
Output window is not initialized until some content is displayed on it, therefore when checking for errors in this window, we need to take into account the scenario where no output has been printed out, therefore the window pane doesn't exist.
