### PR TITLE
simplify logic for update of build number

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -56,9 +56,7 @@ phases:
       - DotNetFramework
       - msbuild
 
-  steps:
-
-  
+  steps:  
   - task: PowerShell@1
     displayName: "Print Environment Variables"
     inputs:
@@ -508,8 +506,7 @@ phases:
   - Build_and_UnitTest
   - Initialize_Build
   variables:
-    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumer.BuildNumber']]
-  condition: "succeeded()"
+    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
   queue:
     name: DDNuGet-Windows
     timeoutInMinutes: 75
@@ -521,8 +518,8 @@ phases:
     inputs:
       scriptType: "inlineScript"
       inlineScript: |
-        gci env:* | sort-object name
         Write-Host "##vso[build.updatebuildnumber]$env:BuildNumber"
+        gci env:* | sort-object name      
 
   - task: PowerShell@1
     displayName: "Bootstrap.ps1"
@@ -605,7 +602,6 @@ phases:
   - Initialize_Build
   variables:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-  condition: "succeeded()"
   queue:
     name: DDNuGet-Windows
     timeoutInMinutes: 75
@@ -617,9 +613,9 @@ phases:
     inputs:
       scriptType: "inlineScript"
       inlineScript: |
-        gci env:* | sort-object name
         Write-Host "##vso[build.updatebuildnumber]$env:BuildNumber"
-
+        gci env:* | sort-object name
+        
   - task: NuGetToolInstaller@0
     displayName: "Use NuGet 4.5.0"
     inputs:

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -19,6 +19,19 @@ phases:
         InitializeAllTestsToPending -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion)
   
   - task: PowerShell@1
+    displayName: "Update Build Number"
+    name: "updatebuildnumber"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        $revision = Get-Content $env:BUILDCOUNTERFILE
+        $newBuildCounter = [System.Decimal]::Parse($revision)
+        $newBuildCounter++
+        Set-Content $env:BUILDCOUNTERFILE $newBuildCounter
+        Write-Host "##vso[build.updatebuildnumber]$newBuildCounter"
+        Write-Host "##vso[task.setvariable variable=BuildNumber;isOutput=true]$newBuildCounter"
+
+  - task: PowerShell@1
     displayName: "Add Build Tags"
     inputs:
       scriptType: "inlineScript"
@@ -28,6 +41,8 @@ phases:
 
 - phase: Build_and_UnitTest
   dependsOn: Initialize_Build
+  variables:
+    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
   queue:
     name: VSEng-MicroBuildVS2017
     timeoutInMinutes: 90
@@ -42,6 +57,16 @@ phases:
       - msbuild
 
   steps:
+
+  
+  - task: PowerShell@1
+    displayName: "Print Environment Variables"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        Write-Host "##vso[build.updatebuildnumber]$env:BuildNumber"
+        gci env:* | sort-object name
+
   - task: PowerShell@1
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
@@ -49,17 +74,10 @@ phases:
     displayName: "Run Configure.ps1"
 
   - task: PowerShell@1
-    name: configuration
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
-      arguments: "-BuildCounterFile $(BuildCounterFile) -BuildInfoJsonFile $(BuildInfoJsonFile) -BuildRTM $(BuildRTM)"
+      arguments: "-BuildCounterFile $(BuildCounterFile) -BuildInfoJsonFile $(BuildInfoJsonFile) -BuildRTM $(BuildRTM) -SkipUpdateBuildNumber"
     displayName: "Configure VSTS CI Environment"
-
-  - task: PowerShell@1
-    displayName: "Print Environment Variables"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: "gci env:* | sort-object name"
 
   - task: MicroBuildLocalizationPlugin@1
     displayName: "Install Localization Plugin"
@@ -88,7 +106,7 @@ phases:
       solution: "build\\build.proj"
       msbuildVersion: "15.0"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:RestoreVS15 /p:BuildNumber=$(Revision) /p:BuildRTM=$(BuildRTM) /v:m"
