### PR TITLE
Updated PowerShellHost to use CPS JTF to avoid hang

### DIFF
--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -247,7 +247,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
                 return NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     var hr = VsMonitorSelection.IsCmdUIContextActive(
                         _solutionExistsCookie, out var pfActive);


### PR DESCRIPTION
Updated PowerShellHost to use CPS JTF to avoid hang.

Fixes VSTS bug 552052

@rrelyea 