### PR TITLE
stop escaping paths while packing

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -735,7 +735,7 @@ namespace NuGet.Packaging
         {
             // Only the segments between the path separators should be escaped
             var segments = path.Split(new[] { '/', '\\', Path.DirectorySeparatorChar }, StringSplitOptions.None)
-                               .Select(Uri.EscapeDataString);
+                .Select(Uri.EscapeDataString);
 
             var escapedPath = String.Join("/", segments);
 
@@ -751,8 +751,7 @@ namespace NuGet.Packaging
             // Get the safe-unescaped form of the URI first. This will unescape all the characters
             Uri safeUnescapedUri = new Uri(partUri.GetComponents(UriComponents.Path, UriFormat.SafeUnescaped), UriKind.Relative);
 
-            //Get the escaped string for the part name as part names should have only ascii characters
-            return safeUnescapedUri.GetComponents(UriComponents.SerializationInfoString, UriFormat.UriEscaped);
+            return safeUnescapedUri.GetComponents(UriComponents.SerializationInfoString, UriFormat.Unescaped);
         }
 
         /// <summary>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -2377,7 +2377,8 @@ Enabling license acceptance requires a license url.");
 
                 using (var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true))
                 {
-                    var files = archive.GetFiles().OrderBy(s => s).ToArray();
+                    // Get raw filenames without un-escaping.
+                    var files = archive.Entries.Select(e => e.FullName).OrderBy(s => s).ToArray();
 
                     // Linux sorts the first two in different order than Windows
                     Assert.Contains<string>(@"[Content_Types].xml", files);


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/5956
Regression: No  
If Regression then when did it last work:   N/A
If Regression then how are we preventing it in future:    N/A

## Fix
Details: This fix simply stops escaping special characters while packing.

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  Scenario already covered by PackageBuilderTest.PackageBuilderWorksWithFileNamesContainingSpecialCharacters
Validation done:  Manual
