### PR TITLE
move netcore and netstandard e2e tests to apex

### DIFF
--- a/NuGet.sln
+++ b/NuGet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27119.0
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{BD1946CE-5544-4F28-A04A-9C3D51113E1A}"
 EndProject
@@ -215,6 +215,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Packaging.FuncTest", "test\NuGet.Core.FuncTests\NuGet.Packaging.FuncTest\NuGet.Packaging.FuncTest.csproj", "{6666CC37-75E0-451E-A24A-C51AF71B0C8E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.MSSigning.Extensions", "src\NuGet.Clients\NuGet.MSSigning.Extensions\NuGet.MSSigning.Extensions.csproj", "{32D8179F-2E22-441C-9DEE-6EB4AB8A5800}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.StaFact", "test\TestExtensions\NuGet.StaFact\NuGet.StaFact.csproj", "{5704AFAE-94ED-4AC9-979F-28A6DF8DF4DF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -514,6 +516,10 @@ Global
 		{32D8179F-2E22-441C-9DEE-6EB4AB8A5800}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{32D8179F-2E22-441C-9DEE-6EB4AB8A5800}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{32D8179F-2E22-441C-9DEE-6EB4AB8A5800}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5704AFAE-94ED-4AC9-979F-28A6DF8DF4DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5704AFAE-94ED-4AC9-979F-28A6DF8DF4DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5704AFAE-94ED-4AC9-979F-28A6DF8DF4DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5704AFAE-94ED-4AC9-979F-28A6DF8DF4DF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -602,6 +608,7 @@ Global
 		{8882D8C0-A77E-4B3D-9FC6-E9BF965031AB} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 		{6666CC37-75E0-451E-A24A-C51AF71B0C8E} = {BB63CACA-866F-454F-BA4C-78B788D032BB}
 		{32D8179F-2E22-441C-9DEE-6EB4AB8A5800} = {08F523EC-3C2A-4A00-A54C-2E54C5AC856B}
+		{5704AFAE-94ED-4AC9-979F-28A6DF8DF4DF} = {23CEFC88-9365-4464-A517-700224ECA033}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3747A66A-00D1-41B8-A9C5-ED0D7BEA9D25}

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -570,7 +570,7 @@ phases:
   condition: "succeeded()"
   queue:
     name: DDNuGet-Windows
-    timeoutInMinutes: 45
+    timeoutInMinutes: 75
     demands: DotNetFramework
 
   steps:

--- a/test/EndToEnd/tests/NetCoreProjectTest.ps1
+++ b/test/EndToEnd/tests/NetCoreProjectTest.ps1
@@ -1,248 +1,9 @@
 ﻿# basic create for .net core template
-function Test-NetCoreConsoleAppCreate {
-
-    # Arrange & Act
-    $project = New-NetCoreConsoleApp ConsoleApp
-
-    # Assert
-    Assert-NetCoreProjectCreation $project
-}
-
-# install package test for .net core
-function Test-NetCoreConsoleAppInstallPackage {
-
-    # Arrange
-    $project = New-NetCoreConsoleApp ConsoleApp
-    $id = 'NuGet.Versioning'
-    $version = '3.5.0'
-    Assert-NetCoreProjectCreation $project
-
-    # Act
-    Install-Package $id -ProjectName $project.Name -version $version
-    $project.Save($project.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCorePackageInstall $project $id $version
-}
-
-# install and uninstall package test for .net core
-function Test-NetCoreConsoleAppUninstallPackage {
-
-    # Arrange
-    $project = New-NetCoreConsoleApp ConsoleApp
-    $id = 'NuGet.Versioning'
-    $version = '3.5.0'
-    Assert-NetCoreProjectCreation $project
-
-    # Act
-    Install-Package $id -ProjectName $project.Name -version $version
-    $project.Save($project.FullName)
-    Build-Solution
-    Assert-NetCorePackageInstall $project $id $version
-
-    Uninstall-Package $id -ProjectName $project.Name
-    $project.Save($project.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCorePackageUninstall $project $id
-}
-
-# install multiple packages test for .net core
-function Test-NetCoreConsoleAppInstallMultiplePackages {
-
-    # Arrange
-    $project = New-NetCoreConsoleApp ConsoleApp
-    $id1 = 'NuGet.Versioning'
-    $version1 = '3.5.0'
-    $id2 = 'NUnit'
-    $version2 = '3.6.0'
-
-    # Act
-    Install-Package $id1 -ProjectName $project.Name -version $version1
-    Install-Package $id2 -ProjectName $project.Name -version $version2
-    $project.Save($project.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCorePackageInstall $project $id1 $version1
-    Assert-NetCorePackageInstall $project $id2 $version2
-}
-
-# install and uninstall multiple packages test for .net core
-function Test-NetCoreConsoleAppUninstallMultiplePackage {
-
-    # Arrange
-    $project = New-NetCoreConsoleApp ConsoleApp
-    $id1 = 'NuGet.Versioning'
-    $version1 = '3.5.0'
-    $id2 = 'NUnit'
-    $version2 = '3.6.0'
-
-    # Act
-    Install-Package $id1 -ProjectName $project.Name -version $version1
-    Install-Package $id2 -ProjectName $project.Name -version $version2
-    $project.Save($project.FullName)
-    Build-Solution
-    Assert-NetCorePackageInstall $project $id1 $version1
-    Assert-NetCorePackageInstall $project $id2 $version2
-    Uninstall-Package $id1 -ProjectName $project.Name
-    Uninstall-Package $id2 -ProjectName $project.Name
-    $project.Save($project.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCorePackageUninstall $project $id1
-    Assert-NetCorePackageUninstall $project $id2
-}
-
-# install and upgrade package test for .net core
-function Test-NetCoreConsoleAppUpgradePackage {
-
-    # Arrange
-    $project = New-NetCoreConsoleApp ConsoleApp
-    $id = 'NuGet.Versioning'
-    $oldVersion = '3.5.0'
-    $newVersion = '4.0.0-rc2'
-    Assert-NetCoreProjectCreation $project
-
-    # Act
-    Install-Package $id -ProjectName $project.Name -version $oldVersion
-    $project.Save($project.FullName)
-    Build-Solution
-    Assert-NetCorePackageInstall $project $id $oldVersion
-
-    Update-Package $id -ProjectName $project.Name -version $newVersion
-    $project.Save($project.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCorePackageInstall $project $id $newVersion
-}
-
-# install and downgrade package test for .net core
-function Test-NetCoreConsoleAppDowngradePackage {
-
-    # Arrange
-    $project = New-NetCoreConsoleApp ConsoleApp
-    $id = 'NuGet.Versioning'
-    $oldVersion = '4.0.0-rc2'
-    $newVersion = '3.5.0'
-    Assert-NetCoreProjectCreation $project
-
-    # Act
-    Install-Package $id -ProjectName $project.Name -version $oldVersion
-    $project.Save($project.FullName)
-    Build-Solution
-    Assert-NetCorePackageInstall $project $id $oldVersion
-
-    Update-Package $id -ProjectName $project.Name -version $newVersion
-    $project.Save($project.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCorePackageInstall $project $id $newVersion
-}
-
-# project reference test for .net core
-function Test-NetCoreConsoleAppProjectReference {
-
-    # Arrange
-    $projectA = New-NetCoreConsoleApp ConsoleAppA
-    $projectB = New-NetCoreConsoleApp ConsoleAppB
-
-    Assert-NetCoreProjectCreation $projectA
-    Assert-NetCoreProjectCreation $projectB
-
-    # Act
-    Add-ProjectReference $projectA $projectB
-
-    $projectA.Save($projectA.FullName)
-    $projectB.Save($projectB.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCoreProjectReference $projectA $projectB
-}
-
-# transitive package dependency test for .net core
-# A -> B
-# B -> C
-# C -> Nuget.Versioning 3.5.0
-# Assert A has reference to NuGet.Versioning
-function Test-NetCoreConsoleAppTransitivePackage {
-
-    # Arrange
-    $projectA = New-NetCoreConsoleApp ConsoleAppA
-    $projectB = New-NetCoreConsoleApp ConsoleAppB
-    $projectC = New-NetCoreConsoleApp ConsoleAppC
-    $id = 'NuGet.Versioning'
-    $version = '3.5.0'
-    Assert-NetCoreProjectCreation $projectA
-    Assert-NetCoreProjectCreation $projectB
-    Assert-NetCoreProjectCreation $projectC
-
-    # Act
-    Add-ProjectReference $projectB $projectC
-    Add-ProjectReference $projectA $projectB
-    Install-Package $id -ProjectName $projectC.Name -version $version
-
-    $projectA.Save($projectA.FullName)
-    $projectB.Save($projectB.FullName)
-    $projectC.Save($projectC.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCorePackageInstall $projectC $id $version
-    Assert-NetCorePackageInLockFile $projectB $id $version
-    Assert-NetCorePackageInLockFile $projectA $id $version
-}
-
-# transitive package dependency limit test for .net core
-# A -> X, B
-# B -> C
-# C -> Nuget.Versioning 3.5.0
-# Assert X does not have reference to NuGet.Versioning
-function Test-NetCoreConsoleAppTransitivePackageLimit {
-
-    # Arrange
-    $projectA = New-NetCoreConsoleApp ConsoleAppA
-    $projectB = New-NetCoreConsoleApp ConsoleAppB
-    $projectC = New-NetCoreConsoleApp ConsoleAppC
-    $projectX = New-NetCoreConsoleApp ConsoleAppX
-    $id = 'NuGet.Versioning'
-    $version = '3.5.0'
-    Assert-NetCoreProjectCreation $projectA
-    Assert-NetCoreProjectCreation $projectB
-    Assert-NetCoreProjectCreation $projectC
-    Assert-NetCoreProjectCreation $projectX
-
-    # Act
-    Add-ProjectReference $projectA $projectX
-    Add-ProjectReference $projectA $projectB
-    Add-ProjectReference $projectB $projectC
-    Install-Package $id -ProjectName $projectC.Name -version $version
-
-    $projectA.Save($projectA.FullName)
-    $projectB.Save($projectB.FullName)
-    $projectC.Save($projectC.FullName)
-    $projectX.Save($projectX.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCorePackageInstall $projectC $id $version
-    Assert-NetCorePackageInLockFile $projectB $id $version
-    Assert-NetCorePackageInLockFile $projectA $id $version
-    Assert-NetCoreNoPackageReference $projectX $id
-    Assert-NetCorePackageNotInLockFile $projectX $id
-}
-
-# basic create for .net core template
 function Test-NetCoreWebApp10Create {
 
     # Arrange & Act
     $project = New-NetCoreWebApp10 ConsoleApp
+    Build-Solution
 
     # Assert
     Assert-NetCoreProjectCreation $project
@@ -254,6 +15,7 @@ function Test-NetCoreWebApp10AppInstallPackage {
 
     # Arrange
     $project = New-NetCoreWebApp10 ConsoleApp
+    Build-Solution
     $id = 'NuGet.Versioning'
     $version = '3.5.0'
     Assert-NetCoreProjectCreation $project
@@ -272,6 +34,7 @@ function Test-NetCoreWebApp10UninstallPackage {
 
     # Arrange
     $project = New-NetCoreWebApp10 ConsoleApp
+    Build-Solution
     $id = 'NuGet.Versioning'
     $version = '3.5.0'
     Assert-NetCoreProjectCreation $project
@@ -295,6 +58,7 @@ function Test-NetCoreWebApp10InstallMultiplePackages {
 
     # Arrange
     $project = New-NetCoreWebApp10 ConsoleApp
+    Build-Solution
     $id1 = 'NuGet.Versioning'
     $version1 = '3.5.0'
     $id2 = 'NUnit'
@@ -316,6 +80,7 @@ function Test-NetCoreWebApp10UninstallMultiplePackage {
 
     # Arrange
     $project = New-NetCoreWebApp10 ConsoleApp
+    Build-Solution
     $id1 = 'NuGet.Versioning'
     $version1 = '3.5.0'
     $id2 = 'NUnit'
@@ -344,9 +109,10 @@ function Test-NetCoreWebApp10UpgradePackage {
 
     # Arrange
     $project = New-NetCoreWebApp10 ConsoleApp
+    Build-Solution
     $id = 'NuGet.Versioning'
     $oldVersion = '3.5.0'
-    $newVersion = '4.0.0-rc2'
+    $newVersion = '4.5.0'
     Assert-NetCoreProjectCreation $project
 
     # Act
@@ -368,8 +134,9 @@ function Test-NetCoreWebApp10DowngradePackage {
 
     # Arrange
     $project = New-NetCoreWebApp10 ConsoleApp
+    Build-Solution
     $id = 'NuGet.Versioning'
-    $oldVersion = '4.0.0-rc2'
+    $oldVersion = '4.5.0'
     $newVersion = '3.5.0'
     Assert-NetCoreProjectCreation $project
 
@@ -393,6 +160,7 @@ function Test-NetCoreWebApp10ProjectReference {
     # Arrange
     $projectA = New-NetCoreWebApp10 ConsoleAppA
     $projectB = New-NetCoreWebApp10 ConsoleAppB
+    Build-Solution
 
     Assert-NetCoreProjectCreation $projectA
     Assert-NetCoreProjectCreation $projectB
@@ -413,6 +181,7 @@ function Test-NetCoreProjectSystemCacheUpdateEvent {
 
     # Arrange
     $projectA = New-NetCoreConsoleApp
+    Build-Solution
     Assert-NetCoreProjectCreation $projectA
 
     $componentModel = Get-VSComponentModel
@@ -511,238 +280,6 @@ function Test-NetCoreProjectSystemCacheUpdateEvent {
 #     Assert-NetCoreNoPackageReference $projectX $id
 #     Assert-NetCorePackageNotInLockFile $projectX $id
 # }
-
-function Test-NetStandardClassLibraryCreate {
-
-    # Arrange & Act
-    $project = New-NetStandardClassLibrary ClassLibrary1
-
-    # Assert
-    Assert-NetCoreProjectCreation $project
-}
-
-function Test-NetStandardClassLibraryInstallPackage {
-
-    # Arrange
-    $project = New-NetStandardClassLibrary ClassLibrary1
-    $id = 'NuGet.Versioning'
-    $version = '3.5.0'
-    Assert-NetCoreProjectCreation $project
-
-    # Act
-    Install-Package $id -ProjectName $project.Name -version $version
-    $project.Save($project.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCorePackageInstall $project $id $version
-}
-
-function Test-NetStandardClassLibraryUninstallPackage {
-
-    # Arrange
-    $project = New-NetStandardClassLibrary ClassLibrary1
-    $id = 'NuGet.Versioning'
-    $version = '3.5.0'
-    Assert-NetCoreProjectCreation $project
-
-    # Act
-    Install-Package $id -ProjectName $project.Name -version $version
-    $project.Save($project.FullName)
-    Build-Solution
-    Assert-NetCorePackageInstall $project $id $version
-
-    Uninstall-Package $id -ProjectName $project.Name
-    $project.Save($project.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCorePackageUninstall $project $id
-}
-
-function Test-NetStandardClassLibraryInstallMultiplePackages {
-
-    # Arrange
-    $project = New-NetStandardClassLibrary ClassLibrary1
-    $id1 = 'NuGet.Versioning'
-    $version1 = '3.5.0'
-    $id2 = 'Newtonsoft.Json'
-    $version2 = '9.0.1'
-
-    # Act
-    Install-Package $id1 -ProjectName $project.Name -version $version1
-    Install-Package $id2 -ProjectName $project.Name -version $version2
-    $project.Save($project.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCorePackageInstall $project $id1 $version1
-    Assert-NetCorePackageInstall $project $id2 $version2
-}
-
-function Test-NetStandardClassLibraryUninstallMultiplePackage {
-
-    # Arrange
-    $project = New-NetStandardClassLibrary ClassLibrary1
-    $id1 = 'NuGet.Versioning'
-    $version1 = '3.5.0'
-    $id2 = 'Newtonsoft.Json'
-    $version2 = '9.0.1'
-
-    # Act
-    Install-Package $id1 -ProjectName $project.Name -version $version1
-    Install-Package $id2 -ProjectName $project.Name -version $version2
-    $project.Save($project.FullName)
-    Build-Solution
-    Assert-NetCorePackageInstall $project $id1 $version1
-    Assert-NetCorePackageInstall $project $id2 $version2
-    Uninstall-Package $id1 -ProjectName $project.Name
-    Uninstall-Package $id2 -ProjectName $project.Name
-    $project.Save($project.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCorePackageUninstall $project $id1
-    Assert-NetCorePackageUninstall $project $id2
-}
-
-function Test-NetStandardClassLibraryUpgradePackage {
-
-    # Arrange
-    $project = New-NetStandardClassLibrary ClassLibrary1
-    $id = 'NuGet.Versioning'
-    $oldVersion = '3.5.0'
-    $newVersion = '4.0.0-rc2'
-    Assert-NetCoreProjectCreation $project
-
-    # Act
-    Install-Package $id -ProjectName $project.Name -version $oldVersion
-    $project.Save($project.FullName)
-    Build-Solution
-    Assert-NetCorePackageInstall $project $id $oldVersion
-
-    Update-Package $id -ProjectName $project.Name -version $newVersion
-    $project.Save($project.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCorePackageInstall $project $id $newVersion
-}
-
-function Test-NetStandardClassLibraryDowngradePackage {
-
-    # Arrange
-    $project = New-NetStandardClassLibrary ClassLibrary1
-    $id = 'NuGet.Versioning'
-    $oldVersion = '4.0.0-rc2'
-    $newVersion = '3.5.0'
-    Assert-NetCoreProjectCreation $project
-
-    # Act
-    Install-Package $id -ProjectName $project.Name -version $oldVersion
-    $project.Save($project.FullName)
-    Build-Solution
-    Assert-NetCorePackageInstall $project $id $oldVersion
-
-    Update-Package $id -ProjectName $project.Name -version $newVersion
-    $project.Save($project.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCorePackageInstall $project $id $newVersion
-}
-
-function Test-NetStandardClassLibraryProjectReference {
-
-    # Arrange
-    $projectA = New-NetStandardClassLibrary ClassLibraryA
-    $projectB = New-NetStandardClassLibrary ClassLibraryB
-
-    Assert-NetCoreProjectCreation $projectA
-    Assert-NetCoreProjectCreation $projectB
-
-    # Act
-    Add-ProjectReference $projectA $projectB
-
-    $projectA.Save($projectA.FullName)
-    $projectB.Save($projectB.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCoreProjectReference $projectA $projectB
-}
-
-# transitive package dependency test for .net core
-# A -> B
-# B -> C
-# C -> Nuget.Versioning 3.5.0
-# Assert A has reference to NuGet.Versioning
-function Test-NetStandardClassLibraryTransitivePackage {
-
-    # Arrange
-    $projectA = New-NetStandardClassLibrary ClassLibraryA
-    $projectB = New-NetStandardClassLibrary ClassLibraryB
-    $projectC = New-NetStandardClassLibrary ClassLibraryC
-    $id = 'NuGet.Versioning'
-    $version = '3.5.0'
-    Assert-NetCoreProjectCreation $projectA
-    Assert-NetCoreProjectCreation $projectB
-    Assert-NetCoreProjectCreation $projectC
-
-    # Act
-    Add-ProjectReference $projectB $projectC
-    Add-ProjectReference $projectA $projectB
-    Install-Package $id -ProjectName $projectC.Name -version $version
-
-    $projectA.Save($projectA.FullName)
-    $projectB.Save($projectB.FullName)
-    $projectC.Save($projectC.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCorePackageInstall $projectC $id $version
-    Assert-NetCorePackageInLockFile $projectB $id $version
-    Assert-NetCorePackageInLockFile $projectA $id $version
-}
-
-# transitive package dependency limit test for .net core
-# A -> X, B
-# B -> C
-# C -> Nuget.Versioning 3.5.0
-# Assert X does not have reference to NuGet.Versioning
-function Test-NetStandardClassLibraryTransitivePackageLimit {
-
-    # Arrange
-    $projectA = New-NetStandardClassLibrary ClassLibraryA
-    $projectB = New-NetStandardClassLibrary ClassLibraryB
-    $projectC = New-NetStandardClassLibrary ClassLibraryC
-    $projectX = New-NetStandardClassLibrary ClassLibraryX
-    $id = 'NuGet.Versioning'
-    $version = '3.5.0'
-    Assert-NetCoreProjectCreation $projectA
-    Assert-NetCoreProjectCreation $projectB
-    Assert-NetCoreProjectCreation $projectC
-    Assert-NetCoreProjectCreation $projectX
-
-    # Act
-    Add-ProjectReference $projectA $projectX
-    Add-ProjectReference $projectA $projectB
-    Add-ProjectReference $projectB $projectC
-    Install-Package $id -ProjectName $projectC.Name -version $version
-
-    $projectA.Save($projectA.FullName)
-    $projectB.Save($projectB.FullName)
-    $projectC.Save($projectC.FullName)
-    $projectX.Save($projectX.FullName)
-    Build-Solution
-
-    # Assert
-    Assert-NetCorePackageInstall $projectC $id $version
-    Assert-NetCorePackageInLockFile $projectB $id $version
-    Assert-NetCorePackageInLockFile $projectA $id $version
-    Assert-NetCoreNoPackageReference $projectX $id
-    Assert-NetCorePackageNotInLockFile $projectX $id
-}
 
 function Test-NetCoreConsoleAppClean {
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
@@ -32,7 +32,9 @@
     <Compile Include="Fixtures\VisualStudioOperationsFixture.cs" />
     <Compile Include="NuGetIVsApiTests\IVsPackageInstallerTestCase.cs" />
     <Compile Include="NuGetIVsApiTests\NuGetConsoleTestCase.cs" />
+    <Compile Include="NuGetIVsApiTests\NetCoreProjectTestCase.cs" />
     <Compile Include="NuGetIVsApiTests\NuGetUITestCase.cs" />
+    <Compile Include="NuGetIVsApiTests\Utils.cs" />
     <Compile Include="Apex\NuGetTypeConstraint.cs" />
     <Compile Include="Apex\NuGetUIProjectTestExtensionVerifier.cs" />
     <Compile Include="Apex\NuGetUIProjectTestExtension.cs" />
@@ -44,11 +46,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Test.Apex-d15rel">
-      <Version>15.0.26131.55</Version>
+      <Version>15.0.27006.00</Version>
     </PackageReference>
-    <PackageReference Include="Xunit.StaFact">
-      <Version>0.2.3-beta</Version>
-    </PackageReference>
+    <PackageReference Include="Xunit.StaFact" Version="0.2.9" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
@@ -60,6 +60,7 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </ProjectReference>
     <ProjectReference Include="..\..\TestUtilities\Test.Utility\Test.Utility.csproj" />
+    <ProjectReference Include="..\..\TestExtensions\NuGet.StaFact\NuGet.StaFact.csproj" />
     <ProjectReference Include="..\NuGet.Console.TestContract\NuGet.Console.TestContract.csproj" />
     <ProjectReference Include="..\NuGet.PackageManagement.UI.TestContract\NuGet.PackageManagement.UI.TestContract.csproj" />
   </ItemGroup>

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NetCoreProjectTestCase.cs
@@ -1,0 +1,65 @@
+using Microsoft.Test.Apex.VisualStudio.Solution;
+using NuGet.StaFact;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Tests.Apex
+{
+    public class NetCoreProjectTestCase : SharedVisualStudioHostTestClass, IClassFixture<VisualStudioHostFixtureFactory>
+    {
+        public NetCoreProjectTestCase(VisualStudioHostFixtureFactory visualStudioHostFixtureFactory)
+            : base(visualStudioHostFixtureFactory)
+        {
+        }
+
+        // basic create for .net core template
+        [NuGetWpfTheory]
+        [InlineData(ProjectTemplate.NetCoreClassLib)]
+        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
+        public void CreateNetCoreProject_RestoresNewProject(ProjectTemplate projectTemplate)
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                EnsureVisualStudioHost();
+                var solutionService = VisualStudio.Get<SolutionService>();
+
+                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
+                var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
+                project.Build();
+                solutionService.SaveAll();
+
+                solutionService.Build();
+                Assert.True(VisualStudio.HasNoErrorsInErrorList());
+            }
+        }
+
+        // basic create for .net core template
+        [NuGetWpfTheory]
+        [InlineData(ProjectTemplate.NetCoreClassLib)]
+        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
+        public void CreateNetCoreProject_AddProjectReference(ProjectTemplate projectTemplate)
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                EnsureVisualStudioHost();
+                var solutionService = VisualStudio.Get<SolutionService>();
+
+                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
+                var project1 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject1");
+                project1.Build();
+                var project2 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject2");
+                project2.Build();
+                project1.References.Dte.AddProjectReference(project2);
+                solutionService.SaveAll();
+
+                solutionService.Build();
+                Assert.True(VisualStudio.HasNoErrorsInErrorList());
+                Assert.True(project1.References.TryFindReferenceByName("TestProject2", out var result));
+            }
+        }
+    }
+}

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
@@ -179,7 +179,10 @@ namespace NuGet.Tests.Apex
                 Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion1));
 
                 Assert.True(nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2));
-                Assert.True(Utils.PackageExistsInLockFile(project.FullPath, packageName, packageVersion2));
+                if (projectTemplate != ProjectTemplate.ClassLibrary)
+                {
+                    Assert.True(Utils.PackageExistsInLockFile(project.FullPath, packageName, packageVersion2));
+                }
                 project.Build();
 
                 Assert.False(nugetConsole.IsPackageInstalled(packageName, packageVersion1));

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using Microsoft.Test.Apex.VisualStudio.Solution;
+using NuGet.StaFact;
 using NuGet.Test.Utility;
 using Xunit;
 
@@ -15,28 +16,40 @@ namespace NuGet.Tests.Apex
         {
         }
 
-        [StaFact]
-        public void InstallPackageFromPMC()
+        [NuGetWpfTheory]
+        [InlineData(ProjectTemplate.ClassLibrary)]
+        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
+        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        public void InstallPackageFromPMC(ProjectTemplate projectTemplate)
         {
             using (var pathContext = new SimpleTestPathContext())
             {
                 // Arrange
                 EnsureVisualStudioHost();
                 var solutionService = VisualStudio.Get<SolutionService>();
-
+            
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
+                var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
+                project.Build();
 
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
-                CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion);
+                Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion);
 
                 var nugetTestService = GetNuGetTestService();
                 Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
 
                 var nugetConsole = nugetTestService.GetPackageManagerConsole(project.Name);
-
+                
                 Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion));
+                if(projectTemplate != ProjectTemplate.ClassLibrary)
+                {
+                    Assert.True(Utils.PackageExistsInLockFile(project.FullPath, packageName, packageVersion));
+                }
+                
+                project.Build();
+                Assert.True(VisualStudio.HasNoErrorsInErrorList());
+                Assert.True(VisualStudio.HasNoErrorsInOutputWindows());
                 Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion));
 
                 nugetConsole.Clear();
@@ -44,8 +57,11 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [StaFact]
-        public void InstallPackageFromPMCFromNuGetOrg()
+        [NuGetWpfTheory]
+        [InlineData(ProjectTemplate.ClassLibrary)]
+        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
+        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        public void InstallPackageFromPMCFromNuGetOrg(ProjectTemplate projectTemplate)
         {
             using (var pathContext = new SimpleTestPathContext())
             {
@@ -54,7 +70,8 @@ namespace NuGet.Tests.Apex
                 var solutionService = VisualStudio.Get<SolutionService>();
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
+                var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
+                project.Build();
 
                 var nugetTestService = GetNuGetTestService();
                 Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
@@ -65,15 +82,25 @@ namespace NuGet.Tests.Apex
                 var packageVersion = "9.0.1";
 
                 Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion, "https://api.nuget.org/v3/index.json"));
+                if (projectTemplate != ProjectTemplate.ClassLibrary)
+                {
+                    Assert.True(Utils.PackageExistsInLockFile(project.FullPath, packageName, packageVersion));
+                }
+                project.Build();
+                Assert.True(VisualStudio.HasNoErrorsInErrorList());
+                Assert.True(VisualStudio.HasNoErrorsInOutputWindows());
                 Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion));
-
                 nugetConsole.Clear();
+
                 solutionService.Save();
             }
         }
 
-        [StaFact]
-        public void UninstallPackageFromPMC()
+        [NuGetWpfTheory]
+        [InlineData(ProjectTemplate.ClassLibrary)]
+        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
+        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        public void UninstallPackageFromPMC(ProjectTemplate projectTemplate)
         {
             using (var pathContext = new SimpleTestPathContext())
             {
@@ -82,11 +109,12 @@ namespace NuGet.Tests.Apex
                 var solutionService = VisualStudio.Get<SolutionService>();
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
+                var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
+                project.Build();
 
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
-                CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion);
+                Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion);
 
                 var nugetTestService = GetNuGetTestService();
                 Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
@@ -94,18 +122,32 @@ namespace NuGet.Tests.Apex
                 var nugetConsole = nugetTestService.GetPackageManagerConsole(project.Name);
 
                 Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion));
-                Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion));
+                if (projectTemplate != ProjectTemplate.ClassLibrary)
+                {
+                    Assert.True(Utils.PackageExistsInLockFile(project.FullPath, packageName, packageVersion));
+                }
+                project.Build();
 
                 Assert.True(nugetConsole.UninstallPackageFromPMC(packageName));
+                if (projectTemplate != ProjectTemplate.ClassLibrary)
+                {
+                    Assert.False(Utils.PackageExistsInLockFile(project.FullPath, packageName, packageVersion));
+                }
+
+                solutionService.Save();
+                project.Build();
+
                 Assert.False(nugetConsole.IsPackageInstalled(packageName, packageVersion));
 
                 nugetConsole.Clear();
-                solutionService.Save();
             }
         }
 
-        [StaFact]
-        public void UpdatePackageFromPMC()
+        [NuGetWpfTheory]
+        [InlineData(ProjectTemplate.ClassLibrary)]
+        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
+        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        public void UpdatePackageFromPMC(ProjectTemplate projectTemplate)
         {
             using (var pathContext = new SimpleTestPathContext())
             {
@@ -114,13 +156,14 @@ namespace NuGet.Tests.Apex
                 var solutionService = VisualStudio.Get<SolutionService>();
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
+                var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
+                project.Build();
 
                 var packageName = "TestPackage";
                 var packageVersion1 = "1.0.0";
                 var packageVersion2 = "2.0.0";
-                CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion1);
-                CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion2);
+                Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion1);
+                Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion2);
 
                 var nugetTestService = GetNuGetTestService();
                 Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
@@ -128,9 +171,17 @@ namespace NuGet.Tests.Apex
                 var nugetConsole = nugetTestService.GetPackageManagerConsole(project.UniqueName);
 
                 Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion1));
+                if (projectTemplate != ProjectTemplate.ClassLibrary)
+                {
+                    Assert.True(Utils.PackageExistsInLockFile(project.FullPath, packageName, packageVersion1));
+                }
+                project.Build();
                 Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion1));
 
                 Assert.True(nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2));
+                Assert.True(Utils.PackageExistsInLockFile(project.FullPath, packageName, packageVersion2));
+                project.Build();
+
                 Assert.False(nugetConsole.IsPackageInstalled(packageName, packageVersion1));
                 Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion2));
 
