### PR TITLE
adding ATF support for GetReferenceNearestTargetFrameworkTask

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
@@ -64,7 +64,7 @@ namespace NuGet.Build.Tasks
                 return false;
             }
 
-            if (AssetTargetFallbackFrameworks != null ||
+            if (AssetTargetFallbackFrameworks != null &&
                 AssetTargetFallbackFrameworks.Length > 0)
             {
                 var fallbackFrameworks = new List<NuGetFramework>();

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
@@ -27,7 +27,7 @@ namespace NuGet.Build.Tasks
         public string CurrentProjectTargetFramework { get; set; }
 
         /// <summary>
-        /// List of target frameworks to be used as Asset Target Fallback frameworks.
+        /// Optional list of target frameworks to be used as Asset Target Fallback frameworks.
         /// </summary>
         public string[] AssetTargetFallbackFrameworks { get; set; }
 
@@ -47,6 +47,12 @@ namespace NuGet.Build.Tasks
             var logger = new MSBuildLogger(Log);
 
             BuildTasksUtility.LogInputParam(logger, nameof(CurrentProjectTargetFramework), CurrentProjectTargetFramework);
+
+            BuildTasksUtility.LogInputParam(logger, nameof(AssetTargetFallbackFrameworks),
+                AssetTargetFallbackFrameworks == null
+                    ? ""
+                    : string.Join(";", AssetTargetFallbackFrameworks.Select(p => p)));
+
             BuildTasksUtility.LogInputParam(logger, nameof(AnnotatedProjectReferences),
                 AnnotatedProjectReferences == null
                     ? ""

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
@@ -66,7 +66,8 @@ namespace NuGet.Build.Tasks
             var frameworksToMatch = new List<NuGetFramework>();
 
             // validate current project framework
-            if (!TryParseAndAddFrameworkToList(CurrentProjectTargetFramework, frameworksToMatch, logger))
+            var errorMessage = string.Format(Strings.UnsupportedTargetFramework, CurrentProjectTargetFramework);
+            if (!TryParseAndAddFrameworkToList(CurrentProjectTargetFramework, frameworksToMatch, errorMessage, logger))
             {
                 return false;
             }
@@ -74,11 +75,11 @@ namespace NuGet.Build.Tasks
             if (FallbackTargetFrameworks != null &&
                 FallbackTargetFrameworks.Length > 0)
             {
-                var fallbackFrameworks = new List<NuGetFramework>();
-                foreach (var assetTargetFallbackFramework in FallbackTargetFrameworks)
+                foreach (var fallbackFramework in FallbackTargetFrameworks)
                 {
                     // validate ATF project framework
-                    if (!TryParseAndAddFrameworkToList(assetTargetFallbackFramework, frameworksToMatch, logger))
+                    errorMessage = string.Format(Strings.UnsupportedFallbackFramework, fallbackFramework);
+                    if (!TryParseAndAddFrameworkToList(fallbackFramework, frameworksToMatch, errorMessage, logger))
                     {
                         return false;
                     }
@@ -121,19 +122,18 @@ namespace NuGet.Build.Tasks
             }
 
             // no match found
-            itemWithProperties.SetMetadata(NEAREST_TARGET_FRAMEWORK, FrameworkConstants.SpecialIdentifiers.Unsupported);
             Log.LogError(string.Format(Strings.NoCompatibleTargetFramework, project.ItemSpec, CurrentProjectTargetFramework, targetFrameworks));
             return itemWithProperties;
         }
 
-        private static bool TryParseAndAddFrameworkToList(string framework, IList<NuGetFramework> frameworkList, MSBuildLogger logger)
+        private static bool TryParseAndAddFrameworkToList(string framework, IList<NuGetFramework> frameworkList, string errorMessage, MSBuildLogger logger)
         {
             var nugetFramework = NuGetFramework.Parse(framework);
 
             // validate framework
             if (nugetFramework.IsUnsupported)
             {
-                logger.LogError(string.Format(Strings.UnsupportedTargetFramework, framework));
+                logger.LogError(errorMessage);
                 return false;
             }
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
@@ -27,9 +27,9 @@ namespace NuGet.Build.Tasks
         public string CurrentProjectTargetFramework { get; set; }
 
         /// <summary>
-        /// Optional list of target frameworks to be used as Asset Target Fallback frameworks.
+        /// Optional list of target frameworks to be used as Fallback target frameworks.
         /// </summary>
-        public string[] AssetTargetFallbackFrameworks { get; set; }
+        public string[] FallbackTargetFrameworks { get; set; }
 
         /// <summary>
         /// The project references for property lookup.
@@ -48,10 +48,10 @@ namespace NuGet.Build.Tasks
 
             BuildTasksUtility.LogInputParam(logger, nameof(CurrentProjectTargetFramework), CurrentProjectTargetFramework);
 
-            BuildTasksUtility.LogInputParam(logger, nameof(AssetTargetFallbackFrameworks),
-                AssetTargetFallbackFrameworks == null
+            BuildTasksUtility.LogInputParam(logger, nameof(FallbackTargetFrameworks),
+                FallbackTargetFrameworks == null
                     ? ""
-                    : string.Join(";", AssetTargetFallbackFrameworks.Select(p => p)));
+                    : string.Join(";", FallbackTargetFrameworks.Select(p => p)));
 
             BuildTasksUtility.LogInputParam(logger, nameof(AnnotatedProjectReferences),
                 AnnotatedProjectReferences == null
@@ -71,11 +71,11 @@ namespace NuGet.Build.Tasks
                 return false;
             }
 
-            if (AssetTargetFallbackFrameworks != null &&
-                AssetTargetFallbackFrameworks.Length > 0)
+            if (FallbackTargetFrameworks != null &&
+                FallbackTargetFrameworks.Length > 0)
             {
                 var fallbackFrameworks = new List<NuGetFramework>();
-                foreach (var assetTargetFallbackFramework in AssetTargetFallbackFrameworks)
+                foreach (var assetTargetFallbackFramework in FallbackTargetFrameworks)
                 {
                     // validate ATF project framework
                     if (!TryParseAndAddFrameworkToList(assetTargetFallbackFramework, frameworksToMatch, logger))

--- a/src/NuGet.Core/NuGet.Build.Tasks/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Strings.Designer.cs
@@ -98,7 +98,16 @@ namespace NuGet.Build.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The framework &apos;{0}&apos; is not a supported target framework..
+        ///   Looks up a localized string similar to The project fallback framework &apos;{0}&apos; is not a supported target framework..
+        /// </summary>
+        internal static string UnsupportedFallbackFramework {
+            get {
+                return ResourceManager.GetString("UnsupportedFallbackFramework", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The project target framework &apos;{0}&apos; is not a supported target framework..
         /// </summary>
         internal static string UnsupportedTargetFramework {
             get {

--- a/src/NuGet.Core/NuGet.Build.Tasks/Strings.resx
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Strings.resx
@@ -129,7 +129,10 @@
   <data name="RestoreCanceled" xml:space="preserve">
     <value>Restore canceled!</value>
   </data>
+  <data name="UnsupportedFallbackFramework" xml:space="preserve">
+    <value>The project fallback framework '{0}' is not a supported target framework.</value>
+  </data>
   <data name="UnsupportedTargetFramework" xml:space="preserve">
-    <value>The framework '{0}' is not a supported target framework.</value>
+    <value>The project target framework '{0}' is not a supported target framework.</value>
   </data>
 </root>

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetReferenceNearestTargetFrameworkTaskTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetReferenceNearestTargetFrameworkTaskTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Moq;
@@ -59,36 +60,6 @@ namespace NuGet.Build.Tasks.Test
             testLogger.Warnings.Should().Be(0);
             testLogger.Errors.Should().Be(1);
             testLogger.DebugMessages.Count.Should().Be(2);
-        }
-
-        [Fact]
-        public void GetReferenceNearestTargetFrameworkTask_NoCompatibleTargetTF()
-        {
-            var buildEngine = new TestBuildEngine();
-            var testLogger = buildEngine.TestLogger;
-
-            var references = new List<ITaskItem>();
-            var reference = new Mock<ITaskItem>();
-            reference.SetupGet(e => e.ItemSpec).Returns("a.csproj");
-            reference.Setup(e => e.GetMetadata("TargetFrameworks")).Returns("net461");
-            reference.Setup(e => e.GetMetadata("HasSingleTargetFramework")).Returns("true");
-            references.Add(reference.Object);
-
-            var task = new GetReferenceNearestTargetFrameworkTask
-            {
-                BuildEngine = buildEngine,
-                CurrentProjectTargetFramework = "net46",
-                AnnotatedProjectReferences = references.ToArray()
-            };
-
-            var result = task.Execute();
-            result.Should().BeFalse();
-
-            task.AssignedProjects.Should().HaveCount(1);
-
-            testLogger.Warnings.Should().Be(0);
-            testLogger.Errors.Should().Be(1);
-            testLogger.DebugMessages.Count.Should().Be(3);
         }
 
         [Fact]
@@ -209,5 +180,138 @@ namespace NuGet.Build.Tasks.Test
             testLogger.DebugMessages.Count.Should().Be(3);
         }
 
+        [Theory]
+        [InlineData("netcoreapp2.0", "netcoreapp2.0")]
+        [InlineData("net46", "net46")]
+        public void GetReferenceNearestTargetFrameworkTask_WithSingleTfmAndSingleAtf(string referenceProjectFramework, string nearestMatchingFramework)
+        {
+            var buildEngine = new TestBuildEngine();
+            var testLogger = buildEngine.TestLogger;
+
+            var references = new List<ITaskItem>();
+            var reference = new Mock<ITaskItem>();
+            reference.SetupGet(e => e.ItemSpec).Returns("a.csproj");
+            reference.Setup(e => e.GetMetadata("TargetFrameworks")).Returns(referenceProjectFramework);
+            reference.Setup(e => e.GetMetadata("HasSingleTargetFramework")).Returns("true");
+            references.Add(reference.Object);
+
+            var task = new GetReferenceNearestTargetFrameworkTask
+            {
+                BuildEngine = buildEngine,
+                CurrentProjectTargetFramework = "netcoreapp2.0",
+                AssetTargetFallbackFrameworks = new string[] { "net46" },
+                AnnotatedProjectReferences = references.ToArray()
+            };
+
+            var result = task.Execute();
+            result.Should().BeTrue();
+
+            task.AssignedProjects.Should().HaveCount(1);
+            task.AssignedProjects[0].GetMetadata("NearestTargetFramework").Should().Be(nearestMatchingFramework);
+
+            testLogger.Warnings.Should().Be(0);
+            testLogger.Errors.Should().Be(0);
+            testLogger.DebugMessages.Count.Should().Be(3);
+        }
+
+        [Theory]
+        [InlineData("netcoreapp2.0", "netcoreapp2.0")]
+        [InlineData("net46", "net46")]
+        public void GetReferenceNearestTargetFrameworkTask_WithSingleTfmAndMultipleAtf(string referenceProjectFramework, string nearestMatchingFramework)
+        {
+            var buildEngine = new TestBuildEngine();
+            var testLogger = buildEngine.TestLogger;
+
+            var references = new List<ITaskItem>();
+            var reference = new Mock<ITaskItem>();
+            reference.SetupGet(e => e.ItemSpec).Returns("a.csproj");
+            reference.Setup(e => e.GetMetadata("TargetFrameworks")).Returns(referenceProjectFramework);
+            reference.Setup(e => e.GetMetadata("HasSingleTargetFramework")).Returns("true");
+            references.Add(reference.Object);
+
+            var task = new GetReferenceNearestTargetFrameworkTask
+            {
+                BuildEngine = buildEngine,
+                CurrentProjectTargetFramework = "netcoreapp2.0",
+                AssetTargetFallbackFrameworks = new string[] { "net46", "net461" },
+                AnnotatedProjectReferences = references.ToArray()
+            };
+
+            var result = task.Execute();
+            result.Should().BeTrue();
+
+            task.AssignedProjects.Should().HaveCount(1);
+            task.AssignedProjects[0].GetMetadata("NearestTargetFramework").Should().Be(nearestMatchingFramework);
+
+            testLogger.Warnings.Should().Be(0);
+            testLogger.Errors.Should().Be(0);
+            testLogger.DebugMessages.Count.Should().Be(3);
+        }
+
+        [Theory]
+        [InlineData("netcoreapp2.0; netcoreapp1.0", "netcoreapp2.0")]
+        [InlineData("net45; net46", "net46")]
+        public void GetReferenceNearestTargetFrameworkTask_WithMultipleTfmAndSingleAtf(string referenceProjectFramework, string nearestMatchingFramework)
+        {
+            var buildEngine = new TestBuildEngine();
+            var testLogger = buildEngine.TestLogger;
+
+            var references = new List<ITaskItem>();
+            var reference = new Mock<ITaskItem>();
+            reference.SetupGet(e => e.ItemSpec).Returns("a.csproj");
+            reference.Setup(e => e.GetMetadata("TargetFrameworks")).Returns(referenceProjectFramework);
+            references.Add(reference.Object);
+
+            var task = new GetReferenceNearestTargetFrameworkTask
+            {
+                BuildEngine = buildEngine,
+                CurrentProjectTargetFramework = "netcoreapp2.0",
+                AssetTargetFallbackFrameworks = new string[] { "net46" },
+                AnnotatedProjectReferences = references.ToArray()
+            };
+
+            var result = task.Execute();
+            result.Should().BeTrue();
+
+            task.AssignedProjects.Should().HaveCount(1);
+            task.AssignedProjects[0].GetMetadata("NearestTargetFramework").Should().Be(nearestMatchingFramework);
+
+            testLogger.Warnings.Should().Be(0);
+            testLogger.Errors.Should().Be(0);
+            testLogger.DebugMessages.Count.Should().Be(3);
+        }
+
+        [Theory]
+        [InlineData("netcoreapp2.0; netcoreapp1.0", "netcoreapp2.0")]
+        [InlineData("net45; net46", "net46")]
+        public void GetReferenceNearestTargetFrameworkTask_WithMultipleTfmAndMultipleAtf(string referenceProjectFramework, string nearestMatchingFramework)
+        {
+            var buildEngine = new TestBuildEngine();
+            var testLogger = buildEngine.TestLogger;
+
+            var references = new List<ITaskItem>();
+            var reference = new Mock<ITaskItem>();
+            reference.SetupGet(e => e.ItemSpec).Returns("a.csproj");
+            reference.Setup(e => e.GetMetadata("TargetFrameworks")).Returns(referenceProjectFramework);
+            references.Add(reference.Object);
+
+            var task = new GetReferenceNearestTargetFrameworkTask
+            {
+                BuildEngine = buildEngine,
+                CurrentProjectTargetFramework = "netcoreapp2.0",
+                AssetTargetFallbackFrameworks = new string[] { "net46", "net45", "net461" },
+                AnnotatedProjectReferences = references.ToArray()
+            };
+
+            var result = task.Execute();
+            result.Should().BeTrue();
+
+            task.AssignedProjects.Should().HaveCount(1);
+            task.AssignedProjects[0].GetMetadata("NearestTargetFramework").Should().Be(nearestMatchingFramework);
+
+            testLogger.Warnings.Should().Be(0);
+            testLogger.Errors.Should().Be(0);
+            testLogger.DebugMessages.Count.Should().Be(3);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetReferenceNearestTargetFrameworkTaskTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetReferenceNearestTargetFrameworkTaskTest.cs
@@ -11,6 +11,9 @@ namespace NuGet.Build.Tasks.Test
 {
     public class GetReferenceNearestTargetFrameworkTaskTest
     {
+        private const int DEBUG_MESSAGE_COUNT_INPUT = 3;
+        private const int DEBUG_MESSAGE_COUNT_INPUT_OUTPUT = DEBUG_MESSAGE_COUNT_INPUT + 1;
+
         [Fact]
         public void GetReferenceNearestTargetFrameworkTask_NoReferences()
         {
@@ -30,7 +33,7 @@ namespace NuGet.Build.Tasks.Test
 
             testLogger.Warnings.Should().Be(0);
             testLogger.Errors.Should().Be(0);
-            testLogger.DebugMessages.Count.Should().Be(2);
+            testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT);
         }
 
         [Fact]
@@ -58,7 +61,7 @@ namespace NuGet.Build.Tasks.Test
 
             testLogger.Warnings.Should().Be(0);
             testLogger.Errors.Should().Be(1);
-            testLogger.DebugMessages.Count.Should().Be(2);
+            testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT);
         }
 
         [Fact]
@@ -88,7 +91,7 @@ namespace NuGet.Build.Tasks.Test
 
             testLogger.Warnings.Should().Be(0);
             testLogger.Errors.Should().Be(1);
-            testLogger.DebugMessages.Count.Should().Be(3);
+            testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT_OUTPUT);
         }
 
         [Fact]
@@ -116,7 +119,7 @@ namespace NuGet.Build.Tasks.Test
 
             testLogger.Warnings.Should().Be(0);
             testLogger.Errors.Should().Be(0);
-            testLogger.DebugMessages.Count.Should().Be(3);
+            testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT_OUTPUT);
         }
 
         [Fact]
@@ -147,7 +150,7 @@ namespace NuGet.Build.Tasks.Test
 
             testLogger.Warnings.Should().Be(0);
             testLogger.Errors.Should().Be(0);
-            testLogger.DebugMessages.Count.Should().Be(3);
+            testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT_OUTPUT);
         }
 
         [Fact]
@@ -177,7 +180,7 @@ namespace NuGet.Build.Tasks.Test
 
             testLogger.Warnings.Should().Be(0);
             testLogger.Errors.Should().Be(0);
-            testLogger.DebugMessages.Count.Should().Be(3);
+            testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT_OUTPUT);
         }
 
         [Fact]
@@ -206,7 +209,66 @@ namespace NuGet.Build.Tasks.Test
 
             testLogger.Warnings.Should().Be(0);
             testLogger.Errors.Should().Be(1);
-            testLogger.DebugMessages.Count.Should().Be(3);
+            testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT_OUTPUT);
+        }
+
+        [Fact]
+        public void GetReferenceNearestTargetFrameworkTask_BadAtf()
+        {
+            var buildEngine = new TestBuildEngine();
+            var testLogger = buildEngine.TestLogger;
+
+            var references = new List<ITaskItem>();
+            var reference = new Mock<ITaskItem>();
+            reference.SetupGet(e => e.ItemSpec).Returns("a.csproj");
+            reference.Setup(e => e.GetMetadata("TargetFrameworks")).Returns("netcoreapp2.0");
+            reference.Setup(e => e.GetMetadata("HasSingleTargetFramework")).Returns("true");
+            references.Add(reference.Object);
+
+            var task = new GetReferenceNearestTargetFrameworkTask
+            {
+                BuildEngine = buildEngine,
+                CurrentProjectTargetFramework = "netcoreapp2.0",
+                AssetTargetFallbackFrameworks = new string[] { "abcdef" },
+                AnnotatedProjectReferences = references.ToArray()
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeFalse();
+            task.AssignedProjects.Should().BeNullOrEmpty();
+            testLogger.Warnings.Should().Be(0);
+            testLogger.Errors.Should().Be(1);
+            testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT);
+        }
+
+        [Fact]
+        public void GetReferenceNearestTargetFrameworkTask_BadMultipleAtf()
+        {
+            var buildEngine = new TestBuildEngine();
+            var testLogger = buildEngine.TestLogger;
+
+            var references = new List<ITaskItem>();
+            var reference = new Mock<ITaskItem>();
+            reference.SetupGet(e => e.ItemSpec).Returns("a.csproj");
+            reference.Setup(e => e.GetMetadata("TargetFrameworks")).Returns("netcoreapp2.0");
+            references.Add(reference.Object);
+
+            var task = new GetReferenceNearestTargetFrameworkTask
+            {
+                BuildEngine = buildEngine,
+                CurrentProjectTargetFramework = "netcoreapp2.0",
+                AssetTargetFallbackFrameworks = new string[] { "net46", "abcdef" },
+                AnnotatedProjectReferences = references.ToArray()
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeFalse();
+            task.AssignedProjects.Should().BeNullOrEmpty();
+            testLogger.Warnings.Should().Be(0);
+            testLogger.Errors.Should().Be(1);
+            testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT);
         }
 
         [Theory]
