### PR TITLE
Fallback to read dte project FullPath in case FullName is empty or null

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ProjectSystems/ProjectNames.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ProjectSystems/ProjectNames.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -63,7 +63,7 @@ namespace NuGet.VisualStudio
             ThreadHelper.ThrowIfNotOnUIThread();
 
             return new ProjectNames(
-                fullName: dteProject.FullName,
+                fullName: EnvDTEProjectInfoUtility.GetFullProjectPath(dteProject),
                 uniqueName: EnvDTEProjectInfoUtility.GetUniqueName(dteProject),
                 shortName: EnvDTEProjectInfoUtility.GetName(dteProject),
                 customUniqueName: await EnvDTEProjectInfoUtility.GetCustomUniqueNameAsync(dteProject));


### PR DESCRIPTION
In some cases, when dte project FullName property is empty because of which NuGet throws ArgumentException. Instead now, we'll fallback to use FullPath.

fixes internal bug# 472018

@rrelyea 