### PR TITLE
[WIP]add options to suppress dependencies and assembly references in packge

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
@@ -27,6 +27,8 @@ namespace NuGet.Build.Tasks.Pack
         string Description { get; }
         bool DevelopmentDependency { get; }
         TItem[] FrameworkAssemblyReferences { get; }
+        TItem[] FrameworksWithSuppressedAssemblyReferences { get; }
+        TItem[] FrameworksWithSuppressedDependencies { get; }
         string IconUrl { get; }
         bool IncludeBuildOutput { get; }
         bool IncludeSource { get; }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -42,6 +42,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ImportNuGetBuildTasksPackTargetsFromSdk Condition="'$(ImportNuGetBuildTasksPackTargetsFromSdk)' == ''">false</ImportNuGetBuildTasksPackTargetsFromSdk>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>.dll; .exe; .winmd; .json; .pri; .xml; $(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>.pdb; .mdb; $(AllowedOutputExtensionsInPackageBuildOutputFolder); $(AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder)</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
+    <SuppressAssemblyReferencesInPackage Condition="'$(SuppressAssemblyReferencesInPackage)' == ''">false</SuppressAssemblyReferencesInPackage>
+    <SuppressDependenciesInPackage Condition="'$(SuppressDependenciesInPackage)' == ''">false</SuppressDependenciesInPackage>
   </PropertyGroup>
   <PropertyGroup Condition="'$(NoBuild)' == 'true' ">
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
@@ -211,6 +213,8 @@ Copyright (c) .NET Foundation. All rights reserved.
               ProjectReferencesWithVersions="@(_ProjectReferencesWithVersions)"
               TargetPathsToSymbols="@(_TargetPathsToSymbols)"
               TargetFrameworks="@(_TargetFrameworks)"
+              FrameworksWithSuppressedAssemblyReferences="@(_FrameworksWithSuppressedAssemblykReferences)"
+              FrameworksWithSuppressedDependencies="@(_FrameworksWithSuppressedDependencies)"
               AssemblyName="$(AssemblyName)"
               PackageOutputPath="$(PackageOutputAbsolutePath)"
               IncludeSymbols="$(IncludeSymbols)"
@@ -345,6 +349,40 @@ Copyright (c) .NET Foundation. All rights reserved.
           TaskParameter="TargetOutputs"
           ItemName="_FrameworkAssemblyReferences" />
     </MSBuild>
+
+    <MSBuild
+      Projects="$(MSBuildProjectFullPath)"
+      Targets="_GetFrameworksWithSuppressedDependencies"
+      Properties="TargetFramework=%(_TargetFrameworks.Identity);
+                  BuildProjectReferences=false;">
+
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="_FrameworksWithSuppressedDependencies" />
+    </MSBuild>
+
+    <MSBuild
+      Projects="$(MSBuildProjectFullPath)"
+      Targets="_GetFrameworksWithSuppressedAssemblyReferences"
+      Properties="TargetFramework=%(_TargetFrameworks.Identity);
+                  BuildProjectReferences=false;">
+
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="_FrameworksWithSuppressedAssemblykReferences" />
+    </MSBuild>
+  </Target>
+
+  <Target Name ="_GetFrameworksWithSuppressedDependencies" Returns="@(_TfmWithDependenciesSuppressed)">
+    <ItemGroup>
+      <_TfmWithDependenciesSuppressed Include="$(TargetFramework)" Condition="'$(SuppressDependenciesInPackage)' == 'true'"/>
+    </ItemGroup>
+  </Target>
+
+  <Target Name ="_GetFrameworksWithSuppressedAssemblyReferences" Returns="@(_TfmWithFrameworkReferencesSuppressed)">
+    <ItemGroup>
+      <_TfmWithDependenciesSuppressed Include="$(TargetFramework)" Condition="'$(SuppressAssemblyReferencesInPackage)' == 'true'"/>
+    </ItemGroup>
   </Target>
 
   <Target Name ="_GetFrameworkAssemblyReferences" DependsOnTargets="ResolveReferences" Returns="@(TfmSpecificFrameworkAssemblyReferences)">

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
@@ -37,6 +37,8 @@ namespace NuGet.Build.Tasks.Pack
         public string[] Tags { get; set; }
         public string ReleaseNotes { get; set; }
         public ITaskItem[] TargetPathsToSymbols { get; set; }
+        public ITaskItem[] FrameworksWithSuppressedAssemblyReferences { get; set; }
+        public ITaskItem[] FrameworksWithSuppressedDependencies { get; set; }
         public string AssemblyName { get; set; }
         public string PackageOutputPath { get; set; }
         public bool IsTool { get; set; }
@@ -154,6 +156,8 @@ namespace NuGet.Build.Tasks.Pack
                 Description = MSBuildStringUtility.TrimAndGetNullForEmpty(Description),
                 DevelopmentDependency = DevelopmentDependency,
                 FrameworkAssemblyReferences = MSBuildUtility.WrapMSBuildItem(FrameworkAssemblyReferences),
+                FrameworksWithSuppressedAssemblyReferences = MSBuildUtility.WrapMSBuildItem(FrameworksWithSuppressedAssemblyReferences),
+                FrameworksWithSuppressedDependencies = MSBuildUtility.WrapMSBuildItem(FrameworksWithSuppressedDependencies),
                 IconUrl = MSBuildStringUtility.TrimAndGetNullForEmpty(IconUrl),
                 IncludeBuildOutput = IncludeBuildOutput,
                 IncludeSource = IncludeSource,

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -192,15 +192,33 @@ namespace NuGet.Build.Tasks.Pack
                     .ToDictionary(msbuildItem => msbuildItem.Identity,
                     msbuildItem => msbuildItem.GetProperty("ProjectVersion"), PathUtility.GetStringComparerBasedOnOS());
             }
