### PR TITLE
Signing: incorrect GeneralizedTime handling

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/DerEncoding/DerGeneralizedTime.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/DerEncoding/DerGeneralizedTime.cs
@@ -1,0 +1,127 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography;
+
+namespace NuGet.Packaging.Signing.DerEncoding
+{
+    /// <remarks>This is public only to facilitate testing.</remarks>
+    public sealed class DerGeneralizedTime
+    {
+        public DateTime DateTime { get; }
+
+        private DerGeneralizedTime(DateTime dateTime)
+        {
+            DateTime = dateTime;
+        }
+
+        public static DerGeneralizedTime Read(string decodedTime)
+        {
+            // YYYYMMDDhhmmssZ
+            var minimumValidLength = 15;
+
+            if (string.IsNullOrEmpty(decodedTime) || decodedTime.Length < minimumValidLength)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            if (decodedTime[decodedTime.Length - 1] != 'Z')
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            int year;
+            if (!int.TryParse(decodedTime.Substring(0, 4), out year))
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            int month;
+            if (!int.TryParse(decodedTime.Substring(4, 2), out month))
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            int day;
+            if (!int.TryParse(decodedTime.Substring(6, 2), out day))
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            int hour;
+            if (!int.TryParse(decodedTime.Substring(8, 2), out hour))
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            int minute;
+            if (!int.TryParse(decodedTime.Substring(10, 2), out minute))
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            int second;
+            if (!int.TryParse(decodedTime.Substring(12, 2), out second))
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            // Millisecond accuracy should be enough.
+            var milliseconds = 0;
+
+            // Still, we need to verify that the DER-encoded GeneralizedTime value is correct (per RFC 3161).
+            if (decodedTime[14] == '.')
+            {
+                // YYYYMMDDhhmmss.sZ
+                minimumValidLength = 17;
+
+                // Disallow YYYYMMDDhhmmss.Z
+                if (decodedTime.Length < minimumValidLength)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                var hasTrailingZero = false;
+
+                // Skip trailing 'Z'.  It was checked earlier.
+                for (var i = 15; i < decodedTime.Length - 1; ++i)
+                {
+                    var c = decodedTime[i];
+
+                    if (!char.IsNumber(c))
+                    {
+                        throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                    }
+
+                    hasTrailingZero = c == '0';
+                }
+
+                if (hasTrailingZero)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                // Since we're only reading milliseconds, the maximum number of digits to read is 3.
+                // The minimum number of digits to read is the count of digits from position 15 to before the 'Z'.
+                var digitsToRead = Math.Min(3, decodedTime.Length - 1 - 15);
+                var fraction = decodedTime.Substring(15, digitsToRead).PadRight(3, '0');
+
+                milliseconds = int.Parse(fraction);
+            }
+
+            DateTime dateTime;
+
+            try
+            {
+                dateTime = new DateTime(year, month, day, hour, minute, second, milliseconds, DateTimeKind.Utc);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            return new DerGeneralizedTime(dateTime);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/TstInfo.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/TstInfo.cs
@@ -89,7 +89,7 @@ namespace NuGet.Packaging.Signing
                 throw new CryptographicException(Strings.InvalidAsn1);
             }
 
-            var genTime = tstInfoReader.ReadRfc3161GeneralizedTime();
+            var genTime = tstInfoReader.ReadGeneralizedTime();
 
             Accuracy accuracy = null;
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuGet.Packaging.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />
 
   <PropertyGroup>
@@ -10,7 +10,8 @@
 
   <!-- Include internal DER encoding helpers for use in tests -->
   <ItemGroup>
-    <Compile Include="$(NuGetCoreSrcDirectory)NuGet.Packaging\Signing\DerEncoding\*.cs" />
+    <Compile Include="$(NuGetCoreSrcDirectory)NuGet.Packaging\Signing\DerEncoding\*.cs"
+             Exclude="$(NuGetCoreSrcDirectory)NuGet.Packaging\Signing\DerEncoding\DerGeneralizedTime.cs"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/DerGeneralizedTimeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/DerGeneralizedTimeTests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography;
+using NuGet.Packaging.Signing.DerEncoding;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class DerGeneralizedTimeTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Read_WhenDecodedTimeNullOrEmpty_Throws(string decodedTime)
+        {
+            var exception = Assert.Throws<CryptographicException>(() => DerGeneralizedTime.Read(decodedTime));
+
+            Assert.Equal("ASN1 corrupted data.", exception.Message);
+        }
+
+        [Fact]
+        public void Read_WithStringTooSmall_Throws()
+        {
+            var exception = Assert.Throws<CryptographicException>(() => DerGeneralizedTime.Read("1985110621062Z"));
+
+            Assert.Equal("ASN1 corrupted data.", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("20180208142637.3")]
+        [InlineData("20180208142637.3-0800")]
+        public void Read_WithNonZuluTime_Throws(string decodedTime)
+        {
+            var exception = Assert.Throws<CryptographicException>(() => DerGeneralizedTime.Read(decodedTime));
+
+            Assert.Equal("ASN1 corrupted data.", exception.Message);
+        }
+
+        [Fact]
+        public void Read_WithNoDigitAfterDecimal_Throws()
+        {
+            var exception = Assert.Throws<CryptographicException>(() => DerGeneralizedTime.Read("19851106210627.Z"));
+
+            Assert.Equal("ASN1 corrupted data.", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("20180208142637.0Z")]
+        [InlineData("20180208142637.30Z")]
+        public void Read_WithTrailingZero_Throws(string decodedTime)
+        {
+            var exception = Assert.Throws<CryptographicException>(() => DerGeneralizedTime.Read(decodedTime));
+
+            Assert.Equal("ASN1 corrupted data.", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("00000208142637Z")]
+        [InlineData("20180008142637Z")]
+        [InlineData("20180200142637Z")]
+        [InlineData("20180208992637Z")]
+        [InlineData("20180208149937Z")]
+        [InlineData("20180208142699Z")]
+        public void Read_WithInvalidDateTimeComponents_Throws(string decodedTime)
+        {
+            var exception = Assert.Throws<CryptographicException>(() => DerGeneralizedTime.Read(decodedTime));
+
+            Assert.Equal("ASN1 corrupted data.", exception.Message);
+        }
+
+        [Fact]
+        public void Read_WithNoFractionalSeconds_ReturnsInstance()
+        {
+            var time = DerGeneralizedTime.Read("20180208142637Z");
+
+            Assert.Equal(new DateTime(2018, 2, 8, 14, 26, 37, DateTimeKind.Utc), time.DateTime);
+        }
+
+        [Theory]
+        [InlineData("1", 100)]
+        [InlineData("01", 10)]
+        [InlineData("001", 1)]
+        [InlineData("12", 120)]
+        [InlineData("123", 123)]
+        public void Read_WithMilliseconds_ReturnsInstance(string millisecondsString, int milliseconds)
+        {
+            var time = DerGeneralizedTime.Read($"20180208142637.{millisecondsString}Z");
+
+            Assert.Equal(new DateTime(2018, 2, 8, 14, 26, 37, milliseconds, DateTimeKind.Utc), time.DateTime);
+        }
+
+        [Fact]
+        public void Read_WithMicroseconds_ReturnsInstanceWithMicrosecondsIgnored()
+        {
+            var time = DerGeneralizedTime.Read("20180208142637.123456Z");
+
+            Assert.Equal(new DateTime(2018, 2, 8, 14, 26, 37, 123, DateTimeKind.Utc), time.DateTime);
+        }
+    }
+}


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/6549.

For the test issue, I'm now passing a string representation of a `DateTime` object, instead of a `DateTime` object.  That _seems_ to avoid the problem, so the fix is speculative.