### PR TITLE
Signing:  enable timestamp accuracy test

### DIFF
--- a/test/TestUtilities/Test.Utility/Signing/TimestampService.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TimestampService.cs
@@ -131,14 +131,13 @@ namespace Test.Utility.Signing
                 return;
             }
 
-            var policyId = _options.AccuracyInSeconds == 1 ? NuGet.Packaging.Signing.Oids.BaselineTimestampPolicy : "1.2.3.4.5";
             var bytes = ReadRequestBody(context.Request);
             var request = new TimeStampRequest(bytes);
             var tokenGenerator = new TimeStampTokenGenerator(
                 _keyPair.Private,
                 Certificate,
                 _options.SignatureHashAlgorithm.Value,
-                policyId);
+                _options.Policy.Value);
 
             if (_options.ReturnSigningCertificate)
             {
@@ -149,7 +148,7 @@ namespace Test.Utility.Signing
                 tokenGenerator.SetCertificates(certificates);
             }
 
-            tokenGenerator.SetAccuracySeconds(_options.AccuracyInSeconds);
+            SetAccuracy(tokenGenerator);
 
             var responseGenerator = new TimeStampResponseGenerator(tokenGenerator, TspAlgorithms.Allowed);
             TimeStampResponse response;
@@ -172,6 +171,27 @@ namespace Test.Utility.Signing
             context.Response.ContentType = ResponseContentType;
 
             WriteResponseBody(context.Response, response.GetEncoded());
+        }
+
+        private void SetAccuracy(TimeStampTokenGenerator tokenGenerator)
+        {
+            if (_options.Accuracy != null)
+            {
+                if (_options.Accuracy.Seconds != null)
+                {
+                    tokenGenerator.SetAccuracySeconds(_options.Accuracy.Seconds.Value.IntValue);
+                }
+
+                if (_options.Accuracy.Millis != null)
+                {
+                    tokenGenerator.SetAccuracyMillis(_options.Accuracy.Millis.Value.IntValue);
+                }
+
+                if (_options.Accuracy.Micros != null)
+                {
+                    tokenGenerator.SetAccuracyMicros(_options.Accuracy.Micros.Value.IntValue);
+                }
+            }
         }
 #endif
     }

--- a/test/TestUtilities/Test.Utility/Signing/TimestampServiceOptions.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TimestampServiceOptions.cs
@@ -3,19 +3,23 @@
 
 using System.Security.Cryptography;
 using NuGet.Packaging.Signing;
+using Org.BouncyCastle.Asn1;
+using BcAccuracy = Org.BouncyCastle.Asn1.Tsp.Accuracy;
 
 namespace Test.Utility.Signing
 {
     public sealed class TimestampServiceOptions
     {
-        public int AccuracyInSeconds { get; set; }
+        public BcAccuracy Accuracy { get; set; }
+        public Oid Policy { get; set; }
         public bool ReturnFailure { get; set; }
         public bool ReturnSigningCertificate { get; set; }
         public Oid SignatureHashAlgorithm { get; set; }
 
         public TimestampServiceOptions()
         {
-            AccuracyInSeconds = 1;
+            Accuracy = new BcAccuracy(seconds: new DerInteger(1), micros: null, millis: null);
+            Policy = new Oid("2.999");
             ReturnSigningCertificate = true;
             SignatureHashAlgorithm = new Oid(Oids.Sha256);
         }


### PR DESCRIPTION
Enable a package signing test for timestamp accuracy that was blocked by the fix (https://github.com/NuGet/NuGet.Client/pull/2007) for https://github.com/NuGet/Home/issues/6519.