### PR TITLE
Fixing NRE in PMC window on RequestRestoreBar

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
+++ b/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
@@ -70,11 +70,6 @@ namespace NuGetConsole.Implementation
             get { return ComponentModel.GetService<IPowerConsoleWindow>() as PowerConsoleWindow; }
         }
 
-        private IVsShell4 VsShell
-        {
-            get { return this.GetService<IVsShell4>(typeof(SVsShell)); }
-        }
-
         private IVsUIShell VsUIShell
         {
             get { return this.GetService<IVsUIShell>(typeof(SVsUIShell)); }
@@ -589,7 +584,7 @@ namespace NuGetConsole.Implementation
             {
                 if (_consoleParentPane == null)
                 {
-                    _consoleParentPane = new ConsoleContainer(VsShell);
+                    _consoleParentPane = new ConsoleContainer();
                 }
                 return _consoleParentPane;
             }

--- a/src/NuGet.Clients/NuGet.Console/Xamls/ConsoleContainer.xaml.cs
+++ b/src/NuGet.Clients/NuGet.Console/Xamls/ConsoleContainer.xaml.cs
@@ -16,9 +16,8 @@ namespace NuGetConsole
     /// </summary>
     public partial class ConsoleContainer : UserControl
     {
-        public ConsoleContainer(IVsShell4 shell)
+        public ConsoleContainer()
         {
-
             InitializeComponent();
 
             ThreadHelper.JoinableTaskFactory.StartOnIdle(
@@ -31,6 +30,7 @@ namespace NuGetConsole
                             var productUpdateService = ServiceLocator.GetInstance<IProductUpdateService>();
                             var packageRestoreManager = ServiceLocator.GetInstance<IPackageRestoreManager>();
                             var deleteOnRestartManager = ServiceLocator.GetInstance<IDeleteOnRestartManager>();
+                            var shell = ServiceLocator.GetGlobalService<SVsShell, IVsShell4>();
 
                             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 


### PR DESCRIPTION
While initializing PMC console, `SvsShell` instance is null since it had not been loaded yet. So changed that to retrieve `SvsShell` instance right before creating RequestRestoreBar.

Fixes internal bug# 548482

@rrelyea 