### PR TITLE
bring test by test vsts integration to github

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -388,6 +388,14 @@ phases:
 
 
   steps:
+  - task: ShellScript@2
+    displayName: "Run Tests"
+    continueOnError: "true"
+    inputs:
+      scriptPath: "scripts/funcTests/runFuncTests.sh"
+      disableAutoCwd: "true"
+      cwd: "$(Build.Repository.LocalPath)"
+  
   - task: ms-devlabs.utilitytasks.task-Shellpp.Shell++@0
     displayName: "Initialize Git Commit Status on GitHub"
     inputs:
@@ -396,14 +404,6 @@ phases:
       args: "$(NuGetLurkerPersonalAccessToken) \"Tests On Linux\" $(Agent.JobStatus)"
       cwd: "$(Build.Repository.LocalPath)"
     condition: "always()"
-
-  - task: ShellScript@2
-    displayName: "Run Tests"
-    continueOnError: "true"
-    inputs:
-      scriptPath: "scripts/funcTests/runFuncTests.sh"
-      disableAutoCwd: "true"
-      cwd: "$(Build.Repository.LocalPath)"
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
@@ -444,7 +444,7 @@ phases:
     inputs:
       type: "FilePath"
       scriptPath: "scripts/utils/PostGitCommitStatus.sh"
-      args: "'$(NuGetLurkerPersonalAccessToken)' 'Tests On Mac' '$(Agent.JobStatus)'"
+      args: "$(NuGetLurkerPersonalAccessToken) \"Tests On Mac\" $(Agent.JobStatus)"
       cwd: "$(Build.Repository.LocalPath)"
     condition: "always()"
 

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -388,6 +388,15 @@ phases:
 
 
   steps:
+  - task: ms-devlabs.utilitytasks.task-Shellpp.Shell++@0
+    displayName: "Initialize Git Commit Status on GitHub"
+    inputs:
+      type: "FilePath"
+      scriptPath: "scripts/utils/PostGitCommitStatus.sh"
+      args: "$(NuGetLurkerPersonalAccessToken) \"Tests On Linux\" $(Agent.JobStatus)"
+      cwd: "$(Build.Repository.LocalPath)"
+    condition: "always()"
+
   - task: ShellScript@2
     displayName: "Run Tests"
     continueOnError: "true"
@@ -395,15 +404,6 @@ phases:
       scriptPath: "scripts/funcTests/runFuncTests.sh"
       disableAutoCwd: "true"
       cwd: "$(Build.Repository.LocalPath)"
-
-  - task: ms-devlabs.utilitytasks.task-Shellpp.Shell++@0
-    displayName: "Initialize Git Commit Status on GitHub"
-    inputs:
-      type: "FilePath"
-      scriptPath: "scripts/utils/PostGitCommitStatus.sh"
-      args: "'$(NuGetLurkerPersonalAccessToken)' 'Tests On Linux' '$(Agent.JobStatus)'"
-      cwd: "$(Build.Repository.LocalPath)"
-    condition: "always()"
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -100,6 +100,15 @@ phases:
       msbuildArguments: "/t:CoreUnitTests;UnitTestsVS15 /p:NUGET_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\NuGetKey.snk /p:MS_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\35MSSharedLib1024.snk  /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(Revision) /p:TestResultOutputFormat=xml"
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
+  - task: PowerShell@1
+    displayName: "Initialize Git Commit Status on GitHub"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        . $(Build.Repository.LocalPath)\\scripts\utils\\PostGitCommitStatus.ps1
+        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Unit Tests On Windows"
+    condition: "and(always(),eq(variables['BuildRTM'], 'true'))"
+
   - task: PublishTestResults@2
     displayName: "Publish Desktop Test Results"
     inputs:
@@ -341,6 +350,15 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/t:CoreFuncTests  /p:BuildRTM=false  /p:BuildNumber=$(Revision) /p:TestResultOutputFormat=xml"
 
+  - task: PowerShell@1
+    displayName: "Initialize Git Commit Status on GitHub"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        . $(Build.Repository.LocalPath)\\scripts\utils\\PostGitCommitStatus.ps1
+        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Functional Tests On Windows"
+    condition: "always()"
+
   - task: PublishTestResults@2
     displayName: "Publish Desktop Test Results"
     continueOnError: "true"
@@ -491,6 +509,15 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
 #       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
 #       arguments: "-PMCCommand $(EndToEndTestCommandToRun) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 15.0"
 
+#   - task: PowerShell@1
+#       displayName: "Initialize Git Commit Status on GitHub"
+#       inputs:
+#         scriptType: "inlineScript"
+#         inlineScript: |
+#           . $(Build.Repository.LocalPath)\\scripts\utils\\PostGitCommitStatus.ps1
+#           SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "EndToEnd Tests On Windows"
+#       condition: "always()"
+
 #   - task: PublishTestResults@2
 #     displayName: "Publish Test Results"
 #     inputs:
@@ -591,6 +618,15 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
 #       msbuildVersion: "15.0"
 #       configuration: "$(BuildConfiguration)"
 #       msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml  /p:NUGET_PFX_PATH=$(System.DefaultWorkingDirectory)\\keys\\NuGetKey.snk /p:MS_PFX_PATH=$(System.DefaultWorkingDirectory)\\keys\\35MSSharedLib1024.snk /p:BuildNumber=$(Build.BuildNumber)"
+
+#   - task: PowerShell@1
+#       displayName: "Initialize Git Commit Status on GitHub"
+#       inputs:
+#         scriptType: "inlineScript"
+#         inlineScript: |
+#           . $(Build.Repository.LocalPath)\\scripts\utils\\PostGitCommitStatus.ps1
+#           SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Apex Tests On Windows"
+#       condition: "always()"
 
 #   - task: PublishTestResults@2
 #     displayName: "Publish Test Results"

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -1,7 +1,25 @@
 name: $(SourceBranchName)-$(Date:yyyyMMdd)-$(rev:rr)
 phases:
