### PR TITLE
DevelopmentDependency flag support for PackageReference

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -146,7 +146,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 LibraryRange = new LibraryRange(
                     name: packageId,
                     versionRange: range,
-                    typeConstraint: LibraryDependencyTarget.Package)
+                    typeConstraint: LibraryDependencyTarget.Package),
+                SuppressParent = __.SuppressParent,
+                IncludeType = __.IncludeType
             };
 
             await ProjectServices.References.AddOrUpdatePackageReferenceAsync(dependency, token);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft;
 using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.References;
 using NuGet.Commands;
 using NuGet.Common;
@@ -275,11 +276,26 @@ namespace NuGet.PackageManagement.VisualStudio
                         originalFramework = framework.GetShortFolderName();
                     }
 
-                    await conditionalService.AddAsync(
+                    var reference = await conditionalService.AddAsync(
                         packageId,
                         formattedRange,
                         TargetFrameworkCondition,
                         originalFramework);
+
+                    // SuppressParent could be set to All if developmentDependency flag is true in package nuspec file.
+                    if (installationContext.SuppressParent != LibraryIncludeFlagUtils.DefaultSuppressParent &&
+                        installationContext.IncludeType != LibraryIncludeFlags.All)
+                    {
+                        await SetPackagePropertyValueAsync(
+                            reference.Metadata,
+                            ProjectItemProperties.PrivateAssets,
+                            MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(installationContext.SuppressParent)));
+
+                        await SetPackagePropertyValueAsync(
+                            reference.Metadata,
+                            ProjectItemProperties.IncludeAssets,
+                            MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(installationContext.IncludeType)));
+                    }
                 }
             }
             else
@@ -298,9 +314,30 @@ namespace NuGet.PackageManagement.VisualStudio
                     var existingReference = result.Reference;
                     await existingReference.Metadata.SetPropertyValueAsync("Version", formattedRange);
                 }
+
+                if (installationContext.SuppressParent != LibraryIncludeFlagUtils.DefaultSuppressParent &&
+                    installationContext.IncludeType != LibraryIncludeFlags.All)
+                {
+                    await SetPackagePropertyValueAsync(
+                        result.Reference.Metadata,
+                        ProjectItemProperties.PrivateAssets,
+                        MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(installationContext.SuppressParent)));
+
+                    await SetPackagePropertyValueAsync(
+                        result.Reference.Metadata,
+                        ProjectItemProperties.IncludeAssets,
+                        MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(installationContext.IncludeType)));
+                }
             }
 
             return true;
+        }
+
+        private async Task SetPackagePropertyValueAsync(IProjectProperties metadata, string propertyName, string propertyValue)
+        {
+            await metadata.SetPropertyValueAsync(
+                propertyName,
+                propertyValue);
         }
 
         public override async Task<bool> UninstallPackageAsync(PackageIdentity packageIdentity, INuGetProjectContext nuGetProjectContext, CancellationToken token)

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/Common/MSBuildUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/Common/MSBuildUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -11,6 +11,8 @@ using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
@@ -32,7 +34,15 @@ namespace NuGet.CommandLine.XPlat
                 packageReferenceArgs.Logger.LogWarning(string.Format(CultureInfo.CurrentCulture,
                     Strings.Warn_AddPkgWithoutRestore));
 
-                msBuild.AddPackageReference(packageReferenceArgs.ProjectPath, packageReferenceArgs.PackageDependency);
+                var libraryDependency = new LibraryDependency
+                {
+                    LibraryRange = new LibraryRange(
+                        name: packageReferenceArgs.PackageDependency.Id,
+                        versionRange: packageReferenceArgs.PackageDependency.VersionRange,
+                        typeConstraint: LibraryDependencyTarget.Package)
+                };
+
+                msBuild.AddPackageReference(packageReferenceArgs.ProjectPath, libraryDependency);
                 return 0;
             }
 
@@ -147,11 +157,10 @@ namespace NuGet.CommandLine.XPlat
                     packageReferenceArgs.PackageDependency.Id,
                     packageReferenceArgs.ProjectPath));
 
-                // If the user did not specify a version then update the version to resolved version
-                UpdatePackageVersionIfNeeded(restorePreviewResult, packageReferenceArgs, userSpecifiedFrameworks);
+                // generate a library dependency with all the metadata like Include, Exlude and SuppressParent
+                var libraryDependency = GenerateLibraryDependency(updatedPackageSpec, packageReferenceArgs, restorePreviewResult, userSpecifiedFrameworks);
 
