### PR TITLE
Mark Test.Utility as Shipping to enable real signing

### DIFF
--- a/test/TestUtilities/Test.Utility/Signing/TrustedTestCert.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TrustedTestCert.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Test.Utility.Signing
@@ -25,15 +24,21 @@ namespace Test.Utility.Signing
         public TrustedTestCert(T source,
             Func<T, X509Certificate2> getCert,
             StoreName storeName = StoreName.TrustedPeople,
-            StoreLocation storeLocation = StoreLocation.CurrentUser)
+            StoreLocation storeLocation = StoreLocation.CurrentUser,
+            TimeSpan? maximumValidityPeriod = null)
         {
             Source = source;
             TrustedCert = getCert(source);
 
-#if IS_DESKTOP
-            if (TrustedCert.NotAfter - TrustedCert.NotBefore > TimeSpan.FromHours(2))
+            if (!maximumValidityPeriod.HasValue)
             {
-                throw new InvalidOperationException("The cert used is valid for more than two hours.");
+                maximumValidityPeriod = TimeSpan.FromHours(2);
+            }
+
+#if IS_DESKTOP
+            if (TrustedCert.NotAfter - TrustedCert.NotBefore > maximumValidityPeriod.Value)
+            {
+                throw new InvalidOperationException($"The certificate used is valid for more than {maximumValidityPeriod}.");
             }
 #endif
             StoreName = storeName;

--- a/test/TestUtilities/Test.Utility/Test.Utility.csproj
+++ b/test/TestUtilities/Test.Utility/Test.Utility.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <PackProject>true</PackProject>
-    <Shipping>false</Shipping>
+    <Shipping>true</Shipping>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Also, allow the trusted certificate validity period to be manipulated. This is helpful when you have a checked into (static) signed package that you want to trust for the life of the test.

I investigated the impact of `<Shipping>true</Shipping>`, and found the following:

1. Shipping non-test projects have their build output in the artifacts directory.
1. Shipping non-xplat projects get PdbGit reference.
1. Shipping projects get real signing (this is what I want)
1. Shipping projects get their symbols indexed
1. Shipping projects get signed (not sure how this differs from number 3)
1. Shipping projects get localized (this does not apply since Test.Utility does not have string resx)