### PR TITLE
make lockfile.getlibrary use case  insensitive comparison

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFile.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFile.cs
@@ -107,7 +107,7 @@ namespace NuGet.ProjectModel
         public LockFileLibrary GetLibrary(string name, NuGetVersion version)
         {
             return Libraries.FirstOrDefault(l =>
-                string.Equals(l.Name, name) &&
+                string.Equals(l.Name, name, StringComparison.OrdinalIgnoreCase) &&
                 l.Version.Equals(version));
         }
 


### PR DESCRIPTION
fixes: https://github.com/NuGet/Home/issues/6500 

we don't have any use of this API in our code base but there might be external dependencies.