### PR TITLE
Build nupkgs without a label for SVC as we do it for RTM

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -127,7 +127,7 @@
       </PropertyGroup>
     </When>
     <!-- If we are excluding the build number, show the release label unless we are RTM. -->
-    <When Condition="'$(ReleaseLabel)' != 'rtm'">
+    <When Condition="'$(ReleaseLabel)' != 'rtm' AND '$(ReleaseLabel)' != 'svc' ">
       <PropertyGroup>
         <PreReleaseInformationVersion>-$(ReleaseLabel)</PreReleaseInformationVersion>
       </PropertyGroup>


### PR DESCRIPTION
## Bug
Fixes: None
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
Build nupkgs without a label for SVC as we do it for RTM
This needs to go to 4.4.0-svc

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  build
Validation done:  