-                msBuild.AddPackageReference(packageReferenceArgs.ProjectPath,
-                    packageReferenceArgs.PackageDependency);
+                msBuild.AddPackageReference(packageReferenceArgs.ProjectPath, libraryDependency);
             }
             else
             {
@@ -166,15 +175,88 @@ namespace NuGet.CommandLine.XPlat
                     .OriginalTargetFrameworks
                     .Where(s => compatibleFrameworks.Contains(NuGetFramework.Parse(s)));
 
-                // If the user did not specify a version then update the version to resolved version
-                UpdatePackageVersionIfNeeded(restorePreviewResult, packageReferenceArgs, userSpecifiedFrameworks);
+                // generate a library dependency with all the metadata like Include, Exlude and SuppressParent
+                var libraryDependency = GenerateLibraryDependency(updatedPackageSpec, packageReferenceArgs, restorePreviewResult, userSpecifiedFrameworks);
 
                 msBuild.AddPackageReferencePerTFM(packageReferenceArgs.ProjectPath,
-                    packageReferenceArgs.PackageDependency,
+                    libraryDependency,
                     compatibleOriginalFrameworks);
             }
 
             return 0;
+        }
+
+        private static LibraryDependency GenerateLibraryDependency(
+            PackageSpec project,
+            PackageReferenceArgs packageReferenceArgs,
+            RestoreResultPair restorePreviewResult,
+            IEnumerable<NuGetFramework> UserSpecifiedFrameworks)
+        {
+            // get the package resolved version from restore preview result
+            var resolvedVersion = GetPackageVersionFromRestoreResult(restorePreviewResult, packageReferenceArgs, UserSpecifiedFrameworks);
+
+            // calculate correct package version to write in project file
+            var version = packageReferenceArgs.PackageDependency.VersionRange;
+
+            // If the user did not specify a version then write the exact resolved version
+            if (packageReferenceArgs.NoVersion)
+            {
+                version = new VersionRange(resolvedVersion);
+            }
+
+            // update default packages path if user specified custom package directory
+            var packagesPath = project.RestoreMetadata.PackagesPath;
+
+            if (!string.IsNullOrEmpty(packageReferenceArgs.PackageDirectory))
+            {
+                packagesPath = packageReferenceArgs.PackageDirectory;
+            }
+
+            // create a path resolver to get nuspec file of the package
+            var pathResolver = new FallbackPackagePathResolver(
+                packagesPath,
+                project.RestoreMetadata.FallbackFolders);
+            var info = pathResolver.GetPackageInfo(packageReferenceArgs.PackageDependency.Id, resolvedVersion);
+            var packageDirectory = info?.PathResolver.GetInstallPath(packageReferenceArgs.PackageDependency.Id, resolvedVersion);
+            var nuspecFile = info?.PathResolver.GetManifestFileName(packageReferenceArgs.PackageDependency.Id, resolvedVersion);
+
+            var nuspecFilePath = Path.GetFullPath(Path.Combine(packageDirectory, nuspecFile));
+
+            // read development dependency from nuspec file
+            var developmentDependency = new NuspecReader(nuspecFilePath).GetDevelopmentDependency();
+
+            if (developmentDependency)
+            {
+                foreach (var frameworkInfo in project.TargetFrameworks
+                    .OrderBy(framework => framework.FrameworkName.ToString(),
+                        StringComparer.Ordinal))
+                {
+                    var dependency = frameworkInfo.Dependencies.First(
+                        dep => dep.Name.Equals(packageReferenceArgs.PackageDependency.Id, StringComparison.OrdinalIgnoreCase));
+
+                    // if suppressParent and IncludeType aren't set by user, then only update those as per dev dependency
+                    if (dependency?.SuppressParent == LibraryIncludeFlagUtils.DefaultSuppressParent &&
+                        dependency?.IncludeType == LibraryIncludeFlags.All)
+                    {
+                        dependency.SuppressParent = LibraryIncludeFlags.All;
+                        dependency.IncludeType = LibraryIncludeFlags.All & ~LibraryIncludeFlags.Runtime;
+                    }
+
+                    if (dependency != null)
+                    {
+                        dependency.LibraryRange.VersionRange = version;
+                        return dependency;
+                    }
+                }
+            }
+
+            return new LibraryDependency
+            {
+                LibraryRange = new LibraryRange(
+                    name: packageReferenceArgs.PackageDependency.Id,
+                    versionRange: version,
+                    typeConstraint: LibraryDependencyTarget.Package)
+            };
         }
 
         private static async Task<RestoreResultPair> PreviewAddPackageReferenceAsync(PackageReferenceArgs packageReferenceArgs,
@@ -227,27 +309,6 @@ namespace NuGet.CommandLine.XPlat
             }
 
             return spec;
