### PR TITLE
Improve reliability of apex PMC tests

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
@@ -24,7 +24,6 @@ namespace NuGet.Console.TestContract
 
         private bool EnsureInitilizeConsole()
         {
-            _wpfConsole.Dispatcher.Start();
             var stopwatch = Stopwatch.StartNew();
             var timeout = TimeSpan.FromMinutes(5);
             do


### PR DESCRIPTION
This PR should fix the issue shown in some Apex tests where it crashed with a `Host can't be null` message.

The dispatcher is already started when the tool window gets started, so there is no need to call it directly. The crash appeared when the tool window had not yet loaded enough to call dispatcher.Start() but we where calling it directly. Because the tool window will call it when it's ready we just need to wait until it is complete instead of trying it to start manually.