### PR TITLE
Add a restore task report on whether the build files changed

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -87,6 +87,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     Restore
     Main entry point for restoring packages
+    Returns a property with comma delimited projects whose imports
+    have been updated. Used by MSBuild in build /restore calls
     ============================================================
   -->
   <Target Name="Restore" DependsOnTargets="_GenerateRestoreGraph" Returns="$(RestoreChangedImportsProjectList)">

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -87,7 +87,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     Restore
     Main entry point for restoring packages
-    Returns a property with comma delimited projects whose imports
+    Returns a property with semicolon delimited projects whose imports
     have been updated. Used by MSBuild in build /restore calls
     ============================================================
   -->

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -89,7 +89,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Main entry point for restoring packages
     ============================================================
   -->
-  <Target Name="Restore" DependsOnTargets="_GenerateRestoreGraph">
+  <Target Name="Restore" DependsOnTargets="_GenerateRestoreGraph" Returns="$(RestoreChangedImportsProjectList)">
 
     <!-- Drop any duplicate items -->
     <RemoveDuplicates
@@ -107,7 +107,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       RestoreIgnoreFailedSources="$(RestoreIgnoreFailedSources)"
       RestoreRecursive="$(RestoreRecursive)"
       RestoreForce="$(RestoreForce)"
-      HideWarningsAndErrors="$(HideWarningsAndErrors)"/>
+      HideWarningsAndErrors="$(HideWarningsAndErrors)">
+      <Output
+        TaskParameter="OutputRestoreChangedImportsProjectList"
+        PropertyName="RestoreChangedImportsProjectList"/>
+      </RestoreTask>
   </Target>
 
   <!--

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
@@ -67,6 +68,9 @@ namespace NuGet.Build.Tasks
         /// The Warnings and Errors are written into the assets file and will be read by an sdk target.
         /// </summary>
         public bool HideWarningsAndErrors { get; set; }
+
+        [Output]
+        public string OutputRestoreChangedImportsProjectList { get; set; }
 
         public override bool Execute()
         {
@@ -167,6 +171,18 @@ namespace NuGet.Build.Tasks
 
                 // Summary
                 RestoreSummary.Log(log, restoreSummaries);
+
+                var projectsWithImportsChanged = new StringBuilder();
+                foreach (var summary in restoreSummaries)
+                {
+                    if(!summary.NoOpRestore & summary.Success)
+                    {
+                        projectsWithImportsChanged.Append(summary.InputPath).Append(';');
+                    }
+                }
+
+                OutputRestoreChangedImportsProjectList = projectsWithImportsChanged.ToString();
+                BuildTasksUtility.LogOutputParam(log, nameof(OutputRestoreChangedImportsProjectList), OutputRestoreChangedImportsProjectList);
 
                 return restoreSummaries.All(x => x.Success);
             }

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -175,7 +175,7 @@ namespace NuGet.Build.Tasks
                 // Summary
                 RestoreSummary.Log(log, restoreSummaries);
                 // Success does not matter here, as long as the files are not changed
