### PR TITLE
Ensure NuGetv3LocalRepository is updated after package install

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
@@ -282,7 +282,10 @@ namespace NuGet.Commands
                             packageExtractionContext,
                             token);
 
-                        if (installed)
+                        // 1) If another project in this process installs the package this will return false but userPackageFolder will contain the package.
+                        // 2) If another process installs the package then this will also return false but we still need to update the cache.
+                        // For #2 double check that the cache has the package now otherwise clear
+                        if (installed || !userPackageFolder.Exists(packageIdentity.Id, packageIdentity.Version))
                         {
                             // If the package was added, clear the cache so that the next caller can see it.
                             // Avoid calling this for packages that were not actually installed.

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/InstallPackagesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/InstallPackagesTests.cs
@@ -1,0 +1,106 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using FluentAssertions;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.Packaging;
+using NuGet.ProjectModel;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class InstallPackagesTests
+    {
+        [Fact]
+        public async Task InstallPackageFromAnotherProcessVerifyCacheIsCleared()
+        {
+            // Arrange
+            var logger = new TestLogger();
+
+            using (var cacheContext = new SourceCacheContext())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var tfi = new List<TargetFrameworkInformation>
+                {
+                    new TargetFrameworkInformation()
+                    {
+                        FrameworkName = NuGetFramework.Parse("net462")
+                    }
+                };
+
+                var spec = NETCoreRestoreTestUtility.GetProject(projectName: "projectA", framework: "net46");
+                spec.Dependencies.Add(new LibraryDependency()
+                {
+                    LibraryRange = new LibraryRange("a", VersionRange.Parse("1.0.0"), LibraryDependencyTarget.Package)
+                });
+
+                var project = NETCoreRestoreTestUtility.CreateProjectsFromSpecs(pathContext, spec).Single();
+
+                var packageA = new SimpleTestPackageContext("a");
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, packageA);
+
+                // Create dg file
+                var dgFile = new DependencyGraphSpec();
+                dgFile.AddProject(spec);
+                dgFile.AddRestore(spec.RestoreMetadata.ProjectUniqueName);
+
+                dgFile.Save(Path.Combine(pathContext.WorkingDirectory, "out.dg"));
+
+                var providerCache = new RestoreCommandProvidersCache();
+                var sources = new List<string>() { pathContext.PackageSource };
+
+                var restoreContext = new RestoreArgs()
+                {
+                    CacheContext = cacheContext,
+                    DisableParallel = true,
+                    GlobalPackagesFolder = pathContext.UserPackagesFolder,
+                    Sources = sources,
+                    Log = logger,
+                    CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(new List<PackageSource>() { new PackageSource(pathContext.PackageSource) })),
+                    PreLoadedRequestProviders = new List<IPreLoadedRestoreRequestProvider>()
+                    {
+                        new DependencyGraphSpecRequestProvider(providerCache, dgFile)
+                    }
+                };
+
+                var request = (await RestoreRunner.GetRequests(restoreContext)).Single();
+                var providers = providerCache.GetOrCreate(pathContext.UserPackagesFolder, sources, new List<SourceRepository>(), cacheContext, logger);
+                var command = new RestoreCommand(request.Request);
+
+                // Add to cache before install on all providers
+                var globalPackages = providers.GlobalPackages;
+                var packages = globalPackages.FindPackagesById("a");
+                packages.Should().BeEmpty("has not been installed yet");
+
+                foreach (var local in providers.LocalProviders)
+                {
+                    await local.GetDependenciesAsync(new LibraryIdentity("a", NuGetVersion.Parse("1.0.0"), LibraryType.Package), NuGetFramework.Parse("net46"), cacheContext, logger, CancellationToken.None);
+                }
+
+                // Install the package without updating the cache
+                await SimpleTestPackageUtility.CreateFolderFeedV3(pathContext.UserPackagesFolder, PackageSaveMode.Defaultv3, packageA);
+
+                // Run restore using an incorrect cache
+                var result = await command.ExecuteAsync();
+
+                // Verify a is in the output assets file
+                result.Success.Should().BeTrue();
+                result.LockFile.GetLibrary("a", new NuGetVersion(1, 0, 0)).Should().NotBeNull();
+            }
+        }
+    }
+}


### PR DESCRIPTION
When another process installs a package it will be detected that the install was a noop. An additional check is needed to ensure that NuGetv3LocalRepository is up to date.

Fixes https://github.com/NuGet/Home/issues/6316

## Bug
Fixes: Fixes https://github.com/NuGet/Home/issues/6316
(found as part of our attempted insertion in CLI -- a test failed in CLI repo)
Regression: Yes
If Regression then when did it last work: 15.5
If Regression then how are we preventing it in future: test

## Fix
Details: Refresh an in-memory cached used to build project.assets.json even if the package install was a noop. This is needed if another process did the install.

## Testing/Validation
Tests Added: Yes
Reason for not adding tests:  
Validation done:  testing
