### PR TITLE
post test failure status and link test run url on github for windows tests

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -21,5 +21,6 @@
   <package id="xunit.runner.console" version="2.3.1" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" />
   <package id="NuGetValidator" version="1.3.7" targetFramework="net461" />
+  <package id="XunitXml.TestLogger" version="2.0.0" />
   <package id="Microsoft.DotNet.Build.Tasks.Feed" version="2.1.0-prerelease-02304-01" />   <!-- For the .NET Core orchestrated build.-->
 </packages>

--- a/build/build.proj
+++ b/build/build.proj
@@ -483,7 +483,7 @@
     </MSBuild>
 
     <PropertyGroup>
-      <TestResultsDirectory>$(RepositoryRootDirectory)TestResults\</TestResultsDirectory>
+      <TestResultsDirectory>$(BuildCommonDirectory)TestResults\</TestResultsDirectory>
     </PropertyGroup>
 
     <!-- Ensure the test results dir exists -->
@@ -500,7 +500,9 @@
       <!-- Build exe commands -->
       <TestResultsXunit Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)$(TestResultsFileName)-xunit.$(TestResultOutputFormat)</TestResultsXunit>
       <TestResultsVsts Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)$(TestResultsFileName)-vsts.$(TestResultOutputFormat)</TestResultsVsts>
-      <VSTestCommand>$(DotnetExePath) vstest $(CoreInputTestAssembliesSpaced) --TestAdapterPath:. --logger:xunit;LogFilePath=$(TestResultsVsts)</VSTestCommand>
+      <VsTestLogger Condition="'$(IsXPlat)' == 'true'">/logger:trx;LogFilePath=$(TestResultsDirectory)$(TestResultsFileName).trx</VsTestLogger>
+      <VsTestLogger Condition="'$(IsXPlat)' != 'true'">--TestAdapterPath:. --logger:xunit;LogFilePath=$(TestResultsVsts)
+      <VSTestCommand>$(DotnetExePath) vstest $(CoreInputTestAssembliesSpaced) $(VsTestLogger)</VSTestCommand>
       <DesktopTestCommand>$(XunitConsoleExePath) $(DesktopInputTestAssembliesSpaced)</DesktopTestCommand>
       <DesktopTestCommand Condition=" '$(TestResultsXunit)' != '' ">$(DesktopTestCommand) -$(TestResultOutputFormat) $(TestResultsXunit)</DesktopTestCommand>
     </PropertyGroup>

--- a/build/build.proj
+++ b/build/build.proj
@@ -483,7 +483,7 @@
     </MSBuild>
 
     <PropertyGroup>
-      <TestResultsDirectory>$(ArtifactsDirectory)TestResults\</TestResultsDirectory>
+      <TestResultsDirectory>$(RepositoryRootDirectory)TestResults\</TestResultsDirectory>
     </PropertyGroup>
 
     <!-- Ensure the test results dir exists -->
@@ -496,12 +496,13 @@
       <CoreInputTestAssemblies>@(TestAssemblyPath->WithMetadataValue("IsCore", "true"))</CoreInputTestAssemblies>
       <CoreInputTestAssembliesSpaced>$(CoreInputTestAssemblies.Replace(';', ' '))</CoreInputTestAssembliesSpaced>
       
-      <TestResultOutputFormat Condition="'$(TestResultOutputFormat)' == ''">html</TestResultOutputFormat>
+      <TestResultOutputFormat Condition="'$(TestResultOutputFormat)' == ''">xml</TestResultOutputFormat>
       <!-- Build exe commands -->
-      <TestResultsHtml Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)$(TestResultsFileName)-xunit.$(TestResultOutputFormat)</TestResultsHtml>
-      <VSTestCommand>$(DotnetExePath) vstest $(CoreInputTestAssembliesSpaced) --TestAdapterPath:. --logger:xunit;LogFileName=$(TestResultsDirectory)$(TestResultsFileName)-vstest.$(TestResultOutputFormat)</VSTestCommand>
+      <TestResultsXunit Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)$(TestResultsFileName)-xunit.$(TestResultOutputFormat)</TestResultsXunit>
+      <TestResultsVsts Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)$(TestResultsFileName)-vsts.$(TestResultOutputFormat)</TestResultsVsts>
+      <VSTestCommand>$(DotnetExePath) vstest $(CoreInputTestAssembliesSpaced) --TestAdapterPath:. --logger:xunit;LogFilePath=$(TestResultsVsts)</VSTestCommand>
       <DesktopTestCommand>$(XunitConsoleExePath) $(DesktopInputTestAssembliesSpaced)</DesktopTestCommand>
-      <DesktopTestCommand Condition=" '$(TestResultsHtml)' != '' ">$(DesktopTestCommand) -$(TestResultOutputFormat) $(TestResultsHtml)</DesktopTestCommand>
+      <DesktopTestCommand Condition=" '$(TestResultsXunit)' != '' ">$(DesktopTestCommand) -$(TestResultOutputFormat) $(TestResultsXunit)</DesktopTestCommand>
     </PropertyGroup>
 
     <!-- Desktop -->
@@ -518,10 +519,10 @@
       <Output TaskParameter="ExitCode" PropertyName="VSTestErrorCode"/>
     </Exec>
 
-    <!--Error Text="Desktop $(TestResultsFileName) tests failed! Results: $(TestResultsHtml)" Condition=" '$(DesktopTestErrorCode)' != '0' AND '$(DesktopTestErrorCode)' != '' " /-->
-    <Error Text="NETCore $(TestResultsFileName) tests failed!" Condition=" '$(VSTestErrorCode)' != '0' AND '$(VSTestErrorCode)' != '' " />
+    <Error Text="Desktop $(TestResultsFileName) tests failed! Results: $(TestResultsXunit)" Condition=" '$(DesktopTestErrorCode)' != '0' AND '$(DesktopTestErrorCode)' != '' " />
+    <Error Text="NETCore $(TestResultsFileName) tests failed! Results: $(TestResultsVsts)" Condition=" '$(VSTestErrorCode)' != '0' AND '$(VSTestErrorCode)' != '' " />
 
