### PR TITLE
Switching NuGet.Build.Tasks.Pack packing to nuspec

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.XPlat.nuspec
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.XPlat.nuspec
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>NuGet.Build.Tasks.Pack</id>
+    <version>$version$</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <description>NuGet pack for dotnet CLI</description>
+  </metadata>
+  <files>
+    <file src="netstandard1.3\*.dll" target="CoreCLR\" />
+    <file src="netstandard1.3\NuGet.Build.Tasks.Pack.targets" target="buildCrossTargeting\NuGet.Build.Tasks.Pack.targets" />
+  </files>
+</package>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.XPlat.nuspec
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.XPlat.nuspec
@@ -9,6 +9,8 @@
   </metadata>
   <files>
     <file src="netstandard1.3\*.dll" target="CoreCLR\" />
+    <file src="netstandard1.3\**\NuGet.Build.Tasks.Pack.resources.dll" target="CoreCLR\" />
     <file src="netstandard1.3\NuGet.Build.Tasks.Pack.targets" target="buildCrossTargeting\NuGet.Build.Tasks.Pack.targets" />
+    <file src="netstandard1.3\NuGet.Build.Tasks.Pack.targets" target="build\NuGet.Build.Tasks.Pack.targets" />
   </files>
 </package>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -6,24 +6,23 @@
     <TargetFrameworks Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">netstandard1.3</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AssemblyName>NuGet.Build.Tasks.Pack</AssemblyName>
-    <PackageId>NuGet.Build.Tasks.Pack</PackageId>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
     <Shipping>true</Shipping>
     <PackProject>true</PackProject>
     <NoBuild>true</NoBuild>
-    <Authors>Microsoft</Authors>
-    <Description>NuGet pack for dotnet CLI</Description>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier> 
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <IncludeBuildOutput>false</IncludeBuildOutput> <!-- We only collect the ILMerged dll when packing on desktop. Build from does not do an ILMerge -->
     <XPLATProject>true</XPLATProject>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\NuGet.Build.Tasks\Common\MSBuildLogger.cs" />
     <Compile Include="..\NuGet.Build.Tasks\GetProjectTargetFrameworksTask.cs" />
+    <Content Include="NuGet.Build.Tasks.Pack.targets">		
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>		
+    </Content>
   </ItemGroup>
 
   <ItemGroup>
@@ -40,61 +39,6 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(IsBuildOnlyXPLATProjects)' != 'true'">
-    <None Include="$(OutputPath)net46\ilmerge\NuGet.Build.Tasks.Pack.dll">
-      <PackagePath>Desktop</PackagePath>
-      <Pack>true</Pack>
-      <Visible>false</Visible>
-    </None>
-    <None Include="$(OutputPath)net46\ilmerge\NuGet.Build.Tasks.Pack.xml">
-      <PackagePath>Desktop</PackagePath>
-      <Pack>true</Pack>
-      <Visible>false</Visible>
-    </None>
-    <None Include="$(OutputPath)net46\ilmerge\**\NuGet.Build.Tasks.Pack.resources.dll">
-      <PackagePath>Desktop</PackagePath>
-      <Pack>true</Pack>
-      <Visible>false</Visible>
-    </None>
-    <None Include="$(OutputPath)netstandard1.3\ilmerge\NuGet.Build.Tasks.Pack.dll">
-      <PackagePath>CoreCLR</PackagePath>
-      <Pack>true</Pack>
-      <Visible>false</Visible>
-    </None>
-    <None Include="$(OutputPath)netstandard1.3\ilmerge\NuGet.Build.Tasks.Pack.xml">
-      <PackagePath>CoreCLR</PackagePath>
-      <Pack>true</Pack>
-      <Visible>false</Visible>
-    </None>
-    <None Include="$(OutputPath)netstandard1.3\ilmerge\**\NuGet.Build.Tasks.Pack.resources.dll">
-      <PackagePath>CoreCLR</PackagePath>
-      <Pack>true</Pack>
-      <Visible>false</Visible>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">
-    <None Include="$(OutputPath)netstandard1.3\*.dll">
-      <PackagePath>CoreCLR</PackagePath>
-      <Pack>true</Pack>
-      <Visible>false</Visible>
-    </None>
-  </ItemGroup>  
-
-  <ItemGroup>
-    <None Include="NuGet.Build.Tasks.Pack.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PackagePath>build</PackagePath>
-      <Pack>true</Pack>
-    </None>
-    <None Include="NuGet.Build.Tasks.Pack.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PackagePath>buildCrossTargeting</PackagePath>
-      <Pack>true</Pack>
-    </None>
-  </ItemGroup>
-
 
   <ItemGroup>
     <Compile Update="Strings.Designer.cs">
@@ -185,4 +129,10 @@
       <SymbolsToIndex Include="$(OutputPath)ilmerge\*.pdb" KeepDuplicates="false" />
     </ItemGroup>
   </Target>
+
+  <PropertyGroup>		
+    <NuspecFile>NuGet.Build.Tasks.Pack.nuspec</NuspecFile>		
+    <NuspecProperties>version=$(Version);configuration=$(Configuration)</NuspecProperties>		
+    <NuspecBasePath>$(OutputPath)</NuspecBasePath>		
+  </PropertyGroup>
 </Project>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -130,8 +130,14 @@
     </ItemGroup>
   </Target>
 
-  <PropertyGroup>		
+  <PropertyGroup Condition="'$(IsBuildOnlyXPLATProjects)' != 'true'">
     <NuspecFile>NuGet.Build.Tasks.Pack.nuspec</NuspecFile>		
