### PR TITLE
Signing: relax validation at signing and verification time

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
@@ -68,7 +68,7 @@ namespace NuGet.Commands
 
             try
             {
-                SigningUtility.Verify(signPackageRequest);
+                SigningUtility.Verify(signPackageRequest, logger);
             }
             catch (Exception e)
             {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1467,7 +1467,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not verify package(s) signature..
+        ///   Looks up a localized string similar to Package signature validation failed..
         /// </summary>
         internal static string VerifyCommand_Failed {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -676,7 +676,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <comment>{0} should be the package identity of the package to verify</comment>
   </data>
   <data name="VerifyCommand_Failed" xml:space="preserve">
-    <value>Could not verify package(s) signature.</value>
+    <value>Package signature validation failed.</value>
   </data>
   <data name="SignCommandCertificateStoreNotFound" xml:space="preserve">
     <value>Certificate store '{0}' not found. For a list of accepted ways to provide a certificate, please visit https://docs.nuget.org/docs/reference/command-line-reference</value>

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -302,7 +302,7 @@ namespace NuGet.Packaging
                 var expectedHash = Convert.FromBase64String(signatureContent.HashValue);
                 if (!SignedPackageArchiveUtility.VerifySignedPackageIntegrity(reader, hashAlgorithm, expectedHash))
                 {
-                    throw new SignatureException(Strings.SignaturePackageIntegrityFailure, GetIdentity());
+                    throw new SignatureException(NuGetLogCode.NU3008, Strings.SignaturePackageIntegrityFailure, GetIdentity());
                 }
             }
 #endif

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/SignPackageRequest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/SignPackageRequest.cs
@@ -107,11 +107,14 @@ namespace NuGet.Packaging.Signing
             }
         }
 
-        internal void BuildSigningCertificateChainOnce()
+        internal void BuildSigningCertificateChainOnce(ILogger logger)
         {
             if (Chain == null)
             {
-                Chain = CertificateChainUtility.GetCertificateChainForSigning(Certificate, AdditionalCertificates, NuGetVerificationCertificateType.Signature);
+                Chain = CertificateChainUtility.GetCertificateChainForSigning(
+                    Certificate,
+                    AdditionalCertificates,
+                    logger);
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/Signer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/Signer.cs
@@ -51,7 +51,7 @@ namespace NuGet.Packaging.Signing
                 throw new SignatureException(NuGetLogCode.NU3006, Strings.ErrorZip64NotSupported);
             }
 
-            SigningUtility.Verify(request);
+            SigningUtility.Verify(request, logger);
 
             var zipArchiveHash = await _package.GetArchiveHashAsync(request.SignatureHashAlgorithm, token);
             var signatureContent = GenerateSignatureContent(request.SignatureHashAlgorithm, zipArchiveHash);

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Oids.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Oids.cs
@@ -68,6 +68,9 @@ namespace NuGet.Packaging.Signing
         // RFC 5126 "signing-certificate-v2" https://tools.ietf.org/html/rfc5126.html#page-34
         public const string SigningCertificateV2 = "1.2.840.113549.1.9.16.2.47";
 
+        // RFC 5280 "id-ce-authorityKeyIdentifier" https://tools.ietf.org/html/rfc5280#section-4.2.1.1
+        public const string AuthorityKeyIdentifier = "2.5.29.35";
+
         // RFC 5280 "id-ce-subjectKeyIdentifier" https://tools.ietf.org/html/rfc5280#section-4.2.1.2
         public const string SubjectKeyIdentifier = "2.5.29.14";
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
@@ -43,8 +43,8 @@ namespace NuGet.Packaging.Signing
             PackageIdentity = package;
         }
 
-        public SignatureException(string message, PackageIdentity package)
-            : this(message)
+        public SignatureException(NuGetLogCode code, string message, PackageIdentity package)
+            : this(code, message)
         {
             PackageIdentity = package;
         }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureLog.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureLog.cs
@@ -46,6 +46,11 @@ namespace NuGet.Packaging.Signing
             return new SignatureLog(level, code, message);
         }
 
+        public static SignatureLog Error(NuGetLogCode code, string message)
+        {
+            return new SignatureLog(LogLevel.Error, code, message);
+        }
+
         public ILogMessage ToLogMessage()
         {
             if (Level == LogLevel.Error)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateChainUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateChainUtility.cs
@@ -113,6 +113,13 @@ namespace NuGet.Packaging.Signing
             return certs;
         }
 
+        /// <summary>
+        /// Get error/warning chain status flags for certificate chain validation during signing.
+        /// </summary>
+        /// <param name="certificate">The certificate to verify.</param>
+        /// <param name="errorStatusFlags">Error chain status flags.</param>
+        /// <param name="warningStatusFlags">Warning chain status flags.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="certificate" /> is <c>null</c>.</exception>
         public static void GetChainStatusFlagsForSigning(
             X509Certificate2 certificate,
             out X509ChainStatusFlags errorStatusFlags,
@@ -125,7 +132,7 @@ namespace NuGet.Packaging.Signing
 
             warningStatusFlags = X509ChainStatusFlags.RevocationStatusUnknown | X509ChainStatusFlags.OfflineRevocation;
 
-            if (CertificateUtility.IsSelfSigned(certificate))
+            if (CertificateUtility.IsSelfIssued(certificate))
             {
                 warningStatusFlags |= X509ChainStatusFlags.UntrustedRoot;
             }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateChainUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateChainUtility.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -16,10 +15,19 @@ namespace NuGet.Packaging.Signing
         /// <summary>
         /// Create a list of certificates in chain order with the leaf first and root last.
         /// </summary>
+        /// <remarks>This must not be used on timestamp certificates as this method does not enforce the requirement
+        /// that timestamps be trusted.</remarks>
+        /// <param name="certificate">The certificate for which a chain should be built.</param>
+        /// <param name="extraStore">A certificate store containing additional certificates necessary
+        /// for chain building.</param>
+        /// <param name="logger">A logger.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="certificate" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="extraStore" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
         public static IReadOnlyList<X509Certificate2> GetCertificateChainForSigning(
             X509Certificate2 certificate,
             X509Certificate2Collection extraStore,
-            NuGetVerificationCertificateType certificateType)
+            ILogger logger)
         {
             if (certificate == null)
             {
@@ -31,6 +39,11 @@ namespace NuGet.Packaging.Signing
                 throw new ArgumentNullException(nameof(extraStore));
             }
 
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
             using (var chainHolder = new X509ChainHolder())
             {
                 var chain = chainHolder.Chain;
@@ -39,16 +52,39 @@ namespace NuGet.Packaging.Signing
                     chain.ChainPolicy,
                     extraStore,
                     DateTime.Now,
-                    certificateType);
+                    NuGetVerificationCertificateType.Signature);
 