@@ -139,12 +190,248 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        private static void CreatePackageInSource(string packageSource, string packageName, string packageVersion)
+        [NuGetWpfTheory]
+        [InlineData(ProjectTemplate.ClassLibrary)]
+        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
+        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        public void InstallMultiplePackagesFromPMC(ProjectTemplate projectTemplate)
         {
-            var package = new SimpleTestPackageContext(packageName, packageVersion);
-            package.Files.Clear();
-            package.AddFile("lib/net45/_._");
-            SimpleTestPackageUtility.CreatePackages(packageSource, package);
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                EnsureVisualStudioHost();
+                var solutionService = VisualStudio.Get<SolutionService>();
+
+                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
+                var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
+                project.Build();
+
+                var packageName1 = "TestPackage1";
+                var packageVersion1 = "1.0.0";
+                Utils.CreatePackageInSource(pathContext.PackageSource, packageName1, packageVersion1);
+
+                var packageName2 = "TestPackage2";
+                var packageVersion2 = "1.2.3";
+                Utils.CreatePackageInSource(pathContext.PackageSource, packageName2, packageVersion2);
+
+                var nugetTestService = GetNuGetTestService();
+                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
+
+                var nugetConsole = nugetTestService.GetPackageManagerConsole(project.Name);
+
+                Assert.True(nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1));
+                Assert.True(nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2));
+                project.Build();
+                Assert.True(VisualStudio.HasNoErrorsInErrorList());
+                Assert.True(VisualStudio.HasNoErrorsInOutputWindows());
+                Assert.True(nugetConsole.IsPackageInstalled(packageName1, packageVersion1));
+                Assert.True(nugetConsole.IsPackageInstalled(packageName2, packageVersion2));
+
+                nugetConsole.Clear();
+                solutionService.Save();
+            }
         }
