### PR TITLE
Signing:  add test timestamp service

### DIFF
--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
@@ -7,6 +7,8 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
 using NuGet.CommandLine.Test;
 using NuGet.Packaging.Signing;
 using NuGet.Test.Utility;
@@ -19,8 +21,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
     /// </summary>
     public class SignCommandTestFixture : IDisposable
     {
-        private static readonly string _testTimestampServer = Environment.GetEnvironmentVariable("TIMESTAMP_SERVER_URL");
-
         private const int _validCertChainLength = 3;
         private const int _invalidCertChainLength = 2;
 
@@ -28,6 +28,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         private TrustedTestCert<TestCertificate> _trustedTestCertWithInvalidEku;
         private TrustedTestCert<TestCertificate> _trustedTestCertExpired;
         private TrustedTestCert<TestCertificate> _trustedTestCertNotYetValid;
+        private TrustedTestCert<X509Certificate2> _trustedTimestampRoot;
         private TrustedTestCertificateChain _trustedTestCertChain;
         private TrustedTestCertificateChain _revokedTestCertChain;
         private TrustedTestCertificateChain _revocationUnknownTestCertChain;
@@ -38,6 +39,10 @@ namespace NuGet.CommandLine.FuncTest.Commands
         private object _crlServerRunningLock = new object();
         private TestDirectory _testDirectory;
         private string _nugetExePath;
+        private Lazy<Task<SigningTestServer>> _testServer;
+        private Lazy<Task<CertificateAuthority>> _defaultTrustedCertificateAuthority;
+        private Lazy<Task<TimestampService>> _defaultTrustedTimestampService;
+        private readonly DisposableList _responders;
 
         public TrustedTestCert<TestCertificate> TrustedTestCertificate
         {
@@ -173,7 +178,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-
         public IList<ISignatureVerificationProvider> TrustProviders
         {
             get
@@ -243,7 +247,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        public string Timestamper => _testTimestampServer;
+        public SignCommandTestFixture()
+        {
+            _testServer = new Lazy<Task<SigningTestServer>>(SigningTestServer.CreateAsync);
+            _defaultTrustedCertificateAuthority = new Lazy<Task<CertificateAuthority>>(CreateDefaultTrustedCertificateAuthorityAsync);
+            _defaultTrustedTimestampService = new Lazy<Task<TimestampService>>(CreateDefaultTrustedTimestampServiceAsync);
+            _responders = new DisposableList();
+        }
 
         private void SetUpCrlDistributionPoint()
         {
@@ -293,18 +303,77 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
+        public async Task<ISigningTestServer> GetSigningTestServerAsync()
+        {
+            return await _testServer.Value;
+        }
+
+        public async Task<CertificateAuthority> GetDefaultTrustedCertificateAuthorityAsync()
+        {
+            return await _defaultTrustedCertificateAuthority.Value;
+        }
+
+        public async Task<TimestampService> GetDefaultTrustedTimestampServiceAsync()
+        {
+            return await _defaultTrustedTimestampService.Value;
+        }
+
         public void Dispose()
         {
             _trustedTestCert?.Dispose();
             _trustedTestCertWithInvalidEku?.Dispose();
             _trustedTestCertExpired?.Dispose();
             _trustedTestCertNotYetValid?.Dispose();
+            _trustedTimestampRoot?.Dispose();
             _trustedTestCertChain?.Dispose();
             _revokedTestCertChain?.Dispose();
             _revocationUnknownTestCertChain?.Dispose();
             _crlServer?.Stop();
             _crlServer?.Dispose();
             _testDirectory?.Dispose();
+            _responders.Dispose();
+
+            if (_testServer.IsValueCreated)
+            {
+                _testServer.Value.Result.Dispose();
+            }
+        }
+
+        private async Task<CertificateAuthority> CreateDefaultTrustedCertificateAuthorityAsync()
+        {
+            var testServer = await _testServer.Value;
+            var rootCa = CertificateAuthority.Create(testServer.Url);
+            var intermediateCa = rootCa.CreateIntermediateCertificateAuthority();
+            var rootCertificate = new X509Certificate2(rootCa.Certificate.GetEncoded());
+
+            _trustedTimestampRoot = new TrustedTestCert<X509Certificate2>(
+                rootCertificate,
+                _ => _,
+                StoreName.Root,
+                StoreLocation.LocalMachine);
+
+            var ca = intermediateCa;
+
+            while (ca != null)
+            {
+                _responders.Add(testServer.RegisterResponder(ca));
+                _responders.Add(testServer.RegisterResponder(ca.OcspResponder));
+
+                ca = ca.Parent;
+            }
+
+            return intermediateCa;
+        }
+
+        private async Task<TimestampService> CreateDefaultTrustedTimestampServiceAsync()
+        {
+            var testServer = await _testServer.Value;
+            var ca = await _defaultTrustedCertificateAuthority.Value;
+            var timestampService = TimestampService.Create(ca);
+
+            _responders.Add(testServer.RegisterResponder(timestampService));
+
+            return timestampService;
         }
     }
 }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
-using System.Threading;
 using System.Threading.Tasks;
 using NuGet.CommandLine.Test;
 using NuGet.Packaging.Signing;
@@ -348,7 +347,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
             _trustedTimestampRoot = new TrustedTestCert<X509Certificate2>(
                 rootCertificate,
-                _ => _,
+                certificate => certificate,
                 StoreName.Root,
                 StoreLocation.LocalMachine);
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MockServer.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MockServer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using NuGet.Common;
 using NuGet.Protocol;
+using Test.Utility;
 
 namespace NuGet.CommandLine.Test
 {
@@ -326,11 +327,6 @@ namespace NuGet.CommandLine.Test
 
         private void HandleRequest()
         {
-            const int ERROR_OPERATION_ABORTED = 995;
-            const int ERROR_INVALID_HANDLE = 6;
-            const int ERROR_INVALID_FUNCTION = 1;
-            const int ERROR_OPERATION_ABORTED_MONO = 500;
-
             while (true)
             {
                 try
@@ -344,10 +340,10 @@ namespace NuGet.CommandLine.Test
                 }
                 catch (HttpListenerException ex)
                 {
-                    if (ex.ErrorCode == ERROR_OPERATION_ABORTED ||
-                        ex.ErrorCode == ERROR_INVALID_HANDLE ||
-                        ex.ErrorCode == ERROR_INVALID_FUNCTION ||
-                        RuntimeEnvironmentHelper.IsMono && ex.ErrorCode == ERROR_OPERATION_ABORTED_MONO)
+                    if (ex.ErrorCode == ErrorConstants.ERROR_OPERATION_ABORTED ||
+                        ex.ErrorCode == ErrorConstants.ERROR_INVALID_HANDLE ||
+                        ex.ErrorCode == ErrorConstants.ERROR_INVALID_FUNCTION ||
+                        RuntimeEnvironmentHelper.IsMono && ex.ErrorCode == ErrorConstants.ERROR_OPERATION_ABORTED_MONO)
                     {
                         return;
                     }

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -44,12 +43,16 @@ namespace NuGet.Packaging.FuncTest
         {
             // Arrange
             var nupkg = new SimpleTestPackageContext();
-            var testLogger = new TestLogger();
+            var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
 
             using (var dir = TestDirectory.Create())
             {
                 // Act
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedAndTimeStampedPackageAsync(_trustedTestCert.Source.Cert, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedAndTimeStampedPackageAsync(
+                    _trustedTestCert.Source.Cert,
+                    nupkg,
+                    dir,
+                    timestampService.Url);
 
                 // Assert
                 using (var stream = File.OpenRead(signedPackagePath))
@@ -68,7 +71,6 @@ namespace NuGet.Packaging.FuncTest
         {
             // Arrange
             var nupkg = new SimpleTestPackageContext();
-            var testLogger = new TestLogger();
 
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
@@ -153,7 +153,7 @@ namespace NuGet.Packaging.FuncTest
 
             _trustedTimestampRoot = new TrustedTestCert<X509Certificate2>(
                 rootCertificate,
-                _ => _,
+                certificate => certificate,
                 StoreName.Root,
                 StoreLocation.LocalMachine);
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using NuGet.Packaging.Signing;
 using Test.Utility.Signing;
 
@@ -14,14 +15,25 @@ namespace NuGet.Packaging.FuncTest
     /// </summary>
     public class SigningTestFixture : IDisposable
     {
-        private static readonly string _testTimestampServer = Environment.GetEnvironmentVariable("TIMESTAMP_SERVER_URL");
-
         private TrustedTestCert<TestCertificate> _trustedTestCert;
         private TrustedTestCert<TestCertificate> _trustedTestCertExpired;
         private TrustedTestCert<TestCertificate> _trustedTestCertNotYetValid;
+        private TrustedTestCert<X509Certificate2> _trustedTimestampRoot;
         private IReadOnlyList<TrustedTestCert<TestCertificate>> _trustedTestCertificateWithReissuedCertificate;
         private IList<ISignatureVerificationProvider> _trustProviders;
         private SigningSpecifications _signingSpecifications;
+        private Lazy<Task<SigningTestServer>> _testServer;
+        private Lazy<Task<CertificateAuthority>> _defaultTrustedCertificateAuthority;
+        private Lazy<Task<TimestampService>> _defaultTrustedTimestampService;
+        private readonly DisposableList _responders;
+
+        public SigningTestFixture()
+        {
+            _testServer = new Lazy<Task<SigningTestServer>>(SigningTestServer.CreateAsync);
+            _defaultTrustedCertificateAuthority = new Lazy<Task<CertificateAuthority>>(CreateDefaultTrustedCertificateAuthorityAsync);
+            _defaultTrustedTimestampService = new Lazy<Task<TimestampService>>(CreateDefaultTrustedTimestampServiceAsync);
+            _responders = new DisposableList();
+        }
 
         public TrustedTestCert<TestCertificate> TrustedTestCertificate
         {
@@ -117,11 +129,78 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        public string Timestamper => _testTimestampServer;
+        public async Task<ISigningTestServer> GetSigningTestServerAsync()
+        {
+            return await _testServer.Value;
+        }
+
+        public async Task<CertificateAuthority> GetDefaultTrustedCertificateAuthorityAsync()
+        {
+            return await _defaultTrustedCertificateAuthority.Value;
+        }
+
+        public async Task<TimestampService> GetDefaultTrustedTimestampServiceAsync()
+        {
+            return await _defaultTrustedTimestampService.Value;
+        }
+
+        private async Task<CertificateAuthority> CreateDefaultTrustedCertificateAuthorityAsync()
+        {
+            var testServer = await _testServer.Value;
+            var rootCa = CertificateAuthority.Create(testServer.Url);
+            var intermediateCa = rootCa.CreateIntermediateCertificateAuthority();
+            var rootCertificate = new X509Certificate2(rootCa.Certificate.GetEncoded());
+
+            _trustedTimestampRoot = new TrustedTestCert<X509Certificate2>(
+                rootCertificate,
+                _ => _,
+                StoreName.Root,
+                StoreLocation.LocalMachine);
+
+            var ca = intermediateCa;
+
+            while (ca != null)
+            {
+                _responders.Add(testServer.RegisterResponder(ca));
+                _responders.Add(testServer.RegisterResponder(ca.OcspResponder));
+
+                ca = ca.Parent;
+            }
+
+            return intermediateCa;
+        }
+
+        private async Task<TimestampService> CreateDefaultTrustedTimestampServiceAsync()
+        {
+            var testServer = await _testServer.Value;
+            var ca = await _defaultTrustedCertificateAuthority.Value;
+            var timestampService = TimestampService.Create(ca);
+
+            _responders.Add(testServer.RegisterResponder(timestampService));
+
+            return timestampService;
+        }
 
         public void Dispose()
         {
             _trustedTestCert?.Dispose();
+            _trustedTestCertExpired?.Dispose();
+            _trustedTestCertNotYetValid?.Dispose();
+            _trustedTimestampRoot?.Dispose();
+            _responders.Dispose();
+
+            if (_trustedTestCertificateWithReissuedCertificate != null)
+            {
+                foreach (var certificate in _trustedTestCertificateWithReissuedCertificate)
+                {
+                    certificate.Dispose();
+                }
+            }
+
+            if (_testServer.IsValueCreated)
+            {
+                _testServer.Value.Result.Dispose();
+            }
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignTestUtility.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignTestUtility.cs
@@ -14,21 +14,6 @@ namespace NuGet.Packaging.Test
 {
     public static class SignTestUtility
     {
-        // Environment variable for a valid RFC 3161 timestamping service.
-        private static readonly string _testTimestampServer = Environment.GetEnvironmentVariable("TIMESTAMP_SERVER_URL");
-
-        /// <summary>
-        /// Sign a package for test purposes.
-        /// </summary>
-        public static async Task SignPackageAsync(TestLogger testLogger, X509Certificate2 certificate, SignedPackageArchive signPackage)
-        {
-            var testSignatureProvider = new X509SignatureProvider(new Rfc3161TimestampProvider(new Uri(_testTimestampServer)));
-            var signer = new Signer(signPackage, testSignatureProvider);
-            var request = new AuthorSignPackageRequest(certificate, HashAlgorithmName.SHA256);
-
-            await signer.SignAsync(request, testLogger, CancellationToken.None);
-        }
-
         public static async Task<VerifySignaturesResult> VerifySignatureAsync(SignedPackageArchive signPackage, SignedPackageVerifierSettings settings)
         {
             var verificationProviders = new[] { new SignatureTrustAndValidityVerificationProvider() };

--- a/test/TestUtilities/Test.Utility/ErrorConstants.cs
+++ b/test/TestUtilities/Test.Utility/ErrorConstants.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Test.Utility
+{
+    public static class ErrorConstants
+    {
+        public const int ERROR_OPERATION_ABORTED = 995;
+        public const int ERROR_INVALID_HANDLE = 6;
+        public const int ERROR_INVALID_FUNCTION = 1;
+        public const int ERROR_OPERATION_ABORTED_MONO = 500;
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/CertificateAuthority.cs
+++ b/test/TestUtilities/Test.Utility/Signing/CertificateAuthority.cs
@@ -1,0 +1,348 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Security.Cryptography;
+using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Asn1.Ocsp;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Operators;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Ocsp;
+using Org.BouncyCastle.X509;
+using Org.BouncyCastle.X509.Extension;
+
+namespace Test.Utility.Signing
+{
+    public sealed class CertificateAuthority : HttpResponder
+    {
+        private readonly Dictionary<BigInteger, X509Certificate> _issuedCertificates;
+        private readonly Dictionary<BigInteger, RevocationInfo> _revokedCertificates;
+        private readonly Lazy<OcspResponder> _ocspResponder;
+        private BigInteger _nextSerialNumber;
+
+        /// <summary>
+        /// This base URI is shared amongst all HTTP responders hosted by the same web host instance.
+        /// </summary>
+        public Uri SharedUri { get; }
+
+        public X509Certificate Certificate { get; }
+
+        /// <summary>
+        /// Gets the base URI specific to this HTTP responder.
+        /// </summary>
+        public override Uri Url { get; }
+
+        public OcspResponder OcspResponder => _ocspResponder.Value;
+        public CertificateAuthority Parent { get; }
+
+        internal Uri CertificateUri { get; }
+        internal Uri OcspResponderUri { get; }
+        internal AsymmetricCipherKeyPair KeyPair { get; }
+
+        private CertificateAuthority(
+            X509Certificate certificate,
+            AsymmetricCipherKeyPair keyPair,
+            Uri sharedUri,
+            CertificateAuthority parentCa)
+        {
+            Certificate = certificate;
+            KeyPair = keyPair;
+            SharedUri = sharedUri;
+            Url = GenerateRandomUri();
+            var fingerprint = CertificateUtilities.GenerateFingerprint(certificate);
+            CertificateUri = new Uri(Url, $"{fingerprint}.cer");
+            OcspResponderUri = GenerateRandomUri();
+            Parent = parentCa;
+            _nextSerialNumber = certificate.SerialNumber.Add(BigInteger.One);
+            _issuedCertificates = new Dictionary<BigInteger, X509Certificate>();
+            _revokedCertificates = new Dictionary<BigInteger, RevocationInfo>();
+            _ocspResponder = new Lazy<OcspResponder>(() => new OcspResponder(this, OcspResponderUri));
+        }
+
+        public X509Certificate IssueCertificate(
+            AsymmetricKeyParameter publicKey,
+            X509Name subjectName,
+            Action<X509V3CertificateGenerator> customizeCertificate = null)
+        {
+            if (publicKey == null)
+            {
+                throw new ArgumentNullException(nameof(publicKey));
+            }
+
+            if (subjectName == null)
+            {
+                throw new ArgumentNullException(nameof(subjectName));
+            }
+
+            var serialNumber = _nextSerialNumber;
+            var issuerName = PrincipalUtilities.GetSubjectX509Principal(Certificate);
+            var now = DateTime.UtcNow;
+
+            if (customizeCertificate == null)
+            {
+                customizeCertificate = generator =>
+                {
+                    generator.AddExtension(
+                        X509Extensions.AuthorityInfoAccess,
+                        critical: false,
+                        extensionValue: new DerSequence(
+                            new AccessDescription(AccessDescription.IdADOcsp,
+                                new GeneralName(GeneralName.UniformResourceIdentifier, OcspResponderUri.OriginalString)),
+                            new AccessDescription(AccessDescription.IdADCAIssuers,
+                                new GeneralName(GeneralName.UniformResourceIdentifier, CertificateUri.OriginalString))));
+                    generator.AddExtension(
+                        X509Extensions.AuthorityKeyIdentifier,
+                        critical: false,
+                        extensionValue: new AuthorityKeyIdentifierStructure(Certificate));
+                    generator.AddExtension(
+                        X509Extensions.SubjectKeyIdentifier,
+                        critical: false,
+                        extensionValue: new SubjectKeyIdentifierStructure(publicKey));
+                    generator.AddExtension(
+                        X509Extensions.BasicConstraints,
+                        critical: true,
+                        extensionValue: new BasicConstraints(cA: false));
+                };
+            }
+
+            var notAfter = now.AddHours(2);
+
+            // An issued certificate should not have a validity period beyond the issuer's validity period.
+            if (notAfter > Certificate.NotAfter)
+            {
+                notAfter = Certificate.NotAfter;
+            }
+
+            var certificate = CreateCertificate(
+                publicKey,
+                KeyPair.Private,
+                serialNumber,
+                issuerName,
+                subjectName,
+                now,
+                notAfter,
+                customizeCertificate);
+
+            _nextSerialNumber = _nextSerialNumber.Add(BigInteger.One);
+            _issuedCertificates.Add(certificate.SerialNumber, certificate);
+
+            return certificate;
+        }
+
+        public CertificateAuthority CreateIntermediateCertificateAuthority()
+        {
+            var keyPair = CertificateUtilities.CreateKeyPair();
+            var certificate = IssueCaCertificate(keyPair.Public);
+
+            return new CertificateAuthority(certificate, keyPair, SharedUri, parentCa: this);
+        }
+
+        public void Revoke(X509Certificate certificate, int reason, DateTimeOffset revocationDate)
+        {
+            if (certificate == null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            if (!_issuedCertificates.ContainsKey(certificate.SerialNumber))
+            {
+                throw new ArgumentException("Unknown serial number.", nameof(certificate));
+            }
+
+            if (_revokedCertificates.ContainsKey(certificate.SerialNumber))
+            {
+                throw new ArgumentException("Certificate already revoked.", nameof(certificate));
+            }
+
+            _revokedCertificates.Add(certificate.SerialNumber, new RevocationInfo(certificate.SerialNumber, revocationDate.UtcDateTime, reason));
+        }
+
+#if IS_DESKTOP
+        public override void Respond(HttpListenerContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (IsGet(context.Request) &&
+                string.Equals(context.Request.RawUrl, CertificateUri.AbsolutePath, StringComparison.OrdinalIgnoreCase))
+            {
+                WriteResponseBody(context.Response, Certificate.GetEncoded());
+            }
+            else
+            {
+                context.Response.StatusCode = 404;
+            }
+        }
+#endif
+
+        public static CertificateAuthority Create(Uri sharedUri)
+        {
+            if (sharedUri == null)
+            {
+                throw new ArgumentNullException(nameof(sharedUri));
+            }
+
+            if (!sharedUri.AbsoluteUri.EndsWith("/"))
+            {
+                sharedUri = new Uri($"{sharedUri.AbsoluteUri}/");
+            }
+
+            var keyPair = CertificateUtilities.CreateKeyPair();
+            var id = Guid.NewGuid().ToString();
+            var subjectName = new X509Name($"C=US,ST=WA,L=Redmond,O=NuGet,CN=NuGet Test Root Certificate Authority ({id})");
+            var now = DateTime.UtcNow;
+
+            void customizeCertificate(X509V3CertificateGenerator generator)
+            {
+                generator.AddExtension(
+                    X509Extensions.SubjectKeyIdentifier,
+                    critical: false,
+                    extensionValue: new SubjectKeyIdentifierStructure(keyPair.Public));
+                generator.AddExtension(
+                    X509Extensions.BasicConstraints,
+                    critical: true,
+                    extensionValue: new BasicConstraints(cA: true));
+                generator.AddExtension(
+                    X509Extensions.KeyUsage,
+                    critical: true,
+                    extensionValue: new KeyUsage(KeyUsage.DigitalSignature | KeyUsage.KeyCertSign | KeyUsage.CrlSign));
+            }
+
+            var certificate = CreateCertificate(
+                keyPair.Public,
+                keyPair.Private,
+                BigInteger.One,
+                subjectName,
+                subjectName,
+                now,
+                now.AddHours(2),
+                customizeCertificate);
+
+            return new CertificateAuthority(certificate, keyPair, sharedUri, parentCa: null);
+        }
+
+        internal CertificateStatus GetStatus(CertificateID certificateId)
+        {
+            if (certificateId == null)
+            {
+                throw new ArgumentNullException(nameof(certificateId));
+            }
+
+            if (certificateId.MatchesIssuer(Certificate) &&
+                _issuedCertificates.ContainsKey(certificateId.SerialNumber))
+            {
+                RevocationInfo revocationInfo;
+
+                if (!_revokedCertificates.TryGetValue(certificateId.SerialNumber, out revocationInfo))
+                {
+                    return CertificateStatus.Good;
+                }
+
+                var revocationDate = new DerGeneralizedTime(revocationInfo.RevocationDate);
+                var reason = new CrlReason(revocationInfo.Reason);
+                var revokedInfo = new RevokedInfo(revocationDate, reason);
+
+                return new RevokedStatus(revokedInfo);
+            }
+
+            return new UnknownStatus();
+        }
+
+        internal Uri GenerateRandomUri()
+        {
+            using (var provider = RandomNumberGenerator.Create())
+            {
+                var bytes = new byte[32];
+
+                provider.GetBytes(bytes);
+
+                var path = BitConverter.ToString(bytes).Replace("-", "");
+
+                return new Uri(SharedUri, $"{path}/");
+            }
+        }
+
+        private X509Certificate IssueCaCertificate(
+            AsymmetricKeyParameter publicKey,
+            Action<X509V3CertificateGenerator> customizeCertificate = null)
+        {
+            var id = Guid.NewGuid().ToString();
+            var subjectName = new X509Name($"C=US,ST=WA,L=Redmond,O=NuGet,CN=NuGet Test Intermediate Certificate Authority ({id})");
+
+            if (customizeCertificate == null)
+            {
+                customizeCertificate = generator =>
+                {
+                    generator.AddExtension(
+                        X509Extensions.AuthorityInfoAccess,
+                        critical: false,
+                        extensionValue: new DerSequence(
+                            new AccessDescription(AccessDescription.IdADOcsp,
+                                new GeneralName(GeneralName.UniformResourceIdentifier, OcspResponderUri.OriginalString)),
+                            new AccessDescription(AccessDescription.IdADCAIssuers,
+                                new GeneralName(GeneralName.UniformResourceIdentifier, CertificateUri.OriginalString))));
+                    generator.AddExtension(
+                        X509Extensions.AuthorityKeyIdentifier,
+                        critical: false,
+                        extensionValue: new AuthorityKeyIdentifierStructure(Certificate));
+                    generator.AddExtension(
+                        X509Extensions.SubjectKeyIdentifier,
+                        critical: false,
+                        extensionValue: new SubjectKeyIdentifierStructure(publicKey));
+                    generator.AddExtension(
+                        X509Extensions.BasicConstraints,
+                        critical: true,
+                        extensionValue: new BasicConstraints(cA: true));
+                };
+            }
+
+            return IssueCertificate(publicKey, subjectName, customizeCertificate);
+        }
+
+        private static X509Certificate CreateCertificate(
+            AsymmetricKeyParameter certificatePublicKey,
+            AsymmetricKeyParameter signingPrivateKey,
+            BigInteger serialNumber,
+            X509Name issuerName,
+            X509Name subjectName,
+            DateTime notBefore,
+            DateTime notAfter,
+            Action<X509V3CertificateGenerator> customizeCertificate)
+        {
+            var generator = new X509V3CertificateGenerator();
+
+            generator.SetSerialNumber(serialNumber);
+            generator.SetIssuerDN(issuerName);
+            generator.SetNotBefore(notBefore);
+            generator.SetNotAfter(notAfter);
+            generator.SetSubjectDN(subjectName);
+            generator.SetPublicKey(certificatePublicKey);
+
+            customizeCertificate(generator);
+
+            var signatureFactory = new Asn1SignatureFactory("SHA256WITHRSA", signingPrivateKey);
+
+            return generator.Generate(signatureFactory);
+        }
+
+        private sealed class RevocationInfo
+        {
+            internal BigInteger SerialNumber { get; }
+            internal DateTime RevocationDate { get; }
+            internal int Reason { get; }
+
+            internal RevocationInfo(BigInteger serialNumber, DateTime revocationDate, int reason)
+            {
+                SerialNumber = serialNumber;
+                RevocationDate = revocationDate;
+                Reason = reason;
+            }
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/CertificateUtilities.cs
+++ b/test/TestUtilities/Test.Utility/Signing/CertificateUtilities.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Common;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.X509;
+
+namespace Test.Utility.Signing
+{
+    internal static class CertificateUtilities
+    {
+        internal static AsymmetricCipherKeyPair CreateKeyPair()
+        {
+            var generator = new RsaKeyPairGenerator();
+
+            generator.Init(new KeyGenerationParameters(new SecureRandom(), strength: 2048));
+
+            return generator.GenerateKeyPair();
+        }
+
+        internal static string GenerateFingerprint(X509Certificate certificate)
+        {
+            using (var hashAlgorithm = CryptoHashUtility.GetSha1HashProvider())
+            {
+                var hash = hashAlgorithm.ComputeHash(certificate.GetEncoded());
+
+                return BitConverter.ToString(hash).Replace("-", "");
+            }
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/DisposableList.cs
+++ b/test/TestUtilities/Test.Utility/Signing/DisposableList.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Test.Utility.Signing
+{
+    public sealed class DisposableList : List<IDisposable>, IDisposable
+    {
+        private bool _isDisposed;
+
+        public void Dispose()
+        {
+            if (!_isDisposed)
+            {
+                foreach (var item in this)
+                {
+                    item.Dispose();
+                }
+
+                Clear();
+
+                GC.SuppressFinalize(this);
+
+                _isDisposed = true;
+            }
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/HttpResponder.cs
+++ b/test/TestUtilities/Test.Utility/Signing/HttpResponder.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Net;
+
+namespace Test.Utility.Signing
+{
+    public abstract class HttpResponder : IHttpResponder
+    {
+        public abstract Uri Url { get; }
+
+#if IS_DESKTOP
+        public abstract void Respond(HttpListenerContext context);
+
+        protected static bool IsGet(HttpListenerRequest request)
+        {
+            return string.Equals(request.HttpMethod, "GET", StringComparison.OrdinalIgnoreCase);
+        }
+
+        protected static bool IsPost(HttpListenerRequest request)
+        {
+            return string.Equals(request.HttpMethod, "POST", StringComparison.OrdinalIgnoreCase);
+        }
+
+        protected static byte[] ReadRequestBody(HttpListenerRequest request)
+        {
+            using (var reader = new BinaryReader(request.InputStream))
+            {
+                return reader.ReadBytes((int)request.ContentLength64);
+            }
+        }
+
+        protected static void WriteResponseBody(HttpListenerResponse response, byte[] bytes)
+        {
+            response.ContentLength64 = bytes.Length;
+
+            using (var writer = new BinaryWriter(response.OutputStream))
+            {
+                writer.Write(bytes);
+            }
+        }
+#endif
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/IHttpResonder.cs
+++ b/test/TestUtilities/Test.Utility/Signing/IHttpResonder.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+
+namespace Test.Utility.Signing
+{
+    public interface IHttpResponder
+    {
+        Uri Url { get; }
+
+#if IS_DESKTOP
+        void Respond(HttpListenerContext context);
+#endif
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/ISigningTestServer.cs
+++ b/test/TestUtilities/Test.Utility/Signing/ISigningTestServer.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Test.Utility.Signing
+{
+    public interface ISigningTestServer
+    {
+        Uri Url { get; }
+
+#if IS_DESKTOP
+        IDisposable RegisterResponder(IHttpResponder responder);
+#endif
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/OcspResponder.cs
+++ b/test/TestUtilities/Test.Utility/Signing/OcspResponder.cs
@@ -1,0 +1,133 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Asn1.Ocsp;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Ocsp;
+using Org.BouncyCastle.X509;
+
+namespace Test.Utility.Signing
+{
+    // https://tools.ietf.org/html/rfc6960
+    public sealed class OcspResponder : HttpResponder
+    {
+        private const string RequestContentType = "application/ocsp-request";
+        private const string ResponseContentType = "application/ocsp-response";
+
+        public override Uri Url { get; }
+
+        internal CertificateAuthority CertificateAuthority { get; }
+
+        internal OcspResponder(CertificateAuthority certificateAuthority, Uri uri)
+        {
+            if (certificateAuthority == null)
+            {
+                throw new ArgumentNullException(nameof(certificateAuthority));
+            }
+
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            CertificateAuthority = certificateAuthority;
+            Url = uri;
+        }
+
+#if IS_DESKTOP
+        public override void Respond(HttpListenerContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var bytes = GetOcspRequest(context);
+
+            if (bytes == null)
+            {
+                context.Response.StatusCode = 400;
+
+                return;
+            }
+
+            var ocspReq = new OcspReq(bytes);
+            var respId = new RespID(CertificateAuthority.Certificate.SubjectDN);
+            var basicOcspRespGenerator = new BasicOcspRespGenerator(respId);
+            var requests = ocspReq.GetRequestList();
+            var nonce = ocspReq.GetExtensionValue(OcspObjectIdentifiers.PkixOcspNonce);
+
+            if (nonce != null)
+            {
+                var extensions = new X509Extensions(new Dictionary<DerObjectIdentifier, X509Extension>()
+                {
+                    { OcspObjectIdentifiers.PkixOcspNonce, new X509Extension(critical: false, value: nonce) }
+                });
+
+                basicOcspRespGenerator.SetResponseExtensions(extensions);
+            }
+
+            var now = DateTime.UtcNow;
+
+            foreach (var request in requests)
+            {
+                var certificateId = request.GetCertID();
+                var certificateStatus = CertificateAuthority.GetStatus(certificateId);
+
+                basicOcspRespGenerator.AddResponse(certificateId, certificateStatus, thisUpdate: now, nextUpdate: now.AddSeconds(1), singleExtensions: null);
+            }
+
+            var certificateChain = GetCertificateChain();
+            var basicOcspResp = basicOcspRespGenerator.Generate("SHA256WITHRSA", CertificateAuthority.KeyPair.Private, certificateChain, now);
+            var ocspRespGenerator = new OCSPRespGenerator();
+            var ocspResp = ocspRespGenerator.Generate(OCSPRespGenerator.Successful, basicOcspResp);
+
+            bytes = ocspResp.GetEncoded();
+
+            context.Response.ContentType = ResponseContentType;
+
+            WriteResponseBody(context.Response, bytes);
+        }
+
+        private static byte[] GetOcspRequest(HttpListenerContext context)
+        {
+            // See https://tools.ietf.org/html/rfc6960#appendix-A.
+            if (IsGet(context.Request))
+            {
+                var path = context.Request.RawUrl;
+                var urlEncoded = path.Substring(path.IndexOf('/', 1)).TrimStart('/');
+                var base64 = WebUtility.UrlDecode(urlEncoded);
+
+                return Convert.FromBase64String(base64);
+            }
+
+            if (IsPost(context.Request) &&
+                string.Equals(context.Request.ContentType, RequestContentType, StringComparison.OrdinalIgnoreCase))
+            {
+                return ReadRequestBody(context.Request);
+            }
+
+            return null;
+        }
+#endif
+
+        private X509Certificate[] GetCertificateChain()
+        {
+            var certificates = new List<X509Certificate>();
+            var certificateAuthority = CertificateAuthority;
+
+            while (certificateAuthority != null)
+            {
+                certificates.Add(certificateAuthority.Certificate);
+
+                certificateAuthority = certificateAuthority.Parent;
+            }
+
+            return certificates.ToArray();
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestServer.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestServer.cs
@@ -104,7 +104,6 @@ namespace Test.Utility.Signing
                 try
                 {
                     var context = _listener.GetContext();
-
                     var path = GetBaseAbsolutePath(context.Request.Url);
 
                     IHttpResponder responder;
@@ -117,7 +116,7 @@ namespace Test.Utility.Signing
                         }
                         catch (Exception ex)
                         {
-                            Console.WriteLine(ex.ToString());
+                            Console.WriteLine($"Unexpected exception in a {nameof(SigningTestServer)} HTTP responder:  {ex.ToString()}");
                         }
                     }
                     else
@@ -139,7 +138,7 @@ namespace Test.Utility.Signing
                         return;
                     }
 
-                    Console.WriteLine("Unexpected error code: {0}. Ex: {1}", ex.ErrorCode, ex);
+                    Console.WriteLine($"Unexpected error code:  {ex.ErrorCode}.  Exception:  {ex.ToString()}");
 
                     throw;
                 }

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestServer.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestServer.cs
@@ -1,0 +1,172 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Test.Server;
+
+namespace Test.Utility.Signing
+{
+    public sealed class SigningTestServer : ISigningTestServer, IDisposable
+    {
+        private readonly ConcurrentDictionary<string, IHttpResponder> _responders = new ConcurrentDictionary<string, IHttpResponder>();
+#if IS_DESKTOP
+        private readonly HttpListener _listener;
+        private bool _isDisposed;
+#endif
+
+        public Uri Url { get; }
+
+#if IS_DESKTOP
+        private SigningTestServer(HttpListener listener, Uri url)
+        {
+            _listener = listener;
+            Url = url;
+        }
+#endif
+
+        public void Dispose()
+        {
+#if IS_DESKTOP
+            if (!_isDisposed)
+            {
+                _listener.Stop();
+                _listener.Abort();
+
+                GC.SuppressFinalize(this);
+
+                _isDisposed = true;
+            }
+#endif
+        }
+
+        public IDisposable RegisterResponder(IHttpResponder responder)
+        {
+            if (responder == null)
+            {
+                throw new ArgumentNullException(nameof(responder));
+            }
+
+            return new Responder(_responders, responder.Url.AbsolutePath, responder);
+        }
+
+        public static Task<SigningTestServer> CreateAsync()
+        {
+#if IS_DESKTOP
+            var portReserver = new PortReserver();
+
+            return portReserver.ExecuteAsync(
+                (port, token) =>
+                {
+                    var url = new Uri($"http://127.0.0.1:{port}/");
+                    var httpListener = new HttpListener();
+
+                    httpListener.IgnoreWriteExceptions = true;
+                    httpListener.Prefixes.Add(url.OriginalString);
+                    httpListener.Start();
+
+                    var server = new SigningTestServer(httpListener, url);
+
+                    using (var taskStartedEvent = new ManualResetEventSlim())
+                    {
+                        Task.Factory.StartNew(() => server.HandleRequest(taskStartedEvent, token));
+
+                        taskStartedEvent.Wait(token);
+                    }
+
+                    return Task.FromResult(server);
+                },
+                CancellationToken.None);
+#else
+
+            throw new NotImplementedException();
+#endif
+        }
+
+#if IS_DESKTOP
+        private static string GetBaseAbsolutePath(Uri url)
+        {
+            var path = url.PathAndQuery;
+
+            return path.Substring(0, path.IndexOf('/', 1) + 1);
+        }
+
+        private void HandleRequest(ManualResetEventSlim mutex, CancellationToken cancellationToken)
+        {
+            mutex.Set();
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    var context = _listener.GetContext();
+
+                    var path = GetBaseAbsolutePath(context.Request.Url);
+
+                    IHttpResponder responder;
+
+                    if (_responders.TryGetValue(path, out responder))
+                    {
+                        try
+                        {
+                            responder.Respond(context);
+                        }
+                        catch (Exception ex)
+                        {
+                            Console.WriteLine(ex.ToString());
+                        }
+                    }
+                    else
+                    {
+                        context.Response.StatusCode = 404;
+                    }
+                }
+                catch (ObjectDisposedException)
+                {
+                    return;
+                }
+                catch (HttpListenerException ex)
+                {
+                    if (ex.ErrorCode == ErrorConstants.ERROR_OPERATION_ABORTED ||
+                        ex.ErrorCode == ErrorConstants.ERROR_INVALID_HANDLE ||
+                        ex.ErrorCode == ErrorConstants.ERROR_INVALID_FUNCTION ||
+                        RuntimeEnvironmentHelper.IsMono && ex.ErrorCode == ErrorConstants.ERROR_OPERATION_ABORTED_MONO)
+                    {
+                        return;
+                    }
+
+                    Console.WriteLine("Unexpected error code: {0}. Ex: {1}", ex.ErrorCode, ex);
+
+                    throw;
+                }
+            }
+        }
+#endif
+
+        private sealed class Responder : IDisposable
+        {
+            private readonly ConcurrentDictionary<string, IHttpResponder> _responders;
+            private readonly string _key;
+            private readonly IHttpResponder _responder;
+
+            internal Responder(ConcurrentDictionary<string, IHttpResponder> responders, string key, IHttpResponder responder)
+            {
+                _responders = responders;
+                _key = key;
+                _responder = responder;
+                _responders[key] = responder;
+            }
+
+            public void Dispose()
+            {
+                IHttpResponder value;
+
+                _responders.TryRemove(_key, out value);
+            }
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -107,7 +107,6 @@ namespace Test.Utility.Signing
                 critical: true,
                 extensionValue: new ExtendedKeyUsage(usages));
 
-
             var notBefore = DateTime.UtcNow.Subtract(TimeSpan.FromHours(1));
             var notAfter = DateTime.UtcNow.Add(TimeSpan.FromSeconds(5));
 
@@ -423,5 +422,27 @@ namespace Test.Utility.Signing
             // This makes all the associated tests to require admin privilege
             return TestCertificate.Generate(actionGenerator).WithTrust(StoreName.Root, StoreLocation.LocalMachine);
         }
+
+#if IS_DESKTOP
+        public static DisposableList RegisterDefaultResponders(
+            this ISigningTestServer testServer,
+            TimestampService timestampService)
+        {
+            var responders = new DisposableList();
+            var ca = timestampService.CertificateAuthority;
+
+            while (ca != null)
+            {
+                responders.Add(testServer.RegisterResponder(ca));
+                responders.Add(testServer.RegisterResponder(ca.OcspResponder));
+
+                ca = ca.Parent;
+            }
+
+            responders.Add(testServer.RegisterResponder(timestampService));
+
+            return responders;
+        }
+#endif
     }
 }

--- a/test/TestUtilities/Test.Utility/Signing/TimestampService.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TimestampService.cs
@@ -1,0 +1,149 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Tsp;
+using Org.BouncyCastle.X509;
+using Org.BouncyCastle.X509.Extension;
+using Org.BouncyCastle.X509.Store;
+
+namespace Test.Utility.Signing
+{
+    // https://tools.ietf.org/html/rfc3161
+    public sealed class TimestampService : HttpResponder
+    {
+        private const string RequestContentType = "application/timestamp-query";
+        private const string ResponseContentType = "application/timestamp-response";
+
+        // "baseline-ts-policy" from RFC 3628 (https://tools.ietf.org/html/rfc3628#section-5.2)
+        private const string BaselineTimeStampPolicy = "0.4.0.2023.1.1";
+
+        private readonly AsymmetricCipherKeyPair _keyPair;
+        private readonly HashSet<BigInteger> _serialNumbers;
+        private BigInteger _nextSerialNumber;
+
+        /// <summary>
+        /// Gets this certificate authority's certificate.
+        /// </summary>
+        public X509Certificate Certificate { get; }
+
+        /// <summary>
+        /// Gets the base URI specific to this HTTP responder.
+        /// </summary>
+        public override Uri Url { get; }
+
+        /// <summary>
+        /// Gets the issuing certificate authority.
+        /// </summary>
+        public CertificateAuthority CertificateAuthority { get; }
+
+        private TimestampService(
+            CertificateAuthority certificateAuthority,
+            X509Certificate certificate,
+            AsymmetricCipherKeyPair keyPair,
+            Uri uri)
+        {
+            CertificateAuthority = certificateAuthority;
+            Certificate = certificate;
+            _keyPair = keyPair;
+            Url = uri;
+            _serialNumbers = new HashSet<BigInteger>();
+            _nextSerialNumber = BigInteger.One;
+        }
+
+        public static TimestampService Create(CertificateAuthority certificateAuthority)
+        {
+            if (certificateAuthority == null)
+            {
+                throw new ArgumentNullException(nameof(certificateAuthority));
+            }
+
+            var keyPair = CertificateUtilities.CreateKeyPair();
+            var id = Guid.NewGuid().ToString();
+            var subjectName = new X509Name($"C=US,ST=WA,L=Redmond,O=NuGet,CN=NuGet Test Timestamp Service ({id})");
+
+            Action<X509V3CertificateGenerator> customizeCertificate = generator =>
+            {
+                generator.AddExtension(
+                    X509Extensions.AuthorityInfoAccess,
+                    critical: false,
+                    extensionValue: new DerSequence(
+                        new AccessDescription(AccessDescription.IdADOcsp,
+                            new GeneralName(GeneralName.UniformResourceIdentifier, certificateAuthority.OcspResponderUri.OriginalString)),
+                        new AccessDescription(AccessDescription.IdADCAIssuers,
+                            new GeneralName(GeneralName.UniformResourceIdentifier, certificateAuthority.CertificateUri.OriginalString))));
+                generator.AddExtension(
+                    X509Extensions.AuthorityKeyIdentifier,
+                    critical: false,
+                    extensionValue: new AuthorityKeyIdentifierStructure(certificateAuthority.Certificate));
+                generator.AddExtension(
+                    X509Extensions.SubjectKeyIdentifier,
+                    critical: false,
+                    extensionValue: new SubjectKeyIdentifierStructure(keyPair.Public));
+                generator.AddExtension(
+                    X509Extensions.BasicConstraints,
+                    critical: true,
+                    extensionValue: new BasicConstraints(cA: false));
+                generator.AddExtension(
+                    X509Extensions.KeyUsage,
+                    critical: true,
+                    extensionValue: new KeyUsage(KeyUsage.DigitalSignature));
+                generator.AddExtension(
+                    X509Extensions.ExtendedKeyUsage,
+                    critical: true,
+                    extensionValue: ExtendedKeyUsage.GetInstance(new DerSequence(KeyPurposeID.IdKPTimeStamping)));
+            };
+
+            var certificate = certificateAuthority.IssueCertificate(keyPair.Public, subjectName, customizeCertificate);
+            var uri = certificateAuthority.GenerateRandomUri();
+
+            return new TimestampService(certificateAuthority, certificate, keyPair, uri);
+        }
+
+#if IS_DESKTOP
+        public override void Respond(HttpListenerContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (!string.Equals(context.Request.ContentType, RequestContentType, StringComparison.OrdinalIgnoreCase))
+            {
+                context.Response.StatusCode = 400;
+
+                return;
+            }
+
+            var bytes = ReadRequestBody(context.Request);
+            var request = new TimeStampRequest(bytes);
+            var tokenGenerator = new TimeStampTokenGenerator(_keyPair.Private, Certificate, TspAlgorithms.Sha256, BaselineTimeStampPolicy);
+
+            if (request.CertReq)
+            {
+                var certificates = X509StoreFactory.Create(
+                    "Certificate/Collection",
+                    new X509CollectionStoreParameters(new[] { Certificate }));
+
+                tokenGenerator.SetCertificates(certificates);
+            }
+
+            var responseGenerator = new TimeStampResponseGenerator(tokenGenerator, TspAlgorithms.Allowed);
+            var response = responseGenerator.Generate(request, _nextSerialNumber, DateTime.UtcNow);
+
+            _serialNumbers.Add(_nextSerialNumber);
+            _nextSerialNumber = _nextSerialNumber.Add(BigInteger.One);
+
+            context.Response.ContentType = ResponseContentType;
+
+            WriteResponseBody(context.Response, response.GetEncoded());
+        }
+#endif
+    }
+}


### PR DESCRIPTION
Resolve https://github.com/NuGet/Home/issues/6239.

This change removes the dependency on an external timestamp service by creating a test timestamp service.  Test fixtures expose a default trusted timestamp service whose lifetime matches the test fixture.

As part of this work, I've created a simple certificate authority class, which is useful for issuing certificates, revoking certificates, providing revocation status for certificates, and issuing a subordinate certificate authority.  In a future PR I'd like to update `SigningTestUtility` to reuse the `CertificateAuthority` class.