### PR TITLE
Enforce default policies for verify

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/VerifyCommand/VerifyCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/VerifyCommand/VerifyCommandRunner.cs
@@ -82,7 +82,11 @@ namespace NuGet.Commands
                     var warnings = logMessages.Count(m => m.Level == LogLevel.Warning);
 
                     logger.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.VerifyCommand_FinishedWithErrors, errors, warnings));
-                    logger.LogError(Environment.NewLine + Strings.VerifyCommand_Failed);
+
+                    if (errors > 0)
+                    {
+                        logger.LogError(Environment.NewLine + Strings.VerifyCommand_Failed);
+                    }
 
                     result = errors;
                 }

--- a/src/NuGet.Core/NuGet.Commands/VerifyCommand/VerifyCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/VerifyCommand/VerifyCommandRunner.cs
@@ -39,7 +39,7 @@ namespace NuGet.Commands
                 LocalFolderUtility.EnsurePackageFileExists(verifyArgs.PackagePath, packagesToVerify);
 
                 var verificationProviders = SignatureVerificationProviderFactory.GetSignatureVerificationProviders();
-                var verifier = new PackageSignatureVerifier(verificationProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
+                var verifier = new PackageSignatureVerifier(verificationProviders, SignedPackageVerifierSettings.VerifyCommandDefaultPolicy);
 
 
                 foreach (var package in packagesToVerify)

--- a/src/NuGet.Core/NuGet.Commands/VerifyCommand/VerifyCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/VerifyCommand/VerifyCommandRunner.cs
@@ -39,7 +39,7 @@ namespace NuGet.Commands
                 LocalFolderUtility.EnsurePackageFileExists(verifyArgs.PackagePath, packagesToVerify);
 
                 var verificationProviders = SignatureVerificationProviderFactory.GetSignatureVerificationProviders();
-                var verifier = new PackageSignatureVerifier(verificationProviders, SignedPackageVerifierSettings.RequireSigned);
+                var verifier = new PackageSignatureVerifier(verificationProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
 
 
                 foreach (var package in packagesToVerify)

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -295,7 +295,7 @@ namespace NuGet.Common
         /// <summary>
         /// Chain building failed for timestamp
         /// </summary>
-        NU3041 = 3041
+        NU3041 = 3041,
 
         /// <summary>
         /// Timestamp certificate not yet effective

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -277,6 +277,12 @@ namespace NuGet.Common
         /// </summary>
         NU3023 = 3023,
         
+        /// <summary>
+        /// Certificate not yet valid
+        /// </summary>
+        NU3024 = 3024,
+
+        /// <summary>
         /// Primary signature verification failed
         /// </summary>
         NU3030 = 3030,
@@ -289,12 +295,7 @@ namespace NuGet.Common
         /// <summary>
         /// Chain building failed for timestamp
         /// </summary>
-        NU3041 = 3041,
-
-        /// <summary>
-        /// Timestamp certificate chain building failed
-        /// </summary>
-        NU3041 = 3041,
+        NU3041 = 3041
 
         /// <summary>
         /// Timestamp certificate not yet effective
@@ -347,9 +348,19 @@ namespace NuGet.Common
         NU3521 = 3521,
 
         /// <summary>
+        /// Certificate not yet valid
+        /// </summary>
+        NU3524 = 3524,
+
+        /// <summary>
         /// Primary signature verification failed
         /// </summary>
         NU3530 = 3530,
+
+        /// <summary>
+        /// Timestamp not yet valid
+        /// </summary>
+        NU3544 = 3544,
 
         /// <summary>
         /// Invalid timestamp in signature

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -238,7 +238,7 @@ namespace NuGet.Common
         NU3011 = 3011,
 
         /// <summary>
-        /// Certificate not valid
+        /// Unsupported signature format version
         /// </summary>
         NU3012 = 3012,
 
@@ -248,7 +248,7 @@ namespace NuGet.Common
         NU3013 = 3013,
 
         /// <summary>
-        /// Invalid password provided for a certificate
+        /// Primary signature count not 1
         /// </summary>
         NU3014 = 3014,
 

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -223,6 +223,16 @@ namespace NuGet.Common
         NU3003 = 3003,
 
         /// <summary>
+        /// Package signature is invalid
+        /// </summary>
+        NU3005 = 3005,
+
+        /// <summary>
+        /// Package is not signed
+        /// </summary>
+        NU3006 = 3006,
+
+        /// <summary>
         /// Certificate chain does not build
         /// </summary>
         NU3011 = 3011,
@@ -233,7 +243,7 @@ namespace NuGet.Common
         NU3012 = 3012,
 
         /// <summary>
-        /// SignedCms.ComputeSignature cannot read the certificate private key
+        /// Primary signature has an unsuported hash algorithm
         /// </summary>
         NU3013 = 3013,
 
@@ -241,6 +251,16 @@ namespace NuGet.Common
         /// Invalid password provided for a certificate
         /// </summary>
         NU3014 = 3014,
+
+        /// <summary>
+        /// Package integrity check failed
+        /// </summary>
+        NU3015 = 3015,
+
+        /// <summary>
+        /// Primary signature does not have certificate
+        /// </summary>
+        NU3020 = 3020,
 
         /// <summary>
         /// Chain building failed for primary signature
@@ -256,6 +276,20 @@ namespace NuGet.Common
         /// Unsupported public key length
         /// </summary>
         NU3023 = 3023,
+        
+        /// Primary signature verification failed
+        /// </summary>
+        NU3030 = 3030,
+
+        /// <summary>
+        /// Timestamp with no certificate
+        /// </summary>
+        NU3040 = 3040,
+
+        /// <summary>
+        /// Chain building failed for timestamp
+        /// </summary>
+        NU3041 = 3041,
 
         /// <summary>
         /// Timestamp certificate chain building failed
@@ -278,6 +312,16 @@ namespace NuGet.Common
         NU3051 = 3051,
 
         /// <summary>
+        /// Timestamp unsupported algorithm
+        /// </summary>
+        NU3052 = 3052,
+
+        /// <summary>
+        /// Timestamp integrity check
+        /// </summary>
+        NU3053 = 3053,
+
+        /// <summary>
         /// Undefined signature warning
         /// </summary>
         NU3500 = 3500,
@@ -293,9 +337,29 @@ namespace NuGet.Common
         NU3502 = 3502,
 
         /// <summary>
+        /// Primary signature has an unsuported hash algorithm
+        /// </summary>
+        NU3513 = 3513,
+
+        /// <summary>
         /// Timestamp url not passed to sign command
         /// </summary>
         NU3521 = 3521,
+
+        /// <summary>
+        /// Primary signature verification failed
+        /// </summary>
+        NU3530 = 3530,
+
+        /// <summary>
+        /// Invalid timestamp in signature
+        /// </summary>
+        NU3550 = 3550,
+
+        /// <summary>
+        /// Timestamp unsupported algorithm
+        /// </summary>
+        NU3552 = 3552,
 
         /// <summary>
         /// Undefined Package Error.

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Content/SignatureContent.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Content/SignatureContent.cs
@@ -160,7 +160,7 @@ namespace NuGet.Packaging.Signing
 
             if (signingSpecifications.Version != signatureFormatVersion)
             {
-                throw new SignatureException(Strings.UnsupportedSignatureFormatVersion);
+                throw new SignatureException(NuGetLogCode.NU3012, Strings.UnsupportedSignatureFormatVersion);
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Oids.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Oids.cs
@@ -56,6 +56,9 @@ namespace NuGet.Packaging.Signing
         // RFC 5126 "id-cti-ets-proofOfReceipt" https://tools.ietf.org/html/rfc5126.html#section-5.11.1
         public const string CommitmentTypeIdentifierProofOfReceipt = "1.2.840.113549.1.9.16.6.2";
 
+        // RFC 2634 "signing-certificate" http://tools.ietf.org/html/rfc2634#section-5.4
+        public const string SigningCertificate = "1.2.840.113549.1.9.16.2.12";
+
         // RFC 5126 "signing-certificate-v2" https://tools.ietf.org/html/rfc5126.html#page-34
         public const string SigningCertificateV2 = "1.2.840.113549.1.9.16.2.47";
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
@@ -16,25 +16,28 @@ namespace NuGet.Packaging.Signing
 
         public PackageIdentity PackageIdentity { get; }
 
-        public SignatureException(string message)
-            : base(NuGetLogCode.NU3000, message)
-        {
-        }
+        public NuGetLogCode Code { get; }
 
         public SignatureException(NuGetLogCode code, string message)
             : base(code, message)
         {
+            Code = code;
+        }
+
+        public SignatureException(string message)
+            : this(NuGetLogCode.NU3000, message)
+        {
         }
 
         public SignatureException(IReadOnlyList<PackageVerificationResult> results, PackageIdentity package)
-            : base(string.Empty)
+            : this(string.Empty)
         {
             Results = results;
             PackageIdentity = package;
         }
 
         public SignatureException(string message, PackageIdentity package)
-            : base(message)
+            : this(message)
         {
             PackageIdentity = package;
         }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureLog.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureLog.cs
@@ -40,7 +40,11 @@ namespace NuGet.Packaging.Signing
 
         public static SignatureLog Issue(bool fatal, NuGetLogCode code, string message)
         {
+            // Warning codes are 500 higher than error codes
+            code = fatal ? code : code + 500;
+            // A fatal issue should be an error, otherwise just a warning
             var level = fatal ? LogLevel.Error : LogLevel.Warning;
+
             return new SignatureLog(level, code, message);
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureLog.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureLog.cs
@@ -38,34 +38,10 @@ namespace NuGet.Packaging.Signing
             return new SignatureLog(LogLevel.Debug, NuGetLogCode.Undefined, message);
         }
 
-        public static SignatureLog InvalidInputError(string message)
+        public static SignatureLog Issue(bool fatal, NuGetLogCode code, string message)
         {
-            return new SignatureLog(LogLevel.Error, NuGetLogCode.NU3001, message);
-        }
-
-        public static SignatureLog InvalidTimestampInSignatureError(string message)
-        {
-            return new SignatureLog(LogLevel.Error, NuGetLogCode.NU3050, message);
-        }
-
-        public static SignatureLog InvalidPackageError(string message)
-        {
-            return new SignatureLog(LogLevel.Error, NuGetLogCode.NU3002, message);
-        }
-
-        public static SignatureLog UntrustedRootError(string message)
-        {
-            return new SignatureLog(LogLevel.Error, NuGetLogCode.NU3002, message);
-        }
-
-        public static SignatureLog SignatureInformationUnavailableWarning(string message)
-        {
-            return new SignatureLog(LogLevel.Warning, NuGetLogCode.NU3502, message);
-        }
-
-        public static SignatureLog TrustOfSignatureCannotBeProvenWarning(string message)
-        {
-            return new SignatureLog(LogLevel.Warning, NuGetLogCode.NU3502, message);
+            var level = fatal ? LogLevel.Error : LogLevel.Warning;
+            return new SignatureLog(level, code, message);
         }
 
         public ILogMessage ToLogMessage()

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using NuGet.Common;
 
 #if IS_DESKTOP
 using System.Security.Cryptography.Pkcs;
 #endif
+
 
 namespace NuGet.Packaging.Signing
 {
@@ -82,7 +84,7 @@ namespace NuGet.Packaging.Signing
         {
             if (cms.SignerInfos.Count != 1)
             {
-                throw new InvalidOperationException(Strings.Error_NotOnePrimarySignature);
+                throw new SignatureException(NuGetLogCode.NU3014, Strings.Error_NotOnePrimarySignature);
             }
 
             return new Signature(cms);

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
@@ -130,8 +130,13 @@ namespace NuGet.Packaging.Signing
         /// <param name="signer">SignerInfo containing signature metadata</param>
         private static SignatureType GetSignatureType(SignerInfo signer)
         {
-            // TODO: Change this to use the new attributes that justin is adding.
-            return SignatureType.Author;
+            var commitmentTypeIndication = signer.SignedAttributes.GetAttributeOrDefault(Oids.CommitmentTypeIndication);
+            if (commitmentTypeIndication != null)
+            {
+                return AttributeUtility.GetCommitmentTypeIndication(commitmentTypeIndication);
+            }
+
+            return SignatureType.Unknown;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SigningUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SigningUtility.cs
@@ -282,15 +282,13 @@ namespace NuGet.Packaging.Signing
 
             if (!spec.AllowedHashAlgorithmOids.Contains(timestampSignerInfo.DigestAlgorithm.Value))
             {
-                var code = failIfInvalid ? NuGetLogCode.NU3052 : NuGetLogCode.NU3552;
-                issues.Add(SignatureLog.Issue(failIfInvalid, code, Strings.TimestampFailureInvalidHashAlgorithmOid));
+                issues.Add(SignatureLog.Issue(failIfInvalid, NuGetLogCode.NU3052, Strings.TimestampFailureInvalidHashAlgorithmOid));
                 isValid = false;
             }
 
             if (IsCertificateValidityPeriodInTheFuture(timestampSignerInfo.Certificate))
             {
-                var code = failIfInvalid ? NuGetLogCode.NU3044 : NuGetLogCode.NU3544;
-                issues.Add(SignatureLog.Issue(failIfInvalid, code, Strings.TimestampNotYetValid));
+                issues.Add(SignatureLog.Issue(failIfInvalid, NuGetLogCode.NU3044, Strings.TimestampNotYetValid));
                 isValid = false;
             }
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SigningUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SigningUtility.cs
@@ -38,6 +38,25 @@ namespace NuGet.Packaging.Signing
             }
         }
 
+
+        /// <summary> 
+        /// Validates the public key requirements for a certificate 
+        /// </summary> 
+        /// <param name="certificate">Certificate to validate</param> 
+        /// <returns>True if the certificate's public key is valid within NuGet signature requirements</returns> 
+        public static bool IsCertificatePublicKeyValid(X509Certificate2 certificate)
+        {
+            // Check if the public key is RSA with a valid keysize 
+            var RSAPublicKey = RSACertificateExtensions.GetRSAPublicKey(certificate);
+
+            if (RSAPublicKey != null)
+            {
+                return RSAPublicKey.KeySize >= SigningSpecifications.V1.RSAPublicKeyMinLength;
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// Validates if the certificate contains the lifetime signing EKU
         /// </summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SigningUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SigningUtility.cs
@@ -271,22 +271,22 @@ namespace NuGet.Packaging.Signing
             return buildSuccess && !IsCertificateValidityPeriodInTheFuture(certificate);
         }
 
-        internal static bool IsTimestampValid(byte[] data, bool failIfInvalid, List<SignatureLog> issues, SignerInfo timestampSignerInfo, Rfc3161TimestampTokenInfo tstInfo, SigningSpecifications spec)
+        internal static bool IsTimestampValid(Timestamp timestamp, byte[] data, bool failIfInvalid, List<SignatureLog> issues, SigningSpecifications spec)
         {
             var isValid = true;
-            if (!tstInfo.HasMessageHash(data))
+            if (!timestamp.TstInfo.HasMessageHash(data))
             {
                 issues.Add(SignatureLog.Issue(failIfInvalid, NuGetLogCode.NU3053, Strings.TimestampFailureInvalidHash));
                 isValid = false;
             }
 
-            if (!spec.AllowedHashAlgorithmOids.Contains(timestampSignerInfo.DigestAlgorithm.Value))
+            if (!spec.AllowedHashAlgorithmOids.Contains(timestamp.SignerInfo.DigestAlgorithm.Value))
             {
                 issues.Add(SignatureLog.Issue(failIfInvalid, NuGetLogCode.NU3052, Strings.TimestampFailureInvalidHashAlgorithmOid));
                 isValid = false;
             }
 
-            if (IsCertificateValidityPeriodInTheFuture(timestampSignerInfo.Certificate))
+            if (IsCertificateValidityPeriodInTheFuture(timestamp.SignerInfo.Certificate))
             {
                 issues.Add(SignatureLog.Issue(failIfInvalid, NuGetLogCode.NU3044, Strings.TimestampNotYetValid));
                 isValid = false;

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SigningUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SigningUtility.cs
@@ -296,8 +296,10 @@ namespace NuGet.Packaging.Signing
         }
 
         // Ignore some chain status flags to special case them
-        public const X509ChainStatusFlags InvalidCertificateFlags =
-            (~(X509ChainStatusFlags)0) &                      // Start with all flags, and exclude known special cases
+        internal const X509ChainStatusFlags NotIgnoredCertificateFlags =
+            // To set the not ignored flags we have to turn on all the flags and then manually turn off ignored flags
+            (~(X509ChainStatusFlags)0) &                      // Start with all flags
+            // These flags are ignored because they are known special cases
             (~X509ChainStatusFlags.NotTimeValid) &
             (~X509ChainStatusFlags.NotTimeNested) &           // Deprecated and therefore ignored.
             (~X509ChainStatusFlags.Revoked) &
@@ -305,7 +307,7 @@ namespace NuGet.Packaging.Signing
             (~X509ChainStatusFlags.CtlNotTimeValid) &
             (~X509ChainStatusFlags.OfflineRevocation);
 
-        public static bool ChainStatusListIncludesStatus(X509ChainStatus[] chainStatuses, X509ChainStatusFlags status, out IReadOnlyList<X509ChainStatus> chainStatus)
+        internal static bool ChainStatusListIncludesStatus(X509ChainStatus[] chainStatuses, X509ChainStatusFlags status, out IReadOnlyList<X509ChainStatus> chainStatus)
         {
             chainStatus = chainStatuses
                 .Where(x => (x.Status & status) != 0)
@@ -319,7 +321,7 @@ namespace NuGet.Packaging.Signing
             return false;
         }
 
-        public static bool TryGetStatusMessage(X509ChainStatus[] chainStatuses, X509ChainStatusFlags status, out IReadOnlyList<string> messages)
+        internal static bool TryGetStatusMessage(X509ChainStatus[] chainStatuses, X509ChainStatusFlags status, out IReadOnlyList<string> messages)
         {
             messages = null;
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampVerificationUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampVerificationUtility.cs
@@ -21,29 +21,15 @@ namespace NuGet.Packaging.Signing
 
 #if IS_DESKTOP
 
-        internal static Tuple<DateTimeOffset, DateTimeOffset> GetTimeStampLimits(Rfc3161TimestampTokenInfo tstInfo)
-        {
-            var tstInfoGenTime = tstInfo.Timestamp;
-            var accuracyInMilliseconds = GetAccuracyInMilliseconds(tstInfo);
-
-            var timestampUpperGenTime = tstInfoGenTime.AddMilliseconds(accuracyInMilliseconds);
-            var timestampLowerGenTime = tstInfoGenTime.Subtract(TimeSpan.FromMilliseconds(accuracyInMilliseconds));
-
-            return new Tuple<DateTimeOffset, DateTimeOffset>(timestampUpperGenTime, timestampLowerGenTime);
-        }
-
         internal static bool ValidateSignerCertificateAgainstTimestamp(
             X509Certificate2 signerCertificate,
-            Tuple<DateTimeOffset, DateTimeOffset> limits)
+            Timestamp timestamp)
         {
-            var timestampLowerGenTime = limits.Item1;
-            var timestampUpperGenTime = limits.Item2;
-
             DateTimeOffset signerCertExpiry = DateTime.SpecifyKind(signerCertificate.NotAfter, DateTimeKind.Local);
             DateTimeOffset signerCertBegin = DateTime.SpecifyKind(signerCertificate.NotBefore, DateTimeKind.Local);
 
-            return timestampUpperGenTime < signerCertExpiry &&
-                timestampLowerGenTime > signerCertBegin;
+            return timestamp.UpperLimit < signerCertExpiry &&
+                timestamp.LowerLimit > signerCertBegin;
         }
 
         internal static bool TryReadTSTInfoFromSignedCms(

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/TimestampException.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/TimestampException.cs
@@ -12,11 +12,22 @@ namespace NuGet.Packaging.Signing
     /// <summary>
     /// Exceptions that are generated while creating a package timestamp.
     /// </summary>
-    public class TimestampException : Exception, ILogMessageException
+    public class TimestampException : SignatureException
     {
         private readonly ILogMessage _logMessage;
 
-        public TimestampException() : base()
+        public TimestampException()
+            : base(string.Empty)
+        {
+        }
+
+        public TimestampException(NuGetLogCode code, string message)
+            : base(code, message)
+        {
+        }
+
+        public TimestampException(string message)
+            : this(NuGetLogCode.NU3000, message)
         {
         }
 
@@ -26,7 +37,7 @@ namespace NuGet.Packaging.Signing
             _logMessage = logMessage ?? throw new ArgumentNullException(nameof(logMessage));
         }
 
-        public ILogMessage AsLogMessage()
+        public override ILogMessage AsLogMessage()
         {
             return _logMessage;
         }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/TimestampException.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/TimestampException.cs
@@ -16,6 +16,10 @@ namespace NuGet.Packaging.Signing
     {
         private readonly ILogMessage _logMessage;
 
+        public TimestampException() : base()
+        {
+        }
+
         public TimestampException(ILogMessage logMessage)
             : base(logMessage?.Message)
         {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/ISignatureVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/ISignatureVerificationProvider.cs
@@ -15,6 +15,6 @@ namespace NuGet.Packaging.Signing
         /// <summary>
         /// Check if <paramref name="signature" /> is trusted by the provider.
         /// </summary>
-        Task<PackageVerificationResult> GetTrustResultAsync(ISignedPackageReader package, Signature signature, CancellationToken token);
+        Task<PackageVerificationResult> GetTrustResultAsync(ISignedPackageReader package, Signature signature, SignedPackageVerifierSettings settings, CancellationToken token);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/IntegrityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/IntegrityVerificationProvider.cs
@@ -44,8 +44,7 @@ namespace NuGet.Packaging.Signing
             }
             else
             {
-                var code = !settings.AllowUntrusted ? NuGetLogCode.NU3013 : NuGetLogCode.NU3513;
-                issues.Add(SignatureLog.Issue(!settings.AllowUntrusted, code, Strings.SignatureFailureInvalidHashAlgorithmOid));
+                issues.Add(SignatureLog.Issue(!settings.AllowUntrusted, NuGetLogCode.NU3013, Strings.SignatureFailureInvalidHashAlgorithmOid));
                 issues.Add(SignatureLog.DebugLog(string.Format(CultureInfo.CurrentCulture, Strings.SignatureDebug_HashOidFound, signatureHashOid)));
             }
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/IntegrityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/IntegrityVerificationProvider.cs
@@ -13,43 +13,46 @@ namespace NuGet.Packaging.Signing
 {
     public class IntegrityVerificationProvider : ISignatureVerificationProvider
     {
-        public Task<PackageVerificationResult> GetTrustResultAsync(ISignedPackageReader package, Signature signature, CancellationToken token)
+        public Task<PackageVerificationResult> GetTrustResultAsync(ISignedPackageReader package, Signature signature, SignedPackageVerifierSettings settings, CancellationToken token)
         {
-            return VerifyPackageIntegrityAsync(package, signature);
+            return VerifyPackageIntegrityAsync(package, signature, settings);
         }
 
 #if IS_DESKTOP
-        private async Task<PackageVerificationResult> VerifyPackageIntegrityAsync(ISignedPackageReader package, Signature signature)
+        private async Task<PackageVerificationResult> VerifyPackageIntegrityAsync(ISignedPackageReader package, Signature signature, SignedPackageVerifierSettings settings)
         {
-            var status = SignatureVerificationStatus.Invalid;
+            var status = SignatureVerificationStatus.Untrusted;
             var issues = new List<SignatureLog>();
 
             var validHashOids = SigningSpecifications.V1.AllowedHashAlgorithmOids;
             var signatureHashOid = signature.SignatureContent.HashAlgorithm.ConvertToOidString();
-            if (!validHashOids.Contains(signatureHashOid, StringComparer.InvariantCultureIgnoreCase))
+            if (validHashOids.Contains(signatureHashOid, StringComparer.InvariantCultureIgnoreCase))
             {
-                issues.Add(SignatureLog.InvalidPackageError(Strings.SignatureFailureInvalidHashAlgorithmOid));
+                issues.Add(SignatureLog.InformationLog(string.Format(CultureInfo.CurrentCulture, Strings.SignatureHashAlgorithm, signature.SignatureContent.HashAlgorithm)));
+
+                try
+                {
+                    await package.ValidateIntegrityAsync(signature.SignatureContent, CancellationToken.None);
+                    status = SignatureVerificationStatus.Trusted;
+                }
+                catch (Exception e)
+                {
+                    status = SignatureVerificationStatus.Invalid;
+                    issues.Add(SignatureLog.Issue(true, NuGetLogCode.NU3015, Strings.SignaturePackageIntegrityFailure));
+                    issues.Add(SignatureLog.DebugLog(e.ToString()));
+                }
+            }
+            else
+            {
+                var code = !settings.AllowUntrusted ? NuGetLogCode.NU3013 : NuGetLogCode.NU3513;
+                issues.Add(SignatureLog.Issue(!settings.AllowUntrusted, code, Strings.SignatureFailureInvalidHashAlgorithmOid));
                 issues.Add(SignatureLog.DebugLog(string.Format(CultureInfo.CurrentCulture, Strings.SignatureDebug_HashOidFound, signatureHashOid)));
-                return new SignedPackageVerificationResult(status, signature, issues);
-            }
-
-            issues.Add(SignatureLog.InformationLog(string.Format(CultureInfo.CurrentCulture, Strings.SignatureHashAlgorithm, signature.SignatureContent.HashAlgorithm)));
-
-            try
-            {
-                await package.ValidateIntegrityAsync(signature.SignatureContent, CancellationToken.None);
-                status = SignatureVerificationStatus.Trusted;
-            }
-            catch (Exception e)
-            {
-                issues.Add(SignatureLog.InvalidPackageError(Strings.SignaturePackageIntegrityFailure));
-                issues.Add(SignatureLog.DebugLog(e.ToString()));
             }
 
             return new SignedPackageVerificationResult(status, signature, issues);
         }
 #else
-        private Task<PackageVerificationResult> VerifyPackageIntegrityAsync(ISignedPackageReader package, Signature signature)
+        private Task<PackageVerificationResult> VerifyPackageIntegrityAsync(ISignedPackageReader package, Signature signature, SignedPackageVerifierSettings settings)
         {
             throw new NotSupportedException();
         }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/PackageSignatureVerifier.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/PackageSignatureVerifier.cs
@@ -43,7 +43,7 @@ namespace NuGet.Packaging.Signing
                     // Verify that the signatures are trusted
                     foreach (var signature in signatures)
                     {
-                        var sigTrustResults = await Task.WhenAll(_verificationProviders.Select(e => e.GetTrustResultAsync(package, signature, token)));
+                        var sigTrustResults = await Task.WhenAll(_verificationProviders.Select(e => e.GetTrustResultAsync(package, signature, _settings, token)));
                         signaturesAreValid &= IsValid(sigTrustResults, _settings.AllowUntrusted);
                         trustResults.AddRange(sigTrustResults);
                     }
@@ -54,7 +54,7 @@ namespace NuGet.Packaging.Signing
                 {
                     // CryptographicException generated while parsing the SignedCms object
                     var issues = new[] {
-                        SignatureLog.InvalidInputError(Strings.ErrorPackageSignatureInvalid),
+                        SignatureLog.Issue(true, NuGetLogCode.NU3005, Strings.ErrorPackageSignatureInvalid),
                         SignatureLog.DebugLog(e.ToString())
                     };
                     trustResults.Add(new InvalidSignaturePackageVerificationResult(SignatureVerificationStatus.Invalid, issues));
@@ -67,7 +67,7 @@ namespace NuGet.Packaging.Signing
             }
             else
             {
-                var issues = new[] { SignatureLog.InvalidInputError(Strings.ErrorPackageNotSigned) };
+                var issues = new[] { SignatureLog.Issue(true, NuGetLogCode.NU3006, Strings.ErrorPackageNotSigned) };
                 trustResults.Add(new UnsignedPackageVerificationResult(SignatureVerificationStatus.Invalid, issues));
             }
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/PackageSignatureVerifier.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/PackageSignatureVerifier.cs
@@ -50,14 +50,23 @@ namespace NuGet.Packaging.Signing
 
                     valid = signaturesAreValid;
                 }
+                catch(SignatureException e)
+                {
+                    // SignatureException generated while parsing signatures
+                    var issues = new[] {
+                        SignatureLog.Issue(!_settings.AllowUntrusted, e.Code, e.Message),
+                        SignatureLog.DebugLog(e.ToString())
+                    };
+                    trustResults.Add(new InvalidSignaturePackageVerificationResult(SignatureVerificationStatus.Untrusted, issues));
+                }
                 catch(CryptographicException e)
                 {
                     // CryptographicException generated while parsing the SignedCms object
                     var issues = new[] {
-                        SignatureLog.Issue(true, NuGetLogCode.NU3005, Strings.ErrorPackageSignatureInvalid),
+                        SignatureLog.Issue(!_settings.AllowUntrusted, NuGetLogCode.NU3005, Strings.ErrorPackageSignatureInvalid),
                         SignatureLog.DebugLog(e.ToString())
                     };
-                    trustResults.Add(new InvalidSignaturePackageVerificationResult(SignatureVerificationStatus.Invalid, issues));
+                    trustResults.Add(new InvalidSignaturePackageVerificationResult(SignatureVerificationStatus.Untrusted, issues));
                 }
             }
             else if (_settings.AllowUnsigned)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/PackageSignatureVerifier.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/PackageSignatureVerifier.cs
@@ -58,6 +58,7 @@ namespace NuGet.Packaging.Signing
                         SignatureLog.DebugLog(e.ToString())
                     };
                     trustResults.Add(new InvalidSignaturePackageVerificationResult(SignatureVerificationStatus.Untrusted, issues));
+                    valid = _settings.AllowUntrusted;
                 }
                 catch(CryptographicException e)
                 {
@@ -67,6 +68,7 @@ namespace NuGet.Packaging.Signing
                         SignatureLog.DebugLog(e.ToString())
                     };
                     trustResults.Add(new InvalidSignaturePackageVerificationResult(SignatureVerificationStatus.Untrusted, issues));
+                    valid = _settings.AllowUntrusted;
                 }
             }
             else if (_settings.AllowUnsigned)
@@ -78,6 +80,7 @@ namespace NuGet.Packaging.Signing
             {
                 var issues = new[] { SignatureLog.Issue(true, NuGetLogCode.NU3006, Strings.ErrorPackageNotSigned) };
                 trustResults.Add(new UnsignedPackageVerificationResult(SignatureVerificationStatus.Invalid, issues));
+                valid = false;
             }
 
             return new VerifySignaturesResult(valid, trustResults);

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
@@ -43,69 +43,57 @@ namespace NuGet.Packaging.Signing
                 SignatureLog.InformationLog(string.Format(CultureInfo.CurrentCulture, Strings.SignatureType, signature.Type.ToString()))
             };
 
-            Tuple<DateTimeOffset, DateTimeOffset> timestampLimits;
+            Timestamp validTimestamp;
             try
             {
-                timestampLimits = GetTimestampLimits(signature, !settings.FailWithMultipleTimestamps, !settings.AllowIgnoreTimestamp, !settings.AllowNoTimestamp, issues);
+                validTimestamp = GetValidTimestamp(signature, !settings.FailWithMultipleTimestamps, !settings.AllowIgnoreTimestamp, !settings.AllowNoTimestamp, issues);
             }
             catch (TimestampException)
             {
                 return new SignedPackageVerificationResult(SignatureVerificationStatus.Invalid, signature, issues);
             }
 
-            var status = VerifySignature(signature, timestampLimits, !settings.AllowUntrusted, issues);
+            var status = VerifySignature(signature, validTimestamp, !settings.AllowUntrusted, issues);
             return new SignedPackageVerificationResult(status, signature, issues);
         }
 
-        private Tuple<DateTimeOffset, DateTimeOffset> GetTimestampLimits(Signature signature, bool ignoreMultipleTimestamps, bool failIfInvalid, bool failIfNoTimestamp, List<SignatureLog> issues)
+        private Timestamp GetValidTimestamp(Signature signature, bool ignoreMultipleTimestamps, bool failIfInvalid, bool failIfNoTimestamp, List<SignatureLog> issues)
         {
-            Tuple<DateTimeOffset, DateTimeOffset> timestampLimits = null;
-            var timestampCms = new SignedCms();
-            var hasFoundOneTimestamp = false;
+            var timestamps = signature.Timestamps;
 
-            var authorUnsignedAttributes = signature.SignerInfo.UnsignedAttributes;
-            foreach (var attribute in authorUnsignedAttributes)
+            if (timestamps.Count == 0)
             {
-                if (StringComparer.Ordinal.Equals(attribute.Oid.Value, Oids.SignatureTimeStampTokenAttributeOid))
-                {
-                    if (hasFoundOneTimestamp && !ignoreMultipleTimestamps)
-                    {
-                        issues.Add(SignatureLog.Issue(true, NuGetLogCode.NU3000, Strings.ErrorMultipleTimestamps));
-                        throw new TimestampException();
-                    }
-                    hasFoundOneTimestamp = true;
-                    timestampCms.Decode(attribute.Values[0].RawData);
-                    using (var authorSignatureNativeCms = NativeCms.Decode(signature.SignedCms.Encode(), detached: false))
-                    {
-                        var signatureHash = NativeCms.GetSignatureValueHash(signature.SignatureContent.HashAlgorithm, authorSignatureNativeCms);
-                        timestampLimits = GetTimestampIfValid(timestampCms, signatureHash, failIfInvalid, issues);
-
-                        if (timestampLimits == null && failIfInvalid)
-                        {
-                            throw new TimestampException();
-                        }
-                    }
-
-                    if (ignoreMultipleTimestamps)
-                    {
-                        break;
-                    }
-                }
-            }
-
-            if (!hasFoundOneTimestamp)
-            {
-                issues.Add(SignatureLog.Issue(failIfNoTimestamp, NuGetLogCode.NU3550, Strings.ErrorNoTimestamp));
+                issues.Add(SignatureLog.Issue(failIfNoTimestamp, NuGetLogCode.NU3050, Strings.ErrorNoTimestamp));
                 if (failIfNoTimestamp)
                 {
                     throw new TimestampException();
                 }
             }
 
-            return timestampLimits;
+            if (timestamps.Count > 1 && !ignoreMultipleTimestamps)
+            {
+                issues.Add(SignatureLog.Issue(true, NuGetLogCode.NU3000, Strings.ErrorMultipleTimestamps));
+                throw new TimestampException();
+            }
+
+            var timestamp = timestamps.FirstOrDefault();
+            if (timestamp != null)
+            {
+                using (var authorSignatureNativeCms = NativeCms.Decode(signature.SignedCms.Encode(), detached: false))
+                {
+                    var signatureHash = NativeCms.GetSignatureValueHash(signature.SignatureContent.HashAlgorithm, authorSignatureNativeCms);
+
+                    if (!IsTimestampValid(timestamp, signatureHash, failIfInvalid, issues) && failIfInvalid)
+                    {
+                        throw new TimestampException();
+                    }
+                }
+            }
+
+            return timestamp;
         }
 
-        private SignatureVerificationStatus VerifySignature(Signature signature, Tuple<DateTimeOffset, DateTimeOffset> timestampLimits, bool failuresAreFatal, List<SignatureLog> issues)
+        private SignatureVerificationStatus VerifySignature(Signature signature, Timestamp timestamp, bool failuresAreFatal, List<SignatureLog> issues)
         {
             var certificate = signature.SignerInfo.Certificate;
             if (certificate != null)
@@ -127,8 +115,8 @@ namespace NuGet.Packaging.Signing
 
                 if (!SigningUtility.IsCertificateValidityPeriodInTheFuture(certificate))
                 {
-                    timestampLimits = timestampLimits ?? new Tuple<DateTimeOffset, DateTimeOffset>(DateTimeOffset.Now, DateTimeOffset.Now);
-                    if (Rfc3161TimestampVerificationUtility.ValidateSignerCertificateAgainstTimestamp(certificate, timestampLimits))
+                    timestamp = timestamp ?? new Timestamp();
+                    if (Rfc3161TimestampVerificationUtility.ValidateSignerCertificateAgainstTimestamp(certificate, timestamp))
                     {
                         // Read signed attribute containing the original cert hashes
                         // var signingCertificateAttribute = signature.SignerInfo.SignedAttributes.GetAttributeOrDefault(Oids.SigningCertificateV2);
@@ -138,7 +126,7 @@ namespace NuGet.Packaging.Signing
 
                         using (var chain = new X509Chain())
                         {
-                            SigningUtility.SetCertBuildChainPolicy(chain.ChainPolicy, certificateExtraStore, timestampLimits.Item2.LocalDateTime, NuGetVerificationCertificateType.Signature);
+                            SigningUtility.SetCertBuildChainPolicy(chain.ChainPolicy, certificateExtraStore, timestamp.UpperLimit.LocalDateTime, NuGetVerificationCertificateType.Signature);
                             var chainBuildingSucceed = SigningUtility.BuildCertificateChain(chain, certificate, out var chainStatusList);
 
                             issues.Add(SignatureLog.DetailedLog(CertificateUtility.X509ChainToString(chain)));
@@ -214,98 +202,89 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         /// <param name="timestampCms">SignedCms response from the timestamp authority.</param>
         /// <param name="data">byte[] data that was signed and timestamped.</param>
-        private Tuple<DateTimeOffset, DateTimeOffset> GetTimestampIfValid(SignedCms timestampCms, byte[] data, bool failuresAreFatal, List<SignatureLog> issues)
+        private bool IsTimestampValid(Timestamp timestamp, byte[] data, bool failuresAreFatal, List<SignatureLog> issues)
         {
-            var timestampSignerInfo = timestampCms.SignerInfos[0];
-            var timestamperCertificate = timestampSignerInfo.Certificate;
+            var timestamperCertificate = timestamp.SignerInfo.Certificate;
 
             if (timestamperCertificate == null)
             {
                 issues.Add(SignatureLog.Issue(failuresAreFatal, NuGetLogCode.NU3040, Strings.TimestampNoCertificate));
-                return null;
+                return false;
             }
 
-            if (Rfc3161TimestampVerificationUtility.TryReadTSTInfoFromSignedCms(timestampCms, out var tstInfo))
+            if (SigningUtility.IsTimestampValid(timestamp, data, failuresAreFatal, issues, _specification))
             {
-                if (SigningUtility.IsTimestampValid(data, failuresAreFatal, issues, timestampSignerInfo, tstInfo, _specification))
+                issues.Add(SignatureLog.InformationLog(string.Format(CultureInfo.CurrentCulture, Strings.TimestampValue, timestamp.GeneralizedTime.LocalDateTime.ToString()) + Environment.NewLine));
+
+                issues.Add(SignatureLog.InformationLog(string.Format(CultureInfo.CurrentCulture,
+                    Strings.VerificationTimestamperCertDisplay,
+                    $"{Environment.NewLine}{CertificateUtility.X509Certificate2ToString(timestamperCertificate)}")));
+
+                //var signingCertificateAttribute = timestampSignerInfo.SignedAttributes.GetAttributeOrDefault(Oids.SigningCertificate);
+                //if (signingCertificateAttribute == null)
+                //{
+                //    signingCertificateAttribute = timestampSignerInfo.SignedAttributes.GetAttributeOrDefault(Oids.SigningCertificateV2);
+                //}
+                // TODO: how are we going to use the signingCertificateAttribute?
+
+                var certificateExtraStore = timestamp.SignedCms.Certificates;
+
+                using (var chain = new X509Chain())
                 {
-                    issues.Add(SignatureLog.InformationLog(string.Format(CultureInfo.CurrentCulture, Strings.TimestampValue, tstInfo.Timestamp.LocalDateTime.ToString()) + Environment.NewLine));
+                    SigningUtility.SetCertBuildChainPolicy(chain.ChainPolicy, certificateExtraStore, DateTime.Now, NuGetVerificationCertificateType.Timestamp);
 
-                    issues.Add(SignatureLog.InformationLog(string.Format(CultureInfo.CurrentCulture,
-                        Strings.VerificationTimestamperCertDisplay,
-                        $"{Environment.NewLine}{CertificateUtility.X509Certificate2ToString(timestamperCertificate)}")));
+                    var chainBuildSucceed = SigningUtility.BuildCertificateChain(chain, timestamperCertificate, out var chainStatusList);
 
-                    //var signingCertificateAttribute = timestampSignerInfo.SignedAttributes.GetAttributeOrDefault(Oids.SigningCertificate);
-                    //if (signingCertificateAttribute == null)
-                    //{
-                    //    signingCertificateAttribute = timestampSignerInfo.SignedAttributes.GetAttributeOrDefault(Oids.SigningCertificateV2);
-                    //}
-                    // TODO: how are we going to use the signingCertificateAttribute?
+                    issues.Add(SignatureLog.DetailedLog(CertificateUtility.X509ChainToString(chain)));
 
-                    var certificateExtraStore = timestampCms.Certificates;
-
-                    using (var chain = new X509Chain())
+                    if (chainBuildSucceed)
                     {
-                        SigningUtility.SetCertBuildChainPolicy(chain.ChainPolicy, certificateExtraStore, DateTime.Now, NuGetVerificationCertificateType.Timestamp);
+                        return true;
+                    }
 
-                        var chainBuildSucceed = SigningUtility.BuildCertificateChain(chain, timestamperCertificate, out var chainStatusList);
+                    var chainBuildingHasIssues = false;
+                    IReadOnlyList<string> messages;
 
-                        issues.Add(SignatureLog.DetailedLog(CertificateUtility.X509ChainToString(chain)));
+                    var timestampInvalidCertificateFlags = SigningUtility.InvalidCertificateFlags |
+                        (X509ChainStatusFlags.Revoked) |
+                        (X509ChainStatusFlags.NotTimeValid) |
+                        (X509ChainStatusFlags.CtlNotTimeValid);
 
-                        if (chainBuildSucceed)
+                    if (SigningUtility.TryGetStatusMessage(chainStatusList, timestampInvalidCertificateFlags, out messages))
+                    {
+                        foreach (var message in messages)
                         {
-                            return Rfc3161TimestampVerificationUtility.GetTimeStampLimits(tstInfo);
+                            issues.Add(SignatureLog.Issue(failuresAreFatal, NuGetLogCode.NU3041, message));
                         }
+                        chainBuildingHasIssues = true;
+                    }
 
-                        var chainBuildingHasIssues = false;
-                        IReadOnlyList<string> messages;
+                    // For all the special cases, chain status list only has unique elements for each chain status flag present
+                    // therefore if we are checking for one specific chain status we can use the first of the returned list
+                    // if we are combining checks for more than one, then we have to use the whole list.
 
-                        var timestampInvalidCertificateFlags = SigningUtility.InvalidCertificateFlags |
-                            (X509ChainStatusFlags.Revoked) |
-                            (X509ChainStatusFlags.NotTimeValid) |
-                            (X509ChainStatusFlags.CtlNotTimeValid);
-
-                        if (SigningUtility.TryGetStatusMessage(chainStatusList, timestampInvalidCertificateFlags, out messages))
+                    const X509ChainStatusFlags RevocationStatusFlags = X509ChainStatusFlags.RevocationStatusUnknown | X509ChainStatusFlags.OfflineRevocation;
+                    if (SigningUtility.TryGetStatusMessage(chainStatusList, RevocationStatusFlags, out messages))
+                    {
+                        if (failuresAreFatal)
                         {
                             foreach (var message in messages)
                             {
                                 issues.Add(SignatureLog.Issue(failuresAreFatal, NuGetLogCode.NU3041, message));
                             }
-                            chainBuildingHasIssues = true;
                         }
-
-                        // For all the special cases, chain status list only has unique elements for each chain status flag present
-                        // therefore if we are checking for one specific chain status we can use the first of the returned list
-                        // if we are combining checks for more than one, then we have to use the whole list.
-
-                        const X509ChainStatusFlags RevocationStatusFlags = X509ChainStatusFlags.RevocationStatusUnknown | X509ChainStatusFlags.OfflineRevocation;
-                        if (SigningUtility.TryGetStatusMessage(chainStatusList, RevocationStatusFlags, out messages))
+                        else if (!chainBuildingHasIssues)
                         {
-                            if (failuresAreFatal)
-                            {
-                                foreach (var message in messages)
-                                {
-                                    issues.Add(SignatureLog.Issue(failuresAreFatal, NuGetLogCode.NU3041, message));
-                                }
-                            }
-                            else if (!chainBuildingHasIssues)
-                            {
-                                return Rfc3161TimestampVerificationUtility.GetTimeStampLimits(tstInfo);
-                            }
-                            chainBuildingHasIssues = true;
+                            return true;
                         }
-
-                        // Debug log any errors
-                        issues.Add(SignatureLog.DebugLog(string.Format(CultureInfo.CurrentCulture, Strings.ErrorInvalidCertificateChain, string.Join(", ", chainStatusList.Select(x => x.ToString())))));
+                        chainBuildingHasIssues = true;
                     }
+
+                    // Debug log any errors
+                    issues.Add(SignatureLog.DebugLog(string.Format(CultureInfo.CurrentCulture, Strings.ErrorInvalidCertificateChain, string.Join(", ", chainStatusList.Select(x => x.ToString())))));
                 }
             }
-            else
-            {
-                issues.Add(SignatureLog.Issue(failuresAreFatal, NuGetLogCode.NU3050, Strings.TimestampFailureInvalidContentType));
-            }
-
-            return null;
+            return false;
         }
 #else
         private PackageVerificationResult VerifyValidityAndTrust(ISignedPackageReader package, Signature signature, SignedPackageVerifierSettings settings)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
@@ -138,7 +138,7 @@ namespace NuGet.Packaging.Signing
 
                             var chainBuildingHasIssues = false;
                             IReadOnlyList<string> messages;
-                            if (SigningUtility.TryGetStatusMessage(chainStatusList, SigningUtility.InvalidCertificateFlags, out messages))
+                            if (SigningUtility.TryGetStatusMessage(chainStatusList, SigningUtility.NotIgnoredCertificateFlags, out messages))
                             {
                                 foreach (var message in messages)
                                 {
@@ -245,7 +245,7 @@ namespace NuGet.Packaging.Signing
                     var chainBuildingHasIssues = false;
                     IReadOnlyList<string> messages;
 
-                    var timestampInvalidCertificateFlags = SigningUtility.InvalidCertificateFlags |
+                    var timestampInvalidCertificateFlags = SigningUtility.NotIgnoredCertificateFlags |
                         (X509ChainStatusFlags.Revoked) |
                         (X509ChainStatusFlags.NotTimeValid) |
                         (X509ChainStatusFlags.CtlNotTimeValid);

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
@@ -225,15 +225,15 @@ namespace NuGet.Packaging.Signing
                 return null;
             }
 
-            issues.Add(SignatureLog.InformationLog(string.Format(CultureInfo.CurrentCulture,
-                Strings.VerificationTimestamperCertDisplay,
-                $"{Environment.NewLine}{CertificateUtility.X509Certificate2ToString(timestamperCertificate)}")));
-
             if (Rfc3161TimestampVerificationUtility.TryReadTSTInfoFromSignedCms(timestampCms, out var tstInfo))
             {
                 if (SigningUtility.IsTimestampValid(data, failuresAreFatal, issues, timestampSignerInfo, tstInfo, _specification))
                 {
                     issues.Add(SignatureLog.InformationLog(string.Format(CultureInfo.CurrentCulture, Strings.TimestampValue, tstInfo.Timestamp.LocalDateTime.ToString()) + Environment.NewLine));
+
+                    issues.Add(SignatureLog.InformationLog(string.Format(CultureInfo.CurrentCulture,
+                        Strings.VerificationTimestamperCertDisplay,
+                        $"{Environment.NewLine}{CertificateUtility.X509Certificate2ToString(timestamperCertificate)}")));
 
                     //var signingCertificateAttribute = timestampSignerInfo.SignedAttributes.GetAttributeOrDefault(Oids.SigningCertificate);
                     //if (signingCertificateAttribute == null)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
@@ -120,8 +120,7 @@ namespace NuGet.Packaging.Signing
                 }
                 catch (Exception e)
                 {
-                    var code = failuresAreFatal ? NuGetLogCode.NU3030 : NuGetLogCode.NU3530;
-                    issues.Add(SignatureLog.Issue(failuresAreFatal, code, Strings.ErrorSignatureVerificationFailed));
+                    issues.Add(SignatureLog.Issue(failuresAreFatal, NuGetLogCode.NU3030, Strings.ErrorSignatureVerificationFailed));
                     issues.Add(SignatureLog.DebugLog(e.ToString()));
                     return SignatureVerificationStatus.Invalid;
                 }
@@ -194,14 +193,12 @@ namespace NuGet.Packaging.Signing
                     }
                     else
                     {
-                        var code = failuresAreFatal ? NuGetLogCode.NU3030 : NuGetLogCode.NU3530;
-                        issues.Add(SignatureLog.Issue(failuresAreFatal, code, Strings.ErrorSignatureVerificationFailed));
+                        issues.Add(SignatureLog.Issue(failuresAreFatal, NuGetLogCode.NU3030, Strings.ErrorSignatureVerificationFailed));
                     }
                 }
                 else
                 {
-                    var code = failuresAreFatal ? NuGetLogCode.NU3024 : NuGetLogCode.NU3524;
-                    issues.Add(SignatureLog.Issue(failuresAreFatal, code, Strings.SignatureNotYetValid));
+                    issues.Add(SignatureLog.Issue(failuresAreFatal, NuGetLogCode.NU3024, Strings.SignatureNotYetValid));
                 }
             }
             else
@@ -305,8 +302,7 @@ namespace NuGet.Packaging.Signing
             }
             else
             {
-                var code = failuresAreFatal ? NuGetLogCode.NU3050 : NuGetLogCode.NU3550;
-                issues.Add(SignatureLog.Issue(failuresAreFatal, code, Strings.TimestampFailureInvalidContentType));
+                issues.Add(SignatureLog.Issue(failuresAreFatal, NuGetLogCode.NU3050, Strings.TimestampFailureInvalidContentType));
             }
 
             return null;

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifierSettings.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifierSettings.cs
@@ -18,30 +18,38 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         public bool AllowUntrusted { get; }
 
-        private SignedPackageVerifierSettings(bool allowUnsigned, bool allowUntrusted)
+        public bool AllowIgnoreTimestamp { get; }
+
+
+        public bool FailWithMultipleTimestamps { get; }
+
+        public bool AllowNoTimestamp { get; }
+
+        private SignedPackageVerifierSettings(bool allowUnsigned, bool allowUntrusted, bool allowIgnoreTimestamp, bool failWithMultupleTimestamps, bool allowNoTimestamp)
         {
             AllowUnsigned = allowUnsigned;
             AllowUntrusted = allowUntrusted;
+            AllowIgnoreTimestamp = allowIgnoreTimestamp;
+            FailWithMultipleTimestamps = failWithMultupleTimestamps;
+            AllowNoTimestamp = allowNoTimestamp;
         }
 
         /// <summary>
         /// Allow unsigned.
         /// </summary>
-        public static SignedPackageVerifierSettings AllowAll { get; } = new SignedPackageVerifierSettings(allowUnsigned: true, allowUntrusted: true);
+        public static SignedPackageVerifierSettings AllowAll { get; } = new SignedPackageVerifierSettings(allowUnsigned: true, allowUntrusted: true, allowIgnoreTimestamp: true, failWithMultupleTimestamps: false, allowNoTimestamp: true);
 
         /// <summary>
         /// Default settings.
         /// </summary>
         public static SignedPackageVerifierSettings Default { get; } = AllowAll;
 
-        /// <summary>
-        /// Require all packages to be signed and valid.
-        /// </summary>
-        public static SignedPackageVerifierSettings RequireSigned { get; } = new SignedPackageVerifierSettings(allowUnsigned: false, allowUntrusted: false);
 
-        /// <summary>
-        /// Require all packages to be signed but allow untrusted packages that are valid.
-        /// </summary>
-        public static SignedPackageVerifierSettings RequireSignedAllowUntrusted { get; } = new SignedPackageVerifierSettings(allowUnsigned: false, allowUntrusted: true);
+        public static SignedPackageVerifierSettings VSClientDefaultPolicy { get; } = new SignedPackageVerifierSettings(allowUnsigned: true, allowUntrusted: true, allowIgnoreTimestamp: true, failWithMultupleTimestamps: false, allowNoTimestamp: true);
+
+        public static SignedPackageVerifierSettings CommandDefaultPolicy { get; } = new SignedPackageVerifierSettings(allowUnsigned: false, allowUntrusted: false, allowIgnoreTimestamp: false, failWithMultupleTimestamps: false, allowNoTimestamp: true);
+
+        public static SignedPackageVerifierSettings ServerDefaultPolicy { get; } = new SignedPackageVerifierSettings(allowUnsigned: false, allowUntrusted: false, allowIgnoreTimestamp: false, failWithMultupleTimestamps: true, allowNoTimestamp: false);
+
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifierSettings.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifierSettings.cs
@@ -44,12 +44,8 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         public static SignedPackageVerifierSettings Default { get; } = AllowAll;
 
-
         public static SignedPackageVerifierSettings VSClientDefaultPolicy { get; } = new SignedPackageVerifierSettings(allowUnsigned: true, allowUntrusted: true, allowIgnoreTimestamp: true, failWithMultupleTimestamps: false, allowNoTimestamp: true);
 
-        public static SignedPackageVerifierSettings CommandDefaultPolicy { get; } = new SignedPackageVerifierSettings(allowUnsigned: false, allowUntrusted: false, allowIgnoreTimestamp: false, failWithMultupleTimestamps: false, allowNoTimestamp: true);
-
-        public static SignedPackageVerifierSettings ServerDefaultPolicy { get; } = new SignedPackageVerifierSettings(allowUnsigned: false, allowUntrusted: false, allowIgnoreTimestamp: false, failWithMultupleTimestamps: true, allowNoTimestamp: false);
-
+        public static SignedPackageVerifierSettings VerifyCommandDefaultPolicy { get; } = new SignedPackageVerifierSettings(allowUnsigned: false, allowUntrusted: false, allowIgnoreTimestamp: false, failWithMultupleTimestamps: false, allowNoTimestamp: true);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -287,11 +287,29 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not validate signature. Signature does not have a certificate..
+        ///   Looks up a localized string similar to Multiple timestamps are not accepted..
+        /// </summary>
+        internal static string ErrorMultipleTimestamps {
+            get {
+                return ResourceManager.GetString("ErrorMultipleTimestamps", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The primary signature did not have a signing certificate..
         /// </summary>
         internal static string ErrorNoCertificate {
             get {
                 return ResourceManager.GetString("ErrorNoCertificate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The primary signature should be timestamped to enable long-term signature validity after the certificate has expired..
+        /// </summary>
+        internal static string ErrorNoTimestamp {
+            get {
+                return ResourceManager.GetString("ErrorNoTimestamp", resourceCulture);
             }
         }
         
@@ -341,7 +359,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Signature verification failed..
+        ///   Looks up a localized string similar to Primary signature validation failed..
         /// </summary>
         internal static string ErrorSignatureVerificationFailed {
             get {
@@ -368,7 +386,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Zip64 archives are not supported.
+        ///   Looks up a localized string similar to ZIP64 signed packages are not supported..
         /// </summary>
         internal static string ErrorZip64NotSupported {
             get {
@@ -575,7 +593,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Signature response does not contain an acceptable hash algorithm..
+        ///   Looks up a localized string similar to The primary signature uses an unsupported hash algorithm..
         /// </summary>
         internal static string SignatureFailureInvalidHashAlgorithmOid {
             get {
@@ -773,7 +791,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Timestamp signature contains invalid content type..
+        ///   Looks up a localized string similar to Timestamp signature validation failed..
         /// </summary>
         internal static string TimestampFailureInvalidContentType {
             get {
@@ -782,7 +800,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Timestamp response contains invalid signature value hash..
+        ///   Looks up a localized string similar to Timestamp integrity check failed..
         /// </summary>
         internal static string TimestampFailureInvalidHash {
             get {
@@ -791,7 +809,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Timestamp response does not contain an acceptable hash algorithm..
+        ///   Looks up a localized string similar to The timestamp uses as unsupported hash algorithm..
         /// </summary>
         internal static string TimestampFailureInvalidHashAlgorithmOid {
             get {
@@ -823,6 +841,15 @@ namespace NuGet.Packaging {
         internal static string TimestampInvalid {
             get {
                 return ResourceManager.GetString("TimestampInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The timestamp signature did not have a signing certificate..
+        /// </summary>
+        internal static string TimestampNoCertificate {
+            get {
+                return ResourceManager.GetString("TimestampNoCertificate", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -161,7 +161,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SignedCms does not have one primary signature..
+        ///   Looks up a localized string similar to The package signature contains multiple primary signatures..
         /// </summary>
         internal static string Error_NotOnePrimarySignature {
             get {
@@ -917,7 +917,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package signature format version is unsupported.  Updating your client may solve this problem..
+        ///   Looks up a localized string similar to The package signature format version is not supported. Updating your client may solve this problem..
         /// </summary>
         internal static string UnsupportedSignatureFormatVersion {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -645,6 +645,15 @@ namespace NuGet.Packaging {
                 return ResourceManager.GetString("SignatureLocalFileHeaderInvalid", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The signing certificate is not yet valid..
+        /// </summary>
+        internal static string SignatureNotYetValid {
+            get {
+                return ResourceManager.GetString("SignatureNotYetValid", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Package integrity check failed..
@@ -850,6 +859,15 @@ namespace NuGet.Packaging {
         internal static string TimestampNoCertificate {
             get {
                 return ResourceManager.GetString("TimestampNoCertificate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The timestamp signing certificate is not yet valid..
+        /// </summary>
+        internal static string TimestampNotYetValid {
+            get {
+                return ResourceManager.GetString("TimestampNotYetValid", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -227,10 +227,10 @@
     <value>Author certificate was not valid when it was timestamped.</value>
   </data>
   <data name="TimestampFailureInvalidHash" xml:space="preserve">
-    <value>Timestamp response contains invalid signature value hash.</value>
+    <value>Timestamp integrity check failed.</value>
   </data>
   <data name="TimestampFailureInvalidHashAlgorithmOid" xml:space="preserve">
-    <value>Timestamp response does not contain an acceptable hash algorithm.</value>
+    <value>The timestamp uses as unsupported hash algorithm.</value>
   </data>
   <data name="TimestampFailureInvalidHttpScheme" xml:space="preserve">
     <value>The timestamper url '{0}' has an invalid uri scheme. The supported schemes are '{1}' and '{2}'.</value>
@@ -246,7 +246,7 @@
     <comment>0 - Reason for failure</comment>
   </data>
   <data name="TimestampFailureInvalidContentType" xml:space="preserve">
-    <value>Timestamp signature contains invalid content type.</value>
+    <value>Timestamp signature validation failed.</value>
   </data>
   <data name="TimestampCertificateChainBuildFailure" xml:space="preserve">
     <value>The timestamp service's certificate chain could not be built for the following certificate: {0}</value>
@@ -335,16 +335,16 @@ Valid from:</comment>
     <value>Could not validate signature. Certificate does not meet the public key requirements.</value>
   </data>
   <data name="ErrorNoCertificate" xml:space="preserve">
-    <value>Could not validate signature. Signature does not have a certificate.</value>
+    <value>The primary signature did not have a signing certificate.</value>
   </data>
   <data name="ErrorSignatureVerificationFailed" xml:space="preserve">
-    <value>Signature verification failed.</value>
+    <value>Primary signature validation failed.</value>
   </data>
   <data name="SignatureDebug_HashOidFound" xml:space="preserve">
     <value>Signature hash oid found: {0}</value>
   </data>
   <data name="SignatureFailureInvalidHashAlgorithmOid" xml:space="preserve">
-    <value>Signature response does not contain an acceptable hash algorithm.</value>
+    <value>The primary signature uses an unsupported hash algorithm.</value>
   </data>
   <data name="SignaturePackageIntegrityFailure" xml:space="preserve">
     <value>Package integrity check failed.</value>
@@ -380,7 +380,7 @@ Valid from:</comment>
     <value>Invalid package archive.</value>
   </data>
   <data name="ErrorZip64NotSupported" xml:space="preserve">
-    <value>Zip64 archives are not supported</value>
+    <value>ZIP64 signed packages are not supported.</value>
   </data>
   <data name="Error_NotOnePrimarySignature" xml:space="preserve">
     <value>SignedCms does not have one primary signature.</value>
@@ -449,5 +449,14 @@ Valid from:</comment>
   </data>
   <data name="SignedPackageArchiveIOInvalidRead" xml:space="preserve">
     <value>Package stream read position cannot be before the current position in the stream.</value>
+  </data>
+  <data name="ErrorMultipleTimestamps" xml:space="preserve">
+    <value>Multiple timestamps are not accepted.</value>
+  </data>
+  <data name="ErrorNoTimestamp" xml:space="preserve">
+    <value>The primary signature should be timestamped to enable long-term signature validity after the certificate has expired.</value>
+  </data>
+  <data name="TimestampNoCertificate" xml:space="preserve">
+    <value>The timestamp signature did not have a signing certificate.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -383,7 +383,7 @@ Valid from:</comment>
     <value>ZIP64 signed packages are not supported.</value>
   </data>
   <data name="Error_NotOnePrimarySignature" xml:space="preserve">
-    <value>SignedCms does not have one primary signature.</value>
+    <value>The package signature contains multiple primary signatures.</value>
   </data>
   <data name="TimestampCertificateInvalid" xml:space="preserve">
     <value>The timestamp service's certificate has a valid time in the future: {0}</value>
@@ -406,7 +406,7 @@ Valid from:</comment>
     <value>Package hash information could not be read from the package signature.</value>
   </data>
   <data name="UnsupportedSignatureFormatVersion" xml:space="preserve">
-    <value>The package signature format version is unsupported.  Updating your client may solve this problem.</value>
+    <value>The package signature format version is not supported. Updating your client may solve this problem.</value>
   </data>
   <data name="SignFailureCertificateInvalidProviderType" xml:space="preserve">
     <value>The following certificate cannot be used for package signing as the private key provider is unsupported:</value>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -459,4 +459,10 @@ Valid from:</comment>
   <data name="TimestampNoCertificate" xml:space="preserve">
     <value>The timestamp signature did not have a signing certificate.</value>
   </data>
+  <data name="SignatureNotYetValid" xml:space="preserve">
+    <value>The signing certificate is not yet valid.</value>
+  </data>
+  <data name="TimestampNotYetValid" xml:space="preserve">
+    <value>The timestamp signing certificate is not yet valid.</value>
+  </data>
 </root>

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/IntegrityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/IntegrityVerificationProviderTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -22,37 +23,55 @@ using Xunit;
 namespace NuGet.Packaging.FuncTest
 {
     [Collection("Signing Funtional Test Collection")]
-    public class SignedPackageVerifierTests
+    public class IntegrityVerificationProviderTests
     {
         private const string _packageTamperedError = "Package integrity check failed.";
         private const string _packageUnsignedError = "Package is not signed.";
         private const string _packageInvalidSignatureError = "Package signature is invalid.";
-        private static readonly string _testCertPassword = Guid.NewGuid().ToString();
-
-        private SigningSpecifications _specification => SigningSpecifications.V1;
 
         private SigningTestFixture _testFixture;
         private TrustedTestCert<TestCertificate> _trustedTestCert;
         private IList<ISignatureVerificationProvider> _trustProviders;
 
-        public SignedPackageVerifierTests(SigningTestFixture fixture)
+        public IntegrityVerificationProviderTests(SigningTestFixture fixture)
         {
             _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
             _trustedTestCert = _testFixture.TrustedTestCertificate;
-            _trustProviders = _testFixture.TrustProviders;
+            _trustProviders = new List<ISignatureVerificationProvider>()
+            {
+                new IntegrityVerificationProvider()
+            };
         }
 
-        [CIOnlyFact]
-        public async Task Signer_VerifyOnSignedPackageAsync()
+        private static SignedPackageVerifierSettings GetSettingsPolicy(string policyString)
+        {
+            if (StringComparer.Ordinal.Equals(policyString, "command"))
+            {
+                return SignedPackageVerifierSettings.VerifyCommandDefaultPolicy;
+            }
+
+            if (StringComparer.Ordinal.Equals(policyString, "vs"))
+            {
+                return SignedPackageVerifierSettings.VSClientDefaultPolicy;
+            }
+
+            return SignedPackageVerifierSettings.Default;
+        }
+
+        [CIOnlyTheory]
+        [InlineData("command")]
+        [InlineData("vs")]
+        public async Task Signer_VerifyOnSignedPackageAsync(string policyString)
         {
             // Arrange
             var nupkg = new SimpleTestPackageContext();
+            var policy = GetSettingsPolicy(policyString);
 
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
+                var verifier = new PackageSignatureVerifier(_trustProviders, policy);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -65,11 +84,14 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
-        public async Task Signer_VerifyOnTamperedPackage_FileDeletedAsync()
+        [CIOnlyTheory]
+        [InlineData("command")]
+        [InlineData("vs")]
+        public async Task Signer_VerifyOnTamperedPackage_FileDeletedAsync(string policyString)
         {
             // Arrange
             var nupkg = new SimpleTestPackageContext();
+            var policy = GetSettingsPolicy(policyString);
 
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
@@ -83,7 +105,7 @@ namespace NuGet.Packaging.FuncTest
                     zip.Entries.First().Delete();
                 }
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
+                var verifier = new PackageSignatureVerifier(_trustProviders, policy);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -96,17 +118,20 @@ namespace NuGet.Packaging.FuncTest
                     result.Valid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     totalErrorIssues.Count().Should().Be(1);
-                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3015);
                     totalErrorIssues.First().Message.Should().Be(_packageTamperedError);
                 }
             }
         }
 
-        [CIOnlyFact]
-        public async Task Signer_VerifyOnTamperedPackage_FileAddedAsync()
+        [CIOnlyTheory]
+        [InlineData("command")]
+        [InlineData("vs")]
+        public async Task Signer_VerifyOnTamperedPackage_FileAddedAsync(string policyString)
         {
             // Arrange
             var nupkg = new SimpleTestPackageContext();
+            var policy = GetSettingsPolicy(policyString);
             var newEntryData = "malicious code";
             var newEntryName = "malicious file";
 
@@ -125,7 +150,7 @@ namespace NuGet.Packaging.FuncTest
                     newEntryDataStream.CopyTo(newEntryStream);
                 }
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
+                var verifier = new PackageSignatureVerifier(_trustProviders, policy);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -138,17 +163,20 @@ namespace NuGet.Packaging.FuncTest
                     result.Valid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     totalErrorIssues.Count().Should().Be(1);
-                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3015);
                     totalErrorIssues.First().Message.Should().Be(_packageTamperedError);
                 }
             }
         }
 
-        [CIOnlyFact]
-        public async Task Signer_VerifyOnTamperedPackage_FileAppendedAsync()
+        [CIOnlyTheory]
+        [InlineData("command")]
+        [InlineData("vs")]
+        public async Task Signer_VerifyOnTamperedPackage_FileAppendedAsync(string policyString)
         {
             // Arrange
             var nupkg = new SimpleTestPackageContext();
+            var policy = GetSettingsPolicy(policyString);
             var extraData = "tampering data";
 
             using (var dir = TestDirectory.Create())
@@ -166,7 +194,7 @@ namespace NuGet.Packaging.FuncTest
                     extraStream.CopyTo(entryStream);
                 }
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
+                var verifier = new PackageSignatureVerifier(_trustProviders, policy);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -179,17 +207,20 @@ namespace NuGet.Packaging.FuncTest
                     result.Valid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     totalErrorIssues.Count().Should().Be(1);
-                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3015);
                     totalErrorIssues.First().Message.Should().Be(_packageTamperedError);
                 }
             }
         }
 
-        [CIOnlyFact]
-        public async Task Signer_VerifyOnTamperedPackage_FileTruncatedAsync()
+        [CIOnlyTheory]
+        [InlineData("command")]
+        [InlineData("vs")]
+        public async Task Signer_VerifyOnTamperedPackage_FileTruncatedAsync(string policyString)
         {
             // Arrange
             var nupkg = new SimpleTestPackageContext();
+            var policy = GetSettingsPolicy(policyString);
 
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
@@ -204,7 +235,7 @@ namespace NuGet.Packaging.FuncTest
                     entryStream.SetLength(entryStream.Length - 1);
                 }
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
+                var verifier = new PackageSignatureVerifier(_trustProviders, policy);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -217,17 +248,20 @@ namespace NuGet.Packaging.FuncTest
                     result.Valid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     totalErrorIssues.Count().Should().Be(1);
-                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3015);
                     totalErrorIssues.First().Message.Should().Be(_packageTamperedError);
                 }
             }
         }
 
-        [CIOnlyFact]
-        public async Task Signer_VerifyOnTamperedPackage_FileMetadataModifiedAsync()
+        [CIOnlyTheory]
+        [InlineData("command")]
+        [InlineData("vs")]
+        public async Task Signer_VerifyOnTamperedPackage_FileMetadataModifiedAsync(string policyString)
         {
             // Arrange
             var nupkg = new SimpleTestPackageContext();
+            var policy = GetSettingsPolicy(policyString);
 
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
@@ -245,7 +279,7 @@ namespace NuGet.Packaging.FuncTest
                     entry.LastWriteTime = entry.LastWriteTime.AddSeconds(2);
                 }
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
+                var verifier = new PackageSignatureVerifier(_trustProviders, policy);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -258,17 +292,20 @@ namespace NuGet.Packaging.FuncTest
                     result.Valid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     totalErrorIssues.Count().Should().Be(1);
-                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3015);
                     totalErrorIssues.First().Message.Should().Be(_packageTamperedError);
                 }           
             }
         }
 
-        [CIOnlyFact]
-        public async Task Signer_VerifyOnTamperedPackage_SignatureRemovedAsync()
+        [CIOnlyTheory]
+        [InlineData("command", false)]
+        [InlineData("vs", true)]
+        public async Task Signer_VerifyOnTamperedPackage_SignatureRemovedAsync(string policyString, bool expectedValidity)
         {
             // Arrange
             var nupkg = new SimpleTestPackageContext();
+            var policy = GetSettingsPolicy(policyString);
 
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
@@ -283,7 +320,7 @@ namespace NuGet.Packaging.FuncTest
                     entry.Delete();
                 }
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
+                var verifier = new PackageSignatureVerifier(_trustProviders, policy);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -293,59 +330,26 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
-                    resultsWithErrors.Count().Should().Be(1);
-                    totalErrorIssues.Count().Should().Be(1);
-                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3001);
-                    totalErrorIssues.First().Message.Should().Be(_packageUnsignedError);
+                    result.Valid.Should().Be(expectedValidity);
+                    if (!expectedValidity)
+                    {
+                        resultsWithErrors.Count().Should().Be(1);
+                        totalErrorIssues.Count().Should().Be(1);
+                        totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3006);
+                        totalErrorIssues.First().Message.Should().Be(_packageUnsignedError);
+                    }
                 }
             }
         }
 
-        [CIOnlyFact]
-<<<<<<< HEAD
-=======
-        public async Task Signer_VerifyOnTamperedPackage_SignatureMetadataModifiedAsync()
+        [CIOnlyTheory]
+        [InlineData("command", false)]
+        [InlineData("vs", true)]
+        public async Task Signer_VerifyOnTamperedPackage_SignatureTruncatedAsync(string policyString, bool expectedValidity)
         {
             // Arrange
             var nupkg = new SimpleTestPackageContext();
-
-            using (var dir = TestDirectory.Create())
-            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
-            {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
-
-                // unsign the package
-                using (var stream = File.Open(signedPackagePath, FileMode.Open))
-                using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
-                {
-                    var entry = zip.GetEntry(SigningSpecifications.V1.SignaturePath);
-
-                    // ZipArchiveEntry.LastWriteTime supports a resolution of two seconds.
-                    // https://msdn.microsoft.com/en-us/library/system.io.compression.ziparchiveentry.lastwritetime(v=vs.110).aspx
-                    entry.LastWriteTime = entry.LastWriteTime.AddSeconds(2);
-                }
-
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
-
-                using (var packageReader = new PackageArchiveReader(signedPackagePath))
-                {
-                    // Act
-                    var result = await verifier.VerifySignaturesAsync(packageReader, CancellationToken.None);
-
-                    // Assert
-                    // No failure expected as the signature file or its metadata is not part of the original hash
-                    result.Valid.Should().BeTrue();
-                }
-            }
-        }
-
-        [CIOnlyFact]
->>>>>>> WIP: enforce default policies for verify
-        public async Task Signer_VerifyOnTamperedPackage_SignatureTruncatedAsync()
-        {
-            // Arrange
-            var nupkg = new SimpleTestPackageContext();
+            var policy = GetSettingsPolicy(policyString);
 
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
@@ -360,7 +364,7 @@ namespace NuGet.Packaging.FuncTest
                     entryStream.SetLength(entryStream.Length - 1);
                 }
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
+                var verifier = new PackageSignatureVerifier(_trustProviders, policy);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -370,11 +374,14 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
-                    resultsWithErrors.Count().Should().Be(1);
-                    totalErrorIssues.Count().Should().Be(1);
-                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3001);
-                    totalErrorIssues.First().Message.Should().Be(_packageInvalidSignatureError);
+                    result.Valid.Should().Be(expectedValidity);
+                    if (!expectedValidity)
+                    {
+                        resultsWithErrors.Count().Should().Be(1);
+                        totalErrorIssues.Count().Should().Be(1);
+                        totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3005);
+                        totalErrorIssues.First().Message.Should().Be(_packageInvalidSignatureError);
+                    }
                 }
             }
         }

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
@@ -58,7 +58,7 @@ namespace NuGet.Packaging.FuncTest
 
                 await SignedArchiveTestUtility.ShiftSignatureMetadataAsync(_specification, signedPackagePath, dir, entryCount - 1, entryCount - 1);
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.Default);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -85,7 +85,7 @@ namespace NuGet.Packaging.FuncTest
 
                 await SignedArchiveTestUtility.ShiftSignatureMetadataAsync(_specification, signedPackagePath, dir, 0, 0);
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.Default);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -119,7 +119,7 @@ namespace NuGet.Packaging.FuncTest
 
                 await SignedArchiveTestUtility.ShiftSignatureMetadataAsync(_specification, signedPackagePath, dir, entryCount - 1, 0);
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.Default);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -153,7 +153,7 @@ namespace NuGet.Packaging.FuncTest
 
                 await SignedArchiveTestUtility.ShiftSignatureMetadataAsync(_specification, signedPackagePath, dir, 0, entryCount - 1);
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.Default);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -188,7 +188,7 @@ namespace NuGet.Packaging.FuncTest
                 var middleEntry = (entryCount - 1) / 2;
                 await SignedArchiveTestUtility.ShiftSignatureMetadataAsync(_specification, signedPackagePath, dir, middleEntry - 1, middleEntry + 1);
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.Default);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
@@ -224,7 +224,7 @@ namespace NuGet.Packaging.FuncTest
                     }
                 }
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.Default);
                 using (var packageReader = new PackageArchiveReader(packageStream))
                 {
                     // Act
@@ -236,7 +236,7 @@ namespace NuGet.Packaging.FuncTest
                     result.Valid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     totalErrorIssues.Count().Should().Be(1);
-                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3015);
                 }
             }
         }
@@ -288,7 +288,7 @@ namespace NuGet.Packaging.FuncTest
                     }
                 }
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.Default);
                 using (var packageReader = new PackageArchiveReader(packageStream))
                 {
                     // Act
@@ -300,7 +300,7 @@ namespace NuGet.Packaging.FuncTest
                     result.Valid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     totalErrorIssues.Count().Should().Be(1);
-                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3015);
                 }
             }
         }
