### PR TITLE
Signing:  implement spec signature algorithm requirements

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -34,8 +34,11 @@ namespace NuGet.Common
     /// Sub groups for Signing:
     /// error/warning - Reason
     /// 3000/3500     - Input
-    /// 3010/3510     - Certificate
-    /// 3020/3520     - Timestamping
+    /// 3010/3510     - Package and package signature file
+    /// 3020/3520     - Primary certificate
+    /// 3030/3530     - Primary signature
+    /// 3040/3540     - Timestamp certificate
+    /// 3050/3550     - Timestamp signature
     /// </summary>
     public enum NuGetLogCode
     {
@@ -68,7 +71,7 @@ namespace NuGet.Common
         /// Unable to resolve package, generic message for unknown type constraints.
         /// </summary>
         NU1100 = 1100,
-        
+
         /// <summary>
         /// No versions of the package exist on any of the sources.
         /// </summary>
@@ -225,7 +228,7 @@ namespace NuGet.Common
         NU3011 = 3011,
 
         /// <summary>
-        /// Certifiate not valid
+        /// Certificate not valid
         /// </summary>
         NU3012 = 3012,
 
@@ -240,14 +243,24 @@ namespace NuGet.Common
         NU3014 = 3014,
 
         /// <summary>
-        /// Invalid timestamp response
+        /// Chain building failed for primary signature
         /// </summary>
         NU3021 = 3021,
 
         /// <summary>
-        /// Invalid timestamp in signature
+        /// Unsupported signature algorithm
         /// </summary>
         NU3022 = 3022,
+
+        /// <summary>
+        /// Invalid timestamp in signature
+        /// </summary>
+        NU3050 = 3050,
+
+        /// <summary>
+        /// Timestamp nonce mismatch
+        /// </summary>
+        NU3051 = 3051,
 
         /// <summary>
         /// Undefined signature warning

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Oids.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Oids.cs
@@ -17,6 +17,15 @@ namespace NuGet.Packaging.Signing
         // RFC 8017 appendix B.1 (https://tools.ietf.org/html/rfc8017#appendix-B.1).
         public const string Sha512Oid = "2.16.840.1.101.3.4.2.3";
 
+        // RFC 4055 "sha256WithRSAEncryption" (https://tools.ietf.org/html/rfc4055#section-5)
+        public const string Sha256WithRSAEncryption = "1.2.840.113549.1.1.11";
+
+        // RFC 4055 "sha384WithRSAEncryption" (https://tools.ietf.org/html/rfc4055#section-5)
+        public const string Sha384WithRSAEncryption = "1.2.840.113549.1.1.12";
+
+        // RFC 4055 "sha512WithRSAEncryption" (https://tools.ietf.org/html/rfc4055#section-5)
+        public const string Sha512WithRSAEncryption = "1.2.840.113549.1.1.13";
+
         // RFC 5280 codeSigning attribute, https://tools.ietf.org/html/rfc5280#section-4.2.1.12
         public const string CodeSigningEkuOid = "1.3.6.1.5.5.7.3.3";
 
@@ -37,7 +46,7 @@ namespace NuGet.Packaging.Signing
 
         // XCN_OID_KP_LIFETIME_SIGNING https://msdn.microsoft.com/en-us/library/windows/desktop/aa378132(v=vs.85).aspx
         public const string LifetimeSignerEkuOid = "1.3.6.1.4.1.311.10.3.13";
-        
+
         // RFC 5126 "commitment-type-indication" https://tools.ietf.org/html/rfc5126.html#section-5.11.1
         public const string CommitmentTypeIndication = "1.2.840.113549.1.9.16.2.16";
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
@@ -9,7 +9,6 @@ namespace NuGet.Packaging.Signing
 {
     public class SignatureException : PackagingException
     {
-
         /// <summary>
         /// Individual trust results.
         /// </summary>
@@ -18,7 +17,7 @@ namespace NuGet.Packaging.Signing
         public PackageIdentity PackageIdentity { get; }
 
         public SignatureException(string message)
-            : base(message)
+            : base(NuGetLogCode.NU3000, message)
         {
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureLog.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureLog.cs
@@ -45,7 +45,7 @@ namespace NuGet.Packaging.Signing
 
         public static SignatureLog InvalidTimestampInSignatureError(string message)
         {
-            return new SignatureLog(LogLevel.Error, NuGetLogCode.NU3022, message);
+            return new SignatureLog(LogLevel.Error, NuGetLogCode.NU3050, message);
         }
 
         public static SignatureLog InvalidPackageError(string message)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SigningUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SigningUtility.cs
@@ -18,7 +18,26 @@ namespace NuGet.Packaging.Signing
     public static class SigningUtility
     {
         /// <summary>
-        /// Validates the public key requiriements for a certificate
+        /// Determines if a certificate's signature algorithm is supported.
+        /// </summary>
+        /// <param name="certificate">Certificate to validate</param>
+        /// <returns>True if the certificate's signature algorithm is supported.</returns>
+        public static bool IsSignatureAlgorithmSupported(X509Certificate2 certificate)
+        {
+            switch (certificate.SignatureAlgorithm.Value)
+            {
+                case Oids.Sha256WithRSAEncryption:
+                case Oids.Sha384WithRSAEncryption:
+                case Oids.Sha512WithRSAEncryption:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Validates the public key requirements for a certificate
         /// </summary>
         /// <param name="certificate">Certificate to validate</param>
         /// <returns>True if the certificate's public key is valid within NuGet signature requirements</returns>
@@ -36,7 +55,7 @@ namespace NuGet.Packaging.Signing
 
 #if IS_DESKTOP
         /// <summary>
-        /// Create an ordered list of certificates. The leaf node is returned first.
+        /// Create a list of certificates in chain order with the leaf first and root last.
         /// </summary>
         public static IReadOnlyList<X509Certificate2> GetCertificateChain(
             X509Certificate2 certificate,

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
@@ -27,7 +27,7 @@ namespace NuGet.Packaging.Signing
     {
         // Url to an RFC 3161 timestamp server
         private readonly Uri _timestamperUrl;
-        private const int _rfc3161RequestTimeoutSeconds = 10;        
+        private const int _rfc3161RequestTimeoutSeconds = 10;
 
         public Rfc3161TimestampProvider(Uri timeStampServerUrl)
         {
@@ -154,7 +154,7 @@ namespace NuGet.Packaging.Signing
             if (!nonce.SequenceEqual(timestampToken.TokenInfo.GetNonce()))
             {
                 throw new TimestampException(LogMessage.CreateError(
-                    NuGetLogCode.NU3021,
+                    NuGetLogCode.NU3051,
                     string.Format(CultureInfo.CurrentCulture,
                     Strings.TimestampResponseExceptionGeneral,
                     Strings.TimestampFailureNonceMismatch)));

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -647,6 +647,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The signing certificate has an unsupported signature algorithm..
+        /// </summary>
+        internal static string SigningCertificateHasUnsupportedSignatureAlgorithm {
+            get {
+                return ResourceManager.GetString("SigningCertificateHasUnsupportedSignatureAlgorithm", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to signing-certificate-v2 attribute value does not match the current certificate chain..
         /// </summary>
         internal static string SigningCertificateV2Invalid {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -409,4 +409,7 @@ Valid from:</comment>
   <data name="ArgumentCannotBeNullOrEmpty" xml:space="preserve">
     <value>The argument cannot be null or empty.</value>
   </data>
+  <data name="SigningCertificateHasUnsupportedSignatureAlgorithm" xml:space="preserve">
+    <value>The signing certificate has an unsupported signature algorithm.</value>
+  </data>
 </root>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/Signing/SignerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/Signing/SignerTests.cs
@@ -1,0 +1,146 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET46
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using Test.Utility.Signing;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class SignerTests
+    {
+        [Fact]
+        public void Constructor_WhenPackageIsNull_Throws()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new Signer(package: null, signatureProvider: Mock.Of<ISignatureProvider>()));
+
+            Assert.Equal("package", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenSignatureProviderIsNull_Throws()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new Signer(Mock.Of<ISignedPackage>(), signatureProvider: null));
+
+            Assert.Equal("signatureProvider", exception.ParamName);
+        }
+
+        [Fact]
+        public async Task SignAsync_WhenRequestIsNull_Throws()
+        {
+            using (var test = SignTest.Create(new X509Certificate2(), HashAlgorithmName.SHA256))
+            {
+                var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+                    () => test.Signer.SignAsync(
+                        request: null,
+                        logger: Mock.Of<ILogger>(),
+                        token: CancellationToken.None));
+
+                Assert.Equal("request", exception.ParamName);
+            }
+        }
+
+        [Fact]
+        public async Task SignAsync_WhenLoggerIsNull_Throws()
+        {
+            using (var test = SignTest.Create(new X509Certificate2(), HashAlgorithmName.SHA256))
+            {
+                var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+                    () => test.Signer.SignAsync(
+                        test.Request,
+                        logger: null,
+                        token: CancellationToken.None));
+
+                Assert.Equal("logger", exception.ParamName);
+            }
+        }
+
+        [Fact]
+        public async Task SignAsync_WhenCancellationTokenIsCancelled_Throws()
+        {
+            using (var test = SignTest.Create(new X509Certificate2(), HashAlgorithmName.SHA256))
+            {
+                await Assert.ThrowsAsync<OperationCanceledException>(
+                    () => test.Signer.SignAsync(
+                        test.Request,
+                        Mock.Of<ILogger>(),
+                        new CancellationToken(canceled: true)));
+            }
+        }
+
+        [Fact]
+        public async Task SignAsync_WhenCertificateSignatureAlgorithmIsUnsupported_Throws()
+        {
+            using (var certificate = SigningTestUtility.GenerateCertificate(
+                "test",
+                generator => { },
+                "SHA256WITHRSAANDMGF1"))
+            using (var test = SignTest.Create(certificate, HashAlgorithmName.SHA256))
+            {
+                var exception = await Assert.ThrowsAsync<SignatureException>(
+                    () => test.Signer.SignAsync(
+                        test.Request,
+                        Mock.Of<ILogger>(),
+                        CancellationToken.None));
+
+                Assert.Equal(NuGetLogCode.NU3022, exception.AsLogMessage().Code);
+            }
+        }
+
+        private sealed class SignTest : IDisposable
+        {
+            private bool _isDisposed = false;
+
+            internal Mock<ISignatureProvider> SignatureProvider { get; }
+            internal Mock<ISignedPackage> Package { get; }
+            internal SignPackageRequest Request { get; }
+            internal Signer Signer { get; }
+
+            private SignTest(Signer signer,
+                Mock<ISignedPackage> package,
+                Mock<ISignatureProvider> signatureProvider,
+                SignPackageRequest request)
+            {
+                Signer = signer;
+                Package = package;
+                SignatureProvider = signatureProvider;
+                Request = request;
+            }
+
+            public void Dispose()
+            {
+                if (!_isDisposed)
+                {
+                    Request.Dispose();
+
+                    _isDisposed = true;
+                }
+            }
+
+            internal static SignTest Create(X509Certificate2 certificate, HashAlgorithmName hashAlgorithm)
+            {
+                var signedPackage = new Mock<ISignedPackage>(MockBehavior.Strict);
+                var signatureProvider = new Mock<ISignatureProvider>(MockBehavior.Strict);
+                var signer = new Signer(signedPackage.Object, signatureProvider.Object);
+
+                var request = new SignPackageRequest()
+                {
+                    Certificate = certificate,
+                    SignatureHashAlgorithm = hashAlgorithm
+                };
+
+                return new SignTest(signer, signedPackage, signatureProvider, request);
+            }
+        }
+    }
+}
+#endif

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/Signing/SigningUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/Signing/SigningUtilityTests.cs
@@ -12,6 +12,36 @@ namespace NuGet.Packaging.Test
 {
     public class SigningUtilityTests
     {
+        [Theory]
+        [InlineData("SHA256WITHRSAENCRYPTION", Oids.Sha256WithRSAEncryption)]
+        [InlineData("SHA384WITHRSAENCRYPTION", Oids.Sha384WithRSAEncryption)]
+        [InlineData("SHA512WITHRSAENCRYPTION", Oids.Sha512WithRSAEncryption)]
+        public void IsSignatureAlgorithmSupported_WhenSupported_ReturnsTrue(string signatureAlgorithm, string expectedSignatureAlgorithmOid)
+        {
+            using (var certificate = SigningTestUtility.GenerateCertificate(
+                "test",
+                generator => { },
+                signatureAlgorithm))
+            {
+                Assert.Equal(expectedSignatureAlgorithmOid, certificate.SignatureAlgorithm.Value);
+                Assert.True(SigningUtility.IsSignatureAlgorithmSupported(certificate));
+            }
+        }
+
+        [Fact]
+        public void IsSignatureAlgorithmSupported_WhenUnsupported_ReturnsFalse()
+        {
+            using (var certificate = SigningTestUtility.GenerateCertificate(
+                "test",
+                generator => { },
+                "SHA256WITHRSAANDMGF1"))
+            {
+                // RSASSA-PSS
+                Assert.Equal("1.2.840.113549.1.1.10", certificate.SignatureAlgorithm.Value);
+                Assert.False(SigningUtility.IsSignatureAlgorithmSupported(certificate));
+            }
+        }
+
         [Fact]
         public void GetCertificateChain_ReturnsCertificatesInOrder()
         {

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -56,7 +56,10 @@ namespace Test.Utility.Signing
         /// <summary>
         /// Create a self signed certificate with bouncy castle.
         /// </summary>
-        public static X509Certificate2 GenerateCertificate(string subjectName, Action<X509V3CertificateGenerator> modifyGenerator)
+        public static X509Certificate2 GenerateCertificate(
+            string subjectName,
+            Action<X509V3CertificateGenerator> modifyGenerator,
+            string signatureAlgorithm = "SHA256WITHRSA")
         {
             if (string.IsNullOrEmpty(subjectName))
             {
@@ -90,7 +93,7 @@ namespace Test.Utility.Signing
             modifyGenerator?.Invoke(certGen);
 
             var issuerPrivateKey = pair.Private;
-            var signatureFactory = new Asn1SignatureFactory("SHA256WITHRSA", issuerPrivateKey, random);
+            var signatureFactory = new Asn1SignatureFactory(signatureAlgorithm, issuerPrivateKey, random);
             var certificate = certGen.Generate(signatureFactory);
             var certResult = new X509Certificate2(certificate.GetEncoded());
 


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/6308.

The implementation doesn't follow the [spec](https://github.com/NuGet/Home/wiki/Package-Signatures-Technical-Details#supported-algorithms) in terms of supported signature algorithms.

This change requires that the signing certificate use one of the following signature algorithms:  sha256WithRSAEncryption, sha384WithRSAEncryption, sha512WithRSAEncryption.

Further updates to `NuGetLogCodes` are planned in future PR's.