### PR TITLE
Add X-NuGet-Session-Id

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
@@ -66,6 +66,13 @@ namespace NuGet.Protocol
                         // disposing it.
                         response?.Dispose();
 
+                        // Add common headers to the request after it is created by the factory. This includes
+                        // X-NuGet-Session-Id which is added to all nuget requests.
+                        foreach (var header in request.AddHeaders)
+                        {
+                            requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                        }
+
                         log.LogInformation("  " + string.Format(
                             CultureInfo.InvariantCulture,
                             Strings.Http_RequestLog,

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandlerRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandlerRequest.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 
 namespace NuGet.Protocol
@@ -49,5 +50,10 @@ namespace NuGet.Protocol
 
         /// <summary>The timeout to apply to <see cref="DownloadTimeoutStream"/> instances.</summary>
         public TimeSpan DownloadTimeout { get; set; }
+
+        /// <summary>
+        /// Additional headers to add to the request.
+        /// </summary>
+        public IList<KeyValuePair<string, IEnumerable<string>>> AddHeaders { get; set; } = new List<KeyValuePair<string, IEnumerable<string>>>();
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/HttpSourceCacheContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSourceCacheContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -8,7 +8,7 @@ namespace NuGet.Protocol.Core.Types
 {
     public class HttpSourceCacheContext
     {
-        private HttpSourceCacheContext(string rootTempFolder, TimeSpan maxAge, bool directDownload)
+        private HttpSourceCacheContext(string rootTempFolder, TimeSpan maxAge, bool directDownload, SourceCacheContext cacheContext)
         {
             if (maxAge <= TimeSpan.Zero)
             {
@@ -27,6 +27,7 @@ namespace NuGet.Protocol.Core.Types
             RootTempFolder = rootTempFolder;
             MaxAge = maxAge;
             DirectDownload = directDownload;
+            SourceCacheContext = cacheContext ?? throw new ArgumentNullException(nameof(cacheContext));
         }
 
         public TimeSpan MaxAge { get; }
@@ -38,6 +39,11 @@ namespace NuGet.Protocol.Core.Types
         /// disposal of the <see cref="SourceCacheContext"/> that was used to create this instance.
         /// </summary>
         public string RootTempFolder { get; }
+
+        /// <summary>
+        /// Inner cache context.
+        /// </summary>
+        public SourceCacheContext SourceCacheContext { get; }
 
         public static HttpSourceCacheContext Create(SourceCacheContext cacheContext, int retryCount)
         {
@@ -51,14 +57,16 @@ namespace NuGet.Protocol.Core.Types
                 return new HttpSourceCacheContext(
                     rootTempFolder: null,
                     maxAge: cacheContext.MaxAgeTimeSpan,
-                    directDownload: cacheContext.DirectDownload);
+                    directDownload: cacheContext.DirectDownload,
+                    cacheContext: cacheContext);
             }
             else
             {
                 return new HttpSourceCacheContext(
                     cacheContext.GeneratedTempFolder,
                     TimeSpan.Zero,
-                    cacheContext.DirectDownload);
+                    cacheContext.DirectDownload,
+                    cacheContext: cacheContext);
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedParser.cs
@@ -599,6 +599,7 @@ namespace NuGet.Protocol
                             response.ReasonPhrase));
                     }
                 },
+                sourceCacheContext,
                 log,
                 token);
             }

--- a/src/NuGet.Core/NuGet.Protocol/ProtocolConstants.cs
+++ b/src/NuGet.Core/NuGet.Protocol/ProtocolConstants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace NuGet.Protocol
@@ -7,5 +7,6 @@ namespace NuGet.Protocol
     {
         public static readonly string ApiKeyHeader = "X-NuGet-ApiKey";
         public static readonly string ServerWarningHeader = "X-NuGet-Warning";
+        public static readonly string SessionId = "X-NuGet-Session-Id";
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/SourceCacheContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SourceCacheContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -47,6 +47,12 @@ namespace NuGet.Protocol.Core.Types
         /// This should only be used for retries.
         /// </summary>
         public bool RefreshMemoryCache { get; set; }
+
+        /// <summary>
+        /// X-NUGET-SESSION
+        /// This should be unique for each package operation.
+        /// </summary>
+        public Guid SessionId { get; set; } = Guid.NewGuid();
 
         /// <summary>
         /// Package version lists from the server older than this time span
@@ -121,7 +127,8 @@ namespace NuGet.Protocol.Core.Types
                 MaxAge = MaxAge,
                 NoCache = NoCache,
                 GeneratedTempFolder = _generatedTempFolder,
-                RefreshMemoryCache = RefreshMemoryCache
+                RefreshMemoryCache = RefreshMemoryCache,
+                SessionId = SessionId
             };
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Utility/GetDownloadResultUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/GetDownloadResultUtility.cs
@@ -95,6 +95,7 @@ namespace NuGet.Protocol
                                     token);
                             }
                         },