+
+        [NuGetWpfTheory]
+        [InlineData(ProjectTemplate.ClassLibrary)]
+        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
+        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        public void UninstallMultiplePackagesFromPMC(ProjectTemplate projectTemplate)
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                EnsureVisualStudioHost();
+                var solutionService = VisualStudio.Get<SolutionService>();
+
+                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
+                var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
+                project.Build();
+
+                var packageName1 = "TestPackage1";
+                var packageVersion1 = "1.0.0";
+                Utils.CreatePackageInSource(pathContext.PackageSource, packageName1, packageVersion1);
+
+                var packageName2 = "TestPackage2";
+                var packageVersion2 = "1.2.3";
+                Utils.CreatePackageInSource(pathContext.PackageSource, packageName2, packageVersion2);
+
+                var nugetTestService = GetNuGetTestService();
+                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
+
+                var nugetConsole = nugetTestService.GetPackageManagerConsole(project.Name);
+
+                Assert.True(nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1));
+                Assert.True(nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2));
+                project.Build();
+                Assert.True(VisualStudio.HasNoErrorsInErrorList());
+                Assert.True(VisualStudio.HasNoErrorsInOutputWindows());
+                Assert.True(nugetConsole.IsPackageInstalled(packageName1, packageVersion1));
+                Assert.True(nugetConsole.IsPackageInstalled(packageName2, packageVersion2));
+
+                Assert.True(nugetConsole.UninstallPackageFromPMC(packageName1));
+                Assert.True(nugetConsole.UninstallPackageFromPMC(packageName2));
+                project.Build();
+                solutionService.SaveAll();
+
+                Assert.False(nugetConsole.IsPackageInstalled(packageName1, packageVersion1));
+                Assert.False(nugetConsole.IsPackageInstalled(packageName2, packageVersion2));
+
+                nugetConsole.Clear();
+                solutionService.Save();
+            }
+        }
+
+        [NuGetWpfTheory]
+        [InlineData(ProjectTemplate.ClassLibrary)]
+        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
+        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        public void DowngradePackageFromPMC(ProjectTemplate projectTemplate)
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                EnsureVisualStudioHost();
+                var solutionService = VisualStudio.Get<SolutionService>();
+
+                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
+                var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
+                project.Build();
+
+                var packageName = "TestPackage";
+                var packageVersion1 = "1.0.0";
+                var packageVersion2 = "2.0.0";
+                Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion1);
+                Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion2);
+
+                var nugetTestService = GetNuGetTestService();
+                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
+
+                var nugetConsole = nugetTestService.GetPackageManagerConsole(project.UniqueName);
+
+                Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion2));
+                project.Build();
+                Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion2));
+
+                Assert.True(nugetConsole.UpdatePackageFromPMC(packageName, packageVersion1));
+                project.Build();
+
+                Assert.False(nugetConsole.IsPackageInstalled(packageName, packageVersion2));
+                Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion1));
+
+                nugetConsole.Clear();
+                solutionService.Save();
+            }
+        }
+
+        [NuGetWpfTheory]
+        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
+        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        public void NetCoreTransitivePackageReference(ProjectTemplate projectTemplate)
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                EnsureVisualStudioHost();
+                var solutionService = VisualStudio.Get<SolutionService>();
+
+
+                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
+                var project1 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject1");
+                project1.Build();
+                var project2 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject2");
+                project2.Build();
+                var project3 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject3");
+                project3.Build();
+                solutionService.Build();
+                
+                var nugetTestService = GetNuGetTestService();
+                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
+
+                project1.References.Dte.AddProjectReference(project2);
+                project2.References.Dte.AddProjectReference(project3);
+                solutionService.SaveAll();
+                solutionService.Build();
+
+
+                var nugetConsole = nugetTestService.GetPackageManagerConsole(project3.UniqueName);
+                var packageName = "newtonsoft.json";
+                var packageVersion = "9.0.1";
+
+                Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion, "https://api.nuget.org/v3/index.json"));
+                project1.Build();
+                project2.Build();
+                project3.Build();
+
+                Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion));
+
+                Assert.True(project1.References.TryFindReferenceByName("newtonsoft.json", out var result));
+                Assert.NotNull(result);
+                Assert.True(project2.References.TryFindReferenceByName("newtonsoft.json", out var result2));
+                Assert.NotNull(result2);
+
+                nugetConsole.Clear();
+                solutionService.Save();
+            }
+        }
+
+        [NuGetWpfTheory]
+        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
+        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        public void NetCoreTransitivePackageReferenceLimit(ProjectTemplate projectTemplate)
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                EnsureVisualStudioHost();
+                var solutionService = VisualStudio.Get<SolutionService>();
+
+
+                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
+                var project1 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject1");
+                project1.Build();
+                var project2 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject2");
+                project2.Build();
+                var project3 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject3");
+                project3.Build();
+                var projectX = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProjectX");
+                projectX.Build();
+                solutionService.Build();
+
+                var nugetTestService = GetNuGetTestService();
+                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
+
+                project1.References.Dte.AddProjectReference(project2);
+                project1.References.Dte.AddProjectReference(projectX);
+                project2.References.Dte.AddProjectReference(project3);
+                solutionService.SaveAll();
+                solutionService.Build();
+
+
+                var nugetConsole = nugetTestService.GetPackageManagerConsole(project3.UniqueName);
+                var packageName = "newtonsoft.json";
+                var packageVersion = "9.0.1";
+
+                Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion, "https://api.nuget.org/v3/index.json"));
+                project1.Build();
+                project2.Build();
+                project3.Build();
+                projectX.Build();
+                solutionService.Build();
+
+                Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion));
+
+                Assert.True(project1.References.TryFindReferenceByName("newtonsoft.json", out var result));
+                Assert.NotNull(result);
+                Assert.True(project2.References.TryFindReferenceByName("newtonsoft.json", out var result2));
+                Assert.NotNull(result2);
+                Assert.False(projectX.References.TryFindReferenceByName("newtonsoft.json", out var resultX));
+                Assert.Null(resultX);
+
+                nugetConsole.Clear();
+                solutionService.Save();
+            }
+        }
+
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/Utils.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/Utils.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Linq;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+
+namespace NuGet.Tests.Apex
+{
+    public class Utils
+    {
+        public static void CreatePackageInSource(string packageSource, string packageName, string packageVersion)
+        {
+            var package = new SimpleTestPackageContext(packageName, packageVersion);
+            package.Files.Clear();
+            package.AddFile("lib/net45/_._");
+            SimpleTestPackageUtility.CreatePackages(packageSource, package);
+        }
+
+        public static bool PackageExistsInLockFile(string projectPath, string packageName, string packageVersion)
+        {
+            var assetsFilePath = GetAssetsFilePath(projectPath);
+            if(File.Exists(assetsFilePath))
+            {
+                var lockFile = new LockFileFormat().Read(assetsFilePath);
+                var lockFileLibrary = lockFile.Libraries.SingleOrDefault(p => (String.Compare(p.Name, packageName, StringComparison.OrdinalIgnoreCase) == 0));
+                return lockFileLibrary !=null && lockFileLibrary.Version.ToNormalizedString() == packageVersion;
+            }
+
+            return false;
+        }
+
+        private static string GetAssetsFilePath(string projectPath)
+        {
+            if(string.IsNullOrEmpty(projectPath))
+            {
+                return string.Empty;
+            }
+            else
+            {
+                var projectDirectory = Path.GetDirectoryName(projectPath);
+                return Path.Combine(projectDirectory, "obj", "project.assets.json");
+            }
+        }
+    }
+}