-- phase: Build_and_UnitTest
 
+- phase: Initialize_GitHub_Status
+  queue:
+    name: VSEng-MicroBuildVS2017
+    timeoutInMinutes: 60
+    demands: 
+      - DotNetFramework
+      - msbuild
+  
+  steps:
+  - task: PowerShell@1
+    displayName: "Initialize Git Commit Status on GitHub"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        . $(Build.Repository.LocalPath)\\scripts\utils\\PostGitCommitStatus.ps1
+        InitializeAllTestsToPending -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion)
+
+- phase: Build_and_UnitTest
+  dependsOn: Initialize_GitHub_Status
   queue:
     name: VSEng-MicroBuildVS2017
     timeoutInMinutes: 90
@@ -14,7 +32,6 @@ phases:
     demands: 
       - DotNetFramework
       - msbuild
-
 
   steps:
   - task: PowerShell@1
@@ -34,7 +51,7 @@ phases:
     displayName: "Print Environment Variables"
     inputs:
       scriptType: "inlineScript"
-      inlineScript: "gci env:* | sort-object name"    
+      inlineScript: "gci env:* | sort-object name"
 
   - task: MicroBuildLocalizationPlugin@1
     displayName: "Install Localization Plugin"
@@ -281,6 +298,7 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
 
 
 - phase: Functional_Tests_On_Windows
+  dependsOn: Initialize_GitHub_Status
   queue:
     name: VSEng-MicroBuildSxS
     timeoutInMinutes: 120
@@ -345,6 +363,7 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
     condition: "succeededOrFailed()"
 
 - phase: Tests_On_Linux
+  dependsOn: Initialize_GitHub_Status
   queue:
     name: DDNuGet-Linux
     timeoutInMinutes: 45

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -471,6 +471,7 @@ phases:
 
 - phase: End_To_End_Tests_On_Windows
   dependsOn: Build_and_UnitTest
+  condition: "succeeded()"
   variables:
     BuildNumber: $[dependencies.Build_and_UnitTest.outputs['RTM.configuration.BuildNumber']]
   condition: "succeeded()"
@@ -561,6 +562,7 @@ phases:
 
 - phase: Apex_Tests_On_Windows
   dependsOn: Build_and_UnitTest
+  condition: "succeeded()"
   variables:
     BuildNumber: $[dependencies.Build_and_UnitTest.outputs['RTM.configuration.BuildNumber']]
   condition: "succeeded()"

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -396,6 +396,22 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
       scriptPath: "scripts/funcTests/runFuncTests.sh"
       disableAutoCwd: "true"
       cwd: "$(Build.Repository.LocalPath)"
+  
+  - task: ms-devlabs.utilitytasks.task-Shellpp.Shell++@0
+    inputs:
+      type: "InlineScript"
+      cwd: "$(Build.Repository.LocalPath)"
+      script: |
+        export JOBSTATUS=`env | grep agent\\.jobstatus | awk -F'=' '{print $2}'`;echo $JOBSTATUS
+        if [ "$JOBSTATUS" == "Succeeded" ]; then
+            STATE="success"
+            DESCRIPTION="succeeded"
+        else
+          STATE="failure"
+          DESCRIPTION="failed"
+        fi
+        curl -H "Authorization: token $NUGETLURKERPERSONALACCESSTOKEN" https://api.github.com/repos/nuget/nuget.client/statuses/$BUILD_SOURCEVERSION --data '{"state":"$STATE","context":"Tests On Linux", "description":"$DESCRIPTION", "target_url":"$BUILDURL"}'
+    condition: "always()"
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
@@ -430,6 +446,22 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
       scriptPath: "scripts/funcTests/runFuncTests.sh"
       disableAutoCwd: "true"
       cwd: "$(Build.Repository.LocalPath)"
+
+  - task: ms-devlabs.utilitytasks.task-Shellpp.Shell++@0
+    inputs:
+      type: "InlineScript"
+      cwd: "$(Build.Repository.LocalPath)"
+      script: |
+        export JOBSTATUS=`env | grep agent\\.jobstatus | awk -F'=' '{print $2}'`;echo $JOBSTATUS
+        if [ "$JOBSTATUS" == "Succeeded" ]; then
+            STATE="success"
+            DESCRIPTION="succeeded"
+        else
+          STATE="failure"
+          DESCRIPTION="failed"
+        fi
+        curl -H "Authorization: token $NUGETLURKERPERSONALACCESSTOKEN" https://api.github.com/repos/nuget/nuget.client/statuses/$BUILD_SOURCEVERSION --data '{"state":"$STATE","context":"Tests On Mac", "description":"$DESCRIPTION", "target_url":"$BUILDURL"}'
+    condition: "always()"
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -15,7 +15,7 @@ phases:
     inputs:
       scriptType: "inlineScript"
       inlineScript: |
-        . $(Build.Repository.LocalPath)\\scripts\utils\\PostGitCommitStatus.ps1
+        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
         InitializeAllTestsToPending -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion)
 
 - phase: Build_and_UnitTest
@@ -105,7 +105,7 @@ phases:
     inputs:
       scriptType: "inlineScript"
       inlineScript: |
-        . $(Build.Repository.LocalPath)\\scripts\utils\\PostGitCommitStatus.ps1
+        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
         SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Unit Tests On Windows"
     condition: "and(always(),eq(variables['BuildRTM'], 'true'))"
 
@@ -355,7 +355,7 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
     inputs:
       scriptType: "inlineScript"
       inlineScript: |
