### PR TITLE
Remove VisualStudioVersion check from IsNonInteractive for nuget.exe

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Program.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Program.cs
@@ -310,21 +310,18 @@ namespace NuGet.CommandLine
 
         private static void SetConsoleInteractivity(IConsole console, Command command)
         {
+            // Apply command setting
+            console.IsNonInteractive = command.NonInteractive;
+
             // Global environment variable to prevent the exe for prompting for credentials
-            string globalSwitch = Environment.GetEnvironmentVariable("NUGET_EXE_NO_PROMPT");
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NUGET_EXE_NO_PROMPT")))
+            {
+                console.IsNonInteractive = true;
+            }
 
-            // When running from inside VS, no input is available to our executable locking up VS.
-            // VS sets up a couple of environment variables one of which is named VisualStudioVersion.
-            // Every time this is setup, we will just fail.
-            // TODO: Remove this in next iteration. This is meant for short-term backwards compat.
-            string vsSwitch = Environment.GetEnvironmentVariable("VisualStudioVersion");
-
-            console.IsNonInteractive = !String.IsNullOrEmpty(globalSwitch) ||
-                                       !String.IsNullOrEmpty(vsSwitch) ||
-                                       (command != null && command.NonInteractive);
-
-            string forceInteractive = Environment.GetEnvironmentVariable("FORCE_NUGET_EXE_INTERACTIVE");
-            if (!String.IsNullOrEmpty(forceInteractive))
+            // Disable non-interactive if force is set.
+            var forceInteractive = Environment.GetEnvironmentVariable("FORCE_NUGET_EXE_INTERACTIVE");
+            if (!string.IsNullOrEmpty(forceInteractive))
             {
                 console.IsNonInteractive = false;
             }


### PR DESCRIPTION
NuGet.exe will now prompt for credentials when VisualStudioVersion is set. This was added as a workaround for nuget.exe restores that ran from VS in NuGet 2.x when prompting was first added. At this point it no longer makes sense to block this, and it leads to confusing behavior for users running in the developer command prompt.

**Risk** This could cause someone running in a non-interactive environment to get a prompt where they didn't before if this env var was set. However prompting and not getting credentials should have ended in a failure, a successful non-interactive run should still be successful if it is interactive.

**Benefit** since many developers use the VS command prompt they are likely hitting this issue and confused as to why they are not getting a prompt. Fixing this will be make it much easier for users of private feeds to authorize.

Fixes https://github.com/NuGet/Home/issues/6385
Fixes https://github.com/NuGet/Home/issues/6341