### PR TITLE
Fixing the certificate error message in timestamp verification

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
@@ -126,7 +126,7 @@ namespace NuGet.Packaging.Signing
                     NuGetLogCode.NU3011,
                     string.Format(CultureInfo.CurrentCulture,
                     Strings.TimestampCertificateChainBuildFailure,
-                    timestampSignerCertificate.FriendlyName)));
+                    CertificateUtility.X509Certificate2ToString(timestampSignerCertificate))));
             }
 
             return timestampCertChain;

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampVerifier.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampVerifier.cs
@@ -85,7 +85,7 @@ namespace NuGet.Packaging.Signing
                     NuGetLogCode.NU3011,
                     string.Format(CultureInfo.CurrentCulture,
                     Strings.TimestampCertificateChainBuildFailure,
-                    timestamperCertificate.FriendlyName)));
+                    CertificateUtility.X509Certificate2ToString(timestamperCertificate))));
             }
         }
 


### PR DESCRIPTION
Fixes an issue that I saw while working with @joelverhagen .

This fixes the display to print the cert details in the same format as the rest of the sign and verify UX.