-    <Message Text="Desktop $(TestResultsFileName) tests passed!" Condition=" '$(DesktopTestErrorCode)' == '0' " />
-    <Message Text="NETCore $(TestResultsFileName) tests passed!" Condition=" '$(VSTestErrorCode)' == '0' " />
+    <Message Text="Desktop $(TestResultsFileName) tests passed! Results: $(TestResultsXunit)" Condition=" '$(DesktopTestErrorCode)' == '0' " />
+    <Message Text="NETCore $(TestResultsFileName) tests passed! Results: $(TestResultsVsts)" Condition=" '$(VSTestErrorCode)' == '0' " />
   </Target>
 </Project>

--- a/build/build.proj
+++ b/build/build.proj
@@ -498,18 +498,18 @@
       
       <TestResultOutputFormat Condition="'$(TestResultOutputFormat)' == ''">html</TestResultOutputFormat>
       <!-- Build exe commands -->
-      <TestResultsHtml Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)$(TestResultsFileName).$(TestResultOutputFormat)</TestResultsHtml>
-      <VSTestCommand>$(DotnetExePath) vstest $(CoreInputTestAssembliesSpaced) $DesktopInputTestAssembliesSpaced /logger:trx;LogFileName=$(TestResultsDirectory)$(TestResultsFileName)</VSTestCommand>
+      <TestResultsHtml Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)$(TestResultsFileName)-xunit.$(TestResultOutputFormat)</TestResultsHtml>
+      <VSTestCommand>$(DotnetExePath) vstest $(CoreInputTestAssembliesSpaced) --TestAdapterPath:. --logger:xunit;LogFileName=$(TestResultsDirectory)$(TestResultsFileName)-vstest.$(TestResultOutputFormat)</VSTestCommand>
       <DesktopTestCommand>$(XunitConsoleExePath) $(DesktopInputTestAssembliesSpaced)</DesktopTestCommand>
       <DesktopTestCommand Condition=" '$(TestResultsHtml)' != '' ">$(DesktopTestCommand) -$(TestResultOutputFormat) $(TestResultsHtml)</DesktopTestCommand>
     </PropertyGroup>
 
     <!-- Desktop -->
-    <!--Exec Command="$(DesktopTestCommand)"
+    <Exec Command="$(DesktopTestCommand)"
           ContinueOnError="true"
           Condition=" '$(DesktopInputTestAssemblies)' != '' AND '$(SkipDesktopTests)' != 'true' ">
       <Output TaskParameter="ExitCode" PropertyName="DesktopTestErrorCode"/>
-    </Exec-->
+    </Exec>
 
     <!-- VSTest/NETCore -->
     <Exec Command="$(VSTestCommand)"
@@ -521,7 +521,7 @@
     <!--Error Text="Desktop $(TestResultsFileName) tests failed! Results: $(TestResultsHtml)" Condition=" '$(DesktopTestErrorCode)' != '0' AND '$(DesktopTestErrorCode)' != '' " /-->
     <Error Text="NETCore $(TestResultsFileName) tests failed!" Condition=" '$(VSTestErrorCode)' != '0' AND '$(VSTestErrorCode)' != '' " />
 
-    <!--Message Text="Desktop $(TestResultsFileName) tests passed!" Condition=" '$(DesktopTestErrorCode)' == '0' " /-->
+    <Message Text="Desktop $(TestResultsFileName) tests passed!" Condition=" '$(DesktopTestErrorCode)' == '0' " />
     <Message Text="NETCore $(TestResultsFileName) tests passed!" Condition=" '$(VSTestErrorCode)' == '0' " />
   </Target>
 </Project>

--- a/build/build.proj
+++ b/build/build.proj
@@ -501,7 +501,7 @@
       <TestResultsXunit Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)$(TestResultsFileName)-xunit.$(TestResultOutputFormat)</TestResultsXunit>
       <TestResultsVsts Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)$(TestResultsFileName)-vsts.$(TestResultOutputFormat)</TestResultsVsts>
       <VsTestLogger Condition="'$(IsXPlat)' == 'true'">/logger:trx;LogFilePath=$(TestResultsDirectory)$(TestResultsFileName).trx</VsTestLogger>
-      <VsTestLogger Condition="'$(IsXPlat)' != 'true'">--TestAdapterPath:. --logger:xunit;LogFilePath=$(TestResultsVsts)
+      <VsTestLogger Condition="'$(IsXPlat)' != 'true'">--TestAdapterPath:. --logger:xunit;LogFilePath=$(TestResultsVsts)</VsTestLogger>
       <VSTestCommand>$(DotnetExePath) vstest $(CoreInputTestAssembliesSpaced) $(VsTestLogger)</VSTestCommand>
       <DesktopTestCommand>$(XunitConsoleExePath) $(DesktopInputTestAssembliesSpaced)</DesktopTestCommand>
       <DesktopTestCommand Condition=" '$(TestResultsXunit)' != '' ">$(DesktopTestCommand) -$(TestResultOutputFormat) $(TestResultsXunit)</DesktopTestCommand>

--- a/build/build.proj
+++ b/build/build.proj
@@ -499,17 +499,17 @@
       <TestResultOutputFormat Condition="'$(TestResultOutputFormat)' == ''">html</TestResultOutputFormat>
       <!-- Build exe commands -->
       <TestResultsHtml Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)$(TestResultsFileName).$(TestResultOutputFormat)</TestResultsHtml>
-      <VSTestCommand>$(DotnetExePath) vstest $(CoreInputTestAssembliesSpaced) /logger:trx;LogFileName=$(TestResultsDirectory)$(TestResultsFileName).trx</VSTestCommand>
+      <VSTestCommand>$(DotnetExePath) vstest $(CoreInputTestAssembliesSpaced) $DesktopInputTestAssembliesSpaced /logger:trx;LogFileName=$(TestResultsDirectory)$(TestResultsFileName)</VSTestCommand>
       <DesktopTestCommand>$(XunitConsoleExePath) $(DesktopInputTestAssembliesSpaced)</DesktopTestCommand>
       <DesktopTestCommand Condition=" '$(TestResultsHtml)' != '' ">$(DesktopTestCommand) -$(TestResultOutputFormat) $(TestResultsHtml)</DesktopTestCommand>
     </PropertyGroup>
 
     <!-- Desktop -->