-        }
-
-        private static void UpdatePackageVersionIfNeeded(RestoreResultPair restorePreviewResult,
-            PackageReferenceArgs packageReferenceArgs,
-            IEnumerable<NuGetFramework> UserSpecifiedFrameworks)
-        {
-            // If the user did not specify a version then write the exact resolved version
-            if (packageReferenceArgs.NoVersion)
-            {
-                // Get the package version from the graph
-                var resolvedVersion = GetPackageVersionFromRestoreResult(restorePreviewResult, 
-                    packageReferenceArgs, 
-                    UserSpecifiedFrameworks);
-
-                if (resolvedVersion != null)
-                {
-                    //Update the packagedependency with the new version
-                    packageReferenceArgs.PackageDependency = new PackageDependency(packageReferenceArgs.PackageDependency.Id,
-                        new VersionRange(resolvedVersion));
-                }
-            }
         }
 
         private static NuGetVersion GetPackageVersionFromRestoreResult(RestoreResultPair restorePreviewResult,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Globalization;
 using System.Threading.Tasks;
+using NuGet.LibraryModel;
 
 namespace NuGet.CommandLine.XPlat
 {
@@ -16,9 +17,16 @@ namespace NuGet.CommandLine.XPlat
                 packageReferenceArgs.PackageDependency.Id,
                 packageReferenceArgs.ProjectPath));
 
+            var libraryDependency = new LibraryDependency
+            {
+                LibraryRange = new LibraryRange(
+                    name: packageReferenceArgs.PackageDependency.Id,
+                    versionRange: packageReferenceArgs.PackageDependency.VersionRange,
+                    typeConstraint: LibraryDependencyTarget.Package)
+            };
+
             // Remove reference from the project
-            var result = msBuild.RemovePackageReference(packageReferenceArgs.ProjectPath,
-                packageReferenceArgs.PackageDependency);
+            var result = msBuild.RemovePackageReference(packageReferenceArgs.ProjectPath, libraryDependency);
 
             return Task.FromResult(result);
         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -545,5 +545,6 @@ namespace NuGet.Commands
 
             return packageVersions;
         }
+
     }
 }

--- a/src/NuGet.Core/NuGet.Common/MsBuildStringUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/MsBuildStringUtility.cs
@@ -99,5 +99,18 @@ namespace NuGet.Common
                 }
             }
         }
+
+        /// <summary>
+        /// Convert the provided string to MSBuild style.
+        /// </summary>
+        public static string Convert(string value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            return value.Replace(',', ';');
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
@@ -163,5 +163,6 @@ namespace NuGet.DependencyResolver
         {
             throw new NotImplementedException();
         }
+
     }
 }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteResolveResult.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteResolveResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegratedInstallationContext.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegratedInstallationContext.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using NuGet.Frameworks;
+using NuGet.LibraryModel;
 using NuGet.ProjectManagement.Projects;
 
 namespace NuGet.ProjectManagement
@@ -39,5 +40,15 @@ namespace NuGet.ProjectManagement
         /// framework evaluation depends on the target framework string matching exactly.
         /// </summary>
         public IDictionary<NuGetFramework, string> OriginalFrameworks { get; }
