### PR TITLE
Retry until PMC is loaded in apex tests

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
+++ b/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
@@ -137,6 +137,11 @@ namespace NuGetConsole.Implementation
             }
         }
 
+        /// <summary>
+        /// Internal for testing, true when the console has been loaded.
+        /// </summary>
+        public bool IsLoaded { get; private set; }
+
         [SuppressMessage(
             "Microsoft.Design",
             "CA1031:DoNotCatchGeneralExceptionTypes",
@@ -159,7 +164,11 @@ namespace NuGetConsole.Implementation
             _loadTask = ThreadHelper.JoinableTaskFactory.StartOnIdle(
                 async () =>
                 {
+                    // Load
                     await Task.Run(LoadConsoleEditorAsync);
+
+                    // Mark as complete
+                    IsLoaded = true;
                 });
         }
 

--- a/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
@@ -58,6 +58,11 @@ namespace NuGet.Console.TestContract
 
         public bool ConsoleContainsMessage(string message)
         {
+            if (!EnsureInitilizeConsole())
+            {
+                return false;
+            }
+
             var snapshot = (_wpfConsole.Content as IWpfTextViewHost).TextView.TextBuffer.CurrentSnapshot;
             for (var i = 0; i < snapshot.LineCount; i++)
             {
@@ -75,6 +80,11 @@ namespace NuGet.Console.TestContract
 
         public void Clear()
         {
+            if (!EnsureInitilizeConsole())
+            {
+                return;
+            }
+
             UIInvoke(() => _wpfConsole.Clear());
         }
 

--- a/test/NuGet.Tests.Apex/NuGet.Console.TestContract/NuGetApexConsoleTestService.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Console.TestContract/NuGetApexConsoleTestService.cs
@@ -88,7 +88,7 @@ namespace NuGet.Console.TestContract
                 if (VSConstants.S_OK == window.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out var toolPane))
                 {
                     powerConsole = (PowerConsoleToolWindow)toolPane;
-                    while (!powerConsole.IsLoaded && (stopwatch.Elapsed < timeout && window == null))
+                    while (!powerConsole.IsLoaded && stopwatch.Elapsed < timeout)
                     {
                         Thread.Sleep(100);
                     }

--- a/test/NuGet.Tests.Apex/NuGet.Console.TestContract/NuGetApexConsoleTestService.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Console.TestContract/NuGetApexConsoleTestService.cs
@@ -3,8 +3,13 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.VisualStudio;
 using NuGetConsole;
+using NuGetConsole.Implementation;
 using NuGetConsole.Implementation.PowerConsole;
 
 namespace NuGet.Console.TestContract
@@ -13,10 +18,28 @@ namespace NuGet.Console.TestContract
     public class NuGetApexConsoleTestService
     {
         private Lazy<IWpfConsole> _wpfConsole => new Lazy<IWpfConsole>(GetWpfConsole);
+        private static readonly TimeSpan _timeout = TimeSpan.FromMinutes(10);
+
         private IWpfConsole GetWpfConsole()
         {
-            var outputConsoleWindow = ServiceLocator.GetInstance<IPowerConsoleWindow>() as PowerConsoleWindow;
-            return outputConsoleWindow.ActiveHostInfo.WpfConsole;
+            PowerConsoleWindow powershellConsole = null;
+            var timer = Stopwatch.StartNew();
+
+            while (powershellConsole?.ActiveHostInfo?.WpfConsole == null)
+            {
+                try
+                {
+                    var outputConsoleWindow = ServiceLocator.GetInstance<IPowerConsoleWindow>();
+                    powershellConsole = outputConsoleWindow as PowerConsoleWindow;
+                }
+                catch when (timer.Elapsed < _timeout)
+                {
+                    // Retry until the console is loaded
+                    Thread.Sleep(100);
+                }
+            }
+
+            return powershellConsole.ActiveHostInfo.WpfConsole;
         }
 
         public NuGetApexConsoleTestService()
@@ -25,7 +48,50 @@ namespace NuGet.Console.TestContract
 
         public ApexTestConsole GetApexTestConsole()
         {
-            return new ApexTestConsole(_wpfConsole.Value);
+            var consoleWindow = GetPowershellConsole();
+
+            if (consoleWindow == null)
+            {
+                throw new InvalidOperationException("Unable to get powershell window");
+            }
+
+            return new ApexTestConsole(_wpfConsole.Value, consoleWindow);
+        }
+
+        private PowerConsoleToolWindow GetPowershellConsole()
+        {
+            IVsWindowFrame window = null;
+            PowerConsoleToolWindow powerConsole = null;
+            var powerConsoleToolWindowGUID = new Guid("0AD07096-BBA9-4900-A651-0598D26F6D24");
+            var stopwatch = Stopwatch.StartNew();
+            var timeout = TimeSpan.FromMinutes(5);
+
+            var uiShell = ServiceLocator.GetInstance<IVsUIShell>();
+
+            // Open PMC in VS
+            do
+            {
+                if (VSConstants.S_OK  == uiShell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fForceCreate, powerConsoleToolWindowGUID, out window))
+                {
+                    window.Show();
+                }
+                else
+                {
+                    System.Threading.Thread.Sleep(100);
+                }
+            }
+            while (stopwatch.Elapsed < timeout && window == null);
+
+            // Get PowerConsoleToolWindow from the VS frame
+            if (window != null)
+            {
+                if (VSConstants.S_OK == window.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out var toolPane))
+                {
+                    powerConsole = (PowerConsoleToolWindow)toolPane;
+                }
+            }
+
+            return powerConsole;
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Console.TestContract/NuGetApexConsoleTestService.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Console.TestContract/NuGetApexConsoleTestService.cs
@@ -77,7 +77,7 @@ namespace NuGet.Console.TestContract
                 }
                 else
                 {
-                    System.Threading.Thread.Sleep(100);
+                    Thread.Sleep(100);
                 }
             }
             while (stopwatch.Elapsed < timeout && window == null);
@@ -88,7 +88,11 @@ namespace NuGet.Console.TestContract
                 if (VSConstants.S_OK == window.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out var toolPane))
                 {
                     powerConsole = (PowerConsoleToolWindow)toolPane;
-                }
+                    while (!powerConsole.IsLoaded && (stopwatch.Elapsed < timeout && window == null))
+                    {
+                        Thread.Sleep(100);
+                    }
+                } 
             }
 
             return powerConsole;

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexBaseTestClass.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexBaseTestClass.cs
@@ -41,8 +41,11 @@ namespace NuGet.Tests.Apex
 
         public virtual void Dispose()
         {
-            CloseVisualStudioHost();
-            //test cleanup
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NUGET_TEST_CLOSE_VS_AFTER_EACH_TEST")))
+            {
+                //test cleanup
+                CloseVisualStudioHost();
+            }
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
@@ -12,9 +12,9 @@ namespace NuGet.Tests.Apex
     {
 
         private VisualStudioHost _visualStudio;
-        private SolutionService _solutionService;
         private SimpleTestPathContext _pathContext;
 
+        public SolutionService SolutionService { get; }
         public ProjectTestExtension Project { get; }
         public string PackageSource => _pathContext.PackageSource;
 
@@ -23,15 +23,15 @@ namespace NuGet.Tests.Apex
         {
             _pathContext = new SimpleTestPathContext();
             _visualStudio = visualStudio;
-            _solutionService = _visualStudio.Get<SolutionService>();
+            SolutionService = _visualStudio.Get<SolutionService>();
 
-            Project = Utils.CreateAndInitProject(projectTemplate, _pathContext, _solutionService);
+            Project = Utils.CreateAndInitProject(projectTemplate, _pathContext, SolutionService);
         }
 
         public void Dispose()
         {
-            _solutionService.Save();
-            _solutionService.Close();
+            SolutionService.Save();
+            SolutionService.Close();
 
             _pathContext.Dispose();
         }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
@@ -13,15 +13,21 @@ namespace NuGet.Tests.Apex
 
         private VisualStudioHost _visualStudio;
         private SimpleTestPathContext _pathContext;
+        private bool _noAutoRestore;
 
         public SolutionService SolutionService { get; }
         public ProjectTestExtension Project { get; }
         public string PackageSource => _pathContext.PackageSource;
 
-
-        public ApexTestContext(VisualStudioHost visualStudio, ProjectTemplate projectTemplate)
+        public ApexTestContext(VisualStudioHost visualStudio, ProjectTemplate projectTemplate, bool noAutoRestore = false)
         {
             _pathContext = new SimpleTestPathContext();
+
+            if (noAutoRestore)
+            {
+                _pathContext.Settings.DisableAutoRestore();
+            }
+
             _visualStudio = visualStudio;
             SolutionService = _visualStudio.Get<SolutionService>();
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Test.Apex.VisualStudio;
+using Microsoft.Test.Apex.VisualStudio.Solution;
+using NuGet.Test.Utility;
+
+namespace NuGet.Tests.Apex
+{
+    internal class ApexTestContext : IDisposable
+    {
+
+        private VisualStudioHost _visualStudio;
+        private SolutionService _solutionService;
+        private SimpleTestPathContext _pathContext;
+
+        public ProjectTestExtension Project { get; }
+        public string PackageSource => _pathContext.PackageSource;
+
+
+        public ApexTestContext(VisualStudioHost visualStudio, ProjectTemplate projectTemplate)
+        {
+            _pathContext = new SimpleTestPathContext();
+            _visualStudio = visualStudio;
+            _solutionService = _visualStudio.Get<SolutionService>();
+
+            Project = Utils.CreateAndInitProject(projectTemplate, _pathContext, _solutionService);
+        }
+
+        public void Dispose()
+        {
+            _solutionService.Save();
+            _solutionService.Close();
+
+            _pathContext.Dispose();
+        }
+    }
+}

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetApexTestService.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetApexTestService.cs
@@ -140,24 +140,8 @@ namespace NuGet.Tests.Apex
 
         public bool EnsurePackageManagerConsoleIsOpen()
         {
-            IVsWindowFrame window = null;
-            var powerConsoleToolWindowGUID = new Guid("0AD07096-BBA9-4900-A651-0598D26F6D24");
-            var stopwatch = Stopwatch.StartNew();
-            var timeout = TimeSpan.FromMinutes(5);
-
-            var found = UIShell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fForceCreate, powerConsoleToolWindowGUID, out window);
-            do
-            {
-                if (found == VSConstants.S_OK && window != null) {
-                    window.Show();
-                    return true;
-                }
-                found = UIShell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fForceCreate, powerConsoleToolWindowGUID, out window);
-
-                System.Threading.Thread.Sleep(100);
-            }
-            while (stopwatch.Elapsed < timeout);
-            return false;
+            var pmconsole = NuGetApexConsoleTestService.GetApexTestConsole();
+            return pmconsole != null;
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetApexVerifier.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetApexVerifier.cs
@@ -48,5 +48,17 @@ namespace NuGet.Tests.Apex
             var project = NugetPackageManager.Dte.Solution.Projects.Item(projectName);
             return IsFalse(NugetPackageManager.InstallerServices.IsPackageInstalled(project, packageName), "Expected NuGet package {0} to not be installed in project {1}.", packageName, project.Name);
         }
+
+        /// <summary>
+        /// Validate whether specific version of a NuGet package is not installed
+        /// </summary>
+        /// <param name="project">Project name</param>
+        /// <param name="packageName">NuGet package name</param>
+        /// <returns>True if the package is not installed; otherwise false</returns>
+        public bool PackageIsNotInstalled(string projectName, string packageName, string packageVersion)
+        {
+            var project = NugetPackageManager.Dte.Solution.Projects.Item(projectName);
+            return IsFalse(NugetPackageManager.InstallerServices.IsPackageInstalledEx(project, packageName, packageVersion), "Expected NuGet package {0}-{1} to not be installed in project {1}.", packageName, packageVersion, project.Name);
+        }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetApexVerifier.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetApexVerifier.cs
@@ -34,7 +34,7 @@ namespace NuGet.Tests.Apex
         public bool PackageIsInstalled(string projectName, string packageName, string packageVersion)
         {
             var project = NugetPackageManager.Dte.Solution.Projects.Item(projectName);
-            return IsTrue(NugetPackageManager.InstallerServices.IsPackageInstalledEx(project, packageName, packageVersion), "Expected NuGet package {0}-{1} to be installed in project {1}.", packageName, packageVersion, project.Name);
+            return IsTrue(NugetPackageManager.InstallerServices.IsPackageInstalledEx(project, packageName, packageVersion), "Expected NuGet package {0}-{1} to be installed in project {2}.", packageName, packageVersion, project.Name);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace NuGet.Tests.Apex
         public bool PackageIsNotInstalled(string projectName, string packageName, string packageVersion)
         {
             var project = NugetPackageManager.Dte.Solution.Projects.Item(projectName);
-            return IsFalse(NugetPackageManager.InstallerServices.IsPackageInstalledEx(project, packageName, packageVersion), "Expected NuGet package {0}-{1} to not be installed in project {1}.", packageName, packageVersion, project.Name);
+            return IsFalse(NugetPackageManager.InstallerServices.IsPackageInstalledEx(project, packageName, packageVersion), "Expected NuGet package {0}-{1} to not be installed in project {2}.", packageName, packageVersion, project.Name);
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetConsoleTestExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetConsoleTestExtension.cs
@@ -22,30 +22,25 @@ namespace NuGet.Tests.Apex
         public bool InstallPackageFromPMC(string packageId, string version)
         {
             var command = $"Install-Package {packageId} -ProjectName {_projectName} -Version {version} ";
-            return _pmConsole.WaitForActionComplete(() => _pmConsole.RunCommand(command), _timeout);
+            return _pmConsole.RunCommand(command, _timeout);
         }
 
         public bool InstallPackageFromPMC(string packageId, string version, string source)
         {
             var command = $"Install-Package {packageId} -ProjectName {_projectName} -Version {version} -Source {source}";
-            return _pmConsole.WaitForActionComplete(() => _pmConsole.RunCommand(command), _timeout);
+            return _pmConsole.RunCommand(command, _timeout);
         }
 
         public bool UninstallPackageFromPMC(string packageId)
         {
             var command = $"Uninstall-Package {packageId} -ProjectName {_projectName}";
-            return _pmConsole.WaitForActionComplete(() => _pmConsole.RunCommand(command), _timeout);
+            return _pmConsole.RunCommand(command, _timeout);
         }
 
         public bool UpdatePackageFromPMC(string packageId, string version)
         {
             var command = $"Update-Package {packageId} -ProjectName {_projectName} -Version {version}";
-            return _pmConsole.WaitForActionComplete(() => _pmConsole.RunCommand(command), _timeout);
-        }
-
-        public bool IsPackageInstalled(string packageId, string version)
-        {
-            return _pmConsole.IsPackageInstalled(_projectName, packageId, version);
+            return _pmConsole.RunCommand(command, _timeout);
         }
 
         public bool IsMessageFoundInPMC(string message)

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/SharedVisualStudioHostTestClass.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/SharedVisualStudioHostTestClass.cs
@@ -54,13 +54,11 @@ namespace NuGet.Tests.Apex
 
         protected NuGetConsoleTestExtension GetConsole(ProjectTestExtension project)
         {
+            VisualStudio.ClearWindows();
+
             var nugetTestService = GetNuGetTestService();
             nugetTestService.EnsurePackageManagerConsoleIsOpen().Should().BeTrue("Console was opened");
             var nugetConsole = nugetTestService.GetPackageManagerConsole(project.Name);
-
-            // Clear everything before starting
-            nugetConsole.Clear();
-            VisualStudio.ClearWindows();
 
             return nugetConsole;
         }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/SharedVisualStudioHostTestClass.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/SharedVisualStudioHostTestClass.cs
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using FluentAssertions;
 using Microsoft.Test.Apex;
 using Microsoft.Test.Apex.VisualStudio;
+using Microsoft.Test.Apex.VisualStudio.Solution;
 using Xunit;
 
 namespace NuGet.Tests.Apex
@@ -48,6 +50,19 @@ namespace NuGet.Tests.Apex
         public override void CloseVisualStudioHost()
         {
             VisualStudio.Stop();
+        }
+
+        protected NuGetConsoleTestExtension GetConsole(ProjectTestExtension project)
+        {
+            var nugetTestService = GetNuGetTestService();
+            nugetTestService.EnsurePackageManagerConsoleIsOpen().Should().BeTrue("Console was opened");
+            var nugetConsole = nugetTestService.GetPackageManagerConsole(project.Name);
+
+            // Clear everything before starting
+            nugetConsole.Clear();
+            VisualStudio.ClearWindows();
+
+            return nugetConsole;
         }
 
         public IOperations Operations => _hostFixture.Value.Operations;

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Fixtures/VisualStudioOperationsFixture.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Fixtures/VisualStudioOperationsFixture.cs
@@ -56,8 +56,16 @@ namespace NuGet.Tests.Apex
                         }
                     }
                     _visualStudioHostConfiguration.AddCompositionAssembly(Assembly.GetExecutingAssembly().Location);
-
                     _visualStudioHostConfiguration.InProcessHostConstraints = new List<ITypeConstraint>() { new NuGetTypeConstraint() };
+
+                    // Use the same environment to avoid elevation
+                    _visualStudioHostConfiguration.InheritProcessEnvironment = true;
+
+                    // Launch in the experimental instance of VS
+                    if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NUGET_TEST_APEX_EXP")))
+                    {
+                        _visualStudioHostConfiguration.CommandLineArguments += " /rootSuffix Exp";
+                    }
                 }
                 return _visualStudioHostConfiguration;
             }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