-    <Exec Command="$(DesktopTestCommand)"
+    <!--Exec Command="$(DesktopTestCommand)"
           ContinueOnError="true"
           Condition=" '$(DesktopInputTestAssemblies)' != '' AND '$(SkipDesktopTests)' != 'true' ">
       <Output TaskParameter="ExitCode" PropertyName="DesktopTestErrorCode"/>
-    </Exec>
+    </Exec-->
 
     <!-- VSTest/NETCore -->
     <Exec Command="$(VSTestCommand)"
@@ -518,10 +518,10 @@
       <Output TaskParameter="ExitCode" PropertyName="VSTestErrorCode"/>
     </Exec>
 
-    <Error Text="Desktop $(TestResultsFileName) tests failed! Results: $(TestResultsHtml)" Condition=" '$(DesktopTestErrorCode)' != '0' AND '$(DesktopTestErrorCode)' != '' " />
+    <!--Error Text="Desktop $(TestResultsFileName) tests failed! Results: $(TestResultsHtml)" Condition=" '$(DesktopTestErrorCode)' != '0' AND '$(DesktopTestErrorCode)' != '' " /-->
     <Error Text="NETCore $(TestResultsFileName) tests failed!" Condition=" '$(VSTestErrorCode)' != '0' AND '$(VSTestErrorCode)' != '' " />
 
-    <Message Text="Desktop $(TestResultsFileName) tests passed!" Condition=" '$(DesktopTestErrorCode)' == '0' " />
+    <!--Message Text="Desktop $(TestResultsFileName) tests passed!" Condition=" '$(DesktopTestErrorCode)' == '0' " /-->
     <Message Text="NETCore $(TestResultsFileName) tests passed!" Condition=" '$(VSTestErrorCode)' == '0' " />
   </Target>
 </Project>

--- a/build/build.proj
+++ b/build/build.proj
@@ -483,7 +483,7 @@
     </MSBuild>
 
     <PropertyGroup>
-      <TestResultsDirectory>$(BuildCommonDirectory)TestResults\</TestResultsDirectory>
+      <TestResultsDirectory>$(BuildCommonDirectory)TestResults</TestResultsDirectory>
     </PropertyGroup>
 
     <!-- Ensure the test results dir exists -->
@@ -498,10 +498,9 @@
       
       <TestResultOutputFormat Condition="'$(TestResultOutputFormat)' == ''">xml</TestResultOutputFormat>
       <!-- Build exe commands -->
-      <TestResultsXunit Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)$(TestResultsFileName)-xunit.$(TestResultOutputFormat)</TestResultsXunit>
-      <TestResultsVsts Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)$(TestResultsFileName)-vsts.$(TestResultOutputFormat)</TestResultsVsts>
-      <VsTestLogger Condition="'$(IsXPlat)' == 'true'">/logger:trx;LogFilePath=$(TestResultsDirectory)$(TestResultsFileName).trx</VsTestLogger>
-      <VsTestLogger Condition="'$(IsXPlat)' != 'true'">--TestAdapterPath:. --logger:xunit;LogFilePath=$(TestResultsVsts)</VsTestLogger>
+      <TestResultsXunit Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)\$(TestResultsFileName)-xunit.$(TestResultOutputFormat)</TestResultsXunit>
+      <TestResultsVsts Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)\$(TestResultsFileName)-vsts.$(TestResultOutputFormat)</TestResultsVsts>
+      <VsTestLogger>--TestAdapterPath:$(XunitXmlLoggerDirectory) --logger:xunit;LogFileName=$(TestResultsFileName)-vsts.$(TestResultOutputFormat)</VsTestLogger>
       <VSTestCommand>$(DotnetExePath) vstest $(CoreInputTestAssembliesSpaced) $(VsTestLogger)</VSTestCommand>
       <DesktopTestCommand>$(XunitConsoleExePath) $(DesktopInputTestAssembliesSpaced)</DesktopTestCommand>
       <DesktopTestCommand Condition=" '$(TestResultsXunit)' != '' ">$(DesktopTestCommand) -$(TestResultOutputFormat) $(TestResultsXunit)</DesktopTestCommand>
@@ -524,7 +523,7 @@
     <Error Text="Desktop $(TestResultsFileName) tests failed! Results: $(TestResultsXunit)" Condition=" '$(DesktopTestErrorCode)' != '0' AND '$(DesktopTestErrorCode)' != '' " />
     <Error Text="NETCore $(TestResultsFileName) tests failed! Results: $(TestResultsVsts)" Condition=" '$(VSTestErrorCode)' != '0' AND '$(VSTestErrorCode)' != '' " />
 
-    <Message Text="Desktop $(TestResultsFileName) tests passed! Results: $(TestResultsXunit)" Condition=" '$(DesktopTestErrorCode)' == '0' " />
-    <Message Text="NETCore $(TestResultsFileName) tests passed! Results: $(TestResultsVsts)" Condition=" '$(VSTestErrorCode)' == '0' " />
+    <Message Text="Desktop $(TestResultsFileName) tests passed! Results: $(TestResultsXunit)" Condition=" '$(DesktopTestErrorCode)' == '0' " Importance="High" />
+    <Message Text="NETCore $(TestResultsFileName) tests passed! Results: $(TestResultsVsts)" Condition=" '$(VSTestErrorCode)' == '0' " Importance="High" />
   </Target>
 </Project>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -24,6 +24,7 @@
     <SolutionPackagesFolder>$(RepositoryRootDirectory)packages\</SolutionPackagesFolder>
     <XunitConsoleExePath>$(SolutionPackagesFolder)xunit.runner.console.2.3.1\tools\net452\xunit.console.x86.exe</XunitConsoleExePath>
     <ILMergeExePath>$(SolutionPackagesFolder)ILMerge.2.14.1208\tools\ILMerge.exe</ILMergeExePath>
+    <XunitXmlLoggerDirectory>$(SolutionPackagesFolder)XunitXml.TestLogger.2.0.0\build\_common</XunitXmlLoggerDirectory>
     <EnlistmentRoot>$(RepositoryRootDirectory)</EnlistmentRoot>
     <EnlistmentRootSrc>$(RepositoryRootDirectory)src</EnlistmentRootSrc>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(RepositoryRootDirectory)</SolutionDir>

