### PR TITLE
Retargetting NuGet.Packaging.FuncTest to fix mac test failures

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/NuGet.Packaging.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/NuGet.Packaging.FuncTest.csproj
@@ -2,9 +2,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IsXPlat)' == 'true' ">netcoreapp1.0</TargetFrameworks>
     <TestProject>true</TestProject>
-    <TestProjectType>functional</TestProjectType>
+    <UseParallelXunit>true</UseParallelXunit>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
@@ -30,7 +30,6 @@ namespace Test.Utility.Signing
             return new TrustedTestCert<TestCertificate>(this, e => PublicCert);
         }
 
-#if IS_DESKTOP
         public static TestCertificate Generate()
         {
             var certName = "NuGetTest " + Guid.NewGuid().ToString();
@@ -42,6 +41,5 @@ namespace Test.Utility.Signing
 
             return pair;
         }
-#endif
     }
 }


### PR DESCRIPTION
Sometime in the last few commits, the mac tests started failing because the `NuGet.Packaging.FuncTest` project was not targeting correctly. This fixes that by correcting the Xplat target framework for the project. I have validated this runs fine on the mac CI.