+      msbuildArguments: "/t:RestoreVS15 /p:BuildNumber=$(BuildNumber) /p:BuildRTM=$(BuildRTM) /v:m"
 
   - task: MSBuild@1
     displayName: "Build for VS2017"
@@ -96,7 +114,7 @@ phases:
       solution: "build\\build.proj"
       msbuildVersion: "15.0"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:BuildVS15NoVSIX /p:NUGET_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\NuGetKey.snk /p:MS_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\35MSSharedLib1024.snk /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(Revision)"
+      msbuildArguments: "/t:BuildVS15NoVSIX /p:NUGET_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\NuGetKey.snk /p:MS_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\35MSSharedLib1024.snk /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
 
   - task: MSBuild@1
     displayName: "Run unit tests"
@@ -105,7 +123,7 @@ phases:
       solution: "build\\build.proj"
       msbuildVersion: "15.0"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:CoreUnitTests;UnitTestsVS15 /p:NUGET_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\NuGetKey.snk /p:MS_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\35MSSharedLib1024.snk  /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(Revision) /p:TestResultOutputFormat=xml"
+      msbuildArguments: "/t:CoreUnitTests;UnitTestsVS15 /p:NUGET_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\NuGetKey.snk /p:MS_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\35MSSharedLib1024.snk  /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml"
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
   - task: PublishTestResults@2
@@ -160,7 +178,7 @@ phases:
       solution: "build\\build.proj"
       msbuildVersion: "15.0"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(Revision)"
+      msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
 
   - task: CopyFiles@2
     displayName: "Copy Nupkgs"
@@ -223,7 +241,7 @@ phases:
       solution: "setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
       msbuildVersion: "15.0"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/p:BuildNumber=$(Revision)"
+      msbuildArguments: "/p:BuildNumber=$(BuildNumber)"
     condition: " and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
   - task: CopyFiles@2
@@ -307,6 +325,8 @@ phases:
 
 - phase: Functional_Tests_On_Windows
   dependsOn: Initialize_Build
+  variables:
+    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
   queue:
     name: VSEng-MicroBuildSxS
     timeoutInMinutes: 120
@@ -315,6 +335,14 @@ phases:
         - msbuild
 
   steps:
+  - task: PowerShell@1
+    displayName: "Print Environment Variables"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        Write-Host "##vso[build.updatebuildnumber]$env:BuildNumber"
+        gci env:* | sort-object name
+
   - task: PowerShell@1
     displayName: "Download Config Files"
     enabled: "false"
@@ -338,7 +366,7 @@ phases:
       solution: "build\\build.proj"
       msbuildVersion: "15.0"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:RestoreVS15 /p:BuildNumber=$(Revision) /p:BuildRTM=false /v:m"
+      msbuildArguments: "/t:RestoreVS15 /p:BuildNumber=$(BuildNumber) /p:BuildRTM=false /v:m"
 
   - task: MSBuild@1
     displayName: "Run Functional Tests"
@@ -347,7 +375,7 @@ phases:
       solution: "build\\build.proj"
       msbuildVersion: "15.0"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:CoreFuncTests  /p:BuildRTM=false  /p:BuildNumber=$(Revision) /p:TestResultOutputFormat=xml"
+      msbuildArguments: "/t:CoreFuncTests  /p:BuildRTM=false  /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml"
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
@@ -372,12 +400,23 @@ phases:
 
 - phase: Tests_On_Linux
   dependsOn: Initialize_Build
+  variables:
+    BUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
   queue:
     name: DDNuGet-Linux
     timeoutInMinutes: 45
     demands: sh
 
   steps:
+  - task: PowerShell@2
+    displayName: "Update Build Number"
+    inputs:
+      targetType: "inline"
+      script: |
+        Write-Host "##vso[build.updatebuildnumber]$env:BUILDNUMBER"
+      failOnStderr: "true"
+    condition: "always()"
+
   - task: ShellScript@2
     displayName: "Run Tests"
     continueOnError: "true"
@@ -408,7 +447,11 @@ phases:
     condition: "always()"
 
 - phase: Tests_On_Mac
