### PR TITLE
copy activitylog to ci drop

### DIFF
--- a/scripts/e2etests/LaunchVS.ps1
+++ b/scripts/e2etests/LaunchVS.ps1
@@ -23,7 +23,7 @@ function LaunchVSAndWaitForDTE {
 
     if($ActivityLogFullPath)
     {
-        LaunchVS -VSVersion $VSVersion -ActivitiyLogFullPath $ActivityLogFullPath
+        LaunchVS -VSVersion $VSVersion -ActivityLogFullPath $ActivityLogFullPath
     }
     else {
         LaunchVS -VSVersion $VSVersion

--- a/scripts/e2etests/LaunchVS.ps1
+++ b/scripts/e2etests/LaunchVS.ps1
@@ -1,39 +1,45 @@
 param (
-[Parameter(Mandatory=$true)]
-[ValidateSet("15.0", "14.0", "12.0", "11.0", "10.0")]
-[string]$VSVersion,
-[Parameter(Mandatory=$true)]
-$DTEReadyPollFrequencyInSecs,
-[Parameter(Mandatory=$true)]
-$NumberOfPolls)
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("15.0", "14.0", "12.0", "11.0", "10.0")]
+    [string]$VSVersion,
+    [Parameter(Mandatory = $true)]
+    $DTEReadyPollFrequencyInSecs,
+    [Parameter(Mandatory = $true)]
+    $NumberOfPolls)
 
