### PR TITLE
Improving LibraryDependency.Clone() to do a deep copy through a constructor

### DIFF
--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
@@ -28,6 +28,24 @@ namespace NuGet.LibraryModel
         /// </summary>
         public bool AutoReferenced { get; set; }
 
+        public LibraryDependency() { }
+
+        public LibraryDependency(
+            LibraryRange libraryRange,
+            LibraryDependencyType type,
+            LibraryIncludeFlags includeType,
+            LibraryIncludeFlags suppressParent,
+            IList<NuGetLogCode> noWarn,
+            bool autoReferenced)
+        {
+            LibraryRange = libraryRange;
+            Type = type;
+            IncludeType = includeType;
+            SuppressParent = suppressParent;
+            NoWarn = noWarn;
+            AutoReferenced = autoReferenced;
+        }
+
         public override string ToString()
         {
             var sb = new StringBuilder();
@@ -88,20 +106,10 @@ namespace NuGet.LibraryModel
 
         public LibraryDependency Clone()
         {
-            return new LibraryDependency
-            {
-                IncludeType = IncludeType,
-                LibraryRange = new LibraryRange
-                {
-                    Name = LibraryRange.Name,
-                    TypeConstraint = LibraryRange.TypeConstraint,
-                    VersionRange = LibraryRange.VersionRange
-                },
-                SuppressParent = SuppressParent,
-                Type = Type,
-                AutoReferenced = AutoReferenced,
-                NoWarn = NoWarn
-            };
+            var clonedLibraryRange = new LibraryRange(LibraryRange.Name, LibraryRange.VersionRange, LibraryRange.TypeConstraint);
+            var clonedNoWarn = new List<NuGetLogCode>(NoWarn);
+
+            return new LibraryDependency(clonedLibraryRange, Type, IncludeType, SuppressParent, clonedNoWarn, AutoReferenced);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -125,11 +125,14 @@ namespace NuGet.ProjectModel.Test
 
         internal static LibraryDependency CreateLibraryDependency()
         {
-            var dependency = new LibraryDependency();
-            dependency.LibraryRange = new LibraryRange(Guid.NewGuid().ToString(), LibraryDependencyTarget.Package);
-            dependency.Type = LibraryDependencyType.Default;
-            dependency.IncludeType = LibraryIncludeFlags.None;
-            dependency.SuppressParent = LibraryIncludeFlags.ContentFiles;
+            var dependency = new LibraryDependency(
+                libraryRange: new LibraryRange(Guid.NewGuid().ToString(), LibraryDependencyTarget.Package),
+                type: LibraryDependencyType.Default,
+                includeType: LibraryIncludeFlags.None,
+                suppressParent: LibraryIncludeFlags.ContentFiles,
+                noWarn: new List<NuGetLogCode>() { NuGetLogCode.NU1000, NuGetLogCode.NU1001, NuGetLogCode.NU1002 },
+                autoReferenced: false);
+
             return dependency;
         }
 
@@ -232,7 +235,7 @@ namespace NuGet.ProjectModel.Test
             methodInfo.Invoke(null, new object[] { PackageSpec });
 
             // Assert
-            
+
             Assert.NotEqual(PackageSpec, clonedPackageSpec);
             if (validateJson)
             {
@@ -245,7 +248,8 @@ namespace NuGet.ProjectModel.Test
             Assert.False(object.ReferenceEquals(PackageSpec, clonedPackageSpec));
         }
 
-        public class PackageSpecModify { 
+        public class PackageSpecModify
+        {
 
             public static void ModifyAuthors(PackageSpec packageSpec)
             {
@@ -322,7 +326,7 @@ namespace NuGet.ProjectModel.Test
 
             public static void ModifyRuntimeGraph(PackageSpec packageSpec)
             {
-                packageSpec.RuntimeGraph.Supports["CompatibilityProfile"].RestoreContexts.Add(CreateFrameworkRuntimePair(rid : "win10-x64"));
+                packageSpec.RuntimeGraph.Supports["CompatibilityProfile"].RestoreContexts.Add(CreateFrameworkRuntimePair(rid: "win10-x64"));
             }
 
             public static void ModifyRestoreSettings(PackageSpec packageSpec)
@@ -541,7 +545,7 @@ namespace NuGet.ProjectModel.Test
 
             // Act
             projectReference.ProjectPath = "NewPath";
-            
+
             // Assert
             Assert.NotEqual(clone, originalPRMFI);
         }
@@ -567,7 +571,7 @@ namespace NuGet.ProjectModel.Test
 
         private ProjectRestoreSettings CreateProjectRestoreSettings()
         {
-            var prs =  new ProjectRestoreSettings();
+            var prs = new ProjectRestoreSettings();
             prs.HideWarningsAndErrors = true;
             return prs;
         }
@@ -589,12 +593,13 @@ namespace NuGet.ProjectModel.Test
         internal static TargetFrameworkInformation CreateTargetFrameworkInformation(string tfm = "net461")
         {
             var framework = NuGetFramework.Parse(tfm);
-            var dependency = new LibraryDependency();
-            dependency.LibraryRange = new LibraryRange("Dependency", LibraryDependencyTarget.Package);
-            dependency.Type = LibraryDependencyType.Default;
-            dependency.IncludeType = LibraryIncludeFlags.None;
-            dependency.SuppressParent = LibraryIncludeFlags.ContentFiles;
-            dependency.NoWarn = new List<NuGetLogCode>() { NuGetLogCode.NU1000, NuGetLogCode.NU1001 };
+            var dependency = new LibraryDependency(
+                libraryRange: new LibraryRange("Dependency", LibraryDependencyTarget.Package),
+                type: LibraryDependencyType.Default,
+                includeType: LibraryIncludeFlags.None,
+                suppressParent: LibraryIncludeFlags.ContentFiles,
+                noWarn: new List<NuGetLogCode>() { NuGetLogCode.NU1000, NuGetLogCode.NU1001 },
+                autoReferenced: false);
             var imports = NuGetFramework.Parse("net45"); // This makes no sense in the context of fallback, just for testing :)
 
             var originalTargetFrameworkInformation = new TargetFrameworkInformation();


### PR DESCRIPTION
As part of https://github.com/NuGet/NuGet.Client/commit/fbf4929de98774f1a2fdcfe0d25ff33bc53d4b59, we fixed `LibraryDependency.Clone()` to also clone the `NoWarn` error codes.
This PR makes the `Clone()` method do a deep copy on the `NoWarn` list and makes it cleaner by using a constructor on `LibraryDependency`.

**This should also be ported to `Release-4.6.0-Preview2` branch along with https://github.com/NuGet/NuGet.Client/commit/fbf4929de98774f1a2fdcfe0d25ff33bc53d4b59**