### PR TITLE
change pack error to warning and turn off by default

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/IsPackableFalseWarningTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/IsPackableFalseWarningTask.cs
@@ -7,12 +7,12 @@ using NuGet.Common;
 
 namespace NuGet.Build.Tasks.Pack
 {
-    public class IsPackableFalseErrorTask : Task
+    public class IsPackableFalseWarningTask : Task
     {
         public ILogger Logger => new MSBuildLogger(Log);
         public override bool Execute()
         {
-            Logger.LogError(string.Format(CultureInfo.CurrentCulture,
+            Logger.LogWarning(string.Format(CultureInfo.CurrentCulture,
                     Strings.IsPackableFalseError));
             return true;
         }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -21,7 +21,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="NuGet.Build.Tasks.Pack.GetPackOutputItemsTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetProjectTargetFrameworksTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.Pack.GetProjectReferencesFromAssetsFileTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
-  <UsingTask TaskName="NuGet.Build.Tasks.Pack.IsPackableFalseErrorTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
+  <UsingTask TaskName="NuGet.Build.Tasks.Pack.IsPackableFalseWarningTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
 
   <PropertyGroup>
     <PackageId Condition=" '$(PackageId)' == '' ">$(AssemblyName)</PackageId>
@@ -41,6 +41,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NoBuild Condition="'$(GeneratePackageOnBuild)' == 'true'">true</NoBuild>
     <AddPriFileDependsOn Condition="'$(MicrosoftPortableCurrentVersionPropsHasBeenImported)' == 'true'">DeterminePortableBuildCapabilities</AddPriFileDependsOn>
     <NuspecOutputPath Condition="'$(NuspecOutputPath)' == ''">$(BaseIntermediateOutputPath)$(Configuration)\</NuspecOutputPath>
+    <WarnOnPackingNonPackableProject Condition="'$(WarnOnPackingNonPackableProject)' == ''">false</WarnOnPackingNonPackableProject>
     <ImportNuGetBuildTasksPackTargetsFromSdk Condition="'$(ImportNuGetBuildTasksPackTargetsFromSdk)' == ''">false</ImportNuGetBuildTasksPackTargetsFromSdk>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>.dll; .exe; .winmd; .json; .pri; .xml; $(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>.pdb; .mdb; $(AllowedOutputExtensionsInPackageBuildOutputFolder); $(AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder)</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
@@ -183,7 +184,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="Pack" DependsOnTargets="$(PackDependsOn)">
-     <IsPackableFalseErrorTask Condition="$(IsPackable) == 'false'"/>
+     <IsPackableFalseWarningTask Condition="'$(IsPackable)' == 'false' AND '$(WarnOnPackingNonPackableProject)' == 'true'"/>
   </Target>
   <Target Name="_IntermediatePack">
     <PropertyGroup>


### PR DESCRIPTION
a lot of users pack their whole solution which also contains test projects that were just skipped earlier.

I have changed the behavior of packing non packable projects to be a warning and turned off by default so it doesn't break anyone.