### PR TITLE
Make apex PMC tests more reliable, second phase

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
+++ b/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
@@ -17,6 +17,7 @@ using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Threading;
 using NuGet.PackageManagement;
@@ -161,9 +162,6 @@ namespace NuGetConsole.Implementation
                 {
                     // Load
                     await Task.Run(LoadConsoleEditorAsync);
-
-                    // Mark as complete
-                    IsLoaded = true;
                 });
         }
 
@@ -412,6 +410,9 @@ namespace NuGetConsole.Implementation
                     {
                         PendingMoveFocus(consolePane);
                     }
+
+                    // Mark as complete
+                    IsLoaded = true;
                 }
             }
             catch (Exception x)
@@ -641,6 +642,23 @@ namespace NuGetConsole.Implementation
                 powerShellConsole.WriteLine(command);
 
                 return host.Execute(powerShellConsole, command, null);
+            }
+            return false;
+        }
+
+        public void StartDispatcher()
+        {
+            if (WpfConsole != null)
+            {
+                WpfConsole.Dispatcher.Start();
+            }
+        }
+
+        public bool IsHostSuccessfullyInitialized()
+        {
+            if (WpfConsole != null)
+            {
+                return WpfConsole.Host.IsInitializedSuccessfully;
             }
             return false;
         }

--- a/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
+++ b/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
@@ -162,6 +162,9 @@ namespace NuGetConsole.Implementation
                 {
                     // Load
                     await Task.Run(LoadConsoleEditorAsync);
+
+                    // Mark as complete
+                    IsLoaded = true;
                 });
         }
 
@@ -410,9 +413,6 @@ namespace NuGetConsole.Implementation
                     {
                         PendingMoveFocus(consolePane);
                     }
-
-                    // Mark as complete
-                    IsLoaded = true;
                 }
             }
             catch (Exception x)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Console/IHost.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Console/IHost.cs
@@ -62,6 +62,8 @@ namespace NuGet.VisualStudio
         void SetDefaultProjectIndex(int index);
 
         string[] GetAvailableProjects();
+
+        bool IsInitializedSuccessfully { get; }
     }
 
     /// <summary>

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -69,6 +69,8 @@ namespace NuGetConsole.Host.PowerShell.Implementation
         // indicates whether this host has been initialized.
         // null = not initilized, true = initialized successfully, false = initialized unsuccessfully
         private bool? _initialized;
+        public bool IsInitializedSuccessfully => _initialized.HasValue && _initialized.Value;
+
         // store the current (non-truncated) project names displayed in the project name combobox
         private string[] _projectSafeNames;
 

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/UnsupportedHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/UnsupportedHost.cs
@@ -71,5 +71,7 @@ namespace NuGetConsole.Host
         {
             get { return null; }
         }
+
+        public bool IsInitializedSuccessfully => false;
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
@@ -47,7 +47,7 @@ namespace NuGet.Console.TestContract
 
                 if (!loaded)
                 {
-                    System.Threading.Thread.Sleep(100);
+                    Thread.Sleep(100);
                 }
             }
             while (!loaded && stopwatch.Elapsed < timeout);

--- a/test/NuGet.Tests.Apex/NuGet.Console.TestContract/NuGetApexConsoleTestService.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Console.TestContract/NuGetApexConsoleTestService.cs
@@ -92,7 +92,12 @@ namespace NuGet.Console.TestContract
                     {
                         Thread.Sleep(100);
                     }
-                } 
+                    powerConsole.StartDispatcher();
+                    while (!powerConsole.IsHostSuccessfullyInitialized() && stopwatch.Elapsed < timeout)
+                    {
+                        Thread.Sleep(100);
+                    }
+                }
             }
 
             return powerConsole;

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetConsoleTestExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetConsoleTestExtension.cs
@@ -19,33 +19,38 @@ namespace NuGet.Tests.Apex
             _projectName = projectName;
         }
 
-        public bool InstallPackageFromPMC(string packageId, string version)
+        public void InstallPackageFromPMC(string packageId, string version)
         {
             var command = $"Install-Package {packageId} -ProjectName {_projectName} -Version {version} ";
-            return _pmConsole.RunCommand(command, _timeout);
+            Execute(command);
         }
 
