### PR TITLE
Fixing tests broken because of IDisposable SigningPackageRequest

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedArchiveTestUtility.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedArchiveTestUtility.cs
@@ -23,7 +23,7 @@ namespace NuGet.Packaging.FuncTest
         /// <param name="nupkg">Package to be signed</param>
         /// <param name="dir">Directory for placing the signed package</param>
         /// <returns>Path to the signed copy of the package</returns>
-        public static async Task<string> CreateSignedPackageAsync(TrustedTestCert<TestCertificate> testCert, SimpleTestPackageContext nupkg, string dir)
+        public static async Task<string> CreateSignedPackageAsync(X509Certificate2 testCert, SimpleTestPackageContext nupkg, string dir)
         {
             var testLogger = new TestLogger();
 
@@ -34,7 +34,7 @@ namespace NuGet.Packaging.FuncTest
                 using (var signPackage = new SignedPackageArchive(zipWriteStream))
                 {
                     // Sign the package
-                    await SignPackageAsync(testLogger, testCert.Source.Cert, signPackage);
+                    await SignPackageAsync(testLogger, testCert, signPackage);
                 }
 
                 zipWriteStream.Seek(offset: 0, loc: SeekOrigin.Begin);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageVerifierTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageVerifierTests.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,9 +25,11 @@ namespace NuGet.Packaging.FuncTest
     [Collection("Signing Funtional Test Collection")]
     public class SignedPackageVerifierTests
     {
-        private const string _packageTamperedError = "Package integrity check failed. The package has been tampered.";
+        private const string _packageTamperedError = "Package integrity check failed.";
         private const string _packageUnsignedError = "Package is not signed.";
         private const string _packageInvalidSignatureError = "Package signature is invalid.";
+        private static readonly string _testCertPassword = Guid.NewGuid().ToString();
+
         private SigningSpecifications _specification => SigningSpecifications.V1;
 
         private SigningTestFixture _testFixture;
@@ -44,11 +47,13 @@ namespace NuGet.Packaging.FuncTest
         public async Task Signer_VerifyOnSignedPackageAsync()
         {
             // Arrange
-            var nupkg = new SimpleTestPackageContext();
+            var nupkg = new SimpleTestPackageContext();            
 
             using (var dir = TestDirectory.Create())
+            using (var testCertificate = new X509Certificate2())
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
+                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
                 var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
@@ -69,8 +74,10 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
+            using (var testCertificate = new X509Certificate2())
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
+                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 // tamper with the package
                 using (var stream = File.Open(signedPackagePath, FileMode.Open))
@@ -106,8 +113,10 @@ namespace NuGet.Packaging.FuncTest
             var newEntryData = "malicious code";
             var newEntryName = "malicious file";
             using (var dir = TestDirectory.Create())
+            using (var testCertificate = new X509Certificate2())
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
+                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 // tamper with the package
                 using (var stream = File.Open(signedPackagePath, FileMode.Open))
@@ -146,8 +155,10 @@ namespace NuGet.Packaging.FuncTest
             var extraData = "tampering data";
 
             using (var dir = TestDirectory.Create())
+            using (var testCertificate = new X509Certificate2())
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
+                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 // tamper with the package
                 using (var stream = File.Open(signedPackagePath, FileMode.Open))
@@ -185,8 +196,10 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
+            using (var testCertificate = new X509Certificate2())
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
+                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 // tamper with the package
                 using (var stream = File.Open(signedPackagePath, FileMode.Open))
@@ -222,8 +235,10 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
+            using (var testCertificate = new X509Certificate2())
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
+                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 // tamper with the package
                 using (var stream = File.Open(signedPackagePath, FileMode.Open))
@@ -262,8 +277,10 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
+            using (var testCertificate = new X509Certificate2())
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
+                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 // unsign the package
                 using (var stream = File.Open(signedPackagePath, FileMode.Open))
@@ -299,8 +316,10 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
+            using (var testCertificate = new X509Certificate2())
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
+                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 // unsign the package
                 using (var stream = File.Open(signedPackagePath, FileMode.Open))
@@ -334,8 +353,10 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
+            using (var testCertificate = new X509Certificate2())
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
+                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 // tamper with the signature
                 using (var stream = File.Open(signedPackagePath, FileMode.Open))

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageVerifierTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageVerifierTests.cs
@@ -50,9 +50,8 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();            
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = new X509Certificate2())
+            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
             {
-                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
                 var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
 
@@ -74,9 +73,8 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = new X509Certificate2())
+            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
             {
-                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 // tamper with the package
@@ -112,10 +110,10 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
             var newEntryData = "malicious code";
             var newEntryName = "malicious file";
+
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = new X509Certificate2())
+            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
             {
-                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 // tamper with the package
@@ -155,9 +153,8 @@ namespace NuGet.Packaging.FuncTest
             var extraData = "tampering data";
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = new X509Certificate2())
+            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
             {
-                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 // tamper with the package
@@ -196,9 +193,8 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = new X509Certificate2())
+            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
             {
-                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 // tamper with the package
@@ -235,9 +231,8 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = new X509Certificate2())
+            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
             {
-                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 // tamper with the package
@@ -277,9 +272,8 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = new X509Certificate2())
+            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
             {
-                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 // unsign the package
@@ -316,9 +310,8 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = new X509Certificate2())
+            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
             {
-                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 // unsign the package
@@ -353,9 +346,8 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = new X509Certificate2())
+            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
             {
-                testCertificate.Import(_trustedTestCert.Source.Cert.Export(X509ContentType.Pfx, _testCertPassword), _testCertPassword, X509KeyStorageFlags.PersistKeySet);
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 // tamper with the signature

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageVerifierTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageVerifierTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -48,7 +49,7 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
                 var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
@@ -71,7 +72,7 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
@@ -110,7 +111,7 @@ namespace NuGet.Packaging.FuncTest
             var newEntryName = "malicious file";
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
@@ -151,7 +152,7 @@ namespace NuGet.Packaging.FuncTest
             var extraData = "tampering data";
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
@@ -191,7 +192,7 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
@@ -229,7 +230,7 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
@@ -270,7 +271,7 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
@@ -308,7 +309,7 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
@@ -344,7 +345,7 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageVerifierTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageVerifierTests.cs
@@ -5,11 +5,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -47,7 +45,7 @@ namespace NuGet.Packaging.FuncTest
         public async Task Signer_VerifyOnSignedPackageAsync()
         {
             // Arrange
-            var nupkg = new SimpleTestPackageContext();            
+            var nupkg = new SimpleTestPackageContext();
 
             using (var dir = TestDirectory.Create())
             using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
@@ -40,9 +40,10 @@ namespace NuGet.Packaging.FuncTest
             var testLogger = new TestLogger();
 
             using (var dir = TestDirectory.Create())
+            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
             {
                 // Act
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert.Source.Cert, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 // Assert
                 using (var stream = File.OpenRead(signedPackagePath))
@@ -61,9 +62,10 @@ namespace NuGet.Packaging.FuncTest
             var testLogger = new TestLogger();
 
             using (var dir = TestDirectory.Create())
+            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
             {
                 // Act
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert.Source.Cert, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
 
                 using (var stream = File.OpenRead(signedPackagePath))
                 using (var zip = new ZipArchive(stream, ZipArchiveMode.Read))

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
@@ -42,7 +42,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             {
                 // Act
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert.Source.Cert, nupkg, dir);
 
                 // Assert
                 using (var stream = File.OpenRead(signedPackagePath))
@@ -63,7 +63,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             {
                 // Act
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(_trustedTestCert.Source.Cert, nupkg, dir);
 
                 using (var stream = File.OpenRead(signedPackagePath))
                 using (var zip = new ZipArchive(stream, ZipArchiveMode.Read))

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NuGet.Packaging.Signing;
@@ -40,7 +41,7 @@ namespace NuGet.Packaging.FuncTest
             var testLogger = new TestLogger();
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 // Act
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
@@ -62,7 +63,7 @@ namespace NuGet.Packaging.FuncTest
             var testLogger = new TestLogger();
 
             using (var dir = TestDirectory.Create())
-            using (var testCertificate = SigningTestUtility.CopyCertificate(_trustedTestCert.Source.Cert))
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 // Act
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.Packaging.Signing;
-using Org.BouncyCastle.Asn1.X509;
-using Org.BouncyCastle.X509;
 using Test.Utility.Signing;
 
 namespace NuGet.Packaging.FuncTest

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -4,9 +4,8 @@
 #if IS_DESKTOP
 
 using System;
-using System.Diagnostics;
-using System.Linq;
 using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using FluentAssertions;
@@ -18,6 +17,7 @@ using Xunit;
 
 namespace NuGet.Packaging.FuncTest
 {
+    [Collection("Signing Funtional Test Collection")]
     public class TimestampProviderTests
     {
         private const string _internalTimestamper = "http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer";
@@ -25,16 +25,26 @@ namespace NuGet.Packaging.FuncTest
         private const string _argumentNullExceptionMessage = "Value cannot be null.\r\nParameter name: {0}";
         private const string _operationCancelledExceptionMessage = "The operation was canceled.";
 
+        private SigningTestFixture _testFixture;
+        private TrustedTestCert<TestCertificate> _trustedTestCert;
+        private SigningSpecifications _signingSpecifications;
+
+        public TimestampProviderTests(SigningTestFixture fixture)
+        {
+            _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+            _trustedTestCert = _testFixture.TrustedTestCertificate;
+            _signingSpecifications = _testFixture.SigningSpecifications;
+        }
+
         [CIOnlyFact]
         public void Rfc3161TimestampProvider_Success()
         {
             // Arrange
             var logger = new TestLogger();
             var timestampProvider = new Rfc3161TimestampProvider(new Uri(_internalTimestamper));
-            var authorCertName = "author@nuget.func.test";
             var data = "Test data to be signed and timestamped";
 
-            using (var authorCert = SigningTestUtility.GenerateCertificate(authorCertName, modifyGenerator: null))
+            using (var authorCert = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 var signedCms = SigningTestUtility.GenerateSignedCms(authorCert, Encoding.ASCII.GetBytes(data));
                 var signatureValue = signedCms.Encode();
@@ -108,10 +118,9 @@ namespace NuGet.Packaging.FuncTest
             // Arrange
             var logger = new TestLogger();
             var timestampProvider = new Rfc3161TimestampProvider(new Uri(_internalTimestamper));
-            var authorCertName = "author@nuget.func.test";
             var data = "Test data to be signed and timestamped";
 
-            using (var authorCert = SigningTestUtility.GenerateCertificate(authorCertName, modifyGenerator: null))
+            using (var authorCert = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 var signedCms = SigningTestUtility.GenerateSignedCms(authorCert, Encoding.ASCII.GetBytes(data));
                 var signatureValue = signedCms.Encode();
@@ -139,10 +148,9 @@ namespace NuGet.Packaging.FuncTest
             // Arrange
             var logger = new TestLogger();
             var timestampProvider = new Rfc3161TimestampProvider(new Uri(_internalTimestamper));
-            var authorCertName = "author@nuget.func.test";
             var data = "Test data to be signed and timestamped";
 
-            using (var authorCert = SigningTestUtility.GenerateCertificate(authorCertName, modifyGenerator: null))
+            using (var authorCert = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 var signedCms = SigningTestUtility.GenerateSignedCms(authorCert, Encoding.ASCII.GetBytes(data));
                 var signatureValue = signedCms.Encode();

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/CIOnlyFactAttribute.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/CIOnlyFactAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -21,7 +21,7 @@ namespace NuGet.Test.Utility
 
                 if (string.IsNullOrEmpty(skip))
                 {
-                    if (XunitAttributeUtility.IsCI)
+                    if (!XunitAttributeUtility.IsCI)
                     {
                         skip = "This test only runs on the CI. To run it locally set the env var CI=true";
                     }

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -23,23 +23,6 @@ namespace Test.Utility.Signing
 {
     public static class SigningTestUtility
     {
-        private static string _testCertPassword = Guid.NewGuid().ToString();
-
-        /// <summary>
-        /// Creates a copy of an X509Certificate2 by exporting the original certificate into a pfx file.
-        /// </summary>
-        /// <param name="originalCertificate">X509Certificate2 to be copied.</param>
-        /// <returns>X509Certificate2 copy of the originalCertificate.</returns>
-        public static X509Certificate2 CopyCertificate(X509Certificate2 originalCertificate)
-        {
-            var copiedCertificate = new X509Certificate2(
-                originalCertificate.Export(X509ContentType.Pfx, _testCertPassword),
-                _testCertPassword,
-                X509KeyStorageFlags.PersistKeySet);
-
-            return copiedCertificate;
-        }
-
         /// <summary>
         /// Modification generator that can be passed to TestCertificate.Generate().
         /// The generator will change the certificate EKU to ClientAuth.

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -23,6 +23,23 @@ namespace Test.Utility.Signing
 {
     public static class SigningTestUtility
     {
+        private static string _testCertPassword = Guid.NewGuid().ToString();
+
+        /// <summary>
+        /// Creates a copy of an X509Certificate2 by exporting the original certificate into a pfx file.
+        /// </summary>
+        /// <param name="originalCertificate">X509Certificate2 to be copied.</param>
+        /// <returns>X509Certificate2 copy of the originalCertificate.</returns>
+        public static X509Certificate2 CopyCertificate(X509Certificate2 originalCertificate)
+        {
+            var copiedCertificate = new X509Certificate2(
+                originalCertificate.Export(X509ContentType.Pfx, _testCertPassword),
+                _testCertPassword,
+                X509KeyStorageFlags.PersistKeySet);
+
+            return copiedCertificate;
+        }
+
         /// <summary>
         /// Modification generator that can be passed to TestCertificate.Generate().
         /// The generator will change the certificate EKU to ClientAuth.


### PR DESCRIPTION
As part of 51bf722c4a09b543eca90a2e5857b1af0239d47b, `SignPackageRequest` was made `IDisposable`. As a side effect, tests were broken because the tests shared a single `X509Certificate2` as part of a test fixture, since creation of test certificate is time consuming. 

This PR fixes this by making each test copy the certificate before generating  a signed package. This way even if the certificate is disposed, the following tests will be able to continue without having to create a new test, keeping the test duration small.