### PR TITLE
Give proper error when signing certificate expired

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/VerifyCommand/VerifyCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/VerifyCommand/VerifyCommandRunner.cs
@@ -83,17 +83,16 @@ namespace NuGet.Commands
 
                     logger.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.VerifyCommand_FinishedWithErrors, errors, warnings));
 
-                    if (errors > 0)
-                    {
-                        logger.LogError(Environment.NewLine + Strings.VerifyCommand_Failed);
-                    }
-
                     result = errors;
                 }
 
                 if (verificationResult.Valid)
                 {
                     logger.LogInformation(Environment.NewLine + Strings.VerifyCommand_Success);
+                }
+                else
+                {
+                    logger.LogError(Environment.NewLine + Strings.VerifyCommand_Failed);
                 }
 
                 return result;

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
@@ -111,10 +111,6 @@ namespace NuGet.Packaging.Signing
                 timestamp = timestamp ?? new Timestamp();
                 if (Rfc3161TimestampVerificationUtility.ValidateSignerCertificateAgainstTimestamp(certificate, timestamp))
                 {
-                    // Read signed attribute containing the original cert hashes
-                    // var signingCertificateAttribute = signature.SignerInfo.SignedAttributes.GetAttributeOrDefault(Oids.SigningCertificateV2);
-                    // TODO: how are we going to use the signingCertificateAttribute?
-
                     var certificateExtraStore = signature.SignedCms.Certificates;
 
                     using (var chain = new X509Chain())
@@ -175,6 +171,10 @@ namespace NuGet.Packaging.Signing
                         issues.Add(SignatureLog.DebugLog(string.Format(CultureInfo.CurrentCulture, Strings.ErrorInvalidCertificateChain, string.Join(", ", chainStatuses.Select(x => x.ToString())))));
                     }
                 }
+                else
+                {
+                    issues.Add(SignatureLog.Issue(treatIssuesAsErrors, NuGetLogCode.NU3003, Strings.SignatureNotTimeValid));
+                }
             }
 
             return SignatureVerificationStatus.Untrusted;
@@ -202,12 +202,6 @@ namespace NuGet.Packaging.Signing
                     Strings.VerificationTimestamperCertDisplay,
                     $"{Environment.NewLine}{CertificateUtility.X509Certificate2ToString(timestamperCertificate)}")));
 
-                //var signingCertificateAttribute = timestampSignerInfo.SignedAttributes.GetAttributeOrDefault(Oids.SigningCertificate);
-                //if (signingCertificateAttribute == null)
-                //{
-                //    signingCertificateAttribute = timestampSignerInfo.SignedAttributes.GetAttributeOrDefault(Oids.SigningCertificateV2);
-                //}
-                // TODO: how are we going to use the signingCertificateAttribute?
 
                 var certificateExtraStore = timestamp.SignedCms.Certificates;
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
@@ -173,7 +173,7 @@ namespace NuGet.Packaging.Signing
                 }
                 else
                 {
-                    issues.Add(SignatureLog.Issue(treatIssuesAsErrors, NuGetLogCode.NU3003, Strings.SignatureNotTimeValid));
+                    issues.Add(SignatureLog.Issue(treatIssuesAsErrors, NuGetLogCode.NU3011, Strings.SignatureNotTimeValid));
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -638,6 +638,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The primary signature validity period has expired..
+        /// </summary>
+        internal static string SignatureNotTimeValid {
+            get {
+                return ResourceManager.GetString("SignatureNotTimeValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The signing certificate is not yet valid..
         /// </summary>
         internal static string SignatureNotYetValid {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -482,4 +482,7 @@ Valid from:</comment>
   <data name="CommitmentTypeIndicationAttributeInvalid" xml:space="preserve">
     <value>The attribute is not a valid commitment-type-indication attribute.</value>
   </data>
+  <data name="SignatureNotTimeValid" xml:space="preserve">
+    <value>The primary signature validity period has expired.</value>
+  </data>
 </root>


### PR DESCRIPTION
When a package was signed without a timestamp and then the signing certificate expired there were two issues that were related:
- No proper error message was displayed to say that the certificate is expired.
- No error message was shown saying that the process failed.