@@ -358,7 +358,7 @@ namespace NuGet.Packaging.FuncTest
                         writer.Write((ushort)1);
                     }
 
-                    var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                    var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.Default);
                     using (var packageReader = new PackageArchiveReader(packageWriteStream))
                     {
                         // Act
@@ -370,7 +370,7 @@ namespace NuGet.Packaging.FuncTest
                         result.Valid.Should().BeFalse();
                         resultsWithErrors.Count().Should().Be(1);
                         totalErrorIssues.Count().Should().Be(1);
-                        totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                        totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3015);
                     }
                 }
             }
@@ -462,14 +462,14 @@ namespace NuGet.Packaging.FuncTest
                         metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);
                         var signatureCentralDirectoryHeader = metadata.CentralDirectoryHeaders[metadata.SignatureCentralDirectoryHeaderIndex];
 
-                        // skip till compressed size (20 bytes total)
-                        writer.BaseStream.Seek(offset: signatureCentralDirectoryHeader.Position + 20L, origin: SeekOrigin.Begin);
+                        // skip till uncompressed size (20 bytes total)
+                        writer.BaseStream.Seek(offset: signatureCentralDirectoryHeader.Position + 24L, origin: SeekOrigin.Begin);
 
-                        // change compressed size
+                        // change uncompressed size
                         writer.Write((uint)1);
                     }
 