-        public bool InstallPackageFromPMC(string packageId, string version, string source)
+        public void InstallPackageFromPMC(string packageId, string version, string source)
         {
             var command = $"Install-Package {packageId} -ProjectName {_projectName} -Version {version} -Source {source}";
-            return _pmConsole.RunCommand(command, _timeout);
+            Execute(command);
         }
 
-        public bool UninstallPackageFromPMC(string packageId)
+        public void UninstallPackageFromPMC(string packageId)
         {
             var command = $"Uninstall-Package {packageId} -ProjectName {_projectName}";
-            return _pmConsole.RunCommand(command, _timeout);
+            Execute(command);
         }
 
-        public bool UpdatePackageFromPMC(string packageId, string version)
+        public void UpdatePackageFromPMC(string packageId, string version)
         {
             var command = $"Update-Package {packageId} -ProjectName {_projectName} -Version {version}";
-            return _pmConsole.RunCommand(command, _timeout);
+            Execute(command);
         }
 
         public bool IsMessageFoundInPMC(string message)
         {
             return _pmConsole.ConsoleContainsMessage(message);
+        }
+
+        public void Execute(string command)
+        {
+            _pmConsole.RunCommand(command, _timeout);
         }
 
         public void Clear()

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using FluentAssertions;
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using NuGet.StaFact;
 using Xunit;
@@ -34,9 +33,7 @@ namespace NuGet.Tests.Apex
 
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
 
-                // Verify install from project.assets.json
-                var inAssetsFile = Utils.IsPackageInstalledInAssetsFile(nugetConsole, testContext.Project.FullPath, packageName, packageVersion);
-                inAssetsFile.Should().BeTrue("package was installed");
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion);
             }
         }
 
@@ -61,10 +58,7 @@ namespace NuGet.Tests.Apex
                 // Build before the install check to ensure that everything is up to date.
                 testContext.Project.Build();
 
-                // Verify install from Get-Package
-                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName, packageVersion);
-
-                VisualStudio.AssertNoErrors();
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion);
             }
         }
 
@@ -86,14 +80,12 @@ namespace NuGet.Tests.Apex
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
                 testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName, packageVersion);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion);
 
                 nugetConsole.UninstallPackageFromPMC(packageName);
                 testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsNotInstalled(testContext.Project.UniqueName, packageName);
-
-                VisualStudio.AssertNoErrors();
+                Utils.AssertPackageIsNotInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion);
             }
         }
 
@@ -117,14 +109,12 @@ namespace NuGet.Tests.Apex
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion1);
                 testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName, packageVersion1);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion1);
 
                 nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2);
                 testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName, packageVersion2);
-
-                VisualStudio.AssertNoErrors();
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion2);
             }
         }
 
@@ -151,10 +141,8 @@ namespace NuGet.Tests.Apex
                 nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2);
                 testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName1, packageVersion1);
-                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName2, packageVersion2);
-
-                VisualStudio.AssertNoErrors();
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName1, packageVersion1);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName2, packageVersion2);
             }
         }
 
@@ -164,15 +152,15 @@ namespace NuGet.Tests.Apex
         {
             // Arrange
             EnsureVisualStudioHost();
+            var packageName1 = "TestPackage1";
+            var packageVersion1 = "1.0.0";
+            var packageName2 = "TestPackage2";
+            var packageVersion2 = "1.2.3";
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate))
             {
-                var packageName1 = "TestPackage1";
-                var packageVersion1 = "1.0.0";
-                Utils.CreatePackageInSource(testContext.PackageSource, packageName1, packageVersion1);
 
-                var packageName2 = "TestPackage2";
-                var packageVersion2 = "1.2.3";
+                Utils.CreatePackageInSource(testContext.PackageSource, packageName1, packageVersion1);
                 Utils.CreatePackageInSource(testContext.PackageSource, packageName2, packageVersion2);
 
                 var nugetConsole = GetConsole(testContext.Project);
@@ -181,17 +169,15 @@ namespace NuGet.Tests.Apex
                 nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2);
                 testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName1, packageVersion1);
