### PR TITLE
 Adding support for reading and setting nested SettingValue into nuget Settings

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,20 +6,21 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.VisualStudio;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
-    [Export(typeof(Configuration.ISettings))]
+    [Export(typeof(ISettings))]
     [PartCreationPolicy(CreationPolicy.Shared)]
-    public class VSSettings : Configuration.ISettings
+    public class VSSettings : ISettings
     {
         private const string NuGetSolutionSettingsFolder = ".nuget";
 
         // to initialize SolutionSettings first time outside MEF constructor
-        private Configuration.ISettings _solutionSettings;
+        private ISettings _solutionSettings;
 
-        private Configuration.ISettings SolutionSettings
+        private ISettings SolutionSettings
         {
             get
             {
@@ -34,7 +35,8 @@ namespace NuGet.PackageManagement.VisualStudio
         }
 
         private ISolutionManager SolutionManager { get; set; }
-        private Configuration.IMachineWideSettings MachineWideSettings { get; set; }
+
+        private IMachineWideSettings MachineWideSettings { get; set; }
 
         public event EventHandler SettingsChanged;
 
@@ -44,14 +46,9 @@ namespace NuGet.PackageManagement.VisualStudio
         }
 
         [ImportingConstructor]
-        public VSSettings(ISolutionManager solutionManager, Configuration.IMachineWideSettings machineWideSettings)
+        public VSSettings(ISolutionManager solutionManager, IMachineWideSettings machineWideSettings)
         {
-            if (solutionManager == null)
-            {
-                throw new ArgumentNullException(nameof(solutionManager));
-            }
-
-            SolutionManager = solutionManager;
+            SolutionManager = solutionManager ?? throw new ArgumentNullException(nameof(solutionManager));
             MachineWideSettings = machineWideSettings;
             SolutionManager.SolutionOpening += OnSolutionOpenedOrClosed;
             SolutionManager.SolutionClosed += OnSolutionOpenedOrClosed;
@@ -73,16 +70,16 @@ namespace NuGet.PackageManagement.VisualStudio
 
             try
             {
-                _solutionSettings = Configuration.Settings.LoadDefaultSettings(root, configFileName: null, machineWideSettings: MachineWideSettings);
+                _solutionSettings = Settings.LoadDefaultSettings(root, configFileName: null, machineWideSettings: MachineWideSettings);
             }
-            catch (Configuration.NuGetConfigurationException ex)
+            catch (NuGetConfigurationException ex)
             {
                 MessageHelper.ShowErrorMessage(ExceptionUtilities.DisplayMessage(ex), Strings.ConfigErrorDialogBoxTitle);
             }
 
             if (_solutionSettings == null)
             {
-                _solutionSettings = Configuration.NullSettings.Instance;
+                _solutionSettings = NullSettings.Instance;
             }
         }
 
@@ -91,10 +88,7 @@ namespace NuGet.PackageManagement.VisualStudio
             ResetSolutionSettings();
 
             // raises event SettingsChanged
-            if (SettingsChanged != null)
-            {
-                SettingsChanged(this, EventArgs.Empty);
-            }
+            SettingsChanged?.Invoke(this, EventArgs.Empty);
         }
 
         public bool DeleteSection(string section)
@@ -112,7 +106,12 @@ namespace NuGet.PackageManagement.VisualStudio
             return SolutionSettings.GetNestedValues(section, subSection);
         }
 
-        public IList<Configuration.SettingValue> GetSettingValues(string section, bool isPath = false)
+        public IList<SettingValue> GetNestedSettingValues(string section, string subSection)
+        {
+            return SolutionSettings.GetNestedSettingValues(section, subSection);
+        }
+
+        public IList<SettingValue> GetSettingValues(string section, bool isPath = false)
         {
             return SolutionSettings.GetSettingValues(section, isPath);
         }
@@ -122,26 +121,25 @@ namespace NuGet.PackageManagement.VisualStudio
             return SolutionSettings.GetValue(section, key, isPath);
         }
 