--- a/build/common.targets
+++ b/build/common.targets
@@ -246,52 +246,6 @@
 
   <!--
     ============================================================
-    RunTests for the current project
-    Top level entry point for tests
-    ============================================================
-  -->
-  <Target Name="RunTests"
-          DependsOnTargets="Build;GetTargetFrameworkSet"
-          Condition=" '$(TestProject)' == 'true' AND '$(SkipTests)' != 'true' ">
-    <Message Text="Running tests for $(ProjectName)" Importance="high" />
-    
-    <!-- Execute tests for each framework -->
-    <MSBuild
-      Projects="$(MSBuildProjectFullPath)"
-      Targets="RunTestsInner"
-      Properties="TargetFramework=%(ProjectTargetFrameworkEntries.Identity);
-                  Configuration=$(Configuration);
-                  VisualStudioVersion=$(VisualStudioVersion);">
-    </MSBuild>
-  </Target>
-
-  <!--
-    ============================================================
-    RunTests for the current framework
-    Called by RunTests, this calls XUnit
-    ============================================================
-  -->
-  <Target Name="RunTestsInner">
-    <PropertyGroup>
-      <TestAssemblyPath>$(OutputPath)$(AssemblyName).dll</TestAssemblyPath>
-    </PropertyGroup>
-    <Message Text="Running tests on $(TestAssemblyPath)" Importance="high" />
-
-    <!-- Ensure the test results dir exists -->
-    <MakeDir Directories="$(TestResultsDirectory)"
-      Condition=" '$(IsDesktop)' == 'true' AND '$(SkipDesktopTests)' != 'true' " />
-
-    <!-- For desktop frameworks use the console runner -->
-    <Exec Command="$(XunitConsoleExePath) $(TestAssemblyPath) -html $(TestResultsDirectory)$(ProjectName).VS$(VisualStudioVersion).html"
-          Condition=" '$(IsDesktop)' == 'true' AND '$(SkipDesktopTests)' != 'true' " />
-
-    <!-- For other frameworks call dotnet test -->
-    <Exec Command="$(DotnetExePath) test -f $(TargetFramework) --no-build -c $(Configuration)"
-          Condition=" '$(IsDesktop)' != 'true' AND '$(SkipCoreTests)' != 'true' " />
-  </Target>
-
-  <!--
-    ============================================================
     GetTestAssemblies
     ============================================================
   -->

--- a/build/test.targets
+++ b/build/test.targets
@@ -16,6 +16,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
+    <PackageReference Include="XunitXml.TestLogger" Version="2.0.0"/>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 

--- a/build/test.targets
+++ b/build/test.targets
@@ -16,12 +16,11 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
-    <PackageReference Include="XunitXml.TestLogger" Version="2.0.0"/>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 
   <PropertyGroup>
-    <TestResultsDirectory>$(ArtifactsDirectory)TestResults\</TestResultsDirectory>
+    <TestResultsDirectory>$(BuildCommonDirectory)TestResults\</TestResultsDirectory>
   </PropertyGroup>
 
   <!-- Workaround for test projects not automatically creating binding redirects -->

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -397,13 +397,23 @@ phases:
       searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
       mergeTestResults: "true"
 
-  - task: ms-devlabs.utilitytasks.task-Shellpp.Shell++@0
+  # - task: ms-devlabs.utilitytasks.task-Shellpp.Shell++@0
+  #   displayName: "Initialize Git Commit Status on GitHub"
+  #   inputs:
+  #     type: "FilePath"
+  #     scriptPath: "scripts/utils/PostGitCommitStatus.sh"
+  #     args: "$(NuGetLurkerPersonalAccessToken) \"Tests On Linux\" $(Agent.JobStatus)"
+  #     cwd: "$(Build.Repository.LocalPath)"
+  #   condition: "always()"
+
+  - task: PowerShell@2
     displayName: "Initialize Git Commit Status on GitHub"
     inputs:
-      type: "FilePath"
-      scriptPath: "scripts/utils/PostGitCommitStatus.sh"
-      args: "$(NuGetLurkerPersonalAccessToken) \"Tests On Linux\" $(Agent.JobStatus)"
-      cwd: "$(Build.Repository.LocalPath)"
+      targetType: "inline"
+      script: |
+        . $(Build.Repository.LocalPath)/scripts/utils/PostGitCommitStatus.ps1
+        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Tests On Linux"        
+      failOnStderr: "true"
     condition: "always()"
 
 - phase: Tests_On_Mac

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -397,23 +397,13 @@ phases:
       searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
       mergeTestResults: "true"
 
-  # - task: ms-devlabs.utilitytasks.task-Shellpp.Shell++@0
-  #   displayName: "Initialize Git Commit Status on GitHub"
-  #   inputs:
-  #     type: "FilePath"
-  #     scriptPath: "scripts/utils/PostGitCommitStatus.sh"
-  #     args: "$(NuGetLurkerPersonalAccessToken) \"Tests On Linux\" $(Agent.JobStatus)"
-  #     cwd: "$(Build.Repository.LocalPath)"
-  #   condition: "always()"
-
-  - task: PowerShell@2
+  - task: ms-devlabs.utilitytasks.task-Shellpp.Shell++@0
     displayName: "Initialize Git Commit Status on GitHub"
     inputs:
-      targetType: "inline"
-      script: |
-        . $(Build.Repository.LocalPath)/scripts/utils/PostGitCommitStatus.ps1
-        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Tests On Linux"        
-      failOnStderr: "true"
+      type: "FilePath"
+      scriptPath: "scripts/utils/PostGitCommitStatus.sh"
+      args: "$(NuGetLurkerPersonalAccessToken) \"Tests On Linux\" $(Agent.JobStatus)"
+      cwd: "$(Build.Repository.LocalPath)"
     condition: "always()"
 
 - phase: Tests_On_Mac

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -118,7 +118,7 @@ phases:
     condition: "and(always(),eq(variables['BuildRTM'], 'true'))"
 
   - task: PublishTestResults@2
-    displayName: "Publish Desktop Test Results"
+    displayName: "Publish Test Results"
     inputs:
       testRunner: "XUnit"
       testResultsFiles: "*.xml"
