### PR TITLE
Cache runtime.json files across project restores

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreRequest.cs
@@ -1,14 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using NuGet.Frameworks;
 using NuGet.Packaging;
-using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
-using NuGet.RuntimeModel;
 
 namespace NuGet.Commands
 {
@@ -18,16 +13,12 @@ namespace NuGet.Commands
             RestoreRequest request,
             PackageSpec packageSpec,
             LockFile existingLockFile,
-            Dictionary<NuGetFramework, RuntimeGraph> runtimeGraphCache,
-            ConcurrentDictionary<PackageIdentity, RuntimeGraph> runtimeGraphCacheByPackage,
             RestoreCollectorLogger log)
         {
             CacheContext = request.CacheContext;
             Log = log;
             PackagesDirectory = request.PackagesDirectory;
             ExistingLockFile = existingLockFile;
-            RuntimeGraphCache = runtimeGraphCache;
-            RuntimeGraphCacheByPackage = runtimeGraphCacheByPackage;
             MaxDegreeOfConcurrency = request.MaxDegreeOfConcurrency;
             PackageSaveMode = request.PackageSaveMode;
             Project = packageSpec;
@@ -43,8 +34,6 @@ namespace NuGet.Commands
         public PackageSpec Project { get; }
         public PackageSaveMode PackageSaveMode { get; }
         public XmlDocFileSaveMode XmlDocFileSaveMode { get; }
-        public Dictionary<NuGetFramework, RuntimeGraph> RuntimeGraphCache { get; }
-        public ConcurrentDictionary<PackageIdentity, RuntimeGraph> RuntimeGraphCacheByPackage { get; }
         public PackageExtractionContext PackageExtractionContext { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -14,11 +13,9 @@ using NuGet.Common;
 using NuGet.DependencyResolver;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
-using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Repositories;
 using NuGet.RuntimeModel;
-using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.Commands
@@ -30,11 +27,6 @@ namespace NuGet.Commands
         private readonly RestoreRequest _request;
 
         private bool _success = true;
-
-        private readonly Dictionary<NuGetFramework, RuntimeGraph> _runtimeGraphCache = new Dictionary<NuGetFramework, RuntimeGraph>();
-
-        private readonly ConcurrentDictionary<PackageIdentity, RuntimeGraph> _runtimeGraphCacheByPackage
-            = new ConcurrentDictionary<PackageIdentity, RuntimeGraph>(PackageIdentity.Comparer);
 
         private readonly Dictionary<RestoreTargetGraph, Dictionary<string, LibraryIncludeFlags>> _includeFlagGraphs
             = new Dictionary<RestoreTargetGraph, Dictionary<string, LibraryIncludeFlags>>();
@@ -211,7 +203,8 @@ namespace NuGet.Commands
 
             var newDgSpecHash = NoOpRestoreUtilities.GetHash(_request);
 
-            if(_request.ProjectStyle == ProjectStyle.DotnetCliTool && _request.AllowNoOp) { // No need to attempt to resolve the tool if no-op is not allowed.
+            if (_request.ProjectStyle == ProjectStyle.DotnetCliTool && _request.AllowNoOp)
+            { // No need to attempt to resolve the tool if no-op is not allowed.
                 NoOpRestoreUtilities.UpdateRequestBestMatchingToolPathsIfAvailable(_request);
             }
 
@@ -240,7 +233,7 @@ namespace NuGet.Commands
             if (_request.ProjectStyle == ProjectStyle.DotnetCliTool)
             {
                 if (noOp) // Only if the hash matches, then load the lock file. This is a performance hit, so we need to delay it as much as possible.
-                { 
+                {
                     _request.ExistingLockFile = LockFileUtilities.GetLockFile(_request.LockFilePath, _logger);
                 }
                 else
@@ -559,8 +552,6 @@ namespace NuGet.Commands
                 _request,
                 _request.Project,
                 _request.ExistingLockFile,
-                _runtimeGraphCache,
-                _runtimeGraphCacheByPackage,
                 _logger);
 
             var projectRestoreCommand = new ProjectRestoreCommand(projectRestoreRequest);

--- a/src/NuGet.Core/NuGet.Protocol/PackagesFolder/LocalPackageInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/PackagesFolder/LocalPackageInfo.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using NuGet.Packaging;
+using NuGet.RuntimeModel;
 using NuGet.Versioning;
 
 namespace NuGet.Repositories
@@ -17,6 +18,7 @@ namespace NuGet.Repositories
         private readonly Lazy<NuspecReader> _nuspec;
         private readonly Lazy<IReadOnlyList<string>> _files;
         private readonly Lazy<string> _sha512;
+        private readonly Lazy<RuntimeGraph> _runtimeGraph;
 
         public LocalPackageInfo(
             string packageId,
@@ -27,7 +29,8 @@ namespace NuGet.Repositories
             string sha512Path,
             Lazy<NuspecReader> nuspec,
             Lazy<IReadOnlyList<string>> files,
-            Lazy<string> sha512)
+            Lazy<string> sha512,
+            Lazy<RuntimeGraph> runtimeGraph)
         {
             Id = packageId;
             Version = version;
@@ -38,6 +41,7 @@ namespace NuGet.Repositories
             _nuspec = nuspec;
             _files = files;
             _sha512 = sha512;
+            _runtimeGraph = runtimeGraph;
         }
 
         public string Id { get; }
@@ -68,6 +72,12 @@ namespace NuGet.Repositories
         /// SHA512 of the package.
         /// </summary>
         public string Sha512 => _sha512.Value;
+
+        /// <summary>
+        /// runtime.json
+        /// </summary>
+        /// <remarks>Returns null if runtime.json does not exist in the package.</remarks>
+        public RuntimeGraph RuntimeGraph => _runtimeGraph.Value;
 
         public override string ToString()
         {

--- a/src/NuGet.Core/NuGet.Protocol/PackagesFolder/NuGetv3LocalRepository.cs
+++ b/src/NuGet.Core/NuGet.Protocol/PackagesFolder/NuGetv3LocalRepository.cs
@@ -83,6 +83,9 @@ namespace NuGet.Repositories
             // sha512
             var sha512 = _packageFileCache.GetOrAddSha512(package.Sha512Path);
 
+            // runtime.json
+            var runtimeGraph = _packageFileCache.GetOrAddRuntimeGraph(package.ExpandedPath);
+
             // Create a new info to match the given id/version
             return new LocalPackageInfo(
                 packageId,
@@ -93,7 +96,8 @@ namespace NuGet.Repositories
                 package.Sha512Path,
                 nuspec,
                 files,
-                sha512);
+                sha512,
+                runtimeGraph);
         }
 
         public IEnumerable<LocalPackageInfo> FindPackagesById(string packageId)
@@ -170,8 +174,9 @@ namespace NuGet.Repositories
                         var nuspec = _packageFileCache.GetOrAddNuspec(manifestPath, fullVersionDir);
                         var files = _packageFileCache.GetOrAddFiles(fullVersionDir);
                         var sha512 = _packageFileCache.GetOrAddSha512(hashPath);
+                        var runtimeGraph = _packageFileCache.GetOrAddRuntimeGraph(fullVersionDir);
 
-                        package = new LocalPackageInfo(id, version, fullVersionDir, manifestPath, zipPath, sha512Path, nuspec, files, sha512);
+                        package = new LocalPackageInfo(id, version, fullVersionDir, manifestPath, zipPath, sha512Path, nuspec, files, sha512, runtimeGraph);
 
                         // Cache the package, if it is valid it will not change
                         // for the life of this restore.


### PR DESCRIPTION
Cache runtime.json files across project restores

* Load runtime.json files from NuGetv3LocalRepository which is shared across all project restores.
* Walk the flattened graph to find runtime.json files instead of the full graph. A similar walk was already done when creating the flattened graph.  This also ensures that nodes are only visited once.
* Remove per project runtime.json caching.

fixes https://github.com/NuGet/Home/issues/6345