### PR TITLE
force kill all running instances of devenv for each install/downgrade attempt

### DIFF
--- a/scripts/e2etests/InstallNuGetVSIX.ps1
+++ b/scripts/e2etests/InstallNuGetVSIX.ps1
@@ -31,6 +31,7 @@ Copy-Item $VSIXSrcPath $VSIXPath
 # Since dev14 vsix is not uild with vssdk 3.0, we can uninstall and re installing
 # For dev 15, we upgrade an installed system component vsix
 if ($VSVersion -eq '14.0') {
+    KillRunningInstancesOfVS
     $success = UninstallVSIX $NuGetVSIXID $VSVersion $ProcessExitTimeoutInSeconds
     if ($success -eq $false) {
         exit 1

--- a/scripts/e2etests/InstallNuGetVSIX.ps1
+++ b/scripts/e2etests/InstallNuGetVSIX.ps1
@@ -23,8 +23,6 @@ if ($success -eq $false) {
     exit 1
 }
 
-KillRunningInstancesOfVS
-
 $VSIXSrcPath = Join-Path $NuGetDropPath 'NuGet.Tools.vsix'
 $VSIXPath = Join-Path $FuncTestRoot 'NuGet.Tools.vsix'
 
@@ -42,6 +40,7 @@ else {
     $numberOfTries = 0
     $success = $false
     do {
+        KillRunningInstancesOfVS
         $numberOfTries++
         Write-Host "Attempt # $numberOfTries to downgrade VSIX..."
         $success = DowngradeVSIX $NuGetVSIXID $VSVersion $ProcessExitTimeoutInSeconds
@@ -55,6 +54,7 @@ else {
 $numberOfTries = 0
 $success = $false
 do {
+    KillRunningInstancesOfVS
     $numberOfTries++
     Write-Host "Attempt # $numberOfTries to install VSIX..."
     $success = InstallVSIX $VSIXPath $VSVersion $ProcessExitTimeoutInSeconds

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -55,11 +55,20 @@ function GetVSIDEFolderPath
 
 function KillRunningInstancesOfVS
 {
-    $processName = 'devenv'
-    Write-Host "Kill any running instances of $processName..."
-    (Get-Process "$processName" -ErrorAction SilentlyContinue) | Stop-Process -ErrorAction SilentlyContinue -Force
-
-    WaitForProcessExit -ProcessName "$processName" -TimeoutInSeconds 30
+    Get-Process | ForEach-Object {
+        if(-not [string]::IsNullOrEmpty($_.Path)) {
+            $processPath = $_.Path | Out-String
+            if($processPath.StartsWith("C:\Program Files (x86)\Microsoft Visual Studio", [System.StringComparison]::OrdinalIgnoreCase))
+            {
+                Write-Host $processPath
+                Stop-Process $_ -ErrorAction SilentlyContinue -Force
+                if($_.HasExited) {
+                Write-Host "Killed process:" $_.Name
+                }
+        
+            }        
+        }
+    }    
 }
 
 function LaunchVS

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -110,7 +110,7 @@ function ExecuteCommand {
     do {
         try {            
             $numberOfTries++
-            Write-Host "Attempt # $numberOfTries"
+            Write-Host "Attempt # $numberOfTries "
             if ($args) {
                 Write-Host 'Executing command ' $command ' with arguments: ' $args
                 $dte2.ExecuteCommand($command, $args)
@@ -127,7 +127,7 @@ function ExecuteCommand {
             }
         }
         catch {
-            Write-Host "$command threw an exception : " $_.Exception.Messsage
+            Write-Host "$command threw an exception: $PSItem" 
             Write-Host "Will wait for $waitTime seconds and retry"
             $success = $false
             start-sleep $waitTime

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -57,7 +57,7 @@ function KillRunningInstancesOfVS
 {
     $processName = 'devenv'
     Write-Host "Kill any running instances of $processName..."
-    (Get-Process "$processName" -ErrorAction SilentlyContinue) | Kill -ErrorAction SilentlyContinue
+    (Get-Process "$processName" -ErrorAction SilentlyContinue) | Stop-Process -ErrorAction SilentlyContinue -Force
 
     WaitForProcessExit -ProcessName "$processName" -TimeoutInSeconds 30
 }

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -105,7 +105,7 @@ function ExecuteCommand {
     )
 
     Write-Host $message
-    $success = false
+    $success = $false
     $numberOfTries = 0
     do {
         try {            


### PR DESCRIPTION
our installnugetvsix.ps1 script fails sometimes because devenv.exe processes are not correctly shut down. trying to make it more robust here by adding the force switch.

also added retry logic to ExecuteCommand which often fails with: 

```
2017-12-18T22:19:00.8245850Z RunFunctionalTests.ps1 threw an exception:  System.Runtime.InteropServices.COMException (0x80004005): Command "View.PackageManagerConsole" is not available.
2017-12-18T22:19:00.8248297Z    at System.Management.Automation.ComInterop.ComRuntimeHelpers.CheckThrowException(Int32 hresult, ExcepInfo& excepInfo, ComMethodDesc method, Object[] args, UInt32 argErr)
2017-12-18T22:19:00.8250142Z    at CallSite.Target(Closure , CallSite , ComObject , String )
2017-12-18T22:19:00.8302950Z    at System.Dynamic.UpdateDelegates.UpdateAndExecute2[T0,T1,TRet](CallSite site, T0 arg0, T1 arg1)
2017-12-18T22:19:00.8305721Z    at System.Dynamic.UpdateDelegates.UpdateAndExecute2[T0,T1,TRet](CallSite site, T0 arg0, T1 arg1)
2017-12-18T22:19:00.8309737Z    at System.Management.Automation.Interpreter.DynamicInstruction`3.Run(InterpretedFrame frame)
2017-12-18T22:19:00.8312687Z    at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
```

