### PR TITLE
Print better logs for apex tests

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -110,36 +110,6 @@
     Run VS15 apex tests
     ============================================================
   -->
-  <Target Name="ApexTestsVS15">
-    <ItemGroup>
-      <ApexTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Tests.Apex\*\*.csproj" />
-    </ItemGroup>
-    
-    <!-- Test inputs -->
-    <PropertyGroup>
-      <TestProjectPaths>@(ApexTestProjects)</TestProjectPaths>
-      <TestResultsFileName>ApexTestsVS15</TestResultsFileName>
-      <TestVisualStudioVersion>15.0</TestVisualStudioVersion>
-    </PropertyGroup>
-
-    <!-- Run tests as a batch -->
-    <MSBuild
-        Projects="$(MSBuildThisFileFullPath)"
-        Targets="RunTestsOnProjects"
-        Properties="$(CommonMSBuildProperties);
-                    VisualStudioVersion=$(TestVisualStudioVersion);
-                    TestResultsFileName=$(TestResultsFileName);
-                    TestProjectPaths=$(TestProjectPaths)">
-      <Output TaskParameter="TargetOutputs"
-              ItemName="TestAssemblyPath" />
-    </MSBuild>
-  </Target>
-
-  <!--
-    ============================================================
-    Run VS15 apex tests
-    ============================================================
-  -->
   <Target Name="ApexTestsStandalone">
 
     <!-- Test inputs -->
@@ -156,33 +126,8 @@
         Properties="$(CommonMSBuildProperties);
                     VisualStudioVersion=$(TestVisualStudioVersion);
                     TestResultsFileName=$(TestResultsFileName);
-                    TestProjectPaths=$(TestProjectPaths)">
-      <Output TaskParameter="TargetOutputs"
-              ItemName="TestAssemblyPath" />
-    </MSBuild>
-  </Target>
-
-  <!--
-    ============================================================
-    Run VS14 unit tests
-    ============================================================
-  -->
-  <Target Name="UnitTestsVS14">
-    <!-- Test inputs -->
-    <PropertyGroup>
-      <TestProjectPaths>@(VSUnitTestProjects)</TestProjectPaths>
-      <TestResultsFileName>UnitTestsVS14</TestResultsFileName>
-      <TestVisualStudioVersion>14.0</TestVisualStudioVersion>
-    </PropertyGroup>
-
-    <!-- Run tests as a batch -->
-    <MSBuild
-        Projects="$(MSBuildThisFileFullPath)"
-        Targets="RunTestsOnProjects"
-        Properties="$(CommonMSBuildProperties);
-                    VisualStudioVersion=$(TestVisualStudioVersion);
-                    TestResultsFileName=$(TestResultsFileName);
-                    TestProjectPaths=$(TestProjectPaths)">
+                    TestProjectPaths=$(TestProjectPaths);
+                    Verbosity=-verbose">
       <Output TaskParameter="TargetOutputs"
               ItemName="TestAssemblyPath" />
     </MSBuild>
@@ -195,24 +140,6 @@
   -->
   <Target Name="RunVS15"  DependsOnTargets="BuildVS15;Pack;CoreUnitTests;UnitTestsVS15">
     <Message Text="Running NuGet Build for VS 15" Importance="high" />
-  </Target>
-
-  <!--
-    ============================================================
-    Build, Pack, Unit tests for VS 14
-    ============================================================
-  -->
-  <Target Name="RunVS14"  DependsOnTargets="BuildVS14;UnitTestsVS14">
-    <Message Text="Running NuGet Build for VS 14" Importance="high" />
-  </Target>
-
-  <!--
-    ============================================================
-    Build for VS14
-    ============================================================
-  -->
-  <Target Name="BuildVS14" Condition=" '$(IsXPlat)' != 'true' " >
-    <Message Text="Building for VS14" Importance="high" />
   </Target>
 
   <!--
@@ -231,19 +158,6 @@
   -->
   <Target Name="BuildXPLAT" DependsOnTargets="GetXPLATProjects">
     <Message Text="Building XPLAT" Importance="high" />
-  </Target>
-
-  <!--
-    ============================================================
-    Build for VS14
-    ============================================================
-  -->
-  <Target Name="BuildVS14NoVSIX" AfterTargets="BuildVS14" Condition=" '$(IsXPlat)' != 'true' ">
-    <Message Text="Building for VS14" Importance="high" />
-    <MSBuild Projects="@(SolutionProjectsWithoutVSIX)"
-             Targets="Build"
-             Properties="$(CommonMSBuildProperties);
-                         VisualStudioVersion=14.0;" />
   </Target>
 
   <!--
@@ -272,22 +186,6 @@
              Targets="Build"
              Properties="$(CommonMSBuildProperties);
                          VisualStudioVersion=15.0;" />
-  </Target>
-
-  <!--
-    ============================================================
-    Build the VS14 VSIX
-    This target always needs to be below BuildVS14NoVSIX so that
-    BuildVS14 runs the NoVSIX targets before this one.
-    ============================================================
-  -->
-  <Target Name="BuildVS14VSIX" AfterTargets= "BuildVS14" Condition=" '$(IsXPlat)' != 'true' ">
-    <Message Text="Building the VSIX for VS14" Importance="high" />
-
-    <MSBuild Projects="$(VSIXProject)"
-             Targets="Build"
-             Properties="$(CommonMSBuildProperties);
-                         VisualStudioVersion=14.0;" />
   </Target>
 
   <!--
@@ -401,23 +299,6 @@
 
   <!--
     ============================================================
-    Restore for VS14
-    ============================================================
-  -->
-  <Target Name="RestoreVS14">
-    <Message Text="Restoring for Visual Studio 14.0" Importance="high" />
-
-    <MSBuild
-      Projects="$(MSBuildThisFileFullPath)"
-      Targets="Restore"
-      Properties="$(CommonMSBuildProperties);
-                  VisualStudioVersion=14.0">
-    </MSBuild>
-  </Target>
-
-
-  <!--
-    ============================================================
     Restore for XPLAT
     ============================================================
   -->
@@ -503,7 +384,7 @@
       <VsTestLogger>--TestAdapterPath:$(XunitXmlLoggerDirectory) --logger:xunit;LogFileName=$(TestResultsFileName)-vsts.$(TestResultOutputFormat)</VsTestLogger>
       <VSTestCommand>$(DotnetExePath) vstest $(CoreInputTestAssembliesSpaced) $(VsTestLogger)</VSTestCommand>
       <DesktopTestCommand>$(XunitConsoleExePath) $(DesktopInputTestAssembliesSpaced)</DesktopTestCommand>
-      <DesktopTestCommand Condition=" '$(TestResultsXunit)' != '' ">$(DesktopTestCommand) -$(TestResultOutputFormat) $(TestResultsXunit)</DesktopTestCommand>
+      <DesktopTestCommand Condition=" '$(TestResultsXunit)' != '' ">$(DesktopTestCommand) -$(TestResultOutputFormat) $(TestResultsXunit) $(Verbosity)</DesktopTestCommand>
     </PropertyGroup>
 
     <!-- Desktop -->

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
@@ -67,6 +67,11 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
   <Import Project="$(BuildCommonDirectory)common.targets" />
 
   <PropertyGroup>

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/xunit.runner.json
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "methodDisplay": "classAndMethod"
+}


### PR DESCRIPTION
Apex output was confusing, with this change it will print out in which test case it is running so it is easier to debug.

Also cleaned up targets not used in build.proj