### PR TITLE
Avoid writing restoreSettings to assets file, sort project references for noop

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -24,7 +24,6 @@ namespace NuGet.Commands
 
         private readonly DependencyGraphSpec _dgFile;
         private readonly RestoreCommandProvidersCache _providerCache;
-        private readonly Dictionary<string, PackageSpec> _projectJsonCache = new Dictionary<string, PackageSpec>(StringComparer.Ordinal);
 
         public DependencyGraphSpecRequestProvider(
             RestoreCommandProvidersCache providerCache,

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -96,7 +96,9 @@ namespace NuGet.ProjectModel
 
         /// <summary>
         /// Project Settings is used to pass settings like HideWarningsAndErrors down to lower levels.
+        /// Currently they do not include any settings that affect the final result of restore.
         /// This should not be part of the Equals and GetHashCode.
+        /// Don't write this to the package spec
         /// </summary>
         public ProjectRestoreSettings RestoreSettings { get; set; } = new ProjectRestoreSettings();
 

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -52,7 +52,6 @@ namespace NuGet.ProjectModel
             SetArrayValue(writer, "contentFiles", packageSpec.ContentFiles);
             SetDictionaryValue(writer, "packInclude", packageSpec.PackInclude);
             SetPackOptions(writer, packageSpec);
-            SetRestoreSettings(writer, packageSpec);
             SetMSBuildMetadata(writer, packageSpec);
             SetDictionaryValues(writer, "scripts", packageSpec.Scripts);
 
@@ -96,6 +95,7 @@ namespace NuGet.ProjectModel
             }
         }
 
+        // The restore settings, current despite the name, do not include any setting that affect the final result of restore, rather just a decision on whether or not to display the errors in the error list ourselves. (in SDK projects, we don't do it)
         private static void SetRestoreSettings(IObjectWriter writer, PackageSpec packageSpec)
         {
             var restoreSettings = packageSpec.RestoreSettings;
@@ -205,7 +205,7 @@ namespace NuGet.ProjectModel
 
                         writer.WriteObjectStart("projectReferences");
 
-                        foreach (var project in framework.ProjectReferences)
+                        foreach (var project in framework.ProjectReferences.OrderBy(e => e.ProjectPath, PathUtility.GetStringComparerBasedOnOS()))
                         {
                             writer.WriteObjectStart(project.ProjectUniqueName);
 

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -95,24 +95,6 @@ namespace NuGet.ProjectModel
             }
         }
 
-        // The restore settings, current despite the name, do not include any setting that affect the final result of restore, rather just a decision on whether or not to display the errors in the error list ourselves. (in SDK projects, we don't do it)
-        private static void SetRestoreSettings(IObjectWriter writer, PackageSpec packageSpec)
-        {
-            var restoreSettings = packageSpec.RestoreSettings;
-
-            // Do not write Restore Setting if the HideWarningsAndErrors is false
-            // This should be changed in the future as more properties are added to ProjectRestoreSettings
-            if (restoreSettings == null || !restoreSettings.HideWarningsAndErrors)
-            {
-                return;
-            }
-            writer.WriteObjectStart(JsonPackageSpecReader.RestoreSettings);
-
-            SetValueIfTrue(writer, JsonPackageSpecReader.HideWarningsAndErrors, restoreSettings.HideWarningsAndErrors);
-
-            writer.WriteObjectEnd();
-        }
-
         private static bool IsMetadataValid(ProjectRestoreMetadata msbuildMetadata)
         {
             if (msbuildMetadata == null)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -5748,7 +5748,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public async Task RestoreNetCore_PackageTypesDoNotAffectAssetsFil()
+        public async Task RestoreNetCore_PackageTypesDoNotAffectAssetsFile()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/PackageSpecWriter_Write_SerializesMembersAsJson.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/PackageSpecWriter_Write_SerializesMembersAsJson.json
@@ -37,9 +37,6 @@
     "licenseUrl": "licenseUrl",
     "requireLicenseAcceptance": true
   },
-  "restoreSettings": {
-    "hideWarningsAndErrors": true
-  },
   "restore": {
     "projectUniqueName": "projectUniqueName",
     "projectName": "projectName",

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -20,6 +20,8 @@ namespace NuGet.Test.Utility
 {
     public class SimpleTestProjectContext
     {
+        private static string ProjectExt = ".csproj";
+
         public SimpleTestProjectContext(string projectName, ProjectStyle type, string solutionRoot)
         {
             if (string.IsNullOrWhiteSpace(projectName))
@@ -33,7 +35,7 @@ namespace NuGet.Test.Utility
             }
 
             ProjectName = projectName;
-            ProjectPath = Path.Combine(solutionRoot, projectName, $"{projectName}.csproj");
+            ProjectPath = Path.Combine(solutionRoot, projectName, $"{projectName}{ProjectExt}");
             OutputPath = Path.Combine(solutionRoot, projectName, "obj");
             Type = type;
         }
@@ -136,6 +138,21 @@ namespace NuGet.Test.Utility
 
                     case ProjectStyle.ProjectJson:
                         return Path.Combine(Path.GetDirectoryName(ProjectPath), "project.lock.json");
+
+                    default:
+                        return null;
+                }
+            }
+        }
+
+        public string CacheFileOutputPath
+        {
+            get
+            {
+                switch (Type)
+                {
+                    case ProjectStyle.PackageReference:
+                        return Path.Combine(OutputPath, $"{ProjectName}{ProjectExt}.nuget.cache");
 
                     default:
                         return null;


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/4627
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
Avoid writing restore settings to the assets file. 
Despite it's name, restoreSettings currently only contains a value that decides whether we display the errors in the error list ourselves. 
That's only true is VS and not consistent with the commandline experience. 
That property does not impact the result of restore, merely the aesthetics.

Sort the project references wrt to environment aware comparer. 

## Testing/Validation
Tests Added: Yes 
Reason for not adding tests:  
Validation done:  
