### PR TITLE
disable e2e and apex from build and move to release

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -410,170 +410,170 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
     condition: "succeededOrFailed()"
 
 
-- phase: End_To_End_Tests_On_Windows
-  dependsOn: Build_and_UnitTest
-  variables:
-    BuildNumber: $[dependencies.Build_and_UnitTest.outputs['RTM.configuration.BuildNumber']]
-  condition: "succeeded()"
-  queue:
-    name: DDNuGet-Windows
-    timeoutInMinutes: 75
-    demands: DotNetFramework
+# - phase: End_To_End_Tests_On_Windows
+#   dependsOn: Build_and_UnitTest
+#   variables:
+#     BuildNumber: $[dependencies.Build_and_UnitTest.outputs['RTM.configuration.BuildNumber']]
+#   condition: "succeeded()"
+#   queue:
+#     name: DDNuGet-Windows
+#     timeoutInMinutes: 75
+#     demands: DotNetFramework
 
 
-  steps:
-  - task: PowerShell@1
-    displayName: "Print Environment Variables"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: "gci env:* | sort-object name;
-      Write-Host \"##vso[build.updatebuildnumber]$env:BuildNumber\""    
+#   steps:
+#   - task: PowerShell@1
+#     displayName: "Print Environment Variables"
+#     inputs:
+#       scriptType: "inlineScript"
+#       inlineScript: "gci env:* | sort-object name;
+#       Write-Host \"##vso[build.updatebuildnumber]$env:BuildNumber\""    
 
-  - task: PowerShell@1
-    displayName: "Bootstrap.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
-      arguments: "-NuGetDropPath $(BuildOutputTargetPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
+#   - task: PowerShell@1
+#     displayName: "Bootstrap.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
+#       arguments: "-NuGetDropPath $(BuildOutputTargetPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
 
-  - task: PowerShell@1
-    displayName: "SetupFunctionalTests.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
-      arguments: "-VSVersion 15.0"
+#   - task: PowerShell@1
+#     displayName: "SetupFunctionalTests.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
+#       arguments: "-VSVersion 15.0"
 
-  - task: PowerShell@1
-    displayName: "CopyToolsAndSetupMachine.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\CopyToolsAndSetupMachine.ps1"
-      arguments: " -NuGetCIToolsFolder $(NuGetCIToolsFolder) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts"
+#   - task: PowerShell@1
+#     displayName: "CopyToolsAndSetupMachine.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\CopyToolsAndSetupMachine.ps1"
+#       arguments: " -NuGetCIToolsFolder $(NuGetCIToolsFolder) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts"
 
-  - task: PowerShell@1
-    displayName: "InstallNuGetVSIX.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
-      arguments: "-NuGetDropPath $(BuildOutputTargetPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 15.0"
-      failOnStandardError: "false"
+#   - task: PowerShell@1
+#     displayName: "InstallNuGetVSIX.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
+#       arguments: "-NuGetDropPath $(BuildOutputTargetPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 15.0"
+#       failOnStandardError: "false"
 
-  - task: PowerShell@1
-    displayName: "LaunchVS.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\LaunchVS.ps1"
-      arguments: "-VSVersion 15.0 -DTEReadyPollFrequencyInSecs 6 -NumberOfPolls 50"
+#   - task: PowerShell@1
+#     displayName: "LaunchVS.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\LaunchVS.ps1"
+#       arguments: "-VSVersion 15.0 -DTEReadyPollFrequencyInSecs 6 -NumberOfPolls 50"
 
-  - task: PowerShell@1
-    displayName: "RunFunctionalTests.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
-      arguments: "-PMCCommand $(EndToEndTestCommandToRun) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 15.0"
+#   - task: PowerShell@1
+#     displayName: "RunFunctionalTests.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
+#       arguments: "-PMCCommand $(EndToEndTestCommandToRun) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 15.0"
 