-                    var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                    var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.Default);
                     using (var packageReader = new PackageArchiveReader(packageWriteStream))
                     {
                         // Act
@@ -481,7 +481,7 @@ namespace NuGet.Packaging.FuncTest
                         result.Valid.Should().BeFalse();
                         resultsWithErrors.Count().Should().Be(1);
                         totalErrorIssues.Count().Should().Be(1);
-                        totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3001);
+                        totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3015);
                     }
                 }
             }
@@ -547,7 +547,7 @@ namespace NuGet.Packaging.FuncTest
                         writer.Write((uint)1);
                     }
 
-                    var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                    var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.Default);
                     using (var packageReader = new PackageArchiveReader(packageWriteStream))
                     {
                         // Act
@@ -559,7 +559,7 @@ namespace NuGet.Packaging.FuncTest
                         result.Valid.Should().BeFalse();
                         resultsWithErrors.Count().Should().Be(1);
                         totalErrorIssues.Count().Should().Be(1);
-                        totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                        totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3015);
                     }
                 }
             }
@@ -625,7 +625,7 @@ namespace NuGet.Packaging.FuncTest
                         writer.Write((ushort)1);
                     }
 
-                    var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                    var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.Default);
                     using (var packageReader = new PackageArchiveReader(packageWriteStream))
                     {
                         // Act
@@ -637,7 +637,7 @@ namespace NuGet.Packaging.FuncTest
                         result.Valid.Should().BeFalse();
                         resultsWithErrors.Count().Should().Be(1);
                         totalErrorIssues.Count().Should().Be(1);
-                        totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                        totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3015);
                     }
                 }
             }
