### PR TITLE
Plugins:  fix race condition

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/AutomaticProgressReporter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/AutomaticProgressReporter.cs
@@ -156,6 +156,11 @@ namespace NuGet.Protocol.Plugins
             {
                 return;
             }
+            catch (ArgumentNullException)
+            {
+                // The semaphore may have been disposed already.
+                return;
+            }
 
             if (_isDisposed)
             {


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/6293.

There's a potential race condition between a timer firing and semaphore disposal.  This change ignores an exception if the semaphore is disposed.