-                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName2, packageVersion2);
-
-                VisualStudio.AssertNoErrors();
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName1, packageVersion1);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName2, packageVersion2);
 
                 nugetConsole.UninstallPackageFromPMC(packageName1);
                 nugetConsole.UninstallPackageFromPMC(packageName2);
                 testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsNotInstalled(testContext.Project.UniqueName, packageName1);
-                GetNuGetTestService().Verify.PackageIsNotInstalled(testContext.Project.UniqueName, packageName2);
+                Utils.AssertPackageIsNotInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName1, packageVersion1);
+                Utils.AssertPackageIsNotInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName2, packageVersion2);
             }
         }
 
@@ -201,12 +187,12 @@ namespace NuGet.Tests.Apex
         {
             // Arrange
             EnsureVisualStudioHost();
+            var packageName = "TestPackage";
+            var packageVersion1 = "1.0.0";
+            var packageVersion2 = "2.0.0";
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate))
             {
-                var packageName = "TestPackage";
-                var packageVersion1 = "1.0.0";
-                var packageVersion2 = "2.0.0";
                 Utils.CreatePackageInSource(testContext.PackageSource, packageName, packageVersion1);
                 Utils.CreatePackageInSource(testContext.PackageSource, packageName, packageVersion2);
 
@@ -215,12 +201,13 @@ namespace NuGet.Tests.Apex
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion2);
                 testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName, packageVersion2);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion2);
+
 
                 nugetConsole.UpdatePackageFromPMC(packageName, packageVersion1);
                 testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName, packageVersion1);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion1);
             }
         }
 
@@ -260,17 +247,12 @@ namespace NuGet.Tests.Apex
                 projectX.Build();
                 testContext.SolutionService.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(project3.UniqueName, packageName);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, project3, packageName, packageVersion);
 
                 // Verify install from project.assets.json
-                var inAssetsFile = Utils.IsPackageInstalledInAssetsFile(nugetConsole, testContext.Project.FullPath, packageName, packageVersion);
-                inAssetsFile.Should().BeTrue("package was installed");
-
-                var inAssetsFile2 = Utils.IsPackageInstalledInAssetsFile(nugetConsole, project2.FullPath, packageName, packageVersion);
-                inAssetsFile2.Should().BeTrue("package 2 was installed");
-
-                var inAssetsFileX = Utils.IsPackageInstalledInAssetsFile(nugetConsole, projectX.FullPath, packageName, packageVersion);
-                inAssetsFileX.Should().BeFalse("package X was installed");
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, project2, packageName, packageVersion);
+                Utils.AssertPackageIsNotInstalled(GetNuGetTestService(), projectTemplate, projectX, packageName, packageVersion);
             }
         }
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
@@ -33,7 +33,7 @@ namespace NuGet.Tests.Apex
 
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
 
-                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, packageName, packageVersion);
             }
         }
 
@@ -58,7 +58,7 @@ namespace NuGet.Tests.Apex
                 // Build before the install check to ensure that everything is up to date.
                 testContext.Project.Build();
 
-                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, packageName, packageVersion);
             }
         }
 
@@ -80,12 +80,12 @@ namespace NuGet.Tests.Apex
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
                 testContext.Project.Build();
 
-                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, packageName, packageVersion);
 
                 nugetConsole.UninstallPackageFromPMC(packageName);
                 testContext.Project.Build();
 
-                Utils.AssertPackageIsNotInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion);
+                Utils.AssertPackageIsNotInstalled(GetNuGetTestService(), testContext.Project, packageName, packageVersion);
             }
         }
 
@@ -109,12 +109,12 @@ namespace NuGet.Tests.Apex
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion1);
                 testContext.Project.Build();
 
-                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion1);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, packageName, packageVersion1);
 
                 nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2);
                 testContext.Project.Build();
 
-                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion2);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, packageName, packageVersion2);
             }
         }
 
@@ -141,8 +141,8 @@ namespace NuGet.Tests.Apex
                 nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2);
                 testContext.Project.Build();
 
-                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName1, packageVersion1);
-                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName2, packageVersion2);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, packageName1, packageVersion1);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, packageName2, packageVersion2);
             }
         }
 
