### PR TITLE
allow version file path to be specified as a param to script

### DIFF
--- a/scripts/utils/InsertNuGetIntoSdkAndCli.ps1
+++ b/scripts/utils/InsertNuGetIntoSdkAndCli.ps1
@@ -32,6 +32,8 @@ param
     [Parameter(Mandatory=$True)]
     [string]$BranchName,
     [Parameter(Mandatory=$True)]
+    [string]$FilePath,
+    [Parameter(Mandatory=$True)]
     [string]$NuGetTag,
     [Parameter(Mandatory=$True)]
     [string]$BuildOutputPath
@@ -196,12 +198,12 @@ $PullRequestUrl | Set-Content $mdFile
 Write-Host "##vso[task.addattachment type=Distributedtask.Core.Summary;name=$RepositoryName Pull Request Url;]$mdFile"  
 }
 
-$xml = GetDependencyVersionPropsFile -RepositoryName $RepositoryName -BranchName $BranchName -FilePath build/DependencyVersions.props
+$xml = GetDependencyVersionPropsFile -RepositoryName $RepositoryName -BranchName $BranchName -FilePath $FilePath
 Write-Host $xml
 
 $updatedXml = UpdateNuGetVersionInXmlFile -XmlContents $xml -NuGetVersion $ProductVersion -NuGetTag $NuGetTag
 
 CreateBranchForPullRequest -RepositoryName $RepositoryName -Headers $Headers -BranchName $BranchName
-UpdateFileContent -RepositoryName $RepositoryName -Headers $Headers -FilePath build/DependencyVersions.props -FileContent $updatedXml
+UpdateFileContent -RepositoryName $RepositoryName -Headers $Headers -FilePath $FilePath -FileContent $updatedXml
 $PullRequestUrl = CreatePullRequest -RepositoryName $RepositoryName -Headers $Headers -CreatedBranchName $CreatedBranchName -BaseBranch $BranchName
 PrintPullRequestUrlToVsts -RepositoryName $RepositoryName -PullRequestUrl $PullRequestUrl


### PR DESCRIPTION
CLI and SDK made changes in the way they manage their dependencies in the version properties file, so this fix is making sure we adapt to it.