### PR TITLE
[Signing]: Moving IsZip64Async to ISignedPackageReader

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -326,5 +326,20 @@ namespace NuGet.Packaging
                 return Task.FromResult(hash);
             }
         }
+
+        public override Task<bool> IsZip64Async(CancellationToken token)
+        {
+            token.ThrowIfCancellationRequested();
+
+            if (ZipReadStream == null)
+            {
+                throw new SignatureException(Strings.SignedPackageUnableToAccessSignature);
+            }
+
+            using (var reader = new BinaryReader(ZipReadStream, new UTF8Encoding(), leaveOpen: true))
+            {
+                return Task.FromResult(SignedPackageArchiveUtility.IsZip64(reader));
+            }
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -239,5 +239,10 @@ namespace NuGet.Packaging
         {
             throw new NotImplementedException();
         }
+
+        public override Task<bool> IsZip64Async(CancellationToken token)
+        {
+            return Task.FromResult(false);
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -553,5 +553,7 @@ namespace NuGet.Packaging
         public abstract Task ValidateIntegrityAsync(SignatureContent signatureContent, CancellationToken token);
 
         public abstract Task<byte[]> GetArchiveHashAsync(HashAlgorithmName hashAlgorithm, CancellationToken token);
+
+        public abstract Task<bool> IsZip64Async(CancellationToken token);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
@@ -36,5 +36,16 @@ namespace NuGet.Packaging.Signing
         /// <param name="signatureContent">SignatureContent with expected hash value and hash algorithm used</param>
         /// <returns></returns>
         Task ValidateIntegrityAsync(SignatureContent signatureContent, CancellationToken token);
+
+        /// <summary>
+        /// Check if a package is Zip64.
+        /// </summary>
+        /// <param name="token">A cancellation token.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="bool" />
+        /// indicating whether the package is signed.</returns>
+        /// <exception cref="OperationCanceledException">Thrown if <paramref name="token" />
+        /// is cancelled.</exception>
+        Task<bool> IsZip64Async(CancellationToken token);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageWriter.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageWriter.cs
@@ -28,17 +28,6 @@ namespace NuGet.Packaging.Signing
         /// <param name="packageSignatureProvider">A stream of the signature to be added to the package.</param>
         /// <param name="token">Cancellation token.</param>
         Task AddSignatureAsync(Stream signatureStream, CancellationToken token);
-
-        /// <summary>
-        /// Check if a package is Zip64.
-        /// </summary>
-        /// <param name="token">A cancellation token.</param>
-        /// <returns>A task that represents the asynchronous operation.
-        /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="bool" />
-        /// indicating whether the package is signed.</returns>
-        /// <exception cref="OperationCanceledException">Thrown if <paramref name="token" />
-        /// is cancelled.</exception>
-        Task<bool> IsZip64Async(CancellationToken token);
 #endif
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/SignedPackageArchive.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/SignedPackageArchive.cs
@@ -86,21 +86,6 @@ namespace NuGet.Packaging.Signing
             }
         }
 
-        public Task<bool> IsZip64Async(CancellationToken token)
-        {
-            token.ThrowIfCancellationRequested();
-
-            if (ZipReadStream == null)
-            {
-                throw new SignatureException(Strings.SignedPackageUnableToAccessSignature);
-            }
-
-            using (var reader = new BinaryReader(ZipReadStream, new UTF8Encoding(), leaveOpen: true))
-            {
-                return Task.FromResult(SignedPackageArchiveUtility.IsZip64(reader));
-            }
-        }
-
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -1144,6 +1144,11 @@ namespace NuGet.Protocol.Plugins
             throw new NotImplementedException();
         }
 
+        public override Task<bool> IsZip64Async(CancellationToken token)
+        {
+            return Task.FromResult(false);
+        }
+
         private sealed class FileStreamCreator : IDisposable
         {
             private readonly string _filePath;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
@@ -263,6 +263,11 @@ namespace NuGet.Protocol.Tests
                 throw new NotImplementedException();
             }
 
+            public override Task<bool> IsZip64Async(CancellationToken token)
+            {
+                return Task.FromResult(false);
+            }
+
             protected override void Dispose(bool disposing)
             {
             }


### PR DESCRIPTION
This PR moves the  zip 64 check method `Task<bool> IsZip64Async(CancellationToken token)` from `ISignedPackageWriter` to `ISignedPackageReader`.

Since checking if a package is a zip 64 package or not, only requires a read stream, it should be  in `ISignedPackageReader`.