@@ -169,15 +169,15 @@ namespace NuGet.Tests.Apex
                 nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2);
                 testContext.Project.Build();
 
-                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName1, packageVersion1);
-                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName2, packageVersion2);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, packageName1, packageVersion1);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, packageName2, packageVersion2);
 
                 nugetConsole.UninstallPackageFromPMC(packageName1);
                 nugetConsole.UninstallPackageFromPMC(packageName2);
                 testContext.Project.Build();
 
-                Utils.AssertPackageIsNotInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName1, packageVersion1);
-                Utils.AssertPackageIsNotInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName2, packageVersion2);
+                Utils.AssertPackageIsNotInstalled(GetNuGetTestService(), testContext.Project, packageName1, packageVersion1);
+                Utils.AssertPackageIsNotInstalled(GetNuGetTestService(), testContext.Project, packageName2, packageVersion2);
             }
         }
 
@@ -201,13 +201,13 @@ namespace NuGet.Tests.Apex
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion2);
                 testContext.Project.Build();
 
-                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion2);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, packageName, packageVersion2);
 
 
                 nugetConsole.UpdatePackageFromPMC(packageName, packageVersion1);
                 testContext.Project.Build();
 
-                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion1);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, packageName, packageVersion1);
             }
         }
 
@@ -247,12 +247,12 @@ namespace NuGet.Tests.Apex
                 projectX.Build();
                 testContext.SolutionService.Build();
 
-                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, project3, packageName, packageVersion);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), project3, packageName, packageVersion);
 
                 // Verify install from project.assets.json
-                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, testContext.Project, packageName, packageVersion);
-                Utils.AssertPackageIsInstalled(GetNuGetTestService(), projectTemplate, project2, packageName, packageVersion);
-                Utils.AssertPackageIsNotInstalled(GetNuGetTestService(), projectTemplate, projectX, packageName, packageVersion);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, packageName, packageVersion);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), project2, packageName, packageVersion);
+                Utils.AssertPackageIsNotInstalled(GetNuGetTestService(), projectX, packageName, packageVersion);
             }
         }
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
@@ -32,8 +32,7 @@ namespace NuGet.Tests.Apex
 
                 var nugetConsole = GetConsole(testContext.Project);
 
-                var installed = nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
-                installed.Should().BeTrue("Install-Package should pass");
+                nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
 
                 // Verify install from project.assets.json
                 var inAssetsFile = Utils.IsPackageInstalledInAssetsFile(nugetConsole, testContext.Project.FullPath, packageName, packageVersion);
@@ -57,8 +56,7 @@ namespace NuGet.Tests.Apex
 
                 var nugetConsole = GetConsole(testContext.Project);
 
-                var installed = nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
-                installed.Should().BeTrue("Install-Package should pass");
+                nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
 
                 // Build before the install check to ensure that everything is up to date.
                 testContext.Project.Build();
@@ -85,12 +83,12 @@ namespace NuGet.Tests.Apex
 
                 var nugetConsole = GetConsole(testContext.Project);
 
-                nugetConsole.InstallPackageFromPMC(packageName, packageVersion).Should().BeTrue("Install-Package");
+                nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
                 testContext.Project.Build();
 
                 GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName, packageVersion);
 
-                nugetConsole.UninstallPackageFromPMC(packageName).Should().BeTrue("Uninstall-Package");
+                nugetConsole.UninstallPackageFromPMC(packageName);
                 testContext.Project.Build();
 
                 GetNuGetTestService().Verify.PackageIsNotInstalled(testContext.Project.UniqueName, packageName);
@@ -116,12 +114,12 @@ namespace NuGet.Tests.Apex
 
                 var nugetConsole = GetConsole(testContext.Project);
 
-                nugetConsole.InstallPackageFromPMC(packageName, packageVersion1).Should().BeTrue("Install-Package");
+                nugetConsole.InstallPackageFromPMC(packageName, packageVersion1);
                 testContext.Project.Build();
 
                 GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName, packageVersion1);
 
-                nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2).Should().BeTrue("UnInstall-Package");
+                nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2);
                 testContext.Project.Build();
 
                 GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName, packageVersion2);
