### PR TITLE
Adding SignatureTrustAndValidityVerificationProvider tests and certificate revocation list tests

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
@@ -147,7 +147,6 @@ namespace NuGet.Packaging.Signing
             var timestampRequest = new TimestampRequest
             {
                 SignatureValue = signature.GetBytes(),
-                Certificate = request.Certificate,
                 SigningSpec = SigningSpecifications.V1,
                 TimestampHashAlgorithm = request.TimestampHashAlgorithm
             };

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/TimestampRequest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/TimestampRequest.cs
@@ -20,11 +20,6 @@ namespace NuGet.Packaging.Signing
         public byte[] SignatureValue { get; set; }
 
         /// <summary>
-        /// X509Certificate2 used to generate the Signature.
-        /// </summary>
-        public X509Certificate2 Certificate { get; set; }
-
-        /// <summary>
         /// Hash algorithm to be used for timestamping.
         /// </summary>
         public HashAlgorithmName TimestampHashAlgorithm { get; set; }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
@@ -20,12 +20,12 @@ namespace NuGet.Packaging.Signing
         {
             token.ThrowIfCancellationRequested();
 
-            var result = VerifyValidityAndTrust(package, signature, settings);
+            var result = VerifyValidityAndTrust(signature, settings);
             return Task.FromResult(result);
         }
 
 #if IS_DESKTOP
-        private PackageVerificationResult VerifyValidityAndTrust(ISignedPackageReader package, Signature signature, SignedPackageVerifierSettings settings)
+        private PackageVerificationResult VerifyValidityAndTrust(Signature signature, SignedPackageVerifierSettings settings)
         {
             var issues = new List<SignatureLog>
             {
@@ -272,7 +272,7 @@ namespace NuGet.Packaging.Signing
             return false;
         }
 #else
-        private PackageVerificationResult VerifyValidityAndTrust(ISignedPackageReader package, Signature signature, SignedPackageVerifierSettings settings)
+        private PackageVerificationResult VerifyValidityAndTrust(Signature signature, SignedPackageVerifierSettings settings)
         {
             throw new NotSupportedException();
         }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifierSettings.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifierSettings.cs
@@ -20,12 +20,11 @@ namespace NuGet.Packaging.Signing
 
         public bool AllowIgnoreTimestamp { get; }
 
-
         public bool FailWithMultipleTimestamps { get; }
 
         public bool AllowNoTimestamp { get; }
 
-        private SignedPackageVerifierSettings(bool allowUnsigned, bool allowUntrusted, bool allowIgnoreTimestamp, bool failWithMultupleTimestamps, bool allowNoTimestamp)
+        public SignedPackageVerifierSettings(bool allowUnsigned, bool allowUntrusted, bool allowIgnoreTimestamp, bool failWithMultupleTimestamps, bool allowNoTimestamp)
         {
             AllowUnsigned = allowUnsigned;
             AllowUntrusted = allowUntrusted;
@@ -44,8 +43,14 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         public static SignedPackageVerifierSettings Default { get; } = AllowAll;
 
+        /// <summary>
+        /// Default policy for scenarios in VS
+        /// </summary>
         public static SignedPackageVerifierSettings VSClientDefaultPolicy { get; } = new SignedPackageVerifierSettings(allowUnsigned: true, allowUntrusted: true, allowIgnoreTimestamp: true, failWithMultupleTimestamps: false, allowNoTimestamp: true);
 
+        /// <summary>
+        /// Default policy for nuget.exe verify --signatures command
+        /// </summary>
         public static SignedPackageVerifierSettings VerifyCommandDefaultPolicy { get; } = new SignedPackageVerifierSettings(allowUnsigned: false, allowUntrusted: false, allowIgnoreTimestamp: false, failWithMultupleTimestamps: false, allowNoTimestamp: true);
     }
 }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
@@ -110,7 +110,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        public TrustedTestCert<TestCertificate> TrustedTestCertificateWithChain
+        public TrustedCertificateChain TrustedTestCertificateChain
         {
             get
             {
@@ -126,7 +126,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     SetUpCrlDistributionPoint();
                 }
 
-                return _trustedTestCertChain.Leaf;
+                return _trustedTestCertChain;
             }
         }
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
@@ -28,9 +28,9 @@ namespace NuGet.CommandLine.FuncTest.Commands
         private TrustedTestCert<TestCertificate> _trustedTestCertWithInvalidEku;
         private TrustedTestCert<TestCertificate> _trustedTestCertExpired;
         private TrustedTestCert<TestCertificate> _trustedTestCertNotYetValid;
