### PR TITLE
ngen nuget vsix assemblies

### DIFF
--- a/build/common.ngen.props
+++ b/build/common.ngen.props
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0">
+  <ItemGroup Condition=" '$(SkipAssemblyAttributes)' != 'true'">
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.Tools</AssemblyName>
+      <Version>$(SemanticVersion).$(PreReleaseVersion)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.Tools.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.Console</AssemblyName>
+      <Version>$(SemanticVersion).$(PreReleaseVersion)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.Console.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.PackageManagement.VisualStudio</AssemblyName>
+      <Version>$(SemanticVersion).$(PreReleaseVersion)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.PackageManagement.VisualStudio.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.PackageManagement.UI</AssemblyName>
+      <Version>$(SemanticVersion).$(PreReleaseVersion)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.PackageManagement.UI.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.Common</AssemblyName>
+      <Version>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.Common.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.Configuration</AssemblyName>
+      <Version>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.Configuration.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.PackageManagement</AssemblyName>
+      <Version>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.PackageManagement.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.Packaging</AssemblyName>
+      <Version>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.Packaging.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.Protocol</AssemblyName>
+      <Version>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.Protocol.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.Credentials</AssemblyName>
+      <Version>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.Credentials.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.VisualStudio.Common</AssemblyName>
+      <Version>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.VisualStudio.Common.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.VisualStudio</AssemblyName>
+      <Version>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.VisualStudio.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.Commands</AssemblyName>
+      <Version>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.Commands.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.Frameworks</AssemblyName>
+      <Version>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.Frameworks.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.LibraryModel</AssemblyName>
+      <Version>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.LibraryModel.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.Packaging.Core</AssemblyName>
+      <Version>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.Packaging.Core.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.ProjectModel</AssemblyName>
+      <Version>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.ProjectModel.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.Resolver</AssemblyName>
+      <Version>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.Resolver.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.Versioning</AssemblyName>
+      <Version>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.Versioning.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.Indexing</AssemblyName>
+      <Version>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.Indexing.dll</CodeBase>
+    </AssemblyAttributes>
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>NuGet.DependencyResolver.Core</AssemblyName>
+      <Version>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</Version>
+      <CodeBase>$PackageFolder$\\NuGet.DependencyResolver.Core.dll</CodeBase>
+    </AssemblyAttributes>
+  </ItemGroup>
+</Project>

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
@@ -7,20 +7,20 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet
         file source=$(NuGetTargetsPath)
         file source=$(ReferenceOutputPath)Microsoft.Web.XmlTransform.dll
         file source=$(ReferenceOutputPath)Newtonsoft.Json.dll
