### PR TITLE
Adding support for -OutputDirectory in sign command

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
@@ -110,17 +110,9 @@ namespace NuGet.Commands
 
             OverwritePackage(tempFilePath, outputPath);
 
-            CleanUp(tempFilePath);
+            FileUtility.Delete(tempFilePath);
 
             return 0;
-        }
-
-        private static void CleanUp(string tempFilePath)
-        {
-            if (File.Exists(tempFilePath))
-            {
-                File.Delete(tempFilePath);
-            }
         }
 
         private static string CopyPackage(string sourceFilePath)

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
@@ -21,6 +21,7 @@ namespace NuGet.Commands
     {
         public int ExecuteCommand(SignArgs signArgs)
         {
+
             var success = true;
 
             // resolve path into multiple packages if needed.
@@ -29,6 +30,7 @@ namespace NuGet.Commands
 
             var cert = GetCertificate(signArgs);
 
+            signArgs.Logger.LogInformation(Environment.NewLine);
             signArgs.Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,
                 Strings.SignCommandDisplayCertificate,
                 $"{Environment.NewLine}{CertificateUtility.X509Certificate2ToString(cert)}"));
@@ -37,7 +39,14 @@ namespace NuGet.Commands
             {
                 signArgs.Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,
                     Strings.SignCommandDisplayTimestamper,
-                    $"{Environment.NewLine}{signArgs.Timestamper}"));
+                    $"{Environment.NewLine}{signArgs.Timestamper}{Environment.NewLine}"));
+            }
+
+            if (!string.IsNullOrEmpty(signArgs.OutputDirectory))
+            {
+                signArgs.Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,
+                    Strings.SignCommandOutputPath,
+                    $"{Environment.NewLine}{signArgs.OutputDirectory}{Environment.NewLine}"));
             }
 
             var signRequest = GenerateSignPackageRequest(signArgs, cert);
@@ -47,7 +56,18 @@ namespace NuGet.Commands
             {
                 try
                 {
-                    SignPackage(packagePath, signArgs.Logger, signatureProvider, signRequest);
+                    string outputPath;
+
+                    if (string.IsNullOrEmpty(signArgs.OutputDirectory))
+                    {
+                        outputPath = packagePath;
+                    }
+                    else
+                    {
+                        outputPath = Path.Combine(signArgs.OutputDirectory, Path.GetFileName(packagePath));
+                    }
+
+                    SignPackage(packagePath, outputPath, signArgs.Logger, signatureProvider, signRequest);
                 }
                 catch (Exception e)
                 {
@@ -76,7 +96,7 @@ namespace NuGet.Commands
             return new X509SignatureProvider(timestampProvider);
         }
 
-        private int SignPackage(string packagePath, ILogger logger, ISignatureProvider signatureProvider, SignPackageRequest request)
+        private int SignPackage(string packagePath, string outputPath, ILogger logger, ISignatureProvider signatureProvider, SignPackageRequest request)
         {
             var tempFilePath = CopyPackage(packagePath);
 
@@ -88,9 +108,19 @@ namespace NuGet.Commands
                 signer.SignAsync(request, logger, CancellationToken.None).Wait();
             }
 
-            OverwritePackage(tempFilePath, packagePath);
-            
+            OverwritePackage(tempFilePath, outputPath);
+
+            CleanUp(tempFilePath);
+
             return 0;
+        }
+
+        private static void CleanUp(string tempFilePath)
+        {
+            if (File.Exists(tempFilePath))
+            {
+                File.Delete(tempFilePath);
+            }
         }
 
         private static string CopyPackage(string sourceFilePath)

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1233,8 +1233,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///Signing package(s) with certificate: {0}.
+        ///   Looks up a localized string similar to Signing package(s) with certificate: {0}.
         /// </summary>
         internal static string SignCommandDisplayCertificate {
             get {
@@ -1243,9 +1242,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///Timestamping package(s) with: {0}
-        ///.
+        ///   Looks up a localized string similar to Timestamping package(s) with: {0}.
         /// </summary>
         internal static string SignCommandDisplayTimestamper {
             get {
@@ -1295,6 +1292,15 @@ namespace NuGet.Commands {
         internal static string SignCommandNoCertException {
             get {
                 return ResourceManager.GetString("SignCommandNoCertException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Signed package(s) output path: {0}.
+        /// </summary>
+        internal static string SignCommandOutputPath {
+            get {
+                return ResourceManager.GetString("SignCommandOutputPath", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -610,8 +610,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>Detected package version outside of dependency constraint: {0} requires {1} but version {2} was resolved.</value>
   </data>
   <data name="SignCommandDisplayCertificate" xml:space="preserve">
-    <value>
-Signing package(s) with certificate: {0}</value>
+    <value>Signing package(s) with certificate: {0}</value>
     <comment>0 -  X509Certificate2 details in the following format -
 Subject Name:
 SHA1 hash:
@@ -656,9 +655,7 @@ Valid from:</comment>
 3 - second property value</comment>
   </data>
   <data name="SignCommandDisplayTimestamper" xml:space="preserve">
-    <value>
-Timestamping package(s) with: {0}
-</value>
+    <value>Timestamping package(s) with: {0}</value>
     <comment>0 -  url to the timestamping authority</comment>
   </data>
   <data name="VerifyCommand_PackageIsNotValid" xml:space="preserve">
@@ -666,5 +663,9 @@ Timestamping package(s) with: {0}
   </data>
   <data name="VerifyCommand_VerificationTypeNotSupported" xml:space="preserve">
     <value>Verification type not supported. Please use only one of the following supported types: -Signatures</value>
+  </data>
+  <data name="SignCommandOutputPath" xml:space="preserve">
+    <value>Signed package(s) output path: {0}</value>
+    <comment>0 - output directory path</comment>
   </data>
 </root>


### PR DESCRIPTION
There was an internally reported feedback that `-OutputDirectory` is not respected in the sign command.
When the sign command was initially done, Signing APIs were not available and this was left out. 

Adding support now that the APIs are relatively stable.
