### PR TITLE
add logic to figure out target vs branch for insertion

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -9,6 +9,8 @@
     <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">$(MajorNuGetVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</SemanticVersion>
     <VsTargetBranch>lab/d15.$(MinorNuGetVersion)stg</VsTargetBranch>
     <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d15.$(MinorNuGetVersion)</VsTargetBranch>
+    <SdkTargetBranch>master</SdkTargetBranch>
+    <CliTargetBranch>master</CliTargetBranch>
     <!-- We need to update this netcoreassembly build number with every milestone to workaround any breaking api
     changes we might have made-->
     <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">1</NetCoreAssemblyBuildNumber>
@@ -50,5 +52,11 @@
   </Target>
   <Target Name="GetVsTargetBranch">
     <Message Text="$(VsTargetBranch)" Importance="High"/>
+  </Target>
+  <Target Name="GetCliTargetBranch">
+    <Message Text="$(CliTargetBranch)" Importance="High"/>
+  </Target>
+  <Target Name="GetSdkTargetBranch">
+    <Message Text="$(SdkTargetBranch)" Importance="High"/>
   </Target>
 </Project>

--- a/build/config.props
+++ b/build/config.props
@@ -2,7 +2,13 @@
 <Project ToolsVersion="15.0">
   <!-- Version -->
   <PropertyGroup>
-    <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">4.7.0</SemanticVersion>
+    <IsEscrowMode>false</IsEscrowMode>
+    <MajorNuGetVersion Condition="'$(MajorNuGetVersion)' == ''">4</MajorNuGetVersion>
+    <MinorNuGetVersion Condition="'$(MinorNuGetVersion)' == ''">7</MinorNuGetVersion>
+    <PatchNuGetVersion Condition="'$(PatchNuGetVersion)' == ''">0</PatchNuGetVersion>
+    <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">$(MajorNuGetVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</SemanticVersion>
+    <VsTargetBranch>lab/d15.$(MinorNuGetVersion)stg</VsTargetBranch>
+    <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d15.$(MinorNuGetVersion)</VsTargetBranch>
     <!-- We need to update this netcoreassembly build number with every milestone to workaround any breaking api
     changes we might have made-->
     <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">1</NetCoreAssemblyBuildNumber>
@@ -41,5 +47,8 @@
 
   <Target Name="GetSemanticVersion">
     <Message Text="$(SemanticVersion)" Importance="High"/>
+  </Target>
+  <Target Name="GetVsTargetBranch">
+    <Message Text="$(VsTargetBranch)" Importance="High"/>
   </Target>
 </Project>

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -175,13 +175,15 @@ else
         $newBuildCounter = $env:BUILD_BUILDNUMBER        
     }
 
-    
+    $VsTargetBranch = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetBranch
+    Write-Host $VsTargetBranch
     $jsonRepresentation = @{
         BuildNumber = $newBuildCounter
         CommitHash = $env:BUILD_SOURCEVERSION
         BuildBranch = $env:BUILD_SOURCEBRANCHNAME
         LocalizationRepositoryBranch = $NuGetLocalizationRepoBranch
         LocalizationRepositoryCommitHash = $LocalizationRepoCommitHash
+        VsTargetBranch = $VsTargetBranch
     }   
 
     New-Item $BuildInfoJsonFile -Force

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -176,6 +176,7 @@ else
     }
 
     $VsTargetBranch = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetBranch
+    $VsTargetBranch = $VsTargetBranch.Trim()
     Write-Host $VsTargetBranch
     $jsonRepresentation = @{
         BuildNumber = $newBuildCounter

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -176,7 +176,8 @@ else
     }
 
     $VsTargetBranch = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetBranch
-    $VsTargetBranch = $VsTargetBranch.Trim()
+    $CliTargetBranch = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetCliTargetBranch
+    $SdkTargetBranch = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSdkTargetBranch
     Write-Host $VsTargetBranch
     $jsonRepresentation = @{
         BuildNumber = $newBuildCounter
@@ -184,7 +185,9 @@ else
         BuildBranch = $env:BUILD_SOURCEBRANCHNAME
         LocalizationRepositoryBranch = $NuGetLocalizationRepoBranch
         LocalizationRepositoryCommitHash = $LocalizationRepoCommitHash
-        VsTargetBranch = $VsTargetBranch
+        VsTargetBranch = $VsTargetBranch.Trim()
+        CliTargetBranch = $CliTargetBranch.Trim()
+        SdkTargetBranch = $SdkTargetBranch.Trim()
     }   
 
     New-Item $BuildInfoJsonFile -Force


### PR DESCRIPTION
this PR tries to make us more intelligent about what branch of VS we should validate/insert into. The release definition side changes will be made once this PR is merged in.

The VsTargetBranch can still be overridden in the release definition, the same way it is done now. The only change will be that the default value of this variable in the release definition will now be blank.