### PR TITLE
fix string matching for xml in insertion script

### DIFF
--- a/scripts/utils/InsertNuGetIntoSdkAndCli.ps1
+++ b/scripts/utils/InsertNuGetIntoSdkAndCli.ps1
@@ -60,7 +60,7 @@ Function UpdateNuGetVersionInXmlFile {
         [string]$NuGetTag
     )
 
-$xmlString = $XmlContents.Split([environment]::NewLine) | where { $_ -cmatch $NuGetTag }
+$xmlString = $XmlContents.Split([environment]::NewLine) | where { $_ -cmatch "<$NuGetTag>" }
 Write-Host $xmlString
 $newXmlString = "<$NuGetTag>$NuGetVersion</$NuGetTag>"
 Write-Host $newXmlString


### PR DESCRIPTION
engineering fix to fix the way xml tags are matched for making insertions into CLI/SDK