### PR TITLE
Changing Package signature to be a single entry

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -227,7 +227,7 @@ namespace NuGet.Packaging
             }
         }
 
-        public override async Task<IReadOnlyList<Signature>> GetSignaturesAsync(CancellationToken token)
+        public override async Task<Signature> GetSignatureAsync(CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
 
@@ -236,7 +236,7 @@ namespace NuGet.Packaging
                 throw new SignatureException(Strings.SignedPackageUnableToAccessSignature);
             }
 
-            var signatures = new List<Signature>();
+            Signature signature = null;
 
             if (await IsSignedAsync(token))
             {
@@ -246,14 +246,13 @@ namespace NuGet.Packaging
                     using (var signatureEntryStream = signatureEntry.Open())
                     {
 #if IS_DESKTOP
-                        var signature = Signature.Load(signatureEntryStream);
-                        signatures.Add(signature);
+                        signature = Signature.Load(signatureEntryStream);
 #endif
                     }
                 }
             }
 
-            return signatures.AsReadOnly();
+            return signature;
         }
 
         public override Task<bool> IsSignedAsync(CancellationToken token)

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -220,9 +220,9 @@ namespace NuGet.Packaging
             // do nothing here
         }
 
-        public override Task<IReadOnlyList<Signature>> GetSignaturesAsync(CancellationToken token)
+        public override Task<Signature> GetSignatureAsync(CancellationToken token)
         {
-            return Task.FromResult<IReadOnlyList<Signature>>(new List<Signature>());
+            return Task.FromResult<Signature>(null);
         }
 
         public override Task<bool> IsSignedAsync(CancellationToken token)

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -546,11 +546,12 @@ namespace NuGet.Packaging
             throw new NotImplementedException();
         }
 
-        public abstract Task<IReadOnlyList<Signature>> GetSignaturesAsync(CancellationToken token);
+        public abstract Task<Signature> GetSignatureAsync(CancellationToken token);
 
         public abstract Task<bool> IsSignedAsync(CancellationToken token);
 
         public abstract Task ValidateIntegrityAsync(SignatureContent signatureContent, CancellationToken token);
+
         public abstract Task<byte[]> GetArchiveHashAsync(HashAlgorithmName hashAlgorithm, CancellationToken token);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
