### PR TITLE
Remove AsList from CreateGraphNode

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -100,9 +100,7 @@ namespace NuGet.DependencyResolver
             // Merge in runtime dependencies
             if (dependencies?.Count > 0)
             {
-                var nodeDependencies = node.Item.Data.Dependencies.AsList();
-
-                foreach (var nodeDep in nodeDependencies)
+                foreach (var nodeDep in node.Item.Data.Dependencies)
                 {
                     if (runtimeDependencies?.Contains(nodeDep.Name, StringComparer.OrdinalIgnoreCase) != true)
                     {


### PR DESCRIPTION
Remove AsList from CreateGraphNode

The implementation behind Dependencies is either Enumerable.Empty or an array. AsList is causing unneeded allocations to happen.