### PR TITLE
fixing invalid Enhanced Key Usage NU error code

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
@@ -117,7 +117,7 @@ namespace NuGet.Commands
                 exceptionBuilder.AppendLine(Strings.SignCommandInvalidCertEku);
                 exceptionBuilder.AppendLine(CertificateUtility.X509Certificate2ToString(cert));
 
-                throw new SignCommandException(LogMessage.CreateError(NuGetLogCode.NU3013, exceptionBuilder.ToString()));
+                throw new SignCommandException(LogMessage.CreateError(NuGetLogCode.NU3012, exceptionBuilder.ToString()));
             }
         }
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -2,11 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
-using System.Threading.Tasks;
 using FluentAssertions;
 using NuGet.Test.Utility;
 using Test.Utility.Signing;
@@ -23,7 +20,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
     {
         private const string _packageAlreadySignedError = "Error NU5000: The package already contains a signature. Please remove the existing signature before adding a new signature.";
         private const string _invalidPasswordErrorCode = "NU3014";
-        private const string _invalidEkuErrorCode = "NU3013";
+        private const string _invalidEkuErrorCode = "NU3012";
         private const string _noTimestamperWarningCode = "NU3521";
 
         private SignCommandTestFixture _testFixture;


### PR DESCRIPTION
Fixing the NU error code for invalid EKU for a certificate used to sign a package. Missed as part of https://github.com/NuGet/NuGet.Client/pull/1836.