-        . $(Build.Repository.LocalPath)\\scripts\utils\\PostGitCommitStatus.ps1
+        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
         SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Functional Tests On Windows"
     condition: "always()"
 
@@ -452,190 +452,216 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
     condition: "succeededOrFailed()"
 
 
-# - phase: End_To_End_Tests_On_Windows
-#   dependsOn: Build_and_UnitTest
-#   variables:
-#     BuildNumber: $[dependencies.Build_and_UnitTest.outputs['RTM.configuration.BuildNumber']]
-#   condition: "succeeded()"
-#   queue:
-#     name: DDNuGet-Windows
-#     timeoutInMinutes: 75
-#     demands: DotNetFramework
+- phase: End_To_End_Tests_On_Windows
+  dependsOn: Build_and_UnitTest
+  variables:
+    BuildNumber: $[dependencies.Build_and_UnitTest.outputs['RTM.configuration.BuildNumber']]
+  condition: "succeeded()"
+  queue:
+    name: DDNuGet-Windows
+    timeoutInMinutes: 75
+    demands: DotNetFramework
 
 
-#   steps:
-#   - task: PowerShell@1
-#     displayName: "Print Environment Variables"
-#     inputs:
-#       scriptType: "inlineScript"
-#       inlineScript: "gci env:* | sort-object name;
-#       Write-Host \"##vso[build.updatebuildnumber]$env:BuildNumber\""    
+  steps:
+  - task: PowerShell@1
+    displayName: "Print Environment Variables"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: "gci env:* | sort-object name;
+      Write-Host \"##vso[build.updatebuildnumber]$env:BuildNumber\""    
 
-#   - task: PowerShell@1
-#     displayName: "Bootstrap.ps1"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
-#       arguments: "-NuGetDropPath $(BuildOutputTargetPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
+  - task: PowerShell@1
+    displayName: "Bootstrap.ps1"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
+      arguments: "-NuGetDropPath $(BuildOutputTargetPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
 
-#   - task: PowerShell@1
-#     displayName: "SetupFunctionalTests.ps1"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
-#       arguments: "-VSVersion 15.0"
+  - task: PowerShell@1
+    displayName: "SetupFunctionalTests.ps1"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
+      arguments: "-VSVersion 15.0"
 
-#   - task: PowerShell@1
-#     displayName: "CopyToolsAndSetupMachine.ps1"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\CopyToolsAndSetupMachine.ps1"
-#       arguments: " -NuGetCIToolsFolder $(NuGetCIToolsFolder) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts"
+  - task: PowerShell@1
+    displayName: "CopyToolsAndSetupMachine.ps1"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\CopyToolsAndSetupMachine.ps1"
+      arguments: " -NuGetCIToolsFolder $(NuGetCIToolsFolder) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts"
 
-#   - task: PowerShell@1
-#     displayName: "InstallNuGetVSIX.ps1"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
-#       arguments: "-NuGetDropPath $(BuildOutputTargetPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 15.0"
-#       failOnStandardError: "false"
+  - task: PowerShell@1
+    displayName: "InstallNuGetVSIX.ps1"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
+      arguments: "-NuGetDropPath $(BuildOutputTargetPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 15.0"
+      failOnStandardError: "false"
 
-#   - task: PowerShell@1
-#     displayName: "LaunchVS.ps1"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\LaunchVS.ps1"
-#       arguments: "-VSVersion 15.0 -DTEReadyPollFrequencyInSecs 6 -NumberOfPolls 50"
+  - task: PowerShell@1
+    displayName: "Collect VS Logs"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        Invoke-WebRequest -Uri $(CollectExeUrl) -OutFile $(System.DefaultWorkingDirectory)\\NuGet.Client\\VSCollect.exe
+        if(-not (Test-Path $(EndToEndResultsDropPath)))
+          {
+            New-Item -Path $(EndToEndResultsDropPath) -ItemType Directory -Force
+          }
+        $(System.DefaultWorkingDirectory)\\NuGet.Client\\VSCollect.exe -zip:$(EndToEndResultsDropPath)\\e2e-collectlogs.zip
+    condition: "failed()"
 
-#   - task: PowerShell@1
-#     displayName: "RunFunctionalTests.ps1"
-#     continueOnError: "true"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
-#       arguments: "-PMCCommand $(EndToEndTestCommandToRun) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 15.0"
+  - task: PowerShell@1
+    displayName: "LaunchVS.ps1"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\LaunchVS.ps1"
+      arguments: "-VSVersion 15.0 -DTEReadyPollFrequencyInSecs 6 -NumberOfPolls 50"
 
-#   - task: PowerShell@1
-#       displayName: "Initialize Git Commit Status on GitHub"
-#       inputs:
-#         scriptType: "inlineScript"
-#         inlineScript: |
-#           . $(Build.Repository.LocalPath)\\scripts\utils\\PostGitCommitStatus.ps1
-#           SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "EndToEnd Tests On Windows"
-#       condition: "always()"
+  - task: PowerShell@1
+    displayName: "RunFunctionalTests.ps1"
+    continueOnError: "true"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
+      arguments: "-PMCCommand $(EndToEndTestCommandToRun) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 15.0"
 