@@ -358,7 +358,7 @@ phases:
     condition: "always()"
 
   - task: PublishTestResults@2
-    displayName: "Publish Desktop Test Results"
+    displayName: "Publish Test Results"
     continueOnError: "true"
     inputs:
       testRunner: "XUnit"
@@ -398,8 +398,8 @@ phases:
     displayName: "Publish Test Results"
     condition: "succeededOrFailed()"
     inputs:
-      testRunner: "VSTest"
-      testResultsFiles: "*.trx"
+      testRunner: "XUnit"
+      testResultsFiles: "*.xml"
       testRunTitle: "NuGet.Client Tests on Linux"
       searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
       mergeTestResults: "true"
@@ -440,23 +440,12 @@ phases:
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
     inputs:
-      testRunner: "VSTest"
-      testResultsFiles: "*.trx"
-      searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
-      mergeTestResults: "true"
-      testRunTitle: "NuGet.Client Tests on Mac"
-    condition: "succeededOrFailed()"
-
-  - task: PublishTestResults@2
-    displayName: "Publish Test Results for Mono"
-    inputs:
       testRunner: "XUnit"
       testResultsFiles: "*.xml"
       searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
       mergeTestResults: "true"
-      testRunTitle: "NuGet.Client Tests on Mono for Mac"
+      testRunTitle: "NuGet.Client Tests On Mac"
     condition: "succeededOrFailed()"
-
 
 - phase: End_To_End_Tests_On_Windows
   dependsOn: Build_and_UnitTest

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -122,18 +122,7 @@ phases:
     inputs:
       testRunner: "XUnit"
       testResultsFiles: "*.xml"
-      testRunTitle: "NuGet.Client Desktop Unit Tests On Windows"
-      searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
-      mergeTestResults: "true"
-      publishRunAttachments: "false"
-    condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
-
-  - task: PublishTestResults@2
-    displayName: "Publish NETCore Test Results"
-    inputs:
-      testRunner: "VSTest"
-      testResultsFiles: "*.trx"
-      testRunTitle: "NuGet.Client .NET Core Unit Tests On Windows"
+      testRunTitle: "NuGet.Client Unit Tests On Windows"
       searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
       mergeTestResults: "true"
       publishRunAttachments: "false"
@@ -376,17 +365,7 @@ phases:
       testResultsFiles: "*.xml"
       searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
       mergeTestResults: "true"
-      testRunTitle: "NuGet.Client Desktop Functional Tests On Windows"
-    condition: "succeededOrFailed()"
-
-  - task: PublishTestResults@2
-    displayName: "Publish NETCore Test Results"
-    inputs:
-      testRunner: "VSTest"
-      testResultsFiles: "*.trx"
-      searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
-      mergeTestResults: "true"
-      testRunTitle: "NuGet.Client .NET Core Funtional Tests On Windows"
+      testRunTitle: "NuGet.Client Functional Tests On Windows"
     condition: "succeededOrFailed()"
 
 - phase: Tests_On_Linux
@@ -420,7 +399,7 @@ phases:
     condition: "succeededOrFailed()"
     inputs:
       testRunner: "VSTest"
-      testResultsFiles: "*.xml"
+      testResultsFiles: "*.trx"
       testRunTitle: "NuGet.Client Tests on Linux"
       searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
       mergeTestResults: "true"
@@ -697,7 +676,7 @@ phases:
     inputs:
       testRunner: "XUnit"
       testResultsFiles: "*.xml"
-      searchFolder: "$(System.DefaultWorkingDirectory)\\build\\testresults"
+      searchFolder: "$(System.DefaultWorkingDirectory)\\build\\TestResults"
       mergeTestResults: "true"
       testRunTitle: "NuGet.Client Apex Tests"
     condition: "succeededOrFailed()"

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -123,7 +123,7 @@ phases:
       testRunner: "XUnit"
       testResultsFiles: "*.xml"
       testRunTitle: "NuGet.Client Desktop Unit Tests On Windows"
-      searchFolder: "$(Build.Repository.LocalPath)\\artifacts\\TestResults"
+      searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
       mergeTestResults: "true"
       publishRunAttachments: "false"
     condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
@@ -134,7 +134,7 @@ phases:
       testRunner: "VSTest"
       testResultsFiles: "*.trx"
       testRunTitle: "NuGet.Client .NET Core Unit Tests On Windows"
-      searchFolder: "$(Build.Repository.LocalPath)\\artifacts\\TestResults"
+      searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
       mergeTestResults: "true"
       publishRunAttachments: "false"
     condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
@@ -374,7 +374,7 @@ phases:
     inputs:
       testRunner: "XUnit"
       testResultsFiles: "*.xml"
-      searchFolder: "$(Build.Repository.LocalPath)\\artifacts\\TestResults"
+      searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
       mergeTestResults: "true"
       testRunTitle: "NuGet.Client Desktop Functional Tests On Windows"
     condition: "succeededOrFailed()"
@@ -384,7 +384,7 @@ phases:
     inputs:
       testRunner: "VSTest"
       testResultsFiles: "*.trx"
-      searchFolder: "$(Build.Repository.LocalPath)\\artifacts\\TestResults"
+      searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
       mergeTestResults: "true"
       testRunTitle: "NuGet.Client .NET Core Funtional Tests On Windows"
     condition: "succeededOrFailed()"
@@ -420,7 +420,7 @@ phases:
     condition: "succeededOrFailed()"
     inputs:
       testRunner: "VSTest"
-      testResultsFiles: "*.trx"
+      testResultsFiles: "*.xml"
       testRunTitle: "NuGet.Client Tests on Linux"
       searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
       mergeTestResults: "true"
@@ -697,7 +697,7 @@ phases:
     inputs:
       testRunner: "XUnit"
       testResultsFiles: "*.xml"