-                if (BuildCertificateChain(chain, certificate, out var chainStatuses))
+                if (chain.Build(certificate))
                 {
                     return GetCertificateListFromChain(chain);
                 }
 
-                var messages = GetMessagesFromChainStatuses(chainStatuses);
+                X509ChainStatusFlags errorStatusFlags;
+                X509ChainStatusFlags warningStatusFlags;
 
-                throw new SignatureException(NuGetLogCode.NU3018, string.Format(CultureInfo.CurrentCulture, Strings.ErrorInvalidCertificateChain, string.Join(", ", messages)));
+                GetChainStatusFlagsForSigning(certificate, out errorStatusFlags, out warningStatusFlags);
+
+                var fatalStatuses = new List<X509ChainStatus>();
+
+                foreach (var chainStatus in chain.ChainStatus)
+                {
+                    if ((chainStatus.Status & errorStatusFlags) != 0)
+                    {
+                        fatalStatuses.Add(chainStatus);
+                        logger.Log(LogMessage.CreateError(NuGetLogCode.NU3018, chainStatus.StatusInformation?.Trim()));
+                    }
+                    else if ((chainStatus.Status & warningStatusFlags) != 0)
+                    {
+                        logger.Log(LogMessage.CreateWarning(NuGetLogCode.NU3018, chainStatus.StatusInformation?.Trim()));
+                    }
+                }
+
+                if (fatalStatuses.Any())
+                {
+                    throw new SignatureException(NuGetLogCode.NU3018, Strings.CertificateChainValidationFailed);
+                }
+
+                return GetCertificateListFromChain(chain);
             }
         }
 
@@ -77,6 +113,26 @@ namespace NuGet.Packaging.Signing
             return certs;
         }
 
+        public static void GetChainStatusFlagsForSigning(
+            X509Certificate2 certificate,
+            out X509ChainStatusFlags errorStatusFlags,
+            out X509ChainStatusFlags warningStatusFlags)
+        {
+            if (certificate == null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            warningStatusFlags = X509ChainStatusFlags.RevocationStatusUnknown | X509ChainStatusFlags.OfflineRevocation;
+
+            if (CertificateUtility.IsSelfSigned(certificate))
+            {
+                warningStatusFlags |= X509ChainStatusFlags.UntrustedRoot;
+            }
+
+            // Every status flag that isn't a warning is an error.
+            errorStatusFlags = (~(X509ChainStatusFlags)0) & ~warningStatusFlags;
+        }
 
         internal static void SetCertBuildChainPolicy(
             X509ChainPolicy policy,
@@ -84,13 +140,13 @@ namespace NuGet.Packaging.Signing
             DateTime verificationTime,
             NuGetVerificationCertificateType certificateType)
         {
-            if (certificateType == NuGetVerificationCertificateType.Signature)
-            {
-                policy.ApplicationPolicy.Add(new Oid(Oids.CodeSigningEku));
-            }
-            else if (certificateType == NuGetVerificationCertificateType.Timestamp)
+            if (certificateType == NuGetVerificationCertificateType.Timestamp)
             {
                 policy.ApplicationPolicy.Add(new Oid(Oids.TimeStampingEku));
+            }
+            else
+            {
+                policy.ApplicationPolicy.Add(new Oid(Oids.CodeSigningEku));
             }
 
             policy.ExtraStore.AddRange(additionalCertificates);
@@ -103,7 +159,6 @@ namespace NuGet.Packaging.Signing
                 policy.VerificationTime = verificationTime;
             }
         }
-
 
         internal static bool BuildCertificateChain(X509Chain chain, X509Certificate2 certificate, out X509ChainStatus[] status)
         {
@@ -120,9 +175,8 @@ namespace NuGet.Packaging.Signing
             return buildSuccess && !CertificateUtility.IsCertificateValidityPeriodInTheFuture(certificate);
         }
 
-
         // Ignore some chain status flags to special case them
-        internal const X509ChainStatusFlags NotIgnoredCertificateFlags =
+        internal const X509ChainStatusFlags DefaultObservedStatusFlags =
             // To set the not ignored flags we have to turn on all the flags and then manually turn off ignored flags
             (~(X509ChainStatusFlags)0) &                      // Start with all flags
                                                               // These flags are ignored because they are known special cases
@@ -138,12 +192,7 @@ namespace NuGet.Packaging.Signing
             chainStatus = chainStatuses
                 .Where(x => (x.Status & status) != 0);
 