-        public string Root
-        {
-            get { return SolutionSettings.Root; }
-        }
+        public string Root => SolutionSettings.Root;
 
-        public string FileName
-        {
-            get { return SolutionSettings.FileName; }
-        }
+        public string FileName => SolutionSettings.FileName;
 
-        public IEnumerable<Configuration.ISettings> Priority
-        {
-            get { return SolutionSettings.Priority; }
-        }
+        public IEnumerable<ISettings> Priority => SolutionSettings.Priority;
 
-        public void SetNestedValues(string section, string subSection, IList<KeyValuePair<string, string>> values)
+        public void SetNestedValues(string section, string subsection, IList<KeyValuePair<string, string>> values)
         {
             if (CanChangeSettings)
             {
-                SolutionSettings.SetNestedValues(section, subSection, values);
+                SolutionSettings.SetNestedValues(section, subsection, values);
+            }
+        }
+
+        public void SetNestedSettingValues(string section, string subsection, IList<SettingValue> values)
+        {
+            if (CanChangeSettings)
+            {
+                SolutionSettings.SetNestedSettingValues(section, subsection, values);
             }
         }
 
@@ -153,7 +151,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
-        public void SetValues(string section, IReadOnlyList<Configuration.SettingValue> values)
+        public void SetValues(string section, IReadOnlyList<SettingValue> values)
         {
             if (CanChangeSettings)
             {
@@ -161,7 +159,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
-        public void UpdateSections(string section, IReadOnlyList<Configuration.SettingValue> values)
+        public void UpdateSections(string section, IReadOnlyList<SettingValue> values)
         {
             if (CanChangeSettings)
             {
@@ -169,13 +167,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
-        private bool CanChangeSettings
-        {
-            get
-            {
-                // The value for SolutionSettings can't possibly be null, but it could be a read-only instance
-                return !object.ReferenceEquals(SolutionSettings, Configuration.NullSettings.Instance);
-            }
-        }
+        // The value for SolutionSettings can't possibly be null, but it could be a read-only instance
+        private bool CanChangeSettings => !ReferenceEquals(SolutionSettings, NullSettings.Instance);
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -43,9 +43,14 @@ namespace NuGet.Configuration
         IList<SettingValue> GetSettingValues(string section, bool isPath = false);
 
         /// <summary>
-        /// Gets all the values under section
+        /// Gets all the values under section as List of KeyValuePair
         /// </summary>
         IList<KeyValuePair<string, string>> GetNestedValues(string section, string subSection);
+
+        /// <summary>
+        /// Gets all the values under section as List of SettingValue
+        /// </summary>
+        IList<SettingValue> GetNestedSettingValues(string section, string subSection);
 
         void SetValue(string section, string key, string value);
 
@@ -65,7 +70,9 @@ namespace NuGet.Configuration
         void UpdateSections(string section, IReadOnlyList<SettingValue> values);
 
         void SetNestedValues(string section, string subSection, IList<KeyValuePair<string, string>> values);
+
         bool DeleteValue(string section, string key);
+
         bool DeleteSection(string section);
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
@@ -52,6 +52,12 @@ namespace NuGet.Configuration
         /// </summary>
         IList<SettingValue> GetNestedSettingValues(string section, string subSection);
 
+        /// <summary>
+        /// Sets the value under the specified <paramref name="section" />.
+        /// </summary>
+        /// <param name="section">The name of the section.</param>
+        /// <param name="key">The key to set set.</param>
+        /// <param name="value">The value to set.</param>
         void SetValue(string section, string key, string value);
 
         /// <summary>
@@ -69,10 +75,35 @@ namespace NuGet.Configuration
         /// <param name="values">The values to set.</param>
         void UpdateSections(string section, IReadOnlyList<SettingValue> values);
 
-        void SetNestedValues(string section, string subSection, IList<KeyValuePair<string, string>> values);
+        /// <summary>
+        /// Sets the values under the specified <paramref name="section" /> and <paramref name="subsection" />.
+        /// </summary>
+        /// <param name="section">The name of the section.</param>
+        /// <param name="subsection">The name of the subsection.</param>
+        /// <param name="values">The values to set.</param>
+        void SetNestedValues(string section, string subsection, IList<KeyValuePair<string, string>> values);
 
+        /// <summary>
+        /// Sets the setting values under the specified <paramref name="section" /> and <paramref name="subsection" />.
+        /// </summary>
+        /// <param name="section">The name of the section.</param>
+        /// <param name="subsection">The name of the subsection.</param>
+        /// <param name="values">The setting values to set.</param>
+        void SetNestedSettingValues(string section, string subsection, IList<SettingValue> values);
+
+        /// <summary>
+        /// Deletes a key from the specified <paramref name="section" />.
+        /// </summary>
+        /// <param name="section">The name of the section.</param>
+        /// <param name="key">The key to be delted.</param>
+        /// <returns>bool indicating success.</returns>
         bool DeleteValue(string section, string key);
 
+        /// <summary>
+        /// Deletes the specified <paramref name="section" />.
+        /// </summary>
+        /// <param name="section">The name of the section.</param>
+        /// <returns>bool indicating success.</returns>
         bool DeleteSection(string section);
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -46,6 +46,11 @@ namespace NuGet.Configuration
         public IList<KeyValuePair<string, string>> GetNestedValues(string section, string subSection)
         {
             return new List<KeyValuePair<string, string>>().AsReadOnly();
+        }
+
+        public IList<SettingValue> GetNestedSettingValues(string section, string subSection)
+        {
+            return new List<SettingValue>().AsReadOnly();
         }
 
         public void SetValue(string section, string key, string value)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
@@ -73,6 +73,11 @@ namespace NuGet.Configuration
             throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, Resources.InvalidNullSettingsOperation, nameof(SetNestedValues)));
         }
 
+        public void SetNestedSettingValues(string section, string subsection, IList<SettingValue> values)
+        {
+            throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, Resources.InvalidNullSettingsOperation, nameof(SetNestedValues)));
+        }
+
         public bool DeleteValue(string section, string key)
         {
             throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, Resources.InvalidNullSettingsOperation, nameof(DeleteValue)));

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingValue.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingValue.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -52,9 +52,7 @@ namespace NuGet.Configuration
             Priority = priority;
             OriginalValue = originalValue;
             AdditionalData = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        }