-      searchFolder: "$(System.DefaultWorkingDirectory)\\artifacts\\testresults"
+      searchFolder: "$(System.DefaultWorkingDirectory)\\build\\testresults"
       mergeTestResults: "true"
       testRunTitle: "NuGet.Client Apex Tests"
     condition: "succeededOrFailed()"

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -108,15 +108,6 @@ phases:
       msbuildArguments: "/t:CoreUnitTests;UnitTestsVS15 /p:NUGET_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\NuGetKey.snk /p:MS_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\35MSSharedLib1024.snk  /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(Revision) /p:TestResultOutputFormat=xml"
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
-  - task: PowerShell@1
-    displayName: "Initialize Git Commit Status on GitHub"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
-        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Unit Tests On Windows"
-    condition: "and(always(),eq(variables['BuildRTM'], 'true'))"
-
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
     inputs:
@@ -127,6 +118,16 @@ phases:
       mergeTestResults: "true"
       publishRunAttachments: "false"
     condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
+
+  - task: PowerShell@1
+    displayName: "Initialize Git Commit Status on GitHub"
+    inputs:
+      scriptType: "inlineScript"
+      arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
+      inlineScript: |
+        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
+        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Unit Tests On Windows"
+    condition: "and(always(),eq(variables['BuildRTM'], 'true'))"
 
   - task: PublishBuildArtifacts@1
     displayName: "Publish NuGet.CommandLine.Test as artifact"
@@ -348,15 +349,6 @@ phases:
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/t:CoreFuncTests  /p:BuildRTM=false  /p:BuildNumber=$(Revision) /p:TestResultOutputFormat=xml"
 
-  - task: PowerShell@1
-    displayName: "Initialize Git Commit Status on GitHub"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
-        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Functional Tests On Windows"
-    condition: "always()"
-
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
     continueOnError: "true"
@@ -367,6 +359,16 @@ phases:
       mergeTestResults: "true"
       testRunTitle: "NuGet.Client Functional Tests On Windows"
     condition: "succeededOrFailed()"
+
+  - task: PowerShell@1
+    displayName: "Initialize Git Commit Status on GitHub"
+    inputs:
+      scriptType: "inlineScript"
+      arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
+      inlineScript: |
+        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
+        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -TestName "Functional Tests On Windows"
+    condition: "always()"
 
 - phase: Tests_On_Linux
   dependsOn: Initialize_Build
@@ -384,7 +386,17 @@ phases:
       scriptPath: "scripts/funcTests/runFuncTests.sh"
       disableAutoCwd: "true"
       cwd: "$(Build.Repository.LocalPath)"
-  
+
+  - task: PublishTestResults@2
+    displayName: "Publish Test Results"
+    condition: "succeededOrFailed()"
+    inputs:
+      testRunner: "XUnit"
+      testResultsFiles: "*.xml"
+      testRunTitle: "NuGet.Client Tests On Linux"
+      searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
+      mergeTestResults: "true"
+
   - task: ms-devlabs.utilitytasks.task-Shellpp.Shell++@0
     displayName: "Initialize Git Commit Status on GitHub"
     inputs:
@@ -393,16 +405,6 @@ phases:
       args: "$(NuGetLurkerPersonalAccessToken) \"Tests On Linux\" $(Agent.JobStatus)"
       cwd: "$(Build.Repository.LocalPath)"
     condition: "always()"
-
-  - task: PublishTestResults@2
-    displayName: "Publish Test Results"
-    condition: "succeededOrFailed()"
-    inputs:
-      testRunner: "XUnit"
-      testResultsFiles: "*.xml"
-      testRunTitle: "NuGet.Client Tests on Linux"
-      searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
-      mergeTestResults: "true"
 
 - phase: Tests_On_Mac
   dependsOn: Build_and_UnitTest
@@ -428,15 +430,6 @@ phases:
       disableAutoCwd: "true"
       cwd: "$(Build.Repository.LocalPath)"
 
-  - task: ms-devlabs.utilitytasks.task-Shellpp.Shell++@0
-    displayName: "Initialize Git Commit Status on GitHub"
-    inputs:
-      type: "FilePath"
-      scriptPath: "scripts/utils/PostGitCommitStatus.sh"
-      args: "$(NuGetLurkerPersonalAccessToken) \"Tests On Mac\" $(Agent.JobStatus)"
-      cwd: "$(Build.Repository.LocalPath)"
-    condition: "always()"
-
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
     inputs:
@@ -446,6 +439,15 @@ phases:
       mergeTestResults: "true"
       testRunTitle: "NuGet.Client Tests On Mac"
     condition: "succeededOrFailed()"
+
+  - task: ms-devlabs.utilitytasks.task-Shellpp.Shell++@0
+    displayName: "Initialize Git Commit Status on GitHub"
+    inputs:
+      type: "FilePath"
+      scriptPath: "scripts/utils/PostGitCommitStatus.sh"
+      args: "$(NuGetLurkerPersonalAccessToken) \"Tests On Mac\" $(Agent.JobStatus)"
+      cwd: "$(Build.Repository.LocalPath)"
+    condition: "always()"
 
 - phase: End_To_End_Tests_On_Windows
   dependsOn: Build_and_UnitTest
@@ -457,7 +459,6 @@ phases:
     name: DDNuGet-Windows
     timeoutInMinutes: 75
     demands: DotNetFramework
-
 
   steps:
   - task: PowerShell@1
@@ -518,15 +519,6 @@ phases:
       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
       arguments: "-PMCCommand $(EndToEndTestCommandToRun) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 15.0"
 
-  - task: PowerShell@1
-    displayName: "Initialize Git Commit Status on GitHub"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
-        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "EndToEnd Tests On Windows"
-    condition: "always()"
-
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
     inputs:
@@ -534,8 +526,18 @@ phases:
       testResultsFiles: "*.xml"
       searchFolder: "$(System.DefaultWorkingDirectory)\\testresults"
       mergeTestResults: "true"
-      testRunTitle: "NuGet.Client End To End Tests "
+      testRunTitle: "NuGet.Client EndToEnd Tests On Windows"
     condition: "succeededOrFailed()"
+
+  - task: PowerShell@1
+    displayName: "Initialize Git Commit Status on GitHub"
+    inputs:
+      scriptType: "inlineScript"
+      arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
+      inlineScript: |
+        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
+        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "EndToEnd Tests On Windows"
+    condition: "always()"
 
   - task: PowerShell@1
     displayName: "Kill running instances of DevEnv"
