### PR TITLE
restore trailing 0 on 4 part legacy version numbers #3050

### DIFF
--- a/src/NuGet.Core/NuGet.Versioning/NuGetVersion.cs
+++ b/src/NuGet.Core/NuGet.Versioning/NuGetVersion.cs
@@ -177,7 +177,7 @@ namespace NuGet.Versioning
         /// </summary>
         public virtual bool IsLegacyVersion
         {
-            get { return Version.Revision > 0; }
+            get { return Version.Revision >= 0; }
         }
 
         /// <summary>


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/3050
fixes one minor item in that issue.
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: Corrected a version number comparison that was using `0` to indicate unused revision when the version object uses `-1` to indicate revision is not in use.

## Testing/Validation
Tests Added: No  
Reason for not adding tests: I don't know the testing framework well enough.
Validation done:  none