--- a/test/TestExtensions/NuGet.StaFact/NuGet.StaFact.csproj
+++ b/test/TestExtensions/NuGet.StaFact/NuGet.StaFact.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <OutputType>Library</OutputType>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <Shipping>false</Shipping>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="XUnit.StaFact" Version="0.2.9" />
+  </ItemGroup>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
+</Project>

--- a/test/TestExtensions/NuGet.StaFact/NuGetWpfFactAttribute.cs
+++ b/test/TestExtensions/NuGet.StaFact/NuGetWpfFactAttribute.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace NuGet.StaFact
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    [XunitTestCaseDiscoverer("NuGet.StaFact.NuGetWpfFactDiscoverer", "NuGet.StaFact")]
+    public sealed class NuGetWpfFactAttribute : FactAttribute
+    {
+    }
+}

--- a/test/TestExtensions/NuGet.StaFact/NuGetWpfFactDiscoverer.cs
+++ b/test/TestExtensions/NuGet.StaFact/NuGetWpfFactDiscoverer.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace NuGet.StaFact
+{
+    public sealed class NuGetWpfFactDiscoverer : IXunitTestCaseDiscoverer
+    {
+        private readonly FactDiscoverer _factDiscoverer;
+
+        public NuGetWpfFactDiscoverer(IMessageSink diagnosticMessageSink)
+        {
+            _factDiscoverer = new FactDiscoverer(diagnosticMessageSink);
+        }
+
+        public IEnumerable<IXunitTestCase> Discover(
+            ITestFrameworkDiscoveryOptions discoveryOptions,
+            ITestMethod testMethod,
+            IAttributeInfo factAttribute)
+        {
+            return _factDiscoverer.Discover(discoveryOptions, testMethod, factAttribute)
+                                  .Select(testCase => new NuGetWpfTestCase(testCase));
+        }
+    }
+}

