### PR TITLE
Fix commitment-type-indication attribute validation

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/CommitmentTypeQualifier.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/CommitmentTypeQualifier.cs
@@ -1,0 +1,56 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Security.Cryptography;
+using NuGet.Packaging.Signing.DerEncoding;
+
+namespace NuGet.Packaging.Signing
+{
+    /*
+        From RFC 5126 (https://tools.ietf.org/html/rfc5126.html#section-5.11.1):
+
+            CommitmentTypeQualifier ::= SEQUENCE {
+               commitmentTypeIdentifier   CommitmentTypeIdentifier,
+               qualifier                  ANY DEFINED BY commitmentTypeIdentifier }
+
+            CommitmentTypeIdentifier ::= OBJECT IDENTIFIER
+    */
+    /// <remarks>This is public only to facilitate testing.</remarks>
+    public sealed class CommitmentTypeQualifier
+    {
+        public Oid CommitmentTypeIdentifier { get; }
+        public byte[] Qualifier { get; }
+
+        private CommitmentTypeQualifier(Oid commitmentTypeIdentifier, byte[] qualifier)
+        {
+            CommitmentTypeIdentifier = commitmentTypeIdentifier;
+            Qualifier = qualifier;
+        }
+
+        public static CommitmentTypeQualifier Read(byte[] bytes)
+        {
+            var reader = DerSequenceReader.CreateForPayload(bytes);
+
+            return Read(reader);
+        }
+
+        internal static CommitmentTypeQualifier Read(DerSequenceReader reader)
+        {
+            var commitmentTypeQualifierReader = reader.ReadSequence();
+            var commitmentTypeIdentifier = commitmentTypeQualifierReader.ReadOid();
+            byte[] qualifier = null;
+
+            if (commitmentTypeQualifierReader.HasData)
+            {
+                qualifier = commitmentTypeQualifierReader.ReadNextEncodedValue();
+
+                if (commitmentTypeQualifierReader.HasData)
+                {
+                    throw new SignatureException(Strings.InvalidAsn1);
+                }
+            }
+
+            return new CommitmentTypeQualifier(commitmentTypeIdentifier, qualifier);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/CommitmentTypeQualifier.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/CommitmentTypeQualifier.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Security.Cryptography;
 using NuGet.Packaging.Signing.DerEncoding;
 
@@ -27,6 +28,16 @@ namespace NuGet.Packaging.Signing
             Qualifier = qualifier;
         }
 
+        public static CommitmentTypeQualifier Create(Oid commitmentTypeIdentifier)
+        {
+            if (commitmentTypeIdentifier == null)
+            {
+                throw new ArgumentNullException(nameof(commitmentTypeIdentifier));
+            }
+
+            return new CommitmentTypeQualifier(commitmentTypeIdentifier, qualifier: null);
+        }
+
         public static CommitmentTypeQualifier Read(byte[] bytes)
         {
             var reader = DerSequenceReader.CreateForPayload(bytes);
@@ -51,6 +62,11 @@ namespace NuGet.Packaging.Signing
             }
 
             return new CommitmentTypeQualifier(commitmentTypeIdentifier, qualifier);
+        }
+
+        internal byte[] Encode()
+        {
+            return DerEncoder.ConstructSequence(DerEncoder.SegmentedEncodeOid(CommitmentTypeIdentifier));
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/AttributeUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/AttributeUtility.cs
@@ -41,31 +41,42 @@ namespace NuGet.Packaging.Signing
         }
 
         /// <summary>
-        /// Oid -> SignatureType
+        /// Gets the signature type from a commitment-type-indication attribute object.
         /// </summary>
         /// <param name="attribute">A commitment-type-indication attribute object.</param>
-        /// <remarks>Unknown Oids are ignored. Throws for empty values and invalid combinations.</remarks>
+        /// <remarks>Unknown OIDs are ignored.</remarks>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="attribute" /> is <c>null</c>.</exception>
+        /// <exception cref="SignatureException">Thrown if <paramref name="attribute" /> is invalid.</exception>
         public static SignatureType GetCommitmentTypeIndication(CryptographicAttributeObject attribute)
         {
-            if (!IsValidCommitmentTypeIndication(attribute))
+            if (attribute == null)
+            {
+                throw new ArgumentNullException(nameof(attribute));
+            }
+
+            if (attribute.Oid.Value != Oids.CommitmentTypeIndication)
             {
                 throw new SignatureException(Strings.CommitmentTypeIndicationAttributeInvalid);
             }
 
-            // Remove unknown values, these could be future values.
-            // Invalid combinations and empty checks have already been done.
-            var knownValues = GetCommitmentTypeIndicationRawValues(attribute)
-                .Where(e => e != SignatureType.Unknown)
-                .ToList();
+            var values = GetCommitmentTypeIndicationRawValues(attribute);
 
-            // Return the only recognized value.
-            if (knownValues.Count == 1)
+            // Remove unknown values, these could be future values.
+            var knownValues = values.Where(e => e != SignatureType.Unknown).Distinct().ToList();
+
+            if (knownValues.Count == 0)
             {
-                return knownValues[0];
+                return SignatureType.Unknown;
             }
 
-            // All values were unknown
-            return SignatureType.Unknown;
+            // Author and repository values are mutually exclusive in the same signature.
+            // If multiple distinct known values exist then the attribute is invalid.
+            if (knownValues.Count > 1)
+            {
+                throw new SignatureException(Strings.CommitmentTypeIndicationAttributeInvalidCombination);
+            }
+
+            return knownValues[0];
         }
 
         internal static SignatureType GetCommitmentTypeIndication(SignerInfo signer)
@@ -77,36 +88,6 @@ namespace NuGet.Packaging.Signing
             }
 
             return SignatureType.Unknown;
