### PR TITLE
RestoreSourceSummaryEvent for package source info

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.legacy.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="$(VSSDKRoot)\build\Microsoft.VSSDK.BuildTools.props" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' "/> <!-- No bootstrapping on XPLAT, this project is not expect to work correctly-->
+  <Import Project="$(VSSDKRoot)\build\Microsoft.VSSDK.BuildTools.props" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' " />
+  <!-- No bootstrapping on XPLAT, this project is not expect to work correctly-->
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -57,6 +58,7 @@
     <Compile Include="SolutionRestoreJob.cs" />
     <Compile Include="SolutionRestoreJobContext.cs" />
     <Compile Include="SolutionRestoreWorker.cs" />
+    <Compile Include="SourceTelemetry.cs" />
     <Compile Include="VerbosityLevel.cs" />
     <Compile Include="VsSolutionRestoreService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -138,6 +140,6 @@
   </ItemGroup>
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' "/>
-  <Import Project="$(VSSDKRoot)\build\Microsoft.VSSDK.BuildTools.targets" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' "/>
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' " />
+  <Import Project="$(VSSDKRoot)\build\Microsoft.VSSDK.BuildTools.targets" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' " />
 </Project>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -245,6 +245,11 @@ namespace NuGet.SolutionRestoreManager
                 duration);
 
             TelemetryActivity.EmitTelemetryEvent(restoreTelemetryEvent);
