### PR TITLE
Fix functional package signing test

### DIFF
--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -20,7 +20,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
     {
         private const string _packageAlreadySignedError = "Error NU5000: The package already contains a signature. Please remove the existing signature before adding a new signature.";
         private const string _invalidPasswordErrorCode = "NU3014";
-        private const string _invalidEkuErrorCode = "NU3012";
+        private const string _invalidEkuErrorCode = "NU5000";
         private const string _noTimestamperWarningCode = "NU3521";
 
         private SignCommandTestFixture _testFixture;
@@ -98,6 +98,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 result.Success.Should().BeFalse();
                 result.AllOutput.Should().Contain(_noTimestamperWarningCode);
                 result.AllOutput.Should().Contain(_invalidEkuErrorCode);
+                result.AllOutput.Should().Contain("NotValidForUsage");
             }
         }
 


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/6299.

PR https://github.com/NuGet/NuGet.Client/pull/1858 broke a functional test (`NuGet.CommandLine.FuncTest.Commands.SignCommandTests.SignCommand_SignPackageWithInvalidEkuFails`).