@@ -7,6 +7,10 @@
     <NETCoreWPFProject>true</NETCoreWPFProject>
     <TestProject>true</TestProject>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="Apex\ApexTestContext.cs" />
+  </ItemGroup>
   
   <ItemGroup>
     <Reference Include="System" />
@@ -20,6 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Apex\ApexBaseTestClass.cs" />
+    <Compile Include="Apex\ApexTestContext.cs" />
     <Compile Include="Apex\NuGetConsoleTestExtension.cs" />
     <Compile Include="Apex\NuGetTestOperationConfiguration.cs" />
     <Compile Include="Apex\SharedVisualStudioHostTestClass.cs" />

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NetCoreProjectTestCase.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using NuGet.StaFact;
 using NuGet.Test.Utility;
@@ -14,58 +15,51 @@ namespace NuGet.Tests.Apex
 
         // basic create for .net core template
         [NuGetWpfTheory]
-        [InlineData(ProjectTemplate.NetCoreClassLib)]
-        [InlineData(ProjectTemplate.NetStandardClassLib)]
-        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
+        [MemberData(nameof(GetNetCoreTemplates))]
         public void CreateNetCoreProject_RestoresNewProject(ProjectTemplate projectTemplate)
         {
-            using (var pathContext = new SimpleTestPathContext())
+            // Arrange
+            EnsureVisualStudioHost();
+
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate))
             {
-                // Arrange
-                EnsureVisualStudioHost();
-                var solutionService = VisualStudio.Get<SolutionService>();
-
-                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
-                project.Build();
-                solutionService.SaveAll();
-
-                solutionService.Build();
-
                 VisualStudio.AssertNoErrors();
-
-                solutionService.SaveAll();
-                solutionService.Close();
             }
         }
 
         // basic create for .net core template
         [NuGetWpfTheory]
-        [InlineData(ProjectTemplate.NetCoreClassLib)]
-        [InlineData(ProjectTemplate.NetStandardClassLib)]
-        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
+        [MemberData(nameof(GetNetCoreTemplates))]
         public void CreateNetCoreProject_AddProjectReference(ProjectTemplate projectTemplate)
         {
-            using (var pathContext = new SimpleTestPathContext())
+            // Arrange
+            EnsureVisualStudioHost();
+
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate))
             {
-                // Arrange
-                EnsureVisualStudioHost();
-                var solutionService = VisualStudio.Get<SolutionService>();
-
-                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project1 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject1");
-                project1.Build();
-                var project2 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject2");
+                var project2 = testContext.SolutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject2");
                 project2.Build();
-                project1.References.Dte.AddProjectReference(project2);
-                solutionService.SaveAll();
 
-                solutionService.Build();
+                testContext.Project.References.Dte.AddProjectReference(project2);
+                testContext.SolutionService.SaveAll();
 
-                Assert.True(project1.References.TryFindReferenceByName("TestProject2", out var result));
+                testContext.SolutionService.Build();
+
+                Assert.True(testContext.Project.References.TryFindReferenceByName("TestProject2", out var result));
                 VisualStudio.AssertNoErrors();
+            }
+        }
 
-                solutionService.Close();
+        // There  is a bug with VS or Apex where NetCoreConsoleApp and NetCoreClassLib create netcore 2.1 projects that are not supported by the sdk
+        // Commenting out any NetCoreConsoleApp or NetCoreClassLib template and swapping it for NetStandardClassLib as both are package ref.
+
+        public static IEnumerable<object[]> GetNetCoreTemplates()
+        {
+            for (var i = 0; i < Utils.GetIterations(); i++)
+            {
+                //yield return new object[] { ProjectTemplate.NetCoreClassLib };
+                //yield return new object[] { ProjectTemplate.NetCoreConsoleApp };
+                yield return new object[] { ProjectTemplate.NetStandardClassLib };
             }
         }
     }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NetCoreProjectTestCase.cs
@@ -31,7 +31,10 @@ namespace NuGet.Tests.Apex
                 solutionService.SaveAll();
 
                 solutionService.Build();
-                Assert.True(VisualStudio.HasNoErrorsInErrorList());
+
+                VisualStudio.AssertNoErrors();
+
+                solutionService.SaveAll();
             }
         }
 
@@ -57,8 +60,9 @@ namespace NuGet.Tests.Apex
                 solutionService.SaveAll();
 
                 solutionService.Build();
-                Assert.True(VisualStudio.HasNoErrorsInErrorList());
+
                 Assert.True(project1.References.TryFindReferenceByName("TestProject2", out var result));
+                VisualStudio.AssertNoErrors();
             }
         }
     }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NetCoreProjectTestCase.cs
@@ -35,6 +35,7 @@ namespace NuGet.Tests.Apex
                 VisualStudio.AssertNoErrors();
 
                 solutionService.SaveAll();
+                solutionService.Close();
             }
         }
 
@@ -63,6 +64,8 @@ namespace NuGet.Tests.Apex
 
                 Assert.True(project1.References.TryFindReferenceByName("TestProject2", out var result));
                 VisualStudio.AssertNoErrors();
+
+                solutionService.Close();
             }
         }
     }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
@@ -1,14 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using FluentAssertions;
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using NuGet.StaFact;
-using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.Tests.Apex
@@ -232,51 +228,10 @@ namespace NuGet.Tests.Apex
 
         [NuGetWpfTheory]
         [MemberData(nameof(GetNetCoreTemplates))]