-
-        
+        }        
 
         /// <summary>
         /// Represents the key of the setting
@@ -67,22 +65,26 @@ namespace NuGet.Configuration
         public string Value { get; set; }
 
         /// <summary>
-        /// original value of the source as in NuGet.Config
+        /// Original value of the source as in NuGet.Config.
+        /// Should be used only if the SettingValue is read from a config file.
         /// </summary>
         public string OriginalValue { get; set; }
 
         /// <summary>
-        /// IsMachineWide tells if the setting is machine-wide or not
+        /// IsMachineWide tells if the setting is machine-wide or not.
+        /// Should be used only if the SettingValue is read from a config file.
         /// </summary>
         public bool IsMachineWide { get; set; }
 
         /// <summary>
-        /// The priority of this setting in the nuget.config hierarchy. Bigger number means higher priority
+        /// The priority of this setting in the nuget.config hierarchy. Bigger number means higher priority.
+        /// Should be used only if the SettingValue is read from a config file.
         /// </summary>
         public int Priority { get; set; }
 
         /// <summary>
         /// Gets the <see cref="ISettings"/> that provided this value.
+        /// Should be used only if the SettingValue is read from a config file.
         /// </summary>
         public ISettings Origin { get; }
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -512,6 +512,13 @@ namespace NuGet.Configuration
 
         public IList<KeyValuePair<string, string>> GetNestedValues(string section, string subSection)
         {
+            var values = GetNestedSettingValues(section, subSection);
+
+            return values.Select(v => new KeyValuePair<string, string>(v.Key, v.Value)).ToList().AsReadOnly();
+        }
+
+        public IList<SettingValue> GetNestedSettingValues(string section, string subSection)
+        {
             if (string.IsNullOrEmpty(section))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(section));