-        }
-
-        /// <summary>
-        /// True if the commitment-type-indication value does not
-        /// contain an invalid combination of values. Unknown
-        /// values are ignored.
-        /// </summary>
-        public static bool IsValidCommitmentTypeIndication(CryptographicAttributeObject attribute)
-        {
-            var values = GetCommitmentTypeIndicationRawValues(attribute);
-
-            // Zero values is invalid.
-            if (values.Count < 1)
-            {
-                return false;
-            }
-
-            // Remove unknown values, these could be future values.
-            var knownValues = values.Where(e => e != SignatureType.Unknown).ToList();
-
-            // Currently the value must be a single value of author or repository. If multiple
-            // known values exist then either there is a duplicate or both author and repository
-            // was listed in the attribute.
-            if (knownValues.Count > 1)
-            {
-                return false;
-            }
-
-            // A known or unknown value is present, and no invalid combinations exist.
-            return true;
         }
 
         /// <summary>
@@ -190,21 +171,6 @@ namespace NuGet.Packaging.Signing
         }
 
         /// <summary>
-        /// CryptographicAttributeObject -> DerSequenceReader
-        /// </summary>
-        internal static DerSequenceReader ToDerSequenceReader(this CryptographicAttributeObject attribute)
-        {
-            var values = attribute.Values.ToList();
-
-            if (values.Count != 1)
-            {
-                ThrowInvalidAttributeException(attribute);
-            }
-
-            return new DerSequenceReader(values[0].RawData);
-        }
-
-        /// <summary>
         /// Throw a signature exception due to an invalid attribute. This is used for unusual situations
         /// where the format is corrupt.
         /// </summary>