-        private TrustedCertificateChain _trustedTestCertChain;
-        private TrustedCertificateChain _revokedTestCertChain;
-        private TrustedCertificateChain _revocationUnknownTestCertChain;
+        private TrustedTestCertificateChain _trustedTestCertChain;
+        private TrustedTestCertificateChain _revokedTestCertChain;
+        private TrustedTestCertificateChain _revocationUnknownTestCertChain;
         private IList<ISignatureVerificationProvider> _trustProviders;
         private SigningSpecifications _signingSpecifications;
         private MockServer _crlServer;
@@ -110,7 +110,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        public TrustedCertificateChain TrustedTestCertificateChain
+        public TrustedTestCertificateChain TrustedTestCertificateChain
         {
             get
             {
@@ -118,7 +118,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 {
                     var certChain = SigningTestUtility.GenerateCertificateChain(_validCertChainLength, CrlServer.Uri, TestDirectory.Path);
 
-                    _trustedTestCertChain = new TrustedCertificateChain()
+                    _trustedTestCertChain = new TrustedTestCertificateChain()
                     {
                         Certificates = certChain
                     };
@@ -138,7 +138,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 {
                     var certChain = SigningTestUtility.GenerateCertificateChain(_invalidCertChainLength, CrlServer.Uri, TestDirectory.Path);
 
-                    _revokedTestCertChain = new TrustedCertificateChain()
+                    _revokedTestCertChain = new TrustedTestCertificateChain()
                     {
                         Certificates = certChain
                     };
@@ -159,19 +159,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
             {
                 if (_revocationUnknownTestCertChain == null)
                 {
-                    var certChain = SigningTestUtility.GenerateCertificateChain(_invalidCertChainLength, CrlServer.Uri, TestDirectory.Path);
+                    var certChain = SigningTestUtility.GenerateCertificateChain(_invalidCertChainLength, CrlServer.Uri, TestDirectory.Path, configureLeafCrl: false);
 
-                    _revocationUnknownTestCertChain = new TrustedCertificateChain()
+                    _revocationUnknownTestCertChain = new TrustedTestCertificateChain()
                     {
                         Certificates = certChain
                     };
-
-                    // delete crl to make revocation status unknown
-                    var crlPath = _revocationUnknownTestCertChain.Certificates[0].Source.Crl.CrlLocalPath;
-                    if (File.Exists(crlPath))
-                    {
-                        File.Delete(crlPath);
-                    }
 
                     SetUpCrlDistributionPoint();
                 }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
@@ -223,6 +223,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 return _nugetExePath;
             }
         }
+
         public MockServer CrlServer
         {
             get

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -198,7 +198,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public void SignCommand_SignPackageWithValidCertChain()
         {
             // Arrange
-            var cert = _testFixture.TrustedTestCertificateWithChain;
+            var cert = _testFixture.TrustedTestCertificateChain.Leaf;
 
             using (var dir = TestDirectory.Create())
             using (var zipStream = new SimpleTestPackageContext().CreateAsStream())

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using FluentAssertions;
@@ -97,7 +96,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 result.Success.Should().BeFalse();
                 result.AllOutput.Should().Contain(_noTimestamperWarningCode);
                 result.AllOutput.Should().Contain(_chainBuildFailureErrorCode);
-                result.AllOutput.Should().Contain("NotValidForUsage");
+                result.AllOutput.Should().Contain("The certificate is not valid for the requested usage");
             }
         }
 
@@ -247,14 +246,14 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 var result = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {cert.Source.Cert.Thumbprint}  -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation} -Verbosity Detailed",
+                    $"sign {packagePath} -CertificateFingerprint {cert.Source.Cert.Thumbprint}  -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation}",
                     waitForExit: true);
 
                 // Assert
                 result.Success.Should().BeFalse();
                 result.AllOutput.Should().Contain(_noTimestamperWarningCode);
                 result.AllOutput.Should().Contain(_chainBuildFailureErrorCode);
-                result.AllOutput.Should().Contain("Revoked");
+                result.AllOutput.Should().Contain("The certificate is revoked");
             }
         }
 
@@ -280,14 +279,14 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 var result = CommandRunner.Run(
                     _nugetExePath,
                     dir,
-                    $"sign {packagePath} -CertificateFingerprint {cert.Source.Cert.Thumbprint} -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation} -Verbosity Detailed",
+                    $"sign {packagePath} -CertificateFingerprint {cert.Source.Cert.Thumbprint} -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation}",
                     waitForExit: true);
 
                 // Assert
                 result.Success.Should().BeFalse();
                 result.AllOutput.Should().Contain(_noTimestamperWarningCode);
                 result.AllOutput.Should().Contain(_chainBuildFailureErrorCode);
