### PR TITLE
Add trailing slash to SolutionDir and transfer SolutionName to MSBuild

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -180,9 +180,10 @@ namespace NuGet.CommandLine
 
         private string GetSolutionDirectory(PackageRestoreInputs packageRestoreInputs)
         {
-            return packageRestoreInputs.RestoringWithSolutionFile ?
+            var solutionDirectory = packageRestoreInputs.RestoringWithSolutionFile ?
                     packageRestoreInputs.DirectoryOfSolutionFile :
                     SolutionDirectory;
+            return solutionDirectory != null ? PathUtility.EnsureTrailingSlash(solutionDirectory) : null;
         }
 
         private void ReadSettings(PackageRestoreInputs packageRestoreInputs)

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -442,6 +442,7 @@ namespace NuGet.CommandLine
                 {
                     dgFileOutput = await GetDependencyGraphSpecAsync(projectsWithPotentialP2PReferences,
                         GetSolutionDirectory(packageRestoreInputs),
+                        packageRestoreInputs.NameOfSolutionFile,
                         ConfigFile);
                 }
                 catch (Exception ex)
@@ -550,7 +551,7 @@ namespace NuGet.CommandLine
         /// <summary>
         ///  Create a dg v2 file using msbuild.
         /// </summary>
-        private async Task<DependencyGraphSpec> GetDependencyGraphSpecAsync(string[] projectsWithPotentialP2PReferences, string solutionDirectory, string configFile)
+        private async Task<DependencyGraphSpec> GetDependencyGraphSpecAsync(string[] projectsWithPotentialP2PReferences, string solutionDirectory, string solutionName, string configFile)
         {
             // Create requests based on the solution directory if a solution was used read settings for the solution.
             // If the solution directory is null, then use config file if present
@@ -579,6 +580,7 @@ namespace NuGet.CommandLine
                 Console,
                 Recursive,
                 solutionDirectory,
+                solutionName,
                 configFile,
                 Source.ToArray(),
                 PackagesDirectory
@@ -771,6 +773,7 @@ namespace NuGet.CommandLine
         private void ProcessSolutionFile(string solutionFileFullPath, PackageRestoreInputs restoreInputs)
         {
             restoreInputs.DirectoryOfSolutionFile = Path.GetDirectoryName(solutionFileFullPath);
+            restoreInputs.NameOfSolutionFile = Path.GetFileNameWithoutExtension(solutionFileFullPath);
 
             // restore packages for the solution
             var solutionLevelPackagesConfig = Path.Combine(
@@ -813,6 +816,8 @@ namespace NuGet.CommandLine
             public bool RestoringWithSolutionFile => !string.IsNullOrEmpty(DirectoryOfSolutionFile);
 
             public string DirectoryOfSolutionFile { get; set; }
+
+            public string NameOfSolutionFile { get; set; }
 
             public List<string> PackagesConfigFiles { get; } = new List<string>();
 

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -74,6 +74,7 @@ namespace NuGet.CommandLine
             IConsole console,
             bool recursive,
             string solutionDirectory,
+            string solutionName,
             string restoreConfigFile,
             string[] sources,
             string packagesDirectory)
@@ -120,7 +121,7 @@ namespace NuGet.CommandLine
                 inputTargetXML.Save(inputTargetPath);
 
                 // Create msbuild parameters and include global properties that cannot be set in the input targets path
-                var arguments = GetMSBuildArguments(entryPointTargetPath, inputTargetPath, nugetExePath, solutionDirectory, restoreConfigFile, sources, packagesDirectory);
+                var arguments = GetMSBuildArguments(entryPointTargetPath, inputTargetPath, nugetExePath, solutionDirectory, solutionName, restoreConfigFile, sources, packagesDirectory);
 
                 var processStartInfo = new ProcessStartInfo
                 {
@@ -221,6 +222,7 @@ namespace NuGet.CommandLine
             string inputTargetPath,
             string nugetExePath,
             string solutionDirectory,
+            string solutionName,
             string restoreConfigFile,
             string[] sources,
             string packagesDirectory)
@@ -259,6 +261,7 @@ namespace NuGet.CommandLine
             AddPropertyIfHasValue(args, "RestoreConfigFile", restoreConfigFile);
             AddPropertyIfHasValue(args, "RestorePackagesPath", packagesDirectory);
             AddPropertyIfHasValue(args, "SolutionDir", solutionDirectory);
+            AddPropertyIfHasValue(args, "SolutionName", solutionName);
 
             // Disable parallel and use ContinueOnError since this may run on an older
             // version of MSBuild that do not support SkipNonexistentTargets.


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/4645
Regression: No

* SolutionDir was set but without the trailing slash (it should be according to https://msdn.microsoft.com/en-us/library/c02as0cs.aspx)
* SolutionName was not set

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  There is only tests for restore from project.json, nothing for solutions.
Validation done:  Tested on a project having issues with both SolutionDir missing trailing slash and SolutionName being not set
