### PR TITLE
Added using OS based StringComparer for P2P references

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -14,8 +14,8 @@ namespace NuGet.ProjectModel
 {
     public class DependencyGraphSpec
     {
-        private readonly SortedSet<string> _restore = new SortedSet<string>(StringComparer.Ordinal);
-        private readonly SortedDictionary<string, PackageSpec> _projects = new SortedDictionary<string, PackageSpec>(StringComparer.Ordinal);
+        private readonly SortedSet<string> _restore = new SortedSet<string>(PathUtility.GetStringComparerBasedOnOS());
+        private readonly SortedDictionary<string, PackageSpec> _projects = new SortedDictionary<string, PackageSpec>(PathUtility.GetStringComparerBasedOnOS());
 
         private const int _version = 1;
 
@@ -136,7 +136,7 @@ namespace NuGet.ProjectModel
 
             var closure = new List<PackageSpec>();
 
-            var added = new SortedSet<string>(StringComparer.Ordinal);
+            var added = new SortedSet<string>(PathUtility.GetStringComparerBasedOnOS());
             var toWalk = new Stack<PackageSpec>();
 
             // Start with the root
@@ -197,7 +197,7 @@ namespace NuGet.ProjectModel
         {
             var projects =
                 dgSpecs.SelectMany(e => e.Projects)
-                    .GroupBy(e => e.RestoreMetadata.ProjectUniqueName, StringComparer.Ordinal)
+                    .GroupBy(e => e.RestoreMetadata.ProjectUniqueName, PathUtility.GetStringComparerBasedOnOS())
                     .Select(e => e.First())
                     .ToList();
 
@@ -330,7 +330,7 @@ namespace NuGet.ProjectModel
         {
             return TopologicalSortUtility.SortPackagesByDependencyOrder(
                 items: packages,
-                comparer: StringComparer.Ordinal,
+                comparer: PathUtility.GetStringComparerBasedOnOS(),
                 getId: GetPackageSpecId,
                 getDependencies: GetPackageSpecDependencyIds);
         }
@@ -400,7 +400,7 @@ namespace NuGet.ProjectModel
                 .TargetFrameworks
                 .SelectMany(r => r.ProjectReferences)
                 .Select(r => r.ProjectUniqueName)
-                .Distinct(StringComparer.Ordinal)
+                .Distinct(PathUtility.GetStringComparerBasedOnOS())
                 .ToArray();
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
@@ -66,6 +66,28 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal("44B29B8D-8413-42D2-8DF4-72225659619B", zClosure.Single().RestoreMetadata.ProjectUniqueName);
         }
 
+        [PlatformFact(Platform.Windows)]
+        public void DependencyGraphSpec_ReadFileWithProjects_CaseInsensitive_GetClosures()
+        {
+            // Arrange
+            var json = JObject.Parse(ResourceTestUtility.GetResource("NuGet.ProjectModel.Test.compiler.resources.test3.dg", typeof(DependencyGraphSpecTests)));
+
+            // Act
+            var dg = DependencyGraphSpec.Load(json);
+
+            var xClosure = dg.GetClosure("A55205E7-4D08-4672-8011-0925467CC45F").OrderBy(e => e.RestoreMetadata.ProjectUniqueName, StringComparer.OrdinalIgnoreCase).ToList();
+            var yClosure = dg.GetClosure("78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F").OrderBy(e => e.RestoreMetadata.ProjectUniqueName, StringComparer.OrdinalIgnoreCase).ToList();
+
+            // Assert
+            Assert.Equal(3, xClosure.Count);
+            Assert.Equal("44B29B8D-8413-42D2-8DF4-72225659619B", xClosure[0].RestoreMetadata.ProjectUniqueName);
+            Assert.Equal("78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F", xClosure[1].RestoreMetadata.ProjectUniqueName);
+            Assert.Equal("A55205E7-4D08-4672-8011-0925467CC45F", xClosure[2].RestoreMetadata.ProjectUniqueName);
+
+            Assert.Equal(1, yClosure.Count);
+            Assert.Equal("78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F", yClosure.Single().RestoreMetadata.ProjectUniqueName);
+        }
+
         [Fact]
         public void DependencyGraphSpec_ProjectsWithToolReferences_GetClosures()
         {

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/test3.dg
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/test3.dg
@@ -42,7 +42,7 @@
           },
           "net45": {
             "projectReferences": {
-              "78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F": {
+              "78a6AD3F-9FA5-47F6-A54E-84B46A48CB2F": {
                 "projectPath": "c:\\y\\y.csproj"
               }
             }


### PR DESCRIPTION
When there is case difference in project unique name vs project name added as project reference then it was failing to get the right project referene since we were comparing against `StringComparer.Ordinal`.

This has been changed now to use our existing utility api which return os based stringcomparer.

@rrelyea 