### PR TITLE
Fix NullReferenceException in PackageIdentity.ToString

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging.Core/PackageIdentity.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/PackageIdentity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -121,7 +121,9 @@ namespace NuGet.Packaging.Core
         /// </summary>
         public override string ToString()
         {
-            return String.Format(CultureInfo.InvariantCulture, ToStringFormat, Id, Version.ToNormalizedString());
+            return HasVersion
+                ? String.Format(CultureInfo.InvariantCulture, ToStringFormat, Id, Version.ToNormalizedString())
+                : Id;
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/PackageIdentityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/PackageIdentityTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Versioning;
@@ -13,6 +13,9 @@ namespace NuGet.Packaging.Core.Test
         {
             var packageIdentity = new PackageIdentity("packageA", new NuGetVersion("1.0.0"));
             Assert.Equal("packageA.1.0.0", packageIdentity.ToString());
+
+            var packageIdentityNoVersion = new PackageIdentity("packageB", null);
+            Assert.Equal("packageB", packageIdentityNoVersion.ToString());
 
             var formattedString = string.Format("This is package '{0}'", packageIdentity);
             Assert.Equal("This is package 'packageA.1.0.0'", formattedString);


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6235
Regression: Yes
If Regression then when did it last work:  When `Version` could not be null
If Regression then how are we preventing it in future: Keep checking `Version` for nullity 

## Fix
Details: Check `Version` for nullity in `ToString`

## Testing/Validation
Tests Added: Yes
Validation done: Yes
