### PR TITLE
Add RuntimeGraph caching

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeDependencySet.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeDependencySet.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -11,7 +11,14 @@ namespace NuGet.RuntimeModel
 {
     public class RuntimeDependencySet : IEquatable<RuntimeDependencySet>
     {
+        /// <summary>
+        /// Package Id
+        /// </summary>
         public string Id { get; }
+
+        /// <summary>
+        /// Package dependencies
+        /// </summary>
         public IReadOnlyDictionary<string, RuntimePackageDependency> Dependencies { get; }
 
         public RuntimeDependencySet(string id)
@@ -22,20 +29,23 @@ namespace NuGet.RuntimeModel
         public RuntimeDependencySet(string id, IEnumerable<RuntimePackageDependency> dependencies)
         {
             Id = id;
-            Dependencies = new ReadOnlyDictionary<string, RuntimePackageDependency>(dependencies.ToDictionary(d => d.Id));
+            Dependencies = new ReadOnlyDictionary<string, RuntimePackageDependency>(dependencies.ToDictionary(d => d.Id, StringComparer.OrdinalIgnoreCase));
         }
 
         public bool Equals(RuntimeDependencySet other)
         {
-            // Breaking this up to ease debugging. The optimizer should be able to handle this, so don't refactor unless you have data :).
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
             if (other == null)
             {
                 return false;
             }
 
-
-            return string.Equals(other.Id, Id, StringComparison.Ordinal)
-                && Dependencies.OrderedEquals(other.Dependencies, p => p.Key, StringComparer.Ordinal);
+            return string.Equals(other.Id, Id, StringComparison.OrdinalIgnoreCase)
+                && Dependencies.OrderedEquals(other.Dependencies, p => p.Key, StringComparer.OrdinalIgnoreCase);
         }
 
         public override bool Equals(object obj)
@@ -46,7 +56,7 @@ namespace NuGet.RuntimeModel
         public override int GetHashCode()
         {
             var combiner = new HashCodeCombiner();
-            combiner.AddObject(Id);
+            combiner.AddObject(Id, StringComparer.OrdinalIgnoreCase);
             combiner.AddDictionary(Dependencies);
             return combiner.CombinedHash;
         }

--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeDescription.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimeDescription.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -12,6 +12,10 @@ namespace NuGet.RuntimeModel
     {
         public string RuntimeIdentifier { get; }
         public IReadOnlyList<string> InheritedRuntimes { get; }
+
+        /// <summary>
+        /// RID specific package dependencies.
+        /// </summary>
         public IReadOnlyDictionary<string, RuntimeDependencySet> RuntimeDependencySets { get; }
 
         public RuntimeDescription(string runtimeIdentifier)
@@ -38,7 +42,11 @@ namespace NuGet.RuntimeModel
 
         public bool Equals(RuntimeDescription other)
         {
-            // Breaking this up to ease debugging. The optimizer should be able to handle this, so don't refactor unless you have data :).
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
             if (other == null)
             {
                 return false;
@@ -46,7 +54,7 @@ namespace NuGet.RuntimeModel
 
             return string.Equals(other.RuntimeIdentifier, RuntimeIdentifier, StringComparison.Ordinal)
                 && InheritedRuntimes.OrderedEquals(other.InheritedRuntimes, s => s, StringComparer.Ordinal, StringComparer.Ordinal)
-                && RuntimeDependencySets.OrderedEquals(other.RuntimeDependencySets, p => p.Key, StringComparer.Ordinal);
+                && RuntimeDependencySets.OrderedEquals(other.RuntimeDependencySets, p => p.Key, StringComparer.OrdinalIgnoreCase);
         }
 
         public RuntimeDescription Clone()

--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimePackageDependency.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/RuntimePackageDependency.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -7,9 +7,19 @@ using NuGet.Versioning;
 
 namespace NuGet.RuntimeModel
 {
+    /// <summary>
+    /// A package dependency for a specific RID.
+    /// </summary>
     public class RuntimePackageDependency : IEquatable<RuntimePackageDependency>
     {
+        /// <summary>
+        /// Dependency package id.
+        /// </summary>
         public string Id { get; }
+
+        /// <summary>
+        /// Dependency version constraint.
+        /// </summary>
         public VersionRange VersionRange { get; }
 
         public RuntimePackageDependency(string id, VersionRange versionRange)
@@ -35,11 +45,26 @@ namespace NuGet.RuntimeModel
 
         public override int GetHashCode()
         {
-            return HashCodeCombiner.GetHashCode(Id, VersionRange);
+            var combiner = new HashCodeCombiner();
+
+            combiner.AddStringIgnoreCase(Id);
+            combiner.AddObject(VersionRange);
+
+            return combiner.CombinedHash;
         }
 
         public bool Equals(RuntimePackageDependency other)
         {
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (other == null)
+            {
+                return false;
+            }
+
             return other != null &&
                 string.Equals(Id, other.Id, StringComparison.OrdinalIgnoreCase) &&
                 VersionRange.Equals(other.VersionRange);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/RuntimeModelTests/RuntimeGraphTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/RuntimeModelTests/RuntimeGraphTests.cs
@@ -1,7 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
+using FluentAssertions;
 using NuGet.Frameworks;
 using NuGet.Versioning;
 using Xunit;
@@ -10,6 +12,376 @@ namespace NuGet.RuntimeModel.Test
 {
     public class RuntimeGraphTests
     {
+        [Fact]
+        public void FindRuntimeDependencies_VerifyExpandCaching()
+        {
+            var graph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("a"),
+                    new RuntimeDescription("d"),
+                    new RuntimeDescription("b", new[] { "a" }),
+                    new RuntimeDescription("e", new[] { "d" }),
+                    new RuntimeDescription("f", new[] { "e" }),
+                    new RuntimeDescription("c", new[] { "b", "f" }),
+                });
+
+            var a = graph.ExpandRuntime("c");
+            var b = graph.ExpandRuntime("c");
+
+            ReferenceEquals(a, b).Should().BeTrue();
+        }
+
+        [Fact]
+        public void FindRuntimeDependencies_VerifyExpandOrderForTree()
+        {
+            // C
+            // - B
+            // --- A
+            // - F
+            // --- E
+            // ----- D
+            var graph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("a"),
+                    new RuntimeDescription("d"),
+                    new RuntimeDescription("b", new[] { "a" }),
+                    new RuntimeDescription("e", new[] { "d" }),
+                    new RuntimeDescription("f", new[] { "e" }),
+                    new RuntimeDescription("c", new[] { "b", "f" }),
+                });
+
+            var expected = new[] { "c", "b", "f", "a", "e", "d" };
+            var actual = graph.ExpandRuntime("c").ToArray();
+            for (var i=0; i < expected.Length; i++)
+            {
+                Assert.Equal(expected[i], actual[i]);
+            }
+        }
+
+        [Fact]
+        public void FindRuntimeDependencies_VerifyExpandOrderForTree2()
+        {
+            // C
+            // - B
+            // --- A
+            // ----- AA
+            // - F
+            // --- E
+            var graph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("aa"),
+                    new RuntimeDescription("e"),
+                    new RuntimeDescription("a", new[] { "aa" }),
+                    new RuntimeDescription("b", new[] { "a" }),
+                    new RuntimeDescription("f", new[] { "e" }),
+                    new RuntimeDescription("c", new[] { "b", "f" }),
+                });
+
+            var expected = new[] { "c", "b", "f", "a", "e", "aa" };
+            var actual = graph.ExpandRuntime("c").ToArray();
+            for (var i = 0; i < expected.Length; i++)
+            {
+                Assert.Equal(expected[i], actual[i]);
+            }
+        }
+
+        [Fact]
+        public void FindRuntimeDependencies_VerifyExpandOrderForTree3()
+        {
+            // C
+            // - B
+            // --- A
+            // - F
+            // --- E
+            // ----- D
+            // --- EE
+            // ----- DD
+            // - X
+            // --- Y
+            // ----- Z
+            var graph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("a"),
+                    new RuntimeDescription("d"),
+                    new RuntimeDescription("y", new[] { "z" }),
+                    new RuntimeDescription("x", new[] { "y" }),
+                    new RuntimeDescription("b", new[] { "a" }),
+                    new RuntimeDescription("e", new[] { "d" }),
+                    new RuntimeDescription("ee", new[] { "dd" }),
+                    new RuntimeDescription("f", new[] { "e", "ee" }),
+                    new RuntimeDescription("c", new[] { "b", "f", "x" }),
+                });
+
+            var expected = new[] { "c", "b", "f", "x", "a", "e", "ee", "y", "d", "dd" };
+            var actual = graph.ExpandRuntime("c").ToArray();
+            for (var i = 0; i < expected.Length; i++)
+            {
+                Assert.Equal(expected[i], actual[i]);
+            }
+        }
+
+        [Fact]
+        public void FindRuntimeDependencies_MultipleDependenciesWithTieInTreeVerifyResult()
+        {
+            // C
+            // - B
+            // --- A -> Y 1.0.0
+            // - F
+            // --- E
+            // ----- D -> Z 1.0.0
+            var graph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("a", new[] { new RuntimeDependencySet("x", new[] { new RuntimePackageDependency("y", VersionRange.Parse("1.0.0")) }) }),
+                    new RuntimeDescription("d", new[] { new RuntimeDependencySet("x", new[] { new RuntimePackageDependency("z", VersionRange.Parse("1.0.0")) }) }),
+                    new RuntimeDescription("b", new[] { "a" }),
+                    new RuntimeDescription("e", new[] { "d" }),
+                    new RuntimeDescription("f", new[] { "e" }),
+                    new RuntimeDescription("c", new[] { "b", "f" }),
+                });
+
+            var dependencies = graph.FindRuntimeDependencies("c", "x").ToList();
+            dependencies.Count.Should().Be(1);
+            dependencies[0].Id.Should().Be("y");
+            dependencies[0].VersionRange.ToShortString().Should().Be("1.0.0");
+        }
+
+        [Fact]
+        public void FindRuntimeDependencies_MultipleDependenciesWithTieInTreeVerifyResult2()
+        {
+            // C
+            // - B
+            // --- A
+            // ----- AA -> Y 1.0.0
+            // - F
+            // --- E -> Z 1.0.0
+            var graph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("aa", new[] { new RuntimeDependencySet("x", new[] { new RuntimePackageDependency("y", VersionRange.Parse("1.0.0")) }) }),
+                    new RuntimeDescription("e", new[] { new RuntimeDependencySet("x", new[] { new RuntimePackageDependency("z", VersionRange.Parse("1.0.0")) }) }),
+                    new RuntimeDescription("a", new[] { "aa" }),
+                    new RuntimeDescription("b", new[] { "a" }),
+                    new RuntimeDescription("f", new[] { "e" }),
+                    new RuntimeDescription("c", new[] { "b", "f" }),
+                });
+
+            var dependencies = graph.FindRuntimeDependencies("c", "x").ToList();
+            dependencies.Count.Should().Be(1);
+            dependencies[0].Id.Should().Be("z");
+            dependencies[0].VersionRange.ToShortString().Should().Be("1.0.0");
+        }
+
+        [Fact]
+        public void FindRuntimeDependencies_MultipleDependenciesWithTieVerifyResult()
+        {
+            // A -> B and A -> C where both have dependencies
+            var graph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("a", new[] { new RuntimeDependencySet("x", new[] { new RuntimePackageDependency("y", VersionRange.Parse("1.0.0")) }) }),
+                    new RuntimeDescription("b", new[] { new RuntimeDependencySet("x", new[] { new RuntimePackageDependency("z", VersionRange.Parse("1.0.0")) }) }),
+                    new RuntimeDescription("c", new[] { "a", "b" }),
+                });
+
+            var dependencies = graph.FindRuntimeDependencies("c", "x").ToList();
+            dependencies.Count.Should().Be(1);
+            dependencies[0].Id.Should().Be("y");
+            dependencies[0].VersionRange.ToShortString().Should().Be("1.0.0");
+        }
+
+        [Fact]
+        public void FindRuntimeDependencies_MultipleDependenciesVerifyNearestTaken()
+        {
+            var graph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("a", new[] { new RuntimeDependencySet("x", new[] { new RuntimePackageDependency("y", VersionRange.Parse("1.0.0")) }) }),
+                    new RuntimeDescription("b", new[] { "a" }),
+                    new RuntimeDescription("c", new[] { "b" }, new[] { new RuntimeDependencySet("x", new[] { new RuntimePackageDependency("z", VersionRange.Parse("1.0.0")) }) }),
+                    new RuntimeDescription("d", new[] { "c" }),
+                });
+
+            var dependencies = graph.FindRuntimeDependencies("d", "x").ToList();
+            dependencies.Count.Should().Be(1);
+            dependencies[0].Id.Should().Be("z");
+            dependencies[0].VersionRange.ToShortString().Should().Be("1.0.0");
+        }
+
+        [Fact]
+        public void FindRuntimeDependencies_VerifyDuplicateDependency()
+        {
+            var graph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("a", new[] { new RuntimeDependencySet("x", new[] { new RuntimePackageDependency("y", VersionRange.Parse("1.0.0")) }) }),
+                    new RuntimeDescription("b", new[] { "a" }),
+                    new RuntimeDescription("c", new[] { "b" }, new[] { new RuntimeDependencySet("x", new[] { new RuntimePackageDependency("y", VersionRange.Parse("1.0.0")) }) }),
+                    new RuntimeDescription("d", new[] { "c" }),
+                });
+
+            var dependencies = graph.FindRuntimeDependencies("d", "x").ToList();
+            dependencies.Count.Should().Be(1);
+            dependencies[0].Id.Should().Be("y");
+            dependencies[0].VersionRange.ToShortString().Should().Be("1.0.0");
+        }
+
+        [Fact]
+        public void FindRuntimeDependencies_VerifyCaching()
+        {
+            var graph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("a", new[] { new RuntimeDependencySet("x", new[] { new RuntimePackageDependency("y", VersionRange.Parse("1.0.0")) }) }),
+                    new RuntimeDescription("b", new[] { "a" }),
+                    new RuntimeDescription("c", new[] { "b" }),
+                    new RuntimeDescription("d", new[] { "c" }),
+                });
+
+            var dependenciesA = graph.FindRuntimeDependencies("d", "x");
+            var dependenciesB = graph.FindRuntimeDependencies("d", "x");
+
+            ReferenceEquals(dependenciesA, dependenciesB).Should().BeTrue();
+        }
+
+        [Fact]
+        public void FindRuntimeDependencies_VerifyDependencyOnCompatibleRID()
+        {
+            var graph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("a", new[] { new RuntimeDependencySet("x", new[] { new RuntimePackageDependency("y", VersionRange.Parse("1.0.0")) }) }),
+                    new RuntimeDescription("b", new[] { "a" }),
+                    new RuntimeDescription("c", new[] { "b" }),
+                    new RuntimeDescription("d", new[] { "c" }),
+                });
+
+            var dependencies = graph.FindRuntimeDependencies("d", "x").ToList();
+            dependencies.Count.Should().Be(1);
+            dependencies[0].Id.Should().Be("y");
+            dependencies[0].VersionRange.ToShortString().Should().Be("1.0.0");
+        }
+
+        [Fact]
+        public void FindRuntimeDependencies_VerifyPackageIdIsCaseInsensitive()
+        {
+            var graph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("a", new[] { new RuntimeDependencySet("x", new[] { new RuntimePackageDependency("y", VersionRange.Parse("1.0.0")) }) })
+                });
+
+            var dependencies = graph.FindRuntimeDependencies("a", "X").ToList();
+            dependencies.Count.Should().Be(1);
+            dependencies[0].Id.Should().Be("y");
+            dependencies[0].VersionRange.ToShortString().Should().Be("1.0.0");
+        }
+
+        [Fact]
+        public void ExpandRuntimes_VerifyChain()
+        {
+            var graph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("a"),
+                    new RuntimeDescription("b", new[] { "a" }),
+                    new RuntimeDescription("c", new[] { "b" }),
+                    new RuntimeDescription("d", new[] { "c" })
+                });
+
+            graph.ExpandRuntime("d").Should().BeEquivalentTo(new[] { "d", "c", "b", "a" });
+        }
+
+        [Fact]
+        public void ExpandRuntimes_UnknownRuntimeVerifySelf()
+        {
+            var graph = new RuntimeGraph();
+
+            graph.ExpandRuntime("x").Should().BeEquivalentTo(new[] { "x" });
+        }
+
+        [Fact]
+        public void ExpandRuntimes_UnknownRuntimeVerifyCompat()
+        {
+            var graph = new RuntimeGraph();
+
+            graph.AreCompatible("x", "x").Should().BeTrue();
+        }
+
+        [Fact]
+        public void AreCompatible_VerifyCompatThroughChain()
+        {
+            var graph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("a"),
+                    new RuntimeDescription("b", new[] { "a" }),
+                    new RuntimeDescription("c", new[] { "b" }),
+                    new RuntimeDescription("d", new[] { "c" })
+                });
+
+            graph.AreCompatible("d", "a").Should().BeTrue();
+        }
+
+        [Fact]
+        public void AreCompatible_VerifyBasicOneWayCompat()
+        {
+            var graph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("win7"),
+                    new RuntimeDescription("win8", new[] { "win7" })
+                });
+
+            graph.AreCompatible("win8", "win7").Should().BeTrue();
+            graph.AreCompatible("win7", "win8").Should().BeFalse();
+        }
+
+        [Fact]
+        public void AreCompatible_VerifyCircularCompat()
+        {
+            var graph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("win7", new[] {"win8" }),
+                    new RuntimeDescription("win8", new[] { "win7" })
+                });
+
+            graph.AreCompatible("win8", "win7").Should().BeTrue();
+            graph.AreCompatible("win7", "win8").Should().BeTrue();
+        }
+
+        [Fact]
+        public void AreCompatible_VerifyCaseSensitiveCheck()
+        {
+            var leftGraph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("win7"),
+                    new RuntimeDescription("win8", new[] { "win7" })
+                });
+
+            var rightGraph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("WIN7"),
+                    new RuntimeDescription("WIN8", new[] { "WIN7" })
+                });
+
+            // Merge
+            var graph = RuntimeGraph.Merge(leftGraph, rightGraph);
+
+            graph.AreCompatible("WIN8", "win7").Should().BeFalse();
+            graph.AreCompatible("win8", "WIN7").Should().BeFalse();
+        }
+
+        [Fact]
+        public void GivenDifferentCasingsVerifyMergeKeepsBoth()
+        {
+            var leftGraph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("any"),
+                    new RuntimeDescription("win8", new[] { "any" })
+                });
+
+            var rightGraph = new RuntimeGraph(new[]
+                {
+                    new RuntimeDescription("any"),
+                    new RuntimeDescription("WIN8", new[] { "any" })
+                });
+
+            // Merge
+            var graph = RuntimeGraph.Merge(leftGraph, rightGraph);
+
+            graph.Runtimes.Keys.Should().BeEquivalentTo(new List<string>() { "any", "win8", "WIN8" });
+        }
+
         [Fact]
         public void MergingInEmptyGraphHasNoEffect()
         {


### PR DESCRIPTION
Add RuntimeGraph caching

* Cache the results of ExpandRuntime and FindRuntimeDependencies to improve performance.
* Index packages with dependencies to avoid walking the RID graph each time to determine if dependencies exist.
* Clean up equality comparers around package ids
* Add tests to verify existing behavior. RuntimeGraph was previously very light on tests.

fixes https://github.com/NuGet/Home/issues/6344

This is part 1 of the RuntimeGraph improvements. The next set of PRs will re-use RuntimeGraphs between project restores in a solution, and skip unneeded restores based on runtime dependencies found. All of this will rely on the caching here.
