### PR TITLE
Fixing initial value for Timestamp.LowerLimit

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Timestamp.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Timestamp.cs
@@ -53,7 +53,7 @@ namespace NuGet.Packaging.Signing
         {
             UpperLimit = DateTimeOffset.Now;
             GeneralizedTime = DateTimeOffset.Now;
-            UpperLimit = DateTimeOffset.Now;
+            LowerLimit = DateTimeOffset.Now;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Timestamp.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Timestamp.cs
@@ -51,9 +51,9 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         public Timestamp()
         {
-            UpperLimit = DateTimeOffset.Now;
             GeneralizedTime = DateTimeOffset.Now;
-            LowerLimit = DateTimeOffset.Now;
+            UpperLimit = GeneralizedTime;
+            LowerLimit = GeneralizedTime;
         }
 
         /// <summary>

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/IntegrityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/IntegrityVerificationProviderTests.cs
@@ -22,7 +22,7 @@ using Xunit;
 
 namespace NuGet.Packaging.FuncTest
 {
-    [Collection("Signing Funtional Test Collection")]
+    [Collection("Signing Functional Test Collection")]
     public class IntegrityVerificationProviderTests
     {
         private const string _packageTamperedError = "Package integrity check failed.";

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
@@ -44,7 +44,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             {
                 // Act
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedAndTimeStampedPackageAsync(_trustedTestCert, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedAndTimeStampedPackageAsync(_trustedTestCert.Source.Cert, nupkg, dir);
 
                 // Assert
                 using (var stream = File.OpenRead(signedPackagePath))

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace NuGet.Packaging.FuncTest
 {
-    [Collection("Signing Funtional Test Collection")]
+    [Collection("Signing Functional Test Collection")]
     public class SignatureTests
     {
         private SigningTestFixture _testFixture;

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace NuGet.Packaging.FuncTest
 {
-    [Collection("Signing Funtional Test Collection")]
+    [Collection("Signing Functional Test Collection")]
     public class SignatureTrustAndValidityVerificationProviderTests
     {
         private SigningSpecifications _specification => SigningSpecifications.V1;

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if IS_DESKTOP
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Packaging.Signing;
+using NuGet.Test.Utility;
+using Test.Utility.Signing;
+using Xunit;
+
+namespace NuGet.Packaging.FuncTest
+{
+    [Collection("Signing Funtional Test Collection")]
+    public class SignatureTrustAndValidityVerificationProviderTests
+    {
+        private SigningSpecifications _specification => SigningSpecifications.V1;
+
+        private SigningTestFixture _testFixture;
+        private TrustedTestCert<TestCertificate> _trustedTestCert;
+        private IList<ISignatureVerificationProvider> _trustProviders;
+
+        public SignatureTrustAndValidityVerificationProviderTests(SigningTestFixture fixture)
+        {
+            _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+            _trustedTestCert = _testFixture.TrustedTestCertificate;
+            _trustProviders = new List<ISignatureVerificationProvider>()
+            {
+                new SignatureTrustAndValidityVerificationProvider()
+            };
+        }
+
+        [CIOnlyFact]
+        public async Task VerifySignedPackage_ValidCertificate_Success()
+        {
+            // Arrange
+            var nupkg = new SimpleTestPackageContext();
+            using (var dir = TestDirectory.Create())
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
+            {
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.VerifyCommandDefaultPolicy);
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    var result = await verifier.VerifySignaturesAsync(packageReader, CancellationToken.None);
+                    var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
+
+                    // Assert
+                    result.Valid.Should().BeTrue();
+                    resultsWithErrors.Count().Should().Be(0);
+                }
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task VerifySignedPackage_ValidCertificateAndTimestamp_Success()
+        {
+            // Arrange
+            var nupkg = new SimpleTestPackageContext();
+            using (var dir = TestDirectory.Create())
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
+            {
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedAndTimeStampedPackageAsync(testCertificate, nupkg, dir);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.VerifyCommandDefaultPolicy);
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    var result = await verifier.VerifySignaturesAsync(packageReader, CancellationToken.None);
+                    var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
+
+                    // Assert
+                    result.Valid.Should().BeTrue();
+                    resultsWithErrors.Count().Should().Be(0);
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedArchiveTestUtility.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedArchiveTestUtility.cs
@@ -59,6 +59,7 @@ namespace NuGet.Packaging.FuncTest
         /// </summary>
         /// <param name="testCert">Certificate to be used while signing the package</param>
         /// <param name="nupkg">Package to be signed</param>
+        /// <param name="dir">Directory for placing the signed package</param>
         /// <returns>Path to the signed copy of the package</returns>
         public static async Task<string> CreateSignedAndTimeStampedPackageAsync(X509Certificate2 testCert, SimpleTestPackageContext nupkg, string dir)
         {

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedArchiveTestUtility.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedArchiveTestUtility.cs
@@ -60,7 +60,7 @@ namespace NuGet.Packaging.FuncTest
         /// <param name="testCert">Certificate to be used while signing the package</param>
         /// <param name="nupkg">Package to be signed</param>
         /// <returns>Path to the signed copy of the package</returns>
-        public static async Task<string> CreateSignedAndTimeStampedPackageAsync(TrustedTestCert<TestCertificate> testCert, SimpleTestPackageContext nupkg, string dir)
+        public static async Task<string> CreateSignedAndTimeStampedPackageAsync(X509Certificate2 testCert, SimpleTestPackageContext nupkg, string dir)
         {
             var testLogger = new TestLogger();
 
@@ -72,7 +72,7 @@ namespace NuGet.Packaging.FuncTest
                 using (var signPackage = new SignedPackageArchive(zipReadStream, zipWriteStream))
                 {
                     // Sign the package
-                    await SignAndTimeStampPackageAsync(testLogger, testCert.Source.Cert, signPackage);
+                    await SignAndTimeStampPackageAsync(testLogger, testCert, signPackage);
                 }
 
                 zipWriteStream.Seek(offset: 0, loc: SeekOrigin.Begin);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
@@ -20,7 +20,7 @@ using Xunit;
 
 namespace NuGet.Packaging.FuncTest
 {
-    [Collection("Signing Funtional Test Collection")]
+    [Collection("Signing Functional Test Collection")]
     public class SignedPackageIntegrityVerificationTests
     {
         private SigningSpecifications _specification => SigningSpecifications.V1;

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace NuGet.Packaging.FuncTest
 {
-    [Collection("Signing Funtional Test Collection")]
+    [Collection("Signing Functional Test Collection")]
     public class SignerTests
     {
         private SigningTestFixture _testFixture;

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestCollection.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestCollection.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace NuGet.Packaging.FuncTest
 {
-    [CollectionDefinition("Signing Funtional Test Collection")]
+    [CollectionDefinition("Signing Functional Test Collection")]
     public class SigningTestCollection : ICollectionFixture<SigningTestFixture>
     {
         // This class has no code, and is never created. Its purpose is simply

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace NuGet.Packaging.FuncTest
 {
-    [Collection("Signing Funtional Test Collection")]
+    [Collection("Signing Functional Test Collection")]
     public class TimestampProviderTests
     {
         private const string _internalTimestamper = "http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer";


### PR DESCRIPTION
## Bug
As part of https://github.com/NuGet/NuGet.Client/commit/bf5457061e37600bc9207ba244153ab8b818f239 we added a constructor for the `Timestamp` class. The constructor was not initializing `Timestamp.Lowerlimit`. This was causing verification failures [here](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs#L215).

## Fix
1. Fixing the constructor.
2. Adding tests that would have caught this issue.
3. Some test cleanup in `SignedArchiveTestUtility.cs`.

## Testing/Validation
Tests Added: Yes
Validation done:  manual validation done 
