### PR TITLE
Package Test.Utility as a package but don't push it from VSTS

### DIFF
--- a/scripts/cibuild/PublishArtifactsFromVsts.ps1
+++ b/scripts/cibuild/PublishArtifactsFromVsts.ps1
@@ -67,7 +67,7 @@ if(Test-Path $NupkgsDir)
 {
     Write-Output "Publishing nupkgs from '$Nupkgs'"
     # Push all nupkgs to the nuget-build feed on myget.
-    Get-Item "$NupkgsDir\*.nupkg"  | Push-ToMyGet -ApiKey $NuGetBuildFeedApiKey -BuildFeed $NuGetBuildFeedUrl -SymbolSource $NuGetBuildSymbolsFeedUrl
+    Get-Item "$NupkgsDir\*.nupkg" -Exclude "Test.*.nupkg" | Push-ToMyGet -ApiKey $NuGetBuildFeedApiKey -BuildFeed $NuGetBuildFeedUrl -SymbolSource $NuGetBuildSymbolsFeedUrl
     # We push NuGet.Build.Tasks.Pack nupkg to dotnet-core feed as per the request of the CLI team.
     Get-Item "$NupkgsDir\NuGet.Build.Tasks.Pack*.nupkg" | Push-ToMyGet -ApiKey $DotnetCoreFeedApiKey -BuildFeed $DotnetCoreFeedUrl -SymbolSource $DotnetCoreSymbolsFeedUrl
 }

--- a/test/TestUtilities/Test.Utility/Test.Utility.csproj
+++ b/test/TestUtilities/Test.Utility/Test.Utility.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <PackProject>true</PackProject>
     <Shipping>false</Shipping>
   </PropertyGroup>
 


### PR DESCRIPTION
This allows server-side to use the Test.Utility package. I plan on manually pushing it to the nuget-build MyGet feed.