+    <NuspecProperties>version=$(Version);configuration=$(Configuration)</NuspecProperties>		
+    <NuspecBasePath>$(OutputPath)</NuspecBasePath>		
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">
+    <NuspecFile>NuGet.Build.Tasks.Pack.XPlat.nuspec</NuspecFile>		
     <NuspecProperties>version=$(Version);configuration=$(Configuration)</NuspecProperties>		
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>		
   </PropertyGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -130,15 +130,10 @@
     </ItemGroup>
   </Target>
 
-  <PropertyGroup Condition="'$(IsBuildOnlyXPLATProjects)' != 'true'">
-    <NuspecFile>NuGet.Build.Tasks.Pack.nuspec</NuspecFile>		
-    <NuspecProperties>version=$(Version);configuration=$(Configuration)</NuspecProperties>		
-    <NuspecBasePath>$(OutputPath)</NuspecBasePath>		
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">
-    <NuspecFile>NuGet.Build.Tasks.Pack.XPlat.nuspec</NuspecFile>		
-    <NuspecProperties>version=$(Version);configuration=$(Configuration)</NuspecProperties>		
-    <NuspecBasePath>$(OutputPath)</NuspecBasePath>		
+  <PropertyGroup>
+    <NuspecFile Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">NuGet.Build.Tasks.Pack.XPlat.nuspec</NuspecFile>
+    <NuspecFile Condition="'$(IsBuildOnlyXPLATProjects)' != 'true'">NuGet.Build.Tasks.Pack.nuspec</NuspecFile>
+    <NuspecProperties>version=$(Version);configuration=$(Configuration)</NuspecProperties>
+    <NuspecBasePath>$(OutputPath)</NuspecBasePath>
   </PropertyGroup>
 </Project>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.nuspec
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>NuGet.Build.Tasks.Pack</id>
+    <version>$version$</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <description>NuGet pack for dotnet CLI</description>
+  </metadata>
+  <files>
+    <file src="net46\ilmerge\NuGet.Build.Tasks.Pack.dll" target="Desktop\" />
+    <file src="net46\ilmerge\NuGet.Build.Tasks.Pack.xml" target="Desktop\" />
+    <file src="netstandard1.3\ilmerge\NuGet.Build.Tasks.Pack.dll" target="CoreCLR\" />
+    <file src="netstandard1.3\ilmerge\NuGet.Build.Tasks.Pack.xml" target="CoreCLR\" />
+    <file src="netstandard1.3\ilmerge\**\NuGet.Build.Tasks.Pack.resources.dll" target="CoreCLR\" />
+    <file src="net46\ilmerge\**\NuGet.Build.Tasks.Pack.resources.dll" target="Desktop\" />
+    <file src="net46\NuGet.Build.Tasks.Pack.targets" target="buildCrossTargeting\NuGet.Build.Tasks.Pack.targets" />
+    <file src="net46\NuGet.Build.Tasks.Pack.targets" target="build\NuGet.Build.Tasks.Pack.targets" />
+  </files>
+</package>


### PR DESCRIPTION
As part of https://github.com/NuGet/NuGet.Client/pull/1772 and https://github.com/NuGet/NuGet.Client/pull/1778 @nkolev92  switched the packing of `NuGet.Build.Tasks.Pack` to using the csproj file instead of a nuspec file.

This creates an issue that surfaced while working on https://github.com/dotnet/sdk/pull/1829. Because of using csproj file the generated package gets package dependencies, which is not accurate as the pack dll is ILmerged.

**nuspec of last inserted package -** 

```
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
  <metadata>
    <id>NuGet.Build.Tasks.Pack</id>
    <version>4.5.0-preview2-4529</version>
    <authors>Microsoft</authors>
    <owners>Microsoft</owners>
    <requireLicenseAcceptance>false</requireLicenseAcceptance>
    <description>NuGet pack for dotnet CLI</description>
    <serviceable>true</serviceable>
  </metadata>
</package>
```

**nuspec of the latest package -** 

```
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
  <metadata>
    <id>NuGet.Build.Tasks.Pack</id>
    <version>4.6.0-preview3-4749</version>
    <authors>Microsoft</authors>
    <owners>Microsoft</owners>
    <requireLicenseAcceptance>false</requireLicenseAcceptance>
    <licenseUrl>https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt</licenseUrl>
    <description>NuGet pack for dotnet CLI</description>
    <copyright>Microsoft Corporation. All rights reserved.</copyright>
    <tags>nuget</tags>
    <serviceable>true</serviceable>
    <repository type="git" url="https://github.com/NuGet/NuGet.Client" />
    <dependencies>
      <group targetFramework=".NETFramework4.6">
        <dependency id="NuGet.Commands" version="4.6.0-preview3-4749" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.3">
        <dependency id="NuGet.Commands" version="4.6.0-preview3-4749" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.0" exclude="Build,Analyzers" />
        <dependency id="Microsoft.Build.Framework" version="15.1.1012" exclude="Build,Analyzers" />
        <dependency id="Microsoft.Build.Tasks.Core" version="15.1.1012" exclude="Build,Analyzers" />
        <dependency id="Microsoft.Build.Utilities.Core" version="15.1.1012" exclude="Build,Analyzers" />
      </group>
    </dependencies>
    <frameworkAssemblies>
      <frameworkAssembly assemblyName="Microsoft.Build.Framework" targetFramework=".NETFramework4.6" />
      <frameworkAssembly assemblyName="Microsoft.Build.Utilities.v4.0" targetFramework=".NETFramework4.6" />
    </frameworkAssemblies>
  </metadata>
</package>
```

This change reverts the packing of the project to using a nuspec file. 
**This will need to be cherry-picked onto the `release-4.6.0-preview2` branch for an updated insertion into cli/sdk**. 
VS insertion is fine as it does not consume this package.