-  - task: PublishTestResults@2
-    displayName: "Publish Test Results"
-    inputs:
-      testRunner: "JUnit"
-      testResultsFiles: "*.xml"
-      searchFolder: "$(System.DefaultWorkingDirectory)\\testresults"
-      mergeTestResults: "true"
-      testRunTitle: "NuGet.Client End To End Tests "
-    condition: "succeededOrFailed()"
+#   - task: PublishTestResults@2
+#     displayName: "Publish Test Results"
+#     inputs:
+#       testRunner: "JUnit"
+#       testResultsFiles: "*.xml"
+#       searchFolder: "$(System.DefaultWorkingDirectory)\\testresults"
+#       mergeTestResults: "true"
+#       testRunTitle: "NuGet.Client End To End Tests "
+#     condition: "succeededOrFailed()"
 
 
-- phase: Apex_Tests_On_Windows
-  dependsOn: Build_and_UnitTest
-  variables:
-    BuildNumber: $[dependencies.Build_and_UnitTest.outputs['RTM.configuration.BuildNumber']]
-  condition: "succeeded()"
-  queue:
-    name: DDNuGet-Windows
-    timeoutInMinutes: 45
-    demands: DotNetFramework
+# - phase: Apex_Tests_On_Windows
+#   dependsOn: Build_and_UnitTest
+#   variables:
+#     BuildNumber: $[dependencies.Build_and_UnitTest.outputs['RTM.configuration.BuildNumber']]
+#   condition: "succeeded()"
+#   queue:
+#     name: DDNuGet-Windows
+#     timeoutInMinutes: 45
+#     demands: DotNetFramework
 
-  steps:
-  - task: PowerShell@1
-    displayName: "Print Environment Variables"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: "gci env:* | sort-object name;
-      Write-Host \"##vso[build.updatebuildnumber]$env:BuildNumber\""
+#   steps:
+#   - task: PowerShell@1
+#     displayName: "Print Environment Variables"
+#     inputs:
+#       scriptType: "inlineScript"
+#       inlineScript: "gci env:* | sort-object name;
+#       Write-Host \"##vso[build.updatebuildnumber]$env:BuildNumber\""
 
-  - task: PowerShell@1
-    displayName: "Configre.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)/configure.ps1"
-      arguments: "-Force -CI"
+#   - task: PowerShell@1
+#     displayName: "Configre.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)/configure.ps1"
+#       arguments: "-Force -CI"
 
-  - task: CopyFiles@2
-    displayName: "Copy Public Key Files"
-    inputs:
-      SourceFolder: "$(NuGetSharePublicKeys)"
-      Contents: "*.snk"
-      TargetFolder: "$(Build.Repository.LocalPath)\\keys"
-      CleanTargetFolder: "true"
-      OverWrite: "true"
-      flattenFolders: "true"
+#   - task: CopyFiles@2
+#     displayName: "Copy Public Key Files"
+#     inputs:
+#       SourceFolder: "$(NuGetSharePublicKeys)"
+#       Contents: "*.snk"
+#       TargetFolder: "$(Build.Repository.LocalPath)\\keys"
+#       CleanTargetFolder: "true"
+#       OverWrite: "true"
+#       flattenFolders: "true"
 
-  - task: PowerShell@1
-    displayName: "Bootstrap.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
-      arguments: "-NuGetDropPath $(BuildOutputTargetPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
+#   - task: PowerShell@1
+#     displayName: "Bootstrap.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
+#       arguments: "-NuGetDropPath $(BuildOutputTargetPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
 
-  - task: PowerShell@1
-    displayName: "SetupFunctionalTests.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
-      arguments: "-VSVersion 15.0"
+#   - task: PowerShell@1
+#     displayName: "SetupFunctionalTests.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
+#       arguments: "-VSVersion 15.0"
 
-  - task: PowerShell@1
-    displayName: "CopyToolsAndSetupMachine.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\CopyToolsAndSetupMachine.ps1"
-      arguments: " -NuGetCIToolsFolder $(NuGetCIToolsFolder) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts"
+#   - task: PowerShell@1
+#     displayName: "CopyToolsAndSetupMachine.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\CopyToolsAndSetupMachine.ps1"
+#       arguments: " -NuGetCIToolsFolder $(NuGetCIToolsFolder) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts"
 
