### PR TITLE
SolutionDir support in NuGet.targets

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -51,6 +51,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Build in parallel -->
     <RestoreBuildInParallel Condition=" '$(BuildInParallel)' != '' ">$(BuildInParallel)</RestoreBuildInParallel>
     <RestoreBuildInParallel Condition=" '$(RestoreBuildInParallel)' == '' ">true</RestoreBuildInParallel>
+    <!-- Check if the restore target was executed on a sln file -->
+    <_RestoreSolutionFileUsed Condition=" '$(_RestoreSolutionFileUsed)' == '' AND '$(SolutionDir)' != '' AND $(MSBuildProjectFullPath.EndsWith('.metaproj')) == 'true' " >true</_RestoreSolutionFileUsed>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -68,6 +70,14 @@ Copyright (c) .NET Foundation. All rights reserved.
       RestoreUseCustomAfterTargets=$(RestoreUseCustomAfterTargets);
       CustomAfterMicrosoftCommonCrossTargetingTargets=$(MSBuildThisFileFullPath);
       CustomAfterMicrosoftCommonTargets=$(MSBuildThisFileFullPath);
+    </_GenerateRestoreGraphProjectEntryInputProperties>
+
+    <!-- Include SolutionDir and SolutionName for solution restores and persist these properties during the walk. -->
+    <_GenerateRestoreGraphProjectEntryInputProperties Condition=" '$(_RestoreSolutionFileUsed)' == 'true' ">
+      $(_GenerateRestoreGraphProjectEntryInputProperties);
+      _RestoreSolutionFileUsed=true;
+      SolutionDir=$(SolutionDir);
+      SolutionName=$(SolutionName);
     </_GenerateRestoreGraphProjectEntryInputProperties>
   </PropertyGroup>
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1,0 +1,82 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+using FluentAssertions;
+using NuGet.Common;
+using NuGet.Packaging.Core;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace Dotnet.Integration.Test
+{
+    [Collection("Dotnet Integration Tests")]
+    public class DotnetRestoreTests
+    {
+        private MsbuildIntegrationTestFixture _msbuildFixture;
+
+        public DotnetRestoreTests(MsbuildIntegrationTestFixture fixture)
+        {
+            _msbuildFixture = fixture;
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void DotnetRestore_SolutionRestoreVerifySolutionDirPassedToProjects()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                _msbuildFixture.CreateDotnetNewProject(pathContext.SolutionRoot, "proj");
+
+                var slnContents = @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27330.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""proj"", ""proj\proj.csproj"", ""{216FF388-8C16-4AF4-87A8-9094030692FA}""
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{216FF388-8C16-4AF4-87A8-9094030692FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{216FF388-8C16-4AF4-87A8-9094030692FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{216FF388-8C16-4AF4-87A8-9094030692FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{216FF388-8C16-4AF4-87A8-9094030692FA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9A6704E2-6E77-4FF4-9E54-B789D88829DD}
+	EndGlobalSection
+EndGlobal";
+
+                var slnPath = Path.Combine(pathContext.SolutionRoot, "proj.sln");
+                File.WriteAllText(slnPath, slnContents);
+
+                var projPath = Path.Combine(pathContext.SolutionRoot, "proj", "proj.csproj");
+                var doc = XDocument.Parse(File.ReadAllText(projPath));
+
+                doc.Root.Add(new XElement(XName.Get("Target"),
+                    new XAttribute(XName.Get("Name"), "ErrorOnSolutionDir"),
+                    new XAttribute(XName.Get("BeforeTargets"), "CollectPackageReferences"),
+                    new XElement(XName.Get("Error"),
+                        new XAttribute(XName.Get("Text"), $"|SOLUTION $(SolutionDir) $(SolutionName)|"))));
+
+                File.Delete(projPath);
+                File.WriteAllText(projPath, doc.ToString());
+
+                var result = _msbuildFixture.RunDotnet(pathContext.SolutionRoot, "msbuild proj.sln /t:restore /p:DisableImplicitFrameworkReferences=true");
+
+                result.ExitCode.Should().Be(1, "error text should be displayed");
+                result.AllOutput.Should().Contain($"|SOLUTION {PathUtility.EnsureTrailingSlash(pathContext.SolutionRoot)} proj|");
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
@@ -144,6 +144,25 @@ namespace Dotnet.Integration.Test
             Assert.True(result.Item3 == "", $"Restore failed with following message in error stream :\n {result.AllOutput}");
         }
 
+        /// <summary>
+        /// dotnet.exe args
+        /// </summary>
+        internal CommandRunnerResult RunDotnet(string workingDirectory, string args)
+        {
+            var envVar = new Dictionary<string, string>
+            {
+                { "MSBuildSDKsPath", MsBuildSdksPath }
+            };
+
+            var result = CommandRunner.Run(TestDotnetCli,
+                workingDirectory,
+                args,
+                waitForExit: true,
+                environmentVariables: _processEnvVars);
+
+            return result;
+        }
+
         internal CommandRunnerResult PackProject(string workingDirectory, string projectName, string args, string nuspecOutputPath = "obj")
         {
             var result = CommandRunner.Run(TestDotnetCli,


### PR DESCRIPTION
Pass the SolutionDir and SolutionName properties from the solution file to all projects during restore evaluation.

`_RestoreSolutionFileUsed` is set to true if restore was executed on a solution file. To the target this appears as a `.metaproj` which will have `SolutionDir` and `SolutionName` set. One this property is true it will be persisted along with the solution properties during the walk and passed to all projects using the existing `_GenerateRestoreGraphProjectEntryInputProperties` property which is always used when `<MSBuild>` is called.

Fixes https://github.com/NuGet/Home/issues/6495