-            if (chainStatus.Any())
-            {
-                return true;
-            }
-
-            return false;
+            return chainStatus.Any();
         }
 
         internal static bool TryGetStatusMessage(X509ChainStatus[] chainStatuses, X509ChainStatusFlags status, out IEnumerable<string> messages)
@@ -152,7 +201,7 @@ namespace NuGet.Packaging.Signing
 
             if (ChainStatusListIncludesStatus(chainStatuses, status, out var chainStatus))
             {
-                messages = GetMessagesFromChainStatuses(chainStatus.ToArray());
+                messages = GetMessagesFromChainStatuses(chainStatus);
 
                 return true;
             }
@@ -160,7 +209,7 @@ namespace NuGet.Packaging.Signing
             return false;
         }
 
-        internal static IEnumerable<string> GetMessagesFromChainStatuses(X509ChainStatus[] chainStatuses)
+        internal static IEnumerable<string> GetMessagesFromChainStatuses(IEnumerable<X509ChainStatus> chainStatuses)
         {
             return chainStatuses
                 .Select(x => x.StatusInformation?.Trim())

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
@@ -242,8 +242,12 @@ namespace NuGet.Packaging.Signing
         /// <summary>
         /// Determines if a certificate is self-issued.
         /// </summary>
-        /// <remarks>Warning:  this method does not evaluate certificate trust, revocation status, or validity!</remarks>
-        /// <param name="certificate"></param>
+        /// <remarks>Warning:  this method does not evaluate certificate trust, revocation status, or validity!
+        /// This method attempts to build a chain for the provided certificate, and although revocation status
+        /// checking is explicitly skipped, the underlying chain building engine may go online to fetch
+        /// additional information (e.g.:  the issuer's certificate).  This method is not a guaranteed offline
+        /// check.</remarks>
+        /// <param name="certificate">The certificate to check.</param>
         /// <returns><c>true</c> if the certificate is self-issued; otherwise, <c>false</c>.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="certificate" /> is <c>null</c>.</exception>
         public static bool IsSelfIssued(X509Certificate2 certificate)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using NuGet.Common;
@@ -78,7 +79,6 @@ namespace NuGet.Packaging.Signing
 
             return collectionStringBuilder.ToString();
         }
-
 
         public static string X509ChainToString(X509Chain chain, HashAlgorithmName fingerprintAlgorithm)
         {
@@ -227,7 +227,7 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         /// <param name="certificate">X509Certificate2 to be compute fingerprint</param>
         /// <param name="hashAlgorithm">Hash algorithm for fingerprint</param>
-        /// <returns></returns>
+        /// <returns>A byte array representing the certificate hash.</returns>
         public static byte[] GetHash(X509Certificate2 certificate, HashAlgorithmName hashAlgorithm)
         {
             if (certificate == null)
@@ -236,6 +236,22 @@ namespace NuGet.Packaging.Signing
             }
 
             return hashAlgorithm.ComputeHash(certificate.RawData);
+        }
+
+        /// <summary>
+        /// Determines if a certificate is self-signed.
+        /// </summary>
+        /// <param name="certificate">The certificate to check.</param>
+        /// <returns>A boolean flag indicating if the certificate is self-signed.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="certificate" /> is <c>null</c>.</exception>
+        public static bool IsSelfSigned(X509Certificate2 certificate)
+        {
+            if (certificate == null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            return certificate.IssuerName.RawData.SequenceEqual(certificate.SubjectName.RawData);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SigningUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SigningUtility.cs
@@ -17,11 +17,16 @@ namespace NuGet.Packaging.Signing
     /// </summary>
     public static class SigningUtility
     {
-        public static void Verify(SignPackageRequest request)
+        public static void Verify(SignPackageRequest request, ILogger logger)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
             }
 
             if (!CertificateUtility.IsSignatureAlgorithmSupported(request.Certificate))
@@ -44,7 +49,7 @@ namespace NuGet.Packaging.Signing
                 throw new SignatureException(NuGetLogCode.NU3017, Strings.SignatureNotYetValid);
             }
 
-            request.BuildSigningCertificateChainOnce();
+            request.BuildSigningCertificateChainOnce(logger);
         }
 
 #if IS_DESKTOP

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/VerificationUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/VerificationUtility.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using NuGet.Common;
 
 namespace NuGet.Packaging.Signing

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/IntegrityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/IntegrityVerificationProvider.cs
@@ -38,7 +38,7 @@ namespace NuGet.Packaging.Signing
                 catch (Exception e)
                 {
                     status = SignatureVerificationStatus.Invalid;
-                    issues.Add(SignatureLog.Issue(true, NuGetLogCode.NU3008, Strings.SignaturePackageIntegrityFailure));
+                    issues.Add(SignatureLog.Error(NuGetLogCode.NU3008, Strings.SignaturePackageIntegrityFailure));
                     issues.Add(SignatureLog.DebugLog(e.ToString()));
                 }
             }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
@@ -44,10 +44,10 @@ namespace NuGet.Packaging.Signing
             {
                 validTimestamp = GetValidTimestamp(
                     signature,
-                    !settings.AllowMultipleTimestamps,
-                    !settings.AllowIgnoreTimestamp,
-                    !settings.AllowNoTimestamp,
-                    !settings.AllowUnknownRevocation,
+                    settings.AllowMultipleTimestamps,
+                    settings.AllowIgnoreTimestamp,
+                    settings.AllowNoTimestamp,
+                    settings.AllowUnknownRevocation,
                     issues);
             }
             catch (TimestampException)
@@ -58,8 +58,9 @@ namespace NuGet.Packaging.Signing
             var status = VerifySignature(
                 signature,
                 validTimestamp,
-                !settings.AllowUntrusted,
-                !settings.AllowUnknownRevocation,
+                settings.AllowUntrusted,
+                settings.AllowUntrustedSelfSignedCertificate,
+                settings.AllowUnknownRevocation,
                 issues);
 
             return new SignedPackageVerificationResult(status, signature, issues);