@@ -703,7 +703,7 @@ namespace NuGet.Packaging.FuncTest
                         writer.Write((ushort)1);
                     }
 
-                    var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                    var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.Default);
                     using (var packageReader = new PackageArchiveReader(packageWriteStream))
                     {
                         // Act
@@ -715,7 +715,7 @@ namespace NuGet.Packaging.FuncTest
                         result.Valid.Should().BeFalse();
                         resultsWithErrors.Count().Should().Be(1);
                         totalErrorIssues.Count().Should().Be(1);
-                        totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                        totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3015);
                     }
                 }
             }
@@ -781,7 +781,7 @@ namespace NuGet.Packaging.FuncTest
                         writer.Write((uint)1);
                     }
 
-                    var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                    var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.Default);
                     using (var packageReader = new PackageArchiveReader(packageWriteStream))
                     {
                         // Act
@@ -793,7 +793,7 @@ namespace NuGet.Packaging.FuncTest
                         result.Valid.Should().BeFalse();
                         resultsWithErrors.Count().Should().Be(1);
                         totalErrorIssues.Count().Should().Be(1);
-                        totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                        totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3015);
                     }
                 }
             }
@@ -862,7 +862,7 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
-                    var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                    var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.Default);
                     using (var packageReader = new PackageArchiveReader(packageStream))
                     {
                         // Act
@@ -874,7 +874,7 @@ namespace NuGet.Packaging.FuncTest
                         result.Valid.Should().BeFalse();
                         resultsWithErrors.Count().Should().Be(1);
                         totalErrorIssues.Count().Should().Be(1);
-                        totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3002);
+                        totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3015);
                     }
                 }
             }

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageVerifierTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageVerifierTests.cs
@@ -52,7 +52,7 @@ namespace NuGet.Packaging.FuncTest
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -83,7 +83,7 @@ namespace NuGet.Packaging.FuncTest
                     zip.Entries.First().Delete();
                 }
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -125,7 +125,7 @@ namespace NuGet.Packaging.FuncTest
                     newEntryDataStream.CopyTo(newEntryStream);
                 }
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -166,7 +166,7 @@ namespace NuGet.Packaging.FuncTest
                     extraStream.CopyTo(entryStream);
                 }
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -204,7 +204,7 @@ namespace NuGet.Packaging.FuncTest
                     entryStream.SetLength(entryStream.Length - 1);
                 }
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -245,7 +245,7 @@ namespace NuGet.Packaging.FuncTest
                     entry.LastWriteTime = entry.LastWriteTime.AddSeconds(2);
                 }
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -283,7 +283,7 @@ namespace NuGet.Packaging.FuncTest
                     entry.Delete();
                 }
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -303,6 +303,45 @@ namespace NuGet.Packaging.FuncTest
         }
 
         [CIOnlyFact]