-        public void NetCoreTransitivePackageReference(ProjectTemplate projectTemplate)
-        {
-            // Arrange
-            EnsureVisualStudioHost();
-
-            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate))
-            {
-                var project2 = testContext.SolutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject2");
-                project2.Build();
-                var project3 = testContext.SolutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject3");
-                project3.Build();
-                testContext.SolutionService.Build();
-
-                testContext.Project.References.Dte.AddProjectReference(project2);
-                project2.References.Dte.AddProjectReference(project3);
-                testContext.SolutionService.SaveAll();
-                testContext.SolutionService.Build();
-
-                var nugetConsole = GetConsole(project3);
-                var packageName = "newtonsoft.json";
-                var packageVersion = "9.0.1";
-                Utils.CreatePackageInSource(testContext.PackageSource, packageName, packageVersion);
-
-                nugetConsole.InstallPackageFromPMC(packageName, packageVersion).Should().BeTrue("Install-Package");
-                testContext.Project.Build();
-                project2.Build();
-                project3.Build();
-
-                GetNuGetTestService().Verify.PackageIsInstalled(project3.UniqueName, packageName, packageVersion);
-
-                testContext.Project.References.TryFindReferenceByName("newtonsoft.json", out var result).Should().BeTrue("Find newtonsoft reference");
-                result.Should().NotBeNull("reference to newtonsoft shoult not be null");
-                project2.References.TryFindReferenceByName("newtonsoft.json", out var result2).Should().BeTrue("Find newtonsoft 2nd reference");
-                result2.Should().NotBeNull("reference2 to newtonsoft shoult not be null");
-            }
-        }
-
-        [NuGetWpfTheory]
-        [MemberData(nameof(GetNetCoreTemplates))]
         public void NetCoreTransitivePackageReferenceLimit(ProjectTemplate projectTemplate)
         {
             // Arrange
             EnsureVisualStudioHost();
-
-            Debugger.Launch();
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate))
             {

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
@@ -1,7 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using FluentAssertions;
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using NuGet.StaFact;
 using NuGet.Test.Utility;
@@ -16,81 +20,107 @@ namespace NuGet.Tests.Apex
         {
         }
 
+        // Verify PR only, packages.config is tested in InstallPackageFromPMCVerifyGetPackageDisplaysPackage
         [NuGetWpfTheory]
-        [InlineData(ProjectTemplate.ClassLibrary)]
-        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
-        [InlineData(ProjectTemplate.NetStandardClassLib)]
-        public void InstallPackageFromPMC(ProjectTemplate projectTemplate)
+        [MemberData(nameof(GetPackageReferenceTemplates))]
+        public void InstallPackageFromPMCWithNoAutoRestoreVerifyAssetsFile(ProjectTemplate projectTemplate)
         {
             using (var pathContext = new SimpleTestPathContext())
             {
                 // Arrange
+                // Turn off auto restore
+                pathContext.Settings.DisableAutoRestore();
+
                 EnsureVisualStudioHost();
                 var solutionService = VisualStudio.Get<SolutionService>();
-            
-                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
-                project.Build();
+
+                var project = CreateAndInitProject(projectTemplate, pathContext, solutionService);
 
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
                 Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion);
 
-                var nugetTestService = GetNuGetTestService();
-                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
+                var nugetConsole = GetConsole(project);
 
-                var nugetConsole = nugetTestService.GetPackageManagerConsole(project.Name);
-                
-                Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion));
-                Assert.True(Utils.IsPackageInstalled(nugetConsole, project.FullPath, packageName, packageVersion));
-                project.Build();
-                Assert.True(VisualStudio.HasNoErrorsInErrorList());
-                Assert.True(VisualStudio.HasNoErrorsInOutputWindows());
+                var installed = nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
+                installed.Should().BeTrue("Install-Package should pass");
 
-                nugetConsole.Clear();
+                // Verify install from project.assets.json
+                var inAssetsFile = Utils.IsPackageInstalledInAssetsFile(nugetConsole, project.FullPath, packageName, packageVersion);
+                inAssetsFile.Should().BeTrue("package was installed");
+
                 solutionService.Save();
             }
         }
 
+        // Verify packages.config and PackageReference
         [NuGetWpfTheory]
-        [InlineData(ProjectTemplate.ClassLibrary)]
-        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
-        [InlineData(ProjectTemplate.NetStandardClassLib)]
-        public void InstallPackageFromPMCFromNuGetOrg(ProjectTemplate projectTemplate)
+        [MemberData(nameof(GetTemplates))]
+        public void InstallPackageFromPMCVerifyGetPackageDisplaysPackage(ProjectTemplate projectTemplate)
         {
             using (var pathContext = new SimpleTestPathContext())
             {
                 // Arrange
                 EnsureVisualStudioHost();
                 var solutionService = VisualStudio.Get<SolutionService>();
+                var project = CreateAndInitProject(projectTemplate, pathContext, solutionService);
 
-                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
+                var packageName = "TestPackage";
+                var packageVersion = "1.0.0";
+                Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion);
+
+                var nugetConsole = GetConsole(project);
+
+                var installed = nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
+                installed.Should().BeTrue("Install-Package should pass");
+
+                // Build before the install check to ensure that everything is up to date.
                 project.Build();
 
-                var nugetTestService = GetNuGetTestService();
-                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
+                // Verify install from Get-Package
+                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName, packageVersion);
 
-                var nugetConsole = nugetTestService.GetPackageManagerConsole(project.UniqueName);
-
-                var packageName = "newtonsoft.json";
-                var packageVersion = "9.0.1";
-
-                Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion, "https://api.nuget.org/v3/index.json"));
-                Assert.True(Utils.IsPackageInstalled(nugetConsole, project.FullPath, packageName, packageVersion));
-                project.Build();
-                Assert.True(VisualStudio.HasNoErrorsInErrorList());
-                Assert.True(VisualStudio.HasNoErrorsInOutputWindows());
-                nugetConsole.Clear();
+                VisualStudio.AssertNoErrors();
 
                 solutionService.Save();
             }
         }
 
         [NuGetWpfTheory]
-        [InlineData(ProjectTemplate.ClassLibrary)]
-        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
-        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        [MemberData(nameof(GetTemplates))]
+        public void InstallPackageFromPMCFromNuGetOrg(ProjectTemplate projectTemplate)
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                pathContext.Settings.DisableAutoRestore();
+
+                var packageSources = SimpleTestSettingsContext.GetOrAddSection(pathContext.Settings.XML, "packageSources");
+                SimpleTestSettingsContext.AddEntry(packageSources, "nugetOnline", "https://api.nuget.org/v3/index.json");
+                pathContext.Settings.Save();
+
+                EnsureVisualStudioHost();
+                var solutionService = VisualStudio.Get<SolutionService>();
+                var project = CreateAndInitProject(projectTemplate, pathContext, solutionService);
+                var nugetConsole = GetConsole(project);
+
+                var packageName = "newtonsoft.json";
+                var packageVersion = "9.0.1";
+
+                nugetConsole.InstallPackageFromPMC(packageName, packageVersion)
+                    .Should()
+                    .BeTrue("Install-Package should return on time");
+
+                project.Build();
+
+                Utils.IsPackageInstalledInAssetsFile(nugetConsole, project.FullPath, packageName, packageVersion).Should().BeTrue("package should exist in the assets file");
+
+                solutionService.Save();
+            }
+        }
+
+        [NuGetWpfTheory]
+        [MemberData(nameof(GetTemplates))]
         public void UninstallPackageFromPMC(ProjectTemplate projectTemplate)
         {
             using (var pathContext = new SimpleTestPathContext())
@@ -100,38 +130,32 @@ namespace NuGet.Tests.Apex
                 var solutionService = VisualStudio.Get<SolutionService>();
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
-                project.Build();
+                var project = CreateAndInitProject(projectTemplate, pathContext, solutionService);
 
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
                 Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion);
 
-                var nugetTestService = GetNuGetTestService();
-                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
+                var nugetConsole = GetConsole(project);
 
-                var nugetConsole = nugetTestService.GetPackageManagerConsole(project.Name);
-
-                Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion));
-                Assert.True(Utils.IsPackageInstalled(nugetConsole, project.FullPath, packageName, packageVersion));
+                nugetConsole.InstallPackageFromPMC(packageName, packageVersion).Should().BeTrue("Install-Package");
                 project.Build();
 
-                Assert.True(nugetConsole.UninstallPackageFromPMC(packageName));
-                Assert.False(Utils.IsPackageInstalled(nugetConsole, project.FullPath, packageName, packageVersion));
+                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName, packageVersion);
+
+                nugetConsole.UninstallPackageFromPMC(packageName).Should().BeTrue("Uninstall-Package");
+                project.Build();
+
+                GetNuGetTestService().Verify.PackageIsNotInstalled(project.UniqueName, packageName);
+
+                VisualStudio.AssertNoErrors();
 
                 solutionService.Save();
-                project.Build();
-                Assert.True(VisualStudio.HasNoErrorsInErrorList());
-                Assert.True(VisualStudio.HasNoErrorsInOutputWindows());
-
-                nugetConsole.Clear();
             }
         }
 
         [NuGetWpfTheory]
-        [InlineData(ProjectTemplate.ClassLibrary)]
-        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
-        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        [MemberData(nameof(GetTemplates))]
         public void UpdatePackageFromPMC(ProjectTemplate projectTemplate)
         {
             using (var pathContext = new SimpleTestPathContext())
@@ -141,8 +165,7 @@ namespace NuGet.Tests.Apex
                 var solutionService = VisualStudio.Get<SolutionService>();
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
-                project.Build();
+                var project = CreateAndInitProject(projectTemplate, pathContext, solutionService);
 
                 var packageName = "TestPackage";
                 var packageVersion1 = "1.0.0";
@@ -150,32 +173,26 @@ namespace NuGet.Tests.Apex
                 Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion1);
                 Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion2);
 
-                var nugetTestService = GetNuGetTestService();
-                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
+                var nugetConsole = GetConsole(project);
 
-                var nugetConsole = nugetTestService.GetPackageManagerConsole(project.UniqueName);
-
-                Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion1));
-                Assert.True(Utils.IsPackageInstalled(nugetConsole, project.FullPath, packageName, packageVersion1));
-                project.Build();
-                
-                Assert.True(nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2));
-                Assert.True(Utils.IsPackageInstalled(nugetConsole, project.FullPath, packageName, packageVersion2));
-                Assert.False(Utils.IsPackageInstalled(nugetConsole, project.FullPath, packageName, packageVersion1));
+                nugetConsole.InstallPackageFromPMC(packageName, packageVersion1).Should().BeTrue("Install-Package");
                 project.Build();
 
-                Assert.True(VisualStudio.HasNoErrorsInErrorList());
-                Assert.True(VisualStudio.HasNoErrorsInOutputWindows());
+                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName, packageVersion1);
 
-                nugetConsole.Clear();
+                nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2).Should().BeTrue("UnInstall-Package");
+                project.Build();
+
+                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName, packageVersion2);
+
+                VisualStudio.AssertNoErrors();
+
                 solutionService.Save();
             }
         }
 
         [NuGetWpfTheory]
-        [InlineData(ProjectTemplate.ClassLibrary)]
-        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
-        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        [MemberData(nameof(GetTemplates))]
         public void InstallMultiplePackagesFromPMC(ProjectTemplate projectTemplate)
         {
             using (var pathContext = new SimpleTestPathContext())
@@ -185,8 +202,7 @@ namespace NuGet.Tests.Apex
                 var solutionService = VisualStudio.Get<SolutionService>();
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
-                project.Build();
+                var project = CreateAndInitProject(projectTemplate, pathContext, solutionService);
 
                 var packageName1 = "TestPackage1";
                 var packageVersion1 = "1.0.0";
@@ -196,28 +212,23 @@ namespace NuGet.Tests.Apex
                 var packageVersion2 = "1.2.3";
                 Utils.CreatePackageInSource(pathContext.PackageSource, packageName2, packageVersion2);
 
-                var nugetTestService = GetNuGetTestService();
-                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
+                var nugetConsole = GetConsole(project);
 
-                var nugetConsole = nugetTestService.GetPackageManagerConsole(project.Name);
-
-                Assert.True(nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1));
-                Assert.True(nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2));
+                nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1).Should().BeTrue("Install-Package 1");
+                nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2).Should().BeTrue("Install-Package 2");
                 project.Build();
