### PR TITLE
Skipping NetworkCallCount_RestoreLargePackagesConfigWithMultipleSourcesMainlyV2 test on mono

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
@@ -388,7 +388,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, SkipMono = true)]
+        [PlatformFact(Platform.Windows)]
         public void NetworkCallCount_RestoreLargePackagesConfigWithMultipleSourcesMainlyV2()
         {
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -388,7 +388,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [Fact]
+        [PlatformFact(Platform.Windows, SkipMono = true)]
         public void NetworkCallCount_RestoreLargePackagesConfigWithMultipleSourcesMainlyV2()
         {
             // Arrange

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PlatformFactAttribute.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PlatformFactAttribute.cs
@@ -1,9 +1,9 @@
-﻿using System;
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using NuGet.Common;
 using Xunit;
 
 namespace NuGet.Test.Utility


### PR DESCRIPTION
## Bug
Fixes: NA
Regression: No

## Fix
Details: Skipping  `NetworkCallCountTest.NetworkCallCount_RestoreLargePackagesConfigWithMultipleSourcesMainlyV2`  on mono because it is flaky on mono.