-                OutputRestoreChangedImportsProjectList = string.Join(";", restoreSummaries.Where(e => e.BuildFilesChanged).Select(e => e.InputPath))
+                OutputRestoreChangedImportsProjectList = string.Join(";", restoreSummaries.Where(e => e.BuildFilesChanged).Select(e => e.InputPath));
                  
                 BuildTasksUtility.LogOutputParam(log, nameof(OutputRestoreChangedImportsProjectList), OutputRestoreChangedImportsProjectList);
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -175,7 +175,8 @@ namespace NuGet.Build.Tasks
                 var projectsWithImportsChanged = new StringBuilder();
                 foreach (var summary in restoreSummaries)
                 {
-                    if(!summary.NoOpRestore & summary.Success)
+                    //  Success does not matter here, as long as the files are not changed
+                    if(summary.BuildFilesChanged)
                     {
                         projectsWithImportsChanged.Append(summary.InputPath).Append(';');
                     }

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -174,18 +174,9 @@ namespace NuGet.Build.Tasks
 
                 // Summary
                 RestoreSummary.Log(log, restoreSummaries);
-
-                var projectsWithImportsChanged = new StringBuilder();
-                foreach (var summary in restoreSummaries)
-                {
-                    // Success does not matter here, as long as the files are not changed
-                    if(summary.BuildFilesChanged)
-                    {
-                        projectsWithImportsChanged.Append(summary.InputPath).Append(';');
-                    }
-                }
-
-                OutputRestoreChangedImportsProjectList = projectsWithImportsChanged.ToString();
+                // Success does not matter here, as long as the files are not changed
+                OutputRestoreChangedImportsProjectList = string.Join(";", restoreSummaries.Where(e => e.BuildFilesChanged).Select(e => e.InputPath))
+                 
                 BuildTasksUtility.LogOutputParam(log, nameof(OutputRestoreChangedImportsProjectList), OutputRestoreChangedImportsProjectList);
 
                 return restoreSummaries.All(x => x.Success);

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -69,6 +69,9 @@ namespace NuGet.Build.Tasks
         /// </summary>
         public bool HideWarningsAndErrors { get; set; }
 
+        /// <summary>
+        /// Semicolon delimited list of projects that have had updates in their targets/props. This is used to avoid throwaway msbuild evaluation during build /restore calls
+        /// </summary>
         [Output]
         public string OutputRestoreChangedImportsProjectList { get; set; }
 
@@ -175,7 +178,7 @@ namespace NuGet.Build.Tasks
                 var projectsWithImportsChanged = new StringBuilder();
                 foreach (var summary in restoreSummaries)
                 {
-                    //  Success does not matter here, as long as the files are not changed
+                    // Success does not matter here, as long as the files are not changed
                     if(summary.BuildFilesChanged)
                     {
                         projectsWithImportsChanged.Append(summary.InputPath).Append(';');

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -65,6 +65,12 @@ namespace NuGet.Commands
         /// </summary>
         protected string CacheFilePath { get;  }
 
+        /// <summary>
+        /// Indicates whether the build files have changed. It will only be updated after the restore result has been committed. It will false Commit has not be called.
+        /// Used to report the status in the restore build task.
+        /// </summary>
+        public bool BuildFilesChanged { get; private set; }
+
         public RestoreResult(
             bool success,
             IEnumerable<RestoreTargetGraph> restoreGraphs,
@@ -153,7 +159,9 @@ namespace NuGet.Commands
             // Visual Studio typically watches the assets file for changes
             // and begins a reload when that file changes.
             var buildFilesToWrite = result.MSBuildOutputFiles
-                    .Where(e => BuildAssetsUtils.HasChanges(e.Content, e.Path, log));
+                    .Where(e => BuildAssetsUtils.HasChanges(e.Content, e.Path, log)).ToList();
+            // Update whether build files have changed
+            BuildFilesChanged = buildFilesToWrite.Count != 0;
 
             BuildAssetsUtils.WriteFiles(buildFilesToWrite, log);
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -66,7 +66,7 @@ namespace NuGet.Commands
         protected string CacheFilePath { get;  }
 
         /// <summary>
-        /// Indicates whether the build files have changed. It will only be updated after the restore result has been committed. It will false Commit has not be called.
+        /// Indicates whether the build files have changed. It will only be updated after the restore result has been committed. It will be false if Commit has not be called.
         /// Used to report the status in the restore build task.
         /// </summary>
         public bool BuildFilesChanged { get; private set; }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -19,6 +19,8 @@ namespace NuGet.Commands
 
         public bool NoOpRestore { get; }
 
+        public bool BuildFilesChanged { get; }
+
         public string InputPath { get; }
 
         public IList<string> ConfigFiles { get; }
@@ -38,6 +40,7 @@ namespace NuGet.Commands
             FeedsUsed = new List<string>().AsReadOnly();
             InstallCount = 0;
             Errors = new List<IRestoreLogMessage>().AsReadOnly();
+            BuildFilesChanged = false;
         }
 
         public RestoreSummary(
@@ -49,6 +52,7 @@ namespace NuGet.Commands
         {
             Success = result.Success;
             NoOpRestore = result is NoOpRestoreResult;
+            BuildFilesChanged = result.BuildFilesChanged;
             InputPath = inputPath;
             ConfigFiles = configFiles.AsList().AsReadOnly();
             FeedsUsed = sourceRepositories

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -42,7 +42,7 @@ namespace NuGet.Commands
         /// Write XML to disk.
         /// Delete files which do not have new XML.
         /// </summary>
-        public static void WriteFiles(IEnumerable<MSBuildOutputFile> files, ILogger log)
+        public static void WriteFiles(List<MSBuildOutputFile> files, ILogger log)
         {
             foreach (var file in files)
             {


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6122
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
Make restore task report whether the build files changed to optimize double evaluation on build /restore. 

It's possible that restore did not happen, yet we save on evaluation if the build assets have not changed. 

Right the result is a property that contains the project paths of projects whose assets have changed. 

Chatting with @AndyGerlicher to understand if we want the property or we want an item group with more information

## Testing/Validation
Tests Added: Yes, only basic tests, can't really test the full integration on our side. 
Reason for not adding tests:  
Validation done:  Manual.
