### PR TITLE
Fix lock file comparisons

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/AssetTargetFallbackFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/AssetTargetFallbackFramework.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -80,7 +80,7 @@ namespace NuGet.Frameworks
 
         public override bool Equals(object obj)
         {
-            return Equals(obj as FallbackFramework);
+            return Equals(obj as AssetTargetFallbackFramework);
         }
 
         public override int GetHashCode()

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -161,7 +161,7 @@ namespace NuGet.ProjectModel
                    OutputPath == other.OutputPath &&
                    ProjectName == other.ProjectName &&
                    ProjectUniqueName == other.ProjectUniqueName &&
-                   EqualityUtility.SequenceEqualWithNullCheck(Sources, other.Sources) &&
+                   Sources.OrderedEquals(other.Sources, source => source.Source, StringComparer.Ordinal) &&
                    PackagesPath == other.PackagesPath &&
                    EqualityUtility.SequenceEqualWithNullCheck(ConfigFilePaths, other.ConfigFilePaths) &&
                    EqualityUtility.SequenceEqualWithNullCheck(FallbackFolders, other.FallbackFolders) &&

--- a/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
@@ -67,7 +67,7 @@ namespace NuGet.ProjectModel
             }
 
             return EqualityUtility.EqualsWithNullCheck(FrameworkName, other.FrameworkName) &&
-                   Dependencies.SequenceEqualWithNullCheck(other.Dependencies) &&
+                   Dependencies.OrderedEquals(other.Dependencies, dependency => dependency.Name, StringComparer.Ordinal) &&
                    Imports.SequenceEqualWithNullCheck(other.Imports) &&
                    AssetTargetFallback == other.AssetTargetFallback;
         }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6491
Regression: No

## Fix
Details:

There are several issues with comparing the data in lock files causing lock files to appear dirty when they aren't. This causes the lock file to be written when not dirty which causes Intellisense builds in Visual Studio that shouldn't run.

## Testing/Validation
Tests Added: No
Reason for not adding tests: Not sure how best to add tests for this scenario. 
Validation done:  Ran tests, manually verified
