### PR TITLE
Adding support for -Overwrite in Sign Command

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SignCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SignCommand.cs
@@ -65,13 +65,16 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "SignCommandOverwriteDescription")]
         public bool Overwrite { get; set; }
 
-        public override Task ExecuteCommandAsync()
+        public override async Task ExecuteCommandAsync()
         {
             var signArgs = GetSignArgs();
             var signCommandRunner = new SignCommandRunner();
-            var result = signCommandRunner.ExecuteCommand(signArgs);
+            var result = await signCommandRunner.ExecuteCommandAsync(signArgs);
 
-            return Task.FromResult(result);
+            if (result != 0)
+            {
+                throw new ExitCodeException(exitCode: result);
+            }
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/ISignCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/ISignCommandRunner.cs
@@ -4,11 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace NuGet.Commands
 {
     public interface ISignCommandRunner
     {
-        int ExecuteCommand(SignArgs signArgs);
+        Task<int> ExecuteCommandAsync(SignArgs signArgs);
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignArgs.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using NuGet.Common;
 using NuGet.Packaging.Signing;
 
@@ -92,5 +93,10 @@ namespace NuGet.Commands
         /// Logger to be used to display the logs during the execution of sign command.
         /// </summary>
         public ILogger Logger { get; set; }
+
+        /// <summary>
+        /// Cancellation Token.
+        /// </summary>
+        public CancellationToken Token { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
@@ -108,8 +108,8 @@ namespace NuGet.Commands
             var tempFilePath = CopyPackage(packagePath);
 
             using (var packageWriteStream = File.Open(tempFilePath, FileMode.Open))
-            {
-                var package = new SignedPackageArchive(packageWriteStream);
+            using (var package = new SignedPackageArchive(packageWriteStream))
+            {               
                 var signer = new Signer(package, signatureProvider);
 
                 if (overwrite)

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -30,6 +30,10 @@ namespace NuGet.Packaging
         /// </summary>
         protected ZipArchive Zip => _zipArchive;
 
+        /// <summary>
+        /// Stream underlying the ZipArchive. Used to do signature verification on a SignedPackageArchive.
+        /// If this is null then we cannot perform signature verification.
+        /// </summary>
         protected Stream ZipStream { get; set; }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -22,7 +22,6 @@ namespace NuGet.Packaging
     public class PackageArchiveReader : PackageReaderBase
     {
         private readonly ZipArchive _zipArchive;
-        private readonly Stream _zipStream;
         private readonly Encoding _utf8Encoding = new UTF8Encoding();
         private readonly SigningSpecifications _signingSpecifications = SigningSpecifications.V1;
 
@@ -30,6 +29,8 @@ namespace NuGet.Packaging
         /// Underlying zip archive.
         /// </summary>
         protected ZipArchive Zip => _zipArchive;
+
+        protected Stream ZipStream { get; set; }
 
         /// <summary>
         /// Nupkg package reader
@@ -71,7 +72,6 @@ namespace NuGet.Packaging
         public PackageArchiveReader(Stream stream, bool leaveStreamOpen, IFrameworkNameProvider frameworkProvider, IFrameworkCompatibilityProvider compatibilityProvider)
             : this(new ZipArchive(stream, ZipArchiveMode.Read, leaveStreamOpen), frameworkProvider, compatibilityProvider)
         {
-            _zipStream = stream;
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace NuGet.Packaging
             try
             {
                 stream = File.OpenRead(filePath);
-                _zipStream = stream;
+                ZipStream = stream;
                 _zipArchive = new ZipArchive(stream, ZipArchiveMode.Read);
             }
             catch
@@ -225,7 +225,7 @@ namespace NuGet.Packaging
         {
             token.ThrowIfCancellationRequested();
 
-            if (_zipStream == null)
+            if (ZipStream == null)
             {
                 throw new SignatureException(Strings.SignedPackageUnableToAccessSignature);
             }
@@ -252,7 +252,7 @@ namespace NuGet.Packaging
         {
             token.ThrowIfCancellationRequested();
 
-            if(_zipStream == null)
+            if(ZipStream == null)
             {
                 throw new SignatureException(Strings.SignedPackageUnableToAccessSignature);
             }
@@ -275,7 +275,7 @@ namespace NuGet.Packaging
         {
             token.ThrowIfCancellationRequested();
 
-            if (_zipStream == null)
+            if (ZipStream == null)
             {
                 throw new SignatureException(Strings.SignedPackageUnableToAccessSignature);
             }
@@ -286,7 +286,7 @@ namespace NuGet.Packaging
             }
 
 #if IS_DESKTOP
-            using (var reader = new BinaryReader(_zipStream, _utf8Encoding, leaveOpen: true))
+            using (var reader = new BinaryReader(ZipStream, _utf8Encoding, leaveOpen: true))
             {
                 var hashAlgorithm = signatureManifest.HashAlgorithm.GetHashProvider();
                 var expectedHash = Convert.FromBase64String(signatureManifest.HashValue);
@@ -299,13 +299,13 @@ namespace NuGet.Packaging
         {
             token.ThrowIfCancellationRequested();
 
-            if (_zipStream == null)
+            if (ZipStream == null)
             {
                 throw new SignatureException(Strings.SignedPackageUnableToAccessSignature);
             }
 
-            _zipStream.Seek(offset: 0, origin: SeekOrigin.Begin);
-            var hash = hashAlgorithm.GetHashProvider().ComputeHash(_zipStream, leaveStreamOpen: true);
+            ZipStream.Seek(offset: 0, origin: SeekOrigin.Begin);
+            var hash = hashAlgorithm.GetHashProvider().ComputeHash(ZipStream, leaveStreamOpen: true);
 
             return Task.FromResult(hash);
         }

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -60,6 +60,7 @@ namespace NuGet.Packaging
         public PackageArchiveReader(Stream stream, bool leaveStreamOpen)
             : this(new ZipArchive(stream, ZipArchiveMode.Read, leaveStreamOpen), DefaultFrameworkNameProvider.Instance, DefaultCompatibilityProvider.Instance)
         {
+            ZipStream = stream;
         }
 
         /// <summary>
@@ -72,6 +73,7 @@ namespace NuGet.Packaging
         public PackageArchiveReader(Stream stream, bool leaveStreamOpen, IFrameworkNameProvider frameworkProvider, IFrameworkCompatibilityProvider compatibilityProvider)
             : this(new ZipArchive(stream, ZipArchiveMode.Read, leaveStreamOpen), frameworkProvider, compatibilityProvider)
         {
+            ZipStream = stream;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageWriter.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageWriter.cs
@@ -14,7 +14,6 @@ namespace NuGet.Packaging.Signing
     /// </summary>
     public interface ISignedPackageWriter
     {
-        Stream ZipWriteStream { get; }
 
 #if IS_DESKTOP
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/SignedPackageArchive.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/SignedPackageArchive.cs
@@ -18,7 +18,7 @@ namespace NuGet.Packaging.Signing
         private readonly SigningSpecifications _signingSpecification = SigningSpecifications.V1;
 
         public SignedPackageArchive(Stream packageStream)
-            : base(new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: false), DefaultFrameworkNameProvider.Instance, DefaultCompatibilityProvider.Instance)
+            : base(new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: true), DefaultFrameworkNameProvider.Instance, DefaultCompatibilityProvider.Instance)
         {
             ZipStream = packageStream ?? throw new ArgumentNullException(nameof(packageStream));
         }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/SignedPackageArchive.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/SignedPackageArchive.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Frameworks;
 
 namespace NuGet.Packaging.Signing
 {
@@ -14,19 +15,12 @@ namespace NuGet.Packaging.Signing
     /// </summary>
     public class SignedPackageArchive : PackageArchiveReader, ISignedPackage
     {
-        private readonly Stream _zipWriteStream;
-        private readonly Stream _zipReadStream;
         private readonly SigningSpecifications _signingSpecification = SigningSpecifications.V1;
 
-        public Stream ZipWriteStream => _zipWriteStream;
-
-        public Stream ZipReadStream => _zipReadStream;
-
-        public SignedPackageArchive(Stream packageReadStream, Stream packageWriteStream)
-            : base(packageReadStream)
+        public SignedPackageArchive(Stream packageStream)
+            : base(new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: false), DefaultFrameworkNameProvider.Instance, DefaultCompatibilityProvider.Instance)
         {
-            _zipWriteStream = packageWriteStream ?? throw new ArgumentNullException(nameof(packageWriteStream));
-            _zipReadStream = packageReadStream ?? throw new ArgumentNullException(nameof(packageReadStream));
+            ZipStream = packageStream ?? throw new ArgumentNullException(nameof(packageStream));
         }
 
         /// <summary>
@@ -39,7 +33,7 @@ namespace NuGet.Packaging.Signing
         {
             token.ThrowIfCancellationRequested();
 
-            if (_zipReadStream == null)
+            if (ZipStream == null)
             {
                 throw new SignatureException(Strings.SignedPackageUnableToAccessSignature);
             }
@@ -49,13 +43,10 @@ namespace NuGet.Packaging.Signing
                 throw new SignatureException(Strings.SignedPackagePackageAlreadySigned);
             }
 
-            using (var writeZip = new ZipArchive(_zipWriteStream, ZipArchiveMode.Update, leaveOpen: true))
+            var signatureEntry = Zip.CreateEntry(_signingSpecification.SignaturePath, CompressionLevel.NoCompression);
+            using (var signatureEntryStream = signatureEntry.Open())
             {
-                var signatureEntry = writeZip.CreateEntry(_signingSpecification.SignaturePath, CompressionLevel.NoCompression);
-                using (var signatureEntryStream = signatureEntry.Open())
-                {
-                    signatureStream.CopyTo(signatureEntryStream);
-                }
+                signatureStream.CopyTo(signatureEntryStream);
             }
         }
 
@@ -67,7 +58,7 @@ namespace NuGet.Packaging.Signing
         {
             token.ThrowIfCancellationRequested();
 
-            if (_zipReadStream == null)
+            if (ZipStream == null)
             {
                 throw new SignatureException(Strings.SignedPackageUnableToAccessSignature);
             }
@@ -77,19 +68,11 @@ namespace NuGet.Packaging.Signing
                 throw new SignatureException(Strings.SignedPackageNotSignedOnRemove);
             }
 
-            using (var writeZip = new ZipArchive(_zipWriteStream, ZipArchiveMode.Update, leaveOpen: true))
-            {
-                writeZip.GetEntry(_signingSpecification.SignaturePath).Delete();
-            }
+            Zip.GetEntry(_signingSpecification.SignaturePath).Delete();
         }
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                _zipWriteStream.Dispose();                
-            }
-
             base.Dispose(disposing);
         }
     }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestCollection.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestCollection.cs
@@ -3,10 +3,10 @@
 
 using Xunit;
 
-namespace NuGet.Packaging.FuncTest
+namespace NuGet.CommandLine.FuncTest.Commands
 {
-    [CollectionDefinition("Signing Funtional Test Collection")]
-    public class SigningTestCollection : ICollectionFixture<SigningTestFixture>
+    [CollectionDefinition("Sign Command Test Collection")]
+    public class SignCommandTestCollection : ICollectionFixture<SignCommandTestFixture>
     {
         // This class has no code, and is never created. Its purpose is simply
         // to be the place to apply [CollectionDefinition] and all the

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
@@ -1,0 +1,89 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using NuGet.CommandLine.Test;
+using NuGet.Packaging.Signing;
+using Test.Utility.Signing;
+
+namespace NuGet.CommandLine.FuncTest.Commands
+{
+    /// <summary>
+    /// Used to bootstrap functional tests for signing.
+    /// </summary>
+    public class SignCommandTestFixture : IDisposable
+    {
+        private const string _timestamper = "http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer";
+
+        private TrustedTestCert<TestCertificate> _trustedTestCert;
+        private IList<ISignatureVerificationProvider> _trustProviders;
+        private SigningSpecifications _signingSpecifications;
+        private string _nugetExePath;
+
+        public TrustedTestCert<TestCertificate> TrustedTestCertificate
+        {
+            get
+            {
+                if (_trustedTestCert == null)
+                {
+                    _trustedTestCert = TestCertificate.Generate().WithPrivateKeyAndTrust();
+                }
+
+                return _trustedTestCert;
+            }
+        }
+
+        public IList<ISignatureVerificationProvider> TrustProviders
+        {
+            get
+            {
+                if (_trustProviders == null)
+                {
+                    _trustProviders = new List<ISignatureVerificationProvider>()
+                    {
+                        new X509SignatureVerificationProvider(),
+                        new NuGetIntegrityVerificationProvider(),
+                        new TimestampVerificationProvider()
+                    };
+                }
+
+                return _trustProviders;
+            }
+        }
+
+        public SigningSpecifications SigningSpecifications
+        {
+            get
+            {
+                if (_signingSpecifications == null)
+                {
+                    _signingSpecifications = SigningSpecifications.V1;
+                }
+
+                return _signingSpecifications;
+            }
+        }
+
+        public string NuGetExePath
+        {
+            get
+            {
+                if (_nugetExePath == null)
+                {
+                    _nugetExePath = Util.GetNuGetExePath();
+                }
+
+                return _nugetExePath;
+            }
+        }
+
+        public string Timestamper => _timestamper;
+
+        public void Dispose()
+        {
+            _trustedTestCert?.Dispose();
+        }
+    }
+}

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -63,7 +63,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public void SignCommand_SignPackageWithTimestamping()
         {
             // Arrange

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -1,0 +1,215 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Test.Utility;
+using Test.Utility.Signing;
+using Xunit;
+
+namespace NuGet.CommandLine.FuncTest.Commands
+{
+    [Collection("Sign Command Test Collection")]
+    public class SignCommandTests
+    {
+        private const string _packageAlreadySignedError = "Error NU5000: The package already contains a signature. Please remove the existing signature before adding a new signature.";
+
+        private SignCommandTestFixture _testFixture;
+        private TrustedTestCert<TestCertificate> _trustedTestCert;
+        private string _nugetExePath;
+        private string _timestamper;
+
+        public SignCommandTests(SignCommandTestFixture fixture)
+        {
+            _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+            _trustedTestCert = _testFixture.TrustedTestCertificate;
+            _nugetExePath = _testFixture.NuGetExePath;
+            _timestamper = _testFixture.Timestamper;
+        }
+
+        [Fact]
+        public void SignCommand_SignPackage()
+        {
+            // Arrange
+            var testLogger = new TestLogger();
+
+            using (var dir = TestDirectory.Create())
+            using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
+            {
+                var packagePath = Path.Combine(dir, new Guid().ToString());
+
+                zipStream.Seek(offset: 0, loc: SeekOrigin.Begin);
+
+                using (Stream fileStream = File.OpenWrite(packagePath))
+                {
+                    zipStream.CopyTo(fileStream);
+                }
+
+                // Act
+                var result = CommandRunner.Run(
+                    _nugetExePath,
+                    dir,
+                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName TrustedPeople",
+                    waitForExit: true,
+                    timeOutInMilliseconds: 10000);
+
+                // Assert
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().Contain("NU3521");
+            }
+        }
+
+        [Fact]
+        public void SignCommand_SignPackageWithTimestamping()
+        {
+            // Arrange
+            var testLogger = new TestLogger();
+
+            using (var dir = TestDirectory.Create())
+            using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
+            {
+                var packagePath = Path.Combine(dir, new Guid().ToString());
+
+                zipStream.Seek(offset: 0, loc: SeekOrigin.Begin);
+
+                using (Stream fileStream = File.OpenWrite(packagePath))
+                {
+                    zipStream.CopyTo(fileStream);
+                }
+
+                // Act
+                var result = CommandRunner.Run(
+                    _nugetExePath,
+                    dir,
+                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName TrustedPeople -Timestamper {_timestamper}",
+                    waitForExit: true,
+                    timeOutInMilliseconds: 10000);
+
+                // Assert
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().NotContain("NU3521");
+            }
+        }
+
+        [Fact]
+        public void SignCommand_SignPackageWithOutputDirectory()
+        {
+            // Arrange
+            var testLogger = new TestLogger();
+
+            using (var dir = TestDirectory.Create())
+            using (var outputDir = TestDirectory.Create())
+            using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
+            {
+                var packagePath = Path.Combine(dir, new Guid().ToString());
+                var signedPackagePath = Path.Combine(dir, new Guid().ToString());
+
+                zipStream.Seek(offset: 0, loc: SeekOrigin.Begin);
+
+                using (Stream fileStream = File.OpenWrite(packagePath))
+                {
+                    zipStream.CopyTo(fileStream);
+                }
+
+                // Act
+                var result = CommandRunner.Run(
+                    _nugetExePath,
+                    dir,
+                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName TrustedPeople -OutputDirectory {outputDir}",
+                    waitForExit: true,
+                    timeOutInMilliseconds: 10000);
+
+                // Assert
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().Contain("NU3521");
+                File.Exists(signedPackagePath).Should().BeTrue();
+            }
+        }
+
+        [Fact]
+        public void SignCommand_ResignPackageWithoutOverwriteFails()
+        {
+            // Arrange
+            var testLogger = new TestLogger();
+
+            using (var dir = TestDirectory.Create())
+            using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
+            {
+                var packagePath = Path.Combine(dir, new Guid().ToString());
+
+                zipStream.Seek(offset: 0, loc: SeekOrigin.Begin);
+
+                using (Stream fileStream = File.OpenWrite(packagePath))
+                {
+                    zipStream.CopyTo(fileStream);
+                }
+
+                var firstResult = CommandRunner.Run(
+                    _nugetExePath,
+                    dir,
+                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName TrustedPeople",
+                    waitForExit: true,
+                    timeOutInMilliseconds: 10000);
+
+                // Act
+                var secondResult = CommandRunner.Run(
+                    _nugetExePath,
+                    dir,
+                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName TrustedPeople",
+                    waitForExit: true,
+                    timeOutInMilliseconds: 10000);
+
+                // Assert
+                firstResult.Success.Should().BeTrue();
+                firstResult.AllOutput.Should().Contain("NU3521");
+                secondResult.Success.Should().BeFalse();
+                secondResult.Errors.Should().Contain(_packageAlreadySignedError);
+            }
+        }
+
+        [Fact]
+        public void SignCommand_ResignPackageWithOverwriteFails()
+        {
+            // Arrange
+            var testLogger = new TestLogger();
+
+            using (var dir = TestDirectory.Create())
+            using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
+            {
+                var packagePath = Path.Combine(dir, new Guid().ToString());
+
+                zipStream.Seek(offset: 0, loc: SeekOrigin.Begin);
+
+                using (Stream fileStream = File.OpenWrite(packagePath))
+                {
+                    zipStream.CopyTo(fileStream);
+                }
+
+                // Act
+                var firstResult = CommandRunner.Run(
+                    _nugetExePath,
+                    dir,
+                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName TrustedPeople",
+                    waitForExit: true,
+                    timeOutInMilliseconds: 10000);
+
+                var secondResult = CommandRunner.Run(
+                    _nugetExePath,
+                    dir,
+                    $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName TrustedPeople -Overwrite",
+                    waitForExit: true,
+                    timeOutInMilliseconds: 10000);
+
+                // Assert
+                firstResult.Success.Should().BeTrue();
+                firstResult.AllOutput.Should().Contain("NU3521");
+                secondResult.Success.Should().BeTrue();
+                secondResult.AllOutput.Should().Contain("NU3521");
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/NuGet.Packaging.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/NuGet.Packaging.FuncTest.csproj
@@ -8,7 +8,7 @@
     <UseParallelXunit>true</UseParallelXunit>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Security" />

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedArchiveTestUtility.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedArchiveTestUtility.cs
@@ -21,15 +21,16 @@ namespace NuGet.Packaging.FuncTest
         /// </summary>
         /// <param name="testCert">Certificate to be used while signing the package</param>
         /// <param name="nupkg">Package to be signed</param>
+        /// <param name="dir">Directory for placing the signed package</param>
         /// <returns>Path to the signed copy of the package</returns>
-        public static async Task<string> CreateSignedPackageAsync(TrustedTestCert<TestCertificate> testCert, SimpleTestPackageContext nupkg)
+        public static async Task<string> CreateSignedPackageAsync(TrustedTestCert<TestCertificate> testCert, SimpleTestPackageContext nupkg, string dir)
         {
             var testLogger = new TestLogger();
             var zipWriteStream = nupkg.CreateAsStream();
 
             var signPackage = new SignedPackageArchive(zipWriteStream);
 
-            var signedPackagePath = Path.GetTempFileName();
+            var signedPackagePath = Path.Combine(dir, Guid.NewGuid().ToString());
 
             // Sign the package
             await SignPackageAsync(testLogger, testCert.Source.Cert, signPackage);
@@ -51,14 +52,14 @@ namespace NuGet.Packaging.FuncTest
         /// <param name="testCert">Certificate to be used while signing the package</param>
         /// <param name="nupkg">Package to be signed</param>
         /// <returns>Path to the signed copy of the package</returns>
-        public static async Task<string> CreateSignedAndTimeStampedPackageAsync(TrustedTestCert<TestCertificate> testCert, SimpleTestPackageContext nupkg)
+        public static async Task<string> CreateSignedAndTimeStampedPackageAsync(TrustedTestCert<TestCertificate> testCert, SimpleTestPackageContext nupkg, string dir)
         {
             var testLogger = new TestLogger();
             var zipWriteStream = nupkg.CreateAsStream();
 
             var signPackage = new SignedPackageArchive(zipWriteStream);
 
-            var signedPackagePath = Path.GetTempFileName();
+            var signedPackagePath = Path.Combine(dir, Guid.NewGuid().ToString());
 
             // Sign the package
             await SignAndTimeStampPackageAsync(testLogger, testCert.Source.Cert, signPackage);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedArchiveTestUtility.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedArchiveTestUtility.cs
@@ -26,24 +26,26 @@ namespace NuGet.Packaging.FuncTest
         public static async Task<string> CreateSignedPackageAsync(TrustedTestCert<TestCertificate> testCert, SimpleTestPackageContext nupkg, string dir)
         {
             var testLogger = new TestLogger();
-            var zipWriteStream = nupkg.CreateAsStream();
 
-            using (var signPackage = new SignedPackageArchive(zipWriteStream))
+            using (var zipWriteStream = nupkg.CreateAsStream())
             {
-                // Sign the package
-                await SignPackageAsync(testLogger, testCert.Source.Cert, signPackage);
+                var signedPackagePath = Path.Combine(dir, Guid.NewGuid().ToString());
+
+                using (var signPackage = new SignedPackageArchive(zipWriteStream))
+                {
+                    // Sign the package
+                    await SignPackageAsync(testLogger, testCert.Source.Cert, signPackage);
+                }
+
+                zipWriteStream.Seek(offset: 0, loc: SeekOrigin.Begin);
+
+                using (Stream fileStream = File.OpenWrite(signedPackagePath))
+                {
+                    zipWriteStream.CopyTo(fileStream);
+                }
+
+                return signedPackagePath;
             }
-
-            var signedPackagePath = Path.Combine(dir, Guid.NewGuid().ToString());
-
-            zipWriteStream.Seek(offset: 0, loc: SeekOrigin.Begin);
-
-            using (Stream fileStream = File.OpenWrite(signedPackagePath))
-            {
-                zipWriteStream.CopyTo(fileStream);
-            }
-
-            return signedPackagePath;
         }
 
         /// <summary>
@@ -56,24 +58,26 @@ namespace NuGet.Packaging.FuncTest
         public static async Task<string> CreateSignedAndTimeStampedPackageAsync(TrustedTestCert<TestCertificate> testCert, SimpleTestPackageContext nupkg, string dir)
         {
             var testLogger = new TestLogger();
-            var zipWriteStream = nupkg.CreateAsStream();
 
-            using (var signPackage = new SignedPackageArchive(zipWriteStream))
+            using (var zipWriteStream = nupkg.CreateAsStream())
             {
-                // Sign the package
-                await SignAndTimeStampPackageAsync(testLogger, testCert.Source.Cert, signPackage);
+                var signedPackagePath = Path.Combine(dir, Guid.NewGuid().ToString());
+
+                using (var signPackage = new SignedPackageArchive(zipWriteStream))
+                {
+                    // Sign the package
+                    await SignAndTimeStampPackageAsync(testLogger, testCert.Source.Cert, signPackage);
+                }
+
+                zipWriteStream.Seek(offset: 0, loc: SeekOrigin.Begin);
+
+                using (Stream fileStream = File.OpenWrite(signedPackagePath))
+                {
+                    zipWriteStream.CopyTo(fileStream);
+                }
+
+                return signedPackagePath;
             }
-
-            var signedPackagePath = Path.Combine(dir, Guid.NewGuid().ToString());
-
-            zipWriteStream.Seek(offset: 0, loc: SeekOrigin.Begin);
-
-            using (Stream fileStream = File.OpenWrite(signedPackagePath))
-            {
-                zipWriteStream.CopyTo(fileStream);
-            }
-
-            return signedPackagePath;
         }
 
         /// <summary>

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedArchiveTestUtility.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedArchiveTestUtility.cs
@@ -25,10 +25,9 @@ namespace NuGet.Packaging.FuncTest
         public static async Task<string> CreateSignedPackageAsync(TrustedTestCert<TestCertificate> testCert, SimpleTestPackageContext nupkg)
         {
             var testLogger = new TestLogger();
-            var zipReadStream = nupkg.CreateAsStream();
             var zipWriteStream = nupkg.CreateAsStream();
 
-            var signPackage = new SignedPackageArchive(zipReadStream, zipWriteStream);
+            var signPackage = new SignedPackageArchive(zipWriteStream);
 
             var signedPackagePath = Path.GetTempFileName();
 
@@ -55,10 +54,9 @@ namespace NuGet.Packaging.FuncTest
         public static async Task<string> CreateSignedAndTimeStampedPackageAsync(TrustedTestCert<TestCertificate> testCert, SimpleTestPackageContext nupkg)
         {
             var testLogger = new TestLogger();
-            var zipReadStream = nupkg.CreateAsStream();
             var zipWriteStream = nupkg.CreateAsStream();
 
-            var signPackage = new SignedPackageArchive(zipReadStream, zipWriteStream);
+            var signPackage = new SignedPackageArchive(zipWriteStream);
 
             var signedPackagePath = Path.GetTempFileName();
 
@@ -87,10 +85,9 @@ namespace NuGet.Packaging.FuncTest
             var copiedSignedPackagePath = Path.GetTempFileName();
             File.Copy(signedPackagePath, copiedSignedPackagePath, overwrite: true);
 
-            using (var zipReadStream = File.OpenRead(signedPackagePath))
             using (var zipWriteStream = File.Open(copiedSignedPackagePath, FileMode.Open))
             {
-                var signedPackage = new SignedPackageArchive(zipReadStream, zipWriteStream);
+                var signedPackage = new SignedPackageArchive(zipWriteStream);
                 var signer = new Signer(signedPackage, testSignatureProvider);
 
                 await signer.RemoveSignaturesAsync(testLogger, CancellationToken.None);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageVerifierTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageVerifierTests.cs
@@ -21,7 +21,7 @@ using Xunit;
 
 namespace NuGet.Packaging.FuncTest
 {
-    [Collection("Siging Funtional Test Collection")]
+    [Collection("Signing Funtional Test Collection")]
     public class SignedPackageVerifierTests
     {
         private const string _packageTamperedError = "Package integrity check failed. The package has been tampered.";

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageVerifierTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageVerifierTests.cs
@@ -45,16 +45,20 @@ namespace NuGet.Packaging.FuncTest
             // Arrange
             var nupkg = new SimpleTestPackageContext();
             var testLogger = new TestLogger();
-            var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg);
-            var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
 
-            using (var packageReader = new PackageArchiveReader(signedPackagePath))
+            using (var dir = TestDirectory.Create())
             {
-                // Act
-                var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
 
-                // Assert
-                result.Valid.Should().BeTrue();
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
+
+                    // Assert
+                    result.Valid.Should().BeTrue();
+                }
             }
         }
 
@@ -64,30 +68,34 @@ namespace NuGet.Packaging.FuncTest
             // Arrange
             var nupkg = new SimpleTestPackageContext();
             var testLogger = new TestLogger();
-            var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg);
 
-            // tamper with the package
-            using (var stream = File.Open(signedPackagePath, FileMode.Open))
-            using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
+            using (var dir = TestDirectory.Create())
             {
-                zip.Entries.First().Delete();
-            }
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
 
-            var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                // tamper with the package
+                using (var stream = File.Open(signedPackagePath, FileMode.Open))
+                using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
+                {
+                    zip.Entries.First().Delete();
+                }
 
-            using (var packageReader = new PackageArchiveReader(signedPackagePath))
-            {
-                // Act
-                var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
-                var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
-                var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
 
-                // Assert
-                result.Valid.Should().BeFalse();
-                resultsWithErrors.Count().Should().Be(1);
-                totalErrorIssues.Count().Should().Be(1);
-                totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
-                totalErrorIssues.First().Message.Should().Be(_packageTamperedError);
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
+                    var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
+                    var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
+
+                    // Assert
+                    result.Valid.Should().BeFalse();
+                    resultsWithErrors.Count().Should().Be(1);
+                    totalErrorIssues.Count().Should().Be(1);
+                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                    totalErrorIssues.First().Message.Should().Be(_packageTamperedError);
+                }
             }
         }
 
@@ -97,35 +105,38 @@ namespace NuGet.Packaging.FuncTest
             // Arrange
             var nupkg = new SimpleTestPackageContext();
             var testLogger = new TestLogger();
-            var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg);
             var newEntryData = "malicious code";
             var newEntryName = "malicious file";
-
-            // tamper with the package
-            using (var stream = File.Open(signedPackagePath, FileMode.Open))
-            using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
-            using (var newEntryStream = zip.CreateEntry(newEntryName).Open())
-            using (var newEntryDataStream = new MemoryStream(Encoding.UTF8.GetBytes(newEntryData)))
+            using (var dir = TestDirectory.Create())
             {
-                newEntryStream.Seek(offset: 0, origin: SeekOrigin.End);
-                newEntryDataStream.CopyTo(newEntryStream);
-            }
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
 
-            var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                // tamper with the package
+                using (var stream = File.Open(signedPackagePath, FileMode.Open))
+                using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
+                using (var newEntryStream = zip.CreateEntry(newEntryName).Open())
+                using (var newEntryDataStream = new MemoryStream(Encoding.UTF8.GetBytes(newEntryData)))
+                {
+                    newEntryStream.Seek(offset: 0, origin: SeekOrigin.End);
+                    newEntryDataStream.CopyTo(newEntryStream);
+                }
 
-            using (var packageReader = new PackageArchiveReader(signedPackagePath))
-            {
-                // Act
-                var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
-                var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
-                var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
 
-                // Assert
-                result.Valid.Should().BeFalse();
-                resultsWithErrors.Count().Should().Be(1);
-                totalErrorIssues.Count().Should().Be(1);
-                totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
-                totalErrorIssues.First().Message.Should().Be(_packageTamperedError);
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
+                    var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
+                    var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
+
+                    // Assert
+                    result.Valid.Should().BeFalse();
+                    resultsWithErrors.Count().Should().Be(1);
+                    totalErrorIssues.Count().Should().Be(1);
+                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                    totalErrorIssues.First().Message.Should().Be(_packageTamperedError);
+                }
             }
         }
 
@@ -135,34 +146,38 @@ namespace NuGet.Packaging.FuncTest
             // Arrange
             var nupkg = new SimpleTestPackageContext();
             var testLogger = new TestLogger();
-            var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg);
             var extraData = "tampering data";
 
-            // tamper with the package
-            using (var stream = File.Open(signedPackagePath, FileMode.Open))
-            using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
-            using (var entryStream = zip.Entries.First().Open())
-            using (var extraStream = new MemoryStream(Encoding.UTF8.GetBytes(extraData)))
+            using (var dir = TestDirectory.Create())
             {
-                entryStream.Seek(offset: 0, origin: SeekOrigin.End);
-                extraStream.CopyTo(entryStream);
-            }
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
 
-            var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                // tamper with the package
+                using (var stream = File.Open(signedPackagePath, FileMode.Open))
+                using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
+                using (var entryStream = zip.Entries.First().Open())
+                using (var extraStream = new MemoryStream(Encoding.UTF8.GetBytes(extraData)))
+                {
+                    entryStream.Seek(offset: 0, origin: SeekOrigin.End);
+                    extraStream.CopyTo(entryStream);
+                }
 
-            using (var packageReader = new PackageArchiveReader(signedPackagePath))
-            {
-                // Act
-                var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
-                var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
-                var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
 
-                // Assert
-                result.Valid.Should().BeFalse();
-                resultsWithErrors.Count().Should().Be(1);
-                totalErrorIssues.Count().Should().Be(1);
-                totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
-                totalErrorIssues.First().Message.Should().Be(_packageTamperedError);
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
+                    var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
+                    var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
+
+                    // Assert
+                    result.Valid.Should().BeFalse();
+                    resultsWithErrors.Count().Should().Be(1);
+                    totalErrorIssues.Count().Should().Be(1);
+                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                    totalErrorIssues.First().Message.Should().Be(_packageTamperedError);
+                }
             }
         }
 
@@ -172,31 +187,35 @@ namespace NuGet.Packaging.FuncTest
             // Arrange
             var nupkg = new SimpleTestPackageContext();
             var testLogger = new TestLogger();
-            var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg);
 
-            // tamper with the package
-            using (var stream = File.Open(signedPackagePath, FileMode.Open))
-            using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
-            using (var entryStream = zip.Entries.First().Open())
+            using (var dir = TestDirectory.Create())
             {
-                entryStream.SetLength(entryStream.Length - 1);
-            }
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
 
-            var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                // tamper with the package
+                using (var stream = File.Open(signedPackagePath, FileMode.Open))
+                using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
+                using (var entryStream = zip.Entries.First().Open())
+                {
+                    entryStream.SetLength(entryStream.Length - 1);
+                }
 
-            using (var packageReader = new PackageArchiveReader(signedPackagePath))
-            {
-                // Act
-                var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
-                var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
-                var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
 
-                // Assert
-                result.Valid.Should().BeFalse();
-                resultsWithErrors.Count().Should().Be(1);
-                totalErrorIssues.Count().Should().Be(1);
-                totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
-                totalErrorIssues.First().Message.Should().Be(_packageTamperedError);
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
+                    var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
+                    var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
+
+                    // Assert
+                    result.Valid.Should().BeFalse();
+                    resultsWithErrors.Count().Should().Be(1);
+                    totalErrorIssues.Count().Should().Be(1);
+                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                    totalErrorIssues.First().Message.Should().Be(_packageTamperedError);
+                }
             }
         }
 
@@ -206,34 +225,38 @@ namespace NuGet.Packaging.FuncTest
             // Arrange
             var nupkg = new SimpleTestPackageContext();
             var testLogger = new TestLogger();
-            var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg);
 
-            // tamper with the package
-            using (var stream = File.Open(signedPackagePath, FileMode.Open))
-            using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
+            using (var dir = TestDirectory.Create())
             {
-                var entry = zip.Entries.First();
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
 
-                // ZipArchiveEntry.LastWriteTime supports a resolution of two seconds.
-                // https://msdn.microsoft.com/en-us/library/system.io.compression.ziparchiveentry.lastwritetime(v=vs.110).aspx
-                entry.LastWriteTime = entry.LastWriteTime.AddSeconds(2);
-            }
+                // tamper with the package
+                using (var stream = File.Open(signedPackagePath, FileMode.Open))
+                using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
+                {
+                    var entry = zip.Entries.First();
 
-            var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                    // ZipArchiveEntry.LastWriteTime supports a resolution of two seconds.
+                    // https://msdn.microsoft.com/en-us/library/system.io.compression.ziparchiveentry.lastwritetime(v=vs.110).aspx
+                    entry.LastWriteTime = entry.LastWriteTime.AddSeconds(2);
+                }
 
-            using (var packageReader = new PackageArchiveReader(signedPackagePath))
-            {
-                // Act
-                var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
-                var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
-                var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
 
-                // Assert
-                result.Valid.Should().BeFalse();
-                resultsWithErrors.Count().Should().Be(1);
-                totalErrorIssues.Count().Should().Be(1);
-                totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
-                totalErrorIssues.First().Message.Should().Be(_packageTamperedError);
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
+                    var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
+                    var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
+
+                    // Assert
+                    result.Valid.Should().BeFalse();
+                    resultsWithErrors.Count().Should().Be(1);
+                    totalErrorIssues.Count().Should().Be(1);
+                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                    totalErrorIssues.First().Message.Should().Be(_packageTamperedError);
+                }           
             }
         }
 
@@ -243,31 +266,35 @@ namespace NuGet.Packaging.FuncTest
             // Arrange
             var nupkg = new SimpleTestPackageContext();
             var testLogger = new TestLogger();
-            var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg);
 
-            // unsign the package
-            using (var stream = File.Open(signedPackagePath, FileMode.Open))
-            using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
+            using (var dir = TestDirectory.Create())
             {
-                var entry = zip.GetEntry(SigningSpecifications.V1.SignaturePath);
-                entry.Delete();
-            }
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
 
-            var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                // unsign the package
+                using (var stream = File.Open(signedPackagePath, FileMode.Open))
+                using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
+                {
+                    var entry = zip.GetEntry(SigningSpecifications.V1.SignaturePath);
+                    entry.Delete();
+                }
 
-            using (var packageReader = new PackageArchiveReader(signedPackagePath))
-            {
-                // Act
-                var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
-                var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
-                var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
 
-                // Assert
-                result.Valid.Should().BeFalse();
-                resultsWithErrors.Count().Should().Be(1);
-                totalErrorIssues.Count().Should().Be(1);
-                totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3001);
-                totalErrorIssues.First().Message.Should().Be(_packageUnsignedError);
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
+                    var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
+                    var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
+
+                    // Assert
+                    result.Valid.Should().BeFalse();
+                    resultsWithErrors.Count().Should().Be(1);
+                    totalErrorIssues.Count().Should().Be(1);
+                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3001);
+                    totalErrorIssues.First().Message.Should().Be(_packageUnsignedError);
+                }
             }
         }
 
