### PR TITLE
generate error on IsPackable = false

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/IsPackableFalseErrorTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/IsPackableFalseErrorTask.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Globalization;
+using Microsoft.Build.Utilities;
+using NuGet.Common;
+
+namespace NuGet.Build.Tasks.Pack
+{
+    public class IsPackableFalseErrorTask : Task
+    {
+        public ILogger Logger => new MSBuildLogger(Log);
+        public override bool Execute()
+        {
+            Logger.LogError(string.Format(CultureInfo.CurrentCulture,
+                    Strings.IsPackableFalseError));
+            return true;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -1,3 +1,4 @@
+
 <!--
 ***********************************************************************************************
 NuGet.targets
@@ -20,6 +21,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="NuGet.Build.Tasks.Pack.GetPackOutputItemsTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetProjectTargetFrameworksTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.Pack.GetProjectReferencesFromAssetsFileTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
+  <UsingTask TaskName="NuGet.Build.Tasks.Pack.IsPackableFalseErrorTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
 
   <PropertyGroup>
     <PackageId Condition=" '$(PackageId)' == '' ">$(AssemblyName)</PackageId>
@@ -181,7 +183,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="Pack" DependsOnTargets="$(PackDependsOn)">
-     <Error Condition="$(IsPackable) == 'false'" Text="Cannot generate a package from a project which has IsPackable = false." />
+     <IsPackableFalseErrorTask Condition="$(IsPackable) == 'false'"/>
   </Target>
   <Target Name="_IntermediatePack">
     <PropertyGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -181,6 +181,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="Pack" DependsOnTargets="$(PackDependsOn)">
+     <Error Condition="$(IsPackable) == 'false'" Text="Cannot generate a package from a project which has IsPackable = false." />
   </Target>
   <Target Name="_IntermediatePack">
     <PropertyGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/Strings.Designer.cs
@@ -20,7 +20,7 @@ namespace NuGet.Build.Tasks.Pack {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -130,6 +130,15 @@ namespace NuGet.Build.Tasks.Pack {
         internal static string InvalidTargetFramework {
             get {
                 return ResourceManager.GetString("InvalidTargetFramework", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot generate a package from a project which has IsPackable property set to false..
+        /// </summary>
+        internal static string IsPackableFalseError {
+            get {
+                return ResourceManager.GetString("IsPackableFalseError", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/Strings.resx
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/Strings.resx
@@ -147,6 +147,9 @@
   <data name="InvalidTargetFramework" xml:space="preserve">
     <value>Invalid target framework for the file '{0}'.</value>
   </data>
+  <data name="IsPackableFalseError" xml:space="preserve">
+    <value>Cannot generate a package from a project which has IsPackable property set to false.</value>
+  </data>
   <data name="NoPackItemProvided" xml:space="preserve">
     <value>No project was provided to the PackTask.</value>
   </data>


### PR DESCRIPTION
fixes: https://github.com/NuGet/Home/issues/6156 

if IsPackable is set to false, and a user tries to pack, earlier it would just no-op . we will start throwing an error now so it's clear to user why no package is being generated.