-#   - task: PublishTestResults@2
-#     displayName: "Publish Test Results"
-#     inputs:
-#       testRunner: "JUnit"
-#       testResultsFiles: "*.xml"
-#       searchFolder: "$(System.DefaultWorkingDirectory)\\testresults"
-#       mergeTestResults: "true"
-#       testRunTitle: "NuGet.Client End To End Tests "
-#     condition: "succeededOrFailed()"
+  - task: PowerShell@1
+    displayName: "Initialize Git Commit Status on GitHub"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
+        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "EndToEnd Tests On Windows"
+    condition: "always()"
+
+  - task: PublishTestResults@2
+    displayName: "Publish Test Results"
+    inputs:
+      testRunner: "JUnit"
+      testResultsFiles: "*.xml"
+      searchFolder: "$(System.DefaultWorkingDirectory)\\testresults"
+      mergeTestResults: "true"
+      testRunTitle: "NuGet.Client End To End Tests "
+    condition: "succeededOrFailed()"
 
 
-# - phase: Apex_Tests_On_Windows
-#   dependsOn: Build_and_UnitTest
-#   variables:
-#     BuildNumber: $[dependencies.Build_and_UnitTest.outputs['RTM.configuration.BuildNumber']]
-#   condition: "succeeded()"
-#   queue:
-#     name: DDNuGet-Windows
-#     timeoutInMinutes: 45
-#     demands: DotNetFramework
+- phase: Apex_Tests_On_Windows
+  dependsOn: Build_and_UnitTest
+  variables:
+    BuildNumber: $[dependencies.Build_and_UnitTest.outputs['RTM.configuration.BuildNumber']]
+  condition: "succeeded()"
+  queue:
+    name: DDNuGet-Windows
+    timeoutInMinutes: 45
+    demands: DotNetFramework
 
-#   steps:
-#   - task: PowerShell@1
-#     displayName: "Print Environment Variables"
-#     inputs:
-#       scriptType: "inlineScript"
-#       inlineScript: "gci env:* | sort-object name;
-#       Write-Host \"##vso[build.updatebuildnumber]$env:BuildNumber\""
+  steps:
+  - task: PowerShell@1
+    displayName: "Print Environment Variables"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: "gci env:* | sort-object name;
+      Write-Host \"##vso[build.updatebuildnumber]$env:BuildNumber\""
 
-#   - task: PowerShell@1
-#     displayName: "Configre.ps1"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)/configure.ps1"
-#       arguments: "-Force -CI"
+  - task: PowerShell@1
+    displayName: "Configure.ps1"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)/configure.ps1"
+      arguments: "-Force -CI"
 
-#   - task: CopyFiles@2
-#     displayName: "Copy Public Key Files"
-#     inputs:
-#       SourceFolder: "$(NuGetSharePublicKeys)"
-#       Contents: "*.snk"
-#       TargetFolder: "$(Build.Repository.LocalPath)\\keys"
-#       CleanTargetFolder: "true"
-#       OverWrite: "true"
-#       flattenFolders: "true"
+  - task: CopyFiles@2
+    displayName: "Copy Public Key Files"
+    inputs:
+      SourceFolder: "$(NuGetSharePublicKeys)"
+      Contents: "*.snk"
+      TargetFolder: "$(Build.Repository.LocalPath)\\keys"
+      CleanTargetFolder: "true"
+      OverWrite: "true"
+      flattenFolders: "true"
 
-#   - task: PowerShell@1
-#     displayName: "Bootstrap.ps1"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
-#       arguments: "-NuGetDropPath $(BuildOutputTargetPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
+  - task: PowerShell@1
+    displayName: "Bootstrap.ps1"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
+      arguments: "-NuGetDropPath $(BuildOutputTargetPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
 
-#   - task: PowerShell@1
-#     displayName: "SetupFunctionalTests.ps1"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
-#       arguments: "-VSVersion 15.0"
+  - task: PowerShell@1
+    displayName: "SetupFunctionalTests.ps1"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
+      arguments: "-VSVersion 15.0"
 
-#   - task: PowerShell@1
-#     displayName: "CopyToolsAndSetupMachine.ps1"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\CopyToolsAndSetupMachine.ps1"
-#       arguments: " -NuGetCIToolsFolder $(NuGetCIToolsFolder) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts"
+  - task: PowerShell@1
+    displayName: "CopyToolsAndSetupMachine.ps1"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\CopyToolsAndSetupMachine.ps1"
+      arguments: " -NuGetCIToolsFolder $(NuGetCIToolsFolder) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts"
 
-#   - task: PowerShell@1
-#     displayName: "InstallNuGetVSIX.ps1"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
-#       arguments: "-NuGetDropPath $(BuildOutputTargetPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 15.0"
-#       failOnStandardError: "false"
+  - task: PowerShell@1
+    displayName: "InstallNuGetVSIX.ps1"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
+      arguments: "-NuGetDropPath $(BuildOutputTargetPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 15.0"
+      failOnStandardError: "false"
 
-#   - task: MSBuild@1
-#     displayName: "Restore for VS2017"
-#     inputs:
-#       solution: "build\\build.proj"
-#       msbuildVersion: "15.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/t:RestoreVS15 /p:BuildNumber=$(Build.BuildNumber)"
+  - task: PowerShell@1
+    displayName: "Collect VS Logs"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        Invoke-WebRequest -Uri $(CollectExeUrl) -OutFile $(System.DefaultWorkingDirectory)\\NuGet.Client\\VSCollect.exe
+        if(-not (Test-Path $(EndToEndResultsDropPath)))
+          {
+            New-Item -Path $(EndToEndResultsDropPath) -ItemType Directory -Force
+          }
+        $(System.DefaultWorkingDirectory)\\NuGet.Client\\VSCollect.exe -zip:$(EndToEndResultsDropPath)\\apex-collectlogs.zip
+    condition: "failed()"
+
+  - task: MSBuild@1
+    displayName: "Restore for VS2017"
+    inputs:
+      solution: "build\\build.proj"
+      msbuildVersion: "15.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:RestoreVS15 /p:BuildNumber=$(Build.BuildNumber)"
       