@@ -67,24 +68,24 @@ namespace NuGet.Packaging.Signing
 
         private Timestamp GetValidTimestamp(
             Signature signature,
-            bool failIfMultipleTimestamps,
-            bool treatIssuesAsErrors,
-            bool failIfNoTimestamp,
-            bool failIfUnknownRevocation,
+            bool allowMultipleTimestamps,
+            bool allowIgnoreTimestamp,
+            bool allowNoTimestamp,
+            bool allowUnknownRevocation,
             List<SignatureLog> issues)
         {
             var timestamps = signature.Timestamps;
 
             if (timestamps.Count == 0)
             {
-                issues.Add(SignatureLog.Issue(failIfNoTimestamp, NuGetLogCode.NU3027, Strings.ErrorNoTimestamp));
-                if (failIfNoTimestamp)
+                issues.Add(SignatureLog.Issue(!allowNoTimestamp, NuGetLogCode.NU3027, Strings.ErrorNoTimestamp));
+                if (!allowNoTimestamp)
                 {
                     throw new TimestampException();
                 }
             }
 
-            if (timestamps.Count > 1 && failIfMultipleTimestamps)
+            if (timestamps.Count > 1 && !allowMultipleTimestamps)
             {
                 issues.Add(SignatureLog.Issue(true, NuGetLogCode.NU3000, Strings.ErrorMultipleTimestamps));
                 throw new TimestampException();
@@ -95,11 +96,14 @@ namespace NuGet.Packaging.Signing
             {
                 using (var authorSignatureNativeCms = NativeCms.Decode(signature.SignedCms.Encode(), detached: false))
                 {
-                    var signatureHash = NativeCms.GetSignatureValueHash(signature.SignatureContent.HashAlgorithm, authorSignatureNativeCms);
-
-                    if (!IsTimestampValid(timestamp, signatureHash, treatIssuesAsErrors, failIfUnknownRevocation, issues) && treatIssuesAsErrors)
+                    if (!allowIgnoreTimestamp)
                     {
-                        throw new TimestampException();
+                        var signatureHash = NativeCms.GetSignatureValueHash(signature.SignatureContent.HashAlgorithm, authorSignatureNativeCms);
+
+                        if (!IsTimestampValid(timestamp, signatureHash, allowIgnoreTimestamp, allowUnknownRevocation, issues))
+                        {
+                            throw new TimestampException();
+                        }
                     }
                 }
             }
@@ -110,15 +114,18 @@ namespace NuGet.Packaging.Signing
         private SignatureVerificationStatus VerifySignature(
             Signature signature,
             Timestamp timestamp,
-            bool treatIssuesAsErrors,
-            bool failIfUnknownRevocation,
+            bool allowUntrusted,
+            bool allowUntrustedSelfSignedCertificate,
+            bool allowUnknownRevocation,
             List<SignatureLog> issues)
         {
+            var treatIssueAsError = !allowUntrusted;
             var certificate = signature.SignerInfo.Certificate;
             if (certificate == null)
             {
-                issues.Add(SignatureLog.Issue(treatIssuesAsErrors, NuGetLogCode.NU3010, Strings.ErrorNoCertificate));
-                return SignatureVerificationStatus.Untrusted;
+                issues.Add(SignatureLog.Issue(treatIssueAsError, NuGetLogCode.NU3010, Strings.ErrorNoCertificate));
+
+                return SignatureVerificationStatus.Invalid;
             }
 
             issues.Add(SignatureLog.InformationLog(string.Format(CultureInfo.CurrentCulture,
@@ -131,12 +138,13 @@ namespace NuGet.Packaging.Signing
             }
             catch (Exception e)
             {
-                issues.Add(SignatureLog.Issue(treatIssuesAsErrors, NuGetLogCode.NU3012, Strings.ErrorSignatureVerificationFailed));
+                issues.Add(SignatureLog.Issue(treatIssueAsError, NuGetLogCode.NU3012, Strings.ErrorSignatureVerificationFailed));
                 issues.Add(SignatureLog.DebugLog(e.ToString()));
+
                 return SignatureVerificationStatus.Invalid;
             }
 
-            if (VerificationUtility.IsSigningCertificateValid(certificate, treatIssuesAsErrors, issues))
+            if (VerificationUtility.IsSigningCertificateValid(certificate, treatIssueAsError, issues))
             {
                 timestamp = timestamp ?? new Timestamp();
                 if (Rfc3161TimestampVerificationUtility.ValidateSignerCertificateAgainstTimestamp(certificate, timestamp))
@@ -147,7 +155,7 @@ namespace NuGet.Packaging.Signing
                     {
                         var chain = chainHolder.Chain;
 
-                        // This flags should only be set for verification scenarios, not signing
+                        // These flags should only be set for verification scenarios not signing
                         chain.ChainPolicy.VerificationFlags = X509VerificationFlags.IgnoreNotTimeValid | X509VerificationFlags.IgnoreCtlNotTimeValid;
 
                         CertificateChainUtility.SetCertBuildChainPolicy(chain.ChainPolicy, certificateExtraStore, timestamp.UpperLimit.LocalDateTime, NuGetVerificationCertificateType.Signature);
@@ -161,15 +169,31 @@ namespace NuGet.Packaging.Signing
                         }
 
                         var chainBuildingHasIssues = false;
+                        var statusFlags = CertificateChainUtility.DefaultObservedStatusFlags;
+                        var isSelfSignedCertificate = CertificateUtility.IsSelfSigned(certificate);
+
+                        if (isSelfSignedCertificate)
+                        {
+                            statusFlags &= ~X509ChainStatusFlags.UntrustedRoot;
+                        }
+
                         IEnumerable<string> messages;
-                        if (CertificateChainUtility.TryGetStatusMessage(chainStatuses, CertificateChainUtility.NotIgnoredCertificateFlags, out messages))
+                        if (CertificateChainUtility.TryGetStatusMessage(chainStatuses, statusFlags, out messages))
                         {
                             foreach (var message in messages)
                             {
-                                issues.Add(SignatureLog.Issue(treatIssuesAsErrors, NuGetLogCode.NU3021, message));
+                                issues.Add(SignatureLog.Issue(treatIssueAsError, NuGetLogCode.NU3012, message));
                             }
+
                             chainBuildingHasIssues = true;
                         }
+
+                        // Debug log any errors
+                        issues.Add(SignatureLog.DebugLog(
+                            string.Format(
+                                CultureInfo.CurrentCulture,
+                                Strings.ErrorInvalidCertificateChain,
+                                string.Join(", ", chainStatuses.Select(x => x.Status.ToString())))));
 
                         // For all the special cases, chain status list only has unique elements for each chain status flag present
                         // therefore if we are checking for one specific chain status we can use the first of the returned list
@@ -178,34 +202,43 @@ namespace NuGet.Packaging.Signing
                         if (CertificateChainUtility.ChainStatusListIncludesStatus(chainStatuses, X509ChainStatusFlags.Revoked, out chainStatus))
                         {
                             var status = chainStatus.First();
-                            issues.Add(SignatureLog.Issue(true, NuGetLogCode.NU3021, status.StatusInformation));
+
+                            issues.Add(SignatureLog.Error(NuGetLogCode.NU3012, status.StatusInformation));
+
                             return SignatureVerificationStatus.Invalid;
+                        }
+
+                        if (isSelfSignedCertificate &&
+                            CertificateChainUtility.TryGetStatusMessage(chainStatuses, X509ChainStatusFlags.UntrustedRoot, out messages))
+                        {
+                            issues.Add(SignatureLog.Issue(!allowUntrustedSelfSignedCertificate, NuGetLogCode.NU3018, messages.First()));
+
+                            if (!chainBuildingHasIssues && allowUntrustedSelfSignedCertificate)
+                            {
+                                return SignatureVerificationStatus.Trusted;
+                            }
                         }
 
                         const X509ChainStatusFlags RevocationStatusFlags = X509ChainStatusFlags.RevocationStatusUnknown | X509ChainStatusFlags.OfflineRevocation;
                         if (CertificateChainUtility.TryGetStatusMessage(chainStatuses, RevocationStatusFlags, out messages))
                         {
-                            if (treatIssuesAsErrors)
+                            foreach (var message in messages)
                             {
-                                foreach (var message in messages)
-                                {
-                                    issues.Add(SignatureLog.Issue(failIfUnknownRevocation, NuGetLogCode.NU3018, message));
-                                }
+                                issues.Add(SignatureLog.Issue(!allowUnknownRevocation, NuGetLogCode.NU3018, message));
                             }
-                            if (!chainBuildingHasIssues && (!treatIssuesAsErrors || !failIfUnknownRevocation))
+
+                            if (!chainBuildingHasIssues && allowUnknownRevocation)
                             {
                                 return SignatureVerificationStatus.Trusted;
                             }
+
                             chainBuildingHasIssues = true;
                         }
-
-                        // Debug log any errors
-                        issues.Add(SignatureLog.DebugLog(string.Format(CultureInfo.CurrentCulture, Strings.ErrorInvalidCertificateChain, string.Join(", ", chainStatuses.Select(x => x.ToString())))));
                     }
                 }
                 else
                 {
-                    issues.Add(SignatureLog.Issue(treatIssuesAsErrors, NuGetLogCode.NU3011, Strings.SignatureNotTimeValid));
+                    issues.Add(SignatureLog.Issue(treatIssueAsError, NuGetLogCode.NU3011, Strings.SignatureNotTimeValid));
                 }
             }
 
@@ -215,18 +248,18 @@ namespace NuGet.Packaging.Signing
         private bool IsTimestampValid(
             Timestamp timestamp,
             byte[] messageHash,
-            bool treatIssuesAsErrors,
-            bool failIfUnknownRevocation,
+            bool allowIgnoreTimestamp,
+            bool allowUnknownRevocation,
             List<SignatureLog> issues)
         {
             var timestamperCertificate = timestamp.SignerInfo.Certificate;
             if (timestamperCertificate == null)
             {
-                issues.Add(SignatureLog.Issue(treatIssuesAsErrors, NuGetLogCode.NU3020, Strings.TimestampNoCertificate));
+                issues.Add(SignatureLog.Issue(!allowIgnoreTimestamp, NuGetLogCode.NU3020, Strings.TimestampNoCertificate));
                 return false;
             }
 
-            if (VerificationUtility.IsTimestampValid(timestamp, messageHash, treatIssuesAsErrors, issues, _specification))
+            if (VerificationUtility.IsTimestampValid(timestamp, messageHash, !allowIgnoreTimestamp, issues, _specification))
             {
                 issues.Add(SignatureLog.InformationLog(string.Format(CultureInfo.CurrentCulture, Strings.TimestampValue, timestamp.GeneralizedTime.LocalDateTime.ToString()) + Environment.NewLine));
 
@@ -257,7 +290,7 @@ namespace NuGet.Packaging.Signing
                     var chainBuildingHasIssues = false;
                     IEnumerable<string> messages;
 
-                    var timestampInvalidCertificateFlags = CertificateChainUtility.NotIgnoredCertificateFlags |
+                    var timestampInvalidCertificateFlags = CertificateChainUtility.DefaultObservedStatusFlags |
                         (X509ChainStatusFlags.Revoked) |
                         (X509ChainStatusFlags.NotTimeValid) |
                         (X509ChainStatusFlags.CtlNotTimeValid);
@@ -266,8 +299,9 @@ namespace NuGet.Packaging.Signing
                     {
                         foreach (var message in messages)
                         {
-                            issues.Add(SignatureLog.Issue(treatIssuesAsErrors, NuGetLogCode.NU3028, message));
+                            issues.Add(SignatureLog.Issue(!allowIgnoreTimestamp, NuGetLogCode.NU3028, message));
                         }
+
                         chainBuildingHasIssues = true;
                     }
 
@@ -278,17 +312,16 @@ namespace NuGet.Packaging.Signing
                     const X509ChainStatusFlags RevocationStatusFlags = X509ChainStatusFlags.RevocationStatusUnknown | X509ChainStatusFlags.OfflineRevocation;
                     if (CertificateChainUtility.TryGetStatusMessage(chainStatusList, RevocationStatusFlags, out messages))
                     {
-                        if (treatIssuesAsErrors)
+                        foreach (var message in messages)
                         {
-                            foreach (var message in messages)
-                            {
-                                issues.Add(SignatureLog.Issue(failIfUnknownRevocation, NuGetLogCode.NU3028, message));
-                            }
+                            issues.Add(SignatureLog.Issue(!allowUnknownRevocation, NuGetLogCode.NU3028, message));
                         }
-                        if (!chainBuildingHasIssues && (!treatIssuesAsErrors || !failIfUnknownRevocation))
+
+                        if (!chainBuildingHasIssues && (allowIgnoreTimestamp || allowUnknownRevocation))
                         {
                             return true;
                         }
+
                         chainBuildingHasIssues = true;
                     }
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifierSettings.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifierSettings.cs
@@ -18,6 +18,8 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         public bool AllowUntrusted { get; }
 
+        public bool AllowUntrustedSelfSignedCertificate { get; }
+
         public bool AllowIgnoreTimestamp { get; }
 
         public bool AllowMultipleTimestamps { get; }
@@ -32,6 +34,7 @@ namespace NuGet.Packaging.Signing
         public SignedPackageVerifierSettings(
             bool allowUnsigned,
             bool allowUntrusted,
+            bool allowUntrustedSelfSignedCertificate,
             bool allowIgnoreTimestamp,
             bool allowMultipleTimestamps,
             bool allowNoTimestamp,
@@ -39,6 +42,7 @@ namespace NuGet.Packaging.Signing
         {
             AllowUnsigned = allowUnsigned;
             AllowUntrusted = allowUntrusted;
+            AllowUntrustedSelfSignedCertificate = allowUntrustedSelfSignedCertificate;
             AllowIgnoreTimestamp = allowIgnoreTimestamp;
             AllowMultipleTimestamps = allowMultipleTimestamps;
             AllowNoTimestamp = allowNoTimestamp;
@@ -51,6 +55,7 @@ namespace NuGet.Packaging.Signing
         public static SignedPackageVerifierSettings AllowAll { get; } = new SignedPackageVerifierSettings(
             allowUnsigned: true,
             allowUntrusted: true,
+            allowUntrustedSelfSignedCertificate: true,
             allowIgnoreTimestamp: true,
             allowMultipleTimestamps: true,
             allowNoTimestamp: true,
@@ -67,10 +72,11 @@ namespace NuGet.Packaging.Signing
         public static SignedPackageVerifierSettings VSClientDefaultPolicy { get; } = new SignedPackageVerifierSettings(
             allowUnsigned: true,
             allowUntrusted: true,
+            allowUntrustedSelfSignedCertificate: true,
             allowIgnoreTimestamp: true,
             allowMultipleTimestamps: true,
             allowNoTimestamp: true,
-            allowUnknownRevocation: false);
+            allowUnknownRevocation: true);
 
         /// <summary>
         /// Default policy for nuget.exe verify --signatures command
@@ -78,9 +84,10 @@ namespace NuGet.Packaging.Signing
         public static SignedPackageVerifierSettings VerifyCommandDefaultPolicy { get; } = new SignedPackageVerifierSettings(
             allowUnsigned: false,
             allowUntrusted: false,
+            allowUntrustedSelfSignedCertificate: true,
             allowIgnoreTimestamp: false,
             allowMultipleTimestamps: true,
             allowNoTimestamp: true,
-            allowUnknownRevocation: false);
+            allowUnknownRevocation: true);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -80,6 +80,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Certificate chain validation failed..
+        /// </summary>
+        internal static string CertificateChainValidationFailed {
+            get {
+                return ResourceManager.GetString("CertificateChainValidationFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} hash: {1}.
         /// </summary>
         internal static string CertUtilityCertificateHash {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -515,4 +515,7 @@ Valid from:</comment>
     <comment>0 - Hash algorithm name
 1 - certificate hash in given hash algorithm</comment>
   </data>
+  <data name="CertificateChainValidationFailed" xml:space="preserve">
+    <value>Certificate chain validation failed.</value>
+  </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
@@ -41,7 +41,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         private Lazy<Task<SigningTestServer>> _testServer;
         private Lazy<Task<CertificateAuthority>> _defaultTrustedCertificateAuthority;
         private Lazy<Task<TimestampService>> _defaultTrustedTimestampService;
-        private readonly DisposableList _responders;
+        private readonly DisposableList<IDisposable> _responders;
 
         public TrustedTestCert<TestCertificate> TrustedTestCertificate
         {
@@ -251,7 +251,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             _testServer = new Lazy<Task<SigningTestServer>>(SigningTestServer.CreateAsync);
             _defaultTrustedCertificateAuthority = new Lazy<Task<CertificateAuthority>>(CreateDefaultTrustedCertificateAuthorityAsync);
             _defaultTrustedTimestampService = new Lazy<Task<TimestampService>>(CreateDefaultTrustedTimestampServiceAsync);
-            _responders = new DisposableList();
+            _responders = new DisposableList<IDisposable>();
         }
 
         private void SetUpCrlDistributionPoint()

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -284,7 +284,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     waitForExit: true);
 
                 // Assert
-                result.Success.Should().BeFalse();
+                result.Success.Should().BeTrue();
                 result.AllOutput.Should().Contain(_noTimestamperWarningCode);
                 result.AllOutput.Should().Contain(_chainBuildFailureErrorCode);
                 result.AllOutput.Should().Contain("The revocation function was unable to check revocation for the certificate");

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignerTests.cs
@@ -74,7 +74,7 @@ namespace NuGet.Packaging.FuncTest
                     () => test.Signer.SignAsync(test.Request, NullLogger.Instance, CancellationToken.None));
 
                 Assert.Equal(NuGetLogCode.NU3018, exception.Code);
-                Assert.Contains("A required certificate is not within its validity period", exception.Message);
+                Assert.Contains("Certificate chain validation failed.", exception.Message);
 
                 var isSigned = await IsSignedAsync(test.WriteStream);
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
@@ -19,6 +19,7 @@ namespace NuGet.Packaging.FuncTest
         private TrustedTestCert<TestCertificate> _trustedTestCertExpired;
         private TrustedTestCert<TestCertificate> _trustedTestCertNotYetValid;
         private TrustedTestCert<X509Certificate2> _trustedTimestampRoot;
+        private TestCertificate _untrustedTestCert;
         private IReadOnlyList<TrustedTestCert<TestCertificate>> _trustedTestCertificateWithReissuedCertificate;
         private IList<ISignatureVerificationProvider> _trustProviders;
         private SigningSpecifications _signingSpecifications;
@@ -96,6 +97,19 @@ namespace NuGet.Packaging.FuncTest
                 }
 
                 return _trustedTestCertificateWithReissuedCertificate;
+            }
+        }
+
+        public TestCertificate UntrustedTestCertificate
+        {
+            get
+            {
+                if (_untrustedTestCert == null)
+                {
+                    _untrustedTestCert = TestCertificate.Generate(SigningTestUtility.CertificateModificationGeneratorForCodeSigningEkuCert);
+                }
+
+                return _untrustedTestCert;
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
@@ -26,14 +26,14 @@ namespace NuGet.Packaging.FuncTest
         private Lazy<Task<SigningTestServer>> _testServer;
         private Lazy<Task<CertificateAuthority>> _defaultTrustedCertificateAuthority;
         private Lazy<Task<TimestampService>> _defaultTrustedTimestampService;
-        private readonly DisposableList _responders;
+        private readonly DisposableList<IDisposable> _responders;
 
         public SigningTestFixture()
         {
             _testServer = new Lazy<Task<SigningTestServer>>(SigningTestServer.CreateAsync);
             _defaultTrustedCertificateAuthority = new Lazy<Task<CertificateAuthority>>(CreateDefaultTrustedCertificateAuthorityAsync);
             _defaultTrustedTimestampService = new Lazy<Task<TimestampService>>(CreateDefaultTrustedTimestampServiceAsync);
-            _responders = new DisposableList();
+            _responders = new DisposableList<IDisposable>();
         }
 
         public TrustedTestCert<TestCertificate> TrustedTestCertificate

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
@@ -33,7 +33,7 @@ namespace NuGet.Packaging.FuncTest
             using (var certificate = new X509Certificate2(_fixture.TrustedTestCertificate.Source.PublicCert.RawData))
             using (var request = new AuthorSignPackageRequest(certificate, HashAlgorithmName.SHA256, HashAlgorithmName.SHA256))
             {
-                SigningUtility.Verify(request);
+                SigningUtility.Verify(request, NullLogger.Instance);
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
@@ -144,7 +144,7 @@ namespace NuGet.Commands.Test
                 await test.Runner.ExecuteCommandAsync(test.Args);
 
                 Assert.Equal(1, test.Logger.LogMessages.Count(
-                    message => message.Level == LogLevel.Error && message.Code == NuGetLogCode.NU3018));
+                    message => message.Level == LogLevel.Warning && message.Code == NuGetLogCode.NU3018));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
@@ -242,6 +242,33 @@ namespace NuGet.Packaging.Test
             }
         }
 
+        [Fact]
+        public void IsSelfSigned_WhenCertificateNull_Throws()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => CertificateUtility.IsSelfSigned(certificate: null));
+
+            Assert.Equal("certificate", exception.ParamName);
+        }
+
+        [Fact]
+        public void IsSelfSigned_WithSelfSignedCertificate_ReturnsTrue()
+        {
+            using (var certificate = _fixture.GetDefaultCertificate())
+            {
+                Assert.True(CertificateUtility.IsSelfSigned(certificate));
+            }
+        }
+
+        [Fact]
+        public void IsSelfSigned_WithNonSelfSignedCertificate_ReturnsFalse()
+        {
+            using (var certificate = _fixture.GetNonSelfSignedCertificate())
+            {
+                Assert.False(CertificateUtility.IsSelfSigned(certificate));
+            }
+        }
+
         private static int GetExtendedKeyUsageCount(X509Certificate2 certificate)
         {
             foreach (var extension in certificate.Extensions)

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
@@ -243,29 +243,56 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
-        public void IsSelfSigned_WhenCertificateNull_Throws()
+        public void IsSelfIssued_WhenCertificateNull_Throws()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => CertificateUtility.IsSelfSigned(certificate: null));
+                () => CertificateUtility.IsSelfIssued(certificate: null));
 
             Assert.Equal("certificate", exception.ParamName);
         }
 
         [Fact]
