### PR TITLE
Fix user agent string for VS

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -152,7 +152,7 @@ namespace NuGet.PackageManagement.VisualStudio
             _vsSolution = _serviceProvider.GetService<SVsSolution, IVsSolution>();
             var dte = _serviceProvider.GetDTE();
             UserAgent.SetUserAgentString(
-                    new UserAgentStringBuilder().WithVisualStudioSKU(dte.GetFullVsVersionString()));
+                    new UserAgentStringBuilder(UserAgentStringBuilder.VSNuGetClientName).WithVisualStudioSKU(dte.GetFullVsVersionString()));
 
             HttpHandlerResourceV3.CredentialService = _credentialServiceProvider.GetCredentialService();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -37,6 +37,7 @@ namespace NuGet.PackageManagement.VisualStudio
     public sealed class VSSolutionManager : IVsSolutionManager, IVsSelectionEvents
     {
         private static readonly INuGetProjectContext EmptyNuGetProjectContext = new EmptyNuGetProjectContext();
+        private static readonly string VSNuGetClientName = "NuGet VS VSIX";
 
         private readonly INuGetLockService _initLock = new NuGetLockService();
 
@@ -152,7 +153,7 @@ namespace NuGet.PackageManagement.VisualStudio
             _vsSolution = _serviceProvider.GetService<SVsSolution, IVsSolution>();
             var dte = _serviceProvider.GetDTE();
             UserAgent.SetUserAgentString(
-                    new UserAgentStringBuilder(UserAgentStringBuilder.VSNuGetClientName).WithVisualStudioSKU(dte.GetFullVsVersionString()));
+                    new UserAgentStringBuilder(VSNuGetClientName).WithVisualStudioSKU(dte.GetFullVsVersionString()));
 
             HttpHandlerResourceV3.CredentialService = _credentialServiceProvider.GetCredentialService();
 

--- a/src/NuGet.Core/NuGet.Protocol/UserAgentStringBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol/UserAgentStringBuilder.cs
@@ -10,6 +10,7 @@ namespace NuGet.Protocol.Core.Types
     public class UserAgentStringBuilder
     {
         public static readonly string DefaultNuGetClientName = "NuGet Client V3";
+        public static readonly string VSNuGetClientName = "NuGet VS VSIX";
 
         private const string UserAgentWithOSDescriptionAndVisualStudioSKUTemplate = "{0}/{1} ({2}, {3})";
         private const string UserAgentWithOSDescriptionTemplate = "{0}/{1} ({2})";

--- a/src/NuGet.Core/NuGet.Protocol/UserAgentStringBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol/UserAgentStringBuilder.cs
@@ -10,7 +10,6 @@ namespace NuGet.Protocol.Core.Types
     public class UserAgentStringBuilder
     {
         public static readonly string DefaultNuGetClientName = "NuGet Client V3";
-        public static readonly string VSNuGetClientName = "NuGet VS VSIX";
 
         private const string UserAgentWithOSDescriptionAndVisualStudioSKUTemplate = "{0}/{1} ({2}, {3})";
         private const string UserAgentWithOSDescriptionTemplate = "{0}/{1} ({2})";


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/5853
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
Change the client name in VS from the default one, to a VS specific one. 
From 
```
NuGet Client V3/4.7.0 (Microsoft Windows NT 10.0.14393.0, VS Enterprise/15.0)
```
to
```
NuGet VS VSIX/4.7.0 (Microsoft Windows NT 10.0.14393.0, VS Enterprise/15.0)
```
## Testing/Validation
Tests Added: Yes/No
Reason for not adding tests:  
Validation done:  