-#   - task: NuGetCommand@2
-#     displayName: "Add Apex Feed Source"
-#     inputs:
-#       command: "custom"
-#       arguments: "sources add -Name ApexFeed -Source $(ApexPackageFeedUrl) -UserName $(ApexPackageFeedUsername) -Password $(ApexPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\\NuGet.config"
+  - task: NuGetCommand@2
+    displayName: "Add Apex Feed Source"
+    inputs:
+      command: "custom"
+      arguments: "sources add -Name ApexFeed -Source $(ApexPackageFeedUrl) -UserName $(ApexPackageFeedUsername) -Password $(ApexPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\\NuGet.config"
 
-#   - task: MSBuild@1
-#     displayName: "Restore Apex Tests"
-#     inputs:
-#       solution: "build\\build.proj"
-#       msbuildVersion: "15.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/t:RestoreApex /p:BuildNumber=$(Build.BuildNumber)"
+  - task: MSBuild@1
+    displayName: "Restore Apex Tests"
+    inputs:
+      solution: "build\\build.proj"
+      msbuildVersion: "15.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:RestoreApex /p:BuildNumber=$(Build.BuildNumber)"
 
-#   - task: MSBuild@1
-#     displayName: "Run Apex Tests"
-#     continueOnError: "true"
-#     inputs:
-#       solution: "build\\build.proj"
-#       msbuildVersion: "15.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml  /p:NUGET_PFX_PATH=$(System.DefaultWorkingDirectory)\\keys\\NuGetKey.snk /p:MS_PFX_PATH=$(System.DefaultWorkingDirectory)\\keys\\35MSSharedLib1024.snk /p:BuildNumber=$(Build.BuildNumber)"
+  - task: MSBuild@1
+    displayName: "Run Apex Tests"
+    continueOnError: "true"
+    inputs:
+      solution: "build\\build.proj"
+      msbuildVersion: "15.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml  /p:NUGET_PFX_PATH=$(System.DefaultWorkingDirectory)\\keys\\NuGetKey.snk /p:MS_PFX_PATH=$(System.DefaultWorkingDirectory)\\keys\\35MSSharedLib1024.snk /p:BuildNumber=$(Build.BuildNumber)"
 
-#   - task: PowerShell@1
-#       displayName: "Initialize Git Commit Status on GitHub"
-#       inputs:
-#         scriptType: "inlineScript"
-#         inlineScript: |
-#           . $(Build.Repository.LocalPath)\\scripts\utils\\PostGitCommitStatus.ps1
-#           SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Apex Tests On Windows"
-#       condition: "always()"
+  - task: PowerShell@1
+    displayName: "Initialize Git Commit Status on GitHub"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
+        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Apex Tests On Windows"
+    condition: "always()"
 
-#   - task: PublishTestResults@2
-#     displayName: "Publish Test Results"
-#     inputs:
-#       testRunner: "XUnit"
-#       testResultsFiles: "*.xml"
-#       searchFolder: "$(System.DefaultWorkingDirectory)\\artifacts\\testresults"
-#       mergeTestResults: "true"
-#       testRunTitle: "NuGet.Client Apex Tests"
-#     condition: "succeededOrFailed()"
+  - task: PublishTestResults@2
+    displayName: "Publish Test Results"
+    inputs:
+      testRunner: "XUnit"
+      testResultsFiles: "*.xml"
+      searchFolder: "$(System.DefaultWorkingDirectory)\\artifacts\\testresults"
+      mergeTestResults: "true"
+      testRunTitle: "NuGet.Client Apex Tests"
+    condition: "succeededOrFailed()"
     
     

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -299,10 +299,9 @@ phases:
     inputs:
       scriptType: "inlineScript"
       arguments: "-BuildOutputTargetPath $(BuildOutputTargetPath)"
-      inlineScript: "param(
-[string]$BuildOutputTargetPath
-)
-Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
+      inlineScript: |
+        param([string]$BuildOutputTargetPath)
+        Remove-Item -Path $BuildOutputTargetPath -Force -Recurse
     condition: "eq(variables['Agent.JobStatus'], 'Failed')"
 
 
@@ -396,21 +395,14 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
       scriptPath: "scripts/funcTests/runFuncTests.sh"
       disableAutoCwd: "true"
       cwd: "$(Build.Repository.LocalPath)"
-  
+
   - task: ms-devlabs.utilitytasks.task-Shellpp.Shell++@0
+    displayName: "Initialize Git Commit Status on GitHub"
     inputs:
-      type: "InlineScript"
+      type: "FilePath"
+      scriptPath: "scripts/utils/PostGitCommitStatus.sh"
+      args: "'$(NuGetLurkerPersonalAccessToken)' 'Tests On Linux' '$(Agent.JobStatus)'"
       cwd: "$(Build.Repository.LocalPath)"
-      script: |
-        export JOBSTATUS=`env | grep agent\\.jobstatus | awk -F'=' '{print $2}'`;echo $JOBSTATUS
-        if [ "$JOBSTATUS" == "Succeeded" ]; then
-            STATE="success"
-            DESCRIPTION="succeeded"
-        else
-          STATE="failure"
-          DESCRIPTION="failed"
-        fi
-        curl -H "Authorization: token $NUGETLURKERPERSONALACCESSTOKEN" https://api.github.com/repos/nuget/nuget.client/statuses/$BUILD_SOURCEVERSION --data '{"state":"$STATE","context":"Tests On Linux", "description":"$DESCRIPTION", "target_url":"$BUILDURL"}'
     condition: "always()"
 
   - task: PublishTestResults@2
@@ -448,19 +440,12 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
       cwd: "$(Build.Repository.LocalPath)"
 
   - task: ms-devlabs.utilitytasks.task-Shellpp.Shell++@0
+    displayName: "Initialize Git Commit Status on GitHub"
     inputs:
-      type: "InlineScript"
+      type: "FilePath"
+      scriptPath: "scripts/utils/PostGitCommitStatus.sh"
+      args: "'$(NuGetLurkerPersonalAccessToken)' 'Tests On Mac' '$(Agent.JobStatus)'"
       cwd: "$(Build.Repository.LocalPath)"