-                Assert.True(VisualStudio.HasNoErrorsInErrorList());
-                Assert.True(VisualStudio.HasNoErrorsInOutputWindows());
-                Assert.True(Utils.IsPackageInstalled(nugetConsole, project.FullPath, packageName1, packageVersion1));
-                Assert.True(Utils.IsPackageInstalled(nugetConsole, project.FullPath, packageName2, packageVersion2));
 
-                nugetConsole.Clear();
+                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName1, packageVersion1);
+                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName2, packageVersion2);
+
+                VisualStudio.AssertNoErrors();
+
                 solutionService.Save();
             }
         }
 
         [NuGetWpfTheory]
-        [InlineData(ProjectTemplate.ClassLibrary)]
-        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
-        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        [MemberData(nameof(GetTemplates))]
         public void UninstallMultiplePackagesFromPMC(ProjectTemplate projectTemplate)
         {
             using (var pathContext = new SimpleTestPathContext())
@@ -227,8 +238,7 @@ namespace NuGet.Tests.Apex
                 var solutionService = VisualStudio.Get<SolutionService>();
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
-                project.Build();
+                var project = CreateAndInitProject(projectTemplate, pathContext, solutionService);
 
                 var packageName1 = "TestPackage1";
                 var packageVersion1 = "1.0.0";
@@ -238,36 +248,31 @@ namespace NuGet.Tests.Apex
                 var packageVersion2 = "1.2.3";
                 Utils.CreatePackageInSource(pathContext.PackageSource, packageName2, packageVersion2);
 
-                var nugetTestService = GetNuGetTestService();
-                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
+                var nugetConsole = GetConsole(project);
 
-                var nugetConsole = nugetTestService.GetPackageManagerConsole(project.Name);
-
-                Assert.True(nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1));
-                Assert.True(nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2));
+                nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1).Should().BeTrue("Install-Package 1");
+                nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2).Should().BeTrue("Install-Package 2");
                 project.Build();
-                Assert.True(VisualStudio.HasNoErrorsInErrorList());
-                Assert.True(VisualStudio.HasNoErrorsInOutputWindows());
-                Assert.True(Utils.IsPackageInstalled(nugetConsole, project.FullPath, packageName1, packageVersion1));
-                Assert.True(Utils.IsPackageInstalled(nugetConsole, project.FullPath, packageName2, packageVersion2));
+
+                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName1, packageVersion1);
+                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName2, packageVersion2);
+
+                VisualStudio.AssertNoErrors();
 
                 Assert.True(nugetConsole.UninstallPackageFromPMC(packageName1));
                 Assert.True(nugetConsole.UninstallPackageFromPMC(packageName2));
                 project.Build();
                 solutionService.SaveAll();
 
-                Assert.False(Utils.IsPackageInstalled(nugetConsole, project.FullPath, packageName1, packageVersion1));
-                Assert.False(Utils.IsPackageInstalled(nugetConsole, project.FullPath, packageName2, packageVersion2));
+                GetNuGetTestService().Verify.PackageIsNotInstalled(project.UniqueName, packageName1);
+                GetNuGetTestService().Verify.PackageIsNotInstalled(project.UniqueName, packageName2);
 
-                nugetConsole.Clear();
                 solutionService.Save();
             }
         }
 
         [NuGetWpfTheory]
-        [InlineData(ProjectTemplate.ClassLibrary)]
-        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
-        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        [MemberData(nameof(GetTemplates))]
         public void DowngradePackageFromPMC(ProjectTemplate projectTemplate)
         {
             using (var pathContext = new SimpleTestPathContext())
@@ -277,8 +282,7 @@ namespace NuGet.Tests.Apex
                 var solutionService = VisualStudio.Get<SolutionService>();
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
-                project.Build();
+                var project = CreateAndInitProject(projectTemplate, pathContext, solutionService);
 
                 var packageName = "TestPackage";
                 var packageVersion1 = "1.0.0";
@@ -286,29 +290,24 @@ namespace NuGet.Tests.Apex
                 Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion1);
                 Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion2);
 
-                var nugetTestService = GetNuGetTestService();
-                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
+                var nugetConsole = GetConsole(project);
 
-                var nugetConsole = nugetTestService.GetPackageManagerConsole(project.UniqueName);
-
-                Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion2));
-                project.Build();
-                Assert.True(Utils.IsPackageInstalled(nugetConsole, project.FullPath, packageName, packageVersion2));
-
-                Assert.True(nugetConsole.UpdatePackageFromPMC(packageName, packageVersion1));
+                nugetConsole.InstallPackageFromPMC(packageName, packageVersion2).Should().BeTrue("Install-Package");
                 project.Build();
 
-                Assert.False(Utils.IsPackageInstalled(nugetConsole, project.FullPath, packageName, packageVersion2));
-                Assert.True(Utils.IsPackageInstalled(nugetConsole, project.FullPath, packageName, packageVersion1));
+                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName, packageVersion2);
 
-                nugetConsole.Clear();
+                nugetConsole.UpdatePackageFromPMC(packageName, packageVersion1).Should().BeTrue("Update-Package");
+                project.Build();
+
+                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName, packageVersion1);
+
                 solutionService.Save();
             }
         }
 
         [NuGetWpfTheory]
-        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
-        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        [MemberData(nameof(GetNetCoreTemplates))]
         public void NetCoreTransitivePackageReference(ProjectTemplate projectTemplate)
         {
             using (var pathContext = new SimpleTestPathContext())
@@ -326,40 +325,34 @@ namespace NuGet.Tests.Apex
                 var project3 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject3");
                 project3.Build();
                 solutionService.Build();
-                
-                var nugetTestService = GetNuGetTestService();
-                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
 
                 project1.References.Dte.AddProjectReference(project2);
                 project2.References.Dte.AddProjectReference(project3);
                 solutionService.SaveAll();
                 solutionService.Build();
 
-
-                var nugetConsole = nugetTestService.GetPackageManagerConsole(project3.UniqueName);
+                var nugetConsole = GetConsole(project3);
                 var packageName = "newtonsoft.json";
                 var packageVersion = "9.0.1";
 
-                Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion, "https://api.nuget.org/v3/index.json"));
+                nugetConsole.InstallPackageFromPMC(packageName, packageVersion, "https://api.nuget.org/v3/index.json").Should().BeTrue("Install-Package");
                 project1.Build();
                 project2.Build();
                 project3.Build();
 
-                Assert.True(Utils.IsPackageInstalled(nugetConsole, project3.FullPath, packageName, packageVersion));
+                GetNuGetTestService().Verify.PackageIsInstalled(project3.UniqueName, packageName, packageVersion);
 
                 Assert.True(project1.References.TryFindReferenceByName("newtonsoft.json", out var result));
                 Assert.NotNull(result);
                 Assert.True(project2.References.TryFindReferenceByName("newtonsoft.json", out var result2));
                 Assert.NotNull(result2);
 
-                nugetConsole.Clear();
                 solutionService.Save();
             }
         }
 
         [NuGetWpfTheory]
-        [InlineData(ProjectTemplate.NetCoreConsoleApp)]
-        [InlineData(ProjectTemplate.NetStandardClassLib)]
+        [MemberData(nameof(GetNetCoreTemplates))]
         public void NetCoreTransitivePackageReferenceLimit(ProjectTemplate projectTemplate)
         {
             using (var pathContext = new SimpleTestPathContext())
@@ -367,7 +360,6 @@ namespace NuGet.Tests.Apex
                 // Arrange
                 EnsureVisualStudioHost();
                 var solutionService = VisualStudio.Get<SolutionService>();
-
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
                 var project1 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject1");
@@ -380,28 +372,25 @@ namespace NuGet.Tests.Apex
                 projectX.Build();
                 solutionService.Build();
 
-                var nugetTestService = GetNuGetTestService();
-                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
-
                 project1.References.Dte.AddProjectReference(project2);
                 project1.References.Dte.AddProjectReference(projectX);
                 project2.References.Dte.AddProjectReference(project3);
                 solutionService.SaveAll();
                 solutionService.Build();
 
+                var nugetConsole = GetConsole(project3);
 
-                var nugetConsole = nugetTestService.GetPackageManagerConsole(project3.UniqueName);
                 var packageName = "newtonsoft.json";
                 var packageVersion = "9.0.1";
 
-                Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion, "https://api.nuget.org/v3/index.json"));
+                nugetConsole.InstallPackageFromPMC(packageName, packageVersion, "https://api.nuget.org/v3/index.json").Should().BeTrue("Install-Package");
                 project1.Build();
                 project2.Build();
                 project3.Build();
                 projectX.Build();
                 solutionService.Build();
 
-                Assert.True(Utils.IsPackageInstalled(nugetConsole, project3.FullPath, packageName, packageVersion));
+                GetNuGetTestService().Verify.PackageIsInstalled(project3.UniqueName, packageName, packageVersion);
 
                 Assert.True(project1.References.TryFindReferenceByName("newtonsoft.json", out var result));
                 Assert.NotNull(result);
@@ -410,10 +399,58 @@ namespace NuGet.Tests.Apex
                 Assert.False(projectX.References.TryFindReferenceByName("newtonsoft.json", out var resultX));
                 Assert.Null(resultX);
 
-                nugetConsole.Clear();
                 solutionService.Save();
             }
         }
 
+        private NuGetConsoleTestExtension GetConsole(ProjectTestExtension project)
+        {
+            var nugetTestService = GetNuGetTestService();
+            nugetTestService.EnsurePackageManagerConsoleIsOpen().Should().BeTrue("Console was opened");
+            var nugetConsole = nugetTestService.GetPackageManagerConsole(project.Name);
+
+            // Clear everything before starting
+            nugetConsole.Clear();
+            VisualStudio.ClearWindows();
+
+            return nugetConsole;
+        }
+
+        private static ProjectTestExtension CreateAndInitProject(ProjectTemplate projectTemplate, SimpleTestPathContext pathContext, SolutionService solutionService)
+        {
+            solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
+            var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
+            solutionService.Save();
+            project.Build();
+
+            return project;
+        }
+
+        public static IEnumerable<object[]> GetNetCoreTemplates()
+        {
+            for (var i = 0; i < Utils.GetIterations(); i++)
+            {
+                yield return new object[] { ProjectTemplate.NetCoreConsoleApp };
+                yield return new object[] { ProjectTemplate.NetStandardClassLib };
+            }
+        }
+
+        public static IEnumerable<object[]> GetPackageReferenceTemplates()
+        {
+            for (var i = 0; i < Utils.GetIterations(); i++)
+            {
+                yield return new object[] { ProjectTemplate.NetCoreConsoleApp };
+                yield return new object[] { ProjectTemplate.NetStandardClassLib };
+            }
+        }
+
+        public static IEnumerable<object[]> GetTemplates()
+        {
+            for (var i = 0; i < Utils.GetIterations(); i++)
+            {
+                yield return new object[] { ProjectTemplate.ClassLibrary };
+                yield return new object[] { ProjectTemplate.NetCoreConsoleApp };
+            }
+        }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
@@ -379,11 +379,13 @@ namespace NuGet.Tests.Apex
             }
         }
 
