### PR TITLE
Add NuGetVersion.Equals check

### DIFF
--- a/src/NuGet.Core/NuGet.Versioning/SemanticVersionBase.cs
+++ b/src/NuGet.Core/NuGet.Versioning/SemanticVersionBase.cs
@@ -111,7 +111,7 @@ namespace NuGet.Versioning
         /// </summary>
         public virtual bool Equals(SemanticVersion other)
         {
-            return Equals(other, VersionComparison.Default);
+            return VersionComparer.Default.Equals(this, other);
         }
 
         /// <summary>
@@ -119,7 +119,8 @@ namespace NuGet.Versioning
         /// </summary>
         public virtual bool Equals(SemanticVersion other, VersionComparison versionComparison)
         {
-            return CompareTo(other, versionComparison) == 0;
+            var comparer = new VersionComparer(versionComparison);
+            return comparer.Equals(this, other);
         }
 
         /// <summary>
@@ -136,7 +137,7 @@ namespace NuGet.Versioning
         /// </summary>
         public static bool operator ==(SemanticVersion version1, SemanticVersion version2)
         {
-            return Compare(version1, version2) == 0;
+            return Equals(version1, version2);
         }
 
         /// <summary>
@@ -144,7 +145,7 @@ namespace NuGet.Versioning
         /// </summary>
         public static bool operator !=(SemanticVersion version1, SemanticVersion version2)
         {
-            return Compare(version1, version2) != 0;
+            return !Equals(version1, version2);
         }
 
         /// <summary>

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGetVersionTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGetVersionTest.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using FluentAssertions;
 using Xunit;
 
 namespace NuGet.Versioning.Test
@@ -199,6 +200,13 @@ namespace NuGet.Versioning.Test
             Assert.False(semVer.Equals(other));
         }
 
+        [Fact]
+        public void EqualsIsTrueForEmptyRevision()
+        {
+            NuGetVersion.Parse("1.0.0.0").Equals(SemanticVersion.Parse("1.0.0")).Should().BeTrue();
+            SemanticVersion.Parse("1.0.0").Equals(NuGetVersion.Parse("1.0.0.0")).Should().BeTrue();
+        }
+
         [Theory]
         [InlineData("1.0", "1.0.0.0")]
         [InlineData("1.23.01", "1.23.1")]
@@ -206,6 +214,8 @@ namespace NuGet.Versioning.Test
         [InlineData("1.45.6-Alpha", "1.45.6-Alpha")]
         [InlineData("1.6.2-BeTa", "1.6.02-beta")]
         [InlineData("22.3.07     ", "22.3.07")]
+        [InlineData("1.0", "1.0.0.0+beta")]
+        [InlineData("1.0.0.0+beta.2", "1.0.0.0+beta.1")]
         public void SemVerEqualsOperatorWorks(string versionA, string versionB)
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionComparerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionComparerTests.cs
@@ -13,6 +13,7 @@ namespace NuGet.Versioning.Test
         [InlineData("1.0.0-BETA", "1.0.0-beta")]
         [InlineData("1.0.0-BETA+AA", "1.0.0-beta+aa")]
         [InlineData("1.0.0-BETA.X.y.5.77.0+AA", "1.0.0-beta.x.y.5.77.0+aa")]
+        [InlineData("1.0.0", "1.0.0+beta")]
         public void VersionComparisonDefaultEqual(string version1, string version2)
         {
             // Arrange & Act
@@ -20,6 +21,34 @@ namespace NuGet.Versioning.Test
 
             // Assert
             Assert.True(match);
+        }
+
+        [Theory]
+        [InlineData("1.0", "1.0.0.0")]
+        [InlineData("1.0+test", "1.0.0.0")]
+        [InlineData("1.0.0.1-1.2.A", "1.0.0.1-1.2.a+A")]
+        [InlineData("1.0.01", "1.0.1.0")]
+        public void VersionComparisonDefaultEqualWithNuGetVersion(string version1, string version2)
+        {
+            // Arrange & Act
+            var match = EqualsWithNuGetVersion(VersionComparer.Default, version1, version2);
+
+            // Assert
+            Assert.True(match);
+        }
+
+        [Theory]
+        [InlineData("1.0", "1.0.0.1")]
+        [InlineData("1.0+test", "1.0.0.1")]
+        [InlineData("1.0.0.1-1.2.A", "1.0.0.1-1.2.a.A+A")]
+        [InlineData("1.0.01", "1.0.1.2")]
+        public void VersionComparisonDefaultNotEqualWithNuGetVersion(string version1, string version2)
+        {
+            // Arrange & Act
+            var match = EqualsWithNuGetVersion(VersionComparer.Default, version1, version2);
+
+            // Assert
+            Assert.False(match);
         }
 
         [Theory]
@@ -110,6 +139,29 @@ namespace NuGet.Versioning.Test
             match &= comparer.Equals(a, d);
             match &= comparer.Equals(c, d);
             match &= comparer.Equals(c, b);
+            match &= comparer.GetHashCode(a) == comparer.GetHashCode(b);
+            match &= comparer.GetHashCode(a) == comparer.GetHashCode(d);
+            match &= comparer.GetHashCode(c) == comparer.GetHashCode(d);
+            match &= comparer.GetHashCode(c) == comparer.GetHashCode(b);
+
+            return match;
+        }
+
+        private static bool EqualsWithNuGetVersion(IVersionComparer comparer, string version1, string version2)
+        {
+            return EqualsOneWayWithNuGetVersion(comparer, version1, version2) && EqualsOneWayWithNuGetVersion(comparer, version2, version1);
+        }
+
+        private static bool EqualsOneWayWithNuGetVersion(IVersionComparer comparer, string version1, string version2)
+        {
+            // Arrange
+            var a = NuGetVersion.Parse(version1);
+            var b = NuGetVersion.Parse(version2);
+
+            // Act
+            var match = comparer.Compare(a, b) == 0;
+            match &= comparer.Equals(a, b);
+            match &= comparer.GetHashCode(a) == comparer.GetHashCode(b);
 
             return match;
         }


### PR DESCRIPTION
Add NuGetVersion.Equals check to directly check equality instead of using Compare which does additional unneeded parsing to convert release labels to numeric labels for compare. Equals can short circut this by checking the number of labels and exiting without finding which version is greater.

This change also reduces allocations from GetHashCode for versions by using the hash code combiner instead of creating a new string to avoid case sensitivity.

For Roslyn.sln I see around 50M less allocations due to the GetHashCode improvements. Time is slightly better due to the extremely high number of version checks happening in restore.

I've added a few more tests, but for the most part there are already plenty of tests covering `Compare` and `Equals` for all scenarios.