### PR TITLE
Fixing comment related build warning in DependencyGraphRestoreUtility

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -170,7 +170,7 @@ namespace NuGet.PackageManagement
         }
 
         /// <summary>
-        /// Restore a build integrated project(PackageReference & Project.Json only) and update the lock file
+        /// Restore a build integrated project(PackageReference and Project.Json only) and update the lock file
         /// </summary>
         public static async Task<RestoreResult> RestoreProjectAsync(
             ISolutionManager solutionManager,


### PR DESCRIPTION
## Bug
Fixes: A build warning [(CS1570)](https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs1570) added as part of https://github.com/NuGet/NuGet.Client/commit/b82a7274e5f58c8af2eb052b8ff98d3d29fed66e 

![image](https://user-images.githubusercontent.com/10507120/35130064-be81dba8-fc73-11e7-9b71-f953fd5822cd.png)

## Fix
Details: Fixes the comment to remove the warning.