+        // There  is a bug with VS or Apex where NetCoreConsoleApp creates a netcore 2.1 project that is not supported by the sdk
+        // Commenting out any NetCoreConsoleApp template and swapping it for NetStandardClassLib as both are package ref.
         public static IEnumerable<object[]> GetNetCoreTemplates()
         {
             for (var i = 0; i < Utils.GetIterations(); i++)
             {
-                yield return new object[] { ProjectTemplate.NetCoreConsoleApp };
+                //yield return new object[] { ProjectTemplate.NetCoreConsoleApp };
                 yield return new object[] { ProjectTemplate.NetStandardClassLib };
             }
         }
@@ -392,7 +394,7 @@ namespace NuGet.Tests.Apex
         {
             for (var i = 0; i < Utils.GetIterations(); i++)
             {
-                yield return new object[] { ProjectTemplate.NetCoreConsoleApp };
+                //yield return new object[] { ProjectTemplate.NetCoreConsoleApp };
                 yield return new object[] { ProjectTemplate.NetStandardClassLib };
             }
         }
@@ -402,7 +404,7 @@ namespace NuGet.Tests.Apex
             for (var i = 0; i < Utils.GetIterations(); i++)
             {
                 yield return new object[] { ProjectTemplate.ClassLibrary };
-                yield return new object[] { ProjectTemplate.NetCoreConsoleApp };
+                yield return new object[] { ProjectTemplate.NetStandardClassLib };
             }
         }
     }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
@@ -50,6 +50,7 @@ namespace NuGet.Tests.Apex
                 inAssetsFile.Should().BeTrue("package was installed");
 
                 solutionService.Save();
+                solutionService.Close();
             }
         }
 
@@ -83,39 +84,7 @@ namespace NuGet.Tests.Apex
                 VisualStudio.AssertNoErrors();
 
                 solutionService.Save();
-            }
-        }
-
-        [NuGetWpfTheory]
-        [MemberData(nameof(GetTemplates))]
-        public void InstallPackageFromPMCFromNuGetOrg(ProjectTemplate projectTemplate)
-        {
-            using (var pathContext = new SimpleTestPathContext())
-            {
-                // Arrange
-                pathContext.Settings.DisableAutoRestore();
-
-                var packageSources = SimpleTestSettingsContext.GetOrAddSection(pathContext.Settings.XML, "packageSources");
-                SimpleTestSettingsContext.AddEntry(packageSources, "nugetOnline", "https://api.nuget.org/v3/index.json");
-                pathContext.Settings.Save();
-
-                EnsureVisualStudioHost();
-                var solutionService = VisualStudio.Get<SolutionService>();
-                var project = Utils.CreateAndInitProject(projectTemplate, pathContext, solutionService);
-                var nugetConsole = GetConsole(project);
-
-                var packageName = "newtonsoft.json";
-                var packageVersion = "9.0.1";
-
-                nugetConsole.InstallPackageFromPMC(packageName, packageVersion)
-                    .Should()
-                    .BeTrue("Install-Package should return on time");
-
-                project.Build();
-
-                Utils.IsPackageInstalledInAssetsFile(nugetConsole, project.FullPath, packageName, packageVersion).Should().BeTrue("package should exist in the assets file");
-
-                solutionService.Save();
+                solutionService.Close();
             }
         }
 
@@ -151,6 +120,7 @@ namespace NuGet.Tests.Apex
                 VisualStudio.AssertNoErrors();
 
                 solutionService.Save();
+                solutionService.Close();
             }
         }
 
@@ -188,6 +158,7 @@ namespace NuGet.Tests.Apex
                 VisualStudio.AssertNoErrors();
 
                 solutionService.Save();
+                solutionService.Close();
             }
         }
 
@@ -224,6 +195,7 @@ namespace NuGet.Tests.Apex
                 VisualStudio.AssertNoErrors();
 
                 solutionService.Save();
+                solutionService.Close();
             }
         }
 
@@ -268,6 +240,7 @@ namespace NuGet.Tests.Apex
                 GetNuGetTestService().Verify.PackageIsNotInstalled(project.UniqueName, packageName2);
 
                 solutionService.Save();
+                solutionService.Close();
             }
         }
 
@@ -303,6 +276,7 @@ namespace NuGet.Tests.Apex
                 GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName, packageVersion1);
 
                 solutionService.Save();
+                solutionService.Close();
             }
         }
 
@@ -348,6 +322,7 @@ namespace NuGet.Tests.Apex
                 Assert.NotNull(result2);
 
                 solutionService.Save();
+                solutionService.Close();
             }
         }
 
@@ -400,6 +375,7 @@ namespace NuGet.Tests.Apex
                 Assert.Null(resultX);
 
                 solutionService.Save();
+                solutionService.Close();
             }
         }
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
@@ -34,7 +34,7 @@ namespace NuGet.Tests.Apex
                 EnsureVisualStudioHost();
                 var solutionService = VisualStudio.Get<SolutionService>();
 
-                var project = CreateAndInitProject(projectTemplate, pathContext, solutionService);
+                var project = Utils.CreateAndInitProject(projectTemplate, pathContext, solutionService);
 
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
@@ -63,7 +63,7 @@ namespace NuGet.Tests.Apex
                 // Arrange
                 EnsureVisualStudioHost();
                 var solutionService = VisualStudio.Get<SolutionService>();
-                var project = CreateAndInitProject(projectTemplate, pathContext, solutionService);
+                var project = Utils.CreateAndInitProject(projectTemplate, pathContext, solutionService);
 
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
@@ -101,7 +101,7 @@ namespace NuGet.Tests.Apex
 
                 EnsureVisualStudioHost();
                 var solutionService = VisualStudio.Get<SolutionService>();
-                var project = CreateAndInitProject(projectTemplate, pathContext, solutionService);
+                var project = Utils.CreateAndInitProject(projectTemplate, pathContext, solutionService);
                 var nugetConsole = GetConsole(project);
 
                 var packageName = "newtonsoft.json";
@@ -130,7 +130,7 @@ namespace NuGet.Tests.Apex
                 var solutionService = VisualStudio.Get<SolutionService>();
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = CreateAndInitProject(projectTemplate, pathContext, solutionService);
+                var project = Utils.CreateAndInitProject(projectTemplate, pathContext, solutionService);
 
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
@@ -165,7 +165,7 @@ namespace NuGet.Tests.Apex
                 var solutionService = VisualStudio.Get<SolutionService>();
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = CreateAndInitProject(projectTemplate, pathContext, solutionService);
+                var project = Utils.CreateAndInitProject(projectTemplate, pathContext, solutionService);
 
                 var packageName = "TestPackage";
                 var packageVersion1 = "1.0.0";
@@ -202,7 +202,7 @@ namespace NuGet.Tests.Apex
                 var solutionService = VisualStudio.Get<SolutionService>();
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = CreateAndInitProject(projectTemplate, pathContext, solutionService);
+                var project = Utils.CreateAndInitProject(projectTemplate, pathContext, solutionService);
 
                 var packageName1 = "TestPackage1";
                 var packageVersion1 = "1.0.0";
@@ -238,7 +238,7 @@ namespace NuGet.Tests.Apex
                 var solutionService = VisualStudio.Get<SolutionService>();
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = CreateAndInitProject(projectTemplate, pathContext, solutionService);
+                var project = Utils.CreateAndInitProject(projectTemplate, pathContext, solutionService);
 
                 var packageName1 = "TestPackage1";
                 var packageVersion1 = "1.0.0";
@@ -282,7 +282,7 @@ namespace NuGet.Tests.Apex
                 var solutionService = VisualStudio.Get<SolutionService>();
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = CreateAndInitProject(projectTemplate, pathContext, solutionService);
+                var project = Utils.CreateAndInitProject(projectTemplate, pathContext, solutionService);
 
                 var packageName = "TestPackage";
                 var packageVersion1 = "1.0.0";
@@ -401,29 +401,6 @@ namespace NuGet.Tests.Apex
 
                 solutionService.Save();
             }
-        }
-
-        private NuGetConsoleTestExtension GetConsole(ProjectTestExtension project)
-        {
-            var nugetTestService = GetNuGetTestService();
-            nugetTestService.EnsurePackageManagerConsoleIsOpen().Should().BeTrue("Console was opened");
-            var nugetConsole = nugetTestService.GetPackageManagerConsole(project.Name);
-
-            // Clear everything before starting
-            nugetConsole.Clear();
-            VisualStudio.ClearWindows();
-
-            return nugetConsole;
-        }
-
-        private static ProjectTestExtension CreateAndInitProject(ProjectTemplate projectTemplate, SimpleTestPathContext pathContext, SolutionService solutionService)
-        {
-            solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-            var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
-            solutionService.Save();
-            project.Build();
-
-            return project;
         }
 
         public static IEnumerable<object[]> GetNetCoreTemplates()

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
@@ -25,32 +25,23 @@ namespace NuGet.Tests.Apex
         [MemberData(nameof(GetPackageReferenceTemplates))]
         public void InstallPackageFromPMCWithNoAutoRestoreVerifyAssetsFile(ProjectTemplate projectTemplate)
         {
-            using (var pathContext = new SimpleTestPathContext())
+            // Arrange
+            EnsureVisualStudioHost();
+
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, noAutoRestore: true))
             {
-                // Arrange
-                // Turn off auto restore
-                pathContext.Settings.DisableAutoRestore();
-
-                EnsureVisualStudioHost();
-                var solutionService = VisualStudio.Get<SolutionService>();
-
-                var project = Utils.CreateAndInitProject(projectTemplate, pathContext, solutionService);
-
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
-                Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion);
+                Utils.CreatePackageInSource(testContext.PackageSource, packageName, packageVersion);
 
-                var nugetConsole = GetConsole(project);
+                var nugetConsole = GetConsole(testContext.Project);
 
                 var installed = nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
                 installed.Should().BeTrue("Install-Package should pass");
 
                 // Verify install from project.assets.json
-                var inAssetsFile = Utils.IsPackageInstalledInAssetsFile(nugetConsole, project.FullPath, packageName, packageVersion);
+                var inAssetsFile = Utils.IsPackageInstalledInAssetsFile(nugetConsole, testContext.Project.FullPath, packageName, packageVersion);
                 inAssetsFile.Should().BeTrue("package was installed");
-
-                solutionService.Save();
-                solutionService.Close();
             }
         }
 
@@ -59,32 +50,27 @@ namespace NuGet.Tests.Apex
         [MemberData(nameof(GetTemplates))]
         public void InstallPackageFromPMCVerifyGetPackageDisplaysPackage(ProjectTemplate projectTemplate)
         {
-            using (var pathContext = new SimpleTestPathContext())
-            {
-                // Arrange
-                EnsureVisualStudioHost();
-                var solutionService = VisualStudio.Get<SolutionService>();
-                var project = Utils.CreateAndInitProject(projectTemplate, pathContext, solutionService);
+            // Arrange
+            EnsureVisualStudioHost();
 
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate))
+            {
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
-                Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion);
+                Utils.CreatePackageInSource(testContext.PackageSource, packageName, packageVersion);
 
-                var nugetConsole = GetConsole(project);
+                var nugetConsole = GetConsole(testContext.Project);
 
                 var installed = nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
                 installed.Should().BeTrue("Install-Package should pass");
 
                 // Build before the install check to ensure that everything is up to date.
-                project.Build();
+                testContext.Project.Build();
 
                 // Verify install from Get-Package
-                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName, packageVersion);
+                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName, packageVersion);
 
                 VisualStudio.AssertNoErrors();
-
-                solutionService.Save();
-                solutionService.Close();
             }
         }
 
