### PR TITLE
Fixing PackageSpec creation for nominated tool restore

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
@@ -64,7 +64,7 @@ namespace NuGet.Commands
                             ProjectReferences = { }
                         }
                     },
-                    ProjectWideWarningProperties = projectWideWarningProperties
+                    ProjectWideWarningProperties = projectWideWarningProperties ?? new WarningProperties()
                 }
             };
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreTransitiveLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreTransitiveLoggingTests.cs
@@ -1059,6 +1059,75 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        // Tests ProjA -> ProjB[PkgX NoWarn NU1603] -> PkgX[NU1603]
+        //                ToolY
+        public void GivenAProjectReferenceNoWarnsVerifyNoWarningWithTool()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("netcoreapp2.0"));
+
+                var projectB = SimpleTestProjectContext.CreateNETCore(
+                    "b",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("netcoreapp2.0"));
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0",
+                    NoWarn = "NU1603"
+                };
+
+                // Created in the source
+                var packageX11 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.1"
+                };
+
+                // Referenced but not created
+                var toolY = new SimpleTestPackageContext()
+                {
+                    Id = "y",
+                    Version = "1.0.1",
+                    PackageType = PackageType.DotnetCliTool
+                };
+
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, packageX11);
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, toolY);
+
+                // B -> X
+                projectB.AddPackageToAllFrameworks(packageX);
+                projectB.Save();
+
+                // A -> B
+                projectA.AddProjectToAllFrameworks(projectB);
+                projectA.AddPackageToAllFrameworks(toolY);
+                projectA.Save();
+
+                solution.Projects.Add(projectA);
+                solution.Projects.Add(projectB);
+                solution.Create(pathContext.SolutionRoot);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.AllOutput.Should().NotContain("NU1603");
+            }
+        }
+
+        [Fact]
         // Tests ProjA[net461] -> ProjB[netstandard2.0][ProjectWide NoWarn NU1603] -> PkgX[NU1603]
         //                                                                         -> ToolY[NU1603]
         public void GivenAProjectReferenceWithToolAndProjectWideNoWarnsVerifyNoWarning()

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreTransitiveLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreTransitiveLoggingTests.cs
@@ -1102,8 +1102,16 @@ namespace NuGet.CommandLine.Test
                     PackageType = PackageType.DotnetCliTool
                 };
 
+                // Created in the source
+                var toolY101 = new SimpleTestPackageContext()
+                {
+                    Id = "y",
+                    Version = "1.0.1",
+                    PackageType = PackageType.DotnetCliTool
+                };
+
                 SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, packageX11);
-                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, toolY);
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, toolY101);
 
                 // B -> X
                 projectB.AddPackageToAllFrameworks(packageX);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/DotnetCliToolTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/DotnetCliToolTests.cs
@@ -3,20 +3,16 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Newtonsoft.Json.Linq;
-using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
-using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
-using NuGet.Protocol;
-using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Xunit;
@@ -40,9 +36,9 @@ namespace NuGet.Commands.Test
                     VersionRange.Parse("1.0.0"),
                     NuGetFramework.Parse("netcoreapp1.0"),
                     pathContext.UserPackagesFolder,
-                    new List<string>() { pathContext.FallbackFolder},
+                    new List<string>() { pathContext.FallbackFolder },
                     new List<PackageSource>() { new PackageSource(pathContext.PackageSource) },
-                    new WarningProperties());
+                    projectWideWarningProperties: null);
 
                 dgFile.AddProject(spec);
                 dgFile.AddRestore(spec.Name);
@@ -104,6 +100,28 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
+        public void DotnetCliTool_VerifyPackageSpecWithoutWarningProperties()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Act
+                var spec = ToolRestoreUtility.GetSpec(
+                    Path.Combine(pathContext.SolutionRoot, "tool", "fake.csproj"),
+                    "a",
+                    VersionRange.Parse("1.0.0"),
+                    NuGetFramework.Parse("netcoreapp1.0"),
+                    pathContext.UserPackagesFolder,
+                    new List<string>() { pathContext.FallbackFolder },
+                    new List<PackageSource>() { new PackageSource(pathContext.PackageSource) },
+                    projectWideWarningProperties: null);
+
+                // Assert
+                spec.RestoreMetadata.ProjectWideWarningProperties.Should().NotBeNull();
+            }
+        }
+
+        [Fact]
         public async Task DotnetCliTool_BasicToolRestore()
         {
             // Arrange
@@ -120,7 +138,7 @@ namespace NuGet.Commands.Test
                     pathContext.UserPackagesFolder,
                     new List<string>() { pathContext.FallbackFolder },
                     new List<PackageSource>() { new PackageSource(pathContext.PackageSource) },
-                    new WarningProperties());
+                    projectWideWarningProperties: null);
 
                 dgFile.AddProject(spec);
                 dgFile.AddRestore(spec.Name);
