### PR TITLE
use nuget restore task intead of running configure.ps1

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -598,11 +598,18 @@ phases:
       inlineScript: "gci env:* | sort-object name;
       Write-Host \"##vso[build.updatebuildnumber]$env:BuildNumber\""
 
-  - task: PowerShell@1
-    displayName: "Configure.ps1"
+  - task: NuGetToolInstaller@0
+    displayName: "Use NuGet 4.5.0"
     inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)/configure.ps1"
-      arguments: "-Force -CI"
+      versionSpec: "4.5.0"
+
+  - task: NuGetCommand@2
+    displayName: "Download packages.config packages"
+    inputs:
+      restoreSolution: ".nuget/packages.config"
+      feedsToUse: "config"
+      nugetConfigPath: "NuGet.Config"
+      restoreDirectory: "$(System.DefaultWorkingDirectory)/packages"
 
   - task: CopyFiles@2
     displayName: "Copy Public Key Files"


### PR DESCRIPTION
was seeing configure.ps1 failures on apex machines, and realized that only reason configure.ps1 is even running is because we need to get the packages listed in packages.config file. this will save some time and prevent unwarranted errors like failing to download the CLI 