+
+        /// <summary>
+        /// Define transitive behavior for each package dependency for the current project.
+        /// </summary>
+        public LibraryIncludeFlags SuppressParent { get; set; } = LibraryIncludeFlagUtils.DefaultSuppressParent;
+
+        /// <summary>
+        /// Define what all sections of the current package to include in this project.
+        /// </summary>
+        public LibraryIncludeFlags IncludeType { get; set; } = LibraryIncludeFlags.All;
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -14,6 +14,7 @@ using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.ProjectModel;
+using NuGet.Versioning;
 
 namespace NuGet.PackageManagement
 {
@@ -143,6 +144,34 @@ namespace NuGet.PackageManagement
             return parentNuGetprojects
                 .OrderBy(parent => parent.MSBuildProjectPath, StringComparer.Ordinal)
                 .ToList();
+        }
+
+        public static void UpdatePackageReferenceMetadata(
+            PackageSpec packageSpec,
+            FallbackPackagePathResolver pathResolver,
+            PackageIdentity package)
+        {
+            var info = pathResolver.GetPackageInfo(package.Id, package.Version);
+            var nuspecFilePath = info?.PathResolver.GetManifestFilePath(package.Id, package.Version);
+            var nuspecReader = new NuspecReader(nuspecFilePath);
+            var developmentDependency = nuspecReader.GetDevelopmentDependency();
+
+            if (developmentDependency)
+            {
+                foreach (var frameworkInfo in packageSpec.TargetFrameworks
+                    .OrderBy(framework => framework.FrameworkName.ToString(),
+                        StringComparer.Ordinal))
+                {
+                    var dependency = frameworkInfo.Dependencies.First(dep => dep.Name.Equals(package.Id, StringComparison.OrdinalIgnoreCase));
+
+                    if (dependency?.SuppressParent == LibraryIncludeFlagUtils.DefaultSuppressParent &&
+                        dependency?.IncludeType == LibraryIncludeFlags.All)
+                    {
+                        dependency.SuppressParent = LibraryIncludeFlags.All;
+                        dependency.IncludeType = LibraryIncludeFlags.All & ~LibraryIncludeFlags.Runtime;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2721,10 +2721,29 @@ namespace NuGet.PackageManagement
                     }
                 }
 
+                var pathResolver = new FallbackPackagePathResolver(
+                    projectAction.RestoreResult.LockFile.PackageSpec.RestoreMetadata.PackagesPath,
+                    projectAction.RestoreResult.LockFile.PackageSpec.RestoreMetadata.FallbackFolders);
+
                 foreach (var originalAction in projectAction.OriginalActions.Where(e => !ignoreActions.Contains(e)))
                 {
                     if (originalAction.NuGetProjectActionType == NuGetProjectActionType.Install)
                     {
+                        if (buildIntegratedProject.ProjectStyle == ProjectStyle.PackageReference)
+                        {
+                            BuildIntegratedRestoreUtility.UpdatePackageReferenceMetadata(
+                                projectAction.RestoreResult.LockFile.PackageSpec,
+                                pathResolver,
+                                originalAction.PackageIdentity);
+
+                            var framework = projectAction.InstallationContext.SuccessfulFrameworks.FirstOrDefault();
+                            var resolvedAction = projectAction.RestoreResult.LockFile.PackageSpec.TargetFrameworks.FirstOrDefault(fm => fm.FrameworkName.Equals(framework))
+                                .Dependencies.First(dependency => dependency.Name.Equals(originalAction.PackageIdentity.Id, StringComparison.OrdinalIgnoreCase));
+
+                            projectAction.InstallationContext.SuppressParent = resolvedAction.SuppressParent;
+                            projectAction.InstallationContext.IncludeType = resolvedAction.IncludeType;
+                        }
+
                         // Install the package to the project
                         await buildIntegratedProject.InstallPackageAsync(
                             originalAction.PackageIdentity.Id,
@@ -2744,8 +2763,6 @@ namespace NuGet.PackageManagement
 
                 var logger = new ProjectContextLogger(nuGetProjectContext);
                 var referenceContext = new DependencyGraphCacheContext(logger, Settings);
-                var pathContext = NuGetPathContext.Create(Settings);
-                var pathResolver = new FallbackPackagePathResolver(pathContext);
 
                 var now = DateTime.UtcNow;
                 Action<SourceCacheContext> cacheContextModifier = c => c.MaxAge = now;

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/IProjectSystemReferencesService.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/IProjectSystemReferencesService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -636,12 +636,17 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     projectServices,
                     _threadingService);
 
+                var buildIntegratedInstallationContext = new BuildIntegratedInstallationContext(
+                    Enumerable.Empty<NuGetFramework>(),
+                    Enumerable.Empty<NuGetFramework>(),
+                    new Dictionary<NuGetFramework, string>());
+
                 // Act
                 var result = await testProject.InstallPackageAsync(
                     "packageA",
                     VersionRange.Parse("1.*"),
                     null,
-                    null,
+                    buildIntegratedInstallationContext,
                     CancellationToken.None);
 
                 // Assert

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -2254,5 +2254,65 @@ namespace ClassLibrary
                 }
             }
         }
+
+        [PlatformFact(Platform.Windows)]
+        public void PackCommand_ManualAddPackage_DevelopmentDependency()
+        {
+            // Arrange
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName);
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", "net45");
+
+                    var attributes = new Dictionary<string, string>();
+
+                    attributes["Version"] = "1.0.2";
+                    ProjectFileUtils.AddItem(
+                        xml,
+                        "PackageReference",
+                        "StyleCop.Analyzers",
+                        "net45",
+                        new Dictionary<string, string>(),
+                        attributes);
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+
+                // Act
+                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory}");
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                // Assert
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var nuspecReader = nupkgReader.NuspecReader;
+
+                    var dependencyGroups = nuspecReader
+                        .GetDependencyGroups()
+                        .OrderBy(x => x.TargetFramework,
+                            new NuGetFrameworkSorter())
+                        .ToList();
+
+                    Assert.Equal(1,
+                        dependencyGroups.Count);
+
+                    Assert.Equal(FrameworkConstants.CommonFrameworks.Net45, dependencyGroups[0].TargetFramework);
+                    Assert.Equal(1, dependencyGroups[0].Packages.Count());
+                }
+            }
+        }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -185,7 +185,8 @@ namespace NuGet.XPlat.FuncTest
         public static SimpleTestPackageContext CreatePackage(string packageId = "packageX",
             string packageVersion = "1.0.0",
             string frameworkString = null,
-            PackageType packageType = null)
+            PackageType packageType = null,
+            bool developmentDependency = false)
         {
             var package = new SimpleTestPackageContext()
             {
@@ -205,7 +206,7 @@ namespace NuGet.XPlat.FuncTest
                 .ForEach(f => package.AddFile($"lib/{f}/a.dll"));
 
             // To ensure that the nuspec does not have System.Runtime.dll
-            package.Nuspec = GetNetCoreNuspec(packageId, packageVersion);
+            package.Nuspec = GetNetCoreNuspec(packageId, packageVersion, developmentDependency);
 
             return package;
         }
@@ -238,8 +239,21 @@ namespace NuGet.XPlat.FuncTest
             };
         }
 
