### PR TITLE
Dispose of PackageArchiveReader after push to filesystem

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -359,8 +359,11 @@ namespace NuGet.Protocol.Core.Types
             CancellationToken token)
         {
             var root = sourceUri.LocalPath;
-            var reader = new PackageArchiveReader(pathToPackage);
-            var packageIdentity = reader.GetIdentity();
+            PackageIdentity packageIdentity = null;
+            using (var reader = new PackageArchiveReader(pathToPackage))
+            {
+                packageIdentity = reader.GetIdentity();
+            }
 
             if (IsV2LocalRepository(root))
             {


### PR DESCRIPTION
Dispose of PackageArchiveReader after push to filesystem

This was causing tests to leave nupkg files behind, and it could happen to users also.

fixes https://github.com/NuGet/Home/issues/6325
