### PR TITLE
fix path of collect.exe

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -529,12 +529,12 @@ phases:
     inputs:
       scriptType: "inlineScript"
       inlineScript: |
-        Invoke-WebRequest -Uri $(CollectExeUrl) -OutFile $(System.DefaultWorkingDirectory)\\NuGet.Client\\VSCollect.exe
+        Invoke-WebRequest -Uri $(CollectExeUrl) -OutFile $(System.DefaultWorkingDirectory)\\VSCollect.exe
         if(-not (Test-Path $(EndToEndResultsDropPath)))
           {
             New-Item -Path $(EndToEndResultsDropPath) -ItemType Directory -Force
           }
-        $(System.DefaultWorkingDirectory)\\NuGet.Client\\VSCollect.exe -zip:$(EndToEndResultsDropPath)\\e2e-collectlogs.zip
+        $(System.DefaultWorkingDirectory)\\VSCollect.exe -zip:$(EndToEndResultsDropPath)\\e2e-collectlogs.zip
     condition: "failed()"
 
   - task: PowerShell@1
@@ -644,12 +644,12 @@ phases:
     inputs:
       scriptType: "inlineScript"
       inlineScript: |
-        Invoke-WebRequest -Uri $(CollectExeUrl) -OutFile $(System.DefaultWorkingDirectory)\\NuGet.Client\\VSCollect.exe
+        Invoke-WebRequest -Uri $(CollectExeUrl) -OutFile $(System.DefaultWorkingDirectory)\\VSCollect.exe
         if(-not (Test-Path $(EndToEndResultsDropPath)))
           {
             New-Item -Path $(EndToEndResultsDropPath) -ItemType Directory -Force
           }
-        $(System.DefaultWorkingDirectory)\\NuGet.Client\\VSCollect.exe -zip:$(EndToEndResultsDropPath)\\apex-collectlogs.zip
+        $(System.DefaultWorkingDirectory)\\VSCollect.exe -zip:$(EndToEndResultsDropPath)\\apex-collectlogs.zip
     condition: "failed()"
 
   - task: MSBuild@1


### PR DESCRIPTION
this is an oversight on my part when moving the e2e and apex definitions from release to build in the collect vs logs task. System.DefaultWorkingDirectory is already set to the root of the repository, so nuget.client does not need to be added to it.