### PR TITLE
Catching CNG failures and adding code sign EKU filter to sign command

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
@@ -54,21 +54,27 @@ namespace NuGet.Commands
                     switch (ex.HResult)
                     {
                         case ERROR_INVALID_PASSWORD_HRESULT:
-                            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
+                            throw new SignCommandException(
+                                LogMessage.CreateError(NuGetLogCode.NU3014,
+                                string.Format(CultureInfo.CurrentCulture,
                                 Strings.SignCommandInvalidPasswordException,
                                 options.CertificatePath,
-                                nameof(options.CertificatePassword)));
+                                nameof(options.CertificatePassword))));
 
                         case ERROR_FILE_NOT_FOUND_HRESULT:
-                            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
+                            throw new SignCommandException(
+                                LogMessage.CreateError(NuGetLogCode.NU3001,
+                                string.Format(CultureInfo.CurrentCulture,
                                     Strings.SignCommandFileNotFound,
                                     CERTIFICATE,
-                                    options.CertificatePath));
+                                    options.CertificatePath)));
 
                         case CRYPT_E_NO_MATCH_HRESULT:
-                            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
+                            throw new SignCommandException(
+                                LogMessage.CreateError(NuGetLogCode.NU3001,
+                                string.Format(CultureInfo.CurrentCulture,
                                     Strings.SignCommandInvalidCertException,
-                                    options.CertificatePath));
+                                    options.CertificatePath)));
 
                         default:
                             throw ex;

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandException.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandException.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NuGet.Common;
+
+namespace NuGet.Commands
+{
+    /// <summary>
+    /// Holds an <see cref="ILogMessage"/> and returns the message for the exception.
+    /// </summary>
+    internal class SignCommandException : Exception, ILogMessageException
+    {
+        private readonly ILogMessage _logMessage;
+
+        public SignCommandException(ILogMessage logMessage)
+            : base(logMessage?.Message)
+        {
+            _logMessage = logMessage ?? throw new ArgumentNullException(nameof(logMessage));
+        }
+
+        public ILogMessage AsLogMessage()
+        {
+            return _logMessage;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
@@ -117,7 +117,7 @@ namespace NuGet.Commands
                 exceptionBuilder.AppendLine(Strings.SignCommandInvalidCertEku);
                 exceptionBuilder.AppendLine(CertificateUtility.X509Certificate2ToString(cert));
 
-                throw new InvalidOperationException(exceptionBuilder.ToString());
+                throw new SignCommandException(LogMessage.CreateError(NuGetLogCode.NU3013, exceptionBuilder.ToString()));
             }
         }
 
@@ -237,7 +237,10 @@ namespace NuGet.Commands
                 {
                     // if on non-windows os or in non interactive mode - display the certs and error out
                     signArgs.Logger.LogInformation(CertificateUtility.X509Certificate2CollectionToString(matchingCertCollection));
-                    throw new InvalidOperationException(string.Format(Strings.SignCommandMultipleCertException, nameof(SignArgs.CertificateFingerprint)));
+                    throw new SignCommandException(
+                        LogMessage.CreateError(NuGetLogCode.NU3003,
+                        string.Format(Strings.SignCommandMultipleCertException,
+                        nameof(SignArgs.CertificateFingerprint))));
                 }
                 else
                 {
@@ -251,13 +254,19 @@ namespace NuGet.Commands
 #else
                 // if on non-windows os or in non interactive mode - display and error out
                 signArgs.Logger.LogError(CertificateUtility.X509Certificate2CollectionToString(matchingCertCollection));
-                throw new InvalidOperationException(string.Format(Strings.SignCommandMultipleCertException, nameof(SignArgs.CertificateFingerprint)));
+
+                throw new SignCommandException(
+                    LogMessage.CreateError(NuGetLogCode.NU3003,
+                    string.Format(Strings.SignCommandMultipleCertException,
+                    nameof(SignArgs.CertificateFingerprint))));
 #endif
             }
 
             if (matchingCertCollection.Count == 0)
             {
-                throw new InvalidOperationException(Strings.SignCommandNoCertException);
+                throw new SignCommandException(
+                    LogMessage.CreateError(NuGetLogCode.NU3003,
+                    Strings.SignCommandNoCertException));
             }
 
             return matchingCertCollection[0];

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
@@ -49,14 +49,21 @@ namespace NuGet.Commands
             }
 
             var signRequest = GenerateSignPackageRequest(signArgs, cert);