@@ -277,29 +304,33 @@ namespace NuGet.Packaging.FuncTest
             // Arrange
             var nupkg = new SimpleTestPackageContext();
             var testLogger = new TestLogger();
-            var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg);
 
-            // unsign the package
-            using (var stream = File.Open(signedPackagePath, FileMode.Open))
-            using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
+            using (var dir = TestDirectory.Create())
             {
-                var entry = zip.GetEntry(SigningSpecifications.V1.SignaturePath);
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
 
-                // ZipArchiveEntry.LastWriteTime supports a resolution of two seconds.
-                // https://msdn.microsoft.com/en-us/library/system.io.compression.ziparchiveentry.lastwritetime(v=vs.110).aspx
-                entry.LastWriteTime = entry.LastWriteTime.AddSeconds(2);
-            }
+                // unsign the package
+                using (var stream = File.Open(signedPackagePath, FileMode.Open))
+                using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
+                {
+                    var entry = zip.GetEntry(SigningSpecifications.V1.SignaturePath);
 
-            var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                    // ZipArchiveEntry.LastWriteTime supports a resolution of two seconds.
+                    // https://msdn.microsoft.com/en-us/library/system.io.compression.ziparchiveentry.lastwritetime(v=vs.110).aspx
+                    entry.LastWriteTime = entry.LastWriteTime.AddSeconds(2);
+                }
 