@@ -92,35 +78,28 @@ namespace NuGet.Tests.Apex
         [MemberData(nameof(GetTemplates))]
         public void UninstallPackageFromPMC(ProjectTemplate projectTemplate)
         {
-            using (var pathContext = new SimpleTestPathContext())
+            // Arrange
+            EnsureVisualStudioHost();
+
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate))
             {
-                // Arrange
-                EnsureVisualStudioHost();
-                var solutionService = VisualStudio.Get<SolutionService>();
-
-                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = Utils.CreateAndInitProject(projectTemplate, pathContext, solutionService);
-
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
-                Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion);
+                Utils.CreatePackageInSource(testContext.PackageSource, packageName, packageVersion);
 
-                var nugetConsole = GetConsole(project);
+                var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion).Should().BeTrue("Install-Package");
-                project.Build();
+                testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName, packageVersion);
+                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName, packageVersion);
 
                 nugetConsole.UninstallPackageFromPMC(packageName).Should().BeTrue("Uninstall-Package");
-                project.Build();
+                testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsNotInstalled(project.UniqueName, packageName);
+                GetNuGetTestService().Verify.PackageIsNotInstalled(testContext.Project.UniqueName, packageName);
 
                 VisualStudio.AssertNoErrors();
-
-                solutionService.Save();
-                solutionService.Close();
             }
         }
 
@@ -128,37 +107,30 @@ namespace NuGet.Tests.Apex
         [MemberData(nameof(GetTemplates))]
         public void UpdatePackageFromPMC(ProjectTemplate projectTemplate)
         {
-            using (var pathContext = new SimpleTestPathContext())
+            // Arrange
+            EnsureVisualStudioHost();
+
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate))
             {
-                // Arrange
-                EnsureVisualStudioHost();
-                var solutionService = VisualStudio.Get<SolutionService>();
-
-                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = Utils.CreateAndInitProject(projectTemplate, pathContext, solutionService);
-
                 var packageName = "TestPackage";
                 var packageVersion1 = "1.0.0";
                 var packageVersion2 = "2.0.0";
-                Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion1);
-                Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion2);
+                Utils.CreatePackageInSource(testContext.PackageSource, packageName, packageVersion1);
+                Utils.CreatePackageInSource(testContext.PackageSource, packageName, packageVersion2);
 
-                var nugetConsole = GetConsole(project);
+                var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion1).Should().BeTrue("Install-Package");
-                project.Build();
+                testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName, packageVersion1);
+                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName, packageVersion1);
 
                 nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2).Should().BeTrue("UnInstall-Package");
-                project.Build();
+                testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName, packageVersion2);
+                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName, packageVersion2);
 
                 VisualStudio.AssertNoErrors();
-
-                solutionService.Save();
-                solutionService.Close();
             }
         }
 
@@ -166,36 +138,29 @@ namespace NuGet.Tests.Apex
         [MemberData(nameof(GetTemplates))]
         public void InstallMultiplePackagesFromPMC(ProjectTemplate projectTemplate)
         {
-            using (var pathContext = new SimpleTestPathContext())
+            // Arrange
+            EnsureVisualStudioHost();
+
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate))
             {
-                // Arrange
-                EnsureVisualStudioHost();
-                var solutionService = VisualStudio.Get<SolutionService>();
-
-                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = Utils.CreateAndInitProject(projectTemplate, pathContext, solutionService);
-
                 var packageName1 = "TestPackage1";
                 var packageVersion1 = "1.0.0";
-                Utils.CreatePackageInSource(pathContext.PackageSource, packageName1, packageVersion1);
+                Utils.CreatePackageInSource(testContext.PackageSource, packageName1, packageVersion1);
 
                 var packageName2 = "TestPackage2";
                 var packageVersion2 = "1.2.3";
-                Utils.CreatePackageInSource(pathContext.PackageSource, packageName2, packageVersion2);
+                Utils.CreatePackageInSource(testContext.PackageSource, packageName2, packageVersion2);
 
-                var nugetConsole = GetConsole(project);
+                var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1).Should().BeTrue("Install-Package 1");
                 nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2).Should().BeTrue("Install-Package 2");
-                project.Build();
+                testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName1, packageVersion1);
-                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName2, packageVersion2);
+                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName1, packageVersion1);
+                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName2, packageVersion2);
 
                 VisualStudio.AssertNoErrors();
-
-                solutionService.Save();
-                solutionService.Close();
             }
         }
 
@@ -203,44 +168,36 @@ namespace NuGet.Tests.Apex
         [MemberData(nameof(GetTemplates))]
         public void UninstallMultiplePackagesFromPMC(ProjectTemplate projectTemplate)
         {
-            using (var pathContext = new SimpleTestPathContext())
+            // Arrange
+            EnsureVisualStudioHost();
+
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate))
             {
-                // Arrange
-                EnsureVisualStudioHost();
-                var solutionService = VisualStudio.Get<SolutionService>();
-
-                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = Utils.CreateAndInitProject(projectTemplate, pathContext, solutionService);
-
                 var packageName1 = "TestPackage1";
                 var packageVersion1 = "1.0.0";
-                Utils.CreatePackageInSource(pathContext.PackageSource, packageName1, packageVersion1);
+                Utils.CreatePackageInSource(testContext.PackageSource, packageName1, packageVersion1);
 
                 var packageName2 = "TestPackage2";
                 var packageVersion2 = "1.2.3";
-                Utils.CreatePackageInSource(pathContext.PackageSource, packageName2, packageVersion2);
+                Utils.CreatePackageInSource(testContext.PackageSource, packageName2, packageVersion2);
 
-                var nugetConsole = GetConsole(project);
+                var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1).Should().BeTrue("Install-Package 1");
                 nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2).Should().BeTrue("Install-Package 2");
-                project.Build();
+                testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName1, packageVersion1);
-                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName2, packageVersion2);
+                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName1, packageVersion1);
+                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName2, packageVersion2);
 
                 VisualStudio.AssertNoErrors();
 
-                Assert.True(nugetConsole.UninstallPackageFromPMC(packageName1));
-                Assert.True(nugetConsole.UninstallPackageFromPMC(packageName2));
-                project.Build();
-                solutionService.SaveAll();
+                nugetConsole.UninstallPackageFromPMC(packageName1).Should().BeTrue("Uninstall package 1");
+                nugetConsole.UninstallPackageFromPMC(packageName2).Should().BeTrue("Uninstall package 2");
+                testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsNotInstalled(project.UniqueName, packageName1);
-                GetNuGetTestService().Verify.PackageIsNotInstalled(project.UniqueName, packageName2);
-
-                solutionService.Save();
-                solutionService.Close();
+                GetNuGetTestService().Verify.PackageIsNotInstalled(testContext.Project.UniqueName, packageName1);
+                GetNuGetTestService().Verify.PackageIsNotInstalled(testContext.Project.UniqueName, packageName2);
             }
         }
 
@@ -248,35 +205,28 @@ namespace NuGet.Tests.Apex
         [MemberData(nameof(GetTemplates))]
         public void DowngradePackageFromPMC(ProjectTemplate projectTemplate)
         {
-            using (var pathContext = new SimpleTestPathContext())
+            // Arrange
+            EnsureVisualStudioHost();
+
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate))
             {
-                // Arrange
-                EnsureVisualStudioHost();
-                var solutionService = VisualStudio.Get<SolutionService>();
-
-                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project = Utils.CreateAndInitProject(projectTemplate, pathContext, solutionService);
-
                 var packageName = "TestPackage";
                 var packageVersion1 = "1.0.0";
                 var packageVersion2 = "2.0.0";
-                Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion1);
-                Utils.CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion2);
+                Utils.CreatePackageInSource(testContext.PackageSource, packageName, packageVersion1);
+                Utils.CreatePackageInSource(testContext.PackageSource, packageName, packageVersion2);
 
-                var nugetConsole = GetConsole(project);
+                var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion2).Should().BeTrue("Install-Package");
-                project.Build();
+                testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName, packageVersion2);
+                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName, packageVersion2);
 
                 nugetConsole.UpdatePackageFromPMC(packageName, packageVersion1).Should().BeTrue("Update-Package");
-                project.Build();
+                testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(project.UniqueName, packageName, packageVersion1);
-
-                solutionService.Save();
-                solutionService.Close();
+                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName, packageVersion1);
             }
         }
 
@@ -284,45 +234,37 @@ namespace NuGet.Tests.Apex
         [MemberData(nameof(GetNetCoreTemplates))]
         public void NetCoreTransitivePackageReference(ProjectTemplate projectTemplate)
         {
-            using (var pathContext = new SimpleTestPathContext())
+            // Arrange
+            EnsureVisualStudioHost();
+
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate))
             {
-                // Arrange
-                EnsureVisualStudioHost();
-                var solutionService = VisualStudio.Get<SolutionService>();
-
-
-                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project1 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject1");
-                project1.Build();
-                var project2 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject2");
+                var project2 = testContext.SolutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject2");
                 project2.Build();
-                var project3 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject3");
+                var project3 = testContext.SolutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject3");
                 project3.Build();
-                solutionService.Build();
+                testContext.SolutionService.Build();
 
-                project1.References.Dte.AddProjectReference(project2);
+                testContext.Project.References.Dte.AddProjectReference(project2);
                 project2.References.Dte.AddProjectReference(project3);
-                solutionService.SaveAll();
-                solutionService.Build();
+                testContext.SolutionService.SaveAll();
+                testContext.SolutionService.Build();
 
                 var nugetConsole = GetConsole(project3);
                 var packageName = "newtonsoft.json";
                 var packageVersion = "9.0.1";
 
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion, "https://api.nuget.org/v3/index.json").Should().BeTrue("Install-Package");
-                project1.Build();
+                testContext.Project.Build();
                 project2.Build();
                 project3.Build();
 
                 GetNuGetTestService().Verify.PackageIsInstalled(project3.UniqueName, packageName, packageVersion);
 
-                Assert.True(project1.References.TryFindReferenceByName("newtonsoft.json", out var result));
-                Assert.NotNull(result);
-                Assert.True(project2.References.TryFindReferenceByName("newtonsoft.json", out var result2));
-                Assert.NotNull(result2);
-
-                solutionService.Save();
-                solutionService.Close();
+                testContext.Project.References.TryFindReferenceByName("newtonsoft.json", out var result).Should().BeTrue("Find newtonsoft reference");
+                result.Should().NotBeNull("reference to newtonsoft shoult not be null");
+                project2.References.TryFindReferenceByName("newtonsoft.json", out var result2).Should().BeTrue("Find newtonsoft 2nd reference");
+                result2.Should().NotBeNull("reference2 to newtonsoft shoult not be null");
             }
         }
 
@@ -330,28 +272,24 @@ namespace NuGet.Tests.Apex
         [MemberData(nameof(GetNetCoreTemplates))]
         public void NetCoreTransitivePackageReferenceLimit(ProjectTemplate projectTemplate)
         {
-            using (var pathContext = new SimpleTestPathContext())
+            // Arrange
+            EnsureVisualStudioHost();
+
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate))
             {
-                // Arrange
-                EnsureVisualStudioHost();
-                var solutionService = VisualStudio.Get<SolutionService>();
-
-                solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                var project1 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject1");
-                project1.Build();
-                var project2 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject2");
+                var project2 = testContext.SolutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject2");
                 project2.Build();
-                var project3 = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject3");
+                var project3 = testContext.SolutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject3");
                 project3.Build();
-                var projectX = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProjectX");
+                var projectX = testContext.SolutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProjectX");
                 projectX.Build();
-                solutionService.Build();
+                testContext.SolutionService.Build();
 
-                project1.References.Dte.AddProjectReference(project2);
-                project1.References.Dte.AddProjectReference(projectX);
+                testContext.Project.References.Dte.AddProjectReference(project2);
+                testContext.Project.References.Dte.AddProjectReference(projectX);
                 project2.References.Dte.AddProjectReference(project3);
-                solutionService.SaveAll();
-                solutionService.Build();
+                testContext.SolutionService.SaveAll();
+                testContext.SolutionService.Build();
 
                 var nugetConsole = GetConsole(project3);
 
@@ -359,23 +297,20 @@ namespace NuGet.Tests.Apex
                 var packageVersion = "9.0.1";
 
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion, "https://api.nuget.org/v3/index.json").Should().BeTrue("Install-Package");
-                project1.Build();
+                testContext.Project.Build();
                 project2.Build();
                 project3.Build();
                 projectX.Build();
