### PR TITLE
Make GetESSCertIDv2Entries public to allow server to prune SignedCms.Certificates

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/AttributeUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/AttributeUtility.cs
@@ -343,8 +343,21 @@ namespace NuGet.Packaging.Signing
         }
 
         // Attribute -> Hashes
-        internal static List<KeyValuePair<Common.HashAlgorithmName, byte[]>> GetESSCertIDv2Entries(CryptographicAttributeObject attribute)
+        public static List<KeyValuePair<Common.HashAlgorithmName, byte[]>> GetESSCertIDv2Entries(CryptographicAttributeObject attribute)
         {
+            if (attribute == null)
+            {
+                throw new ArgumentNullException(nameof(attribute));
+            }
+
+            if (!StringComparer.Ordinal.Equals(Oids.SigningCertificateV2, attribute.Oid.Value))
+            {
+                throw new ArgumentException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.SigningCertificateV2AttributeRequired,
+                    Oids.SigningCertificateV2), nameof(attribute));
+            }
+
             var entries = new List<KeyValuePair<Common.HashAlgorithmName, byte[]>>();
             var reader = attribute.ToDerSequenceReader();
 

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -701,6 +701,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An attribute with &quot;signing-certificate-v2&quot; OID ({0}) is required..
+        /// </summary>
+        internal static string SigningCertificateV2AttributeRequired {
+            get {
+                return ResourceManager.GetString("SigningCertificateV2AttributeRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to String argument &apos;{0}&apos; cannot be null or empty.
         /// </summary>
         internal static string StringCannotBeNullOrEmpty {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -430,4 +430,8 @@ Valid from:</comment>
   <data name="InvalidAuthorSignature" xml:space="preserve">
     <value>The author signature is invalid.</value>
   </data>
+  <data name="SigningCertificateV2AttributeRequired" xml:space="preserve">
+    <value>An attribute with "signing-certificate-v2" OID ({0}) is required.</value>
+    <comment>0 - the expected OID value</comment>
+  </data>
 </root>


### PR DESCRIPTION
Progress on NuGet/Engineering#785.