-      script: |
-        export JOBSTATUS=`env | grep agent\\.jobstatus | awk -F'=' '{print $2}'`;echo $JOBSTATUS
-        if [ "$JOBSTATUS" == "Succeeded" ]; then
-            STATE="success"
-            DESCRIPTION="succeeded"
-        else
-          STATE="failure"
-          DESCRIPTION="failed"
-        fi
-        curl -H "Authorization: token $NUGETLURKERPERSONALACCESSTOKEN" https://api.github.com/repos/nuget/nuget.client/statuses/$BUILD_SOURCEVERSION --data '{"state":"$STATE","context":"Tests On Mac", "description":"$DESCRIPTION", "target_url":"$BUILDURL"}'
     condition: "always()"
 
   - task: PublishTestResults@2

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -75,6 +75,7 @@ phases:
 
   - task: MSBuild@1
     displayName: "Run unit tests"
+    continueOnError: "true"
     inputs:
       solution: "build\\build.proj"
       msbuildVersion: "15.0"
@@ -315,6 +316,7 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
 
   - task: MSBuild@1
     displayName: "Run Functional Tests"
+    continueOnError: "true"
     inputs:
       solution: "build\\build.proj"
       msbuildVersion: "15.0"
@@ -323,6 +325,7 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
 
   - task: PublishTestResults@2
     displayName: "Publish Desktop Test Results"
+    continueOnError: "true"
     inputs:
       testRunner: "XUnit"
       testResultsFiles: "*.xml"
@@ -351,6 +354,7 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
   steps:
   - task: ShellScript@2
     displayName: "Run Tests"
+    continueOnError: "true"
     inputs:
       scriptPath: "scripts/funcTests/runFuncTests.sh"
       disableAutoCwd: "true"
@@ -384,6 +388,7 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
 
   - task: ShellScript@2
     displayName: "Run Tests"
+    continueOnError: "true"
     inputs:
       scriptPath: "scripts/funcTests/runFuncTests.sh"
       disableAutoCwd: "true"
@@ -462,6 +467,7 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
 
 #   - task: PowerShell@1
 #     displayName: "RunFunctionalTests.ps1"
+#     continueOnError: "true"
 #     inputs:
 #       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
 #       arguments: "-PMCCommand $(EndToEndTestCommandToRun) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 15.0"
@@ -560,6 +566,7 @@ Remove-Item -Path $BuildOutputTargetPath -Force -Recurse"
 
 #   - task: MSBuild@1
 #     displayName: "Run Apex Tests"
+#     continueOnError: "true"
 #     inputs:
 #       solution: "build\\build.proj"
 #       msbuildVersion: "15.0"

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -114,7 +114,7 @@ phases:
     inputs:
       testRunner: "XUnit"
       testResultsFiles: "*.xml"
-      testRunTitle: "NuGet.Client Unit Tests On Windows"
+      testRunTitle: "NuGet.Client Desktop Unit Tests On Windows"
       searchFolder: "$(Build.Repository.LocalPath)\\artifacts\\TestResults"
       mergeTestResults: "true"
       publishRunAttachments: "false"
@@ -125,7 +125,7 @@ phases:
     inputs:
       testRunner: "VSTest"
       testResultsFiles: "*.trx"
-      testRunTitle: "NuGet.Client Unit Tests On Windows"
+      testRunTitle: "NuGet.Client .NET Core Unit Tests On Windows"
       searchFolder: "$(Build.Repository.LocalPath)\\artifacts\\TestResults"
       mergeTestResults: "true"
       publishRunAttachments: "false"
@@ -211,8 +211,9 @@ phases:
       SourceFolder: "artifacts"
       Contents: |
         $(VsixPublishDir)\\NuGet.exe
+        $(VsixPublishDir)\\NuGet.pdb
         $(VsixPublishDir)\\NuGet.Mssign.exe
-        $(VsixPublishDir)\\NuGet.pdb 
+        $(VsixPublishDir)\\NuGet.Mssign.pdb
         $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.Core.json 
         $(VsixPublishDir)\\NuGet.Tools.vsix
         $(VsixPublishDir)\\EndToEnd.zip 
@@ -241,7 +242,7 @@ phases:
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\PublishArtifactsFromVsts.ps1"
       arguments: "-NuGetBuildFeedUrl $(NuGetBuildFeed) -NuGetBuildSymbolsFeedUrl $(NuGetBuildSymbolsFeed) -DotnetCoreFeedUrl $(DotnetCoreBuildFeed) -DotnetCoreSymbolsFeedUrl $(DotnetCoreSymbolsFeed) -NuGetBuildFeedApiKey $(NuGetBuildApiKey) -DotnetCoreFeedApiKey $(DotnetCoreFeedApiKey)"
-      failOnStandardError: "false"
+      failOnStandardError: "true"
     condition: " and(succeeded(),eq(variables['PublishArtifactsToMyGet'], 'true'), eq(variables['BuildRTM'], 'false')) "
 
   - task: MSBuild@1
@@ -301,7 +302,8 @@ phases:
       arguments: "-BuildOutputTargetPath $(BuildOutputTargetPath)"
       inlineScript: |
         param([string]$BuildOutputTargetPath)
-        Remove-Item -Path $BuildOutputTargetPath -Force -Recurse
+        Get-ChildItem $(BuildOutputTargetPath) -Recurse | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue
+        Remove-Item -Path $(BuildOutputTargetPath) -Force -Recurse -ErrorAction SilentlyContinue
     condition: "eq(variables['Agent.JobStatus'], 'Failed')"
 
 