-  - task: PowerShell@1
-    displayName: "InstallNuGetVSIX.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
-      arguments: "-NuGetDropPath $(BuildOutputTargetPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 15.0"
-      failOnStandardError: "false"
+#   - task: PowerShell@1
+#     displayName: "InstallNuGetVSIX.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
+#       arguments: "-NuGetDropPath $(BuildOutputTargetPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 15.0"
+#       failOnStandardError: "false"
 
-  - task: MSBuild@1
-    displayName: "Restore for VS2017"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "15.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:RestoreVS15 /p:BuildNumber=$(Build.BuildNumber)"
+#   - task: MSBuild@1
+#     displayName: "Restore for VS2017"
+#     inputs:
+#       solution: "build\\build.proj"
+#       msbuildVersion: "15.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/t:RestoreVS15 /p:BuildNumber=$(Build.BuildNumber)"
       
-  - task: NuGetCommand@2
-    displayName: "Add Apex Feed Source"
-    inputs:
-      command: "custom"
-      arguments: "sources add -Name ApexFeed -Source $(ApexPackageFeedUrl) -UserName $(ApexPackageFeedUsername) -Password $(ApexPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\\NuGet.config"
+#   - task: NuGetCommand@2
+#     displayName: "Add Apex Feed Source"
+#     inputs:
+#       command: "custom"
+#       arguments: "sources add -Name ApexFeed -Source $(ApexPackageFeedUrl) -UserName $(ApexPackageFeedUsername) -Password $(ApexPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\\NuGet.config"
 
-  - task: MSBuild@1
-    displayName: "Restore Apex Tests"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "15.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:RestoreApex /p:BuildNumber=$(Build.BuildNumber)"
+#   - task: MSBuild@1
+#     displayName: "Restore Apex Tests"
+#     inputs:
+#       solution: "build\\build.proj"
+#       msbuildVersion: "15.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/t:RestoreApex /p:BuildNumber=$(Build.BuildNumber)"
 
-  - task: MSBuild@1
-    displayName: "Run Apex Tests"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "15.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml  /p:NUGET_PFX_PATH=$(System.DefaultWorkingDirectory)\\keys\\NuGetKey.snk /p:MS_PFX_PATH=$(System.DefaultWorkingDirectory)\\keys\\35MSSharedLib1024.snk /p:BuildNumber=$(Build.BuildNumber)"
+#   - task: MSBuild@1
+#     displayName: "Run Apex Tests"
+#     inputs:
+#       solution: "build\\build.proj"
+#       msbuildVersion: "15.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml  /p:NUGET_PFX_PATH=$(System.DefaultWorkingDirectory)\\keys\\NuGetKey.snk /p:MS_PFX_PATH=$(System.DefaultWorkingDirectory)\\keys\\35MSSharedLib1024.snk /p:BuildNumber=$(Build.BuildNumber)"
 
-  - task: PublishTestResults@2
-    displayName: "Publish Test Results"
-    inputs:
-      testRunner: "XUnit"
-      testResultsFiles: "*.xml"
-      searchFolder: "$(System.DefaultWorkingDirectory)\\artifacts\\testresults"
-      mergeTestResults: "true"
-      testRunTitle: "NuGet.Client Apex Tests"
-    condition: "succeededOrFailed()"
+#   - task: PublishTestResults@2
+#     displayName: "Publish Test Results"
+#     inputs:
+#       testRunner: "XUnit"
+#       testResultsFiles: "*.xml"
+#       searchFolder: "$(System.DefaultWorkingDirectory)\\artifacts\\testresults"
+#       mergeTestResults: "true"
+#       testRunTitle: "NuGet.Client Apex Tests"
+#     condition: "succeededOrFailed()"
     
     


### PR DESCRIPTION
One thing I didn't consider was that unless a build is successful, we cannot trigger a release from it. For us that means, unless we get a green build we won't be able to use automation to trigger val builds or insertions.

Keeping that in mind, I am moving e2e and apex tests to run under release definitions like they used to and rest of the tests (which are more stable) as part of the build.

This does not mean that we do not need to work on stabilizing e2e and apex

CC: @rrelyea 