### PR TITLE
Add CommitmentTypeIndication and SigningCertificateV2 attributes

### DIFF
--- a/src/NuGet.Core/NuGet.Common/CryptoHashUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/CryptoHashUtility.cs
@@ -65,6 +65,17 @@ namespace NuGet.Common
         /// <summary>
         /// Compute the hash as a byte[].
         /// </summary>
+        public static byte[] ComputeHash(this HashAlgorithmName hashAlgorithmName, byte[] data)
+        {
+            using (var provider = hashAlgorithmName.GetHashProvider())
+            {
+                return provider.ComputeHash(data);
+            }
+        }
+
+        /// <summary>
+        /// Compute the hash as a byte[].
+        /// </summary>
         /// <remarks>Closes the stream by default.</remarks>
         /// <param name="hashAlgorithm">Algorithm to use for hashing.</param>
         /// <param name="data">Stream to hash.</param>

--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -50,6 +50,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Update="Signing\DerEncoding\SR.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SR.resx</DependentUpon>
+    </Compile>
     <Compile Update="Strings.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -58,6 +63,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Update="Signing\DerEncoding\SR.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>SR.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
     <EmbeddedResource Update="Strings.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/AttributeUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/AttributeUtility.cs
@@ -1,0 +1,404 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using NuGet.Common;
+using NuGet.Packaging.Signing.DerEncoding;
+using System.Globalization;
+
+#if IS_DESKTOP
+using System.Security.Cryptography.Pkcs;
+#endif
+
+namespace NuGet.Packaging.Signing
+{
+    public static class AttributeUtility
+    {
+#if IS_DESKTOP
+
+        /// <summary>
+        /// Create a CommitmentTypeIndication attribute.
+        /// https://tools.ietf.org/html/rfc5126.html#section-5.11.1
+        /// </summary>
+        public static CryptographicAttributeObject GetCommitmentTypeIndication(SignatureType type)
+        {
+            // SignatureType -> Oid
+            var valueOid = GetSignatureTypeOid(type);
+
+            // DER encode the signature type Oid in a sequence.
+            // CommitmentTypeQualifier ::= SEQUENCE {
+            // commitmentTypeIdentifier CommitmentTypeIdentifier,
+            // qualifier                  ANY DEFINED BY commitmentTypeIdentifier }
+            var commitmentTypeData = DerEncoder.ConstructSequence(new List<byte[][]>() { DerEncoder.SegmentedEncodeOid(valueOid) });
+            var data = new AsnEncodedData(Oids.CommitmentTypeIndication, commitmentTypeData);
+
+            // Create an attribute
+            return new CryptographicAttributeObject(
+                oid: new Oid(Oids.CommitmentTypeIndication),
+                values: new AsnEncodedDataCollection(data));
+        }
+
+        /// <summary>
+        /// Oid -> SignatureType
+        /// </summary>
+        /// <remarks>Unknown Oids are ignored. Throws for empty values and invalid combinations.</remarks>
+        public static SignatureType GetCommitmentTypeIndication(CryptographicAttributeObject attribute)
+        {
+            if (!IsValidCommitmentTypeIndication(attribute))
+            {
+                throw new SignatureException(Strings.CommitmentTypeIndicationAttributeInvalid);
+            }
+
+            // Remove unknown values, these could be future values.
+            // Invalid combinations and empty checks have already been done.
+            var knownValues = GetCommitmentTypeIndicationRawValues(attribute)
+                .Where(e => e != SignatureType.Unknown)
+                .ToList();
+
+            // Return the only recognized value.
+            if (knownValues.Count == 1)
+            {
+                return knownValues[0];
+            }
+
+            // All values were unknown
+            return SignatureType.Unknown;
+        }
+
+        /// <summary>
+        /// True if the commitment-type-indication value does not
+        /// contain an invalid combination of values. Unknown
+        /// values are ignored.
+        /// </summary>
+        public static bool IsValidCommitmentTypeIndication(CryptographicAttributeObject attribute)
+        {
+            var values = GetCommitmentTypeIndicationRawValues(attribute);
+
+            // Zero values is invalid.
+            if (values.Count < 1)
+            {
+                return false;
+            }
+
+            // Remove unknown values, these could be future values.
+            var knownValues = values.Where(e => e != SignatureType.Unknown).ToList();
+
+            // Currently the value must be a single value of author or repository. If multiple
+            // known values exist then either there is a duplicate or both author and repository
+            // was listed in the attribute.
+            if (knownValues.Count > 1)
+            {
+                return false;
+            }
+
+            // A known or unknown value is present, and no invalid combinations exist.
+            return true;
+        }
+
+        /// <summary>
+        /// Oid -> SignatureType
+        /// </summary>
+        public static SignatureType GetSignatureType(string oid)
+        {
+            switch (oid)
+            {
+                case Oids.CommitmentTypeIdentifierProofOfOrigin:
+                    return SignatureType.Author;
+                case Oids.CommitmentTypeIdentifierProofOfReceipt:
+                    return SignatureType.Repository;
+                default:
+                    return SignatureType.Unknown;
+            }
+        }
+
+        /// <summary>
+        /// SignatureType -> Oid
+        /// </summary>
+        public static string GetSignatureTypeOid(SignatureType signatureType)
+        {
+            switch (signatureType)
+            {
+                case SignatureType.Author:
+                    return Oids.CommitmentTypeIdentifierProofOfOrigin;
+                case SignatureType.Repository:
+                    return Oids.CommitmentTypeIdentifierProofOfReceipt;
+                default:
+                    throw new ArgumentException(nameof(signatureType));
+            }
+        }
+
+        /// <summary>
+        /// Create a signing-certificate-v2 from a certificate.
+        /// </summary>
+        public static CryptographicAttributeObject GetSigningCertificateV2(X509Certificate2 cert, Common.HashAlgorithmName hashAlgorithm)
+        {
+            using (var chain = new X509Chain())
+            {
+                chain.Build(cert);
+
+                return GetSigningCertificateV2(SigningUtility.GetCertificateChain(chain), hashAlgorithm);
+            }
+        }
+
+        /// <summary>
+        /// Create a signing-certificate-v2 from a certificate.
+        /// </summary>
+        public static CryptographicAttributeObject GetSigningCertificateV2(IEnumerable<X509Certificate2> chain, Common.HashAlgorithmName hashAlgorithm)
+        {
+            // Build the cert chain as-is
+            var certEntries = chain.Select(e => CreateESSCertIDv2Entry(e, hashAlgorithm)).ToList();
+
+            var data = new AsnEncodedData(Oids.SigningCertificateV2, DerEncoder.ConstructSequence(certEntries));
+
+            // Create an attribute
+            return new CryptographicAttributeObject(
+                oid: new Oid(Oids.SigningCertificateV2),
+                values: new AsnEncodedDataCollection(data));
+        }
+
+        /// <summary>
+        /// Verify a signing-certificate-v2 attribute.
+        /// </summary>
+        public static bool IsValidSigningCertificateV2(
+            X509Certificate2 signatureCertificate,
+            X509Chain chain,
+            CryptographicAttributeObject signingCertV2Attribute,
+            SigningSpecifications signingSpecifications)
+        {
+            return IsValidSigningCertificateV2(
+                signatureCertificate: signatureCertificate,
+                chain: SigningUtility.GetCertificateChain(chain),
+                signingCertV2Attribute: signingCertV2Attribute,
+                signingSpecifications: signingSpecifications);
+        }
+
+        /// <summary>
+        /// Verify a signing-certificate-v2 attribute.
+        /// </summary>
+        public static bool IsValidSigningCertificateV2(
+            X509Certificate2 signatureCertificate,
+            IReadOnlyList<X509Certificate2> chain,
+            CryptographicAttributeObject signingCertV2Attribute,
+            SigningSpecifications signingSpecifications)
+        {
+            return IsValidSigningCertificateV2(
+                signatureCertificate: signatureCertificate,
+                localCertificateChain: chain,
+                attributeCertificateChain: GetESSCertIDv2Entries(signingCertV2Attribute),
+                signingSpecifications: signingSpecifications);
+        }
+
+        /// <summary>
+        /// Verify components of a signing-certificate-v2 attribute.
+        /// </summary>
+        public static bool IsValidSigningCertificateV2(
+            X509Certificate2 signatureCertificate,
+            IReadOnlyList<X509Certificate2> localCertificateChain,
+            IReadOnlyList<KeyValuePair<Common.HashAlgorithmName, byte[]>> attributeCertificateChain,
+            SigningSpecifications signingSpecifications)
+        {
+            // Verify chain counts to avoid unneeded hashing
+            if (localCertificateChain.Count != attributeCertificateChain.Count || attributeCertificateChain.Count < 1)
+            {
+                return false;
+            }
+
+            // Check each entry in the chain
+            for (var i = 0; i < attributeCertificateChain.Count; i++)
+            {
+                var attributeEntry = attributeCertificateChain[i];
+                var localEntry = localCertificateChain[i];
+
+                // Verify hash algorithm is allowed
+                if (!signingSpecifications.AllowedHashAlgorithmOids.Contains(
+                    attributeEntry.Key.ConvertToOidString(),
+                    StringComparer.Ordinal))
+                {
+                    return false;
+                }
+
+                // Hash the local cert using the attribute hash algorithm
+                var localValue = GetESSCertIDv2Entry(localEntry, attributeEntry.Key);
+
+                // Verify the hashes match
+                if (!VerifyHash(localValue, attributeEntry))
+                {
+                    return false;
+                }
+
+                // Verify the first entry is the leaf cert used
+                if (i == 0)
+                {
+                    var leafHash = GetESSCertIDv2Entry(signatureCertificate, attributeEntry.Key);
+
+                    if (!VerifyHash(leafHash, attributeEntry))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Returns the first attribute if the Oid is found.
+        /// Returns null if the attribute is not found.
+        /// </summary>
+        internal static CryptographicAttributeObject GetAttributeOrDefault(this CryptographicAttributeObjectCollection attributes, string oid)
+        {
+            if (oid == null)
+            {
+                throw new ArgumentNullException(nameof(oid));
+            }
+
+            foreach (var attribute in attributes)
+            {
+                if (StringComparer.Ordinal.Equals(oid, attribute.Oid.Value))
+                {
+                    return attribute;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Compare hash values.
+        /// </summary>
+        private static bool VerifyHash(KeyValuePair<Common.HashAlgorithmName, byte[]> a, KeyValuePair<Common.HashAlgorithmName, byte[]> b)
+        {
+            return VerifyHash(a.Value, b.Value);
+        }
+
+        /// <summary>
+        /// Compare hash values.
+        /// </summary>
+        private static bool VerifyHash(byte[] a, byte[] b)
+        {
+            return a.SequenceEqual(b);
+        }
+
+        /// <summary>
+        /// CryptographicAttributeObject -> DerSequenceReader
+        /// </summary>
+        private static DerSequenceReader ToDerSequenceReader(this CryptographicAttributeObject attribute)
+        {
+            var values = attribute.Values.ToList();
+
+            if (values.Count != 1)
+            {
+                ThrowInvalidAttributeException(attribute);
+            }
+
+            return new DerSequenceReader(values[0].RawData);
+        }
+
+        /// <summary>
+        /// Throw a signature exception due to an invalid attribute. This is used for unusual situations
+        /// where the format is corrupt.
+        /// </summary>
+        internal static void ThrowInvalidAttributeException(CryptographicAttributeObject attribute)
+        {
+            throw new SignatureException(string.Format(CultureInfo.CurrentCulture, Strings.SignatureContainsInvalidAttribute, attribute.Oid.Value));
+        }
+
+        /// <summary>
+        /// Enumerate AsnEncodedDataCollection
+        /// </summary>
+        private static List<AsnEncodedData> ToList(this AsnEncodedDataCollection collection)
+        {
+            var values = new List<AsnEncodedData>();
+
+            foreach (var value in collection)
+            {
+                values.Add(value);
+            }
+
+            return values;
+        }
+
+        // ESSCertIDv2::=  SEQUENCE {
+        //    hashAlgorithm AlgorithmIdentifier
+        //           DEFAULT {algorithm id-sha256 },
+        //    certHash Hash,
+        //    issuerSerial IssuerSerial OPTIONAL
+        // }
+        private static byte[][] CreateESSCertIDv2Entry(X509Certificate2 cert, Common.HashAlgorithmName hashAlgorithm)
+        {
+            // Get hash Oid
+            var hashAlgorithmOid = hashAlgorithm.ConvertToOidString();
+            var entry = GetESSCertIDv2Entry(cert, hashAlgorithm);
+
+            return DerEncoder.ConstructSegmentedSequence(new List<byte[][]>()
+            {
+                // AlgorithmIdentifier
+                DerEncoder.SegmentedEncodeOid(hashAlgorithmOid),
+
+                // Hash
+                DerEncoder.SegmentedEncodeOctetString(entry.Value)
+            });
+        }
+
+        // Cert -> Hash pair
+        private static KeyValuePair<Common.HashAlgorithmName, byte[]> GetESSCertIDv2Entry(X509Certificate2 cert, Common.HashAlgorithmName hashAlgorithm)
+        {
+            // Hash the certificate
+            var hashValue = GetCertificateHash(cert, hashAlgorithm);
+
+            return new KeyValuePair<Common.HashAlgorithmName, byte[]>(hashAlgorithm, hashValue);
+        }
+
+        // Cert -> Hash
+        private static byte[] GetCertificateHash(X509Certificate2 cert, Common.HashAlgorithmName hashAlgorithm)
+        {
+            return hashAlgorithm.ComputeHash(cert.RawData);
+        }
+
+        // Attribute -> Hashes
+        private static List<KeyValuePair<Common.HashAlgorithmName, byte[]>> GetESSCertIDv2Entries(CryptographicAttributeObject attribute)
+        {
+            var entries = new List<KeyValuePair<Common.HashAlgorithmName, byte[]>>();
+            var reader = attribute.ToDerSequenceReader();
+
+            while (reader.HasData)
+            {
+                entries.Add(GetESSCertIDv2Entry(reader.ReadSequence()));
+            }
+
+            return entries;
+        }
+
+        // DER -> Hash
+        private static KeyValuePair<Common.HashAlgorithmName, byte[]> GetESSCertIDv2Entry(DerSequenceReader reader)
+        {
+            var hashAlgorithm = CryptoHashUtility.OidToHashAlgorithmName(reader.ReadOidAsString());
+            var attributeHashValue = reader.ReadOctetString();
+
+            return new KeyValuePair<Common.HashAlgorithmName, byte[]>(hashAlgorithm, attributeHashValue);
+        }
+
+                /// <summary>
+        /// Attribute -> SignatureType values with no validation.
+        /// </summary>
+        private static List<SignatureType> GetCommitmentTypeIndicationRawValues(CryptographicAttributeObject attribute)
+        {
+            var values = new List<SignatureType>(1);
+            var reader = attribute.ToDerSequenceReader();
+
+            while (reader.HasData)
+            {
+                values.Add(GetSignatureType(reader.ReadOidAsString()));
+            }
+
+            return values;
+        }
+#endif
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/SignPackageRequest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/SignPackageRequest.cs
@@ -45,5 +45,9 @@ namespace NuGet.Packaging.Signing
 #endif
         }
 
+        /// <summary>
+        /// Author or Repository signature type.
+        /// </summary>
+        public SignatureType SignatureType { get; set; } = SignatureType.Author;
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
@@ -61,7 +61,7 @@ namespace NuGet.Packaging.Signing
 #if IS_DESKTOP
         private Signature CreateSignature(SignPackageRequest request, SignatureManifest signatureManifest)
         {
-            var attributes = SigningUtility.GetSignAttributes();
+            var attributes = SigningUtility.GetSignAttributes(request);
 
             using (request)
             {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Oids.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Oids.cs
@@ -37,5 +37,19 @@ namespace NuGet.Packaging.Signing
 
         // XCN_OID_KP_LIFETIME_SIGNING https://msdn.microsoft.com/en-us/library/windows/desktop/aa378132(v=vs.85).aspx
         public const string LifetimeSignerEkuOid = "1.3.6.1.4.1.311.10.3.13";
+        
+        // RFC 5126 "commitment-type-indication" https://tools.ietf.org/html/rfc5126.html#section-5.11.1
+        public const string CommitmentTypeIndication = "1.2.840.113549.1.9.16.2.16";
+
+        // RFC 5126 "id-cti-ets-proofOfOrigin" https://tools.ietf.org/html/rfc5126.html#section-5.11.1
+        public const string CommitmentTypeIdentifierProofOfOrigin = "1.2.840.113549.1.9.16.6.1";
+
+        // RFC 5126 "id-cti-ets-proofOfReceipt" https://tools.ietf.org/html/rfc5126.html#section-5.11.1
+        public const string CommitmentTypeIdentifierProofOfReceipt = "1.2.840.113549.1.9.16.6.2";
+
+        // RFC 5126 "signing-certificate-v2" https://tools.ietf.org/html/rfc5126.html#page-34
+        public const string SigningCertificateV2 = "1.2.840.113549.1.9.16.2.47";
+
+
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -116,6 +116,24 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to commitment-type-indication attribute contains an invalid value..
+        /// </summary>
+        internal static string CommitmentTypeIndicationAttributeInvalid {
+            get {
+                return ResourceManager.GetString("CommitmentTypeIndicationAttributeInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to commitment-type-indication attribute is invalid..
+        /// </summary>
+        internal static string CommitmentTypeIndicationInvalid {
+            get {
+                return ResourceManager.GetString("CommitmentTypeIndicationInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Certificate inside main SignerInfo is null..
         /// </summary>
         internal static string DebugNoCertificate {
@@ -512,6 +530,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package signature contains an invalid attribute: {0}.
+        /// </summary>
+        internal static string SignatureContainsInvalidAttribute {
+            get {
+                return ResourceManager.GetString("SignatureContainsInvalidAttribute", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Signature hash oid found: {0}.
         /// </summary>
         internal static string SignatureDebug_HashOidFound {
@@ -589,6 +616,15 @@ namespace NuGet.Packaging {
         internal static string SignedPackageUnableToAccessSignature {
             get {
                 return ResourceManager.GetString("SignedPackageUnableToAccessSignature", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to signing-certificate-v2 attribute value does not match the current certificate chain..
+        /// </summary>
+        internal static string SigningCertificateV2Invalid {
+            get {
+                return ResourceManager.GetString("SigningCertificateV2Invalid", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -316,8 +316,14 @@ Valid from:</comment>
   <data name="DebugNoCertificate" xml:space="preserve">
     <value>Certificate inside main SignerInfo is null.</value>
   </data>
+  <data name="CommitmentTypeIndicationAttributeInvalid" xml:space="preserve">
+    <value>commitment-type-indication attribute contains an invalid value.</value>
+  </data>
   <data name="ErrorByteSignatureNotFound" xml:space="preserve">
     <value>Byte signature not found in package archive:</value>
+  </data>
+  <data name="SignatureContainsInvalidAttribute" xml:space="preserve">
+    <value>Package signature contains an invalid attribute: {0}</value>
   </data>
   <data name="ErrorByteSignatureTooBig" xml:space="preserve">
     <value>Byte signature too big to seek in current stream position.</value>
@@ -386,5 +392,11 @@ Valid from:</comment>
     <value>The timestamp service's certificate has a valid time in the future. -
 {0}</value>
     <comment>0 -  X509Certificate2 friendly name</comment>
+  </data>
+  <data name="SigningCertificateV2Invalid" xml:space="preserve">
+    <value>signing-certificate-v2 attribute value does not match the current certificate chain.</value>
+  </data>
+  <data name="CommitmentTypeIndicationInvalid" xml:space="preserve">
+    <value>commitment-type-indication attribute is invalid.</value>
   </data>
 </root>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
@@ -8,6 +8,11 @@
     <UseParallelXunit>true</UseParallelXunit>
   </PropertyGroup>
 
+  <!-- Include internal DER encoding helpers for use in tests -->
+  <ItemGroup>
+    <Compile Include="$(NuGetCoreSrcDirectory)NuGet.Packaging\Signing\DerEncoding\*.cs" />
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
   </ItemGroup>
@@ -18,6 +23,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Security" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedAttributeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedAttributeTests.cs
@@ -1,0 +1,278 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+#if NET46
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using FluentAssertions;
+using Moq;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using NuGet.Packaging.Signing.DerEncoding;
+using Test.Utility.Signing;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class SignedAttributeTests
+    {
+        [Fact]
+        public void GetCommitmentTypeIndication_CommitmentTypeIndicationWithAuthorSignature()
+        {
+            var attribute = AttributeUtility.GetCommitmentTypeIndication(SignatureType.Author);
+            AttributeUtility.GetCommitmentTypeIndication(attribute).Should().Be(SignatureType.Author);
+        }
+
+        [Fact]
+        public void GetCommitmentTypeIndication_CommitmentTypeIndicationWithRepositorySignature()
+        {
+            var attribute = AttributeUtility.GetCommitmentTypeIndication(SignatureType.Repository);
+            AttributeUtility.GetCommitmentTypeIndication(attribute).Should().Be(SignatureType.Repository);
+        }
+
+        [Fact]
+        public void GetCommitmentTypeIndication_CommitmentTypeIndicationWithAuthorSignatureAndUnknownVerifyAuthor()
+        {
+            var attribute = GetCommitmentTypeTestAttribute(Oids.CommitmentTypeIdentifierProofOfOrigin, "1.3.6.1.5.5.7.3.3");
+            AttributeUtility.GetCommitmentTypeIndication(attribute).Should().Be(SignatureType.Author);
+        }
+
+        [Fact]
+        public void GetCommitmentTypeIndication_CommitmentTypeIndicationWithUnknownSignatureType()
+        {
+            var attribute = GetCommitmentTypeTestAttribute("1.3.6.1.5.5.7.3.3");
+            AttributeUtility.GetCommitmentTypeIndication(attribute).Should().Be(SignatureType.Unknown);
+        }
+
+        [Fact]
+        public void IsValidCommitmentTypeIndication_CommitmentTypeIndicationWithBothRepoAndAuthorVerifyFailure()
+        {
+            var attribute = GetCommitmentTypeTestAttribute(Oids.CommitmentTypeIdentifierProofOfReceipt, Oids.CommitmentTypeIdentifierProofOfOrigin);
+            AttributeUtility.IsValidCommitmentTypeIndication(attribute).Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsValidCommitmentTypeIndication_CommitmentTypeIndicationWithDuplicateValuesVerifyFailure()
+        {
+            var attribute = GetCommitmentTypeTestAttribute(Oids.CommitmentTypeIdentifierProofOfOrigin, Oids.CommitmentTypeIdentifierProofOfOrigin);
+            AttributeUtility.IsValidCommitmentTypeIndication(attribute).Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsValidCommitmentTypeIndication_CommitmentTypeIndicationWithNoValueVerifyFailure()
+        {
+            var attribute = GetCommitmentTypeTestAttribute();
+            AttributeUtility.IsValidCommitmentTypeIndication(attribute).Should().BeFalse();
+        }
+
+        [Fact]
+        public void GetCommitmentTypeIndication_CommitmentTypeIndicationWithBothRepoAndAuthorVerifyThrows()
+        {
+            var attribute = GetCommitmentTypeTestAttribute(Oids.CommitmentTypeIdentifierProofOfReceipt, Oids.CommitmentTypeIdentifierProofOfOrigin);
+            Assert.Throws<SignatureException>(() => AttributeUtility.GetCommitmentTypeIndication(attribute));
+        }
+
+        [Fact]
+        public void GetCommitmentTypeIndication_CommitmentTypeIndicationWithDuplicateValuesVerifyThrows()
+        {
+            var attribute = GetCommitmentTypeTestAttribute(Oids.CommitmentTypeIdentifierProofOfOrigin, Oids.CommitmentTypeIdentifierProofOfOrigin);
+            Assert.Throws<SignatureException>(() => AttributeUtility.GetCommitmentTypeIndication(attribute));
+        }
+
+        [Fact]
+        public void GetCommitmentTypeIndication_CommitmentTypeIndicationWithNoValueVerifyThrows()
+        {
+            var attribute = GetCommitmentTypeTestAttribute();
+            Assert.Throws<SignatureException>(() => AttributeUtility.GetCommitmentTypeIndication(attribute));
+        }
+
+        [Fact]
+        public void IsValidSigningCertificateV2_VerifySuccess()
+        {
+            var cert = TestCertificate.Generate();
+            var attribute = AttributeUtility.GetSigningCertificateV2(new[] { cert.PublicCert }, Common.HashAlgorithmName.SHA512);
+            AttributeUtility.IsValidSigningCertificateV2(cert.PublicCert, new[] { cert.PublicCert }, attribute, SigningSpecifications.V1).Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsValidSigningCertificateV2_VerifyFailure()
+        {
+            var cert = TestCertificate.Generate();
+            var cert2 = TestCertificate.Generate();
+            var attribute = AttributeUtility.GetSigningCertificateV2(new[] { cert.PublicCert }, Common.HashAlgorithmName.SHA512);
+            AttributeUtility.IsValidSigningCertificateV2(cert2.PublicCert, new[] { cert2.PublicCert }, attribute, SigningSpecifications.V1).Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsValidSigningCertificateV2_HashNotAllowedVerifyFailure()
+        {
+            var cert = TestCertificate.Generate();
+
+            // Allow only 512
+            var spec = new Mock<SigningSpecifications>();
+            spec.SetupGet(e => e.AllowedHashAlgorithmOids).Returns(new string[] { Common.HashAlgorithmName.SHA512.ConvertToOidString() });
+
+            // Hash with 256
+            var attribute = AttributeUtility.GetSigningCertificateV2(new[] { cert.PublicCert }, Common.HashAlgorithmName.SHA256);
+
+            // Verify failure
+            AttributeUtility.IsValidSigningCertificateV2(cert.PublicCert, new[] { cert.PublicCert }, attribute, spec.Object).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SignedAttribute_IsValidSigningCertificateV2_SignatureCertIsNotFirstInListVerifyFailure()
+        {
+            var signerLeaf = TestCertificate.Generate().PublicCert;
+            var rootCert = TestCertificate.Generate().PublicCert;
+
+            var localChain = new List<X509Certificate2>() { rootCert, signerLeaf };
+            var attributeChain = new List<KeyValuePair<Common.HashAlgorithmName, byte[]>>()
+            {
+                new KeyValuePair<Common.HashAlgorithmName, byte[]>(Common.HashAlgorithmName.SHA512, Common.HashAlgorithmName.SHA512.GetHashProvider().ComputeHash(rootCert.RawData)),
+                new KeyValuePair<Common.HashAlgorithmName, byte[]>(Common.HashAlgorithmName.SHA512, Common.HashAlgorithmName.SHA512.GetHashProvider().ComputeHash(signerLeaf.RawData))
+            };
+
+            // Verify leaf node is first in the list
+            AttributeUtility.IsValidSigningCertificateV2(signerLeaf, localChain, attributeChain, SigningSpecifications.V1)
+                .Should()
+                .BeFalse();
+        }
+
+        [Fact]
+        public void IsValidSigningCertificateV2_OrderChangeVerifyFailure()
+        {
+            var child = TestCertificate.Generate().PublicCert;
+            var parent = TestCertificate.Generate().PublicCert;
+
+            var localChain = new List<X509Certificate2>() { child, parent };
+            var attributeChain = new List<KeyValuePair<Common.HashAlgorithmName, byte[]>>()
+            {
+                new KeyValuePair<Common.HashAlgorithmName, byte[]>(Common.HashAlgorithmName.SHA512, Common.HashAlgorithmName.SHA512.GetHashProvider().ComputeHash(parent.RawData)),
+                new KeyValuePair<Common.HashAlgorithmName, byte[]>(Common.HashAlgorithmName.SHA512, Common.HashAlgorithmName.SHA512.GetHashProvider().ComputeHash(child.RawData))
+            };
+
+            AttributeUtility.IsValidSigningCertificateV2(child, localChain, attributeChain, SigningSpecifications.V1)
+                .Should()
+                .BeFalse();
+
+            AttributeUtility.IsValidSigningCertificateV2(parent, localChain, attributeChain, SigningSpecifications.V1)
+                .Should()
+                .BeFalse();
+        }
+
+        [Fact]
+        public void IsValidSigningCertificateV2_AttributeCountChangeVerifyFailure()
+        {
+            var child = TestCertificate.Generate().PublicCert;
+            var parent = TestCertificate.Generate().PublicCert;
+            var extra = TestCertificate.Generate().PublicCert;
+
+            var localChain = new List<X509Certificate2>() { child, parent };
+            var attributeChain = new List<KeyValuePair<Common.HashAlgorithmName, byte[]>>()
+            {
+                new KeyValuePair<Common.HashAlgorithmName, byte[]>(Common.HashAlgorithmName.SHA512, Common.HashAlgorithmName.SHA512.GetHashProvider().ComputeHash(child.RawData)),
+                new KeyValuePair<Common.HashAlgorithmName, byte[]>(Common.HashAlgorithmName.SHA512, Common.HashAlgorithmName.SHA512.GetHashProvider().ComputeHash(parent.RawData)),
+                new KeyValuePair<Common.HashAlgorithmName, byte[]>(Common.HashAlgorithmName.SHA512, Common.HashAlgorithmName.SHA512.GetHashProvider().ComputeHash(extra.RawData))
+            };
+
+            AttributeUtility.IsValidSigningCertificateV2(child, localChain, attributeChain, SigningSpecifications.V1)
+                .Should()
+                .BeFalse();
+        }
+
+        [Fact]
+        public void IsValidSigningCertificateV2_LocalCountChangeVerifyFailure()
+        {
+            var child = TestCertificate.Generate().PublicCert;
+            var parent = TestCertificate.Generate().PublicCert;
+            var extra = TestCertificate.Generate().PublicCert;
+
+            var localChain = new List<X509Certificate2>() { child, parent, extra };
+            var attributeChain = new List<KeyValuePair<Common.HashAlgorithmName, byte[]>>()
+            {
+                new KeyValuePair<Common.HashAlgorithmName, byte[]>(Common.HashAlgorithmName.SHA512, Common.HashAlgorithmName.SHA512.GetHashProvider().ComputeHash(child.RawData)),
+                new KeyValuePair<Common.HashAlgorithmName, byte[]>(Common.HashAlgorithmName.SHA512, Common.HashAlgorithmName.SHA512.GetHashProvider().ComputeHash(parent.RawData))
+            };
+
+            AttributeUtility.IsValidSigningCertificateV2(child, localChain, attributeChain, SigningSpecifications.V1)
+                .Should()
+                .BeFalse();
+        }
+
+        [Fact]
+        public void IsValidSigningCertificateV2_HashChangeVerifyFailure()
+        {
+            var child = TestCertificate.Generate().PublicCert;
+            var parent = TestCertificate.Generate().PublicCert;
+
+            var localChain = new List<X509Certificate2>() { child, parent };
+            var attributeChain = new List<KeyValuePair<Common.HashAlgorithmName, byte[]>>()
+            {
+                new KeyValuePair<Common.HashAlgorithmName, byte[]>(Common.HashAlgorithmName.SHA512, Common.HashAlgorithmName.SHA512.GetHashProvider().ComputeHash(child.RawData)),
+                new KeyValuePair<Common.HashAlgorithmName, byte[]>(Common.HashAlgorithmName.SHA512, new byte[] { 1, 1, 1 })
+            };
+
+            AttributeUtility.IsValidSigningCertificateV2(child, localChain, attributeChain, SigningSpecifications.V1)
+                .Should()
+                .BeFalse();
+        }
+
+        [Fact]
+        public void IsValidSigningCertificateV2_EmptyChainVerifyFailure()
+        {
+            var child = TestCertificate.Generate().PublicCert;
+            var parent = TestCertificate.Generate().PublicCert;
+
+            var localChain = new List<X509Certificate2>() { child, parent };
+            var attributeChain = new List<KeyValuePair<Common.HashAlgorithmName, byte[]>>();
+
+            AttributeUtility.IsValidSigningCertificateV2(child, localChain, attributeChain, SigningSpecifications.V1)
+                .Should()
+                .BeFalse();
+        }
+
+        [Fact]
+        public void IsValidSigningCertificateV2_DirectHashVerifySuccess()
+        {
+            var child = TestCertificate.Generate().PublicCert;
+            var parent = TestCertificate.Generate().PublicCert;
+
+            var localChain = new List<X509Certificate2>() { child, parent };
+            var attributeChain = new List<KeyValuePair<Common.HashAlgorithmName, byte[]>>()
+            {
+                new KeyValuePair<Common.HashAlgorithmName, byte[]>(Common.HashAlgorithmName.SHA512, Common.HashAlgorithmName.SHA512.GetHashProvider().ComputeHash(child.RawData)),
+                new KeyValuePair<Common.HashAlgorithmName, byte[]>(Common.HashAlgorithmName.SHA512, Common.HashAlgorithmName.SHA512.GetHashProvider().ComputeHash(parent.RawData)),
+            };
+
+            AttributeUtility.IsValidSigningCertificateV2(child, localChain, attributeChain, SigningSpecifications.V1)
+                .Should()
+                .BeTrue();
+        }
+
+        /// <summary>
+        /// Allows encoding bad data that the production helper does not.
+        /// </summary>
+        private static CryptographicAttributeObject GetCommitmentTypeTestAttribute(params string[] oids)
+        {
+            var values = new List<byte[][]>();
+
+            foreach (var oid in oids)
+            {
+                values.Add(DerEncoder.SegmentedEncodeOid(oid));
+            }
+
+            var commitmentTypeData = DerEncoder.ConstructSequence(values);
+            var data = new AsnEncodedData(Oids.CommitmentTypeIndication, commitmentTypeData);
+
+            // Create an attribute
+            return new CryptographicAttributeObject(
+                oid: new Oid(Oids.CommitmentTypeIndication),
+                values: new AsnEncodedDataCollection(data));
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
Add CommitmentTypeIndication and SigningCertificateV2 attributes

This may need to be updated to react to other verification and signing PRs. I've tried to put everything into static utility methods to make it easy to move around where signing and verification of these attributes occur.

Fixes https://github.com/NuGet/Home/issues/6174
Fixes https://github.com/NuGet/Home/issues/6172