-                solutionService.Build();
+                testContext.SolutionService.Build();
 
                 GetNuGetTestService().Verify.PackageIsInstalled(project3.UniqueName, packageName, packageVersion);
 
-                Assert.True(project1.References.TryFindReferenceByName("newtonsoft.json", out var result));
-                Assert.NotNull(result);
-                Assert.True(project2.References.TryFindReferenceByName("newtonsoft.json", out var result2));
-                Assert.NotNull(result2);
-                Assert.False(projectX.References.TryFindReferenceByName("newtonsoft.json", out var resultX));
-                Assert.Null(resultX);
-
-                solutionService.Save();
-                solutionService.Close();
+                testContext.Project.References.TryFindReferenceByName("newtonsoft.json", out var result).Should().BeTrue("Find newtonsoft reference");
+                result.Should().NotBeNull("reference to newtonsoft shoult not be null");
+                project2.References.TryFindReferenceByName("newtonsoft.json", out var result2).Should().BeTrue("Find newtonsoft 2nd reference");
+                result2.Should().NotBeNull("reference 2 to newtonsoft shoult not be null");
+                projectX.References.TryFindReferenceByName("newtonsoft.json", out var resultX).Should().BeTrue("Find newtonsoft X reference");
+                resultX.Should().NotBeNull("reference X to newtonsoft shoult not be null");
             }
         }
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetPackageSigningTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetPackageSigningTestCase.cs
@@ -2,11 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using NuGet.StaFact;

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetUITestCase.cs
@@ -33,8 +33,7 @@ namespace NuGet.Tests.Apex
             uiwindow.SeachPackgeFromUI("newtonsoft.json");
 
             // Assert
-            Assert.True(VisualStudio.HasNoErrorsInErrorList());
-            Assert.True(VisualStudio.HasNoErrorsInOutputWindows());
+            VisualStudio.AssertNoErrors();
         }
 
         [StaFact]
@@ -54,11 +53,11 @@ namespace NuGet.Tests.Apex
             var nugetTestService = GetNuGetTestService();
             var uiwindow = nugetTestService.GetUIWindowfromProject(project);
             uiwindow.InstallPackageFromUI("newtonsoft.json","9.0.1");
+            project.Build();
 
             // Assert
-            Assert.True(VisualStudio.HasNoErrorsInErrorList());
-            Assert.True(VisualStudio.HasNoErrorsInOutputWindows());
             Assert.True(uiwindow.IsPackageInstalled("newtonsoft.json", "9.0.1"));
+            VisualStudio.AssertNoErrors();
         }
 
         [StaFact]
@@ -79,22 +78,22 @@ namespace NuGet.Tests.Apex
             var nugetTestService = GetNuGetTestService();
             var uiwindow = nugetTestService.GetUIWindowfromProject(nuProject);
             uiwindow.InstallPackageFromUI("newtonsoft.json", "9.0.1");
+            project.Build();
 
             // Assert
-            Assert.True(VisualStudio.HasNoErrorsInErrorList());
-            Assert.True(VisualStudio.HasNoErrorsInOutputWindows());
+            VisualStudio.AssertNoErrors();
 
             VisualStudio.ClearOutputWindow();
             VisualStudio.SelectProjectInSolutionExplorer(project.Name);
             dte.ExecuteCommand("Project.ManageNuGetPackages");
             var uiwindow2 = nugetTestService.GetUIWindowfromProject(project);
             uiwindow2.InstallPackageFromUI("newtonsoft.json", "9.0.1");
+            project.Build();
 
             // Assert
-            Assert.True(VisualStudio.HasNoErrorsInErrorList());
-            Assert.True(VisualStudio.HasNoErrorsInOutputWindows());
             Assert.True(uiwindow.IsPackageInstalled("newtonsoft.json", "9.0.1"));
             Assert.True(uiwindow2.IsPackageInstalled("newtonsoft.json", "9.0.1"));
+            VisualStudio.AssertNoErrors();
         }
 
         [StaFact]
@@ -107,24 +106,25 @@ namespace NuGet.Tests.Apex
 
             solutionService.CreateEmptySolution();
             var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
-            VisualStudio.ClearOutputWindow();
+            VisualStudio.ClearWindows();
 
             // Act
             dte.ExecuteCommand("Project.ManageNuGetPackages");
             var nugetTestService = GetNuGetTestService();
             var uiwindow = nugetTestService.GetUIWindowfromProject(project);
             uiwindow.InstallPackageFromUI("newtonsoft.json", "9.0.1");
+            project.Build();
 
             // Assert
             Assert.True(uiwindow.IsPackageInstalled("newtonsoft.json", "9.0.1"));
 
             // Act
             uiwindow.UninstallPackageFromUI("newtonsoft.json");
+            project.Build();
 
             // Assert
-            VisualStudio.HasNoErrorsInErrorList();
-            VisualStudio.HasNoErrorsInOutputWindows();
             Assert.False(uiwindow.IsPackageInstalled("newtonsoft.json", "9.0.1"));
+            VisualStudio.AssertNoErrors();
         }
 
         [StaFact]
@@ -137,27 +137,27 @@ namespace NuGet.Tests.Apex
 
             solutionService.CreateEmptySolution();
             var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
-            VisualStudio.ClearOutputWindow();
+            VisualStudio.ClearWindows();
 
             // Act
             dte.ExecuteCommand("Project.ManageNuGetPackages");
             var nugetTestService = GetNuGetTestService();
             var uiwindow = nugetTestService.GetUIWindowfromProject(project);
             uiwindow.InstallPackageFromUI("newtonsoft.json", "9.0.1");
+            project.Build();
 
             // Assert
-            VisualStudio.HasNoErrorsInErrorList();
-            VisualStudio.HasNoErrorsInOutputWindows();
             Assert.True(uiwindow.IsPackageInstalled("newtonsoft.json", "9.0.1"));
+            VisualStudio.AssertNoErrors();
 
             // Act
-            VisualStudio.ClearOutputWindow();
+            VisualStudio.ClearWindows();
             uiwindow.UpdatePackageFromUI("newtonsoft.json", "10.0.3");
+            project.Build();
 
             // Assert
-            VisualStudio.HasNoErrorsInErrorList();
-            VisualStudio.HasNoErrorsInOutputWindows();
             Assert.True(uiwindow.IsPackageInstalled("newtonsoft.json", "10.0.3"));
+            VisualStudio.AssertNoErrors();
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/Utils.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/Utils.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
+using Microsoft.Test.Apex.VisualStudio.Solution;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -146,6 +147,16 @@ namespace NuGet.Tests.Apex
                 // Run directly
                 action();
             }