@@ -240,7 +302,7 @@ namespace NuGet.Build.Tasks.Test
 
             testLogger.Warnings.Should().Be(0);
             testLogger.Errors.Should().Be(0);
-            testLogger.DebugMessages.Count.Should().Be(3);
+            testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT_OUTPUT);
         }
 
         [Theory]
@@ -274,7 +336,7 @@ namespace NuGet.Build.Tasks.Test
 
             testLogger.Warnings.Should().Be(0);
             testLogger.Errors.Should().Be(0);
-            testLogger.DebugMessages.Count.Should().Be(3);
+            testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT_OUTPUT);
         }
 
         [Theory]
@@ -307,7 +369,7 @@ namespace NuGet.Build.Tasks.Test
 
             testLogger.Warnings.Should().Be(0);
             testLogger.Errors.Should().Be(0);
-            testLogger.DebugMessages.Count.Should().Be(3);
+            testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT_OUTPUT);
         }
 
         [Theory]
@@ -340,7 +402,7 @@ namespace NuGet.Build.Tasks.Test
 
             testLogger.Warnings.Should().Be(0);
             testLogger.Errors.Should().Be(0);
-            testLogger.DebugMessages.Count.Should().Be(3);
+            testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT_OUTPUT);
         }
 
 
@@ -373,7 +435,7 @@ namespace NuGet.Build.Tasks.Test
 
             testLogger.Warnings.Should().Be(0);
             testLogger.Errors.Should().Be(1);