--- a/test/TestExtensions/NuGet.StaFact/NuGetWpfTestCase.cs
+++ b/test/TestExtensions/NuGet.StaFact/NuGetWpfTestCase.cs
@@ -1,0 +1,142 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Threading;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace NuGet.StaFact
+{
+    [DebuggerDisplay(@"\{ class = {TestMethod.TestClass.Class.Name}, method = {TestMethod.Method.Name}, display = {DisplayName}, skip = {SkipReason} \}")]
+    public sealed class NuGetWpfTestCase : LongLivedMarshalByRefObject, IXunitTestCase
+    {
+        private IXunitTestCase _testCase;
+
+        public string DisplayName => _testCase.DisplayName;
+        public IMethodInfo Method => _testCase.Method;
+        public string SkipReason => _testCase.SkipReason;
+        public ITestMethod TestMethod => _testCase.TestMethod;
+        public object[] TestMethodArguments => _testCase.TestMethodArguments;
+        public Dictionary<string, List<string>> Traits => _testCase.Traits;
+        public string UniqueID => _testCase.UniqueID;
+
+        public ISourceInformation SourceInformation
+        {
+            get { return _testCase.SourceInformation; }
+            set { _testCase.SourceInformation = value; }
+        }
+
+        public NuGetWpfTestCase(IXunitTestCase testCase)
+        {
+            if (testCase == null)
+            {
+                throw new ArgumentNullException(nameof(testCase));
+            }
+
+            _testCase = testCase;
+        }
+
+        [Obsolete("Called by the deserializer", error: true)]
+        public NuGetWpfTestCase() { }
+
+        public Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
+            IMessageBus messageBus,
+            object[] constructorArguments,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource)
+        {
+            var taskCompletionSource = new TaskCompletionSource<RunSummary>();
+            var thread = new Thread(() =>
+                {
+                    try
+                    {
+                        // Set up the SynchronizationContext so that any awaits
+                        // resume on the STA thread as they would in a GUI app.
+                        SynchronizationContext.SetSynchronizationContext(new DispatcherSynchronizationContext());
+
+                        // Start off the test method.
+                        var testCaseTask = _testCase.RunAsync(diagnosticMessageSink, messageBus, constructorArguments, aggregator, cancellationTokenSource);
+
+                        // Arrange to pump messages to execute any async work associated with the test.
+                        var frame = new DispatcherFrame();
+                        Task.Run(async delegate
+                        {
+                            try
+                            {
+                                await testCaseTask;
+                            }
+                            finally
+                            {
+                                // The test case's execution is done. Terminate the message pump.
+                                frame.Continue = false;
+                            }
+                        });
+                        Dispatcher.PushFrame(frame);
+
+                        // Report the result back to the Task we returned earlier.
+                        CopyTaskResultFrom(taskCompletionSource, testCaseTask);
+                    }
+                    catch (Exception e)
+                    {
+                        taskCompletionSource.SetException(e);
+                    }
+                    finally
+                    {
+                        Dispatcher.CurrentDispatcher.InvokeShutdown();
+                    }
+                });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+
+            return taskCompletionSource.Task;
+        }
+
+        public void Deserialize(IXunitSerializationInfo info)
+        {
+            _testCase = info.GetValue<IXunitTestCase>("InnerTestCase");
+        }
+
+        public void Serialize(IXunitSerializationInfo info)
+        {
+            info.AddValue("InnerTestCase", _testCase);
+        }
+
+        private static void CopyTaskResultFrom<T>(TaskCompletionSource<T> taskCompletionSource, Task<T> template)
+        {
+            if (taskCompletionSource == null)
+            {
+                throw new ArgumentNullException(nameof(taskCompletionSource));
+            }
+
+            if (template == null)
+            {
+                throw new ArgumentNullException(nameof(template));
+            }
+
+            if (!template.IsCompleted)
+            {
+                throw new ArgumentException("Task must be completed first.", nameof(template));
+            }
+
+            if (template.IsFaulted)
+            {
+                taskCompletionSource.SetException(template.Exception);
+            }
+            else if (template.IsCanceled)
+            {
+                taskCompletionSource.SetCanceled();
+            }
+            else
+            {
+                taskCompletionSource.SetResult(template.Result);
+            }
+        }
+    }
+}