@@ -14,9 +14,9 @@ namespace NuGet.Packaging.Signing
     public interface ISignedPackageReader : IDisposable
     {
         /// <summary>
-        /// Get all signatures used to sign a package.
+        /// Get package signature.
         /// </summary>
-        /// <remarks>Returns an empty list if the package is unsigned.</remarks>
+        /// <remarks>Returns a null if the package is unsigned.</remarks>
         Task<Signature> GetSignatureAsync(CancellationToken token);
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -18,7 +17,7 @@ namespace NuGet.Packaging.Signing
         /// Get all signatures used to sign a package.
         /// </summary>
         /// <remarks>Returns an empty list if the package is unsigned.</remarks>
-        Task<IReadOnlyList<Signature>> GetSignaturesAsync(CancellationToken token);
+        Task<Signature> GetSignatureAsync(CancellationToken token);
 
         /// <summary>
         /// Check if a package contains signing information.

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/PackageSignatureVerifier.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/PackageSignatureVerifier.cs
@@ -36,18 +36,19 @@ namespace NuGet.Packaging.Signing
                 try
                 {
                     // Read package signatures
-                    var signatures = await package.GetSignaturesAsync(token);
-                    var signaturesAreValid = signatures.Count > 0; // Fail if there are no signatures
+                    var signature = await package.GetSignatureAsync(token);
 
-                    // Verify that the signatures are trusted
-                    foreach (var signature in signatures)
+                    if (signature != null)
                     {
+                        // Verify that the signature is trusted
                         var sigTrustResults = await Task.WhenAll(_verificationProviders.Select(e => e.GetTrustResultAsync(package, signature, _settings, token)));
-                        signaturesAreValid &= IsValid(sigTrustResults, _settings.AllowUntrusted);
+                        valid = IsValid(sigTrustResults, _settings.AllowUntrusted);
                         trustResults.AddRange(sigTrustResults);
                     }
-
-                    valid = signaturesAreValid;
+                    else
+                    {
+                        valid = false;
+                    }
                 }
                 catch (SignatureException e)
                 {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/PackageSignatureVerifier.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/PackageSignatureVerifier.cs
@@ -35,7 +35,6 @@ namespace NuGet.Packaging.Signing
             {
                 try
                 {
-                    // Read package signatures
                     var signature = await package.GetSignatureAsync(token);
 
                     if (signature != null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -1124,9 +1124,9 @@ namespace NuGet.Protocol.Plugins
             return tempDirectoryPath;
         }
 
-        public override Task<IReadOnlyList<Signature>> GetSignaturesAsync(CancellationToken token)
+        public override Task<Signature> GetSignatureAsync(CancellationToken token)
         {
-            return Task.FromResult<IReadOnlyList<Signature>>(new List<Signature>());
+            return Task.FromResult<Signature>(null);
         }
 
         public override Task<bool> IsSignedAsync(CancellationToken token)

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
@@ -55,11 +55,9 @@ namespace NuGet.Packaging.FuncTest
                 using (var stream = File.OpenRead(signedPackagePath))
                 using (var reader = new PackageArchiveReader(stream))
                 {
-                    var signatures = await reader.GetSignaturesAsync(CancellationToken.None);
+                    var signature = await reader.GetSignatureAsync(CancellationToken.None);
 
-                    signatures.Count.Should().Be(1);
-
-                    var signature = signatures[0];
+                    signature.Should().NotBeNull();
                     signature.Timestamps.Should().NotBeEmpty();
                 }
             }
@@ -82,11 +80,9 @@ namespace NuGet.Packaging.FuncTest
                 using (var stream = File.OpenRead(signedPackagePath))
                 using (var reader = new PackageArchiveReader(stream))
                 {
-                    var signatures = await reader.GetSignaturesAsync(CancellationToken.None);
+                    var signature = await reader.GetSignatureAsync(CancellationToken.None);
 
-                    signatures.Count.Should().Be(1);
-
-                    var signature = signatures[0];
+                    signature.Should().NotBeNull();
                     signature.Timestamps.Should().BeEmpty();
                 }
             }
@@ -157,7 +153,7 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageReader = new PackageArchiveReader(packageFilePath))
                 {
-                    var signature = (await packageReader.GetSignaturesAsync(CancellationToken.None)).Single();
+                    var signature = (await packageReader.GetSignatureAsync(CancellationToken.None));
 
                     var certificateStore = X509StoreFactory.Create(
                         "Certificate/Collection",

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -96,7 +96,7 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageReader = new PackageArchiveReader(packageFilePath))
                 {
-                    var signature = (await packageReader.GetSignaturesAsync(CancellationToken.None)).Single();
+                    var signature = (await packageReader.GetSignatureAsync(CancellationToken.None));
                     var invalidSignature = GenerateInvalidSignature(signature);
                     var provider = new SignatureTrustAndValidityVerificationProvider();
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -96,7 +96,7 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageReader = new PackageArchiveReader(packageFilePath))
                 {
-                    var signature = (await packageReader.GetSignatureAsync(CancellationToken.None));
+                    var signature = await packageReader.GetSignatureAsync(CancellationToken.None);
                     var invalidSignature = GenerateInvalidSignature(signature);
                     var provider = new SignatureTrustAndValidityVerificationProvider();
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
@@ -243,9 +243,9 @@ namespace NuGet.Protocol.Tests
                 throw new NotImplementedException();
             }
 
-            public override Task<IReadOnlyList<Signature>> GetSignaturesAsync(CancellationToken token)
+            public override Task<Signature> GetSignatureAsync(CancellationToken token)
             {
-                throw new NotImplementedException();
+                return Task.FromResult<Signature>(null);
             }
 
             public override Stream GetStream(string path)
@@ -255,7 +255,7 @@ namespace NuGet.Protocol.Tests
 
             public override Task<bool> IsSignedAsync(CancellationToken token)
             {
-                throw new NotImplementedException();
+                return Task.FromResult(false);
             }
 
             public override Task ValidateIntegrityAsync(SignatureContent signatureContent, CancellationToken token)


### PR DESCRIPTION
## Bug
Currently we expose `ISignedPackageReader` signature as a a List of Signatures. This is no longer compliant with the design.

## Fix
Details: Changes the `ISignedPackageReader` and its children classes to have the updated method signature - 

`public async Task<Signature> GetSignatureAsync(CancellationToken token)`