@@ -530,7 +537,7 @@ namespace NuGet.Configuration
                 curr = curr._next;
             }
 
-            return values.Select(v => new KeyValuePair<string, string>(v.Key, v.Value)).ToList().AsReadOnly();
+            return values.AsReadOnly();
         }
 
         public void SetValue(string section, string key, string value)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -63,12 +63,12 @@ namespace NuGet.Configuration
 
         public Settings(string root, string fileName, bool isMachineWideSettings)
         {
-            if (String.IsNullOrEmpty(root))
+            if (string.IsNullOrEmpty(root))
             {
                 throw new ArgumentException("root cannot be null or empty", nameof(root));
             }
 
-            if (String.IsNullOrEmpty(fileName))
+            if (string.IsNullOrEmpty(fileName))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(fileName));
             }
@@ -307,14 +307,14 @@ namespace NuGet.Configuration
             {
                 // Path.Combine is performed with root so it should not be null
                 // However, it is legal for it be empty in this method
-                root = String.Empty;
+                root = string.Empty;
             }
             // for the default location, allow case where file does not exist, in which case it'll end
             // up being created if needed
             Settings appDataSettings = null;
             if (configFileName == null)
             {
-                var defaultSettingsFilePath = String.Empty;
+                var defaultSettingsFilePath = string.Empty;
                 if (useTestingGlobalPath)
                 {
                     defaultSettingsFilePath = Path.Combine(root, "TestingGlobalPath", DefaultSettingsFileName);
@@ -361,7 +361,7 @@ namespace NuGet.Configuration
                 else
                 {
                     appDataSettings = ReadSettings(root, defaultSettingsFilePath);
-                    bool IsEmptyConfig = !appDataSettings.GetSettingValues(ConfigurationConstants.PackageSources).Any();
+                    var IsEmptyConfig = !appDataSettings.GetSettingValues(ConfigurationConstants.PackageSources).Any();
 
                     if (IsEmptyConfig)
                     {
@@ -381,7 +381,7 @@ namespace NuGet.Configuration
             {
                 if (!FileSystemUtility.DoesFileExistIn(root, configFileName))
                 {
-                    var message = String.Format(CultureInfo.CurrentCulture,
+                    var message = string.Format(CultureInfo.CurrentCulture,
                         Resources.FileDoesNotExist,
                         Path.Combine(root, configFileName));
                     throw new InvalidOperationException(message);
@@ -414,7 +414,7 @@ namespace NuGet.Configuration
             string root,
             params string[] paths)
         {
-            if (String.IsNullOrEmpty(root))
+            if (string.IsNullOrEmpty(root))
             {
                 throw new ArgumentException("root cannot be null or empty");
             }
@@ -452,12 +452,12 @@ namespace NuGet.Configuration
 
         public string GetValue(string section, string key, bool isPath = false)
         {
-            if (String.IsNullOrEmpty(section))
+            if (string.IsNullOrEmpty(section))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(section));
             }
 
-            if (String.IsNullOrEmpty(key))
+            if (string.IsNullOrEmpty(key))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(key));
             }
@@ -494,7 +494,7 @@ namespace NuGet.Configuration
 
         public IList<SettingValue> GetSettingValues(string section, bool isPath = false)
         {
-            if (String.IsNullOrEmpty(section))
+            if (string.IsNullOrEmpty(section))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(section));
             }
@@ -512,12 +512,12 @@ namespace NuGet.Configuration
 
         public IList<KeyValuePair<string, string>> GetNestedValues(string section, string subSection)
         {
-            if (String.IsNullOrEmpty(section))
+            if (string.IsNullOrEmpty(section))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(section));
             }
 
-            if (String.IsNullOrEmpty(subSection))
+            if (string.IsNullOrEmpty(subSection))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(subSection));
             }
@@ -547,7 +547,7 @@ namespace NuGet.Configuration
                 return;
             }
 
-            if (String.IsNullOrEmpty(section))
+            if (string.IsNullOrEmpty(section))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(section));
             }