-            testLogger.DebugMessages.Count.Should().Be(3);
+            testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT_OUTPUT);
         }
 
         [Theory]
@@ -405,7 +467,7 @@ namespace NuGet.Build.Tasks.Test
 
             testLogger.Warnings.Should().Be(0);
             testLogger.Errors.Should().Be(1);
-            testLogger.DebugMessages.Count.Should().Be(3);
+            testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT_OUTPUT);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetReferenceNearestTargetFrameworkTaskTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetReferenceNearestTargetFrameworkTaskTest.cs
@@ -229,7 +229,7 @@ namespace NuGet.Build.Tasks.Test
             {
                 BuildEngine = buildEngine,
                 CurrentProjectTargetFramework = "netcoreapp2.0",
-                AssetTargetFallbackFrameworks = new string[] { "abcdef" },
+                FallbackTargetFrameworks = new string[] { "abcdef" },
                 AnnotatedProjectReferences = references.ToArray()
             };
 
@@ -258,7 +258,7 @@ namespace NuGet.Build.Tasks.Test
             {
                 BuildEngine = buildEngine,
                 CurrentProjectTargetFramework = "netcoreapp2.0",
-                AssetTargetFallbackFrameworks = new string[] { "net46", "abcdef" },
+                FallbackTargetFrameworks = new string[] { "net46", "abcdef" },
                 AnnotatedProjectReferences = references.ToArray()
             };
 