+        }
+
+        internal static ProjectTestExtension CreateAndInitProject(ProjectTemplate projectTemplate, SimpleTestPathContext pathContext, SolutionService solutionService)
+        {
+            solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
+            var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
+            solutionService.Save();
+            project.Build();
+
+            return project;
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/Utils.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/Utils.cs
@@ -153,16 +153,6 @@ namespace NuGet.Tests.Apex
 
         internal static ProjectTestExtension CreateAndInitProject(ProjectTemplate projectTemplate, SimpleTestPathContext pathContext, SolutionService solutionService)
         {
-            //FrameworkName framework;
-            //if (projectTemplate == ProjectTemplate.NetCoreConsoleApp)
-            //{
-            //    framework = new FrameworkName(".NETCoreApp,Version=v2.0");
-            //}
-            //else
-            //{
-            //    framework = new FrameworkName(".NETFramework,Version=v4.6");
-            //}
-
             solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
             var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
             solutionService.Save();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/Utils.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/Utils.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using Microsoft.Test.Apex.VisualStudio.Solution;
@@ -41,6 +42,7 @@ namespace NuGet.Tests.Apex
             var package = new SimpleTestPackageContext(packageName, packageVersion);
             package.Files.Clear();
             package.AddFile("lib/net45/_._");
+            package.AddFile("lib/netstandard1.0/_._");
 
             return package;
         }
@@ -151,6 +153,16 @@ namespace NuGet.Tests.Apex
 
         internal static ProjectTestExtension CreateAndInitProject(ProjectTemplate projectTemplate, SimpleTestPathContext pathContext, SolutionService solutionService)
         {
+            //FrameworkName framework;
+            //if (projectTemplate == ProjectTemplate.NetCoreConsoleApp)
+            //{
+            //    framework = new FrameworkName(".NETCoreApp,Version=v2.0");
+            //}
+            //else
+            //{
+            //    framework = new FrameworkName(".NETFramework,Version=v4.6");
+            //}
+
             solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
             var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
             solutionService.Save();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/VisualStudioHostExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/VisualStudioHostExtension.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
 using Microsoft.Test.Apex.VisualStudio;
+using NuGet.VisualStudio;
 
 namespace NuGet.Tests.Apex
 {
@@ -7,45 +11,119 @@ namespace NuGet.Tests.Apex
     {
         static private readonly Guid _nugetOutputWindowGuid = new Guid("CEC55EC8-CC51-40E7-9243-57B87A6F6BEB");
 
-        public static bool HasNoErrorsInErrorList(this VisualStudioHost host)
+        /// <summary>
+        /// Assert no errors in the error list or output window
+        /// </summary>
+        internal static void AssertNoErrors(this VisualStudioHost host)
         {
-            return host.ObjectModel.Shell.ToolWindows.ErrorList.Verify.HasNoErrors();
+            host.AssertNuGetOutputDoesNotHaveErrors();
+            host.GetErrorListErrors().Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// Assert no errors in the error list
+        /// </summary>
+        internal static List<string> GetErrorListErrors(this VisualStudioHost host)
+        {
+            var errors = new List<string>();
+
+            Utils.UIInvoke(() =>
+            {
+                errors.AddRange(host.ObjectModel.Shell.ToolWindows.ErrorList.Messages.Select(e => e.Description));
+            });
+
+            return errors;
+        }
+
+        /// <summary>
+        /// Assert no errors in nuget output window
+        /// </summary>
+        internal static void AssertNuGetOutputDoesNotHaveErrors(this VisualStudioHost host)
+        {
+            host.GetErrorsInOutputWindows().Should().BeEmpty();
         }
 
         public static bool HasNoErrorsInOutputWindows(this VisualStudioHost host)
         {
+            return host.GetErrorsInOutputWindows().Count == 0;
+        }
+
+        public static List<string> GetErrorsInOutputWindows(this VisualStudioHost host)
+        {
+            return host.GetOutputWindowsLines().Where(e => e.IndexOf("failed", StringComparison.OrdinalIgnoreCase) > -1).ToList();
+        }
+
+        public static List<string> GetOutputWindowsLines(this VisualStudioHost host)
+        {
+            if (host == null)
+            {
+                throw new ArgumentNullException(nameof(host));
+            }
+
+            var lines = new List<string>();
+
             try
             {
-                var outputPane = host.ObjectModel.Shell.ToolWindows.OutputWindow.GetOutputPane(_nugetOutputWindowGuid);
 
-                return !outputPane.Text.ToLowerInvariant().Contains("failed");
+                Utils.UIInvoke(() =>
+                {
+                    var outputPane = host.ObjectModel.Shell.ToolWindows.OutputWindow.GetOutputPane(_nugetOutputWindowGuid);
+                    lines.AddRange(outputPane.Text.Split('\n').Select(e => e.Trim()).Where(e => !string.IsNullOrEmpty(e)));
+                });
             }
             catch (ArgumentException)
             {
                 // If no output has been printed into the nuget output window then the output pane will not be initialized
                 // If no output has been printed we know there is no error in the output window.
-                return true;
             }
+
+            return lines;
         }
 
         public static void SelectProjectInSolutionExplorer(this VisualStudioHost host, string project)
         {
-            var item = host.ObjectModel.Shell.ToolWindows.SolutionExplorer.FindItemRecursive(project);
-
-            item.Select();
+            Utils.UIInvoke(() =>
+            {
+                var item = host.ObjectModel.Shell.ToolWindows.SolutionExplorer.FindItemRecursive(project);
+                item.Select();
+            });
         }
 
         public static void ClearOutputWindow(this VisualStudioHost host)
         {
             try
             {
-                var outputPane = host.ObjectModel.Shell.ToolWindows.OutputWindow.GetOutputPane(_nugetOutputWindowGuid);
-                outputPane.Clear();
+                Utils.UIInvoke(() =>
+                {
+                    var outputPane = host.ObjectModel.Shell.ToolWindows.OutputWindow.GetOutputPane(_nugetOutputWindowGuid);
+                    outputPane.Clear();
+                });
             }
             catch (ArgumentException)
             {
-                //if outputPane doesn't exist, ignore it
+                // if outputPane doesn't exist, ignore it
             }
+        }
+
+        public static void ClearErrorWindow(this VisualStudioHost host)
+        {
+            try
+            {
+                Utils.UIInvoke(() => host.ObjectModel.Shell.ToolWindows.ErrorList.HideAllItems());
+            }
+            catch (ArgumentException)
+            {
+                // ignore errors
+            }
+        }
+
+        /// <summary>
+        /// Clear the error list and output window
+        /// </summary>
+        public static void ClearWindows(this VisualStudioHost host)
+        {
+            host.ClearOutputWindow();
+            host.ClearErrorWindow();
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/VisualStudioHostExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/VisualStudioHostExtension.cs
@@ -17,7 +17,7 @@ namespace NuGet.Tests.Apex
         internal static void AssertNoErrors(this VisualStudioHost host)
         {
             host.AssertNuGetOutputDoesNotHaveErrors();
-            host.GetErrorListErrors().Should().BeEmpty();
+            host.GetErrorListErrors().Should().BeEmpty("Empty errors in error list");
         }
 
         /// <summary>

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/xunit.runner.json
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/xunit.runner.json
@@ -1,3 +1,5 @@
 {
-  "methodDisplay": "classAndMethod"
+  "methodDisplay": "classAndMethod",
+  "longRunningTestSeconds": 120,
+  "diagnosticMessages": true
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/xunit.runner.json
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/xunit.runner.json
@@ -1,5 +1,6 @@
 {
   "methodDisplay": "classAndMethod",
   "longRunningTestSeconds": 120,
-  "diagnosticMessages": true
+  "diagnosticMessages": true,
+  "preEnumerateTheories": false
 }

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPathContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPathContext.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Xml.Linq;
 
 namespace NuGet.Test.Utility
 {
@@ -12,23 +11,55 @@ namespace NuGet.Test.Utility
     /// </summary>
     public class SimpleTestPathContext : IDisposable
     {
+        /// <summary>
+        /// Root working directory
+        /// </summary>
         public TestDirectory WorkingDirectory { get; }
 
+        /// <summary>
+        /// Solution folder
+        /// </summary>
         public string SolutionRoot { get; }
 
+        /// <summary>
+        /// PackageReference install location
+        /// </summary>
         public string UserPackagesFolder { get; }
 
+        /// <summary>
+        /// Packages.config install location
+        /// </summary>
         public string PackagesV2 { get; }
 
+        /// <summary>
+        /// NuGet.Config path
+        /// </summary>
         public string NuGetConfig { get; }
 
+        /// <summary>
+        /// Local package source
+        /// </summary>
         public string PackageSource { get; }
 
+        /// <summary>
+        /// Fallback folder
+        /// </summary>
         public string FallbackFolder { get; }
 
+        /// <summary>
+        /// Http cache location
+        /// </summary>
         public string HttpCacheFolder { get; }
 
+        /// <summary>
+        /// If false the folder will be left after the test finishes
+        /// </summary>
         public bool CleanUp { get; set; } = true;
+
+        /// <summary>
+        /// settings from <see cref="NuGetConfig"/>
+        /// </summary>
+        public SimpleTestSettingsContext Settings { get; }
 
         public SimpleTestPathContext()
         {
@@ -47,49 +78,8 @@ namespace NuGet.Test.Utility
             Directory.CreateDirectory(PackageSource);
             Directory.CreateDirectory(FallbackFolder);
 
-            CreateNuGetConfig();
-        }
-
-        private void CreateNuGetConfig()
-        {
-            var doc = new XDocument();
-            var configuration = new XElement(XName.Get("configuration"));
-            doc.Add(configuration);
-
-            var config = new XElement(XName.Get("config"));
-            configuration.Add(config);
-
-            var globalFolder = new XElement(XName.Get("add"));
-            globalFolder.Add(new XAttribute(XName.Get("key"), "globalPackagesFolder"));
-            globalFolder.Add(new XAttribute(XName.Get("value"), UserPackagesFolder));
-            config.Add(globalFolder);
-
-            var solutionDir = new XElement(XName.Get("add"));
-            solutionDir.Add(new XAttribute(XName.Get("key"), "repositoryPath"));
-            solutionDir.Add(new XAttribute(XName.Get("value"), PackagesV2));
-            config.Add(solutionDir);
-
-            var packageSources = new XElement(XName.Get("packageSources"));
-            configuration.Add(packageSources);
-            packageSources.Add(new XElement(XName.Get("clear")));
-
-            var sourceEntry = new XElement(XName.Get("add"));
-            sourceEntry.Add(new XAttribute(XName.Get("key"), "source"));
-            sourceEntry.Add(new XAttribute(XName.Get("value"), PackageSource));
-            packageSources.Add(sourceEntry);
-
-            var disabledSources = new XElement(XName.Get("disabledPackageSources"));
-            configuration.Add(disabledSources);
-            disabledSources.Add(new XElement(XName.Get("clear")));
-
-            var fallbackFolders = new XElement(XName.Get("fallbackPackageFolders"));
-            configuration.Add(fallbackFolders);
-            var fallbackEntry = new XElement(XName.Get("add"));
-            fallbackEntry.Add(new XAttribute(XName.Get("key"), "shared"));
-            fallbackEntry.Add(new XAttribute(XName.Get("value"), FallbackFolder));
-            fallbackFolders.Add(fallbackEntry);
-
-            File.WriteAllText(NuGetConfig, doc.ToString());
+            Settings = new SimpleTestSettingsContext(NuGetConfig, UserPackagesFolder, PackagesV2, FallbackFolder, PackageSource);
+            Settings.Save();
         }
 
         public void Dispose()

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -1,0 +1,141 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using NuGet.Common;
+
+namespace NuGet.Test.Utility
+{
+    public class SimpleTestSettingsContext
+    {
+        /// <summary>
+        /// NuGet.Config path on disk
+        /// </summary>
+        public string ConfigPath { get; }
+
+        /// <summary>
+        /// XML
+        /// </summary>
+        public XDocument XML { get; }
+
+
+        public SimpleTestSettingsContext(string nugetConfigPath, string userPackagesFolder, string packagesV2, string fallbackFolder, string packageSource)
+            : this(nugetConfigPath, GetDefault(userPackagesFolder, packagesV2, fallbackFolder, packageSource))
+        {
+        }
+
+        public SimpleTestSettingsContext(string path, XDocument xml)
+        {
+            XML = xml ?? throw new ArgumentNullException(nameof(xml));
+            ConfigPath = path ?? throw new ArgumentNullException(nameof(path));
+        }
+
+        /// <summary>
+        /// Save to disk
+        /// </summary>
+        public void Save()
+        {
+            FileUtility.Replace((outputPath) =>
+            {
+                using (var output = new FileStream(outputPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
+                {
+                    XML.Save(output);
+                }
+            },
+            ConfigPath);
+        }
+
+        /// <summary>
+        /// Disable automatic package restore and save the file.
+        /// </summary>
+        public void DisableAutoRestore()
+        {
+            var section = GetOrAddSection(XML, "packageRestore");
+
+            AddEntry(section, "enabled", "false");
+            AddEntry(section, "automatic", "false");
+
+            Save();
+        }
+
+        private static XDocument GetDefault(string userPackagesFolder, string packagesV2, string fallbackFolder, string packageSource)
+        {
+            var doc = GetEmptyConfig();
+
+            var packageSources = GetOrAddSection(doc, "packageSources");
+            AddEntry(packageSources, "source", packageSource);
+
+            var fallbackFolders = GetOrAddSection(doc, "fallbackPackageFolders");
+            AddEntry(fallbackFolders, "shared", fallbackFolder);
+
+            AddSetting(doc, "globalPackagesFolder", userPackagesFolder);
+            AddSetting(doc, "repositoryPath", packagesV2);
+
+            return doc;
+        }
+
+        private static XDocument GetEmptyConfig()
+        {
+            var doc = new XDocument();
+            var configuration = new XElement(XName.Get("configuration"));
+            doc.Add(configuration);
+
+            var config = GetOrAddSection(doc, "config");
+            var packageSources = GetOrAddSection(doc, "packageSources");
+            var disabledSources = GetOrAddSection(doc, "disabledPackageSources");
+            var fallbackFolders = GetOrAddSection(doc, "fallbackPackageFolders");
+
+            packageSources.Add(new XElement(XName.Get("clear")));
+            disabledSources.Add(new XElement(XName.Get("clear")));
+
+            return doc;
+        }
+
+        public static XElement GetOrAddSection(XDocument doc, string name)
+        {
+            var root = doc.Element(XName.Get("configuration"));
+
+            var node = root.Element(XName.Get(name));
+
+            if (node == null)
+            {
+                node = new XElement(XName.Get(name));
+                root.Add(node);
+            }
+
+            return node;
+        }
+
+        public static void AddEntry(XElement section, string key, string value)
+        {
+            var setting = new XElement(XName.Get("add"));
+            setting.Add(new XAttribute(XName.Get("key"), key));
+            setting.Add(new XAttribute(XName.Get("value"), value));
+            section.Add(setting);
+        }
+
+        public static void AddSetting(XDocument doc, string key, string value)
+        {
+            RemoveSetting(doc, key);
+            var config = GetOrAddSection(doc, "config");
+
+            var setting = new XElement(XName.Get("add"));
+            setting.Add(new XAttribute(XName.Get("key"), key));
+            setting.Add(new XAttribute(XName.Get("value"), value));
+            config.Add(setting);
+        }
+
+        public static void RemoveSetting(XDocument doc, string key)
+        {
+            var config = GetOrAddSection(doc, "config");
+
+            foreach (var item in config.Elements(XName.Get("add")).Where(e => e.Name.LocalName.Equals(key, StringComparison.OrdinalIgnoreCase)).ToArray())
+            {
+                item.Remove();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR does a bunch of optimizations to the PMC apex tests that should make them more reliable. They will still be failing sometimes, but it should be less consistent now.

As part of this PR, the apex test suite should now take around 10 minutes to run, and have a better printing experience for logs