@@ -149,8 +147,8 @@ namespace NuGet.Tests.Apex
 
                 var nugetConsole = GetConsole(testContext.Project);
 
-                nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1).Should().BeTrue("Install-Package 1");
-                nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2).Should().BeTrue("Install-Package 2");
+                nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1);
+                nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2);
                 testContext.Project.Build();
 
                 GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName1, packageVersion1);
@@ -179,8 +177,8 @@ namespace NuGet.Tests.Apex
 
                 var nugetConsole = GetConsole(testContext.Project);
 
-                nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1).Should().BeTrue("Install-Package 1");
-                nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2).Should().BeTrue("Install-Package 2");
+                nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1);
+                nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2);
                 testContext.Project.Build();
 
                 GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName1, packageVersion1);
@@ -188,8 +186,8 @@ namespace NuGet.Tests.Apex
 
                 VisualStudio.AssertNoErrors();
 
-                nugetConsole.UninstallPackageFromPMC(packageName1).Should().BeTrue("Uninstall package 1");
-                nugetConsole.UninstallPackageFromPMC(packageName2).Should().BeTrue("Uninstall package 2");
+                nugetConsole.UninstallPackageFromPMC(packageName1);
+                nugetConsole.UninstallPackageFromPMC(packageName2);
                 testContext.Project.Build();
 
                 GetNuGetTestService().Verify.PackageIsNotInstalled(testContext.Project.UniqueName, packageName1);
@@ -214,12 +212,12 @@ namespace NuGet.Tests.Apex
 
                 var nugetConsole = GetConsole(testContext.Project);
 
-                nugetConsole.InstallPackageFromPMC(packageName, packageVersion2).Should().BeTrue("Install-Package");
+                nugetConsole.InstallPackageFromPMC(packageName, packageVersion2);
                 testContext.Project.Build();
 
                 GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName, packageVersion2);
 
-                nugetConsole.UpdatePackageFromPMC(packageName, packageVersion1).Should().BeTrue("Update-Package");
+                nugetConsole.UpdatePackageFromPMC(packageName, packageVersion1);
                 testContext.Project.Build();
 
                 GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, packageName, packageVersion1);
@@ -255,7 +253,7 @@ namespace NuGet.Tests.Apex
                 var packageVersion = "9.0.1";
                 Utils.CreatePackageInSource(testContext.PackageSource, packageName, packageVersion);
 
-                nugetConsole.InstallPackageFromPMC(packageName, packageVersion).Should().BeTrue("Install-Package");
+                nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
                 testContext.Project.Build();
                 project2.Build();
                 project3.Build();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetPackageSigningTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetPackageSigningTestCase.cs
@@ -38,7 +38,7 @@ namespace NuGet.Tests.Apex
 
                 var nugetConsole = GetConsole(testContext.Project);
 
-                nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version).Should().BeTrue("Install-Package should pass");
+                nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version);
 
                 // Build before the install check to ensure that everything is up to date.
                 testContext.Project.Build();
@@ -63,12 +63,12 @@ namespace NuGet.Tests.Apex
 
                 var nugetConsole = GetConsole(testContext.Project);
 
-                nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version).Should().BeTrue("Install-Package");
+                nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version);
                 testContext.Project.Build();
 
                 GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, signedPackage.Id, signedPackage.Version);
 
-                nugetConsole.UninstallPackageFromPMC(signedPackage.Id).Should().BeTrue("Uninstall-Package");
+                nugetConsole.UninstallPackageFromPMC(signedPackage.Id);
                 testContext.Project.Build();
 
                 GetNuGetTestService().Verify.PackageIsNotInstalled(testContext.Project.UniqueName, signedPackage.Id);
@@ -92,12 +92,12 @@ namespace NuGet.Tests.Apex
 
                 var nugetConsole = GetConsole(testContext.Project);
 
-                nugetConsole.InstallPackageFromPMC(signedPackage.Id, packageVersion09).Should().BeTrue("Install-Package");
+                nugetConsole.InstallPackageFromPMC(signedPackage.Id, packageVersion09);
                 testContext.Project.Build();
 
                 GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, signedPackage.Id, packageVersion09);
 