+            var nuGetFrameworkComparer = new NuGetFrameworkFullComparer();
+            var frameworksWithSuppressedDependencies = new HashSet<NuGetFramework>(nuGetFrameworkComparer);
+            var frameworksWithSuppressedAssemblyReferences = new HashSet<NuGetFramework>(nuGetFrameworkComparer);
+            if (request.FrameworksWithSuppressedDependencies != null && request.FrameworksWithSuppressedDependencies.Any())
+            {
+                frameworksWithSuppressedDependencies =
+                    new HashSet<NuGetFramework>(request.FrameworksWithSuppressedDependencies
+                    .Select(t => NuGetFramework.Parse(t.Identity)).ToList(), nuGetFrameworkComparer);
+            }
+
+            if (request.FrameworksWithSuppressedAssemblyReferences != null && request.FrameworksWithSuppressedAssemblyReferences.Any())
+            {
+                frameworksWithSuppressedAssemblyReferences =
+                    new HashSet<NuGetFramework>(request.FrameworksWithSuppressedAssemblyReferences
+                    .Select(t => NuGetFramework.Parse(t.Identity)).ToList(), nuGetFrameworkComparer);
+            }
 
             PopulateProjectAndPackageReferences(builder,
                 assetsFile,
-                projectRefToVersionMap);
-            PopulateFrameworkAssemblyReferences(builder, request);
+                projectRefToVersionMap,
+                frameworksWithSuppressedDependencies);
+            PopulateFrameworkAssemblyReferences(builder, request, frameworksWithSuppressedAssemblyReferences);
             return builder;
         }
 