-        file source=$(ReferenceOutputPath)NuGet.Build.Tasks.dll  
-        file source=$(ReferenceOutputPath)NuGet.Commands.dll  
-        file source=$(ReferenceOutputPath)NuGet.Common.dll  
-        file source=$(ReferenceOutputPath)NuGet.Configuration.dll  
-        file source=$(ReferenceOutputPath)NuGet.DependencyResolver.Core.dll  
-        file source=$(ReferenceOutputPath)NuGet.Frameworks.dll  
-        file source=$(ReferenceOutputPath)NuGet.LibraryModel.dll  
-        file source=$(ReferenceOutputPath)NuGet.PackageManagement.dll  
-        file source=$(ReferenceOutputPath)NuGet.Packaging.Core.dll  
-        file source=$(ReferenceOutputPath)NuGet.Packaging.dll  
-        file source=$(ReferenceOutputPath)NuGet.ProjectModel.dll  
-        file source=$(ReferenceOutputPath)NuGet.Protocol.dll  
-        file source=$(ReferenceOutputPath)NuGet.Resolver.dll  
-        file source=$(ReferenceOutputPath)NuGet.Versioning.dll  
+        file source=$(ReferenceOutputPath)NuGet.Build.Tasks.dll vs.file.ngenArchitecture=x86
+        file source=$(ReferenceOutputPath)NuGet.Commands.dll vs.file.ngenArchitecture=x86
+        file source=$(ReferenceOutputPath)NuGet.Common.dll vs.file.ngenArchitecture=x86
+        file source=$(ReferenceOutputPath)NuGet.Configuration.dll vs.file.ngenArchitecture=x86
+        file source=$(ReferenceOutputPath)NuGet.DependencyResolver.Core.dll vs.file.ngenArchitecture=x86
+        file source=$(ReferenceOutputPath)NuGet.Frameworks.dll vs.file.ngenArchitecture=x86
+        file source=$(ReferenceOutputPath)NuGet.LibraryModel.dll vs.file.ngenArchitecture=x86
+        file source=$(ReferenceOutputPath)NuGet.PackageManagement.dll vs.file.ngenArchitecture=x86
+        file source=$(ReferenceOutputPath)NuGet.Packaging.Core.dll vs.file.ngenArchitecture=x86
+        file source=$(ReferenceOutputPath)NuGet.Packaging.dll vs.file.ngenArchitecture=x86
+        file source=$(ReferenceOutputPath)NuGet.ProjectModel.dll vs.file.ngenArchitecture=x86
+        file source=$(ReferenceOutputPath)NuGet.Protocol.dll vs.file.ngenArchitecture=x86
+        file source=$(ReferenceOutputPath)NuGet.Resolver.dll vs.file.ngenArchitecture=x86
+        file source=$(ReferenceOutputPath)NuGet.Versioning.dll vs.file.ngenArchitecture=x86
 
 folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\cs 
         file source=$(XmlTransformPath)cs\Microsoft.Web.XmlTransform.resources.dll

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
@@ -23,6 +23,13 @@
     <IncludeNuGetSharedFiles>true</IncludeNuGetSharedFiles>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
+  <ItemGroup Condition=" '$(SkipAssemblyAttributes)' != 'true'">
+    <AssemblyAttributes Include="Microsoft.VisualStudio.Shell.ProvideCodeBase">
+      <AssemblyName>$(AssemblyName)</AssemblyName>
+      <Version>$(SemanticVersion).$(PreReleaseVersion)</Version>
+      <CodeBase>$PackageFolder$\\$(AssemblyName).dll</CodeBase>
+    </AssemblyAttributes>
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime">
       <HintPath>$(SolutionPackagesFolder)Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime.14.3.25407\lib\Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime.dll</HintPath>

--- a/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
+++ b/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.legacy.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.ngen.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.common.props')" />
   <Import Project="$(VSSDKRoot)\build\Microsoft.VSSDK.BuildTools.props" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' "/> <!-- No bootstrapping on XPLAT, this project is not expect to work correctly-->
   <PropertyGroup>

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -45,7 +45,6 @@ namespace NuGetVSExtension
     [ProvideOptionPage(typeof(PackageSourceOptionsPage), "NuGet Package Manager", "Package Sources", 113, 114, true)]
     [ProvideOptionPage(typeof(GeneralOptionPage), "NuGet Package Manager", "General", 113, 115, true)]
     [ProvideSearchProvider(typeof(NuGetSearchProvider), "NuGet Search")]
-    [ProvideBindingPath] // Definition dll needs to be on VS binding path
     [ProvideAutoLoad(GuidList.guidAutoLoadNuGetString)]
     [ProvideAutoLoad(VSConstants.UICONTEXT.ProjectRetargeting_string)]
     [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionOrProjectUpgrading_string)]

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -4,6 +4,13 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.common.props')" />
   <Import Project="$(VSSDKRoot)\build\Microsoft.VSSDK.BuildTools.props" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' " />
   <!-- No bootstrapping on XPLAT, this project is not expect to work correctly-->
+  <ItemDefinitionGroup>
+    <ProjectReference>
+      <Ngen>True</Ngen>
+      <NgenArchitecture>x86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
+    </ProjectReference>
+  </ItemDefinitionGroup>
   <PropertyGroup>
     <Shipping>true</Shipping>
     <ProjectGuid>{3B96F91B-3B58-40ED-B06E-5CD133A79A63}</ProjectGuid>


### PR DESCRIPTION
Bringing back the old PR to Ngen all NuGet vsix assemblies. Earlier we missed updating the Revision.txt file in Vs branch which didn't allow it to ngen properly.

@rrelyea 