-            using (var packageReader = new PackageArchiveReader(signedPackagePath))
-            {
-                // Act
-                var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
 
-                // Assert
-                // No failure expected as the signature file or its metadata is not part of the original hash
-                result.Valid.Should().BeTrue();
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
+
+                    // Assert
+                    // No failure expected as the signature file or its metadata is not part of the original hash
+                    result.Valid.Should().BeTrue();
+                }
             }
         }
 
@@ -309,31 +340,35 @@ namespace NuGet.Packaging.FuncTest
             // Arrange
             var nupkg = new SimpleTestPackageContext();
             var testLogger = new TestLogger();
-            var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg);
 
-            // tamper with the signature
-            using (var stream = File.Open(signedPackagePath, FileMode.Open))
-            using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
-            using (var entryStream = zip.GetEntry(SigningSpecifications.V1.SignaturePath).Open())
+            using (var dir = TestDirectory.Create())
             {
-                entryStream.SetLength(entryStream.Length - 1);
-            }
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
 
-            var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                // tamper with the signature
+                using (var stream = File.Open(signedPackagePath, FileMode.Open))
+                using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
+                using (var entryStream = zip.GetEntry(SigningSpecifications.V1.SignaturePath).Open())
+                {
+                    entryStream.SetLength(entryStream.Length - 1);
+                }
 