@@ -234,11 +200,30 @@ namespace NuGet.Packaging.Signing
         private static List<SignatureType> GetCommitmentTypeIndicationRawValues(CryptographicAttributeObject attribute)
         {
             var values = new List<SignatureType>(1);
-            var reader = attribute.ToDerSequenceReader();
 
-            while (reader.HasData)
+            /*
+                From RFC 5126 (https://tools.ietf.org/html/rfc5126.html#section-5.11.1):
+
+                    CommitmentTypeIndication ::= SEQUENCE {
+                      commitmentTypeId CommitmentTypeIdentifier,
+                      commitmentTypeQualifier SEQUENCE SIZE (1..MAX) OF
+                                     CommitmentTypeQualifier OPTIONAL}
+
+                    CommitmentTypeIdentifier ::= OBJECT IDENTIFIER
+            */
+
+            // CryptographicAttributeObject.Values represent the values in the commitmentTypeQualifier sequence above.
+            // CryptographicAttributeObject forces its Values property to be an empty collection, so it is impossible
+            // from CryptographicAttributeObject to distinguish between the sequence being absent, which is permitted
+            // here, and the sequence being empty, which is invalid here.
+            // We'll err on the side of leniency and treat an empty sequence like an absent sequence.
+
+            foreach (var value in attribute.Values)
             {
-                values.Add(GetSignatureType(reader.ReadOidAsString()));
+                var qualifier = CommitmentTypeQualifier.Read(value.RawData);
+                var signatureType = GetSignatureType(qualifier.CommitmentTypeIdentifier.Value);
+
+                values.Add(signatureType);
             }
 
             return values;

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/AttributeUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/AttributeUtility.cs
@@ -193,7 +193,8 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         private static List<SignatureType> GetCommitmentTypeIndicationRawValues(CryptographicAttributeObject attribute)
         {
-            var values = new List<SignatureType>(1);
+            // Most packages should have either 0 or 1 signature types.
+            var values = new List<SignatureType>(capacity: 1);
 
             /*
                 From RFC 5126 (https://tools.ietf.org/html/rfc5126.html#section-5.11.1):

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/AttributeUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/AttributeUtility.cs
@@ -10,7 +10,6 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 #endif
 using System.Security.Cryptography.X509Certificates;
-using NuGet.Packaging.Signing.DerEncoding;
 
 namespace NuGet.Packaging.Signing
 {
@@ -25,19 +24,14 @@ namespace NuGet.Packaging.Signing
         public static CryptographicAttributeObject CreateCommitmentTypeIndication(SignatureType type)
         {
             // SignatureType -> Oid
-            var valueOid = GetSignatureTypeOid(type);
+            var oid = GetSignatureTypeOid(type);
 
-            // DER encode the signature type Oid in a sequence.
-            // CommitmentTypeQualifier ::= SEQUENCE {
-            // commitmentTypeIdentifier CommitmentTypeIdentifier,
-            // qualifier                  ANY DEFINED BY commitmentTypeIdentifier }
-            var commitmentTypeData = DerEncoder.ConstructSequence(new List<byte[][]>() { DerEncoder.SegmentedEncodeOid(valueOid) });
-            var data = new AsnEncodedData(Oids.CommitmentTypeIndication, commitmentTypeData);
+            var commitmentTypeQualifier = CommitmentTypeQualifier.Create(new Oid(oid));
+            var value = new AsnEncodedData(Oids.CommitmentTypeIndication, commitmentTypeQualifier.Encode());
 
-            // Create an attribute
             return new CryptographicAttributeObject(
-                oid: new Oid(Oids.CommitmentTypeIndication),
-                values: new AsnEncodedDataCollection(data));
+                new Oid(Oids.CommitmentTypeIndication),
+                new AsnEncodedDataCollection(value));
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SignatureUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SignatureUtility.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
 #if IS_DESKTOP
@@ -10,6 +11,7 @@ using System.Security.Cryptography.Pkcs;
 #endif
 using System.Security.Cryptography.X509Certificates;
 using NuGet.Common;
+using NuGet.Packaging.Signing.DerEncoding;
 
 namespace NuGet.Packaging.Signing
 {
@@ -264,7 +266,7 @@ namespace NuGet.Packaging.Signing
 
             if (signingCertificateV2Attribute != null)
             {
-                var reader = signingCertificateV2Attribute.ToDerSequenceReader();
+                var reader = CreateDerSequenceReader(signingCertificateV2Attribute);
                 var signingCertificateV2 = SigningCertificateV2.Read(reader);
 
                 if (signingCertificateV2.Certificates.Count == 0)
@@ -297,7 +299,7 @@ namespace NuGet.Packaging.Signing
 
             if (signingCertificateAttribute != null)
             {
-                var reader = signingCertificateAttribute.ToDerSequenceReader();
+                var reader = CreateDerSequenceReader(signingCertificateAttribute);
                 var signingCertificate = SigningCertificate.Read(reader);
 
                 if (signingCertificate.Certificates.Count == 0)
@@ -434,6 +436,16 @@ namespace NuGet.Packaging.Signing
 
                 return CertificateChainUtility.GetCertificateListFromChain(chain);
             }
+        }
+
+        private static DerSequenceReader CreateDerSequenceReader(CryptographicAttributeObject attribute)
+        {
+            if (attribute.Values.Count != 1)
+            {
+                throw new SignatureException(string.Format(CultureInfo.CurrentCulture, Strings.SignatureContainsInvalidAttribute, attribute.Oid.Value));
+            }
+
+            return new DerSequenceReader(attribute.Values[0].RawData);
         }
 
         private sealed class Errors

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -134,11 +134,20 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to commitment-type-indication attribute contains an invalid value..
+        ///   Looks up a localized string similar to The attribute is not a valid commitment-type-indication attribute..
         /// </summary>
         internal static string CommitmentTypeIndicationAttributeInvalid {
             get {
                 return ResourceManager.GetString("CommitmentTypeIndicationAttributeInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The commitment-type-indication attribute contains an invalid combination of values..
+        /// </summary>
+        internal static string CommitmentTypeIndicationAttributeInvalidCombination {
+            get {
+                return ResourceManager.GetString("CommitmentTypeIndicationAttributeInvalidCombination", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -297,8 +297,8 @@ Valid from:</comment>
   <data name="ErrorPackageSignatureInvalid" xml:space="preserve">
     <value>The package signature is invalid.</value>
   </data>
-  <data name="CommitmentTypeIndicationAttributeInvalid" xml:space="preserve">
-    <value>commitment-type-indication attribute contains an invalid value.</value>
+  <data name="CommitmentTypeIndicationAttributeInvalidCombination" xml:space="preserve">
+    <value>The commitment-type-indication attribute contains an invalid combination of values.</value>
   </data>
   <data name="ErrorByteSignatureNotFound" xml:space="preserve">
     <value>Byte signature not found in package archive:  0x{0}</value>
@@ -476,5 +476,8 @@ Valid from:</comment>
   </data>
   <data name="TimestampCertificateFailsPublicKeyLengthRequirement" xml:space="preserve">
     <value>The timestamp certificate does not meet a minimum public key length requirement.</value>
+  </data>
+  <data name="CommitmentTypeIndicationAttributeInvalid" xml:space="preserve">
+    <value>The attribute is not a valid commitment-type-indication attribute.</value>
   </data>
 </root>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/AttributeUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/AttributeUtilityTests.cs
@@ -3,14 +3,11 @@
 
 #if NET46
 using System;
-using System.Collections.Generic;
 using System.Security.Cryptography;
 using FluentAssertions;
 using NuGet.Common;
 using NuGet.Packaging.Signing;
 using NuGet.Packaging.Signing.DerEncoding;
-using Org.BouncyCastle.Asn1;
-using Org.BouncyCastle.Asn1.Pkcs;
 using Xunit;
 
 namespace NuGet.Packaging.Test
@@ -33,14 +30,21 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
-        public void CreateCommitmentTypeIndication_CommitmentTypeIndicationWithAuthorSignature()
+        public void CreateCommitmentTypeIndication_WithUnknownSignature_Throws()
+        {
+            Assert.Throws<ArgumentException>(
+                () => AttributeUtility.CreateCommitmentTypeIndication(SignatureType.Unknown));
+        }
+
+        [Fact]
+        public void CreateCommitmentTypeIndication_WithAuthorSignature_ReturnsOriginType()
         {
             var attribute = AttributeUtility.CreateCommitmentTypeIndication(SignatureType.Author);
             AttributeUtility.GetCommitmentTypeIndication(attribute).Should().Be(SignatureType.Author);
         }
 
         [Fact]
-        public void CreateCommitmentTypeIndication_CommitmentTypeIndicationWithRepositorySignature()
+        public void CreateCommitmentTypeIndication_WithRepositorySignature_ReturnsReceiptType()
         {
             var attribute = AttributeUtility.CreateCommitmentTypeIndication(SignatureType.Repository);
             AttributeUtility.GetCommitmentTypeIndication(attribute).Should().Be(SignatureType.Repository);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/AttributeUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/AttributeUtilityTests.cs
@@ -9,12 +9,17 @@ using FluentAssertions;
 using NuGet.Common;
 using NuGet.Packaging.Signing;
 using NuGet.Packaging.Signing.DerEncoding;
+using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Asn1.Pkcs;
 using Xunit;
 
 namespace NuGet.Packaging.Test
 {
     public class AttributeUtilityTests : IClassFixture<CertificatesFixture>
     {
+        private const string CommitmentTypeIdentifierProofOfDelivery = "1.2.840.113549.1.9.16.6.3";
+        private const string CommitmentTypeIdentifierProofOfSender = "1.2.840.113549.1.9.16.6.4";
+
         private readonly CertificatesFixture _fixture;
 
         public AttributeUtilityTests(CertificatesFixture fixture)
@@ -42,58 +47,96 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
-        public void GetCommitmentTypeIndication_CommitmentTypeIndicationWithAuthorSignatureAndUnknownVerifyAuthor()
+        public void GetCommitmentTypeIndication_WhenAttributeNull_Throws()
         {
-            var attribute = GetCommitmentTypeTestAttribute(Oids.CommitmentTypeIdentifierProofOfOrigin, "1.3.6.1.5.5.7.3.3");
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => AttributeUtility.GetCommitmentTypeIndication(attribute: null));
+
+            Assert.Equal("attribute", exception.ParamName);
+        }
+
+        [Fact]
+        public void GetCommitmentTypeIndication_WhenAttributeNotCommitmentTypeIndication_Throws()
+        {
+            var attribute = new CryptographicAttributeObject(new Oid(Oids.SigningCertificateV2));
+
+            var exception = Assert.Throws<SignatureException>(
+                () => AttributeUtility.GetCommitmentTypeIndication(attribute));
+
+            Assert.Equal("The attribute is not a valid commitment-type-indication attribute.", exception.Message);
+        }
+
+        [Fact]
+        public void GetCommitmentTypeIndication_WithOriginType_ReturnsAuthor()
+        {
+            var attribute = GetCommitmentTypeTestAttribute(Oids.CommitmentTypeIdentifierProofOfOrigin);
             AttributeUtility.GetCommitmentTypeIndication(attribute).Should().Be(SignatureType.Author);
         }
 
         [Fact]
-        public void GetCommitmentTypeIndication_CommitmentTypeIndicationWithUnknownSignatureType()
+        public void GetCommitmentTypeIndication_WithReceiptType_ReturnsRepository()
         {
-            var attribute = GetCommitmentTypeTestAttribute("1.3.6.1.5.5.7.3.3");
+            var attribute = GetCommitmentTypeTestAttribute(Oids.CommitmentTypeIdentifierProofOfReceipt);
+            AttributeUtility.GetCommitmentTypeIndication(attribute).Should().Be(SignatureType.Repository);
+        }
+
+        [Fact]
+        public void GetCommitmentTypeIndication_WithUnknownType_ReturnsUnknown()
+        {
+            var attribute = GetCommitmentTypeTestAttribute(CommitmentTypeIdentifierProofOfDelivery);
             AttributeUtility.GetCommitmentTypeIndication(attribute).Should().Be(SignatureType.Unknown);
         }
 
         [Fact]
-        public void IsValidCommitmentTypeIndication_CommitmentTypeIndicationWithBothRepoAndAuthorVerifyFailure()
+        public void GetCommitmentTypeIndication_WithMultipleUnknownTypes_ReturnsUnknown()
         {
-            var attribute = GetCommitmentTypeTestAttribute(Oids.CommitmentTypeIdentifierProofOfReceipt, Oids.CommitmentTypeIdentifierProofOfOrigin);
-            AttributeUtility.IsValidCommitmentTypeIndication(attribute).Should().BeFalse();
+            var attribute = GetCommitmentTypeTestAttribute(
+                CommitmentTypeIdentifierProofOfDelivery, CommitmentTypeIdentifierProofOfSender);
+            AttributeUtility.GetCommitmentTypeIndication(attribute).Should().Be(SignatureType.Unknown);
         }
 
         [Fact]
-        public void IsValidCommitmentTypeIndication_CommitmentTypeIndicationWithDuplicateValuesVerifyFailure()
-        {
-            var attribute = GetCommitmentTypeTestAttribute(Oids.CommitmentTypeIdentifierProofOfOrigin, Oids.CommitmentTypeIdentifierProofOfOrigin);
-            AttributeUtility.IsValidCommitmentTypeIndication(attribute).Should().BeFalse();
-        }
-
-        [Fact]
-        public void IsValidCommitmentTypeIndication_CommitmentTypeIndicationWithNoValueVerifyFailure()
+        public void GetCommitmentTypeIndication_WithNoType_ReturnsUnknown()
         {
             var attribute = GetCommitmentTypeTestAttribute();
-            AttributeUtility.IsValidCommitmentTypeIndication(attribute).Should().BeFalse();
+
+            Assert.Equal(SignatureType.Unknown, AttributeUtility.GetCommitmentTypeIndication(attribute));
+        }
+
+        [Fact]
+        public void GetCommitmentTypeIndication_WithBothOriginAndReceiptTypes_Throws()
+        {
+            var attribute = GetCommitmentTypeTestAttribute(
+                Oids.CommitmentTypeIdentifierProofOfOrigin, Oids.CommitmentTypeIdentifierProofOfReceipt);
+
+            var exception = Assert.Throws<SignatureException>(
+                () => AttributeUtility.GetCommitmentTypeIndication(attribute));
+
+            Assert.Equal("The commitment-type-indication attribute contains an invalid combination of values.", exception.Message);
+        }
+
+        [Fact]
+        public void GetCommitmentTypeIndication_WithDuplicateOriginTypes_ReturnsAuthor()
+        {
+            var attribute = GetCommitmentTypeTestAttribute(
+                Oids.CommitmentTypeIdentifierProofOfOrigin, Oids.CommitmentTypeIdentifierProofOfOrigin);
+
+            Assert.Equal(SignatureType.Author, AttributeUtility.GetCommitmentTypeIndication(attribute));
+        }
+
+        [Fact]
+        public void GetCommitmentTypeIndication_WithOriginAndUnknownType_ReturnsAuthor()
+        {
+            var attribute = GetCommitmentTypeTestAttribute(
+                Oids.CommitmentTypeIdentifierProofOfOrigin, CommitmentTypeIdentifierProofOfSender);
+
+            Assert.Equal(SignatureType.Author, AttributeUtility.GetCommitmentTypeIndication(attribute));
         }
 
         [Fact]
         public void GetCommitmentTypeIndication_CommitmentTypeIndicationWithBothRepoAndAuthorVerifyThrows()
         {
             var attribute = GetCommitmentTypeTestAttribute(Oids.CommitmentTypeIdentifierProofOfReceipt, Oids.CommitmentTypeIdentifierProofOfOrigin);
-            Assert.Throws<SignatureException>(() => AttributeUtility.GetCommitmentTypeIndication(attribute));
-        }
-
-        [Fact]
-        public void GetCommitmentTypeIndication_CommitmentTypeIndicationWithDuplicateValuesVerifyThrows()
-        {
-            var attribute = GetCommitmentTypeTestAttribute(Oids.CommitmentTypeIdentifierProofOfOrigin, Oids.CommitmentTypeIdentifierProofOfOrigin);
-            Assert.Throws<SignatureException>(() => AttributeUtility.GetCommitmentTypeIndication(attribute));
-        }
-
-        [Fact]
-        public void GetCommitmentTypeIndication_CommitmentTypeIndicationWithNoValueVerifyThrows()
-        {
-            var attribute = GetCommitmentTypeTestAttribute();
             Assert.Throws<SignatureException>(() => AttributeUtility.GetCommitmentTypeIndication(attribute));
         }
 
@@ -164,19 +207,17 @@ namespace NuGet.Packaging.Test
         /// </summary>
         private static CryptographicAttributeObject GetCommitmentTypeTestAttribute(params string[] oids)
         {
-            var values = new List<byte[][]>();
+            var commitmentTypeIndication = new Oid(Oids.CommitmentTypeIndication);
+            var values = new AsnEncodedDataCollection();
 
             foreach (var oid in oids)
             {
-                values.Add(DerEncoder.SegmentedEncodeOid(oid));
+                var value = DerEncoder.ConstructSequence(DerEncoder.SegmentedEncodeOid(oid));
+
+                values.Add(new AsnEncodedData(commitmentTypeIndication, value));
             }
 
-            var commitmentTypeData = DerEncoder.ConstructSequence(values);
-            var data = new AsnEncodedData(Oids.CommitmentTypeIndication, commitmentTypeData);
-
-            return new CryptographicAttributeObject(
-                new Oid(Oids.CommitmentTypeIndication),
-                new AsnEncodedDataCollection(data));
+            return new CryptographicAttributeObject(commitmentTypeIndication, values);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CommitmentTypeQualifierTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CommitmentTypeQualifierTests.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Security.Cryptography;
+using NuGet.Packaging.Signing;
+using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Asn1.Pkcs;
+using Xunit;
+using BcCommitmentTypeQualifier = Org.BouncyCastle.Asn1.Esf.CommitmentTypeQualifier;
+
+namespace NuGet.Packaging.Test
+{
+    public class CommitmentTypeQualifierTests
+    {
+        [Fact]
+        public void Read_WithInvalidAsn1_Throws()
+        {
+            Assert.Throws<CryptographicException>(
+                () => CommitmentTypeQualifier.Read(new byte[] { 0x30, 0x07 }));
+        }
+
+        [Fact]
+        public void Read_WithOnlyCommitmentTypeId_ReturnsCommitmentTypeQualifier()
+        {
+            var bcCommitmentTypeQualifier = new BcCommitmentTypeQualifier(PkcsObjectIdentifiers.IdCtiEtsProofOfSender);
+            var bytes = bcCommitmentTypeQualifier.GetDerEncoded();
+
+            var commitmentTypeQualifier = CommitmentTypeQualifier.Read(bytes);
+
+            Assert.Equal(
+                bcCommitmentTypeQualifier.CommitmentTypeIdentifier.ToString(),
+                commitmentTypeQualifier.CommitmentTypeIdentifier.Value);
+            Assert.Null(commitmentTypeQualifier.Qualifier);
+        }
+
+        [Fact]
+        public void Read_WithQualifier_ReturnsCommitmentTypeQualifier()
+        {
+            var bcCommitmentTypeQualifier = new BcCommitmentTypeQualifier(
+                PkcsObjectIdentifiers.IdCtiEtsProofOfReceipt, DerNull.Instance);
+            var bytes = bcCommitmentTypeQualifier.GetDerEncoded();
+
+            var commitmentTypeQualifier = CommitmentTypeQualifier.Read(bytes);
+
+            Assert.Equal(
+                bcCommitmentTypeQualifier.CommitmentTypeIdentifier.ToString(),
+                commitmentTypeQualifier.CommitmentTypeIdentifier.Value);
+            Assert.Equal(DerNull.Instance.GetDerEncoded(), commitmentTypeQualifier.Qualifier);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CommitmentTypeQualifierTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CommitmentTypeQualifierTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Security.Cryptography;
 using NuGet.Packaging.Signing;
 using Org.BouncyCastle.Asn1;
@@ -12,6 +13,24 @@ namespace NuGet.Packaging.Test
 {
     public class CommitmentTypeQualifierTests
     {
+        [Fact]
+        public void Create_WhenCommitmentTypeIdentifierNull_Throws()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => CommitmentTypeQualifier.Create(commitmentTypeIdentifier: null));
+
+            Assert.Equal("commitmentTypeIdentifier", exception.ParamName);
+        }
+
+        [Fact]
+        public void Create_WithCommitmentTypeIdentifier_ReturnsCommitmentTypeQualifier()
+        {
+            var commitmentTypeQualifier = CommitmentTypeQualifier.Create(new Oid(Oids.CommitmentTypeIdentifierProofOfOrigin));
+
+            Assert.Equal(Oids.CommitmentTypeIdentifierProofOfOrigin, commitmentTypeQualifier.CommitmentTypeIdentifier.Value);
+            Assert.Null(commitmentTypeQualifier.Qualifier);
+        }
+
         [Fact]
         public void Read_WithInvalidAsn1_Throws()
         {


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/6401.

Issues:

1.  The `commitment-type-attribute` [[RFC 5126]](https://tools.ietf.org/html/rfc5126.html#section-5.11.1) allows duplicate commitment type indication values, but 
NuGet code disallowed them.  This is now allowed.
1.  The `commitment-type-attribute` allows no sequence of commitment type indication values, but NuGet code disallowed this.  Since it's infeasible to check this case, we'll treat it the same as the next case.
1.  The `commitment-type-attribute` requires a sequence of commitment type indication values to be non-empty, but NuGet code disallowed this case.  This is now allowed.
1.  The test code that generated test `commitment-type-attribute` attributes generated grammatically incorrect ASN.1 and some tests were invalidated by this.