-        public static XDocument GetNetCoreNuspec(string package, string packageVersion)
+        public static XDocument GetNetCoreNuspec(string package, string packageVersion, bool developmentDependency = false)
         {
+            if (developmentDependency)
+            {
+                return XDocument.Parse($@"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <package>
+                        <metadata>
+                            <id>{package}</id>
+                            <version>{packageVersion}</version>
+                            <developmentDependency>true</developmentDependency>
+                            <title />
+                        </metadata>
+                        </package>");
+            }
+
             return XDocument.Parse($@"<?xml version=""1.0"" encoding=""utf-8""?>
                         <package>
                         <metadata>
@@ -252,7 +266,7 @@ namespace NuGet.XPlat.FuncTest
 
         // Assert Helper Methods
 
-        public static bool ValidateReference(XElement root, string packageId, string version, PackageType packageType = null)
+        public static bool ValidateReference(XElement root, string packageId, string version, PackageType packageType = null, bool developmentDependency = false)
         {
 
             var packageReferences = root
@@ -273,6 +287,26 @@ namespace NuGet.XPlat.FuncTest
             {
                 return false;
             }
+
+            if (developmentDependency)
+            {
+                var privateAssets = packageReferences.First().Element("PrivateAssets");
+
+                if (privateAssets == null ||
+                    !privateAssets.Value.Equals("all", StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+
+                var includeAssets = packageReferences.First().Element("IncludeAssets");
+
+                if (includeAssets == null ||
+                    !includeAssets.Value.Equals("compile; build; native; contentfiles; analyzers", StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+
             return true;
         }
 

--- a/test/TestUtilities/Test.Utility/DebuggerUtils.cs
+++ b/test/TestUtilities/Test.Utility/DebuggerUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;


### PR DESCRIPTION
This PR adds `developmentDependency` support for `PackageReference` based projects. Package author can set this developmentDependency flag to true inside their package's nuspec file which signifies that corresponding package should be used only for development and should neither flow transitively nor be part of project dependencies while creating NuGet package through `pack` command.

Scenarios covered:
- Install a package as PackageReference either with net core or desktop project.
- dotnet add command is also covered to add PackageReference.

Not covered:
- Manually adding a PackageReference item in csproj.

What it does:
Add a package which has developmentDependency set to true as a `PackageReference` item like below and accordingly reflect this change in `project.assets.json` file.
```
<PackageReference Include="abc" Version="1.0.0">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
</PackageReference>
```
It also allows package consumer to overwrite this default behavior by manually updating these `PrivateAssets` and `IncludeAssets` flags for a specific package.

Basic Design:
During restore, while resolving all the dependencies through nuspec file, it also take note of `developmentDependency` flag specified in that file. And accordingly set applicable metadata on PackageReference item which also flows into `project.assets.json` file.

Fixes https://github.com/NuGet/Home/issues/4125
Spec https://github.com/NuGet/Home/wiki/DevelopmentDependency-support-for-PackageReference

@rrelyea 