### PR TITLE
Add support to allow users to input password through commandline to sign command

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SignCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SignCommand.cs
@@ -111,7 +111,8 @@ namespace NuGet.CommandLine
                 Overwrite = Overwrite,
                 NonInteractive = NonInteractive,
                 Timestamper = Timestamper,
-                TimestampHashAlgorithm = timestampHashAlgorithm
+                TimestampHashAlgorithm = timestampHashAlgorithm,
+                PasswordProvider = new ConsolePasswordProvider(Console)
             };
         }
 

--- a/src/NuGet.Clients/NuGet.CommandLine/ConsolePasswordProvider.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/ConsolePasswordProvider.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Commands.SignCommand;
+
+namespace NuGet.CommandLine
+{
+    /// <summary>
+    /// Allows requesting a user to input their password through Console.
+    /// </summary>
+    internal class ConsolePasswordProvider : IPasswordProvider
+    {
+        private IConsole _console;
+
+        public ConsolePasswordProvider(IConsole console)
+        {
+            _console = console ?? throw new ArgumentNullException(nameof(console));
+        }
+
+#if IS_DESKTOP
+        /// <summary>
+        /// Requests user to input password and returns it as a SecureString on Console.
+        /// </summary>
+        /// <param name="filePath">Path to the file that needs a password to open.</param>
+        /// <param name="token">Cancellation token.</param>
+        /// <returns>SecureString containing the user input password. The SecureString should be disposed after use.</returns>
+        public Task<SecureString> GetPassword(string filePath, CancellationToken token)
+        {
+            token.ThrowIfCancellationRequested();
+
+            var password = new SecureString();
+
+            _console.WriteLine(string.Format(CultureInfo.CurrentCulture, NuGetResources.ConsolePasswordProvider_DisplayFile, filePath));
+            _console.Write(NuGetResources.ConsolePasswordProvider_PromptForPassword);
+            _console.ReadSecureString(password);
+
+            return Task.FromResult(password);
+        }
+#endif
+    }
+}

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.CommandLine {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class NuGetResources {
@@ -1092,6 +1092,24 @@ namespace NuGet.CommandLine {
         public static string ConsoleConfirmMessageAccept_trk {
             get {
                 return ResourceManager.GetString("ConsoleConfirmMessageAccept_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please provide password for: {0}.
+        /// </summary>
+        public static string ConsolePasswordProvider_DisplayFile {
+            get {
+                return ResourceManager.GetString("ConsolePasswordProvider_DisplayFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password: .
+        /// </summary>
+        public static string ConsolePasswordProvider_PromptForPassword {
+            get {
+                return ResourceManager.GetString("ConsolePasswordProvider_PromptForPassword", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6151,4 +6151,11 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="Error_ResponseFileTooLarge" xml:space="preserve">
     <value>Response file '{0}' cannot be larger than {1}mb</value>
   </data>
+  <data name="ConsolePasswordProvider_DisplayFile" xml:space="preserve">
+    <value>Please provide password for: {0}</value>
+    <comment>0 - file that requires password</comment>
+  </data>
+  <data name="ConsolePasswordProvider_PromptForPassword" xml:space="preserve">
+    <value>Password: </value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateFindOptions.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateFindOptions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
+using NuGet.Common;
 
 namespace NuGet.Commands
 {
@@ -42,6 +43,16 @@ namespace NuGet.Commands
         /// The SHA-1 fingerprint of the certificate.
         /// </summary>
         public string Fingerprint { get; set; }
+
+        /// <summary>
+        /// bool used to indicate if the user can be prompted for password.
+        /// </summary>
+        public bool NonInteractive { get; set; }
+
+        /// <summary>
+        /// bool used to indicate if the user can be prompted for password.
+        /// </summary>
+        public ILogger Logger { get; set; }
 
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateFindOptions.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateFindOptions.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using NuGet.Commands.SignCommand;
 using NuGet.Common;
 
 namespace NuGet.Commands
@@ -50,9 +52,14 @@ namespace NuGet.Commands
         public bool NonInteractive { get; set; }
 
         /// <summary>
-        /// bool used to indicate if the user can be prompted for password.
+        /// Password provider to get the password from user for opening a pfx file.
         /// </summary>
-        public ILogger Logger { get; set; }
+        public IPasswordProvider PasswordProvider { get; set; }
+
+        /// <summary>
+        /// Cancellation token.
+        /// </summary>
+        public CancellationToken Token { get; set; }
 
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/IPasswordProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/IPasswordProvider.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Commands.SignCommand
+{
+    public interface IPasswordProvider
+    {
+// Currently there is no cross platform interactive scenario
+#if IS_DESKTOP
+        /// <summary>
+        /// Requests user to input password and returns it as a SecureString.
+        /// </summary>
+        /// <param name="filePath">Path to the file that needs a password to open.</param>
+        /// <param name="token">Cancellation token.</param>
+        /// <returns>SecureString containing the user input password. The SecureString should be disposed after use.</returns>
+        Task<SecureString> GetPassword(string filePath, CancellationToken token);
+#endif
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignArgs.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
+using NuGet.Commands.SignCommand;
 using NuGet.Common;
-using NuGet.Packaging.Signing;
 
 namespace NuGet.Commands
 {
@@ -93,6 +93,11 @@ namespace NuGet.Commands
         /// Logger to be used to display the logs during the execution of sign command.
         /// </summary>
         public ILogger Logger { get; set; }
+
+        /// <summary>
+        /// Password provider to get the password from user for opening a pfx file.
+        /// </summary>
+        public IPasswordProvider PasswordProvider { get; set; }
 
         /// <summary>
         /// Cancellation Token.

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
@@ -183,7 +183,9 @@ namespace NuGet.Commands
                 Fingerprint = signArgs.CertificateFingerprint,
                 StoreLocation = signArgs.CertificateStoreLocation,
                 StoreName = signArgs.CertificateStoreName,
-                SubjectName = signArgs.CertificateSubjectName
+                SubjectName = signArgs.CertificateSubjectName,
+                NonInteractive = signArgs.NonInteractive,
+                Logger = signArgs.Logger
             };
 
             // get matching certificates

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
@@ -29,7 +29,7 @@ namespace NuGet.Commands
             var packagesToSign = LocalFolderUtility.ResolvePackageFromPath(signArgs.PackagePath);
             LocalFolderUtility.EnsurePackageFileExists(signArgs.PackagePath, packagesToSign);
 
-            var cert = GetCertificate(signArgs);
+            var cert = await GetCertificateAsync(signArgs);
 
             signArgs.Logger.LogInformation(Environment.NewLine);
             signArgs.Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,
@@ -174,7 +174,7 @@ namespace NuGet.Commands
             };
         }
 
-        private static X509Certificate2 GetCertificate(SignArgs signArgs)
+        private static async Task<X509Certificate2> GetCertificateAsync(SignArgs signArgs)
         {
             var certFindOptions = new CertificateSourceOptions()
             {
@@ -185,11 +185,12 @@ namespace NuGet.Commands
                 StoreName = signArgs.CertificateStoreName,
                 SubjectName = signArgs.CertificateSubjectName,
                 NonInteractive = signArgs.NonInteractive,
-                Logger = signArgs.Logger
+                PasswordProvider = signArgs.PasswordProvider,
+                Token = signArgs.Token
             };
 
             // get matching certificates
-            var matchingCertCollection = CertificateProvider.GetCertificates(certFindOptions);
+            var matchingCertCollection = await CertificateProvider.GetCertificatesAsync(certFindOptions);
 
             if (matchingCertCollection.Count > 1)
             {


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/5904
Regression: No

## Fix
Details: This PR adds support in sign command to allow users to interactively type pfx file password securely. To allow this I have added  `IPasswordProvider.cs` and its implementation `ConsolePasswordProvider.cs` that allows `SignCommandRunner` to read password from console in `-NonInteractive` mode. The underlying implementation comes from `IConsole.ReadSecureString`.

I have also added some tests using pfx files and done some cleanup in the test code.

## Testing/Validation
Tests Added: Yes
Validation done:  manual testing with pfx files.
