### PR TITLE
add f1 help keywords to pmc and pm ui

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
+++ b/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
@@ -36,7 +36,7 @@ namespace NuGetConsole.Implementation
     public sealed class PowerConsoleToolWindow : ToolWindowPane, IOleCommandTarget, IPowerConsoleService
     {
         private JoinableTask _loadTask;
-
+        private const string F1KeywordValuePmc = "VS.NuGet.PackageManager.Console";
         /// <summary>
         /// Get VS IComponentModel service.
         /// </summary>
@@ -150,15 +150,7 @@ namespace NuGetConsole.Implementation
             if (windowFrame != null)
             {
                 // Set F1 help keyword
-                object varUserContext = null;
-                if (ErrorHandler.Succeeded(windowFrame.GetProperty((int)__VSFPROPID.VSFPROPID_UserContext, out varUserContext)))
-                {
-                    var userContext = varUserContext as IVsUserContext;
-                    if (userContext != null)
-                    {
-                        userContext.AddAttribute(VSUSERCONTEXTATTRIBUTEUSAGE.VSUC_Usage_LookupF1, "keyword", "VS.NuGet.PackageManager.Console");
-                    }
-                }
+                WindowFrameHelper.AddF1HelpKeyword(windowFrame, keywordValue: F1KeywordValuePmc);
             }
             var cmdUi = VSConstants.GUID_TextEditorFactory;
             windowFrame.SetGuidProperty((int)__VSFPROPID.VSFPROPID_InheritKeyBindings, ref cmdUi);

--- a/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
+++ b/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
@@ -147,6 +147,19 @@ namespace NuGetConsole.Implementation
 
             // Register key bindings to use in the editor
             var windowFrame = (IVsWindowFrame)Frame;
+            if (windowFrame != null)
+            {
+                // Set F1 help keyword
+                object varUserContext = null;
+                if (ErrorHandler.Succeeded(windowFrame.GetProperty((int)__VSFPROPID.VSFPROPID_UserContext, out varUserContext)))
+                {
+                    var userContext = varUserContext as IVsUserContext;
+                    if (userContext != null)
+                    {
+                        userContext.AddAttribute(VSUSERCONTEXTATTRIBUTEUSAGE.VSUC_Usage_LookupF1, "keyword", "VS.NuGet.PackageManager.Console");
+                    }
+                }
+            }
             var cmdUi = VSConstants.GUID_TextEditorFactory;
             windowFrame.SetGuidProperty((int)__VSFPROPID.VSFPROPID_InheritKeyBindings, ref cmdUi);
 

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -58,7 +58,7 @@ namespace NuGetVSExtension
     {
         // It is displayed in the Help - About box of Visual Studio
         public const string ProductVersion = "4.6.0";
-
+        private const string F1KeywordValuePmUI = "VS.NuGet.PackageManager.UI";
         private static readonly object _credentialsPromptLock = new object();
         private readonly HashSet<Uri> _credentialRequested = new HashSet<Uri>();
 
@@ -480,6 +480,10 @@ namespace NuGetVSExtension
                     string.Empty,
                     null,
                     out windowFrame);
+                if (windowFrame != null)
+                {
+                    WindowFrameHelper.AddF1HelpKeyword(windowFrame, keywordValue: F1KeywordValuePmUI);
+                }
             }
             finally
             {
@@ -667,6 +671,11 @@ namespace NuGetVSExtension
                     string.Empty,
                     null,
                     out windowFrame);
+
+                if (windowFrame != null)
+                {
+                    WindowFrameHelper.AddF1HelpKeyword(windowFrame, keywordValue: F1KeywordValuePmUI);
+                }
             }
             finally
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/WindowFrameHelper.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/WindowFrameHelper.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace NuGet.VisualStudio
+{
+    public static class WindowFrameHelper
+    {
+        public static void AddF1HelpKeyword(IVsWindowFrame windowFrame, string keywordValue)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            // Set F1 help keyword
+            object varUserContext = null;
+            if (ErrorHandler.Succeeded(windowFrame.GetProperty((int)__VSFPROPID.VSFPROPID_UserContext, out varUserContext)))
+            {
+                var userContext = varUserContext as IVsUserContext;
+                if (userContext != null)
+                {
+                    userContext.AddAttribute(VSUSERCONTEXTATTRIBUTEUSAGE.VSUC_Usage_LookupF1, "keyword", keywordValue);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/5912

Adds help keyword to redirect to the right docs page when F1 is pressed for a control.

Doc side PR : https://github.com/NuGet/docs.microsoft.com-nuget/pull/642 