-        private void PopulateFrameworkAssemblyReferences(PackageBuilder builder, IPackTaskRequest<IMSBuildItem> request)
+        private void PopulateFrameworkAssemblyReferences(PackageBuilder builder, IPackTaskRequest<IMSBuildItem> request,
+            ISet<NuGetFramework> frameworksWithSuppressedAssemblyReferences)
         {
             // First add all the assembly references which are not specific to a certain TFM.
             var tfmSpecificRefs = new Dictionary<string, IList<string>>(StringComparer.OrdinalIgnoreCase);
@@ -208,6 +226,10 @@ namespace NuGet.Build.Tasks.Pack
             foreach (var tfmRef in request.FrameworkAssemblyReferences)
             {
                 var targetFramework = tfmRef.GetProperty("TargetFramework");
+                if(frameworksWithSuppressedAssemblyReferences.Contains(NuGetFramework.Parse(targetFramework)))
+                {
+                    continue;
+                }
 
                 if (tfmSpecificRefs.ContainsKey(tfmRef.Identity))
                 {
@@ -585,12 +607,13 @@ namespace NuGet.Build.Tasks.Pack
         }
 
         private void PopulateProjectAndPackageReferences(PackageBuilder packageBuilder, LockFile assetsFile,
-            IDictionary<string, string> projectRefToVersionMap)
+            IDictionary<string, string> projectRefToVersionMap,
+            ISet<NuGetFramework> frameworksWithSuppressedDependencies)
         {
             var dependenciesByFramework = new Dictionary<NuGetFramework, HashSet<LibraryDependency>>();
 
-            InitializeProjectDependencies(assetsFile, dependenciesByFramework, projectRefToVersionMap);
-            InitializePackageDependencies(assetsFile, dependenciesByFramework);
+            InitializeProjectDependencies(assetsFile, dependenciesByFramework, projectRefToVersionMap, frameworksWithSuppressedDependencies);
+            InitializePackageDependencies(assetsFile, dependenciesByFramework, frameworksWithSuppressedDependencies);
 
             foreach (var pair in dependenciesByFramework)
             {
@@ -601,7 +624,8 @@ namespace NuGet.Build.Tasks.Pack
         private static void InitializeProjectDependencies(
             LockFile assetsFile,
             IDictionary<NuGetFramework, HashSet<LibraryDependency>> dependenciesByFramework,
-            IDictionary<string, string> projectRefToVersionMap)
+            IDictionary<string, string> projectRefToVersionMap,
+            ISet<NuGetFramework> frameworkWithSuppressedDependencies)
         {
             // From the package spec, all we know is each absolute path to the project reference the the target
             // framework that project reference applies to.
@@ -625,7 +649,7 @@ namespace NuGet.Build.Tasks.Pack
             foreach (var framework in assetsFile.PackageSpec.RestoreMetadata.TargetFrameworks)
             {
                 var target = assetsFile.GetTarget(framework.FrameworkName, runtimeIdentifier: null);
-                if (target == null)
+                if (target == null || frameworkWithSuppressedDependencies.Contains(framework.FrameworkName))
                 {
                     continue;
                 }
@@ -684,11 +708,17 @@ namespace NuGet.Build.Tasks.Pack
 
         private static void InitializePackageDependencies(
             LockFile assetsFile,
-            Dictionary<NuGetFramework, HashSet<LibraryDependency>> dependenciesByFramework)
+            Dictionary<NuGetFramework, HashSet<LibraryDependency>> dependenciesByFramework,
+            ISet<NuGetFramework> frameworkWithSuppressedDependencies)
         {
             // From the package spec, we know the direct package dependencies of this project.
             foreach (var framework in assetsFile.PackageSpec.TargetFrameworks)
             {
+                if(frameworkWithSuppressedDependencies.Contains(framework.FrameworkName))
+                {
+                    continue;
+                }
+
                 // First, add each of the generic package dependencies to the framework-specific list.
                 var packageDependencies = assetsFile
                     .PackageSpec

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
@@ -54,5 +54,7 @@ namespace NuGet.Build.Tasks.Pack
         public string[] TargetFrameworks { get; set; }
         public IMSBuildItem[] TargetPathsToSymbols { get; set; }
         public string Title { get; set; }
+        public IMSBuildItem[] FrameworksWithSuppressedAssemblyReferences { get; set; }
+        public IMSBuildItem[] FrameworksWithSuppressedDependencies { get; set; }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -346,8 +346,10 @@ namespace NuGet.Build.Tasks.Pack.Test
                 Tags = new string[0],
                 TargetFrameworks = new string[0],
                 BuildOutputInPackage = new ITaskItem[0],
-                TargetPathsToSymbols = new ITaskItem[0]
-            };
+                TargetPathsToSymbols = new ITaskItem[0],
+                FrameworksWithSuppressedAssemblyReferences = new ITaskItem[0],
+                FrameworksWithSuppressedDependencies = new ITaskItem[0]
+    };
 
             var settings = new JsonSerializerSettings
             {


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6354 

## Fix
Details: Adds two flags - one to suppress framewor assembly references, and other to suppress package dependencies. These can be framework specific based on msbuild conditions.
These flags are called: ```SuppressAssemblyReferencesInPackage``` and  ``` SuppressDependenciesInPackage ```


## Testing/Validation
Tests Added:  Writing tests

  