@@ -159,7 +177,7 @@ namespace NuGet.Commands.Test
                                         pathContext.UserPackagesFolder,
                     new List<string>() { pathContext.FallbackFolder },
                     new List<PackageSource>() { new PackageSource(pathContext.PackageSource) },
-                    new WarningProperties());
+                    projectWideWarningProperties: null);
 
                 var spec2 = ToolRestoreUtility.GetSpec(
                     Path.Combine(pathContext.SolutionRoot, "fake2.csproj"),
@@ -169,7 +187,7 @@ namespace NuGet.Commands.Test
                                         pathContext.UserPackagesFolder,
                     new List<string>() { pathContext.FallbackFolder },
                     new List<PackageSource>() { new PackageSource(pathContext.PackageSource) },
-                    new WarningProperties());
+                    projectWideWarningProperties: null);
 
                 var dgFile1 = new DependencyGraphSpec();
                 dgFile1.AddProject(spec1);
@@ -230,7 +248,7 @@ namespace NuGet.Commands.Test
                                             pathContext.UserPackagesFolder,
                     new List<string>() { pathContext.FallbackFolder },
                     new List<PackageSource>() { new PackageSource(pathContext.PackageSource) },
-                    new WarningProperties());
+                    projectWideWarningProperties: null);
 
                     dgFile.AddProject(spec);
                     dgFile.AddRestore(spec.Name);
@@ -283,7 +301,7 @@ namespace NuGet.Commands.Test
                                             pathContext.UserPackagesFolder,
                     new List<string>() { pathContext.FallbackFolder },
                     new List<PackageSource>() { new PackageSource(pathContext.PackageSource) },
-                    new WarningProperties());
+                    projectWideWarningProperties: null);
 
                     dgFile.AddProject(spec);
                     dgFile.AddRestore(spec.Name);
@@ -320,7 +338,7 @@ namespace NuGet.Commands.Test
         }
 
         [Theory]
-        [InlineData("tool","netcoreapp1.0","1.0.0", "tool-netcoreapp1.0-[1.0.0, )")]
+        [InlineData("tool", "netcoreapp1.0", "1.0.0", "tool-netcoreapp1.0-[1.0.0, )")]
         [InlineData("Tool", "netcoreapp1.0", "1.0.0", "tool-netcoreapp1.0-[1.0.0, )")]
         [InlineData("tOOl", "NetCoreapp1.0", "1.0.0", "tool-netcoreapp1.0-[1.0.0, )")]
         public void DotnetCliTool_TestGetUniqueName(string name, string framework, string version, string expected)
@@ -328,7 +346,7 @@ namespace NuGet.Commands.Test
             Assert.Equal(expected, ToolRestoreUtility.GetUniqueName(name, framework, VersionRange.Parse(version)));
         }
 
-        [Fact] 
+        [Fact]
         public void DotnetCliTool_TestGetUniqueName_VersionRangeAll()
         {
             Assert.Equal("tool-netcoreapp1.0-(, )", ToolRestoreUtility.GetUniqueName("tool", "netcoreapp1.0", VersionRange.All));


### PR DESCRIPTION
## Bug
Fixes: Internal issue 543484
Regression: Yes
If Regression then when did it last work: 15.3

## Fix
Details: The package spec creation for nomination has been using `ToolRestoreUtility` which was not correctly initializing `ProjectWideWarningProperties` in the `RestoreMetadata`, resulting in a null ref exception in tool restore. I have fixed this by keeping the assignment consistent with other DgSpec creation [code](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs#L830) to have a default warning properties. 

## Testing/Validation
Tests Added: Yes
Validation done:  Manual validation for the failing case.