@@ -366,7 +368,7 @@ phases:
       testResultsFiles: "*.xml"
       searchFolder: "$(Build.Repository.LocalPath)\\artifacts\\TestResults"
       mergeTestResults: "true"
-      testRunTitle: "NuGet.Client Functional Tests On Windows"
+      testRunTitle: "NuGet.Client Desktop Functional Tests On Windows"
     condition: "succeededOrFailed()"
 
   - task: PublishTestResults@2
@@ -376,7 +378,7 @@ phases:
       testResultsFiles: "*.trx"
       searchFolder: "$(Build.Repository.LocalPath)\\artifacts\\TestResults"
       mergeTestResults: "true"
-      testRunTitle: "NuGet.Client Funtional Tests On Windows"
+      testRunTitle: "NuGet.Client .NET Core Funtional Tests On Windows"
     condition: "succeededOrFailed()"
 
 - phase: Tests_On_Linux

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -12,7 +12,7 @@ Function Update-GitCommitStatus {
         [Parameter(Mandatory = $True)]
         [string]$TestName,
         [Parameter(Mandatory = $True)]
-        [ValidateSet( "Pending", "Success", "Error", "Failure")]
+        [ValidateSet( "pending", "success", "error", "failure")]
         [string]$Status,
         [Parameter(Mandatory = $True)]
         [string]$CommitSha,
@@ -48,13 +48,13 @@ Function InitializeAllTestsToPending {
         [string]$CommitSha
     )
 
-    $TargetUrl = $BuildUrl -f $(Build.BuildId)
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Unit Tests On Windows" - Status "Pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional Tests On Windows" - Status "Pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests On Mac" - Status "Pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests on Linux" - Status "Pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "EndToEnd Tests On Windows" - Status "Pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Apex Tests On Windows" - Status "Pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
+    $TargetUrl = $env:BUILDURL -f $env:BUILD_BUILDID
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Unit Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests On Mac" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests on Linux" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "EndToEnd Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Apex Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
 }
 
 function SetCommitStatusForTestResult {
@@ -67,11 +67,11 @@ function SetCommitStatusForTestResult {
         [string]$CommitSha
     )
 
-    $TargetUrl = $BuildUrl -f $(Build.BuildId)
-    if ($(Agent.JobStatus) -eq "Succeeded") {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName - Status "Success" -CommitSha $CommitSha -TargetUrl $TargetUrl
+    $TargetUrl = $env:BUILDURL -f $env:BUILD_BUILDID
+    if ($env:AGENT_JOBSTATUS -eq "Succeeded") {
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "success" -CommitSha $CommitSha -TargetUrl $TargetUrl
     }
     else {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName - Status "Failed" -CommitSha $CommitSha -TargetUrl $TargetUrl
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "failure" -CommitSha $CommitSha -TargetUrl $TargetUrl
     }
 }

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -17,7 +17,9 @@ Function Update-GitCommitStatus {
         [Parameter(Mandatory = $True)]
         [string]$CommitSha,
         [Parameter(Mandatory = $True)]
-        [string]$TargetUrl
+        [string]$TargetUrl,
+        [Parameter(Mandatory = $True)]
+        [string]$Description
     )
 
     $Token = $PersonalAccessToken
@@ -31,6 +33,7 @@ Function Update-GitCommitStatus {
         state      = $Status;
         context    = $TestName;
         target_url = $TargetUrl;
+        description = $Description
     } | ConvertTo-Json;
 
     Write-Host $Body
@@ -49,12 +52,12 @@ Function InitializeAllTestsToPending {
     )
 
     $TargetUrl = $env:BUILDURL -f $env:BUILD_BUILDID
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Unit Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests On Mac" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests on Linux" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "EndToEnd Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Apex Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Unit Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl -Description "in progress"
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl -Description "in progress"
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests On Mac" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl -Description "in progress"
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests on Linux" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl -Description "in progress"
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "EndToEnd Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl -Description "in progress"
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Apex Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl -Description "in progress"
 }
 
 function SetCommitStatusForTestResult {
@@ -69,9 +72,9 @@ function SetCommitStatusForTestResult {
 
     $TargetUrl = $env:BUILDURL -f $env:BUILD_BUILDID
     if ($env:AGENT_JOBSTATUS -eq "Succeeded") {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "success" -CommitSha $CommitSha -TargetUrl $TargetUrl
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "success" -CommitSha $CommitSha -TargetUrl $TargetUrl -Description "succeeded"
     }
     else {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "failure" -CommitSha $CommitSha -TargetUrl $TargetUrl
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "failure" -CommitSha $CommitSha -TargetUrl $TargetUrl -Description "failed"
     }
 }

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -1,6 +1,7 @@
 ﻿<#
 .SYNOPSIS
 Script to post status of tests for the commit to GitHub
+https://developer.github.com/v3/repos/statuses/ 
 
 .DESCRIPTION
 Uses the Personal Access Token of NuGetLurker to automate the tagging process.

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -51,13 +51,12 @@ Function InitializeAllTestsToPending {
         [string]$CommitSha
     )
 
-    $TargetUrl = $env:BUILDURL -f $env:BUILD_BUILDID
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Unit Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl -Description "in progress"
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl -Description "in progress"
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests On Mac" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl -Description "in progress"
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests on Linux" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl -Description "in progress"
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "EndToEnd Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl -Description "in progress"
-    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Apex Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $TargetUrl -Description "in progress"
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Unit Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests On Mac" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests on Linux" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "EndToEnd Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Apex Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
 }
 
 function SetCommitStatusForTestResult {
@@ -70,11 +69,10 @@ function SetCommitStatusForTestResult {
         [string]$CommitSha
     )
 
-    $TargetUrl = $env:BUILDURL -f $env:BUILD_BUILDID
     if ($env:AGENT_JOBSTATUS -eq "Succeeded") {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "success" -CommitSha $CommitSha -TargetUrl $TargetUrl -Description "succeeded"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "succeeded"
     }
     else {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "failure" -CommitSha $CommitSha -TargetUrl $TargetUrl -Description "failed"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "failure" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "failed"
     }
 }

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -1,0 +1,77 @@
+﻿<#
+.SYNOPSIS
+Script to post status of tests for the commit to GitHub
+
+.DESCRIPTION
+Uses the Personal Access Token of NuGetLurker to automate the tagging process.
+#>
+Function Update-GitCommitStatus {
+    param(
+        [Parameter(Mandatory = $True)]
+        [string]$PersonalAccessToken,
+        [Parameter(Mandatory = $True)]
+        [string]$TestName,
+        [Parameter(Mandatory = $True)]
+        [ValidateSet( "Pending", "Success", "Error", "Failure")]
+        [string]$Status,
+        [Parameter(Mandatory = $True)]
+        [string]$CommitSha,
+        [Parameter(Mandatory = $True)]
+        [string]$TargetUrl
+    )
+
+    $Token = $PersonalAccessToken
+    $Base64Token = [System.Convert]::ToBase64String([char[]]$Token)
+
+    $Headers = @{
+        Authorization = 'Basic {0}' -f $Base64Token;
+    }
+
+    $Body = @{
+        state      = $Status;
+        context    = $TestName;
+        target_url = $TargetUrl;
+    } | ConvertTo-Json;
+
+    Write-Host $Body
+
+    $r1 = Invoke-RestMethod -Headers $Headers -Method Post -Uri "https://api.github.com/repos/nuget/nuget.client/statuses/$CommitSha" -Body $Body
+
+    Write-Host $r1
+}
+
+Function InitializeAllTestsToPending {
+    param(
+        [Parameter(Mandatory = $True)]
+        [string]$PersonalAccessToken,
+        [Parameter(Mandatory = $True)]
+        [string]$CommitSha
+    )
+
+    $TargetUrl = $BuildUrl -f $(Build.BuildId)
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Unit Tests On Windows" - Status "Pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional Tests On Windows" - Status "Pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests On Mac" - Status "Pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests on Linux" - Status "Pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "EndToEnd Tests On Windows" - Status "Pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
+    Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Apex Tests On Windows" - Status "Pending" -CommitSha $CommitSha -TargetUrl $TargetUrl
+}
+
+function SetCommitStatusForTestResult {
+    param(
+        [Parameter(Mandatory = $True)]
+        [string]$PersonalAccessToken,
+        [Parameter(Mandatory = $True)]
+        [string]$TestName,
+        [Parameter(Mandatory = $True)]
+        [string]$CommitSha
+    )
+
+    $TargetUrl = $BuildUrl -f $(Build.BuildId)
+    if ($(Agent.JobStatus) -eq "Succeeded") {
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName - Status "Success" -CommitSha $CommitSha -TargetUrl $TargetUrl
+    }
+    else {
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName - Status "Failed" -CommitSha $CommitSha -TargetUrl $TargetUrl
+    }
+}