-                nugetConsole.UpdatePackageFromPMC(signedPackage.Id, signedPackage.Version).Should().BeTrue("Update-Package");
+                nugetConsole.UpdatePackageFromPMC(signedPackage.Id, signedPackage.Version);
                 testContext.Project.Build();
 
                 GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, signedPackage.Id, signedPackage.Version);
@@ -127,12 +127,12 @@ namespace NuGet.Tests.Apex
 
                 var nugetConsole = GetConsole(testContext.Project);
 
-                nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version).Should().BeTrue("Install-Package");
+                nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version);
                 testContext.Project.Build();
 
                 GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, signedPackage.Id, signedPackage.Version);
 
-                nugetConsole.UpdatePackageFromPMC(signedPackage.Id, packageVersion09).Should().BeTrue("Update-Package");
+                nugetConsole.UpdatePackageFromPMC(signedPackage.Id, packageVersion09);
                 testContext.Project.Build();
 
                 GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, signedPackage.Id, packageVersion09);
@@ -156,7 +156,7 @@ namespace NuGet.Tests.Apex
 
                 var nugetConsole = GetConsole(testContext.Project);
 
-                nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version).Should().BeTrue("Install-Package");
+                nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version);
                 testContext.Project.Build();
 
                 // TODO: Fix bug where no warnings are shwon when package is untrusted but still installed
@@ -181,8 +181,7 @@ namespace NuGet.Tests.Apex
 
                 var nugetConsole = GetConsole(testContext.Project);
 
-                // TODO: install should fail, therefore Should().BeFalse()
-                nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version).Should().BeTrue("Install-Package");
+                nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version);
                 nugetConsole.IsMessageFoundInPMC("package integrity check failed").Should().BeTrue("Integrity failed message shown.");
                 testContext.Project.Build();
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetPackageSigningTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetPackageSigningTestCase.cs
@@ -43,8 +43,7 @@ namespace NuGet.Tests.Apex
                 // Build before the install check to ensure that everything is up to date.
                 testContext.Project.Build();
 
-                // Verify install from Get-Package
-                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, signedPackage.Id, signedPackage.Version);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, signedPackage.Id, signedPackage.Version);
             }
         }
 
@@ -66,12 +65,12 @@ namespace NuGet.Tests.Apex
                 nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version);
                 testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, signedPackage.Id, signedPackage.Version);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, signedPackage.Id, signedPackage.Version);
 
                 nugetConsole.UninstallPackageFromPMC(signedPackage.Id);
                 testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsNotInstalled(testContext.Project.UniqueName, signedPackage.Id);
+                Utils.AssertPackageIsNotInstalled(GetNuGetTestService(), testContext.Project, signedPackage.Id, signedPackage.Version);
             }
         }
 
@@ -95,13 +94,13 @@ namespace NuGet.Tests.Apex
                 nugetConsole.InstallPackageFromPMC(signedPackage.Id, packageVersion09);
                 testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, signedPackage.Id, packageVersion09);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, signedPackage.Id, packageVersion09);
 
                 nugetConsole.UpdatePackageFromPMC(signedPackage.Id, signedPackage.Version);
                 testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, signedPackage.Id, signedPackage.Version);
-                GetNuGetTestService().Verify.PackageIsNotInstalled(testContext.Project.UniqueName, signedPackage.Id, packageVersion09);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, signedPackage.Id, signedPackage.Version);
+                Utils.AssertPackageIsNotInstalled(GetNuGetTestService(), testContext.Project, signedPackage.Id, packageVersion09);
             }
         }
 
@@ -130,13 +129,13 @@ namespace NuGet.Tests.Apex
                 nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version);
                 testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, signedPackage.Id, signedPackage.Version);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, signedPackage.Id, signedPackage.Version);
 
                 nugetConsole.UpdatePackageFromPMC(signedPackage.Id, packageVersion09);
                 testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, signedPackage.Id, packageVersion09);