@@ -651,15 +653,6 @@ phases:
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml  /p:NUGET_PFX_PATH=$(System.DefaultWorkingDirectory)\\keys\\NuGetKey.snk /p:MS_PFX_PATH=$(System.DefaultWorkingDirectory)\\keys\\35MSSharedLib1024.snk /p:BuildNumber=$(Build.BuildNumber)"
 
-  - task: PowerShell@1
-    displayName: "Initialize Git Commit Status on GitHub"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
-        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Apex Tests On Windows"
-    condition: "always()"
-
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
     inputs:
@@ -667,8 +660,18 @@ phases:
       testResultsFiles: "*.xml"
       searchFolder: "$(System.DefaultWorkingDirectory)\\build\\TestResults"
       mergeTestResults: "true"
-      testRunTitle: "NuGet.Client Apex Tests"
+      testRunTitle: "NuGet.Client Apex Tests On Windows"
     condition: "succeededOrFailed()"
+
+  - task: PowerShell@1
+    displayName: "Initialize Git Commit Status on GitHub"
+    inputs:
+      arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
+      scriptType: "inlineScript"
+      inlineScript: |
+        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
+        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Apex Tests On Windows"
+    condition: "always()"
 
   - task: PowerShell@1
     displayName: "Kill running instances of DevEnv"

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -70,9 +70,15 @@ fi
 # Unit tests
 echo "$DOTNET msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta"
 $DOTNET msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta
-$RESULTFILE = "build/TestResults/TestResults.xml"
-if [ -f  "$RESULTFILE" ]; then
-	mv "$RESULTFILE" "build/TestResults/TestResults.$(date +%H%M%S).xml"
+RESULTFILE="build/TestResults/TestResults.xml"
+
+echo "Checking if result file exists at $DIR$RESULTFILE"
+if [ -f  "$DIR$RESULTFILE" ]
+then
+	echo "Renaming $DIR$RESULTFILE"
+	mv "$RESULTFILE" "$DIR/build/TestResults/TestResults.$(date +%H%M%S).xml"
+else
+	echo "$DIR$RESULTFILE not found."
 fi
 
 if [ $? -ne 0 ]; then
@@ -83,8 +89,13 @@ fi
 # Func tests
 echo "$DOTNET msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta"
 $DOTNET msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta
-if [ -f  "$RESULTFILE" ]; then
-	mv "$RESULTFILE" "build/TestResults/TestResults.$(date +%H%M%S).xml"
+echo "Checking if result file exists at $DIR$RESULTFILE"
+if [ -f  "$DIR$RESULTFILE" ]
+then
+	echo "Renaming $DIR$RESULTFILE"
+	mv "$RESULTFILE" "$DIR/build/TestResults/TestResults.$(date +%H%M%S).xml"
+else
+	echo "$DIR$RESULTFILE not found."
 fi
 
 if [ $? -ne 0 ]; then

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -70,6 +70,11 @@ fi
 # Unit tests
 echo "$DOTNET msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta"
 $DOTNET msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta
+$RESULTFILE = "build/TestResults/TestResults.xml"
+if [ -f  "$RESULTFILE" ]; then
+	mv "$RESULTFILE" "build/TestResults/TestResults.$(date +%H%M%S).xml"
+fi
+
 if [ $? -ne 0 ]; then
 	echo "CoreUnitTests failed!!"
 	RESULTCODE=1
@@ -78,6 +83,10 @@ fi
 # Func tests
 echo "$DOTNET msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta"
 $DOTNET msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta
+if [ -f  "$RESULTFILE" ]; then
+	mv "$RESULTFILE" "build/TestResults/TestResults.$(date +%H%M%S).xml"
+fi
+
 if [ $? -ne 0 ]; then
 	RESULTCODE='1'
 	echo "CoreFuncTests failed!!"

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 env
+sudo ln -s /usr/bin/pwsh /usr/bin/powershell
+chmod +x /usr/bin/powershell
+chmod + /usr/bin/pwsh
+
 while true ; do
 	case "$1" in
 		-c|--clear-cache) CLEAR_CACHE=1 ; shift ;;

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -15,6 +15,19 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DIR=$SCRIPTDIR/../../
 pushd $DIR
 
+NuGetExe="$DIR/.nuget/nuget.exe"
+#Get NuGet.exe
+curl -o $NuGetExe https://dist.nuget.org/win-x86-commandline/v4.4.1/nuget.exe
+
+mono --version
+
+#restore solution packages
+mono $NuGetExe restore  "$DIR/.nuget/packages.config" -SolutionDirectory "$DIR"
+if [ $? -ne 0 ]; then
+	echo "Restore failed!!"
+	exit 1
+fi
+
 # Download the CLI install script to cli
 echo "Installing dotnet CLI"
 mkdir -p cli
@@ -78,19 +91,6 @@ fi
 #run mono test
 TestDir="$DIR/artifacts/NuGet.CommandLine.Test/"
 XunitConsole="$DIR/packages/xunit.runner.console.2.3.1/tools/net452/xunit.console.exe"
-NuGetExe="$DIR/.nuget/nuget.exe"
-
-#Get NuGet.exe
-curl -o $NuGetExe https://dist.nuget.org/win-x86-commandline/v4.4.1/nuget.exe
-
-mono --version
-
-#restore solution packages
-mono $NuGetExe restore  "$DIR/.nuget/packages.config" -SolutionDirectory "$DIR"
-if [ $? -ne 0 ]; then
-	echo "Restore failed!!"
-	exit 1
-fi
 
 #Clean System dll
 rm -r -f "$TestDir/System.*" "$TestDir/WindowsBase.dll" "$TestDir/Microsoft.CSharp.dll" "$TestDir/Microsoft.Build.Engine.dll"

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 env
-sudo ln -s /usr/bin/pwsh /usr/bin/powershell
-chmod +x /usr/bin/powershell
-chmod + /usr/bin/pwsh
-
 while true ; do
 	case "$1" in
 		-c|--clear-cache) CLEAR_CACHE=1 ; shift ;;

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -83,8 +83,8 @@ function SetCommitStatusForTestResult {
     # the status for those tests will forever be in pending state.
     if(($env:AGENT_JOBSTATUS -eq "Failed" -or $env:AGENT_JOBSTATUS -eq "Canceled") -and $TestName -eq "Unit Tests On Windows")
     {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests On Mac" -Status "failure" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "failed"
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "EndToEnd Tests On Windows" -Status "failure" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "failed"
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Apex Tests On Windows" -Status "failure" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "failed"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests On Mac" -Status "failure" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description $env:AGENT_JOBSTATUS
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "EndToEnd Tests On Windows" -Status "failure" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description $env:AGENT_JOBSTATUS
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Apex Tests On Windows" -Status "failure" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description $env:AGENT_JOBSTATUS
     }
 }

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -68,14 +68,21 @@ function SetCommitStatusForTestResult {
         [Parameter(Mandatory = $True)]
         [string]$TestName,
         [Parameter(Mandatory = $True)]
-        [string]$CommitSha
+        [string]$CommitSha,
+        [Parameter(Mandatory = $True)]
+        [string]$VstsPersonalAccessToken
     )