--- a/test/TestExtensions/NuGet.StaFact/NuGetWpfTheoryAttribute.cs
+++ b/test/TestExtensions/NuGet.StaFact/NuGetWpfTheoryAttribute.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace NuGet.StaFact
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    [XunitTestCaseDiscoverer("NuGet.StaFact.NuGetWpfTheoryDiscoverer", "NuGet.StaFact")]
+    public sealed class NuGetWpfTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/test/TestExtensions/NuGet.StaFact/NuGetWpfTheoryDiscoverer.cs
+++ b/test/TestExtensions/NuGet.StaFact/NuGetWpfTheoryDiscoverer.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace NuGet.StaFact
+{
+    public sealed class NuGetWpfTheoryDiscoverer : IXunitTestCaseDiscoverer
+    {
+        private readonly TheoryDiscoverer _theoryDiscoverer;
+
+        public NuGetWpfTheoryDiscoverer(IMessageSink diagnosticMessageSink)
+        {
+            _theoryDiscoverer = new TheoryDiscoverer(diagnosticMessageSink);
+        }
+
+        public IEnumerable<IXunitTestCase> Discover(
+            ITestFrameworkDiscoveryOptions discoveryOptions,
+            ITestMethod testMethod,
+            IAttributeInfo factAttribute)
+        {
+            return _theoryDiscoverer.Discover(discoveryOptions, testMethod, factAttribute)
+                                    .Select(testCase => new NuGetWpfTestCase(testCase));
+        }
+    }
+}


### PR DESCRIPTION
since our e2e tests based on netcore and netstandard projects are flaky , i have moved them to apex in a bid to make them more reliable. of all the tests in netcoreprojecttests.ps1 which were flaky (from the list in NuGet/Home#5944) , i have moved netcore and netstandard projects based tests , while aspnet core tests are still pending migration because apex doesn't support that project template yet.

Fixes a part of : NuGet/Home#5944

CC: @rrelyea 