-            return await ExecuteCommandAsync(packagesToSign,
-                signRequest, signArgs.Timestamper, signArgs.Logger, signArgs.OutputDirectory, signArgs.Overwrite, signArgs.Token);
+
+            return await ExecuteCommandAsync(
+                packagesToSign,
+                signRequest,
+                signArgs.Timestamper,
+                signArgs.Logger,
+                signArgs.OutputDirectory,
+                signArgs.Overwrite,
+                signArgs.Token);
         }
 
         public async Task<int> ExecuteCommandAsync(
             IEnumerable<string> packagesToSign,
             SignPackageRequest signPackageRequest,
-            string Timestamper,
+            string timestamper,
             ILogger logger,
             string outputDirectory,
             bool overwrite,
@@ -64,7 +71,7 @@ namespace NuGet.Commands
         {
             var success = true;
 
-            var signatureProvider = GetSignatureProvider(Timestamper);
+            var signatureProvider = GetSignatureProvider(timestamper);
 
             foreach (var packagePath in packagesToSign)
             {
@@ -114,7 +121,7 @@ namespace NuGet.Commands
             }
         }
 
-        private static ISignatureProvider GetSignatureProvider(SignArgs signArgs)
+        private static ISignatureProvider GetSignatureProvider(string timestamper)
         {
             Rfc3161TimestampProvider timestampProvider = null;
 

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1233,7 +1233,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Signing package(s) with certificate: {0}.
+        ///   Looks up a localized string similar to Signing package(s) with certificate:.
         /// </summary>
         internal static string SignCommandDisplayCertificate {
             get {
@@ -1242,7 +1242,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Timestamping package(s) with: {0}.
+        ///   Looks up a localized string similar to Timestamping package(s) with:.
         /// </summary>
         internal static string SignCommandDisplayTimestamper {
             get {
@@ -1256,6 +1256,15 @@ namespace NuGet.Commands {
         internal static string SignCommandFileNotFound {
             get {
                 return ResourceManager.GetString("SignCommandFileNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The following certificate cannot be used for signing a package as it does not have Code Signing enhanced key usage:.
+        /// </summary>
+        internal static string SignCommandInvalidCertEku {
+            get {
+                return ResourceManager.GetString("SignCommandInvalidCertEku", resourceCulture);
             }
         }
         
@@ -1296,7 +1305,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Signed package(s) output path: {0}.
+        ///   Looks up a localized string similar to Signed package(s) output path:.
         /// </summary>
         internal static string SignCommandOutputPath {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -610,12 +610,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>Detected package version outside of dependency constraint: {0} requires {1} but version {2} was resolved.</value>
   </data>
   <data name="SignCommandDisplayCertificate" xml:space="preserve">
-    <value>Signing package(s) with certificate: {0}</value>
-    <comment>0 -  X509Certificate2 details in the following format -
-Subject Name:
-SHA1 hash:
-Issued by:
-Valid from:</comment>
+    <value>Signing package(s) with certificate:</value>
   </data>
   <data name="SignCommandDialogMessage" xml:space="preserve">
     <value>Please select a valid certificate</value>
@@ -655,8 +650,7 @@ Valid from:</comment>
 3 - second property value</comment>
   </data>
   <data name="SignCommandDisplayTimestamper" xml:space="preserve">
-    <value>Timestamping package(s) with: {0}</value>
-    <comment>0 -  url to the timestamping authority</comment>
+    <value>Timestamping package(s) with:</value>
   </data>
   <data name="VerifyCommand_PackageIsNotValid" xml:space="preserve">
     <value>'{0}' is not a valid package file.</value>
@@ -665,8 +659,10 @@ Valid from:</comment>
     <value>Verification type not supported. Please use only one of the following supported types: -All, -Signatures</value>
   </data>
   <data name="SignCommandOutputPath" xml:space="preserve">
-    <value>Signed package(s) output path: {0}</value>
-    <comment>0 - output directory path</comment>
+    <value>Signed package(s) output path:</value>
+  </data>
+  <data name="SignCommandInvalidCertEku" xml:space="preserve">
+    <value>The following certificate cannot be used for signing a package as it does not have Code Signing enhanced key usage:</value>
   </data>
   <data name="VerifyCommand_FinishedWithErrors" xml:space="preserve">
     <value>Finished with {0} errors and {1} warnings.</value>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -215,6 +215,11 @@ namespace NuGet.Common
         NU3002 = 3002,
 
         /// <summary>
+        /// Invalid number of certificates were found while signing package
+        /// </summary>
+        NU3003 = 3003,
+
+        /// <summary>
         /// Certificate chain does not build
         /// </summary>
         NU3011 = 3011,
@@ -228,6 +233,11 @@ namespace NuGet.Common
         /// SignedCms.ComputeSignature cannot read the certificate private key
         /// </summary>
         NU3013 = 3013,
+
+        /// <summary>
+        /// Invalid password provided for a certificate
+        /// </summary>
+        NU3014 = 3014,
 
         /// <summary>
         /// Invalid timestamp response

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -225,6 +225,11 @@ namespace NuGet.Common
         NU3012 = 3012,
 
         /// <summary>
+        /// SignedCms.ComputeSignature cannot read the certificate private key
+        /// </summary>
+        NU3013 = 3013,
+
+        /// <summary>
         /// Invalid timestamp response
         /// </summary>
         NU3021 = 3021,

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
@@ -85,7 +85,7 @@ namespace NuGet.Packaging.Signing
                 }
 
             cmsSigner.IncludeOption = X509IncludeOption.WholeChain;
-            cmsSigner.DigestAlgorithm = cert.SignatureAlgorithm;
+            cmsSigner.DigestAlgorithm = request.Certificate.SignatureAlgorithm;
 
             var cms = new SignedCms(contentInfo);
 
@@ -97,7 +97,7 @@ namespace NuGet.Packaging.Signing
             {
                 var exceptionBuilder = new StringBuilder();
                 exceptionBuilder.AppendLine(Strings.SignFailureCertificateInvalidProviderType);
-                exceptionBuilder.AppendLine(CertificateUtility.X509Certificate2ToString(cert));
+                exceptionBuilder.AppendLine(CertificateUtility.X509Certificate2ToString(request.Certificate));
 
                 throw new SignatureException(NuGetLogCode.NU3013, exceptionBuilder.ToString());
             }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
@@ -3,14 +3,16 @@
 
 using System;
 using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading;
-using System.Threading.Tasks;
-using NuGet.Common;
 
 #if IS_DESKTOP
 using System.Security.Cryptography.Pkcs;
 #endif
+
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
 
 namespace NuGet.Packaging.Signing
 {
@@ -19,6 +21,10 @@ namespace NuGet.Packaging.Signing
     /// </summary>
     public class X509SignatureProvider : ISignatureProvider
     {
+        // Occurs when SignedCms.ComputeSignature cannot read the certificate private key
+        // "Invalid provider type specified." (INVALID_PROVIDER_TYPE)
+        private const int INVALID_PROVIDER_TYPE_HRESULT = unchecked((int)0x80090014);
+
         private readonly ITimestampProvider _timestampProvider;
 
         public X509SignatureProvider(ITimestampProvider timestampProvider)
@@ -78,10 +84,23 @@ namespace NuGet.Packaging.Signing
                     cmsSigner.SignedAttributes.Add(attribute);
                 }
 
-                cmsSigner.IncludeOption = X509IncludeOption.WholeChain;
+            cmsSigner.IncludeOption = X509IncludeOption.WholeChain;
+            cmsSigner.DigestAlgorithm = cert.SignatureAlgorithm;
 
-                var cms = new SignedCms(contentInfo);
+            var cms = new SignedCms(contentInfo);
+
+            try
+            {
                 cms.ComputeSignature(cmsSigner);
+            }
+            catch (CryptographicException ex) when (ex.HResult == INVALID_PROVIDER_TYPE_HRESULT)
+            {
+                var exceptionBuilder = new StringBuilder();
+                exceptionBuilder.AppendLine(Strings.SignFailureCertificateInvalidProviderType);
+                exceptionBuilder.AppendLine(CertificateUtility.X509Certificate2ToString(cert));
+
+                throw new SignatureException(NuGetLogCode.NU3013, exceptionBuilder.ToString());
+            }
 
                 return Signature.Load(cms);
             }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using NuGet.Common;
 using NuGet.Packaging.Core;
 
 namespace NuGet.Packaging.Signing
@@ -16,7 +17,13 @@ namespace NuGet.Packaging.Signing
 
         public PackageIdentity PackageIdentity { get; }
 
-        public SignatureException(string message) : base(message)
+        public SignatureException(string message)
+            : base(message)
+        {
+        }
+
+        public SignatureException(NuGetLogCode code, string message)
+            : base(code, message)
         {
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SigningUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SigningUtility.cs
@@ -78,9 +78,10 @@ namespace NuGet.Packaging.Signing
 #if IS_DESKTOP
         public static CryptographicAttributeObjectCollection GetSignAttributes(SignPackageRequest request)
         {
-            var attributes = new CryptographicAttributeObjectCollection();
-
-            attributes.Add(new Pkcs9SigningTime());
+            var attributes = new CryptographicAttributeObjectCollection
+            {
+                new Pkcs9SigningTime()
+            };
 
             if (request.SignatureType != SignatureType.Unknown)
             {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
@@ -9,10 +9,10 @@ using System.Security.Cryptography;
 
 #if IS_DESKTOP
 using System.Security.Cryptography.Pkcs;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 #endif
 
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -145,6 +145,20 @@ namespace NuGet.Packaging.Signing
 
                 return signatureNativeCms.Encode();
             }
+        }
+
+        private static X509Chain GetTimestampCertChain(X509Certificate2 timestamperCertificate)
+        {
+            if (!SigningUtility.IsCertificateValid(timestamperCertificate, out var timestampCertChain, allowUntrustedRoot: false, checkRevocationStatus: true))
+            {
+                var exceptionBuilder = new StringBuilder();
+                exceptionBuilder.AppendLine(Strings.TimestampCertificateChainBuildFailure);
+                exceptionBuilder.AppendLine(CertificateUtility.X509Certificate2ToString(timestamperCertificate));
+
+                throw new TimestampException(LogMessage.CreateError(NuGetLogCode.NU3011, exceptionBuilder.ToString()));
+            }
+
+            return timestampCertChain;
         }
 
         private static void ValidateTimestampResponseNonce(

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
@@ -147,20 +147,6 @@ namespace NuGet.Packaging.Signing
             }
         }
 
-        private static X509Chain GetTimestampCertChain(X509Certificate2 timestamperCertificate)
-        {
-            if (!SigningUtility.IsCertificateValid(timestamperCertificate, out var timestampCertChain, allowUntrustedRoot: false, checkRevocationStatus: true))
-            {
-                var exceptionBuilder = new StringBuilder();
-                exceptionBuilder.AppendLine(Strings.TimestampCertificateChainBuildFailure);
-                exceptionBuilder.AppendLine(CertificateUtility.X509Certificate2ToString(timestamperCertificate));
-
-                throw new TimestampException(LogMessage.CreateError(NuGetLogCode.NU3011, exceptionBuilder.ToString()));
-            }
-
-            return timestampCertChain;
-        }
-
         private static void ValidateTimestampResponseNonce(
                 byte[] nonce,
                 Rfc3161TimestampToken timestampToken)

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -629,11 +629,19 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+<<<<<<< HEAD
         ///   Looks up a localized string similar to signing-certificate-v2 attribute value does not match the current certificate chain..
         /// </summary>
         internal static string SigningCertificateV2Invalid {
             get {
                 return ResourceManager.GetString("SigningCertificateV2Invalid", resourceCulture);
+=======
+        ///   Looks up a localized string similar to The following certificate cannot be used for package signing as the private key provider is unsupported:.
+        /// </summary>
+        internal static string SignFailureCertificateInvalidProviderType {
+            get {
+                return ResourceManager.GetString("SignFailureCertificateInvalidProviderType", resourceCulture);
+>>>>>>> dev-anmishr-certvalidation
             }
         }
         
@@ -647,8 +655,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The timestamp service&apos;s certificate chain could not be built for the following certificate - 
-        ///{0}.
+        ///   Looks up a localized string similar to The timestamp service&apos;s certificate chain could not be built for the following certificate:.
         /// </summary>
         internal static string TimestampCertificateChainBuildFailure {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -629,19 +629,20 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-<<<<<<< HEAD
-        ///   Looks up a localized string similar to signing-certificate-v2 attribute value does not match the current certificate chain..
-        /// </summary>
-        internal static string SigningCertificateV2Invalid {
-            get {
-                return ResourceManager.GetString("SigningCertificateV2Invalid", resourceCulture);
-=======
         ///   Looks up a localized string similar to The following certificate cannot be used for package signing as the private key provider is unsupported:.
         /// </summary>
         internal static string SignFailureCertificateInvalidProviderType {
             get {
                 return ResourceManager.GetString("SignFailureCertificateInvalidProviderType", resourceCulture);
->>>>>>> dev-anmishr-certvalidation
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to signing-certificate-v2 attribute value does not match the current certificate chain..
+        /// </summary>
+        internal static string SigningCertificateV2Invalid {
+            get {
+                return ResourceManager.GetString("SigningCertificateV2Invalid", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -252,9 +252,7 @@
     <value>Timestamp signature contains invalid content type.</value>
   </data>
   <data name="TimestampCertificateChainBuildFailure" xml:space="preserve">
-    <value>The timestamp service's certificate chain could not be built for the following certificate - 
-{0}</value>
-    <comment>0 -  X509Certificate2 friendly name</comment>
+    <value>The timestamp service's certificate chain could not be built for the following certificate:</value>
   </data>
   <data name="SignedPackageUnableToAccessSignature" xml:space="preserve">
     <value>The package was not opened correctly to perform Signature operations. Please use a Stream based constructor to have access to Signature attributes of the package.</value>
@@ -407,5 +405,8 @@ Valid from:</comment>
   </data>
   <data name="UnsupportedSignatureFormatVersion" xml:space="preserve">
     <value>The package signature format version is unsupported.  Updating your client may solve this problem.</value>
+  </data>
+  <data name="SignFailureCertificateInvalidProviderType" xml:space="preserve">
+    <value>The following certificate cannot be used for package signing as the private key provider is unsupported:</value>
   </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.CommandLine.Test;
 using NuGet.Packaging.Signing;
@@ -32,16 +31,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             {
                 if (_trustedTestCert == null)
                 {
-                    Action<X509V3CertificateGenerator> actionGenerator = delegate (X509V3CertificateGenerator gen)
-                    {
-                        // CodeSigning EKU
-                        var usages = new[] { KeyPurposeID.IdKPCodeSigning };
-
-                        gen.AddExtension(
-                            X509Extensions.ExtendedKeyUsage.Id,
-                            critical: true,
-                            extensionValue: new ExtendedKeyUsage(usages));
-                    };
+                    var actionGenerator = SigningTestUtility.CertificateModificationGeneratorForCodeSigningEku;
 
                     // Code Sign EKU needs trust to a root authority
                     // Add the cert to Root CA list in LocalMachine as it does not prompt a dialog
@@ -59,16 +49,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             {
                 if (_trustedTestCertWithInvalidEku == null)
                 {
-                    Action<X509V3CertificateGenerator> actionGenerator = delegate (X509V3CertificateGenerator gen)
-                    {
-                        // any EKU besides CodeSigning
-                        var usages = new[] { KeyPurposeID.IdKPClientAuth };
-
-                        gen.AddExtension(
-                            X509Extensions.ExtendedKeyUsage.Id,
-                            critical: true,
-                            extensionValue: new ExtendedKeyUsage(usages));
-                    };
+                    var actionGenerator = SigningTestUtility.CertificateModificationGeneratorForInvalidEku;
 
                     // Add the cert to Root CA list in LocalMachine as it does not prompt a dialog
                     // This makes all the associated tests to require admin privilege

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
@@ -3,9 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.CommandLine.Test;
 using NuGet.Packaging.Signing;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.X509;
 using Test.Utility.Signing;
 
 namespace NuGet.CommandLine.FuncTest.Commands
@@ -18,6 +21,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         private const string _timestamper = "http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer";
 
         private TrustedTestCert<TestCertificate> _trustedTestCert;
+        private TrustedTestCert<TestCertificate> _trustedTestCertWithInvalidEku;
         private IList<ISignatureVerificationProvider> _trustProviders;
         private SigningSpecifications _signingSpecifications;
         private string _nugetExePath;
@@ -28,10 +32,50 @@ namespace NuGet.CommandLine.FuncTest.Commands
             {
                 if (_trustedTestCert == null)
                 {
-                    _trustedTestCert = TestCertificate.Generate().WithPrivateKeyAndTrust();
+                    Action<X509V3CertificateGenerator> actionGenerator = delegate (X509V3CertificateGenerator gen)
+                    {
+                        // CodeSigning EKU
+                        var usages = new[] { KeyPurposeID.IdKPCodeSigning };
+
+                        gen.AddExtension(
+                            X509Extensions.ExtendedKeyUsage.Id,
+                            critical: true,
+                            extensionValue: new ExtendedKeyUsage(usages));
+                    };
+
+                    // Code Sign EKU needs trust to a root authority
+                    // Add the cert to Root CA list in LocalMachine as it does not prompt a dialog
+                    // This makes all the associated tests to require admin privilege
+                    _trustedTestCert = TestCertificate.Generate(actionGenerator).WithPrivateKeyAndTrust(StoreName.Root, StoreLocation.LocalMachine);
                 }
 
                 return _trustedTestCert;
+            }
+        }
+
+        public TrustedTestCert<TestCertificate> TrustedTestCertificateWithInvalidEku
+        {
+            get
+            {
+                if (_trustedTestCertWithInvalidEku == null)
+                {
+                    Action<X509V3CertificateGenerator> actionGenerator = delegate (X509V3CertificateGenerator gen)
+                    {
+                        // any EKU besides CodeSigning
+                        var usages = new[] { KeyPurposeID.IdKPClientAuth };
+
+                        gen.AddExtension(
+                            X509Extensions.ExtendedKeyUsage.Id,
+                            critical: true,
+                            extensionValue: new ExtendedKeyUsage(usages));
+                    };
+
+                    // Add the cert to Root CA list in LocalMachine as it does not prompt a dialog
+                    // This makes all the associated tests to require admin privilege
+                    _trustedTestCertWithInvalidEku = TestCertificate.Generate(actionGenerator).WithPrivateKeyAndTrust(StoreName.Root, StoreLocation.LocalMachine);
+                }
+
+                return _trustedTestCertWithInvalidEku;
             }
         }
 
@@ -83,6 +127,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public void Dispose()
         {
             _trustedTestCert?.Dispose();
+            _trustedTestCertWithInvalidEku?.Dispose();
         }
     }
 }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -64,8 +64,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     _nugetExePath,
                     dir,
                     $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
-                    waitForExit: true,
-                    timeOutInMilliseconds: 10000);
+                    waitForExit: true);
 
                 // Assert
                 result.Success.Should().BeTrue();
@@ -96,8 +95,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     _nugetExePath,
                     dir,
                     $"sign {packagePath} -CertificateFingerprint {_trustedTestCertWithInvalidEku.Source.Cert.Thumbprint} -CertificateStoreName {_trustedTestCertWithInvalidEku.StoreName} -CertificateStoreLocation {_trustedTestCertWithInvalidEku.StoreLocation}",
-                    waitForExit: true,
-                    timeOutInMilliseconds: 10000);
+                    waitForExit: true);
 
                 // Assert
                 result.Success.Should().BeFalse();
@@ -129,8 +127,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     _nugetExePath,
                     dir,
                     $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint}  -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation} -Timestamper {_timestamper}",
-                    waitForExit: true,
-                    timeOutInMilliseconds: 10000);
+                    waitForExit: true);
 
                 // Assert
                 result.Success.Should().BeTrue();
@@ -164,8 +161,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     _nugetExePath,
                     dir,
                     $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint}  -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation} -OutputDirectory {outputDir}",
-                    waitForExit: true,
-                    timeOutInMilliseconds: 10000);
+                    waitForExit: true);
 
                 // Assert
                 result.Success.Should().BeTrue();
@@ -196,16 +192,14 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     _nugetExePath,
                     dir,
                     $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint}  -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
-                    waitForExit: true,
-                    timeOutInMilliseconds: 10000);
+                    waitForExit: true);
 
                 // Act
                 var secondResult = CommandRunner.Run(
                     _nugetExePath,
                     dir,
                     $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint}  -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
-                    waitForExit: true,
-                    timeOutInMilliseconds: 10000);
+                    waitForExit: true);
 
                 // Assert
                 firstResult.Success.Should().BeTrue();
@@ -238,15 +232,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     _nugetExePath,
                     dir,
                     $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation}",
-                    waitForExit: true,
-                    timeOutInMilliseconds: 10000);
+                    waitForExit: true);
 
                 var secondResult = CommandRunner.Run(
                     _nugetExePath,
                     dir,
                     $"sign {packagePath} -CertificateFingerprint {_trustedTestCert.Source.Cert.Thumbprint} -CertificateStoreName {_trustedTestCert.StoreName} -CertificateStoreLocation {_trustedTestCert.StoreLocation} -Overwrite",
-                    waitForExit: true,
-                    timeOutInMilliseconds: 10000);
+                    waitForExit: true);
 
                 // Assert
                 firstResult.Success.Should().BeTrue();