-
+    $testRun = Get-TestRun -TestName "NuGet.Client $TestName" -PersonalAccessToken $VstsPersonalAccessToken
+    $url = $testRun[0]
+    $failures = $testRun[1]
     if ($env:AGENT_JOBSTATUS -eq "Succeeded") {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "succeeded"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "success" -CommitSha $CommitSha -TargetUrl $url -Description $env:AGENT_JOBSTATUS
+    }
+    elseif ($env:AGENT_JOBSTATUS -eq "SucceededWithIssues") {
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "failure" -CommitSha $CommitSha -TargetUrl $url -Description "$failures tests failed"
     }
     else {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "failure" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "Failed"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "error" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description $env:AGENT_JOBSTATUS
     }
 
     # If the build gets cancelled or fails when the unit tests are running , we also need to call the github api to update status
@@ -87,4 +94,27 @@ function SetCommitStatusForTestResult {
         Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "EndToEnd Tests On Windows" -Status "failure" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description $env:AGENT_JOBSTATUS
         Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Apex Tests On Windows" -Status "failure" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description $env:AGENT_JOBSTATUS
     }
+}
+
+function Get-TestRun {
+    param(
+        [Parameter(Mandatory = $True)]
+        [string]$TestName,
+        [Parameter(Mandatory = $True)]
+        [string]$PersonalAccessToken
+    )
+    $url = "$env:VstsTestRunsRestApi$env:BUILD_BUILDID"
+    Write-Host $url
+    $Token = ":$PersonalAccessToken"
+    $Base64Token = [System.Convert]::ToBase64String([char[]]$Token)
+
+    $Headers = @{
+        Authorization = 'Basic {0}' -f $Base64Token;
+    }
+    $testRuns = Invoke-RestMethod -Uri $url -Method GET -Headers $Headers
+    Write-Host $testRuns
+    $matchingRun = $testRuns.value | where { $_.name -ieq $TestName }
+    $testUrl = $env:VstsTestRunUrl -f $matchingRun.id
+    $failedTests = $matchingRun.unanalyzedTests
+    return $testUrl,$failedTests
 }

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -75,7 +75,7 @@ function SetCommitStatusForTestResult {
         Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "succeeded"
     }
     else {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "failure" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "failed"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName $TestName -Status "failure" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "Failed"
     }
 
     # If the build gets cancelled or fails when the unit tests are running , we also need to call the github api to update status

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -114,7 +114,14 @@ function Get-TestRun {
     $testRuns = Invoke-RestMethod -Uri $url -Method GET -Headers $Headers
     Write-Host $testRuns
     $matchingRun = $testRuns.value | where { $_.name -ieq $TestName }
-    $testUrl = $env:VstsTestRunUrl -f $matchingRun.id
+    if(-not $matchingRun)
+    {
+        $testUrl = $env:BUILDURL
+    }
+    else
+    {
+        $testUrl = $env:VstsTestRunUrl -f $matchingRun.id
+    }
     $failedTests = $matchingRun.unanalyzedTests
     return $testUrl,$failedTests
 }

--- a/scripts/utils/PostGitCommitStatus.sh
+++ b/scripts/utils/PostGitCommitStatus.sh
@@ -7,7 +7,7 @@ echo "$3"
 if [ "$3" == "Succeeded" ]; then
     echo "Tests succeeded"
     STATE="success"
-    DESCRIPTION="succeeded"
+    DESCRIPTION="Succeeded"
 elif [ "$3" == "Canceled" ]; then
     echo "Tests succeeded"
     STATE="error"

--- a/scripts/utils/PostGitCommitStatus.sh
+++ b/scripts/utils/PostGitCommitStatus.sh
@@ -8,10 +8,14 @@ if [ "$3" == "Succeeded" ]; then
     echo "Tests succeeded"
     STATE="success"
     DESCRIPTION="succeeded"
+elif [ "$3" == "Canceled" ]; then
+    echo "Tests succeeded"
+    STATE="error"
+    DESCRIPTION="Canceled"
 else
     echo "Tests failed or were cancelled"
 	STATE="failure"
-    DESCRIPTION="failed"
+    DESCRIPTION="Failed"
 fi
 
 curl -u nugetlurker:$1 https://api.github.com/repos/nuget/nuget.client/statuses/$BUILD_SOURCEVERSION --data "{\"state\":\"$STATE\",\"context\":\"$2\", \"description\":\"$DESCRIPTION\", \"target_url\":\"$BUILDURL\"}"


### PR DESCRIPTION
  this is a required change to make some improvements to test reporting in the GitHub status.

This makes sure that each test publish task only has to publish to one test URL which can be linked to in the GitHub status .

Since dotnet vstest runner only outputs test results in the TRX format, I have used a test logger adapter to output results in XUnit xml format in this PR.

Summary:

Use the VSTS Test Run API to obtain the test run URL for each of the test phase, and use that url to update the git commit status. It also finds the number of test failures and adds that to the description in case any tests failed. If tests did not run or error'd out before the results could even be published, then the linked URL will be the build url.

Right now, this is only being done for windows based machines as i am waiting for our IT team to install powershell on the linux and mac machines, and then we will be able to use the same scripts across all OS.

CC: @rrelyea 
  