-  dependsOn: Build_and_UnitTest
+  dependsOn:
+  - Build_and_UnitTest
+  - Initialize_Build
+  variables:
+    BUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
   condition: "succeeded()"
   queue:
     name: VSEng-MicroBuildMacSierra
@@ -416,6 +459,15 @@ phases:
     demands: sh
 
   steps:
+  - task: PowerShell@2
+    displayName: "Update Build Number"
+    inputs:
+      targetType: "inline"
+      script: |
+        Write-Host "##vso[build.updatebuildnumber]$env:BUILDNUMBER"
+      failOnStderr: "true"
+    condition: "always()"
+
   - task: DownloadBuildArtifacts@0
     displayName: "Download NuGet.ComamandLine.Test artifacts"
     inputs:
@@ -452,10 +504,11 @@ phases:
     condition: "always()"
 
 - phase: End_To_End_Tests_On_Windows
-  dependsOn: Build_and_UnitTest
-  condition: "succeeded()"
+  dependsOn:
+  - Build_and_UnitTest
+  - Initialize_Build
   variables:
-    BuildNumber: $[dependencies.Build_and_UnitTest.outputs['RTM.configuration.BuildNumber']]
+    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumer.BuildNumber']]
   condition: "succeeded()"
   queue:
     name: DDNuGet-Windows
@@ -467,8 +520,9 @@ phases:
     displayName: "Print Environment Variables"
     inputs:
       scriptType: "inlineScript"
-      inlineScript: "gci env:* | sort-object name;
-      Write-Host \"##vso[build.updatebuildnumber]$env:BuildNumber\""    
+      inlineScript: |
+        gci env:* | sort-object name
+        Write-Host "##vso[build.updatebuildnumber]$env:BuildNumber"
 
   - task: PowerShell@1
     displayName: "Bootstrap.ps1"
@@ -546,10 +600,11 @@ phases:
 
 
 - phase: Apex_Tests_On_Windows
-  dependsOn: Build_and_UnitTest
-  condition: "succeeded()"
+  dependsOn:
+  - Build_and_UnitTest
+  - Initialize_Build
   variables:
-    BuildNumber: $[dependencies.Build_and_UnitTest.outputs['RTM.configuration.BuildNumber']]
+    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
   condition: "succeeded()"
   queue:
     name: DDNuGet-Windows
@@ -561,8 +616,9 @@ phases:
     displayName: "Print Environment Variables"
     inputs:
       scriptType: "inlineScript"
-      inlineScript: "gci env:* | sort-object name;
-      Write-Host \"##vso[build.updatebuildnumber]$env:BuildNumber\""
+      inlineScript: |
+        gci env:* | sort-object name
+        Write-Host "##vso[build.updatebuildnumber]$env:BuildNumber"
 
   - task: NuGetToolInstaller@0
     displayName: "Use NuGet 4.5.0"

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -28,7 +28,9 @@ param
     [string]$BuildInfoJsonFile,
 
     [Parameter(Mandatory=$True)]