-        public void IsSelfSigned_WithSelfSignedCertificate_ReturnsTrue()
+        public void IsSelfIssued_WithPartialChain_ReturnsFalse()
         {
-            using (var certificate = _fixture.GetDefaultCertificate())
+            using (var certificate = SignTestUtility.GetCertificate("leaf.crt"))
             {
-                Assert.True(CertificateUtility.IsSelfSigned(certificate));
+                Assert.False(CertificateUtility.IsSelfIssued(certificate));
             }
         }
 
         [Fact]
-        public void IsSelfSigned_WithNonSelfSignedCertificate_ReturnsFalse()
+        public void IsSelfIssued_WithNonSelfSignedCertificate_ReturnsFalse()
         {
             using (var certificate = _fixture.GetNonSelfSignedCertificate())
             {
-                Assert.False(CertificateUtility.IsSelfSigned(certificate));
+                Assert.False(CertificateUtility.IsSelfIssued(certificate));
+            }
+        }
+
+        [Fact]
+        public void IsSelfIssued_WithSelfSignedCertificate_ReturnsTrue()
+        {
+            using (var certificate = _fixture.GetDefaultCertificate())
+            {
+                Assert.True(CertificateUtility.IsSelfIssued(certificate));
+            }
+        }
+
+        [Fact]
+        public void IsSelfIssued_WithSelfIssuedCertificate_ReturnsTrue()
+        {
+            using (var certificate = _fixture.GetSelfIssuedCertificate())
+            {
+                Assert.True(CertificateUtility.IsSelfIssued(certificate));
+            }
+        }
+
+        [Fact]
+        public void IsSelfIssued_WithRootCertificate_ReturnsTrue()
+        {
+            using (var certificate = _fixture.GetRootCertificate())
+            {
+                Assert.True(CertificateUtility.IsSelfIssued(certificate));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificatesFixture.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificatesFixture.cs
@@ -7,6 +7,7 @@ using NuGet.Packaging.Signing;
 using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Security;
 using Test.Utility.Signing;
 
 namespace NuGet.Packaging.Test
@@ -16,7 +17,9 @@ namespace NuGet.Packaging.Test
         private readonly X509Certificate2 _defaultCertificate;
         private readonly X509Certificate2 _rsaSsaPssCertificate;
         private readonly X509Certificate2 _lifetimeSigningCertificate;
+        private readonly X509Certificate2 _expiredCertificate;
         private readonly X509Certificate2 _notYetValidCertificate;
+        private readonly X509Certificate2 _nonSelfSignedCertificate;
 
         private bool _isDisposed;
 
@@ -36,10 +39,16 @@ namespace NuGet.Packaging.Test
                         critical: true,
                         extensionValue: new DerSequence(new DerObjectIdentifier(Oids.LifetimeSigningEku)));
                 });