@@ -570,7 +570,7 @@ namespace NuGet.Configuration
                 return;
             }
 
-            if (String.IsNullOrEmpty(section))
+            if (string.IsNullOrEmpty(section))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(section));
             }
@@ -721,7 +721,7 @@ namespace NuGet.Configuration
                 return;
             }
 
-            if (String.IsNullOrEmpty(section))
+            if (string.IsNullOrEmpty(section))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(section));
             }
@@ -753,11 +753,11 @@ namespace NuGet.Configuration
                 return _next.DeleteValue(section, key);
             }
 
-            if (String.IsNullOrEmpty(section))
+            if (string.IsNullOrEmpty(section))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(section));
             }
-            if (String.IsNullOrEmpty(key))
+            if (string.IsNullOrEmpty(key))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(key));
             }
@@ -791,7 +791,7 @@ namespace NuGet.Configuration
                 return _next.DeleteSection(section);
             }
 
-            if (String.IsNullOrEmpty(section))
+            if (string.IsNullOrEmpty(section))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(section));
             }
@@ -869,7 +869,7 @@ namespace NuGet.Configuration
             var value = XElementUtility.GetOptionalAttributeValue(element, ConfigurationConstants.ValueAttribute);
             value = ApplyEnvironmentTransform(value);
             if (!isPath
-                || String.IsNullOrEmpty(value))
+                || string.IsNullOrEmpty(value))
             {
                 return value;
             }
@@ -944,10 +944,10 @@ namespace NuGet.Configuration
             var valueAttribute = element.Attribute(ConfigurationConstants.ValueAttribute);
 
             if (keyAttribute == null
-                || String.IsNullOrEmpty(keyAttribute.Value)
+                || string.IsNullOrEmpty(keyAttribute.Value)
                 || valueAttribute == null)
             {
-                throw new InvalidDataException(String.Format(CultureInfo.CurrentCulture, Resources.UserSettings_UnableToParseConfigFile, ConfigFilePath));
+                throw new InvalidDataException(string.Format(CultureInfo.CurrentCulture, Resources.UserSettings_UnableToParseConfigFile, ConfigFilePath));
             }
 
             var value = ApplyEnvironmentTransform(valueAttribute.Value);
@@ -982,7 +982,7 @@ namespace NuGet.Configuration
 
         private void SetValueInternal(XElement sectionElement, string key, string value, IDictionary<string, string> attributes)
         {
-            if (String.IsNullOrEmpty(key))
+            if (string.IsNullOrEmpty(key))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, ConfigurationConstants.KeyAttribute);
             }
@@ -1031,7 +1031,7 @@ namespace NuGet.Configuration
             }
             else if (!FileSystemUtility.IsPathAFile(settingsPath))
             {
-                var fullPath = Path.Combine(root ?? String.Empty, settingsPath);
+                var fullPath = Path.Combine(root ?? string.Empty, settingsPath);
                 root = Path.GetDirectoryName(fullPath);
                 fileName = Path.GetFileName(fullPath);
             }
@@ -1148,8 +1148,7 @@ namespace NuGet.Configuration
         private static void SetClearTagForSettings(List<Settings> settings)
         {
             var result = new List<Settings>();
-
-            bool foundClear = false;
+            var foundClear = false;
 
             foreach (var setting in settings)
             {


### PR DESCRIPTION
## Bug
Addresses first part of https://github.com/NuGet/Home/issues/6525
Spec detailing the proposed schema changes is [here](https://github.com/NuGet/Home/wiki/%5BSpec%5D-NuGet-Config-schema-changes-to-enable-repository-signatures)
Regression: No  

## Fix
Details: This PR adds support to read and write `SettingValue` types into the `Settings` class. Bulk of the change is refactoring of existing code to allow `Settings` class to accept `SettingValue` type for nested operations along with `KeyValuePair` type. Plus some code cleanup.

This will be followed by changes to read and write `TrustedSources` section to nuget config files, which is needed to allow users to trust nuget sources.

## Testing/Validation
Tests Added: Yes  