+<<<<<<< HEAD
+=======
+        public async Task Signer_VerifyOnTamperedPackage_SignatureMetadataModifiedAsync()
+        {
+            // Arrange
+            var nupkg = new SimpleTestPackageContext();
+
+            using (var dir = TestDirectory.Create())
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
+            {
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+
+                // unsign the package
+                using (var stream = File.Open(signedPackagePath, FileMode.Open))
+                using (var zip = new ZipArchive(stream, ZipArchiveMode.Update))
+                {
+                    var entry = zip.GetEntry(SigningSpecifications.V1.SignaturePath);
+
+                    // ZipArchiveEntry.LastWriteTime supports a resolution of two seconds.
+                    // https://msdn.microsoft.com/en-us/library/system.io.compression.ziparchiveentry.lastwritetime(v=vs.110).aspx
+                    entry.LastWriteTime = entry.LastWriteTime.AddSeconds(2);
+                }
+
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
+
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    var result = await verifier.VerifySignaturesAsync(packageReader, CancellationToken.None);
+
+                    // Assert
+                    // No failure expected as the signature file or its metadata is not part of the original hash
+                    result.Valid.Should().BeTrue();
+                }
+            }
+        }
+
+        [CIOnlyFact]
+>>>>>>> WIP: enforce default policies for verify
         public async Task Signer_VerifyOnTamperedPackage_SignatureTruncatedAsync()
         {
             // Arrange
@@ -321,7 +360,7 @@ namespace NuGet.Packaging.FuncTest
                     entryStream.SetLength(entryStream.Length - 1);
                 }
 
-                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.RequireSigned);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.CommandDefaultPolicy);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureContentTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureContentTests.cs
@@ -56,7 +56,7 @@ namespace NuGet.Packaging.Test
                 () => SignatureContent.Load(bytes, SigningSpecifications.V1));
 
             Assert.Equal(
-                "The package signature format version is unsupported.  Updating your client may solve this problem.",
+                "The package signature format version is not supported. Updating your client may solve this problem.",
                 exception.Message);
         }
 


### PR DESCRIPTION
Package verification should enforce different policies depending on the context. This PR addressed the default policies for verification in the API to consider those scenarios.