### PR TITLE
kill dotnet.exe and devenv.exe on cleanup

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -561,6 +561,15 @@ phases:
       testRunTitle: "NuGet.Client End To End Tests "
     condition: "succeededOrFailed()"
 
+  - task: PowerShell@1
+    displayName: "Kill running instances of DevEnv"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        . $(Build.Repository.LocalPath)\\scripts\\e2etests\\VSUtils.ps1
+        KillRunningInstancesOfVS
+    condition: "always()"
+
 
 - phase: Apex_Tests_On_Windows
   dependsOn: Build_and_UnitTest
@@ -684,5 +693,14 @@ phases:
       mergeTestResults: "true"
       testRunTitle: "NuGet.Client Apex Tests"
     condition: "succeededOrFailed()"
+
+  - task: PowerShell@1
+    displayName: "Kill running instances of DevEnv"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        . $(Build.Repository.LocalPath)\\scripts\\e2etests\\VSUtils.ps1
+        KillRunningInstancesOfVS
+    condition: "always()"
     
     

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
@@ -187,8 +187,27 @@ namespace Dotnet.Integration.Test
 
         public void Dispose()
         {
-
+            KillDotnetExe(TestDotnetCli);
             DeleteDirectory(Path.GetDirectoryName(TestDotnetCli));
+        }
+
+        private static void KillDotnetExe(string pathToDotnetExe)
+        {
+            var processes = Process.GetProcessesByName("dotnet");
+            if(processes != null && processes.Length >=1)
+            {
+                try
+                {
+                    foreach(var process in processes)
+                    {
+                        if(string.Compare(process.MainModule.FileName, Path.GetFullPath(pathToDotnetExe), true) == 0)
+                        {
+                            process.Kill();
+                        }
+                    }
+                }
+                catch { }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
we have been seeing seem "access is denied" related issues in our build, which I suspect are due to some instances of devenv.exe or dotnet.exe that aren't killed even after the build is finished. There is no harm in being extra safe and doing the cleanup manually.