+
+            var sources = _sourceRepositoryProvider.PackageSourceProvider.LoadPackageSources().ToList();
+            var sourceEvent = SourceTelemetry.GetSourceSummaryEvent(_nuGetProjectContext.OperationId, sources);
+
+            TelemetryActivity.EmitTelemetryEvent(sourceEvent);
         }
 
         private async Task RestorePackageSpecProjectsAsync(
@@ -398,7 +403,7 @@ namespace NuGet.SolutionRestoreManager
                 _status = NuGetOperationStatus.Failed;
 
                 _logger.Do((l, _) =>
-                { 
+                {
                     foreach (var projectName in args.ProjectNames)
                     {
                         var exceptionMessage =

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SourceTelemetry.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SourceTelemetry.cs
@@ -1,0 +1,103 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Common;
+using NuGet.Configuration;
+
+namespace NuGet.SolutionRestoreManager
+{
+    public static class SourceTelemetry
+    {
+        /// <summary>
+        /// Create a SourceSummaryEvent event with counts of local vs http and v2 vs v3 feeds.
+        /// </summary>
+        public static TelemetryEvent GetSourceSummaryEvent(Guid parentId, IEnumerable<PackageSource> packageSources)
+        {
+            var local = 0;
+            var httpV2 = 0;
+            var httpV3 = 0;
+            var hasNuGetOrgV3 = false;
+            var nugetOrg = "NotPresent";
+
+            if (packageSources != null)
+            {
+                foreach (var source in packageSources)
+                {
+                    // Ignore disabled sources
+                    if (source.IsEnabled)
+                    {
+                        if (source.IsHttp)
+                        {
+                            if (IsHttpV3(source))
+                            {
+                                // Http V3 feed
+                                httpV3++;
+
+                                if (IsHttpNuGetOrg(source))
+                                {
+                                    hasNuGetOrgV3 = true;
+                                    nugetOrg = "YesV3";
+                                }
+                            }
+                            else
+                            {
+                                // Http V2 feed
+                                httpV2++;
+
+                                // Prefer v3 over v2 if v3 is found
+                                if (!hasNuGetOrgV3 && IsHttpNuGetOrg(source))
+                                {
+                                    nugetOrg = "YesV2";
+                                }
+                            }
+                        }
+                        else
+                        {
+                            // Local or UNC feed
+                            local++;
+                        }
+                    }
+                }
+            }
+
+            return new SourceSummaryEvent(parentId, local, httpV2, httpV3, nugetOrg);
+        }
+
+        /// <summary>
+        /// True if the source is http and ends with index.json
+        /// </summary>
+        private static bool IsHttpV3(PackageSource source)
+        {
+            return source.IsHttp &&
+                (source.Source.EndsWith("index.json", StringComparison.OrdinalIgnoreCase)
+                || source.ProtocolVersion == 3);
+        }
+
+        /// <summary>
+        /// True if the source is http and has a *.nuget.org host.
+        /// </summary>
+        private static bool IsHttpNuGetOrg(PackageSource source)
+        {
+            return (source.IsHttp && source.TrySourceAsUri?.Host.EndsWith(".nuget.org", StringComparison.OrdinalIgnoreCase) == true);
+        }
+
+        // NumLocalFeeds(c:\ or \\ or file:///)
+        // NumHTTPv2Feeds
+        // NumHTTPv3Feeds
+        // NuGetOrg: [NotPresent | YesV2 | YesV3]
+        private class SourceSummaryEvent : TelemetryEvent
+        {
+            public SourceSummaryEvent(Guid parentId, int local, int httpV2, int httpV3, string nugetOrg)
+                : base("RestorePackageSourceSummary")
+            {
+                this["NumLocalFeeds"] = local;
+                this["NumHTTPv2Feeds"] = httpV2;
+                this["NumHTTPv3Feeds"] = httpV3;
+                this["NuGetOrg"] = nugetOrg;
+                this["ParentId"] = parentId.ToString();
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SourceTelemetryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SourceTelemetryTests.cs
@@ -1,0 +1,226 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using NuGet.Common;
+using NuGet.Configuration;
+using Xunit;
+
+namespace NuGet.SolutionRestoreManager.Test
+{
+    public class SourceTelemetryTests
+    {
+        private static readonly Guid Parent = Guid.Parse("33411664-388A-4C48-A607-A2C554171FCE");
+
+        [Fact]
+        public void SourceTelemetry_GivenEmptySourcesVerifyZeroCounts()
+        {
+            var sources = new List<PackageSource>();
+            var summary = SourceTelemetry.GetSourceSummaryEvent(Parent, sources);
+            var summaryStrings = GetValuesAsStrings(summary);
+            var summaryInts = GetValuesAsInts(summary);
+
+            summaryInts["NumLocalFeeds"].Should().Be(0);
+            summaryInts["NumHTTPv2Feeds"].Should().Be(0);
+            summaryInts["NumHTTPv3Feeds"].Should().Be(0);
+            summaryStrings["ParentId"].Should().Be(Parent.ToString());
+            summaryStrings["NuGetOrg"].Should().Be("NotPresent");
+        }
+
+        [Fact]
+        public void SourceTelemetry_GivenOnlyNuGetV2VerifySummary()
+        {
+            var sources = new List<PackageSource>()
+            {
+                new PackageSource("https://www.NuGet.org/api/v2/")
+            };
+
+            var summary = SourceTelemetry.GetSourceSummaryEvent(Parent, sources);
+            var summaryStrings = GetValuesAsStrings(summary);
+            var summaryInts = GetValuesAsInts(summary);
+
+            summaryInts["NumLocalFeeds"].Should().Be(0);
+            summaryInts["NumHTTPv2Feeds"].Should().Be(1);
+            summaryInts["NumHTTPv3Feeds"].Should().Be(0);
+            summaryStrings["ParentId"].Should().Be(Parent.ToString());
+            summaryStrings["NuGetOrg"].Should().Be("YesV2");
+        }
+
+        [Fact]
+        public void SourceTelemetry_GivenOnlyNuGetV3VerifySummary()
+        {
+            var sources = new List<PackageSource>()
+            {
+                new PackageSource("https://api.nuget.org/v3/index.JSON")
+            };
+
+            var summary = SourceTelemetry.GetSourceSummaryEvent(Parent, sources);
+            var summaryStrings = GetValuesAsStrings(summary);
+            var summaryInts = GetValuesAsInts(summary);
+
+            summaryInts["NumLocalFeeds"].Should().Be(0);
+            summaryInts["NumHTTPv2Feeds"].Should().Be(0);
+            summaryInts["NumHTTPv3Feeds"].Should().Be(1);
+            summaryStrings["ParentId"].Should().Be(Parent.ToString());
+            summaryStrings["NuGetOrg"].Should().Be("YesV3");
+        }
+
+        [Fact]
+        public void SourceTelemetry_GivenOnlyNuGetV2andV3VerifySummary()
+        {
+            var sources = new List<PackageSource>()
+            {
+                new PackageSource("https://www.NuGet.org/api/v2/"),
+                new PackageSource("https://api.nuget.org/v3/index.json")
+            };
+
+            var summary = SourceTelemetry.GetSourceSummaryEvent(Parent, sources);
+            var summaryStrings = GetValuesAsStrings(summary);
+            var summaryInts = GetValuesAsInts(summary);
+
+            summaryInts["NumHTTPv2Feeds"].Should().Be(1);
+            summaryInts["NumHTTPv3Feeds"].Should().Be(1);
+            summaryStrings["NuGetOrg"].Should().Be("YesV3");
+        }
+
+        [Fact]
+        public void SourceTelemetry_GivenDisabledFeedsVerifyCount()
+        {
+            var sources = new List<PackageSource>()
+            {
+                new PackageSource("https://www.NuGet.org/api/v2/", "n1", isEnabled: false),
+                new PackageSource("https://api.nuget.org/v3/index.json", "n2", isEnabled: false),
+                new PackageSource("packages")
+            };
+
+            var summary = SourceTelemetry.GetSourceSummaryEvent(Parent, sources);
+            var summaryStrings = GetValuesAsStrings(summary);
+            var summaryInts = GetValuesAsInts(summary);
+
+            summaryInts["NumLocalFeeds"].Should().Be(1);
+            summaryInts["NumHTTPv2Feeds"].Should().Be(0);
+            summaryInts["NumHTTPv3Feeds"].Should().Be(0);
+            summaryStrings["NuGetOrg"].Should().Be("NotPresent");
+        }
+
+        [Fact]
+        public void SourceTelemetry_VerifySubDomainNuGetOrgIsNotCounted()
+        {
+            var sources = new List<PackageSource>()
+            {
+                new PackageSource("https://www.NuGet.org.myget.org/www.nuget.org/v2/"),
+                new PackageSource("https://api.nuget.org.myget.org/api.nuget.org/index.json")
+            };
+
+            var summary = SourceTelemetry.GetSourceSummaryEvent(Parent, sources);
+            var summaryStrings = GetValuesAsStrings(summary);
+            var summaryInts = GetValuesAsInts(summary);
+
+            summaryStrings["NuGetOrg"].Should().Be("NotPresent");
+        }
+
+        [Fact]
+        public void SourceTelemetry_LocalFeedsVerifyCount()
+        {
+            var sources = new List<PackageSource>()
+            {
+                new PackageSource("packages"),
+                new PackageSource(UriUtility.CreateSourceUri(Path.Combine(Path.GetTempPath(), "packages"), UriKind.Absolute).AbsoluteUri),
+                new PackageSource(@"\\share\packages"),
+            };
+
+            var summary = SourceTelemetry.GetSourceSummaryEvent(Parent, sources);
+            var summaryStrings = GetValuesAsStrings(summary);
+            var summaryInts = GetValuesAsInts(summary);
+
+            summaryStrings["NuGetOrg"].Should().Be("NotPresent");
+            summaryInts["NumLocalFeeds"].Should().Be(3);
+            summaryInts["NumHTTPv2Feeds"].Should().Be(0);
+            summaryInts["NumHTTPv3Feeds"].Should().Be(0);
+        }
+
+        [Fact]
+        public void SourceTelemetry_GivenAnInvalidSourceVerifyNoFailures()
+        {
+            var sources = new List<PackageSource>()
+            {
+                new PackageSource("file:/bad!|source"),
+                new PackageSource("https:/bad"),
+            };
+
+            var summary = SourceTelemetry.GetSourceSummaryEvent(Parent, sources);
+            var summaryStrings = GetValuesAsStrings(summary);
+            var summaryInts = GetValuesAsInts(summary);
+
+            summaryStrings["NuGetOrg"].Should().Be("NotPresent");
+            summaryInts["NumLocalFeeds"].Should().Be(2);
+            summaryInts["NumHTTPv2Feeds"].Should().Be(0);
+            summaryInts["NumHTTPv3Feeds"].Should().Be(0);
+        }
+
+        [Fact]
+        public void SourceTelemetry_VerifyV3Feed()
+        {
+            var sources = new List<PackageSource>()
+            {
+                new PackageSource("http://tempuri.local/index.json")
+            };
+
+            var summary = SourceTelemetry.GetSourceSummaryEvent(Parent, sources);
+            var summaryStrings = GetValuesAsStrings(summary);
+            var summaryInts = GetValuesAsInts(summary);
+
+            summaryStrings["NuGetOrg"].Should().Be("NotPresent");
+            summaryInts["NumLocalFeeds"].Should().Be(0);
+            summaryInts["NumHTTPv2Feeds"].Should().Be(0);
+            summaryInts["NumHTTPv3Feeds"].Should().Be(1);
+        }
+
+        [Fact]
+        public void SourceTelemetry_VerifyV2Feed()
+        {
+            var sources = new List<PackageSource>()
+            {
+                new PackageSource("http://tempuri.local/packages/")
+            };
+
+            var summary = SourceTelemetry.GetSourceSummaryEvent(Parent, sources);
+            var summaryStrings = GetValuesAsStrings(summary);
+            var summaryInts = GetValuesAsInts(summary);
+
+            summaryStrings["NuGetOrg"].Should().Be("NotPresent");
+            summaryInts["NumLocalFeeds"].Should().Be(0);
+            summaryInts["NumHTTPv2Feeds"].Should().Be(1);
+            summaryInts["NumHTTPv3Feeds"].Should().Be(0);
+        }
+
+        private static Dictionary<string, string> GetValuesAsStrings(TelemetryEvent item)
+        {
+            var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var e = item.GetEnumerator();
+
+            while (e.MoveNext())
+            {
+                values.Add(e.Current.Key, e.Current.Value as string);
+            }
+
+            return values;
+        }
+
+        private static Dictionary<string, int?> GetValuesAsInts(TelemetryEvent item)
+        {
+            var values = new Dictionary<string, int?>(StringComparer.OrdinalIgnoreCase);
+            var e = item.GetEnumerator();
+
+            while (e.MoveNext())
+            {
+                values.Add(e.Current.Key, e.Current.Value as int?);
+            }
+
+            return values;
+        }
+    }
+}


### PR DESCRIPTION
RestoreSourceSummaryEvent for package source info

Summarize source info for each restore, this will be used to determine package signing defaults.

I've verified the output manually for packages.config and PackageReference restore.

Fixes https://github.com/NuGet/Home/issues/6527