-            using (var packageReader = new PackageArchiveReader(signedPackagePath))
-            {
-                // Act
-                var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
-                var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
-                var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
 
-                // Assert
-                result.Valid.Should().BeFalse();
-                resultsWithErrors.Count().Should().Be(1);
-                totalErrorIssues.Count().Should().Be(1);
-                totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3001);
-                totalErrorIssues.First().Message.Should().Be(_packageInvalidSignatureError);
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    var result = await verifier.VerifySignaturesAsync(packageReader, testLogger, CancellationToken.None);
+                    var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
+                    var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
+
+                    // Assert
+                    result.Valid.Should().BeFalse();
+                    resultsWithErrors.Count().Should().Be(1);
+                    totalErrorIssues.Count().Should().Be(1);
+                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3001);
+                    totalErrorIssues.First().Message.Should().Be(_packageInvalidSignatureError);
+                }
             }
         }
     }

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
@@ -71,8 +71,9 @@ namespace NuGet.Packaging.FuncTest
                     zip.GetEntry(_signingSpecifications.SignaturePath).Should().NotBeNull();
                 }
 
-                await SignedArchiveTestUtility.UnsignPackageAsync(signedPackagePath);
+                await SignedArchiveTestUtility.UnsignPackageAsync(signedPackagePath, dir);
 
