### PR TITLE
Fixed RemoveDirectory powershell api to fix some flaky e2e tests

### DIFF
--- a/test/EndToEnd/tests/PackageRestoreTest.ps1
+++ b/test/EndToEnd/tests/PackageRestoreTest.ps1
@@ -371,6 +371,9 @@ function RemoveDirectory {
     {
         if (Test-Path $dir)
         {
+            # because -Recurse parameter in Remove-Item has a known issue so using Get-ChildItem to
+            # first delete all the children and then delete the folder.
+            Get-ChildItem $dir -Recurse | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue
             Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue
         }
         else 


### PR DESCRIPTION
As per powershell official documentation, -Recurse flag with Remove-Item has known issues while deleting all the child items. So they recommend using Get-ChildItem to first remove all the content from the folder and then delete the folder itself.

Fixes VSTS test bug# 542989

@rrelyea 