@@ -290,7 +290,7 @@ namespace NuGet.Build.Tasks.Test
             {
                 BuildEngine = buildEngine,
                 CurrentProjectTargetFramework = "netcoreapp2.0",
-                AssetTargetFallbackFrameworks = new string[] { "net46" },
+                FallbackTargetFrameworks = new string[] { "net46" },
                 AnnotatedProjectReferences = references.ToArray()
             };
 
@@ -324,7 +324,7 @@ namespace NuGet.Build.Tasks.Test
             {
                 BuildEngine = buildEngine,
                 CurrentProjectTargetFramework = "netcoreapp2.0",
-                AssetTargetFallbackFrameworks = new string[] { "net46", "net461" },
+                FallbackTargetFrameworks = new string[] { "net46", "net461" },
                 AnnotatedProjectReferences = references.ToArray()
             };
 
@@ -357,7 +357,7 @@ namespace NuGet.Build.Tasks.Test
             {
                 BuildEngine = buildEngine,
                 CurrentProjectTargetFramework = "netcoreapp2.0",
-                AssetTargetFallbackFrameworks = new string[] { "net46" },
+                FallbackTargetFrameworks = new string[] { "net46" },
                 AnnotatedProjectReferences = references.ToArray()
             };
 
@@ -390,7 +390,7 @@ namespace NuGet.Build.Tasks.Test
             {
                 BuildEngine = buildEngine,
                 CurrentProjectTargetFramework = "netcoreapp2.0",
-                AssetTargetFallbackFrameworks = new string[] { "net46", "net45", "net461" },
+                FallbackTargetFrameworks = new string[] { "net46", "net45", "net461" },
                 AnnotatedProjectReferences = references.ToArray()
             };
 
@@ -424,7 +424,7 @@ namespace NuGet.Build.Tasks.Test
             {
                 BuildEngine = buildEngine,
                 CurrentProjectTargetFramework = "netcoreapp1.0",
-                AssetTargetFallbackFrameworks = new string[] { "net40", "net41" },
+                FallbackTargetFrameworks = new string[] { "net40", "net41" },
                 AnnotatedProjectReferences = references.ToArray()
             };
 
@@ -456,7 +456,7 @@ namespace NuGet.Build.Tasks.Test
             {
                 BuildEngine = buildEngine,
                 CurrentProjectTargetFramework = "netcoreapp1.0",
-                AssetTargetFallbackFrameworks = new string[] { "net45" },
+                FallbackTargetFrameworks = new string[] { "net45" },
                 AnnotatedProjectReferences = references.ToArray()
             };
 


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6322  
Regression: No

## Fix
Details: Enabling  `GetReferenceNearestTargetFrameworkTask` to accept an optional parameter  for ATF frameworks for the project. The compatibility is then checked by comparing the referenced project frameworks with the current project framework first and then the ATF frameworks, if present.

## Testing/Validation
Tests Added: Yes 
