### PR TITLE
Adding NoWarn to LibraryDependency.Clone()

### DIFF
--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -99,7 +99,8 @@ namespace NuGet.LibraryModel
                 },
                 SuppressParent = SuppressParent,
                 Type = Type,
-                AutoReferenced = AutoReferenced
+                AutoReferenced = AutoReferenced,
+                NoWarn = NoWarn
             };
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -594,6 +594,7 @@ namespace NuGet.ProjectModel.Test
             dependency.Type = LibraryDependencyType.Default;
             dependency.IncludeType = LibraryIncludeFlags.None;
             dependency.SuppressParent = LibraryIncludeFlags.ContentFiles;
+            dependency.NoWarn = new List<NuGetLogCode>() { NuGetLogCode.NU1000, NuGetLogCode.NU1001 };
             var imports = NuGetFramework.Parse("net45"); // This makes no sense in the context of fallback, just for testing :)
 
             var originalTargetFrameworkInformation = new TargetFrameworkInformation();


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6340
Regression: Yes
If Regression then when did it last work: 15.5
If Regression then how are we preventing it in future:  Added tests

## Fix
Details: As part of https://github.com/NuGet/NuGet.Client/commit/2cd603d1b54f9ccb92429102576f7edc1b48cbec we optimized package spec cloning. That exposed a bug in `LibraryDependency.Clone()` where `NoWarn` properties were not getting cloned.
This fixes that and adapts the test that should have caught that.

## Testing/Validation
Tests Added: Yes
Validation done:  manual validation done