+                // Assert
                 using (var stream = File.OpenRead(signedPackagePath))
                 using (var zip = new ZipArchive(stream, ZipArchiveMode.Read))
                 {

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace NuGet.Packaging.FuncTest
 {
-    [Collection("Siging Funtional Test Collection")]
+    [Collection("Signing Funtional Test Collection")]
     public class SignerTests
     {
         private SigningTestFixture _testFixture;

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
@@ -39,14 +39,17 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
             var testLogger = new TestLogger();
 
-            // Act
-            var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg);
-
-            // Assert
-            using (var stream = File.OpenRead(signedPackagePath))
-            using (var zip = new ZipArchive(stream, ZipArchiveMode.Read))
+            using (var dir = TestDirectory.Create())
             {
-                zip.GetEntry(_signingSpecifications.SignaturePath).Should().NotBeNull();
+                // Act
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
+
+                // Assert
+                using (var stream = File.OpenRead(signedPackagePath))
+                using (var zip = new ZipArchive(stream, ZipArchiveMode.Read))
+                {
+                    zip.GetEntry(_signingSpecifications.SignaturePath).Should().NotBeNull();
+                }
             }
         }
 
@@ -57,21 +60,24 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
             var testLogger = new TestLogger();
 
-            // Act
-            var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg);
-
-            using (var stream = File.OpenRead(signedPackagePath))
-            using (var zip = new ZipArchive(stream, ZipArchiveMode.Read))
+            using (var dir = TestDirectory.Create())
             {
-                zip.GetEntry(_signingSpecifications.SignaturePath).Should().NotBeNull();
-            }
+                // Act
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
 