-
+            _expiredCertificate = SigningTestUtility.GenerateCertificate(
+                "test",
+                SigningTestUtility.CertificateModificationGeneratorExpiredCert);
             _notYetValidCertificate = SigningTestUtility.GenerateCertificate(
                 "test",
                 SigningTestUtility.CertificateModificationGeneratorNotYetValidCert);
+            _nonSelfSignedCertificate = SigningTestUtility.GenerateCertificate(
+                "test non-self-signed certificate", // Must be different than the issuing certificate's subject name.
+                generator => { },
+                chainCertificateRequest: new ChainCertificateRequest() { Issuer = _defaultCertificate });
         }
 
         public void Dispose()
@@ -48,8 +57,10 @@ namespace NuGet.Packaging.Test
             {
                 _defaultCertificate.Dispose();
                 _lifetimeSigningCertificate.Dispose();
+                _expiredCertificate.Dispose();
                 _notYetValidCertificate.Dispose();
                 _rsaSsaPssCertificate.Dispose();
+                _nonSelfSignedCertificate.Dispose();
 
                 GC.SuppressFinalize(this);
 
@@ -58,7 +69,9 @@ namespace NuGet.Packaging.Test
         }
 
         internal X509Certificate2 GetDefaultCertificate() => Clone(_defaultCertificate);
+        internal X509Certificate2 GetExpiredCertificate() => Clone(_expiredCertificate);
         internal X509Certificate2 GetLifetimeSigningCertificate() => Clone(_lifetimeSigningCertificate);
+        internal X509Certificate2 GetNonSelfSignedCertificate() => Clone(_nonSelfSignedCertificate);
         internal X509Certificate2 GetNotYetValidCertificate() => Clone(_notYetValidCertificate);
         internal X509Certificate2 GetRsaSsaPssCertificate() => Clone(_rsaSsaPssCertificate);
 

--- a/test/TestUtilities/Test.Utility/Signing/DisposableList.cs
+++ b/test/TestUtilities/Test.Utility/Signing/DisposableList.cs
@@ -6,7 +6,8 @@ using System.Collections.Generic;
 
 namespace Test.Utility.Signing
 {
-    public sealed class DisposableList : List<IDisposable>, IDisposable
+    public sealed class DisposableList<T> : List<T>, IDisposable
+        where T : IDisposable
     {
         private bool _isDisposed;
 


### PR DESCRIPTION
Resolve https://github.com/NuGet/Home/issues/6508.

For the default client policy, at signing time and verification time:

* warn for but allow untrusted self-signed certificates
* warn for but do not error if revocation information is unavailable