### PR TITLE
Signing:  fix incorrect timestamp hash verification

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -335,7 +335,7 @@ namespace NuGet.Common
         NU3023 = 3023,
 
         /// <summary>
-        /// The timestamp uses as unsupported hash algorithm.
+        /// The timestamp signing certificate has an unsupported signature algorithm.
         /// </summary>
         NU3024 = 3024,
 
@@ -363,6 +363,11 @@ namespace NuGet.Common
         /// The timestamp signature is invalid.
         /// </summary>
         NU3029 = 3029,
+
+        /// <summary>
+        /// The timestamp's message imprint uses an unsupported hash algorithm.
+        /// </summary>
+        NU3030 = 3030,
 
         /// <summary>
         /// Undefined Package Error.

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
@@ -94,9 +94,10 @@ namespace NuGet.Packaging.Signing
             var timestamp = timestamps.FirstOrDefault();
             if (timestamp != null)
             {
-                using (var authorSignatureNativeCms = NativeCms.Decode(signature.SignedCms.Encode(), detached: false))
+                using (var primarySignatureNativeCms = NativeCms.Decode(signature.SignedCms.Encode(), detached: false))
                 {
-                    var signatureHash = NativeCms.GetSignatureValueHash(signature.SignatureContent.HashAlgorithm, authorSignatureNativeCms);
+                    var timestampHashAlgorithmName = CryptoHashUtility.OidToHashAlgorithmName(timestamp.TstInfo.HashAlgorithmId.Value);
+                    var signatureHash = NativeCms.GetSignatureValueHash(timestampHashAlgorithmName, primarySignatureNativeCms);
 
                     if (!IsTimestampValid(timestamp, signatureHash, allowIgnoreTimestamp, allowUnknownRevocation, issues) && !allowIgnoreTimestamp)
                     {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -998,6 +998,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The timestamp&apos;s message imprint uses an unsupported hash algorithm..
+        /// </summary>
+        internal static string TimestampMessageImprintUnsupportedHashAlgorithm {
+            get {
+                return ResourceManager.GetString("TimestampMessageImprintUnsupportedHashAlgorithm", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The timestamp signature does not have a signing certificate..
         /// </summary>
         internal static string TimestampNoCertificate {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -514,4 +514,7 @@ Valid from:</comment>
   <data name="CertificateChainValidationFailed" xml:space="preserve">
     <value>Certificate chain validation failed.</value>
   </data>
+  <data name="TimestampMessageImprintUnsupportedHashAlgorithm" xml:space="preserve">
+    <value>The timestamp's message imprint uses an unsupported hash algorithm.</value>
+  </data>
 </root>

--- a/test/TestUtilities/Test.Utility/Signing/SignedArchiveTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SignedArchiveTestUtility.cs
@@ -64,16 +64,18 @@ namespace Test.Utility.Signing
         /// Generates a signed copy of a package and returns the path to that package
         /// This method timestamps a package and should only be used with tests marked with [CIOnlyFact]
         /// </summary>
-        /// <param name="testCert">Certificate to be used while signing the package</param>
+        /// <param name="certificate">Certificate to be used while signing the package</param>
         /// <param name="nupkg">Package to be signed</param>
         /// <param name="dir">Directory for placing the signed package</param>
         /// <param name="timestampService">RFC 3161 timestamp service URL.</param>
+        /// <param name="request">An author signing request.</param>
         /// <returns>Path to the signed copy of the package</returns>
         public static async Task<string> CreateSignedAndTimeStampedPackageAsync(
-            X509Certificate2 testCert,
+            X509Certificate2 certificate,
             SimpleTestPackageContext nupkg,
             string dir,
-            Uri timestampService)
+            Uri timestampService,
+            AuthorSignPackageRequest request = null)
         {
             var testLogger = new TestLogger();
 
@@ -84,8 +86,10 @@ namespace Test.Utility.Signing
 
                 using (var signPackage = new SignedPackageArchive(zipReadStream, zipWriteStream))
                 {
+                    request = request ?? new AuthorSignPackageRequest(certificate, HashAlgorithmName.SHA256);
+
                     // Sign the package
-                    await SignAndTimeStampPackageAsync(testLogger, testCert, signPackage, timestampService);
+                    await SignAndTimeStampPackageAsync(testLogger, certificate, signPackage, timestampService, request);
                 }
 
                 zipWriteStream.Seek(offset: 0, loc: SeekOrigin.Begin);
@@ -147,11 +151,11 @@ namespace Test.Utility.Signing
             TestLogger testLogger,
             X509Certificate2 certificate,
             SignedPackageArchive signPackage,
-            Uri timestampService)
+            Uri timestampService,
+            AuthorSignPackageRequest request)
         {
             var testSignatureProvider = new X509SignatureProvider(new Rfc3161TimestampProvider(timestampService));
             var signer = new Signer(signPackage, testSignatureProvider);
-            var request = new AuthorSignPackageRequest(certificate, HashAlgorithmName.SHA256);
 
             await signer.SignAsync(request, testLogger, CancellationToken.None);
         }


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/6539.

The old code used the primary signature hash algorithm to verify the timestamp message hash.  Timestamp validation succeeded when the hash algorithms of the primary signature and timestamp were conveniently the same but failed when they weren't.