-            await SignedArchiveTestUtility.UnsignPackageAsync(signedPackagePath);
+                using (var stream = File.OpenRead(signedPackagePath))
+                using (var zip = new ZipArchive(stream, ZipArchiveMode.Read))
+                {
+                    zip.GetEntry(_signingSpecifications.SignaturePath).Should().NotBeNull();
+                }
 
-            using (var stream = File.OpenRead(signedPackagePath))
-            using (var zip = new ZipArchive(stream, ZipArchiveMode.Read))
-            {
-                zip.GetEntry(_signingSpecifications.SignaturePath).Should().BeNull();
+                await SignedArchiveTestUtility.UnsignPackageAsync(signedPackagePath);
+
+                using (var stream = File.OpenRead(signedPackagePath))
+                using (var zip = new ZipArchive(stream, ZipArchiveMode.Read))
+                {
+                    zip.GetEntry(_signingSpecifications.SignaturePath).Should().BeNull();
+                }
             }
         }
     }

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -111,5 +111,14 @@ namespace Test.Utility.Signing
         {
             return new X509Certificate2(cert.Export(X509ContentType.Cert));
         }
+
+        /// <summary>
+        /// Returns the public cert with the private key.
+        /// </summary>
+        public static X509Certificate2 GetPublicCertWithPrivateKey(X509Certificate2 cert)
+        {
+            var pass = new Guid().ToString();
+            return new X509Certificate2(cert.Export(X509ContentType.Pfx, pass), pass, X509KeyStorageFlags.PersistKeySet);
+        }
     }
 }