@@ -289,8 +281,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     _nugetExePath,
                     dir,
                     $"sign {packagePath} -CertificatePath {pfxPath} -CertificatePassword {password}",
-                    waitForExit: true,
-                    timeOutInMilliseconds: 10000);
+                    waitForExit: true);
 
                 // Assert
                 firstResult.Success.Should().BeTrue();
@@ -336,8 +327,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     inputAction: (w) =>
                     {
                         w.WriteLine(password);
-                    },
-                    timeOutInMilliseconds: 10000);
+                    });
 
                 // Assert
                 firstResult.Success.Should().BeTrue();
@@ -382,8 +372,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     inputAction: (w) =>
                     {
                         w.WriteLine(Guid.NewGuid().ToString());
-                    },
-                    timeOutInMilliseconds: 10000);
+                    });
 
                 // Assert
                 firstResult.Success.Should().BeFalse();
@@ -424,8 +413,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     _nugetExePath,
                     dir,
                     $"sign {packagePath} -CertificatePath {pfxPath} -NonInteractive",
-                    waitForExit: true,
-                    timeOutInMilliseconds: 10000);
+                    waitForExit: true);
 
                 // Assert
                 firstResult.Success.Should().BeFalse();
@@ -470,8 +458,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     inputAction: (w) =>
                     {
                         w.WriteLine(Guid.NewGuid().ToString());
-                    },
-                    timeOutInMilliseconds: 10000);
+                    });
 
                 // Assert
                 firstResult.Success.Should().BeFalse();

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -22,8 +22,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
     public class SignCommandTests
     {
         private const string _packageAlreadySignedError = "Error NU5000: The package already contains a signature. Please remove the existing signature before adding a new signature.";
-        private const string _invalidPasswordError = @"Invalid password was provided for the certificate file '{0}'. Please provide a valid password using the '-CertificatePassword' option";
-        private const string _invalidEkuError = "The following certificate cannot be used for signing a package as it does not have Code Signing enhanced key usage";
+        private const string _invalidPasswordErrorCode = "NU3014";
+        private const string _invalidEkuErrorCode = "NU3013";
         private const string _noTimestamperWarningCode = "NU3521";
 
         private SignCommandTestFixture _testFixture;
@@ -100,7 +100,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 // Assert
                 result.Success.Should().BeFalse();
                 result.AllOutput.Should().Contain(_noTimestamperWarningCode);
-                result.AllOutput.Should().Contain(_invalidEkuError);
+                result.AllOutput.Should().Contain(_invalidEkuErrorCode);
             }
         }
 
