### PR TITLE
Display errors when a PackageReference rollback occurs

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -318,7 +318,8 @@ namespace NuGet.PackageManagement.UI
                     ex is FrameworkException ||
                     ex is NuGetProtocolException ||
                     ex is PackagingException ||
-                    ex is InvalidOperationException)
+                    ex is InvalidOperationException ||
+                    ex is PackageReferenceRollbackException)
                 {
                     // for exceptions that are known to be normal error cases, just
                     // display the message.
@@ -327,6 +328,19 @@ namespace NuGet.PackageManagement.UI
                     // write to activity log
                     var activityLogMessage = string.Format(CultureInfo.CurrentCulture, ex.ToString());
                     ActivityLog.LogError(LogEntrySource, activityLogMessage);
+
+                    // Log additional messages to the error list to provide context on why the rollback failed
+                    var rollbackException = ex as PackageReferenceRollbackException;
+                    if (rollbackException != null)
+                    {
+                        foreach (var message in rollbackException.LogMessages)
+                        {
+                            if (message.Level == LogLevel.Error)
+                            {
+                                UILogger.ReportError(message.Message);
+                            }
+                        }
+                    }
                 }
                 else
                 {

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/PackageReferenceRollbackException.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/PackageReferenceRollbackException.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Common;
+
+namespace NuGet.PackageManagement
+{
+    /// <summary>
+    /// An exception containing a generic rollback message for the user
+    /// and additional log messages with specific information on
+    /// what caused the rollback.
+    /// </summary>
+    public class PackageReferenceRollbackException : InvalidOperationException
+    {
+        /// <summary>
+        /// Additional log messages for the error list.
+        /// </summary>
+        public IReadOnlyList<ILogMessage> LogMessages { get; }
+
+        /// <summary>
+        /// Create a PackageReferenceRollbackException
+        /// </summary>
+        /// <param name="message">High level exception message.</param>
+        /// <param name="logMessages">Log messages to be shown in the error list.</param>
+        public PackageReferenceRollbackException(string message, IEnumerable<ILogMessage> logMessages)
+            : base(message)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (logMessages == null)
+            {
+                throw new ArgumentNullException(nameof(logMessages));
+            }
+
+            LogMessages = logMessages.ToList();
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/LogUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/LogUtility.cs
@@ -3,6 +3,7 @@
 
 using NuGet.Common;
 using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
 
 namespace NuGet.PackageManagement
 {
@@ -25,6 +26,28 @@ namespace NuGet.PackageManagement
                 default:
                     return MessageLevel.Debug;
             }
+        }
+
+        /// <summary>
+        /// Converts an IAssetsLogMessage into a RestoreLogMessage.
+        /// This is needed when an IAssetsLogMessage needs to be logged and loggers do not have visibility to IAssetsLogMessage.
+        /// </summary>
+        /// <param name="logMessage">IAssetsLogMessage to be converted.</param>
+        /// <returns>RestoreLogMessage equivalent to the IAssetsLogMessage.</returns>
+        internal static RestoreLogMessage AsRestoreLogMessage(this IAssetsLogMessage logMessage)
+        {
+            return new RestoreLogMessage(logMessage.Level, logMessage.Code, logMessage.Message)
+            {
+                ProjectPath = logMessage.ProjectPath,
+                WarningLevel = logMessage.WarningLevel,
+                FilePath = logMessage.FilePath,
+                LibraryId = logMessage.LibraryId,
+                TargetGraphs = logMessage.TargetGraphs,
+                StartLineNumber = logMessage.StartLineNumber,
+                StartColumnNumber = logMessage.StartColumnNumber,
+                EndLineNumber = logMessage.EndLineNumber,
+                EndColumnNumber = logMessage.EndColumnNumber
+            };
         }
     }
 }


### PR DESCRIPTION
Display errors when a PackageReference rollback occurs. This change will read the previewed assets file and throw errors along with the rollback exception.

Since this exception is also thrown to the VS API and other scenarios, it needs to stay as an InvalidOperationException at the base level, this way callers catching InvalidOperationExceptions will not see any breaking changes.

Example UI:
![image](https://user-images.githubusercontent.com/6381138/35466424-90582d22-02b8-11e8-8a1d-293a68bf1a37.png)

Previously only the generic rollback message was displayed. 