--- a/scripts/utils/PostGitCommitStatus.sh
+++ b/scripts/utils/PostGitCommitStatus.sh
@@ -4,7 +4,7 @@
 echo "$1"
 echo "$2"
 echo "$3"
-if [ "$3" = "Succeeded" ]; then
+if [ "$3" == "Succeeded" ]; then
     echo "Tests succeeded"
     STATE="success"
     DESCRIPTION="succeeded"
@@ -14,4 +14,4 @@ else
     DESCRIPTION="failed"
 fi
 
-curl -H "Authorization: token '$1'" https://api.github.com/repos/rohit21agrawal/nuget.client/statuses/$BUILD_SOURCEVERSION --data '{"state":"$STATE","context":"$2", "description":"$DESCRIPTION", "target_url":"$BUILDURL"}'
+curl -u nugetlurker:$1 https://api.github.com/repos/nuget/nuget.client/statuses/$BUILD_SOURCEVERSION --data "{\"state\":\"$STATE\",\"context\":\"$2\", \"description\":\"$DESCRIPTION\", \"target_url\":\"$BUILDURL\"}"

--- a/scripts/utils/PostGitCommitStatus.sh
+++ b/scripts/utils/PostGitCommitStatus.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#This script is called for Mac/Linux agents and provided 3 positional arguments - the first one being the PAT for NuGetLurker account,
+#the second one is the context value for the github api and the third one is the value of env variable agent.jobstatus
+echo "$1"
+echo "$2"
+echo "$3"
+if [ "$3" = "Succeeded" ]; then
+    echo "Tests succeeded"
+    STATE="success"
+    DESCRIPTION="succeeded"
+else
+    echo "Tests failed or were cancelled"
+	STATE="failure"
+    DESCRIPTION="failed"
+fi
+
+curl -H "Authorization: token '$1'" https://api.github.com/repos/rohit21agrawal/nuget.client/statuses/$BUILD_SOURCEVERSION --data '{"state":"$STATE","context":"$2", "description":"$DESCRIPTION", "target_url":"$BUILDURL"}'


### PR DESCRIPTION
- adds the capability of each test type being able to report its status to the github PR page 
- doesn't fail a build if tests fail, instead a build will "Succeed with issues". This still allows us to trigger val builds or insertions on that build. The GitHub status will still show failed however for only the test type that failed or "succeeded with issues".
- Brings back end to end tests and apex tests into the build, since their flakiness won't cause builds to fail anymore with the continueOnError behavior as explained above.
- set failOnStandardError to true for Publish Artifacts to MyGet task
- correct the test run title name for .net core and desktop unit/functional tests on windows
- fix the clean up task for scenarios when build fails
- copies the nuget.mssign.pdb file too along with the exe to the ci ouput folder