### PR TITLE
Build NuGet.PackageManagement for .NET Standard 2.0

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -26,9 +26,7 @@ Set-Alias nuget $NuGetExe
 Set-Alias xunit $XunitConsole
 Set-Alias ilmerge $ILMerge
 
-$Version = New-Object -TypeName System.Version -ArgumentList "4.0"
-
-if ($PSVersionTable.PSVersion.CompareTo($Version) -lt 0) {
+if ($PSVersionTable.PSVersion.Major.CompareTo(4) -lt 0) {
     Set-Alias wget Invoke-WebRequest
 }
 
@@ -182,7 +180,7 @@ Function Install-NuGet {
     if ($Force -or -not (Test-Path $NuGetExe)) {
         Trace-Log 'Downloading nuget.exe'
 
-        wget https://dist.nuget.org/win-x86-commandline/v4.4.1/nuget.exe -OutFile $NuGetExe
+        Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/v4.4.1/nuget.exe -OutFile $NuGetExe
     }
 
     # Display nuget info

--- a/build/common.targets
+++ b/build/common.targets
@@ -6,7 +6,7 @@
     <IsDesktop>true</IsDesktop>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' OR '$(TargetFramework)' == 'netcoreapp1.1' OR'$(TargetFramework)' == 'netstandard1.0' OR '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard1.4' OR '$(TargetFramework)' == 'netstandard1.5' OR '$(TargetFramework)' == 'netstandard1.6' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' OR '$(TargetFramework)' == 'netcoreapp1.1' OR'$(TargetFramework)' == 'netstandard1.0' OR '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard1.4' OR '$(TargetFramework)' == 'netstandard1.5' OR '$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);IS_CORECLR</DefineConstants>
     <IsCore>true</IsCore>
   </PropertyGroup>

--- a/src/NuGet.Core/NuGet.PackageManagement/FileModifiers/XdtTransformer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/FileModifiers/XdtTransformer.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if NET46
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -140,3 +142,5 @@ namespace NuGet.ProjectManagement
         }
     }
 }
+
+#endif

--- a/src/NuGet.Core/NuGet.PackageManagement/FileModifiers/XdtTransformer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/FileModifiers/XdtTransformer.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET46
+#if IS_DESKTOP
 
 using System;
 using System.Collections.Generic;

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
@@ -1,10 +1,17 @@
 ﻿<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
+  <!--
+    Import the SDK props manually _after_ we've imported the build customizations that
+    set things like IntermediateOutputPath, OutputPath, etc. This is required due to
+    https://github.com/Microsoft/msbuild/issues/2245. Without applying this fix,
+    a reference to netstandard.dll is never brought in, and the build fails.
+  -->
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
     <Description>NuGet Package Management</Description>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591;CS1580;CS1574;CS1573</NoWarn>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
@@ -15,9 +22,17 @@
     <ProjectReference Include="..\NuGet.Commands\NuGet.Commands.csproj" />
     <ProjectReference Include="..\NuGet.Resolver\NuGet.Resolver.csproj" />
   </ItemGroup>
-  
-  <ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46'">
     <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="4.5.0-preview2-26202-05" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
@@ -27,7 +42,10 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-  
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Update="Strings.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -35,7 +53,7 @@
       <DependentUpon>Strings.resx</DependentUpon>
     </Compile>
   </ItemGroup>
-  
+
   <ItemGroup>
     <EmbeddedResource Update="Strings.resx">
       <Generator>ResXFileCodeGenerator</Generator>
@@ -43,6 +61,10 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
+  <!--
+    See comment at the top of the project file about the SDK props.
+    The same logic applies here: we bring in SDK targets after customizing.
+  -->
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="4.5.0-preview2-26202-05" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
@@ -1,17 +1,11 @@
 ﻿<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
-  <!--
-    Import the SDK props manually _after_ we've imported the build customizations that
-    set things like IntermediateOutputPath, OutputPath, etc. This is required due to
-    https://github.com/Microsoft/msbuild/issues/2245. Without applying this fix,
-    a reference to netstandard.dll is never brought in, and the build fails.
-  -->
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
     <Description>NuGet Package Management</Description>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">netstandard2.0</TargetFrameworks>
+    <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1580;CS1574;CS1573</NoWarn>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
@@ -43,9 +37,6 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-  </ItemGroup>
-
   <ItemGroup>
     <Compile Update="Strings.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -53,7 +44,6 @@
       <DependentUpon>Strings.resx</DependentUpon>
     </Compile>
   </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Update="Strings.resx">
       <Generator>ResXFileCodeGenerator</Generator>
@@ -62,9 +52,5 @@
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets" />
-  <!--
-    See comment at the top of the project file about the SDK props.
-    The same logic applies here: we bring in SDK targets after customizing.
-  -->
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
@@ -35,7 +35,9 @@ namespace NuGet.ProjectManagement
                 {
                     { new FileTransformExtensions(".transform", ".transform"), new XmlTransformer(GetConfigMappings()) },
                     { new FileTransformExtensions(".pp", ".pp"), new Preprocessor() },
+#if NET46
                     { new FileTransformExtensions(".install.xdt", ".uninstall.xdt"), new XdtTransformer() }
+#endif
                 };
 
         #region Events

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
@@ -35,7 +35,7 @@ namespace NuGet.ProjectManagement
                 {
                     { new FileTransformExtensions(".transform", ".transform"), new XmlTransformer(GetConfigMappings()) },
                     { new FileTransformExtensions(".pp", ".pp"), new Preprocessor() },
-#if NET46
+#if IS_DESKTOP
                     { new FileTransformExtensions(".install.xdt", ".uninstall.xdt"), new XdtTransformer() }
 #endif
                 };


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6150
Regression: No 

## Fix
Details: Brings .NET Standard 2.0 support to NuGet.PackageManagement. The only difference
between it and the .NET 4.6-targeted version is the lack of XDT transforms in the .NET Standard 2.0 package due to Microsoft.Web.Xdt not being available there.

Currently requires a preview version of the System.ComponentModel.Composition package that is available from the .NET Core MyGet feed. Progress of getting that published to stable
appears to be in https://github.com/dotnet/corefx/issues/11857.

## Testing/Validation
Tests Added: No
Validation done:  Build https://github.com/Microsoft/workbooks against the .NET Standard 2.0 assembly and verified that NuGet-related tests pass.
