### PR TITLE
ignore case when comparing path root on windows

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
@@ -179,7 +179,7 @@ namespace NuGet.Common
             {
                 compare = StringComparison.OrdinalIgnoreCase;
                 // check if paths are on the same volume
-                if (!string.Equals(Path.GetPathRoot(path1), Path.GetPathRoot(path2)))
+                if (!string.Equals(Path.GetPathRoot(path1), Path.GetPathRoot(path2), compare))
                 {
                     // on different volumes, "relative" path is just path2
                     return path2;

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/PathUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/PathUtilityTests.cs
@@ -1,0 +1,22 @@
+using Xunit;
+
+namespace NuGet.Common.Test
+{
+    public class PathUtilityTests
+    {
+        [Fact]
+        public void PathUtility_RelativePathDifferenctRootCase()
+        {
+            if (RuntimeEnvironmentHelper.IsWindows)
+            {
+                // Arrange & Act
+                var path1 = @"C:\foo\";
+                var path2 = @"c:\foo\bar";
+                var path = PathUtility.GetRelativePath(path1, path2);
+
+                // Assert
+                Assert.Equal("bar", path);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/5888
Regression: not sure  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
ignore the case when comparing Path root on windows  

## Testing/Validation
Tests Added: Yes

