### PR TITLE
Refresh Manager UI after install or uninstall through PMC

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
@@ -356,6 +356,9 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             {
                 // Execute project actions by Package Manager
                 await PackageManager.ExecuteNuGetProjectActionsAsync(Projects, actions, this, sourceCacheContext, Token);
+
+                // Refresh Manager UI if needed
+                RefreshUI(actions);
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -271,6 +271,13 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             }
         }
 
+        protected void RefreshUI(IEnumerable<NuGetProjectAction> actions)
+        {
+            var resolvedActions = actions.Select(action => new ResolvedAction(action.Project, action));
+
+            VsSolutionManager.OnActionsExecuted(resolvedActions);
+        }
+
         #region Cmdlets base APIs
 
         protected SourceValidationResult ValidateSource(string source)

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/PackageActionBaseCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/PackageActionBaseCommand.cs
@@ -148,6 +148,9 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                     NuGetPackageManager.SetDirectInstall(identity, projectContext);
                     await PackageManager.ExecuteNuGetProjectActionsAsync(project, actions, this, resolutionContext.SourceCacheContext, CancellationToken.None);
                     NuGetPackageManager.ClearDirectInstall(projectContext);
+
+                    // Refresh Manager UI if needed
+                    RefreshUI(actions);
                 }
             }
             catch (InvalidOperationException ex)
@@ -219,6 +222,9 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                     NuGetPackageManager.SetDirectInstall(identity, projectContext);
                     await PackageManager.ExecuteNuGetProjectActionsAsync(project, actions, this, resolutionContext.SourceCacheContext, CancellationToken.None);
                     NuGetPackageManager.ClearDirectInstall(projectContext);
+
+                    // Refresh Manager UI if needed
+                    RefreshUI(actions);
                 }
             }
             catch (InvalidOperationException ex)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -964,7 +964,7 @@ namespace NuGet.PackageManagement.UI
             var solutionManager = Model.Context.SolutionManager;
             solutionManager.NuGetProjectAdded -= SolutionManager_ProjectsChanged;
             solutionManager.NuGetProjectRemoved -= SolutionManager_ProjectsChanged;
-            solutionManager.NuGetProjectUpdated -= SolutionManager_ProjectsChanged;
+            solutionManager.NuGetProjectUpdated -= SolutionManager_ProjectsUpdated;
             solutionManager.NuGetProjectRenamed -= SolutionManager_ProjectRenamed;
             solutionManager.ActionsExecuted -= SolutionManager_ActionsExecuted;
             solutionManager.AfterNuGetCacheUpdated -= SolutionManager_CacheUpdated;


### PR DESCRIPTION
This PR fixes the issue to refresh manager UI after an action is executed through PMC. Right now it only works with net core project and that too because of project system nomination.

Fixes https://github.com/NuGet/Home/issues/5939 

@rrelyea 