@@ -376,7 +376,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 firstResult.Success.Should().BeFalse();
-                firstResult.AllOutput.Should().Contain(string.Format(_invalidPasswordError, pfxPath));
+                firstResult.AllOutput.Should().Contain(string.Format(_invalidPasswordErrorCode, pfxPath));
             }
         }
 
@@ -417,7 +417,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 firstResult.Success.Should().BeFalse();
-                firstResult.AllOutput.Should().Contain(string.Format(_invalidPasswordError, pfxPath));
+                firstResult.AllOutput.Should().Contain(string.Format(_invalidPasswordErrorCode, pfxPath));
             }
         }
 
@@ -462,7 +462,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 firstResult.Success.Should().BeFalse();
-                firstResult.AllOutput.Should().Contain(string.Format(_invalidPasswordError, pfxPath));
+                firstResult.AllOutput.Should().Contain(string.Format(_invalidPasswordErrorCode, pfxPath));
             }
         }
     }

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageVerifierTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageVerifierTests.cs
@@ -40,7 +40,7 @@ namespace NuGet.Packaging.FuncTest
             _trustProviders = _testFixture.TrustProviders;
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task Signer_VerifyOnSignedPackageAsync()
         {
             // Arrange
@@ -62,7 +62,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task Signer_VerifyOnTamperedPackage_FileDeletedAsync()
         {
             // Arrange
@@ -98,7 +98,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task Signer_VerifyOnTamperedPackage_FileAddedAsync()
         {
             // Arrange
@@ -138,7 +138,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task Signer_VerifyOnTamperedPackage_FileAppendedAsync()
         {
             // Arrange
@@ -178,7 +178,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task Signer_VerifyOnTamperedPackage_FileTruncatedAsync()
         {
             // Arrange
@@ -215,7 +215,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task Signer_VerifyOnTamperedPackage_FileMetadataModifiedAsync()
         {
             // Arrange
@@ -255,7 +255,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task Signer_VerifyOnTamperedPackage_SignatureRemovedAsync()
         {
             // Arrange
@@ -292,7 +292,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task Signer_VerifyOnTamperedPackage_SignatureMetadataModifiedAsync()
         {
             // Arrange
@@ -327,7 +327,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task Signer_VerifyOnTamperedPackage_SignatureTruncatedAsync()
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
@@ -32,7 +32,7 @@ namespace NuGet.Packaging.FuncTest
             _signingSpecifications = _testFixture.SigningSpecifications;
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task Signer_SignPackageAsync()
         {
             // Arrange
@@ -53,7 +53,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task Signer_UnsignPackageAsync()
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
@@ -26,16 +26,7 @@ namespace NuGet.Packaging.FuncTest
             {
                 if (_trustedTestCert == null)
                 {
-                    Action<X509V3CertificateGenerator> actionGenerator = delegate (X509V3CertificateGenerator gen)
-                    {
-                        // CodeSigning EKU
-                        var usages = new[] { KeyPurposeID.IdKPCodeSigning };
-
-                        gen.AddExtension(
-                            X509Extensions.ExtendedKeyUsage.Id,
-                            critical: true,
-                            extensionValue: new ExtendedKeyUsage(usages));
-                    };
+                    var actionGenerator = SigningTestUtility.CertificateModificationGeneratorForCodeSigningEku;
 
                     // Code Sign EKU needs trust to a root authority
                     // Add the cert to Root CA list in LocalMachine as it does not prompt a dialog

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -24,6 +24,36 @@ namespace Test.Utility.Signing
     public static class SigningTestUtility
     {
         /// <summary>
+        /// Modification generator that can be passed to TestCertificate.Generate().
+        /// The generator will change the certificate EKU to ClientAuth.
+        /// </summary>
+        public static Action<X509V3CertificateGenerator> CertificateModificationGeneratorForInvalidEku = delegate (X509V3CertificateGenerator gen)
+        {
+            // any EKU besides CodeSigning
+            var usages = new[] { KeyPurposeID.IdKPClientAuth };
+
+            gen.AddExtension(
+                X509Extensions.ExtendedKeyUsage.Id,
+                critical: true,
+                extensionValue: new ExtendedKeyUsage(usages));
+        };
+
+        /// <summary>
+        /// Modification generator that can be passed to TestCertificate.Generate().
+        /// The generator will change the certificate EKU to CodeSigning.
+        /// </summary>
+        public static Action<X509V3CertificateGenerator> CertificateModificationGeneratorForCodeSigningEku = delegate (X509V3CertificateGenerator gen)
+        {
+            // CodeSigning EKU
+            var usages = new[] { KeyPurposeID.IdKPCodeSigning };
+
+            gen.AddExtension(
+                X509Extensions.ExtendedKeyUsage.Id,
+                critical: true,
+                extensionValue: new ExtendedKeyUsage(usages));
+        };
+
+        /// <summary>
         /// Create a self signed certificate with bouncy castle.
         /// </summary>
         public static X509Certificate2 GenerateCertificate(string subjectName, Action<X509V3CertificateGenerator> modifyGenerator)

--- a/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Security.Cryptography.X509Certificates;
+using Org.BouncyCastle.X509;
 
 namespace Test.Utility.Signing
 {
@@ -30,27 +31,27 @@ namespace Test.Utility.Signing
         /// Trust the PublicCert cert for the life of the object.
         /// </summary>
         /// <remarks>Dispose of the object returned!</remarks>
-        public TrustedTestCert<TestCertificate> WithTrust()
+        public TrustedTestCert<TestCertificate> WithTrust(StoreName storeName = StoreName.TrustedPeople, StoreLocation storeLocation = StoreLocation.CurrentUser)
         {
-            return new TrustedTestCert<TestCertificate>(this, e => PublicCert);
+            return new TrustedTestCert<TestCertificate>(this, e => PublicCert, storeName, storeLocation);
         }
 
         /// <summary>
         /// Trust the PublicCert cert for the life of the object.
         /// </summary>
         /// <remarks>Dispose of the object returned!</remarks>
-        public TrustedTestCert<TestCertificate> WithPrivateKeyAndTrust()
+        public TrustedTestCert<TestCertificate> WithPrivateKeyAndTrust(StoreName storeName = StoreName.TrustedPeople, StoreLocation storeLocation = StoreLocation.CurrentUser)
         {
-            return new TrustedTestCert<TestCertificate>(this, e => PublicCertWithPrivateKey);
+            return new TrustedTestCert<TestCertificate>(this, e => PublicCertWithPrivateKey, storeName, storeLocation);
         }
 
-        public static TestCertificate Generate()
+        public static TestCertificate Generate(Action<X509V3CertificateGenerator> modifyGenerator = null)
         {
             var certName = "NuGetTest " + Guid.NewGuid().ToString();
 
             var pair = new TestCertificate
             {
-                Cert = SigningTestUtility.GenerateCertificate(certName, modifyGenerator: null)
+                Cert = SigningTestUtility.GenerateCertificate(certName, modifyGenerator)
             };
 
             return pair;

--- a/test/TestUtilities/Test.Utility/Signing/TrustedTestCert.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TrustedTestCert.cs
@@ -17,7 +17,14 @@ namespace Test.Utility.Signing
 
         public T Source { get; }
 
-        public TrustedTestCert(T source, Func<T, X509Certificate2> getCert)
+        public StoreName StoreName { get; }
+
+        public StoreLocation StoreLocation { get; }
+
+        public TrustedTestCert(T source,
+            Func<T, X509Certificate2> getCert,
+            StoreName storeName = StoreName.TrustedPeople,
+            StoreLocation storeLocation = StoreLocation.CurrentUser)
         {
             Source = source;
 
@@ -31,8 +38,9 @@ namespace Test.Utility.Signing
                 throw new InvalidOperationException("The cert used is valid for more than two hours.");
             }
 #endif
-
-            _store = new X509Store(StoreName.TrustedPeople, StoreLocation.CurrentUser);
+            StoreName = storeName;
+            StoreLocation = storeLocation;
+            _store = new X509Store(StoreName, StoreLocation);
             _store.Open(OpenFlags.ReadWrite);
             _store.Add(TrustedCert);
         }
@@ -42,6 +50,9 @@ namespace Test.Utility.Signing
             using (_store)
             {
                 _store.Remove(TrustedCert);
+#if IS_DESKTOP
+                _store.Close();
+#endif
             }
         }
     }


### PR DESCRIPTION
This PR adds the following functionality - 
1. If a certificate has a CNG key (which is not supported in .NET till 4.7.2), we will print a relevant message instead of a generic cryptographic exception.
2. Only allow Code Sign certificates to be used in the sign command - 
    a. By filtering the certificates in the cert picker UI to only code sign certificates.
    b. If a user passes a cert path, validate that it has code sign EKU. Show a relevant failure test if needed.

I have also changed test fixtures to deal with this by adding the trusted certs to LocalMachine/Root. This is needed because code sign certificates need to chain to a trusted root. However, this mandates that these tests need admin privilege to run.


