### PR TITLE
Fix CreateVsPathContextWithConfiguration 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ packages/
 .nuget/nuget.exe
 */.nuget/
 
+# ignore nuget.exe for e2e tests
+test/EndToEnd/nuget.exe
+
 # remove ilmerge log
 mergelog.txt
 

--- a/test/EndToEnd/tests/ServicesTest.ps1
+++ b/test/EndToEnd/tests/ServicesTest.ps1
@@ -863,8 +863,9 @@ function Test-CreateVsPathContextWithConfiguration {
     <add key="globalPackagesFolder" value="{0}" />
   </config>
   <fallbackPackageFolders>
+    <clear />
     <add key="a" value="{1}" />
-	<add key="b" value="{2}" />
+    <add key="b" value="{2}" />
   </fallbackPackageFolders>
 </configuration>
 "@


### PR DESCRIPTION
Add a clear for the auto generated nuget.config in CreateVsPathContextWithConfiguration. This test was failing due to the extra fallback folder added by VS.

Add a git ignore for the nuget.exe used by E2E tests. After running tests locally this appears as an added file in git.

Fixes https://github.com/NuGet/Home/issues/6323