--- a/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
@@ -22,12 +22,26 @@ namespace Test.Utility.Signing
         public X509Certificate2 PublicCert => SigningTestUtility.GetPublicCert(Cert);
 
         /// <summary>
+        /// Public cert.
+        /// </summary>
+        public X509Certificate2 PublicCertWithPrivateKey => SigningTestUtility.GetPublicCertWithPrivateKey(Cert);
+
+        /// <summary>
         /// Trust the PublicCert cert for the life of the object.
         /// </summary>
         /// <remarks>Dispose of the object returned!</remarks>
         public TrustedTestCert<TestCertificate> WithTrust()
         {
             return new TrustedTestCert<TestCertificate>(this, e => PublicCert);
+        }
+
+        /// <summary>
+        /// Trust the PublicCert cert for the life of the object.
+        /// </summary>
+        /// <remarks>Dispose of the object returned!</remarks>
+        public TrustedTestCert<TestCertificate> WithPrivateKeyAndTrust()
+        {
+            return new TrustedTestCert<TestCertificate>(this, e => PublicCertWithPrivateKey);
         }
 
         public static TestCertificate Generate()


### PR DESCRIPTION
This adds `-Overwrite` support to sign command. 

If the flag is passed then the existing signature from the package is first removed and then new signature is added. 
Further - 
1. I have cleaned up the `SignedPackageArchive` to take a `ZipArchive` as an input.
2. Added functional tests around `NuGet.exe sign` command