-    [string]$BuildRTM
+    [string]$BuildRTM,
+    
+    [switch]$SkipUpdateBuildNumber
 )
 
 Function Get-Version {
@@ -125,43 +127,55 @@ if ($BuildRTM -eq 'true')
     # Set the $(NupkgOutputDir) build variable in VSTS build
     Write-Host "##vso[task.setvariable variable=NupkgOutputDir;]ReleaseNupkgs"
     Write-Host "##vso[task.setvariable variable=VsixPublishDir;]VS15-RTM"
-    $numberOfTries = 0
-    do{
-        Write-Host "Waiting for buildinfo.json to be generated..."
-        $numberOfTries++
-        Start-Sleep -s 15
-    }
-    until ((Test-Path $BuildInfoJsonFile) -or ($numberOfTries -gt 50))
-    $json = (Get-Content $BuildInfoJsonFile -Raw) | ConvertFrom-Json
-    $currentBuild = [System.Decimal]::Parse($json.BuildNumber)
-    # Set the $(Revision) build variable in VSTS build
-    Write-Host "##vso[task.setvariable variable=Revision;]$currentBuild"
-    Write-Host "##vso[build.updatebuildnumber]$currentBuild" 
-    Write-Host "##vso[task.setvariable variable=BuildNumber;isOutput=true]$currentBuild"
-    $oldBuildOutputDirectory = Split-Path -Path $BuildInfoJsonFile
-    $branchDirectory = Split-Path -Path $oldBuildOutputDirectory
-    $newBuildOutputFolder =  Join-Path $branchDirectory $currentBuild
-    if(Test-Path $newBuildOutputFolder)
+    # Only for backward compatibility with orchestrated builds
+    if(-not $SkipUpdateBuildNumber)
     {
-        Move-Item -Path $BuildInfoJsonFile -Destination $newBuildOutputFolder
-        Remove-Item -Path $oldBuildOutputDirectory -Force
-    }
-    else
-    {
-        Rename-Item $oldBuildOutputDirectory $currentBuild
-    }
-    
+        $numberOfTries = 0
+        do{
+            Write-Host "Waiting for buildinfo.json to be generated..."
+            $numberOfTries++
+            Start-Sleep -s 15
+        }
+        until ((Test-Path $BuildInfoJsonFile) -or ($numberOfTries -gt 50))
+        $json = (Get-Content $BuildInfoJsonFile -Raw) | ConvertFrom-Json
+        $currentBuild = [System.Decimal]::Parse($json.BuildNumber)
+        # Set the $(Revision) build variable in VSTS build
+        Write-Host "##vso[task.setvariable variable=Revision;]$currentBuild"
+        Write-Host "##vso[build.updatebuildnumber]$currentBuild" 
+        $oldBuildOutputDirectory = Split-Path -Path $BuildInfoJsonFile
+        $branchDirectory = Split-Path -Path $oldBuildOutputDirectory
+        $newBuildOutputFolder =  Join-Path $branchDirectory $currentBuild
+        if(Test-Path $newBuildOutputFolder)
+        {
+            Move-Item -Path $BuildInfoJsonFile -Destination $newBuildOutputFolder
+            Remove-Item -Path $oldBuildOutputDirectory -Force
+        }
+        else
+        {
+            Rename-Item $oldBuildOutputDirectory $currentBuild
+        }   
+    }    
 }
 else
 {
-    $revision = Get-Content $BuildCounterFile
-    $newBuildCounter = [System.Decimal]::Parse($revision)
-    $newBuildCounter++
-    Set-Content $BuildCounterFile $newBuildCounter
-    # Set the $(Revision) build variable in VSTS build
-    Write-Host "##vso[task.setvariable variable=Revision;]$newBuildCounter"
-    Write-Host "##vso[build.updatebuildnumber]$newBuildCounter"
-    Write-Host "##vso[task.setvariable variable=BuildNumber;isOutput=true]$newBuildCounter"
+    # Only for backward compatibility with orchestrated builds
+    if(-not $SkipUpdateBuildNumber)
+    {
+        $revision = Get-Content $BuildCounterFile
+        $newBuildCounter = [System.Decimal]::Parse($revision)
+        $newBuildCounter++
+        Set-Content $BuildCounterFile $newBuildCounter
+        # Set the $(Revision) build variable in VSTS build
+        Write-Host "##vso[task.setvariable variable=Revision;]$newBuildCounter"
+        Write-Host "##vso[build.updatebuildnumber]$newBuildCounter"
+        Write-Host "##vso[task.setvariable variable=BuildNumber;isOutput=true]$newBuildCounter"
+    }
+    else
+    {
+        $newBuildCounter = $env:BUILD_BUILDNUMBER        
+    }
+
+    
     $jsonRepresentation = @{
         BuildNumber = $newBuildCounter
         CommitHash = $env:BUILD_SOURCEVERSION


### PR DESCRIPTION
instead of updating build number in the Build_And_UnitTest phase, where one machine would wait for the other to update the build number, this change updates the BuildNumber in the Initialize_Build phase, and every subsequent phase reads the output variable of this phase and updates its own build number.