### PR TITLE
Signing:  signing-certificate V1/V2 attribute requirement not enforced for timestamps

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -800,6 +800,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Either the signing-certificate or signing-certificate-v2 attribute must be present..
+        /// </summary>
+        internal static string SigningCertificateV1OrV2AttributeMustBePresent {
+            get {
+                return ResourceManager.GetString("SigningCertificateV1OrV2AttributeMustBePresent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The signing-certificate-v2 attribute must be present..
         /// </summary>
         internal static string SigningCertificateV2AttributeMustBePresent {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -485,4 +485,7 @@ Valid from:</comment>
   <data name="SignatureNotTimeValid" xml:space="preserve">
     <value>The primary signature validity period has expired.</value>
   </data>
+  <data name="SigningCertificateV1OrV2AttributeMustBePresent" xml:space="preserve">
+    <value>Either the signing-certificate or signing-certificate-v2 attribute must be present.</value>
+  </data>
 </root>


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/6442.

A negative test for this requirement is not included as it is difficult to create a timestamp signature that does not have this attribute but is otherwise valid.