### PR TITLE
Fix timestamping

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Native/NativeMethods.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Native/NativeMethods.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace NuGet.Packaging.Signing
 {
@@ -16,7 +14,7 @@ namespace NuGet.Packaging.Signing
         internal const int ERROR_MORE_DATA = 234;
         internal const uint CMSG_SIGNED = 2;
 
-        [DllImport("Crypt32.dll", SetLastError = true)]
+        [DllImport("crypt32.dll", SetLastError = true)]
         public static extern SafeCryptMsgHandle CryptMsgOpenToEncode(
             uint dwMsgEncodingType,
             uint dwFlags,
@@ -91,7 +89,7 @@ namespace NuGet.Packaging.Signing
     }
 
     internal sealed class SafeCryptMsgHandle : SafeHandle
-    { 
+    {
         internal static SafeCryptMsgHandle InvalidHandle => new SafeCryptMsgHandle(IntPtr.Zero);
 
         public override bool IsInvalid => handle == IntPtr.Zero;
@@ -139,7 +137,7 @@ namespace NuGet.Packaging.Signing
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal struct CRYPT_INTEGER_BLOB_INTPTR
+    internal struct CRYPT_INTEGER_BLOB
     {
         internal uint cbData;
         internal IntPtr pbData;
@@ -159,7 +157,7 @@ namespace NuGet.Packaging.Signing
     {
         internal uint cbSize;
         internal uint dwSignerIndex;
-        internal CRYPT_INTEGER_BLOB_INTPTR BLOB;
+        internal CRYPT_INTEGER_BLOB BLOB;
     }
 
     [Flags]
@@ -270,13 +268,13 @@ namespace NuGet.Packaging.Signing
     internal struct CRYPT_ALGORITHM_IDENTIFIER
     {
         public string pszObjId;
-        public CRYPT_INTEGER_BLOB_INTPTR Parameters;
+        public CRYPT_INTEGER_BLOB Parameters;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct BLOB
     {
-        public int cbData;
+        public uint cbData;
         public IntPtr pbData;
 
         public void Dispose()
@@ -288,7 +286,7 @@ namespace NuGet.Packaging.Signing
     [StructLayout(LayoutKind.Sequential)]
     internal struct CERT_ID
     {
-        internal int dwIdChoice;
+        internal uint dwIdChoice;
         internal BLOB IssuerSerialNumberOrKeyIdOrHashId;
     }
 
@@ -309,9 +307,9 @@ namespace NuGet.Packaging.Signing
     [StructLayout(LayoutKind.Sequential)]
     internal struct CERT_CONTEXT
     {
-        public int dwCertEncodingType;
+        public uint dwCertEncodingType;
         public IntPtr pbCertEncoded;
-        public int cbCertEncoded;
+        public uint cbCertEncoded;
         public IntPtr pCertInfo;
         public IntPtr hCertStore;
     }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSignCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSignCommandTest.cs
@@ -6,7 +6,6 @@ using System.Security.Cryptography.X509Certificates;
 using Moq;
 using NuGet.Commands;
 using NuGet.Common;
-using NuGet.Packaging.Signing;
 using Xunit;
 
 namespace NuGet.CommandLine.Test
@@ -313,8 +312,6 @@ namespace NuGet.CommandLine.Test
             var nonInteractive = true;
             var overwrite = true;
             var outputDir = @".\test\output\path";
-            var csp = "csp_name";
-            var kc = "kc_name";
             var mockConsole = new Mock<IConsole>();
             mockConsole.Setup(c => c.Verbosity).Returns(Verbosity.Detailed);
 
@@ -369,8 +366,6 @@ namespace NuGet.CommandLine.Test
             var nonInteractive = true;
             var overwrite = true;
             var outputDir = @".\test\output\path";
-            var csp = "csp_name";
-            var kc = "kc_name";
             var mockConsole = new Mock<IConsole>();
             mockConsole.Setup(c => c.Verbosity).Returns(Verbosity.Detailed);
 
@@ -425,8 +420,6 @@ namespace NuGet.CommandLine.Test
             var nonInteractive = true;
             var overwrite = true;
             var outputDir = @".\test\output\path";
-            var csp = "csp_name";
-            var kc = "kc_name";
             var mockConsole = new Mock<IConsole>();
             mockConsole.Setup(c => c.Verbosity).Returns(Verbosity.Detailed);
 


### PR DESCRIPTION
Fix NuGet/Home#6258.

Timestamping was broken by the removal of [this statement](https://github.com/NuGet/NuGet.Client/pull/1823/files#diff-9de9a2555ba61a56b5d822d0d90bf765L147) in NuGet/NuGet.Client#1823.

Also cleaned up some code/comments.

CC @onovotny