### PR TITLE
Make VersionRange.TryParse return false on null values instead of throwing

### DIFF
--- a/src/NuGet.Core/NuGet.Versioning/VersionRangeFactory.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRangeFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -59,6 +59,11 @@ namespace NuGet.Versioning
         /// </summary>
         public static VersionRange Parse(string value, bool allowFloating)
         {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
             VersionRange versionInfo;
             if (!TryParse(value, allowFloating, out versionInfo))
             {
@@ -83,12 +88,12 @@ namespace NuGet.Versioning
         /// </summary>
         public static bool TryParse(string value, bool allowFloating, out VersionRange versionRange)
         {
+            versionRange = null;
+
             if (value == null)
             {
-                throw new ArgumentNullException(nameof(value));
+                return false;
             }
-
-            versionRange = null;
 
             var trimmedValue = value.Trim();
 

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -559,6 +559,20 @@ namespace NuGet.Versioning.Test
 
             Assert.False(parsed);
             Assert.Null(versionInfo);
+        }
+
+        [Fact]
+        public void TryParseNullVersionRange()
+        {
+            // Arrange
+            VersionRange output;
+
+            // Act
+            var parsed = VersionRange.TryParse(null, out output);
+
+            // Assert
+            Assert.False(parsed);
+            Assert.Null(output);
         }
 
         [Fact]


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6247
Regression: no

## Fix
Details: explicitly handle the `null` can and return `false` instead of throwing

## Testing/Validation
Tests Added: yes
Validation done: CI pending 