+                        downloadContext.SourceCacheContext,
                         logger,
                         token);
                 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MockServer.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MockServer.cs
@@ -36,6 +36,11 @@ namespace NuGet.CommandLine.Test
         public string Uri { get { return PortReserver.BaseUri; } }
 
         /// <summary>
+        /// Observe requests without handling them directly.
+        /// </summary>
+        public Action<HttpListenerContext> RequestObserver { get; set; } = (x) => { };
+
+        /// <summary>
         /// Initializes an instance of MockServer.
         /// </summary>
         public MockServer()
@@ -332,7 +337,10 @@ namespace NuGet.CommandLine.Test
                 try
                 {
                     var context = Listener.GetContext();
+
                     GenerateResponse(context);
+
+                    RequestObserver(context);
                 }
                 catch (ObjectDisposedException)
                 {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetMockServerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetMockServerTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Frameworks;
+using NuGet.Protocol;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.Test
+{
+    public class NuGetMockServerTests
+    {
+        [Fact]
+        public void MockServer_RestorePRVerifySessionId()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var nugetexe = Util.GetNuGetExePath();
+
+                var packageA = new ZipPackage(Util.CreateTestPackage("a", "1.0.0", pathContext.PackageSource));
+                var packageB = new ZipPackage(Util.CreateTestPackage("b", "1.0.0", pathContext.PackageSource));
+
+                var project = SimpleTestProjectContext.CreateNETCore("proj", pathContext.SolutionRoot, NuGetFramework.Parse("net46"));
+
+                project.AddPackageToAllFrameworks(new SimpleTestPackageContext("a", "1.0.0"));
+                project.AddPackageToAllFrameworks(new SimpleTestPackageContext("b", "1.0.0"));
+
+                project.Save();
+
+                var ids = new List<string>();
+
+                using (var server = Util.CreateMockServer(new[] { packageA, packageB }))
+                {
+                    server.RequestObserver = context =>
+                    {
+                        ids.Add(context.Request.Headers.Get(ProtocolConstants.SessionId));
+                    };
+
+                    server.Start();
+
+                    var result = Util.Restore(pathContext, project.ProjectPath, 0, "-Source", server.Uri + "nuget");
+
+                    result.Success.Should().BeTrue();
+
+                    ids.Distinct().Count().Should().Be(1, "all requests should be in the same session");
+                    ids.All(s => !string.IsNullOrEmpty(s) && Guid.TryParse(s, out var r)).Should().BeTrue("the values should guids");
+                }
+            }
+        }
+
+        [Fact]
+        public void MockServer_RestorePCVerifySessionId()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var nugetexe = Util.GetNuGetExePath();
+
+                var packageA = new ZipPackage(Util.CreateTestPackage("a", "1.0.0", pathContext.PackageSource));
+                var packageB = new ZipPackage(Util.CreateTestPackage("b", "1.0.0", pathContext.PackageSource));
+
+                Util.CreateFile(pathContext.SolutionRoot, "packages.config",
+@"<packages>
+  <package id=""a"" version=""1.0.0"" targetFramework=""net45"" />
+  <package id=""b"" version=""1.0.0"" targetFramework=""net45"" />
+</packages>");
+
+                var ids = new List<string>();
+
+                using (var server = Util.CreateMockServer(new[] { packageA, packageB }))
+                {
+                    server.RequestObserver = context =>
+                    {
+                        ids.Add(context.Request.Headers.Get(ProtocolConstants.SessionId));
+                    };
+
+                    server.Start();
+
+                    var result = Util.Restore(pathContext, Path.Combine(pathContext.SolutionRoot, "packages.config"), 0, "-Source", server.Uri + "nuget");
+
+                    result.Success.Should().BeTrue();
+
+                    // Not all ids will be in the same session, this is due to how cache contexts are shared for packages.config
+                    ids.Distinct().Count().Should().BeLessThan(ids.Count(), "Verify some requests share the same cache context and session id.");
+                    ids.All(s => !string.IsNullOrEmpty(s) && Guid.TryParse(s, out var r)).Should().BeTrue("the values should guids");
+                }
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/HttpRetryHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/HttpRetryHandlerTests.cs
@@ -2,10 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using NuGet.Common;
 using NuGet.Protocol;
 using NuGet.Test.Server;


### PR DESCRIPTION
Add a X-NuGet-Session-Id header to all outgoing client requests. The id is based on SourceCacheContext, all calls using the same context will add the same id. The id is a randomly generated GUID that can be used by servers to help diagnose issues by putting together all calls from a single operation.

Note that the concept of a session here is based on SourceCacheContext. For PackageReference restore the entire operation is done for all projects and sources using a single context object. For packages.config restore a few different contexts are used for v2 sources which makes means not everything will get the same id, but retries and some parts the restore will an id, so it is still useful. Unifying SourceCacheContext objects for packages.config could be improved in the future. 
    
Fixes https://github.com/NuGet/Home/issues/5330