### PR TITLE
Fix issue where ToVSHierarchy was not running on UI thread when checking for CPS JTF context

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
@@ -72,9 +72,9 @@ namespace NuGet.VisualStudio
                 {
                     await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                    var VsHierarchy = VsHierarchyUtility.ToVsHierarchy(project);
-                    if (VsHierarchy != null &&
-                        VsHierarchyUtility.IsCPSCapabilityComplaint(VsHierarchy))
+                    var vsHierarchy = VsHierarchyUtility.ToVsHierarchy(project);
+                    if (vsHierarchy != null &&
+                        VsHierarchyUtility.IsCPSCapabilityComplaint(vsHierarchy))
                     {
                         // Lazy load the CPS enabled JoinableTaskFactory for the UI.
                         NuGetUIThreadHelper.SetJoinableTaskFactoryFromService(ProjectServiceAccessor.Value as IProjectServiceAccessor);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
@@ -68,16 +68,21 @@ namespace NuGet.VisualStudio
         {
             if (!_isCPSJTFLoaded)
             {
-                var VsHierarchy = VsHierarchyUtility.ToVsHierarchy(project);
-                if (VsHierarchy != null &&
-                    VsHierarchyUtility.IsCPSCapabilityComplaint(VsHierarchy))
+                NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
-                    // Lazy load the CPS enabled JoinableTaskFactory for the UI.
-                    NuGetUIThreadHelper.SetJoinableTaskFactoryFromService(ProjectServiceAccessor.Value as IProjectServiceAccessor);
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                    PumpingJTF = new PumpingJTF(NuGetUIThreadHelper.JoinableTaskFactory.Context);
-                    _isCPSJTFLoaded = true;
-                }
+                    var VsHierarchy = VsHierarchyUtility.ToVsHierarchy(project);
+                    if (VsHierarchy != null &&
+                        VsHierarchyUtility.IsCPSCapabilityComplaint(VsHierarchy))
+                    {
+                        // Lazy load the CPS enabled JoinableTaskFactory for the UI.
+                        NuGetUIThreadHelper.SetJoinableTaskFactoryFromService(ProjectServiceAccessor.Value as IProjectServiceAccessor);
+
+                        PumpingJTF = new PumpingJTF(NuGetUIThreadHelper.JoinableTaskFactory.Context);
+                        _isCPSJTFLoaded = true;
+                    }
+                });
             }
 
             PumpingJTF.Run(asyncTask);


### PR DESCRIPTION
This fixes issue found by failing Apex test, introduced by checking for CPS JTF context