### PR TITLE
Fixed an intermittently failing e2e test

### DIFF
--- a/test/EndToEnd/assert.ps1
+++ b/test/EndToEnd/assert.ps1
@@ -109,6 +109,21 @@ function Assert-NotEqual {
     }
 }
 
+function Assert-Contains {
+    param(
+        [parameter(Mandatory = $true)]
+        [string]$Expected,
+        [parameter(Mandatory = $true)]
+        [string]$Actual,
+        [string]$Message
+    )
+
+    if($Actual -notmatch $Expected) {
+        Write-Error (Get-AssertError "Expected <$Expected> but got <$Actual>" $Message)
+    }
+}
+
+
 function Assert-PathExists {
     param(
           [parameter(Mandatory = $true)]

--- a/test/EndToEnd/tests/InstallPackageTest.ps1
+++ b/test/EndToEnd/tests/InstallPackageTest.ps1
@@ -712,9 +712,18 @@ function Test-InstallPackageWithNonExistentFrameworkReferences {
 
     # Arrange
     $p = New-ClassLibrary
+    $expectedExceptionMessage = "Failed to add reference. The package 'PackageWithNonExistentGacReferences' tried to add a framework reference to 'System.Awesome' which was not found in the GAC. This is possibly a bug in the package. Please contact the package owners for assistance."
+    $actualExceptionMessage = [string]::Empty
 
     # Arrange
-    Assert-Throws { $p | Install-Package PackageWithNonExistentGacReferences -Source $context.RepositoryRoot } "Failed to add reference. The package 'PackageWithNonExistentGacReferences' tried to add a framework reference to 'System.Awesome' which was not found in the GAC. This is possibly a bug in the package. Please contact the package owners for assistance.`r`n  Reference unavailable."
+    try {
+        $p | Install-Package PackageWithNonExistentGacReferences -Source $context.RepositoryRoot
+    }
+    catch {
+        $actualExceptionMessage = $_.Exception.Message
+    }
+
+    Assert-Contains $expectedExceptionMessage $actualExceptionMessage
 }
 
 function Test-InstallPackageWithFrameworkFacadeReference {


### PR DESCRIPTION
Sometimes this test InstallPackageWithNonExistentFrameworkReferences fails because underline error message from Project System is different which doesn't change anything for NuGet. For us, it just failed to add reference which is what we should be checking for. So added a new PS api Assert-Contains which will match if actual exception message has matching text for "failed to add reference..."

Fixes VSTS Test bug# 542985

@rrelyea 