-trap
-{
+trap {
     Write-Host $_.Exception -ForegroundColor Red
     exit 1
 }
 
 . "$PSScriptRoot\VSUtils.ps1"
 
-function LaunchVSAndWaitForDTE
-{
+function LaunchVSAndWaitForDTE {
+    param (
+        [string]$ActivityLogFullPath
+    )
+
     KillRunningInstancesOfVS
 
-    LaunchVS $VSVersion
+    if($ActivityLogFullPath)
+    {
+        LaunchVS -VSVersion $VSVersion -ActivitiyLogFullPath $ActivityLogFullPath
+    }
+    else {
+        LaunchVS -VSVersion $VSVersion
+    }
 
     $dte2 = $null
     $count = 0
     Write-Host "Will wait for $NumberOfPolls times and $DTEReadyPollFrequencyInSecs seconds each time."
 
-    while($count -lt $NumberOfPolls)
-    {
+    while ($count -lt $NumberOfPolls) {
         # Wait for $VSLaunchWaitTimeInSecs secs for VS to load before getting the DTE COM object
         Write-Host "Waiting for $DTEReadyPollFrequencyInSecs seconds for DTE to become available"
         start-sleep $DTEReadyPollFrequencyInSecs
 
         $dte2 = GetDTE2 $VSVersion
-        if ($dte2)
-        {
+        if ($dte2) {
             Write-Host 'Obtained DTE. Wait for 5 seconds...'
             start-sleep 5
             return $true
@@ -44,12 +50,10 @@ function LaunchVSAndWaitForDTE
 }
 
 $result = LaunchVSAndWaitForDTE
-if ($result -eq $true)
-{
+if ($result -eq $true) {
     Write-Host 'Do the kill VS, Launch VS and wait for DTE one more time'
-    $result = LaunchVSAndWaitForDTE
-    if ($result -eq $true)
-    {
+    $result = LaunchVSAndWaitForDTE -ActivityLogFullPath $env:ActivityLogFullPath
+    if ($result -eq $true) {
         exit 0
     }
 }

--- a/scripts/e2etests/LaunchVS.ps1
+++ b/scripts/e2etests/LaunchVS.ps1
@@ -21,8 +21,7 @@ function LaunchVSAndWaitForDTE {
 
     KillRunningInstancesOfVS
 
-    if($ActivityLogFullPath)
-    {
+    if ($ActivityLogFullPath) {
         LaunchVS -VSVersion $VSVersion -ActivityLogFullPath $ActivityLogFullPath
     }
     else {

--- a/scripts/e2etests/NuGetFunctionalTestUtils.ps1
+++ b/scripts/e2etests/NuGetFunctionalTestUtils.ps1
@@ -222,6 +222,13 @@ function CopyResultsToCI
             New-Item -Path $env:EndToEndResultsDropPath -ItemType Directory -Force
         }
         Copy-Item $FullLogFilePath -Destination $env:EndToEndResultsDropPath -Force  -ErrorAction SilentlyContinue
+        
+        if($env:ActivityLogFullPath) 
+        {
+            Write-Host "Copying activity log file from $env:ActivityLogFullPath to $env:EndToEndResultsDropPath"
+            Copy-Item $env:ActivityLogFullPath -Destination $env:EndToEndResultsDropPath -Force  -ErrorAction SilentlyContinue
+        }
+
         Write-Host "Copying test results file from $resultsFile to $env:EndToEndResultsDropPath"
         Copy-Item $resultsFile -Destination $env:EndToEndResultsDropPath -Force -ErrorAction SilentlyContinue
     }

--- a/scripts/e2etests/NuGetFunctionalTestUtils.ps1
+++ b/scripts/e2etests/NuGetFunctionalTestUtils.ps1
@@ -152,6 +152,7 @@ function RealTimeLogResults
                 else
                 {
                     Write-Error $logContentLastLine
+                    CopyActivityLogToCI
                 }
 
                 $resultsFile = Join-Path $currentBinFolder.FullName results.html
@@ -177,6 +178,7 @@ function RealTimeLogResults
         $errorMessage = 'Run Failed - Results.html did not get created. ' `
         + 'This indicates that the tests did not finish running. It could be that the VS crashed or a test timed out. Please investigate.'
         CopyResultsToCI $NuGetDropPath $RunCounter $testResults
+        CopyActivityLogToCI
         # if($env:CI)
         # {
         ## Running into some hangs, so comment it out for now.
@@ -222,18 +224,21 @@ function CopyResultsToCI
             New-Item -Path $env:EndToEndResultsDropPath -ItemType Directory -Force
         }
         Copy-Item $FullLogFilePath -Destination $env:EndToEndResultsDropPath -Force  -ErrorAction SilentlyContinue
-        
-        if($env:ActivityLogFullPath) 
-        {
-            Write-Host "Copying activity log file from $env:ActivityLogFullPath to $env:EndToEndResultsDropPath"
-            Copy-Item $env:ActivityLogFullPath -Destination $env:EndToEndResultsDropPath -Force  -ErrorAction SilentlyContinue
-        }
 
         Write-Host "Copying test results file from $resultsFile to $env:EndToEndResultsDropPath"
         Copy-Item $resultsFile -Destination $env:EndToEndResultsDropPath -Force -ErrorAction SilentlyContinue
     }
 
     OutputResultsForCI -NuGetDropPath $NuGetDropPath -RunCounter $RunCounter -RealTimeResultsFilePath $RealTimeResultsFilePath
+}
+
+function CopyActivityLogToCI
+{    
+    if($env:ActivityLogFullPath) 
+    {
+        Write-Host "Copying activity log file from $env:ActivityLogFullPath to $env:EndToEndResultsDropPath"
+        Copy-Item $env:ActivityLogFullPath -Destination $env:EndToEndResultsDropPath -Force  -ErrorAction SilentlyContinue
+    }
 }
 
 function OutputResultsForCI

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -65,13 +65,19 @@ function LaunchVS {
     param(
         [Parameter(Mandatory = $true)]
         [ValidateSet("15.0", "14.0", "12.0", "11.0", "10.0")]
-        [string]$VSVersion
+        [string]$VSVersion,
+        [string]$ActivityLogFullPath
     )
 
     $VSIDEFolderPath = GetVSIDEFolderPath $VSVersion
     $VSPath = Join-Path $VSIDEFolderPath "devenv.exe"
     Write-Host 'Starting ' $VSPath
-    start-process $VSPath
+    if ($ActivityLogFullPath) {
+        start-process $VSPath -ArgumentList "/log $ActivityLogFullPath"
+    }
+    else {
+        start-process $VSPath
+    }
 }
 
 function GetDTE2 {


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/6368

Enables copying of activity logs to the CI Drop in case of a test failure or time out.