### PR TITLE
Adding support for publishing artifacts to blob feeds

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -21,4 +21,5 @@
   <package id="xunit.runner.console" version="2.3.1" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" />
   <package id="NuGetValidator" version="1.3.7" targetFramework="net461" />
+  <package id="Microsoft.DotNet.Build.Tasks.Feed" version="1.0.0-prerelease-02121-01" />   <!-- For the .NET Core orchestrated build.-->
 </packages>

--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -21,5 +21,5 @@
   <package id="xunit.runner.console" version="2.3.1" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" />
   <package id="NuGetValidator" version="1.3.7" targetFramework="net461" />
-  <package id="Microsoft.DotNet.Build.Tasks.Feed" version="1.0.0-prerelease-02121-01" />   <!-- For the .NET Core orchestrated build.-->
+  <package id="Microsoft.DotNet.Build.Tasks.Feed" version="2.1.0-prerelease-02304-01" />   <!-- For the .NET Core orchestrated build.-->
 </packages>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -34,7 +34,7 @@
     <LocalizationFilesDirectory>$(ArtifactsDirectory)LocalizedFiles</LocalizationFilesDirectory>
     <MicroBuildDirectory>$(SolutionPackagesFolder)MicroBuild.Core.0.2.0\build\</MicroBuildDirectory>
     <IsBuildOnlyXPLATProjects>$(DotNetBuildFromSource)</IsBuildOnlyXPLATProjects>
-    <BlobPublishTargetsPath>$(SolutionPackagesFolder)Microsoft.DotNet.Build.Tasks.Feed.1.0.0-prerelease-02121-01\build\Microsoft.DotNet.Build.Tasks.Feed.targets</BlobPublishTargetsPath>
+    <BlobPublishTargetsPath>$(SolutionPackagesFolder)Microsoft.DotNet.Build.Tasks.Feed.2.1.0-prerelease-02304-01\build\Microsoft.DotNet.Build.Tasks.Feed.targets</BlobPublishTargetsPath>
   </PropertyGroup>
 
   <!-- Defaults -->

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -34,6 +34,7 @@
     <LocalizationFilesDirectory>$(ArtifactsDirectory)LocalizedFiles</LocalizationFilesDirectory>
     <MicroBuildDirectory>$(SolutionPackagesFolder)MicroBuild.Core.0.2.0\build\</MicroBuildDirectory>
     <IsBuildOnlyXPLATProjects>$(DotNetBuildFromSource)</IsBuildOnlyXPLATProjects>
+    <BlobPublishTargetsPath>$(SolutionPackagesFolder)Microsoft.DotNet.Build.Tasks.Feed.1.0.0-prerelease-02121-01\build\Microsoft.DotNet.Build.Tasks.Feed.targets</BlobPublishTargetsPath>
   </PropertyGroup>
 
   <!-- Defaults -->

--- a/build/publish.proj
+++ b/build/publish.proj
@@ -15,14 +15,18 @@
     <ItemsToPush Include="$(NupkgOutputDirectory)*.nupkg" />
   </ItemGroup>
 
-  <Target Name="Build" Condition=" '$(BuildRTM)' == 'false' AND Exists($(NupkgOutputDirectory))">
+  <Target Name="Build" Condition=" '$(BuildRTM)' != 'true'">
+    <Error Text="Package output directory '$(NupkgOutputDirectory)' does not exist."
+          Condition="!Exists($(NupkgOutputDirectory))" />
+
     <Error Text="The FeedUrl property must be passed."
           Condition="'$(FeedUrl)' == ''" />
 
     <Error Text="The FeedApiKey property must be passed."
           Condition="'$(FeedApiKey)' == ''" />
 
-    <Error Condition="'@(ItemsToPush)' == ''" Text="No packages to push." />
+    <Error Text="No packages to push."
+          Condition="'@(ItemsToPush)' == ''" />
 
     <PushToBlobFeed ExpectedFeedUrl="$(FeedUrl)"
                     AccountKey="$(FeedApiKey)"

--- a/build/publish.proj
+++ b/build/publish.proj
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
+
+  <!--
+    ============================================================
+    This is for orchestrated build scenarios. The NuGet.Client-Orchestrated build definition builds this file directly.
+    ============================================================
+  -->
+
+  <Import Project="$(BlobPublishTargetsPath)" />
+  <Import Project="$(BuildCommonDirectory)common.targets" />
+
+  <ItemGroup>
+    <ItemsToPush Include="$(NupkgOutputDirectory)*.nupkg" />
+  </ItemGroup>
+
+  <Target Name="Build" Condition=" '$(BuildRTM)' == 'false' AND Exists($(NupkgOutputDirectory))">
+    <Error Text="The FeedUrl property must be passed."
+          Condition="'$(FeedUrl)' == ''" />
+
+    <Error Text="The FeedApiKey property must be passed."
+          Condition="'$(FeedApiKey)' == ''" />
+
+    <Error Condition="'@(ItemsToPush)' == ''" Text="No packages to push." />
+
+    <PushToBlobFeed ExpectedFeedUrl="$(FeedUrl)"
+                    AccountKey="$(FeedApiKey)"
+                    ItemsToPush="@(ItemsToPush)"
+                    Overwrite="$(PublishOverwrite)" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
This is part of the orchestrated build effort for .NET Core framework builds.

This PR adds `build/publish.proj` to our repo which is triggered by the [NuGet.Client-Orchestrated](https://devdiv.visualstudio.com/DevDiv/NuGet/_build/index?definitionId=7937&_a=completed) build definition in the `Publish Artifacts to BlobFeed` step.

The step invokes build on the `build/publish.proj` file with the `FeedUrl` and `FeedApiKey` properties. The project then invokes a custom target from `Microsoft.DotNet.Build.Tasks.Feed.2.1.0-prerelease-02304-01\build\Microsoft.DotNet.Build.Tasks.Feed.targets`. 

The step is conditioned on - 

` and(succeeded(),eq(variables['PublishArtifactsToMyGet'], 'true'), eq(variables['BuildRTM'], 'false'), contains(variables['PB_PublishType'], 'blob')) `


This will result in publishing of our build packages to a blob feed which is passed to the build definition when it is invoked.