-                result.AllOutput.Should().Contain("RevocationStatusUnknown");
+                result.AllOutput.Should().Contain("The revocation function was unable to check revocation for the certificate");
             }
         }
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using FluentAssertions;
@@ -21,7 +22,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
     {
         private const string _packageAlreadySignedError = "NU3001: The package already contains a signature. Please remove the existing signature before adding a new signature.";
         private readonly string _invalidPasswordErrorCode = NuGetLogCode.NU3001.ToString();
-        private readonly string _invalidEkuErrorCode = NuGetLogCode.NU3018.ToString();
+        private readonly string _chainBuildFailureErrorCode = NuGetLogCode.NU3018.ToString();
         private readonly string _noCertFoundErrorCode = NuGetLogCode.NU3001.ToString();
         private readonly string _noTimestamperWarningCode = NuGetLogCode.NU3002.ToString();
 
@@ -42,8 +43,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public void SignCommand_SignPackage()
         {
             // Arrange
-            var testLogger = new TestLogger();
-
             using (var dir = TestDirectory.Create())
             using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
             {
@@ -73,7 +72,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public void SignCommand_SignPackageWithInvalidEkuFails()
         {
             // Arrange
-            var testLogger = new TestLogger();
             var invalidEkuCert = _testFixture.TrustedTestCertificateWithInvalidEku;
 
             using (var dir = TestDirectory.Create())
@@ -98,8 +96,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 // Assert
                 result.Success.Should().BeFalse();
                 result.AllOutput.Should().Contain(_noTimestamperWarningCode);
-                result.AllOutput.Should().Contain(_invalidEkuErrorCode);
-                result.AllOutput.Should().Contain("The certificate is not valid for the requested usage");
+                result.AllOutput.Should().Contain(_chainBuildFailureErrorCode);
+                result.AllOutput.Should().Contain("NotValidForUsage");
             }
         }
 
@@ -107,7 +105,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public void SignCommand_SignPackageWithExpiredCertificateFails()
         {
             // Arrange
-            var testLogger = new TestLogger();
             var expiredCert = _testFixture.TrustedTestCertificateExpired;
 
             using (var dir = TestDirectory.Create())
@@ -140,7 +137,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public void SignCommand_SignPackageWithNotYetValidCertificateFails()
         {
             // Arrange
-            var testLogger = new TestLogger();
             var cert = _testFixture.TrustedTestCertificateNotYetValid;
 
             using (var dir = TestDirectory.Create())
@@ -173,8 +169,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public void SignCommand_SignPackageWithTimestamping()
         {
             // Arrange
-            var testLogger = new TestLogger();
-
             using (var dir = TestDirectory.Create())
             using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
             {
@@ -201,11 +195,106 @@ namespace NuGet.CommandLine.FuncTest.Commands
         }
 
         [CIOnlyFact]
+        public void SignCommand_SignPackageWithValidCertChain()
+        {
+            // Arrange
+            var cert = _testFixture.TrustedTestCertificateWithChain;
+
+            using (var dir = TestDirectory.Create())
+            using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
+            {
+                var packagePath = Path.Combine(dir, Guid.NewGuid().ToString());
+
+                zipStream.Seek(offset: 0, loc: SeekOrigin.Begin);
+
+                using (var fileStream = File.OpenWrite(packagePath))
+                {
+                    zipStream.CopyTo(fileStream);
+                }
+
+                // Act
+                var result = CommandRunner.Run(
+                    _nugetExePath,
+                    dir,
+                    $"sign {packagePath} -CertificateFingerprint {cert.Source.Cert.Thumbprint}  -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation}",
+                    waitForExit: true);
+
+                // Assert
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+            }
+        }
+
+        [CIOnlyFact]
+        public void SignCommand_SignPackageWithRevokedLeafCertChain()
+        {
+            // Arrange
+            var cert = _testFixture.RevokedTestCertificateWithChain;
+
+            using (var dir = TestDirectory.Create())
+            using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
+            {
+                var packagePath = Path.Combine(dir, Guid.NewGuid().ToString());
+
+                zipStream.Seek(offset: 0, loc: SeekOrigin.Begin);
+
+                using (var fileStream = File.OpenWrite(packagePath))
+                {
+                    zipStream.CopyTo(fileStream);
+                }
+
+                // Act
+                var result = CommandRunner.Run(
+                    _nugetExePath,
+                    dir,
+                    $"sign {packagePath} -CertificateFingerprint {cert.Source.Cert.Thumbprint}  -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation} -Verbosity Detailed",
+                    waitForExit: true);
+
+                // Assert
+                result.Success.Should().BeFalse();
+                result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+                result.AllOutput.Should().Contain(_chainBuildFailureErrorCode);
+                result.AllOutput.Should().Contain("Revoked");
+            }
+        }
+
+        [CIOnlyFact]
+        public void SignCommand_SignPackageWithUnknownRevocationCertChain()
+        {
+            // Arrange
+            var cert = _testFixture.RevocationUnknownTestCertificateWithChain;
+
+            using (var dir = TestDirectory.Create())
+            using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
+            {
+                var packagePath = Path.Combine(dir, Guid.NewGuid().ToString());
+
+                zipStream.Seek(offset: 0, loc: SeekOrigin.Begin);
+
+                using (var fileStream = File.OpenWrite(packagePath))
+                {
+                    zipStream.CopyTo(fileStream);
+                }
+
+                // Act
+                var result = CommandRunner.Run(
+                    _nugetExePath,
+                    dir,
+                    $"sign {packagePath} -CertificateFingerprint {cert.Source.Cert.Thumbprint} -CertificateStoreName {cert.StoreName} -CertificateStoreLocation {cert.StoreLocation} -Verbosity Detailed",
+                    waitForExit: true);
+
+                // Assert
+                result.Success.Should().BeFalse();
+                result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+                result.AllOutput.Should().Contain(_chainBuildFailureErrorCode);
+                result.AllOutput.Should().Contain("RevocationStatusUnknown");
+            }
+        }
+
+        [CIOnlyFact]
         public void SignCommand_SignPackageWithOutputDirectory()
         {
             // Arrange
-            var testLogger = new TestLogger();
-
             using (var dir = TestDirectory.Create())
             using (var outputDir = TestDirectory.Create())
             using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
@@ -239,8 +328,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public void SignCommand_ResignPackageWithoutOverwriteFails()
         {
             // Arrange
-            var testLogger = new TestLogger();
-
             using (var dir = TestDirectory.Create())
             using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
             {
@@ -278,8 +365,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public void SignCommand_ResignPackageWithOverwriteSuccess()
         {
             // Arrange
-            var testLogger = new TestLogger();
-
             using (var dir = TestDirectory.Create())
             using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
             {
@@ -317,8 +402,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public void SignCommand_SignPackageWithOverwriteSuccess()
         {
             // Arrange
-            var testLogger = new TestLogger();
-
             using (var dir = TestDirectory.Create())
             using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
             {
@@ -348,8 +431,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public void SignCommand_SignPackageWithPfxFileSuccess()
         {
             // Arrange
-            var testLogger = new TestLogger();
-
             using (var dir = TestDirectory.Create())
             using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
             {
@@ -389,8 +470,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public void SignCommand_SignPackageWithPfxFileInteractiveSuccess()
         {
             // Arrange
-            var testLogger = new TestLogger();
-
             using (var dir = TestDirectory.Create())
             using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
             {
@@ -434,8 +513,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public void SignCommand_SignPackageWithPfxFileInteractiveInvalidPasswordFails()
         {
             // Arrange
-            var testLogger = new TestLogger();
-
             using (var dir = TestDirectory.Create())
             using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
             {
@@ -479,8 +556,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public void SignCommand_SignPackageWithPfxFileWithoutPasswordAndWithNonInteractiveFails()
         {
             // Arrange
-            var testLogger = new TestLogger();
-
             using (var dir = TestDirectory.Create())
             using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
             {
@@ -520,8 +595,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public void SignCommand_SignPackageWithPfxFileWithNonInteractiveAndStdInPasswordFails()
         {
             // Arrange
-            var testLogger = new TestLogger();
-
             using (var dir = TestDirectory.Create())
             using (var zipStream = new SimpleTestPackageContext().CreateAsStream())
             {

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -183,7 +183,7 @@ namespace NuGet.Packaging.FuncTest
 
             using (var package = new PackageArchiveReader(nupkg.CreateAsStream(), leaveStreamOpen: false))
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
-            using (var signatureRequest = new SignPackageRequest() { Certificate = testCertificate, SignatureType = SignatureType.Author })
+            using (var signatureRequest = new SignPackageRequest(testCertificate, HashAlgorithmName.SHA256))
             {
                 var signature = await SignedArchiveTestUtility.CreateSignatureForPackageAsync(signatureProvider, package, signatureRequest, testLogger);
                 var timestampedSignature = await SignedArchiveTestUtility.TimestampSignature(timestampProvider, signatureRequest, signature, testLogger);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -117,6 +117,144 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
+        [CIOnlyFact]
+        public async Task VerifySignedPackage_ValidCertificateChain_Success()
+        {
+            // Arrange
+            var nupkg = new SimpleTestPackageContext();
+            using (var dir = TestDirectory.Create())
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
+            {
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.VerifyCommandDefaultPolicy);
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    var result = await verifier.VerifySignaturesAsync(packageReader, CancellationToken.None);
+                    var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
+
+                    // Assert
+                    result.Valid.Should().BeTrue();
+                    resultsWithErrors.Count().Should().Be(0);
+                }
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task GetTrustResultAsync_WithNoSigningCertificate_Throws()
+        {
+            var package = new SimpleTestPackageContext();
+
+            using (var directory = TestDirectory.Create())
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
+            {
+                var packageFilePath = await SignedArchiveTestUtility.CreateSignedAndTimeStampedPackageAsync(testCertificate, package, directory);
+
+                using (var packageReader = new PackageArchiveReader(packageFilePath))
+                {
+                    var signature = (await packageReader.GetSignaturesAsync(CancellationToken.None)).Single();
+                    var signatureWithNoCertificates = GenerateSignatureWithNoCertificates(signature);
+                    var provider = new SignatureTrustAndValidityVerificationProvider();
+
+                    var result = await provider.GetTrustResultAsync(
+                        packageReader,
+                        signatureWithNoCertificates,
+                        SignedPackageVerifierSettings.Default,
+                        CancellationToken.None);
+
+                    var issue = result.Issues.FirstOrDefault(log => log.Code == NuGetLogCode.NU3010);
+
+                    Assert.NotNull(issue);
+                    Assert.Equal("The primary signature does not have a signing certificate.", issue.Message);
+                }
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task VerifySignedPackage_SettingsRequireExactlyOneTimestamp_MultipleTimestamps_Fails()
+        {
+            // Arrange
+            var nupkg = new SimpleTestPackageContext();
+            var testLogger = new TestLogger();
+            var setting = new SignedPackageVerifierSettings(allowUnsigned: false, allowUntrusted: false, allowIgnoreTimestamp: false, failWithMultupleTimestamps: true, allowNoTimestamp: false);
+            var signatureProvider = new X509SignatureProvider(timestampProvider: null);
+            var timestampProvider = new Rfc3161TimestampProvider(new Uri(_testFixture.Timestamper));
+            var verificationProvider = new SignatureTrustAndValidityVerificationProvider();
+
+            using (var package = new PackageArchiveReader(nupkg.CreateAsStream(), leaveStreamOpen: false))
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
+            using (var signatureRequest = new SignPackageRequest() { Certificate = testCertificate, SignatureType = SignatureType.Author })
+            {
+                var signature = await SignedArchiveTestUtility.CreateSignatureForPackageAsync(signatureProvider, package, signatureRequest, testLogger);
+                var timestampedSignature = await SignedArchiveTestUtility.TimestampSignature(timestampProvider, signatureRequest, signature, testLogger);
+                var reTimestampedSignature = await SignedArchiveTestUtility.TimestampSignature(timestampProvider, signatureRequest, timestampedSignature, testLogger);
+
+                timestampedSignature.Timestamps.Count.Should().Be(1);
+                reTimestampedSignature.Timestamps.Count.Should().Be(2);
+
+                // Act
+                var result = await verificationProvider.GetTrustResultAsync(package, reTimestampedSignature, setting, CancellationToken.None);
+                var totalErrorIssues = result.GetErrorIssues();
+
+                // Assert
+                result.Trust.Should().Be(SignatureVerificationStatus.Invalid);
+                totalErrorIssues.Count().Should().Be(1);
+                totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3000);
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task VerifySignedPackage_SettingsRequireTimestamp_NoTimestamp_Fails()
+        {
+            // Arrange
+            var nupkg = new SimpleTestPackageContext();
+            var setting = new SignedPackageVerifierSettings(allowUnsigned: false, allowUntrusted: false, allowIgnoreTimestamp: false, failWithMultupleTimestamps: false, allowNoTimestamp: false);
+
+            using (var dir = TestDirectory.Create())
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
+            {
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var verifier = new PackageSignatureVerifier(_trustProviders, setting);
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    var result = await verifier.VerifySignaturesAsync(packageReader, CancellationToken.None);
+                    var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
+                    var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
+
+                    // Assert
+                    result.Valid.Should().BeFalse();
+                    resultsWithErrors.Count().Should().Be(1);
+                    totalErrorIssues.Count().Should().Be(1);
+                    totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3027);
+                }
+            }
+        }
+
+        private static Signature GenerateSignatureWithNoCertificates(Signature signature)
+        {
+            var certificateStore = X509StoreFactory.Create(
+                "Certificate/Collection",
+                new X509CollectionStoreParameters(Array.Empty<Org.BouncyCastle.X509.X509Certificate>()));
+            var crlStore = X509StoreFactory.Create(
+                "CRL/Collection",
+                new X509CollectionStoreParameters(Array.Empty<Org.BouncyCastle.X509.X509Crl>()));
+            var bytes = signature.SignedCms.Encode();
+
+            using (var readStream = new MemoryStream(bytes))
+            using (var writeStream = new MemoryStream())
+            {
+                CmsSignedDataParser.ReplaceCertificatesAndCrls(
+                    readStream,
+                    certificateStore,
+                    crlStore,
+                    certificateStore,
+                    writeStream);
+
+                return Signature.Load(writeStream.ToArray());
+            }
+        }
+
         private static Signature GenerateInvalidSignature(Signature signature)
         {
             var hash = Encoding.UTF8.GetBytes(signature.SignatureContent.HashValue);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.Packaging.Signing;
 using Org.BouncyCastle.Crypto;
@@ -17,6 +18,9 @@ namespace NuGet.Packaging.FuncTest
     /// </summary>
     public class SigningTestFixture : IDisposable
     {
+        private const string _timestamper = "http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer";
+        private const int _trustedCertChainLength = 3;
+
         private TrustedTestCert<TestCertificate> _trustedTestCert;
         private TrustedTestCert<TestCertificate> _trustedTestCertExpired;
         private TrustedTestCert<TestCertificate> _trustedTestCertNotYetValid;
@@ -138,6 +142,8 @@ namespace NuGet.Packaging.FuncTest
                 return _signingSpecifications;
             }
         }
+
+        public string Timestamper => _timestamper;
 
         public void Dispose()
         {

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.Packaging.Signing;
 using Org.BouncyCastle.Crypto;
@@ -18,8 +17,7 @@ namespace NuGet.Packaging.FuncTest
     /// </summary>
     public class SigningTestFixture : IDisposable
     {
-        private const string _timestamper = "http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer";
-        private const int _trustedCertChainLength = 3;
+        private static readonly string _testTimestampServer = Environment.GetEnvironmentVariable("TIMESTAMP_SERVER_URL");
 
         private TrustedTestCert<TestCertificate> _trustedTestCert;
         private TrustedTestCert<TestCertificate> _trustedTestCertExpired;
@@ -143,7 +141,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        public string Timestamper => _timestamper;
+        public string Timestamper => _testTimestampServer;
 
         public void Dispose()
         {

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -51,7 +51,6 @@ namespace NuGet.Packaging.FuncTest
 
                 var request = new TimestampRequest
                 {
-                    Certificate = authorCert,
                     SigningSpec = SigningSpecifications.V1,
                     TimestampHashAlgorithm = Common.HashAlgorithmName.SHA256,
                     SignatureValue = signatureValue
@@ -97,7 +96,6 @@ namespace NuGet.Packaging.FuncTest
 
                 var request = new TimestampRequest
                 {
-                    Certificate = authorCert,
                     SigningSpec = SigningSpecifications.V1,
                     TimestampHashAlgorithm = Common.HashAlgorithmName.SHA256,
                     SignatureValue = signatureValue
@@ -127,7 +125,6 @@ namespace NuGet.Packaging.FuncTest
 
                 var request = new TimestampRequest
                 {
-                    Certificate = authorCert,
                     SigningSpec = SigningSpecifications.V1,
                     TimestampHashAlgorithm = Common.HashAlgorithmName.SHA256,
                     SignatureValue = signatureValue
@@ -157,7 +154,6 @@ namespace NuGet.Packaging.FuncTest
 
                 var request = new TimestampRequest
                 {
-                    Certificate = authorCert,
                     SigningSpec = SigningSpecifications.V1,
                     TimestampHashAlgorithm = Common.HashAlgorithmName.SHA256,
                     SignatureValue = signatureValue

--- a/test/TestUtilities/Test.Utility/Signing/CertificateRevocationList.cs
+++ b/test/TestUtilities/Test.Utility/Signing/CertificateRevocationList.cs
@@ -51,14 +51,8 @@ namespace Test.Utility.Signing
             crlGen.SetIssuerDN(bcIssuerCert.SubjectDN);
             crlGen.SetThisUpdate(DateTime.Now);
             crlGen.SetNextUpdate(DateTime.Now.AddYears(1));
-
-            crlGen.AddExtension(X509Extensions.AuthorityKeyIdentifier,
-                               false,
-                               new AuthorityKeyIdentifierStructure(bcIssuerCert));
-
-            crlGen.AddExtension(X509Extensions.CrlNumber,
-                               false,
-                               new CrlNumber(version));
+            crlGen.AddExtension(X509Extensions.AuthorityKeyIdentifier, false, new AuthorityKeyIdentifierStructure(bcIssuerCert));
+            crlGen.AddExtension(X509Extensions.CrlNumber, false, new CrlNumber(version));
 
             if (revokedCertificate != null)
             {

--- a/test/TestUtilities/Test.Utility/Signing/CertificateRevocationList.cs
+++ b/test/TestUtilities/Test.Utility/Signing/CertificateRevocationList.cs
@@ -1,0 +1,120 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto.Operators;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.OpenSsl;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.X509;
+using Org.BouncyCastle.X509.Extension;
+
+namespace Test.Utility.Signing
+{
+    public class CertificateRevocationList : IDisposable
+    {
+        public X509Crl Crl { get; set; }
+
+        public X509Certificate2 IssuerCert { get; private set; }
+
+        public string CrlLocalPath { get; private set; }
+
+        public BigInteger Version { get; private set; }
+
+#if IS_DESKTOP
+        public static CertificateRevocationList CreateCrl(
+            X509Certificate2 issuerCert,
+            string crlLocalUri)
+        {
+            var version = BigInteger.One;
+            var crl = CreateCrl(issuerCert, version);
+
+            return new CertificateRevocationList()
+            {
+                Crl = crl,
+                IssuerCert = issuerCert,
+                CrlLocalPath = Path.Combine(crlLocalUri, $"{issuerCert.Subject}.crl"),
+                Version = version
+            };
+        }
+
+        private static X509Crl CreateCrl(
+            X509Certificate2 issuerCert,
+            BigInteger version,
+            X509Certificate2 revokedCertificate = null)
+        {
+            var bcIssuerCert = DotNetUtilities.FromX509Certificate(issuerCert);
+            var crlGen = new X509V2CrlGenerator();
+            crlGen.SetIssuerDN(bcIssuerCert.SubjectDN);
+            crlGen.SetThisUpdate(DateTime.Now);
+            crlGen.SetNextUpdate(DateTime.Now.AddYears(1));
+
+            crlGen.AddExtension(X509Extensions.AuthorityKeyIdentifier,
+                               false,
+                               new AuthorityKeyIdentifierStructure(bcIssuerCert));
+
+            crlGen.AddExtension(X509Extensions.CrlNumber,
+                               false,
+                               new CrlNumber(version));
+
+            if (revokedCertificate != null)
+            {
+                var bcRevokedCert = DotNetUtilities.FromX509Certificate(revokedCertificate);
+                crlGen.AddCrlEntry(bcRevokedCert.SerialNumber, DateTime.Now, CrlReason.PrivilegeWithdrawn);
+            }
+
+            var random = new SecureRandom();
+            var issuerPrivateKey = DotNetUtilities.GetKeyPair(issuerCert.PrivateKey).Private;
+            var signatureFactory = new Asn1SignatureFactory(bcIssuerCert.SigAlgOid, issuerPrivateKey, random);
+            var crl = crlGen.Generate(signatureFactory);
+            return crl;
+        }
+
+        public void RevokeCertificate(X509Certificate2 revokedCertificate)
+        {
+            UpdateVersion();
+            Crl = CreateCrl(IssuerCert, Version, revokedCertificate);
+            ExportCrl();
+        }
+
+        public void ExportCrl()
+        {
+            var pemWriter = new PemWriter(new StreamWriter(File.Open(CrlLocalPath, FileMode.Create)));
+            pemWriter.WriteObject(Crl);
+            pemWriter.Writer.Flush();
+            pemWriter.Writer.Close();
+        }
+
+        private void UpdateVersion()
+        {
+            Version = Version?.Add(BigInteger.One) ?? BigInteger.One;
+        }
+#else
+        public static CertificateRevocationList CreateCrl(X509Certificate2 certCA, string crlLocalUri)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RevokeCertificate(X509Certificate2 revokedCertificate)
+        {
+            throw new NotImplementedException();
+        }
+
+         public void ExportCrl()
+        { 
+            throw new NotImplementedException();
+        }
+#endif
+
+        public void Dispose()
+        {
+            if (!string.IsNullOrEmpty(CrlLocalPath) && File.Exists(CrlLocalPath))
+            {
+                File.Delete(CrlLocalPath);
+            }
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/ChainCertificateRequest.cs
+++ b/test/TestUtilities/Test.Utility/Signing/ChainCertificateRequest.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Test.Utility.Signing
+{
+    public class ChainCertificateRequest
+    {
+        public string CrlServerBaseUri { get; set; }
+
+        public string CrlLocalBaseUri { get; set; }
+
+        public bool IsCA { get; set; }
+
+        public X509Certificate2 Issuer { get; set; }
+
+        public string IssuerDN => Issuer?.Subject;
+
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/ChainCertificateRequest.cs
+++ b/test/TestUtilities/Test.Utility/Signing/ChainCertificateRequest.cs
@@ -14,9 +14,10 @@ namespace Test.Utility.Signing
 
         public bool IsCA { get; set; }
 
+        public bool ConfigureCrl { get; set; } = true;
+
         public X509Certificate2 Issuer { get; set; }
 
         public string IssuerDN => Issuer?.Subject;
-
     }
 }

--- a/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
@@ -53,7 +53,7 @@ namespace Test.Utility.Signing
 
         public static string GenerateCertificateName()
         {
-            return "NuGetTest " + Guid.NewGuid().ToString();
+            return "NuGetTest-" + Guid.NewGuid().ToString();
         }
 
         public static TestCertificate Generate(Action<X509V3CertificateGenerator> modifyGenerator = null, ChainCertificateRequest chainCertificateRequest = null)

--- a/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
@@ -28,6 +28,12 @@ namespace Test.Utility.Signing
         public X509Certificate2 PublicCertWithPrivateKey => SigningTestUtility.GetPublicCertWithPrivateKey(Cert);
 
         /// <summary>
+        /// Certificate Revocation List associated with a certificate.
+        /// This will be null if the certificate was not created as a CA certificate.
+        /// </summary>
+        public CertificateRevocationList Crl { get; set; }
+
+        /// <summary>
         /// Trust the PublicCert cert for the life of the object.
         /// </summary>
         /// <remarks>Dispose of the object returned!</remarks>
@@ -50,16 +56,25 @@ namespace Test.Utility.Signing
             return "NuGetTest " + Guid.NewGuid().ToString();
         }
 
-        public static TestCertificate Generate(Action<X509V3CertificateGenerator> modifyGenerator = null)
+        public static TestCertificate Generate(Action<X509V3CertificateGenerator> modifyGenerator = null, ChainCertificateRequest chainCertificateRequest = null)
         {
             var certName = GenerateCertificateName();
+            var cert = SigningTestUtility.GenerateCertificate(certName, modifyGenerator, chainCertificateRequest: chainCertificateRequest);
+            CertificateRevocationList crl = null;
 
-            var pair = new TestCertificate
+            // create a crl only if the certificate is part of a chain and it is a CA
+            if (chainCertificateRequest != null && chainCertificateRequest.IsCA)
             {
-                Cert = SigningTestUtility.GenerateCertificate(certName, modifyGenerator)
+                crl = CertificateRevocationList.CreateCrl(cert, chainCertificateRequest.CrlLocalBaseUri);
+            }
+
+            var testCertificate = new TestCertificate
+            {
+                Cert = cert,
+                Crl = crl
             };
 
-            return pair;
+            return testCertificate;
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/Signing/TrustedCertificateChain.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TrustedCertificateChain.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Test.Utility.Signing
+{
+    public class TrustedCertificateChain : IDisposable
+    {
+        public IList<TrustedTestCert<TestCertificate>> Certificates { get; set; }
+
+        public TrustedTestCert<TestCertificate> Root => Certificates?.First();
+
+        public TrustedTestCert<TestCertificate> Leaf => Certificates?.Last();
+
+        public void Dispose()
+        {
+            (Certificates as List<TrustedTestCert<TestCertificate>>)?.ForEach(c => c.Dispose());
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/TrustedCertificateChain.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TrustedCertificateChain.cs
@@ -9,7 +9,7 @@ namespace Test.Utility.Signing
 {
     public class TrustedCertificateChain : IDisposable
     {
-        public IList<TrustedTestCert<TestCertificate>> Certificates { get; set; }
+        public IList<TrustedTestCert<TestCertificate>> Certificates { get; set; } = new List<TrustedTestCert<TestCertificate>>();
 
         public TrustedTestCert<TestCertificate> Root => Certificates?.First();
 
@@ -17,7 +17,13 @@ namespace Test.Utility.Signing
 
         public void Dispose()
         {
-            (Certificates as List<TrustedTestCert<TestCertificate>>)?.ForEach(c => c.Dispose());
+            if (Certificates != null)
+            {
+                foreach (var certificate in Certificates)
+                {
+                    certificate.Dispose();
+                }
+            }
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/Signing/TrustedTestCertificateChain.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TrustedTestCertificateChain.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Test.Utility.Signing
 {
-    public class TrustedCertificateChain : IDisposable
+    public class TrustedTestCertificateChain : IDisposable
     {
         public IList<TrustedTestCert<TestCertificate>> Certificates { get; set; } = new List<TrustedTestCert<TestCertificate>>();
 


### PR DESCRIPTION
This PR adds the following - 
1. Adds functional test for `SignatureTrustAndValidityVerificationProvider`.
2. Adds support for creating test certificate chains along with revocation lists.
3. Adds functional tests for sign and verify commands with certificate chains.
4. Some product code clean up to remove `TimestampRequest.Certificate` as it was not being used.