### PR TITLE
disable automatically pushing symbols package to symbol server

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -35,26 +35,6 @@ namespace NuGet.Commands
             }
 
             var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, source);
-
-            // only push to SymbolSource when the actual package is being pushed to the official NuGet.org
-            var sourceUri = packageUpdateResource.SourceUri;
-            if (string.IsNullOrEmpty(symbolSource)
-                && !noSymbols
-                && !sourceUri.IsFile
-                && sourceUri.IsAbsoluteUri)
-            {
-                if (sourceUri.Host.Equals(NuGetConstants.NuGetHostName, StringComparison.OrdinalIgnoreCase) // e.g. nuget.org
-                    || sourceUri.Host.EndsWith("." + NuGetConstants.NuGetHostName, StringComparison.OrdinalIgnoreCase)) // *.nuget.org, e.g. www.nuget.org
-                {
-                    symbolSource = NuGetConstants.DefaultSymbolServerUrl;
-
-                    if (string.IsNullOrEmpty(symbolApiKey))
-                    {
-                        // Use the nuget.org API key if it was given
-                        symbolApiKey = apiKey;
-                    }
-                }
-            }
 
             await packageUpdateResource.Push(
                 packagePath,


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6113
Regression: No
If Regression then when did it last work:   N/A
If Regression then how are we preventing it in future:   N/A

## Fix
Details: This fix prevents symbols from automatically being uploaded to the symbol server if the package source is nuget.org and the symbols package is right next to the main nupkg.

## Testing/Validation
Tests Added: No
Reason for not adding tests:  Since this was a very specific scenario for nuget.org, we can't validate it against actual nuget.org.
Validation done:  Manual testing.
