### PR TITLE
Move test temp folder to .test/work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 project.lock.json
 artifacts/
 
+# Tests
+.test/
+
 # VSCode
 **/.vs/
 **/.vscode/

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -359,8 +359,11 @@ namespace NuGet.Protocol.Core.Types
             CancellationToken token)
         {
             var root = sourceUri.LocalPath;
-            var reader = new PackageArchiveReader(pathToPackage);
-            var packageIdentity = reader.GetIdentity();
+            PackageIdentity packageIdentity = null;
+            using (var reader = new PackageArchiveReader(pathToPackage))
+            {
+                packageIdentity = reader.GetIdentity();
+            }
 
             if (IsV2LocalRepository(root))
             {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -128,9 +128,13 @@ namespace NuGet.CommandLine.Test
         {
             string nugetexe = Util.GetNuGetExePath();
 
-            using (TestDirectory packageDirectory = TestDirectory.Create())
-            using (TestDirectory source = TestDirectory.Create())
+            using (var root = TestDirectory.Create())
             {
+                var packageDirectory = Path.Combine(root, "packages");
+                var source = Path.Combine(root, "source");
+                Directory.CreateDirectory(packageDirectory);
+                Directory.CreateDirectory(source);
+
                 // Arrange
                 string packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 string config = $@"<?xml version='1.0' encoding='utf-8'?>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -1230,12 +1230,12 @@ namespace NuGet.CommandLine.Test
                 // Check the custom package folder is used in the assembly reference
                 var content1 = File.ReadAllText(projectFile);
                 var customPackageFolderName = new DirectoryInfo(packagesDirectory.Path).Name;
-                var a1Path = @".." + Path.DirectorySeparatorChar + customPackageFolderName + Path.DirectorySeparatorChar +
+                var a1Path = Path.DirectorySeparatorChar + customPackageFolderName + Path.DirectorySeparatorChar +
                     Path.Combine("A.1.0.0", "lib", "net45", "file.dll");
-                var a2Path = @".." + Path.DirectorySeparatorChar + customPackageFolderName + Path.DirectorySeparatorChar +
+                var a2Path = Path.DirectorySeparatorChar + customPackageFolderName + Path.DirectorySeparatorChar +
                     Path.Combine("A.2.0.0", "lib", "net45", "file.dll");
-                Assert.False(content1.Contains(Util.GetHintPath(a1Path)));
-                Assert.True(content1.Contains(Util.GetHintPath(a2Path)));
+                Assert.DoesNotContain(a1Path, content1);
+                Assert.Contains(a2Path, content1);
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -49,7 +49,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             using (var testDirectory = TestDirectory.Create())
             {
                 var testBaseIntermediateOutputPath = Path.Combine(testDirectory, "obj");
-                TestDirectory.Create(testBaseIntermediateOutputPath);
+                Directory.CreateDirectory(testBaseIntermediateOutputPath);
                 var projectAdapter = Mock.Of<IVsProjectAdapter>();
                 Mock.Get(projectAdapter)
                     .SetupGet(x => x.BaseIntermediateOutputPath)
@@ -103,7 +103,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             {
                 var testProj = "project.csproj";
                 var testBaseIntermediateOutputPath = Path.Combine(testDirectory, "obj");
-                TestDirectory.Create(testBaseIntermediateOutputPath);
+                Directory.CreateDirectory(testBaseIntermediateOutputPath);
                 var projectAdapter = Mock.Of<IVsProjectAdapter>();
                 Mock.Get(projectAdapter)
                     .SetupGet(x => x.BaseIntermediateOutputPath)
@@ -161,7 +161,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             {
                 var testProj = "project.csproj";
                 var testBaseIntermediateOutputPath = Path.Combine(testDirectory, "obj");
-                TestDirectory.Create(testBaseIntermediateOutputPath);
+                Directory.CreateDirectory(testBaseIntermediateOutputPath);
                 var projectAdapter = Mock.Of<IVsProjectAdapter>();
                 Mock.Get(projectAdapter)
                     .SetupGet(x => x.BaseIntermediateOutputPath)
@@ -777,7 +777,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 .ReturnsAsync(NuGetFramework.Parse("netstandard13"));
 
             var testBaseIntermediateOutputPath = Path.Combine(fullPath, "obj");
-            TestDirectory.Create(testBaseIntermediateOutputPath);
+            Directory.CreateDirectory(testBaseIntermediateOutputPath);
             projectAdapter
                 .Setup(x => x.BaseIntermediateOutputPath)
                 .Returns(testBaseIntermediateOutputPath);

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreSettingTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreSettingTaskTests.cs
@@ -78,8 +78,8 @@ namespace NuGet.Build.Tasks.Test
 
             var baseConfigPath = "NuGet.Config";
 
-            using (var machineWide = TestDirectory.Create())
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var machineWide = TestDirectory.CreateInTemp())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 var subFolder = Path.Combine(mockBaseDirectory, "sub");
                 var solutionDirectoryConfig = Path.Combine(mockBaseDirectory, NuGetConstants.NuGetSolutionSettingsFolder);
@@ -111,8 +111,8 @@ namespace NuGet.Build.Tasks.Test
         public void GetRestoreSettingsTask_FindConfigInProjectFolder()
         {
             // Verifies that we include any config file found in the project folder
-            using (var machineWide = TestDirectory.Create())
-            using (var workingDir = TestDirectory.Create())
+            using (var machineWide = TestDirectory.CreateInTemp())
+            using (var workingDir = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 ConfigurationFileTestUtility.CreateConfigurationFile(Settings.DefaultSettingsFileName, machineWide, machineWideSettingsConfig);
@@ -143,7 +143,7 @@ namespace NuGet.Build.Tasks.Test
         [Fact]
         public void GetRestoreSettingsTask_VerifyRestoreAdditionalProjectSourcesAreAppended()
         {
-            using (var testDir = TestDirectory.Create())
+            using (var testDir = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var buildEngine = new TestBuildEngine();
@@ -175,7 +175,7 @@ namespace NuGet.Build.Tasks.Test
         [Fact]
         public void GetRestoreSettingsTask_VerifyRestoreAdditionalProjectFallbackFoldersAreAppended()
         {
-            using (var testDir = TestDirectory.Create())
+            using (var testDir = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var buildEngine = new TestBuildEngine();
@@ -207,7 +207,7 @@ namespace NuGet.Build.Tasks.Test
         [Fact]
         public void GetRestoreSettingsTask_VerifyRestoreAdditionalProjectFallbackFoldersWithExcludeAreNotAdded()
         {
-            using (var testDir = TestDirectory.Create())
+            using (var testDir = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var buildEngine = new TestBuildEngine();
@@ -244,7 +244,7 @@ namespace NuGet.Build.Tasks.Test
         [Fact]
         public void GetRestoreSettingsTask_VerifyAggregationAcrossFrameworks()
         {
-            using (var testDir = TestDirectory.Create())
+            using (var testDir = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var buildEngine = new TestBuildEngine();
@@ -299,7 +299,7 @@ namespace NuGet.Build.Tasks.Test
         [Fact]
         public void GetRestoreSettingsTask_VerifyNullPerFrameworkSettings()
         {
-            using (var testDir = TestDirectory.Create())
+            using (var testDir = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var buildEngine = new TestBuildEngine();
@@ -327,7 +327,7 @@ namespace NuGet.Build.Tasks.Test
         [Fact]
         public void GetRestoreSettingsTask_VerifyEmptyPerFrameworkSettings()
         {
-            using (var testDir = TestDirectory.Create())
+            using (var testDir = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var buildEngine = new TestBuildEngine();
@@ -357,7 +357,7 @@ namespace NuGet.Build.Tasks.Test
         public void GetRestoreSettingsTask_VerifyDisabledSourcesAreExcluded()
         {
 
-            using (var testDir = TestDirectory.Create())
+            using (var testDir = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var buildEngine = new TestBuildEngine();

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/IncludeTypeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/IncludeTypeTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -2052,14 +2052,17 @@ namespace NuGet.Commands.Test
 
                 if (targets != null)
                 {
-                    var xml = XDocument.Load(targets.OpenRead());
-
-                    foreach (var package in xml.Descendants()
-                        .Where(node => node.Name.LocalName == "Import")
-                        .Select(node => node.Attribute(XName.Get("Project")))
-                        .Select(file => Path.GetFileNameWithoutExtension(file.Value)))
+                    using (var stream = targets.OpenRead())
                     {
-                        result[dir.Name].Add(package);
+                        var xml = XDocument.Load(stream);
+
+                        foreach (var package in xml.Descendants()
+                            .Where(node => node.Name.LocalName == "Import")
+                            .Select(node => node.Attribute(XName.Get("Project")))
+                            .Select(file => Path.GetFileNameWithoutExtension(file.Value)))
+                        {
+                            result[dir.Name].Add(package);
+                        }
                     }
                 }
             }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/ConfigurationDefaultsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/ConfigurationDefaultsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -17,7 +17,7 @@ namespace NuGet.Configuration
         public void CreateConfigurationDefaultsReturnsNonNullConfigurationDefaults()
         {
             // Arrange
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 ConfigurationDefaults ConfigurationDefaults = GetConfigurationDefaults(@"<configuration></configuration>", mockBaseDirectory);
 
@@ -35,7 +35,7 @@ namespace NuGet.Configuration
             var feed1 = "http://contoso.com/packages/";
             var feed2 = "http://wwww.somerandomURL.com/";
 
-            using (var nugetConfigFileFolder = TestDirectory.Create())
+            using (var nugetConfigFileFolder = TestDirectory.CreateInTemp())
             {
                 var nugetConfigFile = "NuGetDefaults.config";
                 var nugetConfigFilePath = Path.Combine(nugetConfigFileFolder, nugetConfigFile);
@@ -69,7 +69,7 @@ namespace NuGet.Configuration
             var feed1 = "http://contoso.com/packages/";
             var feed2 = "http://wwww.somerandomURL.com/";
 
-            using (var nugetConfigFileFolder = TestDirectory.Create())
+            using (var nugetConfigFileFolder = TestDirectory.CreateInTemp())
             {
                 var nugetConfigFile = "NuGetDefaults.config";
                 var nugetConfigFilePath = Path.Combine(nugetConfigFileFolder, nugetConfigFile);
@@ -92,7 +92,7 @@ namespace NuGet.Configuration
         public void GetDefaultPushSourceReturnsNull()
         {
             //Arrange
-            using (var nugetConfigFileFolder = TestDirectory.Create())
+            using (var nugetConfigFileFolder = TestDirectory.CreateInTemp())
             {
                 var nugetConfigFile = "NuGetDefaults.config";
                 var nugetConfigFilePath = Path.Combine(nugetConfigFileFolder, nugetConfigFile);
@@ -109,7 +109,7 @@ namespace NuGet.Configuration
         public void GetDefaultPushSourceReadsTheCorrectValue()
         {
             // Arrange
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 var configurationDefaultsContent = @"
 <configuration>
@@ -129,7 +129,7 @@ namespace NuGet.Configuration
         public void GetDefaultPackageSourcesReturnsValidPackageSources()
         {
             // Arrange
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 var configurationDefaultsContent = @"
 <configuration>
@@ -164,7 +164,7 @@ namespace NuGet.Configuration
         public void GetDefaultPackageSourcesReturnsEmptyList()
         {
             //Arrange
-            using (var nugetConfigFileFolder = TestDirectory.Create())
+            using (var nugetConfigFileFolder = TestDirectory.CreateInTemp())
             {
                 var nugetConfigFile = "NuGetDefaults.config";
                 var nugetConfigFilePath = Path.Combine(nugetConfigFileFolder, nugetConfigFile);
@@ -181,7 +181,7 @@ namespace NuGet.Configuration
         public void GetDefaultPackageSourcesFromSourceProvider()
         {
             // Arrange
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 var configurationDefaultsContent = @"
 <configuration>
@@ -223,7 +223,7 @@ namespace NuGet.Configuration
         public void GetDefaultSameNamePackageSourcesFromSourceProvider()
         {
             // Arrange
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 var configurationDefaultsContent = @"
 <configuration>
@@ -261,7 +261,7 @@ namespace NuGet.Configuration
         public void GetDefaultSameSourcePackageSourcesFromSourceProvider()
         {
             // Arrange
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 var configurationDefaultsContent = @"
 <configuration>

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -21,7 +21,7 @@ namespace NuGet.Configuration.Test
         {
             // Act
             //Create nuget.config that has active package source defined
-            using (var nugetConfigFileFolder = TestDirectory.Create())
+            using (var nugetConfigFileFolder = TestDirectory.CreateInTemp())
             {
                 var nugetConfigFilePath = Path.Combine(nugetConfigFileFolder, "nuget.Config");
 
@@ -45,7 +45,7 @@ namespace NuGet.Configuration.Test
         {
             // Act
             //Create nuget.config that has active package source defined
-            using (var nugetConfigFileFolder = TestDirectory.Create())
+            using (var nugetConfigFileFolder = TestDirectory.CreateInTemp())
             {
                 var nugetConfigFilePath = Path.Combine(nugetConfigFileFolder, "nuget.Config");
 
@@ -67,7 +67,7 @@ namespace NuGet.Configuration.Test
         {
             // Act
             //Create nuget.config that has active package source defined
-            using (var nugetConfigFileFolder = TestDirectory.Create())
+            using (var nugetConfigFileFolder = TestDirectory.CreateInTemp())
             {
                 var nugetConfigFilePath = Path.Combine(nugetConfigFileFolder, "nuget.Config");
 
@@ -92,7 +92,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             //Create nuget.config that has active package source defined
-            using (var nugetConfigFileFolder = TestDirectory.Create())
+            using (var nugetConfigFileFolder = TestDirectory.CreateInTemp())
             {
                 var nugetConfigFilePath = Path.Combine(nugetConfigFileFolder, "nuget.Config");
 
@@ -296,7 +296,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void SavePackageSourcesWithRelativePath()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var configContents =
@@ -340,7 +340,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void SavePackageSourcesWithRelativePathAndAddNewSource()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var configContents =
@@ -386,7 +386,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void SavePackageSourcesWithOneClear()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var configContents =
@@ -436,9 +436,9 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void SavePackageSourcesWithMoreCLear()
+        public void SavePackageSourcesWithMoreClear()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var configContents =
@@ -492,7 +492,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void SavePackageSourcesWithOnlyClear()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var configContents =
@@ -542,7 +542,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void SavePackageSourcesWithHierarchyClear()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // assert
                 var nugetConfigPath = "NuGet.Config";
@@ -606,7 +606,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void SavePackageSources_RetainUnavailableDisabledSources()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var configContents =
@@ -659,7 +659,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void SavePackageSources_EnablesDisabledSources()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var configContents =
@@ -1550,7 +1550,7 @@ namespace NuGet.Configuration.Test
         public void HighPrioritySourceDisabled()
         {
             // Arrange
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 var configContent1 = @"<configuration>
     <disabledPackageSources>
@@ -1590,7 +1590,7 @@ namespace NuGet.Configuration.Test
         public void LowPrioritySourceDisabled()
         {
             // Arrange
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 var configContent1 = @"<configuration>
     <disabledPackageSources>
@@ -1629,7 +1629,7 @@ namespace NuGet.Configuration.Test
         public void V2NotDisabled()
         {
             // Arrange
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 var configContent = @"<configuration>
     <packageSources>
@@ -1659,7 +1659,7 @@ namespace NuGet.Configuration.Test
         public void AddPackageSourcesWithConfigFile()
         {
 
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var configContents =
@@ -1701,7 +1701,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void SavePackageSources_AddDisabledSourceToTheConfigContainingSource()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var config1Contents =
@@ -1760,7 +1760,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void SavePackageSources_WritesToTheSettingsFileWithTheNearestPriority()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var config1Contents =
@@ -1835,7 +1835,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void SavePackageSources_UpdatesSourceInAllConfigs()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var config1Contents =
@@ -1913,7 +1913,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void SavePackageSources_AddsNewSourcesToTheSettingWithLowestPriority()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var config1Contents =
@@ -1992,7 +1992,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void SavePackageSources_AddsOrderingForCollapsedFeeds()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var configContents =
@@ -2069,7 +2069,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void DisabledMachineWideSourceByDefault()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var configContents =
@@ -2122,7 +2122,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void SavePackageSources_DisabledOneMachineWideSource()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var configContents =
@@ -2168,7 +2168,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void DisabledMachineWideSourceByDefaultWithNull()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
@@ -2189,7 +2189,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void LoadPackageSourceEmptyConfigFileOnUserMachine()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var configContents =
@@ -2219,7 +2219,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void LoadPackageSourceLocalConfigFileOnUserMachine()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var configContents =
@@ -2253,7 +2253,7 @@ namespace NuGet.Configuration.Test
 
         public void SavePackageSource_IgnoreSettingBeforeClear()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var configContents =
@@ -2293,7 +2293,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void SavePackageSources_ThrowWhenConfigReadOnly()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var configContents =
@@ -2332,7 +2332,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void DefaultPushSourceInNuGetConfig()
         {
-            using (TestDirectory mockBaseDirectory = TestDirectory.Create())
+            using (TestDirectory mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 string configContentsWithDefault =
@@ -2378,7 +2378,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void LoadPackageSources_DoesNotDecryptPassword()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var configContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -2417,7 +2417,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void LoadPackageSources_DoesNotLoadClearedSource()
         {
-            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockBaseDirectory = TestDirectory.CreateInTemp())
             {
                 // Arrange
                 var configContents = @"<?xml version=""1.0"" encoding=""utf-8""?>

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPathContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPathContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -48,9 +48,6 @@ namespace NuGet.Test.Utility
             Directory.CreateDirectory(FallbackFolder);
 
             CreateNuGetConfig();
-
-            // Record who wrote this out incase a test isn't cleaning up
-            File.WriteAllText(Path.Combine(WorkingDirectory, "testStack.txt"), Environment.StackTrace);
         }
 
         private void CreateNuGetConfig()

--- a/test/TestUtilities/Test.Utility/TestDirectory.cs
+++ b/test/TestUtilities/Test.Utility/TestDirectory.cs
@@ -34,10 +34,29 @@ namespace NuGet.Test.Utility
             }
         }
 
+        /// <summary>
+        /// Create a temp folder under .test/work/
+        /// </summary>
         public static TestDirectory Create()
         {
-            string parentPath = null;
             var root = TestFileSystemUtility.NuGetTestFolder;
+            return Create(root);
+        }
+
+        /// <summary>
+        /// Create a temp folder under %TEMP%
+        /// </summary>
+        public static TestDirectory CreateInTemp()
+        {
+            var root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "NuGetTestFolder");
+            Directory.CreateDirectory(root);
+
+            return Create(root);
+        }
+
+        private static TestDirectory Create(string root)
+        {
+            string parentPath = null;
 
             // Loop until we find a directory that isn't taken (extremely unlikely this would need multiple guids).
             while (true)

--- a/test/TestUtilities/Test.Utility/TestDirectory.cs
+++ b/test/TestUtilities/Test.Utility/TestDirectory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,11 +6,17 @@ using System.IO;
 
 namespace NuGet.Test.Utility
 {
+    /// <summary>
+    /// Temporary new folder under .test/work/
+    /// </summary>
     public class TestDirectory : IDisposable
     {
-        private TestDirectory(string path)
+        private readonly string _parentPath;
+
+        private TestDirectory(string path, string parentPath)
         {
             Path = path;
+            _parentPath = parentPath;
             Info = new DirectoryInfo(path);
         }
 
@@ -19,23 +25,54 @@ namespace NuGet.Test.Utility
 
         public void Dispose()
         {
-            TestFileSystemUtility.DeleteRandomTestFolder(Path);
+            // Try to delete the sub folder first, avoid removing
+            // the parent folder containing extra test info
+            // if the sub folder cannot be removed.
+            if (TestFileSystemUtility.DeleteRandomTestFolder(Path))
+            {
+                TestFileSystemUtility.DeleteRandomTestFolder(_parentPath);
+            }
         }
 
-        public static TestDirectory Create(string path = null)
+        public static TestDirectory Create()
         {
-            var randomFolderName = Guid.NewGuid().ToString();
+            string parentPath = null;
+            var root = TestFileSystemUtility.NuGetTestFolder;
 
-            path = string.IsNullOrWhiteSpace(path) ? System.IO.Path.Combine(TestFileSystemUtility.NuGetTestFolder, randomFolderName) : path;
-
-            if (Directory.Exists(path))
+            // Loop until we find a directory that isn't taken (extremely unlikely this would need multiple guids).
+            while (true)
             {
-                throw new InvalidOperationException("Guid collision");
+                var guid = Guid.NewGuid().ToString();
+
+                // Use a shorter path to this easier when debugging
+                parentPath = System.IO.Path.Combine(root, guid.Split('-')[0]);
+
+                if (Directory.Exists(parentPath))
+                {
+                    // If a collision happens use the full guid
+                    parentPath = System.IO.Path.Combine(root, guid);
+
+                    if (!Directory.Exists(parentPath))
+                    {
+                        break;
+                    }
+                }
+                else
+                {
+                    break;
+                }
             }
 
+            Directory.CreateDirectory(parentPath);
+
+            // Record what created this folder in case there is a problem with clean up.
+            File.WriteAllText(System.IO.Path.Combine(parentPath, "testStack.txt"), Environment.StackTrace);
+
+            // Create a random sub folder to use, this keeps tests from relying on the folder name.
+            var path = System.IO.Path.Combine(parentPath, Guid.NewGuid().ToString().Split('-')[0]);
             Directory.CreateDirectory(path);
 
-            return new TestDirectory(path);
+            return new TestDirectory(path, parentPath);
         }
 
         public static implicit operator string(TestDirectory directory)

--- a/test/TestUtilities/Test.Utility/TestFileSystemUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestFileSystemUtility.cs
@@ -1,19 +1,77 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 
 namespace NuGet.Test.Utility
 {
     public static class TestFileSystemUtility
     {
-        public static readonly string NuGetTestFolder =
-            Path.Combine(Path.GetTempPath(), "NuGetTestFolder");
+        private static readonly Lazy<string> _root = new Lazy<string>(() => GetRootDirectory());
+        private static readonly Lazy<bool> _skipCleanUp = new Lazy<bool>(() => SkipCleanUp());
 
-        public static void DeleteRandomTestFolder(string randomTestPath)
+        /// <summary>
+        /// Root test folder where temporary test outputs should go.
+        /// </summary>
+        public static string NuGetTestFolder => _root.Value;
+
+        private static bool SkipCleanUp()
         {
-            if (Directory.Exists(randomTestPath))
+            // Option to leave files around for debugging
+            var val = Environment.GetEnvironmentVariable("NUGET_PERSIST_TESTFOLDERS");
+
+            if (StringComparer.OrdinalIgnoreCase.Equals(val, "true"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static string GetRootDirectory()
+        {
+            var repoRoot = GetRepositoryRoot();
+
+            // Default for tests outside of the repo
+            var path = Path.Combine(Path.GetTempPath(), "NuGetTestFolder");
+
+            if (repoRoot != null)
+            {
+                path = Path.Combine(repoRoot, ".test");
+                Directory.CreateDirectory(path);
+                path = Path.Combine(path, "work");
+            }
+
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        private static string GetRepositoryRoot()
+        {
+            var assemblyPath = new FileInfo(typeof(TestFileSystemUtility).GetTypeInfo().Assembly.Location);
+            var currentDir = assemblyPath.Directory;
+
+            while (currentDir != null)
+            {
+                if (currentDir.GetFiles().Any(e => e.Name.Equals("build.ps1", StringComparison.OrdinalIgnoreCase)))
+                {
+                    // We have found the repo root.
+                    break;
+                }
+
+                currentDir = currentDir.Parent;
+            }
+
+            return currentDir?.FullName;
+        }
+
+        public static bool DeleteRandomTestFolder(string randomTestPath)
+        {
+            // Avoid cleaning up test folders if 
+            if (!_skipCleanUp.Value && Directory.Exists(randomTestPath))
             {
                 AssertNotTempPath(randomTestPath);
 
@@ -23,8 +81,13 @@ namespace NuGet.Test.Utility
                 }
                 catch
                 {
+                    // Failure
+                    return false;
                 }
             }
+
+            // Success or skipped
+            return true;
         }
 
         public static void AssertNotTempPath(string path)
@@ -55,7 +118,7 @@ namespace NuGet.Test.Utility
 
         public static IDisposable SetCurrentDirectory(string path)
         {
-            string oldPath = Directory.GetCurrentDirectory();
+            var oldPath = Directory.GetCurrentDirectory();
             Directory.SetCurrentDirectory(path);
 
             return new ResetDirectory()


### PR DESCRIPTION
Move temp directory for tests from `%TEMP%` to `<repo>/.test/work/`

This makes it easier to find where test output went when debugging. It also lets you clean up these temp files with git clean, without this these temp files pile up over months of running tests locally.

For older tests that are broken by this change I've added `TestDirectory.CreateInTemp()` to go back to the old behavior.

Temp folder format is: `<repo>/.test/work/<random dir>/<random dir>/`
The parent test directory contains a stack trace of who created the folder, this makes it easier to track down which tests are leaving behind files. When looking into this I came across a bug in product code with push, so there is some value to finding this out.

CI is green with this change, it looks like everything is passing.