-                GetNuGetTestService().Verify.PackageIsNotInstalled(testContext.Project.UniqueName, signedPackage.Id, signedPackage.Version);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, signedPackage.Id, packageVersion09);
+                Utils.AssertPackageIsNotInstalled(GetNuGetTestService(), testContext.Project, signedPackage.Id, signedPackage.Version);
             }
         }
 
@@ -161,7 +160,7 @@ namespace NuGet.Tests.Apex
 
                 // TODO: Fix bug where no warnings are shwon when package is untrusted but still installed
                 //nugetConsole.IsMessageFoundInPMC("expired certificate").Should().BeTrue("expired certificate warning");
-                GetNuGetTestService().Verify.PackageIsInstalled(testContext.Project.UniqueName, signedPackage.Id, signedPackage.Version);
+                Utils.AssertPackageIsInstalled(GetNuGetTestService(), testContext.Project, signedPackage.Id, signedPackage.Version);
             }
         }
 
@@ -185,7 +184,7 @@ namespace NuGet.Tests.Apex
                 nugetConsole.IsMessageFoundInPMC("package integrity check failed").Should().BeTrue("Integrity failed message shown.");
                 testContext.Project.Build();
 
-                GetNuGetTestService().Verify.PackageIsNotInstalled(testContext.Project.UniqueName, signedPackage.Id);
+                Utils.AssertPackageIsNotInstalled(GetNuGetTestService(), testContext.Project, signedPackage.Id, signedPackage.Version);
             }
         }
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/Utils.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/Utils.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.Versioning;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
+using FluentAssertions;
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
@@ -47,7 +48,39 @@ namespace NuGet.Tests.Apex
             return package;
         }
 
-        public static bool IsPackageInstalledInAssetsFile(NuGetConsoleTestExtension nuGetConsole, string projectPath, string packageName, string packageVersion)
+        public static void AssertPackageIsInstalled(NuGetApexTestService testService, ProjectTemplate projectTemplate, ProjectTestExtension project, string packageName, string packageVersion)
+        {
+            switch (projectTemplate)
+            {
+                case ProjectTemplate.ClassLibrary:
+                    testService.Verify.PackageIsInstalled(project.UniqueName, packageName, packageVersion);
+                    break;
+                case ProjectTemplate.NetCoreClassLib:
+                case ProjectTemplate.NetCoreConsoleApp:
+                case ProjectTemplate.NetStandardClassLib:
+                    var inAssetsFile = Utils.IsPackageInstalledInAssetsFile(project.FullPath, packageName, packageVersion);
+                    inAssetsFile.Should().BeTrue($"{packageName}-{packageVersion} should be installed in {project.Name}");
+                    break;
+            }
+        }
+
+        public static void AssertPackageIsNotInstalled(NuGetApexTestService testService, ProjectTemplate projectTemplate, ProjectTestExtension project, string packageName, string packageVersion)
+        {
+            switch (projectTemplate)
+            {
+                case ProjectTemplate.ClassLibrary:
+                    testService.Verify.PackageIsNotInstalled(project.UniqueName, packageName, packageVersion);
+                    break;
+                case ProjectTemplate.NetCoreClassLib:
+                case ProjectTemplate.NetCoreConsoleApp:
+                case ProjectTemplate.NetStandardClassLib:
+                    var inAssetsFile = Utils.IsPackageInstalledInAssetsFile(project.FullPath, packageName, packageVersion);
+                    inAssetsFile.Should().BeFalse($"{packageName}-{packageVersion} should not be installed in {project.Name}");
+                    break;
+            }
+        }
+
+        public static bool IsPackageInstalledInAssetsFile(string projectPath, string packageName, string packageVersion)
         {
             var assetsFile = GetAssetsFilePath(projectPath);
             var packagesConfig = GetPackagesConfigPath(projectPath);


### PR DESCRIPTION
This eliminates some flakiness by making sure the dispatcher is initialized before running any command.

Also eliminated unnecessary bool return when running a command. Currently our product doesn't have a way to know if a command executed succeeded or failed, therefore running a command should be a void method in Apex.

I also refactored the IsPackageInstalled check to use the assets file if it's a PR project and use the IVS api if is a PC.

There's still a known issue where a pending restore can make the assets file be outdated and therefore our checks will fail to notice a package was installed or uninstalled. This will still cause some flakiness.