### PR TITLE
Fixed installing packages for website projects hosted in IIS

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/EnvDTEProjectInfoUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/EnvDTEProjectInfoUtility.cs
@@ -91,6 +91,18 @@ namespace NuGet.VisualStudio
             // for start up scenarios such as VS Templates. In these cases we need to fallback 
             // until we can find one containing the full path.
 
+            // For website projects, always read FullPath from properties list
+            if (IsWebProject(envDTEProject))
+            {
+                // FullPath
+                var fullProjectPath = GetPropertyValue<string>(envDTEProject, FullPath);
+
+                if (!string.IsNullOrEmpty(fullProjectPath))
+                {
+                    return fullProjectPath;
+                }
+            }
+
             // FullName
             if (!string.IsNullOrEmpty(envDTEProject.FullName))
             {


### PR DESCRIPTION
For website projects, always use FullPath of dte properties instead of FullName metadata to access project path.

fixes https://github.com/NuGet/Home/issues/6352