### PR TITLE
Signing: assert package signature file is a regular file

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -233,7 +233,7 @@ namespace NuGet.Common
         NU3006 = 3006,
 
         /// <summary>
-        /// Certificate chain does not build
+        /// ZIP entry is either not a regular file or is not stored (no compression)
         /// </summary>
         NU3011 = 3011,
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -301,7 +301,7 @@ namespace NuGet.Packaging
             {
                 var hashAlgorithm = signatureContent.HashAlgorithm.GetHashProvider();
                 var expectedHash = Convert.FromBase64String(signatureContent.HashValue);
-                if (!SignedPackageArchiveUtility.VerifySignedZipIntegrity(reader, hashAlgorithm, expectedHash))
+                if (!SignedPackageArchiveUtility.VerifySignedPackageIntegrity(reader, hashAlgorithm, expectedHash))
                 {
                     throw new SignatureException(Strings.SignaturePackageIntegrityFailure, GetIdentity());
                 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/CentralDirectoryHeader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/CentralDirectoryHeader.cs
@@ -1,0 +1,78 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+
+namespace NuGet.Packaging.Signing
+{
+    internal sealed class CentralDirectoryHeader
+    {
+        internal const uint Signature = 0x02014b50;
+
+        internal ushort VersionMadeBy { get; private set; }
+        internal ushort VersionNeededToExtract { get; private set; }
+        internal ushort GeneralPurposeBitFlag { get; private set; }
+        internal ushort CompressionMethod { get; private set; }
+        internal ushort LastModFileTime { get; private set; }
+        internal ushort LastModFileDate { get; private set; }
+        internal uint Crc32 { get; private set; }
+        internal uint CompressedSize { get; private set; }
+        internal uint UncompressedSize { get; private set; }
+        internal ushort FileNameLength { get; private set; }
+        internal ushort ExtraFieldLength { get; private set; }
+        internal ushort FileCommentLength { get; private set; }
+        internal ushort DiskNumberStart { get; private set; }
+        internal ushort InternalFileAttributes { get; private set; }
+        internal uint ExternalFileAttributes { get; private set; }
+        internal uint RelativeOffsetOfLocalHeader { get; private set; }
+        internal byte[] FileName { get; private set; }
+        internal byte[] ExtraField { get; private set; }
+        internal byte[] FileComment { get; private set; }
+
+        internal uint GetSize()
+        {
+            return SignedPackageArchiveIOUtility.CentralDirectoryFileHeaderSizeWithoutSignature
+                + FileNameLength
+                + ExtraFieldLength
+                + FileCommentLength;
+        }
+
+        internal static bool TryRead(BinaryReader reader, out CentralDirectoryHeader header)
+        {
+            header = null;
+
+            var signature = reader.ReadUInt32();
+
+            if (signature != Signature)
+            {
+                reader.BaseStream.Seek(offset: -sizeof(uint), origin: SeekOrigin.Current);
+
+                return false;
+            }
+
+            header = new CentralDirectoryHeader();
+
+            header.VersionMadeBy = reader.ReadUInt16();
+            header.VersionNeededToExtract = reader.ReadUInt16();
+            header.GeneralPurposeBitFlag = reader.ReadUInt16();
+            header.CompressionMethod = reader.ReadUInt16();
+            header.LastModFileTime = reader.ReadUInt16();
+            header.LastModFileDate = reader.ReadUInt16();
+            header.Crc32 = reader.ReadUInt32();
+            header.CompressedSize = reader.ReadUInt32();
+            header.UncompressedSize = reader.ReadUInt32();
+            header.FileNameLength = reader.ReadUInt16();
+            header.ExtraFieldLength = reader.ReadUInt16();
+            header.FileCommentLength = reader.ReadUInt16();
+            header.DiskNumberStart = reader.ReadUInt16();
+            header.InternalFileAttributes = reader.ReadUInt16();
+            header.ExternalFileAttributes = reader.ReadUInt32();
+            header.RelativeOffsetOfLocalHeader = reader.ReadUInt32();
+            header.FileName = reader.ReadBytes(header.FileNameLength);
+            header.ExtraField = reader.ReadBytes(header.ExtraFieldLength);
+            header.FileComment = reader.ReadBytes(header.FileCommentLength);
+
+            return true;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/CentralDirectoryHeader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/CentralDirectoryHeader.cs
@@ -7,6 +7,8 @@ namespace NuGet.Packaging.Signing
 {
     internal sealed class CentralDirectoryHeader
     {
+        internal const uint SizeInBytesOfFixedLengthFields = 46;
+
         internal const uint Signature = 0x02014b50;
 
         internal ushort VersionMadeBy { get; private set; }
@@ -29,12 +31,12 @@ namespace NuGet.Packaging.Signing
         internal byte[] ExtraField { get; private set; }
         internal byte[] FileComment { get; private set; }
 
-        internal uint GetSize()
+        internal uint GetSizeInBytes()
         {
-            return SignedPackageArchiveIOUtility.CentralDirectoryFileHeaderSizeWithoutSignature
-                + FileNameLength
-                + ExtraFieldLength
-                + FileCommentLength;
+            return SizeInBytesOfFixedLengthFields +
+                FileNameLength +
+                ExtraFieldLength +
+                FileCommentLength;
         }
 
         internal static bool TryRead(BinaryReader reader, out CentralDirectoryHeader header)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/CentralDirectoryHeaderMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/CentralDirectoryHeaderMetadata.cs
@@ -30,7 +30,7 @@ namespace NuGet.Packaging.Signing
         public string Filename { get; set; }
 
         /// <summary>
-        /// Size of central directory header, in bytes, excluding the central directory header signature.
+        /// Size of central directory header, in bytes.
         /// </summary>
         public long HeaderSize { get; set; }
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/CentralDirectoryHeaderMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/CentralDirectoryHeaderMetadata.cs
@@ -1,16 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace NuGet.Packaging.Signing
 {
     /// <summary>
     /// This class is used to hold metadata about the central directory archive structure
     /// </summary>
-    public class CentralDirectoryHeaderMetadata
+    public sealed class CentralDirectoryHeaderMetadata
     {
         /// <summary>
         /// Position in bytes of the corresponding central directory header relative to the start of the archive

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveIOUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveIOUtility.cs
@@ -23,13 +23,11 @@ namespace NuGet.Packaging.Signing
 
         // All the signatures have a fixed length of 4 bytes
         internal const uint ZipHeaderSignatureSize = 4;
-        internal const uint CentralDirectoryHeaderSignature = 0x02014b50;
         internal const uint EndOfCentralDirectorySignature = 0x06054b50;
         internal const uint Zip64EndOfCentralDirectorySignature = 0x06064b50;
         internal const uint Zip64EndOfCentralDirectoryLocatorSignature = 0x07064b50;
         internal const uint LocalFileHeaderSignature = 0x04034b50;
 
-        private const uint Crc32Polynomial = 0xedb88320;
         private static readonly SigningSpecifications _signingSpecification = SigningSpecifications.V1;
 
         // used while converting DateTime to MS-DOS date time format
@@ -248,51 +246,33 @@ namespace NuGet.Packaging.Signing
 
             // Read central directory records
             var possibleSignatureCentralDirectoryRecordPosition = reader.BaseStream.Position;
-            var isReadingCentralDirectoryRecords = true;
+            CentralDirectoryHeader header;
 
-            while (isReadingCentralDirectoryRecords)
+            while (CentralDirectoryHeader.TryRead(reader, out header))
             {
-                var centralDirectoryMetadata = new CentralDirectoryHeaderMetadata
+                if (header.RelativeOffsetOfLocalHeader < metadata.StartOfFileHeaders)
                 {
+                    metadata.StartOfFileHeaders = header.RelativeOffsetOfLocalHeader;
+                }
+
+                var isUtf8 = SignedPackageArchiveUtility.IsUtf8(header.GeneralPurposeBitFlag);
+
+                var centralDirectoryMetadata = new CentralDirectoryHeaderMetadata()
+                {
+                    Filename = SignedPackageArchiveUtility.GetString(header.FileName, isUtf8),
+                    HeaderSize = header.GetSize(),
+                    OffsetToFileHeader = header.RelativeOffsetOfLocalHeader,
                     Position = possibleSignatureCentralDirectoryRecordPosition
                 };
-                var centralDirectoryHeaderSignature = reader.ReadUInt32();
-                if (centralDirectoryHeaderSignature != CentralDirectoryHeaderSignature)
-                {
-                    throw new InvalidDataException(Strings.ErrorInvalidPackageArchive);
-                }
 
-                // Skip until file name length, 24 bytes after signature of central directory record (excluding signature length)
-                reader.BaseStream.Seek(offset: 24, origin: SeekOrigin.Current);
-                var filenameLength = reader.ReadUInt16();
-                var extraFieldLength = reader.ReadUInt16();
-                var fileCommentLength = reader.ReadUInt16();
-
-                // Skip to read local header offset (8 bytes after file comment length field)
-                reader.BaseStream.Seek(offset: 8, origin: SeekOrigin.Current);
-
-                centralDirectoryMetadata.OffsetToFileHeader = reader.ReadUInt32();
-
-                if (centralDirectoryMetadata.OffsetToFileHeader < metadata.StartOfFileHeaders)
-                {
-                    metadata.StartOfFileHeaders = centralDirectoryMetadata.OffsetToFileHeader;
-                }
-
-                var filename = reader.ReadBytes(filenameLength);
-                centralDirectoryMetadata.Filename = Encoding.ASCII.GetString(filename);
-                // Save total size of central directory record + variable length fields
-                centralDirectoryMetadata.HeaderSize = CentralDirectoryFileHeaderSizeWithoutSignature + filenameLength + extraFieldLength + fileCommentLength;
-
-                try
-                {
-                    SeekReaderForwardToMatchByteSignature(reader, BitConverter.GetBytes(CentralDirectoryHeaderSignature));
-                    possibleSignatureCentralDirectoryRecordPosition = reader.BaseStream.Position;
-                }
-                catch
-                {
-                    isReadingCentralDirectoryRecords = false;
-                }
                 centralDirectoryRecords.Add(centralDirectoryMetadata);
+
+                possibleSignatureCentralDirectoryRecordPosition = reader.BaseStream.Position;
+            }
+
+            if (centralDirectoryRecords.Count == 0)
+            {
+                throw new InvalidDataException(Strings.ErrorInvalidPackageArchive);
             }
 
             var lastCentralDirectoryRecord = centralDirectoryRecords.Last();
@@ -364,7 +344,7 @@ namespace NuGet.Packaging.Signing
                 // No local File header found (entry must be the last entry), search for the start of the first central directory
                 catch
                 {
-                    SeekReaderForwardToMatchByteSignature(reader, BitConverter.GetBytes(CentralDirectoryHeaderSignature));
+                    SeekReaderForwardToMatchByteSignature(reader, BitConverter.GetBytes(CentralDirectoryHeader.Signature));
                 }
 
                 record.IndexInHeaders = centralDirectoryRecordIndex;
@@ -442,17 +422,19 @@ namespace NuGet.Packaging.Signing
             var signatureEntryErrorCode = NuGetLogCode.NU3011;
 
             // Assert general purpose bits to 0
-            AssertUInt16(
-                reader: reader,
-                expectedValue: 0,
+            uint actualValue = reader.ReadUInt16();
+            AssertValue(
+                expectedValue: 0U,
+                actualValue: actualValue,
                 errorCode: signatureEntryErrorCode,
                 errorMessagePrefix: errorPrefix,
                 errorMessageSuffix: Strings.SignatureInvalidGeneralPurposeBits);
 
             // Assert compression method to 0
-            AssertUInt16(
-                reader: reader,
-                expectedValue: 0,
+            actualValue = reader.ReadUInt16();
+            AssertValue(
+                expectedValue: 0U,
+                actualValue: actualValue,
                 errorCode: signatureEntryErrorCode,
                 errorMessagePrefix: errorPrefix,
                 errorMessageSuffix: Strings.SignatureInvalidCompressionMethod);
@@ -469,17 +451,28 @@ namespace NuGet.Packaging.Signing
                     signatureEntryErrorCode,
                     string.Format(CultureInfo.CurrentCulture, errorPrefix, Strings.SignatureFileCompressed));
             }
+
+            // Skip file name length (2 bytes), extra field length (2 bytes), file comment length (2 bytes),
+            // disk number start (2 bytes), and internal file attributes (2 bytes)
+            reader.BaseStream.Seek(offset: 10, origin: SeekOrigin.Current);
+
+            actualValue = reader.ReadUInt32();
+            AssertValue(
+                expectedValue: 0U,
+                actualValue: actualValue,
+                errorCode: signatureEntryErrorCode,
+                errorMessagePrefix: errorPrefix,
+                errorMessageSuffix: Strings.SignatureInvalidExternalFileAttributes);
         }
 
-        private static void AssertUInt16(
-            BinaryReader reader,
-            ushort expectedValue,
+        private static void AssertValue(
+            uint expectedValue,
+            uint actualValue,
             NuGetLogCode errorCode,
             string errorMessagePrefix,
             string errorMessageSuffix)
         {
-            var actualValue = reader.ReadUInt16();
-            if (actualValue != expectedValue)
+            if (!actualValue.Equals(expectedValue))
             {
                 var failureCause = string.Format(
                     CultureInfo.CurrentCulture,
@@ -558,7 +551,8 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         /// <param name="writer">BinaryWriter to be used to write file.</param>
         /// <param name="fileData">Byte[] of the corresponding file to be written into the zip.</param>
-        /// <param name="fileTime">Last modified DateTime for the file data.</param>
+        /// <param name="crc32">CRC-32 for the file.</param>
+        /// <param name="dosDateTime">Last modified DateTime for the file data.</param>
         /// <returns>Number of total bytes written into the zip.</returns>
         private static long WriteLocalFileHeaderIntoZip(
             BinaryWriter writer,
@@ -569,13 +563,13 @@ namespace NuGet.Packaging.Signing
             // Write the file header signature
             writer.Write(LocalFileHeaderSignature);
 
-            // 2.0 - File is compressed using Deflate compression - Version needed to extract
+            // Version needed to extract:  2.0
             writer.Write((ushort)20);
 
-            // 00 - Normal (-en) compression option was used.
+            // General purpose bit flags
             writer.Write((ushort)0);
 
-            // 00 - The file is stored (no compression)
+            // The file is stored (no compression)
             writer.Write((ushort)0);
 
             // write date and time
@@ -591,7 +585,7 @@ namespace NuGet.Packaging.Signing
             writer.Write((uint)fileData.Length);
 
             // write file name length
-            var fileNameBytes = _signingSpecification.Encoding.GetBytes(_signingSpecification.SignaturePath);
+            var fileNameBytes = Encoding.ASCII.GetBytes(_signingSpecification.SignaturePath);
             var fileNameLength = fileNameBytes.Length;
             writer.Write((ushort)fileNameLength);
 
@@ -629,7 +623,8 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         /// <param name="writer">BinaryWriter to be used to write file.</param>
         /// <param name="fileData">Byte[] of the file to be written into the zip.</param>
-        /// <param name="fileTime">Last modified DateTime for the file data.</param>
+        /// <param name="crc32">CRC-32 checksum for the file.</param>
+        /// <param name="dosDateTime">Last modified DateTime for the file data.</param>
         /// <param name="fileOffset">Offset, in bytes, for the local file header of the corresponding file from the start of the archive.</param>
         /// <returns>Number of total bytes written into the zip.</returns>
         private static long WriteCentralDirectoryHeaderIntoZip(
@@ -640,18 +635,18 @@ namespace NuGet.Packaging.Signing
             long fileOffset)
         {
             // Write the file header signature
-            writer.Write(CentralDirectoryHeaderSignature);
+            writer.Write(CentralDirectoryHeader.Signature);
 
-            // 2.0 - File is compressed using Deflate compression - Version made by
+            // Version made by:  2.0
             writer.Write((ushort)20);
 
-            // 2.0 - File is compressed using Deflate compression - Version needed to extract
+            // Version needed to extract:  2.0
             writer.Write((ushort)20);
 
-            // 00 - Normal (-en) compression option was used.
+            // General purpose bit flags
             writer.Write((ushort)0);
 
-            // 00 - The file is stored (no compression)
+            // The file is stored (no compression)
             writer.Write((ushort)0);
 
             // write date and time
@@ -667,7 +662,7 @@ namespace NuGet.Packaging.Signing
             writer.Write((uint)fileData.Length);
 
             // write file name length
-            var fileNameBytes = _signingSpecification.Encoding.GetBytes(_signingSpecification.SignaturePath);
+            var fileNameBytes = Encoding.ASCII.GetBytes(_signingSpecification.SignaturePath);
             var fileNameLength = fileNameBytes.Length;
             writer.Write((ushort)fileNameLength);
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveUtility.cs
@@ -146,8 +146,8 @@ namespace NuGet.Packaging.Signing
                     var relativeOffsetOfLocalFileHeader = (uint)(reader.ReadUInt32() + record.ChangeInOffset);
                     SignedPackageArchiveIOUtility.HashBytes(hashAlgorithm, BitConverter.GetBytes(relativeOffsetOfLocalFileHeader));
 
-                    // We already read and hash the whole header, skip only filenameLength + extraFieldLength + fileCommentLength
-                    SignedPackageArchiveIOUtility.ReadAndHashUntilPosition(reader, hashAlgorithm, reader.BaseStream.Position + record.HeaderSize - SignedPackageArchiveIOUtility.CentralDirectoryFileHeaderSizeWithoutSignature);
+                    // Continue hashing file name, extra field, and file comment fields.
+                    SignedPackageArchiveIOUtility.ReadAndHashUntilPosition(reader, hashAlgorithm, reader.BaseStream.Position + record.HeaderSize - CentralDirectoryHeader.SizeInBytesOfFixedLengthFields);
                 }
 
                 reader.BaseStream.Seek(offset: metadata.EndOfCentralDirectory, origin: SeekOrigin.Begin);

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -629,6 +629,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package signature file entry is invalid..
+        /// </summary>
+        internal static string SignatureInvalidExternalFileAttributes {
+            get {
+                return ResourceManager.GetString("SignatureInvalidExternalFileAttributes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid general purpose bit flags. Expected &apos;{0}&apos;, actual &apos;{1}&apos;..
         /// </summary>
         internal static string SignatureInvalidGeneralPurposeBits {
@@ -645,7 +654,7 @@ namespace NuGet.Packaging {
                 return ResourceManager.GetString("SignatureLocalFileHeaderInvalid", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The signing certificate is not yet valid..
         /// </summary>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -465,4 +465,7 @@ Valid from:</comment>
   <data name="TimestampNotYetValid" xml:space="preserve">
     <value>The timestamp signing certificate is not yet valid.</value>
   </data>
+  <data name="SignatureInvalidExternalFileAttributes" xml:space="preserve">
+    <value>The package signature file entry is invalid.</value>
+  </data>
 </root>


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/6343.

Also:

* fix incorrect decoding of ZIP entry file names
* simplify ZIP-reading code