### PR TITLE
Adding APIs for saving trusted sources into NuGet.Config files

### DIFF
--- a/build/Shared/EqualityUtility.cs
+++ b/build/Shared/EqualityUtility.cs
@@ -152,6 +152,17 @@ namespace NuGet.Shared
             return self.Equals(other);
         }
 
+        internal static bool EqualsWithNullCheck<T>(T self, T other, IEqualityComparer<T> comparer)
+        {
+            bool identityEquals;
+            if (TryIdentityEquals(self, other, out identityEquals))
+            {
+                return identityEquals;
+            }
+
+            return comparer.Equals(self, other);
+        }
+
         private static bool TryIdentityEquals<T>(T self, T other, out bool equals)
         {
             // Are they the same instance? This handles the case where both are null.

--- a/build/Shared/EqualityUtility.cs
+++ b/build/Shared/EqualityUtility.cs
@@ -152,17 +152,6 @@ namespace NuGet.Shared
             return self.Equals(other);
         }
 
-        internal static bool EqualsWithNullCheck<T>(T self, T other, IEqualityComparer<T> comparer)
-        {
-            bool identityEquals;
-            if (TryIdentityEquals(self, other, out identityEquals))
-            {
-                return identityEquals;
-            }
-
-            return comparer.Equals(self, other);
-        }
-
         private static bool TryIdentityEquals<T>(T self, T other, out bool equals)
         {
             // Are they the same instance? This handles the case where both are null.

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
@@ -172,6 +172,14 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
+        public void UpdateSubsections(string section, string subsection, IReadOnlyList<SettingValue> values)
+        {
+            if (CanChangeSettings)
+            {
+                SolutionSettings.UpdateSubsections(section, subsection, values);
+            }
+        }
+
         // The value for SolutionSettings can't possibly be null, but it could be a read-only instance
         private bool CanChangeSettings => !ReferenceEquals(SolutionSettings, NullSettings.Instance);
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
@@ -121,6 +121,11 @@ namespace NuGet.PackageManagement.VisualStudio
             return SolutionSettings.GetValue(section, key, isPath);
         }
 
+        public IList<string> GetAllSubsections(string section)
+        {
+            return SolutionSettings.GetAllSubsections(section);
+        }
+
         public string Root => SolutionSettings.Root;
 
         public string FileName => SolutionSettings.FileName;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
@@ -106,7 +106,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return SolutionSettings.GetNestedValues(section, subSection);
         }
 
-        public IList<SettingValue> GetNestedSettingValues(string section, string subSection)
+        public IReadOnlyList<SettingValue> GetNestedSettingValues(string section, string subSection)
         {
             return SolutionSettings.GetNestedSettingValues(section, subSection);
         }
@@ -121,7 +121,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return SolutionSettings.GetValue(section, key, isPath);
         }
 
-        public IList<string> GetAllSubsections(string section)
+        public IReadOnlyList<string> GetAllSubsections(string section)
         {
             return SolutionSettings.GetAllSubsections(section);
         }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -25,18 +25,12 @@ namespace NuGet.Configuration
         /// <summary>
         /// Returns null if Source is an invalid URI
         /// </summary>
-        public Uri TrySourceAsUri
-        {
-            get { return UriUtility.TryCreateSourceUri(Source, UriKind.Absolute); }
-        }
+        public Uri TrySourceAsUri => UriUtility.TryCreateSourceUri(Source, UriKind.Absolute);
 
         /// <summary>
         /// Throws if Source is an invalid URI
         /// </summary>
-        public Uri SourceUri
-        {
-            get { return UriUtility.CreateSourceUri(Source, UriKind.Absolute); }
-        }
+        public Uri SourceUri => UriUtility.CreateSourceUri(Source, UriKind.Absolute);
 
         /// <summary>
         /// This does not represent just the NuGet Official Feed alone
@@ -82,7 +76,7 @@ namespace NuGet.Configuration
             {
                 if (!_isLocal.HasValue)
                 {
-                    Uri uri = TrySourceAsUri;
+                    var uri = TrySourceAsUri;
                     if (uri != null)
                     {
                         _isLocal = uri.IsFile;
@@ -103,14 +97,12 @@ namespace NuGet.Configuration
         public ISettings Origin { get; set; }
 
         public PackageSource(string source)
-            :
-                this(source, source, isEnabled: true)
+            : this(source, source, isEnabled: true)
         {
         }
 
         public PackageSource(string source, string name)
-            :
-                this(source, name, isEnabled: true)
+            : this(source, name, isEnabled: true)
         {
         }
 
@@ -126,18 +118,8 @@ namespace NuGet.Configuration
             bool isOfficial,
             bool isPersistable = true)
         {
-            if (source == null)
-            {
-                throw new ArgumentNullException("source");
-            }
-
-            if (name == null)
-            {
-                throw new ArgumentNullException("name");
-            }
-
-            Name = name;
-            Source = source;
+            Name = name ?? throw new ArgumentNullException("name");
+            Source = source ?? throw new ArgumentNullException("source");
             IsEnabled = isEnabled;
             IsOfficial = isOfficial;
             IsPersistable = isPersistable;

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -96,6 +96,11 @@ namespace NuGet.Configuration
         /// </summary>
         public ISettings Origin { get; set; }
 
+        /// <summary>
+        /// Corresponding trusted source details. Null if the package source does not have trusted sources information.
+        /// </summary>
+        public TrustedSource TrustedSource { get; set; }
+
         public PackageSource(string source)
             : this(source, source, isEnabled: true)
         {
@@ -162,9 +167,10 @@ namespace NuGet.Configuration
             return new PackageSource(Source, Name, IsEnabled, IsOfficial, IsPersistable)
             {
                 Description = Description,
-                Credentials = Credentials,
+                Credentials = Credentials?.Clone(),
                 IsMachineWide = IsMachineWide,
-                ProtocolVersion = ProtocolVersion
+                ProtocolVersion = ProtocolVersion,
+                TrustedSource = TrustedSource?.Clone()
             };
         }
     }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -123,8 +123,8 @@ namespace NuGet.Configuration
             bool isOfficial,
             bool isPersistable = true)
         {
-            Name = name ?? throw new ArgumentNullException("name");
-            Source = source ?? throw new ArgumentNullException("source");
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Source = source ?? throw new ArgumentNullException(nameof(source));
             IsEnabled = isEnabled;
             IsOfficial = isOfficial;
             IsPersistable = isPersistable;

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceCredential.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceCredential.cs
@@ -72,18 +72,8 @@ namespace NuGet.Configuration
         /// <param name="isPasswordClearText">Hints if password provided in clear text</param>
         public PackageSourceCredential(string source, string username, string passwordText, bool isPasswordClearText)
         {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (username == null)
-            {
-                throw new ArgumentNullException(nameof(username));
-            }
-
-            Source = source;
-            Username = username;
+            Source = source ?? throw new ArgumentNullException(nameof(source));
+            Username = username ?? throw new ArgumentNullException(nameof(username));
             PasswordText = passwordText;
             IsPasswordClearText = isPasswordClearText;
         }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceCredential.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceCredential.cs
@@ -124,5 +124,10 @@ namespace NuGet.Configuration
                     string.Format(CultureInfo.CurrentCulture, Resources.UnsupportedEncryptPassword, source), e);
             }
         }
+
+        internal PackageSourceCredential Clone()
+        {
+            return new PackageSourceCredential(Source, Username, PasswordText, IsPasswordClearText);
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -447,6 +447,17 @@ namespace NuGet.Configuration
                     GetCredentialValues(source.Credentials));
             }
 
+            // Update/Add trusted sources
+            // Deletion of a trusted shource should be done separately using TrustedSourceProvider.DeleteSource()
+            var trustedSources = sources
+                .Where(s => s.TrustedSource != null)
+                .Select(s => s.TrustedSource);
+
+            if (trustedSources.Any())
+            {
+                _trustedSourceProvider.SaveTrustedSources(trustedSources);
+            }
+
             OnPackageSourcesChanged();
         }
 

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -15,6 +15,8 @@ namespace NuGet.Configuration
 {
     public class PackageSourceProvider : IPackageSourceProvider
     {
+        private ITrustedSourceProvider _trustedSourceProvider;
+
         public ISettings Settings { get; private set; }
 
         private const int MaxSupportedProtocolVersion = 3;
@@ -41,15 +43,11 @@ namespace NuGet.Configuration
             IEnumerable<PackageSource> configurationDefaultSources
             )
         {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
-
-            Settings = settings;
+            Settings = settings ?? throw new ArgumentNullException(nameof(settings));
             Settings.SettingsChanged += (_, __) => { OnPackageSourcesChanged(); };
             _migratePackageSources = migratePackageSources;
             _configurationDefaultSources = LoadConfigurationDefaultSources(configurationDefaultSources);
+            _trustedSourceProvider = new TrustedSourceProvider(Settings);
         }
 
         private IEnumerable<PackageSource> LoadConfigurationDefaultSources(IEnumerable<PackageSource> configurationDefaultSources)
@@ -145,8 +143,8 @@ namespace NuGet.Configuration
 
             foreach (var packageSource in _configurationDefaultSources)
             {
-                bool sourceMatching = loadedPackageSources.Any(p => p.Source.Equals(packageSource.Source, StringComparison.CurrentCultureIgnoreCase));
-                bool feedNameMatching = loadedPackageSources.Any(p => p.Name.Equals(packageSource.Name, StringComparison.CurrentCultureIgnoreCase));
+                var sourceMatching = loadedPackageSources.Any(p => p.Source.Equals(packageSource.Source, StringComparison.CurrentCultureIgnoreCase));
+                var feedNameMatching = loadedPackageSources.Any(p => p.Name.Equals(packageSource.Name, StringComparison.CurrentCultureIgnoreCase));
 
                 if (!sourceMatching && !feedNameMatching)
                 {
@@ -176,6 +174,12 @@ namespace NuGet.Configuration
             if (credentials != null)
             {
                 packageSource.Credentials = credentials;
+            }
+
+            var trustedSource = ReadTrustedSource(name);
+            if (trustedSource != null)
+            {
+                packageSource.TrustedSource = trustedSource;
             }
 
             packageSource.ProtocolVersion = ReadProtocolVersion(setting);
@@ -223,6 +227,11 @@ namespace NuGet.Configuration
             return packageIndex;
         }
 
+        private TrustedSource ReadTrustedSource(string name)
+        {
+            return _trustedSourceProvider.LoadTrustedSource(name);
+        }
+
         private PackageSourceCredential ReadCredential(string sourceName)
         {
             var environmentCredentials = ReadCredentialFromEnvironment(sourceName);
@@ -238,16 +247,16 @@ namespace NuGet.Configuration
             {
                 var userName = values.FirstOrDefault(k => k.Key.Equals(ConfigurationConstants.UsernameToken, StringComparison.OrdinalIgnoreCase)).Value;
 
-                if (!String.IsNullOrEmpty(userName))
+                if (!string.IsNullOrEmpty(userName))
                 {
                     var encryptedPassword = values.FirstOrDefault(k => k.Key.Equals(ConfigurationConstants.PasswordToken, StringComparison.OrdinalIgnoreCase)).Value;
-                    if (!String.IsNullOrEmpty(encryptedPassword))
+                    if (!string.IsNullOrEmpty(encryptedPassword))
                     {
                         return new PackageSourceCredential(sourceName, userName, encryptedPassword, isPasswordClearText: false);
                     }
 
                     var clearTextPassword = values.FirstOrDefault(k => k.Key.Equals(ConfigurationConstants.ClearTextPasswordToken, StringComparison.Ordinal)).Value;
-                    if (!String.IsNullOrEmpty(clearTextPassword))
+                    if (!string.IsNullOrEmpty(clearTextPassword))
                     {
                         return new PackageSourceCredential(sourceName, userName, clearTextPassword, isPasswordClearText: true);
                     }
@@ -446,10 +455,7 @@ namespace NuGet.Configuration
         /// </summary>
         private void OnPackageSourcesChanged()
         {
-            if (PackageSourcesChanged != null)
-            {
-                PackageSourcesChanged(this, EventArgs.Empty);
-            }
+            PackageSourcesChanged?.Invoke(this, EventArgs.Empty);
         }
 
         private static KeyValuePair<string, string>[] GetCredentialValues(PackageSourceCredential credentials)
@@ -469,7 +475,7 @@ namespace NuGet.Configuration
         {
             get
             {
-                string source = SettingsUtility.GetDefaultPushSource(Settings);
+                var source = SettingsUtility.GetDefaultPushSource(Settings);
 
                 if (string.IsNullOrEmpty(source))
                 {
@@ -501,7 +507,7 @@ namespace NuGet.Configuration
 
             // It doesn't matter what value it is.
             // As long as the package source name is persisted in the <disabledPackageSources> section, the source is disabled.
-            return String.IsNullOrEmpty(value);
+            return string.IsNullOrEmpty(value);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -448,7 +448,7 @@ namespace NuGet.Configuration
             }
 
             // Update/Add trusted sources
-            // Deletion of a trusted shource should be done separately using TrustedSourceProvider.DeleteSource()
+            // Deletion of a trusted source should be done separately using TrustedSourceProvider.DeleteSource()
             var trustedSources = sources
                 .Where(s => s.TrustedSource != null)
                 .Select(s => s.TrustedSource);

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
@@ -38,6 +38,13 @@ namespace NuGet.Configuration
         string GetValue(string section, string key, bool isPath = false);
 
         /// <summary>
+        /// Gets all subsection element names under section as a List of string.
+        /// </summary>
+        /// <param name="section">Name of the section.</param>
+        /// <returns>List of string containing subsection element names.</returns>
+        IList<string> GetAllSubsections(string section);
+
+        /// <summary>
         /// Gets all the values under section
         /// </summary>
         IList<SettingValue> GetSettingValues(string section, bool isPath = false);

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
@@ -42,7 +42,7 @@ namespace NuGet.Configuration
         /// </summary>
         /// <param name="section">Name of the section.</param>
         /// <returns>List of string containing subsection element names.</returns>
-        IList<string> GetAllSubsections(string section);
+        IReadOnlyList<string> GetAllSubsections(string section);
 
         /// <summary>
         /// Gets all the values under section
@@ -57,7 +57,7 @@ namespace NuGet.Configuration
         /// <summary>
         /// Gets all the values under section as List of SettingValue
         /// </summary>
-        IList<SettingValue> GetNestedSettingValues(string section, string subSection);
+        IReadOnlyList<SettingValue> GetNestedSettingValues(string section, string subSection);
 
         /// <summary>
         /// Sets the value under the specified <paramref name="section" />.

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
@@ -83,6 +83,15 @@ namespace NuGet.Configuration
         void UpdateSections(string section, IReadOnlyList<SettingValue> values);
 
         /// <summary>
+        /// Updates nested <paramref name="values" /> across multiple <see cref="ISettings" /> instances in the hierarchy.
+        /// Values are updated in the <see cref="ISettings" /> with the nearest priority.
+        /// </summary>
+        /// <param name="section">The name of the section.</param>
+        /// <param name="subsection">The name of the subsection.</param>
+        /// <param name="values">The values to set.</param>
+        void UpdateSubsections(string section, string subsection, IReadOnlyList<SettingValue> values);
+
+        /// <summary>
         /// Sets the values under the specified <paramref name="section" /> and <paramref name="subsection" />.
         /// </summary>
         /// <param name="section">The name of the section.</param>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
@@ -48,12 +48,12 @@ namespace NuGet.Configuration
             return new List<KeyValuePair<string, string>>().AsReadOnly();
         }
 
-        public IList<SettingValue> GetNestedSettingValues(string section, string subSection)
+        public IReadOnlyList<SettingValue> GetNestedSettingValues(string section, string subSection)
         {
             return new List<SettingValue>().AsReadOnly();
         }
 
-        public IList<string> GetAllSubsections(string section)
+        public IReadOnlyList<string> GetAllSubsections(string section)
         {
             return new List<string>().AsReadOnly();
         }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
@@ -53,6 +53,11 @@ namespace NuGet.Configuration
             return new List<SettingValue>().AsReadOnly();
         }
 
+        public IList<string> GetAllSubsections(string section)
+        {
+            return new List<string>().AsReadOnly();
+        }
+
         public void SetValue(string section, string key, string value)
         {
             throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, Resources.InvalidNullSettingsOperation, nameof(SetValue)));

--- a/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
@@ -92,5 +92,10 @@ namespace NuGet.Configuration
         {
             throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, Resources.InvalidNullSettingsOperation, nameof(DeleteSection)));
         }
+
+        public void UpdateSubsections(string section, string subsection, IReadOnlyList<SettingValue> values)
+        {
+            throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, Resources.InvalidNullSettingsOperation, nameof(DeleteValue)));
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
@@ -80,7 +80,7 @@ namespace NuGet.Configuration
 
         public void SetNestedSettingValues(string section, string subsection, IList<SettingValue> values)
         {
-            throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, Resources.InvalidNullSettingsOperation, nameof(SetNestedValues)));
+            throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, Resources.InvalidNullSettingsOperation, nameof(SetNestedSettingValues)));
         }
 
         public bool DeleteValue(string section, string key)
@@ -95,7 +95,7 @@ namespace NuGet.Configuration
 
         public void UpdateSubsections(string section, string subsection, IReadOnlyList<SettingValue> values)
         {
-            throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, Resources.InvalidNullSettingsOperation, nameof(DeleteValue)));
+            throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, Resources.InvalidNullSettingsOperation, nameof(UpdateSubsections)));
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -511,6 +511,47 @@ namespace NuGet.Configuration
             return settingValues.AsReadOnly();
         }
 
+        public IList<string> GetAllSubsections(string section)
+        {
+            if (string.IsNullOrEmpty(section))
+            {
+                throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(section));
+            }
+
+            var settingValues = new List<string>();
+            var curr = this;
+            while (curr != null)
+            {
+                settingValues.AddRange(curr.GetSubsections(section));
+                curr = curr._next;
+            }
+
+            return settingValues.AsReadOnly();
+        }
+
+        private IList<string> GetSubsections(string section)
+        {
+            if (string.IsNullOrEmpty(section))
+            {
+                throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(section));
+            }
+
+            var subsections = new List<string>();
+            var sectionElement = GetSection(ConfigXDocument.Root, section);
+
+            if (sectionElement != null)
+            {
+                var subsectionElements = GetAllSections(sectionElement);
+
+                foreach (var element in subsectionElements)
+                {
+                    subsections.Add(element.Name.LocalName);
+                }
+            }
+
+            return subsections;
+        }
+
         public IList<KeyValuePair<string, string>> GetNestedValues(string section, string subSection)
         {
             var values = GetNestedSettingValues(section, subSection);
@@ -839,6 +880,11 @@ namespace NuGet.Configuration
         {
             section = XmlConvert.EncodeLocalName(section);
             return parentElement.Element(section);
+        }
+
+        private static IEnumerable<XElement> GetAllSections(XElement parentElement)
+        {
+            return parentElement.Elements();
         }
 
         private static XElement GetOrCreateSection(XElement parentElement, string sectionName)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -512,7 +512,7 @@ namespace NuGet.Configuration
             return settingValues.AsReadOnly();
         }
 
-        public IList<string> GetAllSubsections(string section)
+        public IReadOnlyList<string> GetAllSubsections(string section)
         {
             if (string.IsNullOrEmpty(section))
             {
@@ -530,7 +530,7 @@ namespace NuGet.Configuration
             return subsections.AsReadOnly();
         }
 
-        private IList<string> GetSubsections(string section)
+        private IReadOnlyList<string> GetSubsections(string section)
         {
             if (string.IsNullOrEmpty(section))
             {
@@ -542,7 +542,7 @@ namespace NuGet.Configuration
 
             if (sectionElement != null)
             {
-                var subsectionElements = GetAllSections(sectionElement);
+                var subsectionElements = sectionElement.Elements();
 
                 foreach (var element in subsectionElements)
                 {
@@ -550,7 +550,7 @@ namespace NuGet.Configuration
                 }
             }
 
-            return subsections;
+            return subsections.AsReadOnly();
         }
 
         public IList<KeyValuePair<string, string>> GetNestedValues(string section, string subSection)
@@ -560,7 +560,7 @@ namespace NuGet.Configuration
             return values.Select(v => new KeyValuePair<string, string>(v.Key, v.Value)).ToList().AsReadOnly();
         }
 
-        public IList<SettingValue> GetNestedSettingValues(string section, string subSection)
+        public IReadOnlyList<SettingValue> GetNestedSettingValues(string section, string subSection)
         {
             if (string.IsNullOrEmpty(section))
             {
@@ -951,11 +951,13 @@ namespace NuGet.Configuration
 
         public bool DeleteSection(string section)
         {
-            var result = DeleteSectionFromRoot(ConfigXDocument.Root, section);
+            if (DeleteSectionFromRoot(ConfigXDocument.Root, section))
+            {
+                Save();
+                return true;
+            }
 
-            Save();
-
-            return result;
+            return false;
         }
 
         private bool DeleteSectionFromRoot(XElement root, string section)
@@ -1004,11 +1006,6 @@ namespace NuGet.Configuration
         {
             section = XmlConvert.EncodeLocalName(section);
             return parentElement.Element(section);
-        }
-
-        private static IEnumerable<XElement> GetAllSections(XElement parentElement)
-        {
-            return parentElement.Elements();
         }
 
         private static XElement GetOrCreateSection(XElement parentElement, string sectionName)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -226,12 +226,12 @@ namespace NuGet.Configuration
         public static ISettings LoadSettingsGivenConfigPaths(IList<string> configFilePaths)
         {
             var settings = new List<Settings>();
-            if(configFilePaths == null || configFilePaths.Count == 0)
+            if (configFilePaths == null || configFilePaths.Count == 0)
             {
                 return NullSettings.Instance;
             }
 
-            foreach(var configFile in configFilePaths)
+            foreach (var configFile in configFilePaths)
             {
                 settings.Add(LoadSettings(configFile));
             }
@@ -752,8 +752,9 @@ namespace NuGet.Configuration
                     XElementUtility.AddIndented(sectionElement, element);
                 }
             }
-            else
+            else if (!ContainsClearTag(sectionElement))
             {
+                // Delete the section if it does not have values and a clear tag
                 DeleteSectionFromRoot(root, section);
             }
         }
@@ -800,6 +801,24 @@ namespace NuGet.Configuration
                     element.Remove();
                 }
             }
+        }
+
+        /// <summary>
+        /// Checks if a section contains clear tag.
+        /// </summary>
+        /// <param name="section">XElement section.</param>
+        private static bool ContainsClearTag(XElement section)
+        {
+            if (section == null)
+            {
+                return false;
+            }
+
+            return section
+                .Nodes()
+                .Where(n => n.NodeType == XmlNodeType.Element)
+                .Select(n => (XElement)n)
+                .Any(e => string.Equals(e.Name.LocalName, "clear", StringComparison.OrdinalIgnoreCase));
         }
 
         private static void SetElementValues(XElement element, string key, string value, IDictionary<string, string> attributes)

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/CertificateTrustEntry.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/CertificateTrustEntry.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Common;
+using NuGet.Shared;
+
+namespace NuGet.Configuration
+{
+    public class CertificateTrustEntry : IEquatable<CertificateTrustEntry>
+    {
+        /// <summary>
+        /// Certificate fingerprint.
+        /// </summary>
+        public string Fingerprint { get; }
+
+        /// <summary>
+        /// Certificate subject name.
+        /// </summary>
+        public string SubjectName { get; }
+
+        /// <summary>
+        /// Hash algorithm used to generate the certificate fingerprint.
+        /// </summary>
+        public HashAlgorithmName FingerprintAlgorithm { get; }
+
+        public CertificateTrustEntry(string fingerprint, string subjectName, HashAlgorithmName algorithm)
+        {
+            Fingerprint = fingerprint ?? throw new ArgumentNullException(nameof(fingerprint));
+            SubjectName = subjectName ?? throw new ArgumentNullException(nameof(subjectName));
+            FingerprintAlgorithm = algorithm;
+        }
+
+        public bool Equals(CertificateTrustEntry other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return FingerprintAlgorithm == other.FingerprintAlgorithm &&
+                string.Equals(Fingerprint, other.Fingerprint, StringComparison.Ordinal) &&
+                string.Equals(SubjectName, other.SubjectName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = new HashCodeCombiner();
+
+            // certificate fingerprint is a good quick check for inequality
+            hashCode.AddObject(Fingerprint);
+
+            return hashCode.CombinedHash;
+        }
+
+        public override bool Equals(object other)
+        {
+            return Equals(other as CertificateTrustEntry);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/CertificateTrustEntry.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/CertificateTrustEntry.cs
@@ -7,7 +7,7 @@ using NuGet.Shared;
 
 namespace NuGet.Configuration
 {
-    public class CertificateTrustEntry : IEquatable<CertificateTrustEntry>
+    public class CertificateTrustEntry : ITrustEntry, IEquatable<CertificateTrustEntry>
     {
         /// <summary>
         /// Certificate fingerprint.

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/CertificateTrustEntry.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/CertificateTrustEntry.cs
@@ -24,11 +24,23 @@ namespace NuGet.Configuration
         /// </summary>
         public HashAlgorithmName FingerprintAlgorithm { get; }
 
+        /// <summary>
+        /// The priority of this certificate entry in the nuget.config hierarchy. Same as SettingValue.Priority.
+        /// Should be used only if the CertificateTrustEntry is read from a config file.
+        /// </summary>
+        public int Priority { get; }
+
         public CertificateTrustEntry(string fingerprint, string subjectName, HashAlgorithmName algorithm)
+            : this(fingerprint, subjectName, algorithm, priority: 0)
+        {
+        }
+
+        public CertificateTrustEntry(string fingerprint, string subjectName, HashAlgorithmName algorithm, int priority)
         {
             Fingerprint = fingerprint ?? throw new ArgumentNullException(nameof(fingerprint));
             SubjectName = subjectName ?? throw new ArgumentNullException(nameof(subjectName));
             FingerprintAlgorithm = algorithm;
+            Priority = priority;
         }
 
         public bool Equals(CertificateTrustEntry other)
@@ -60,6 +72,11 @@ namespace NuGet.Configuration
         public override bool Equals(object other)
         {
             return Equals(other as CertificateTrustEntry);
+        }
+
+        internal CertificateTrustEntry Clone()
+        {
+            return new CertificateTrustEntry(Fingerprint, SubjectName, FingerprintAlgorithm, Priority);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/CertificateTrustEntry.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/CertificateTrustEntry.cs
@@ -26,19 +26,29 @@ namespace NuGet.Configuration
 
         /// <summary>
         /// The priority of this certificate entry in the nuget.config hierarchy. Same as SettingValue.Priority.
-        /// Should be used only if the CertificateTrustEntry is read from a config file.
+        /// Null if this entry is not read from a config file.
         /// </summary>
-        public int Priority { get; }
+        public int? Priority { get; }
 
         public CertificateTrustEntry(string fingerprint, string subjectName, HashAlgorithmName algorithm)
-            : this(fingerprint, subjectName, algorithm, priority: 0)
+            : this(fingerprint, subjectName, algorithm, priority: null)
         {
         }
 
-        public CertificateTrustEntry(string fingerprint, string subjectName, HashAlgorithmName algorithm, int priority)
+        public CertificateTrustEntry(string fingerprint, string subjectName, HashAlgorithmName algorithm, int? priority)
         {
-            Fingerprint = fingerprint ?? throw new ArgumentNullException(nameof(fingerprint));
-            SubjectName = subjectName ?? throw new ArgumentNullException(nameof(subjectName));
+            if (string.IsNullOrEmpty(fingerprint))
+            {
+                throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(fingerprint));
+            }
+
+            if (string.IsNullOrEmpty(subjectName))
+            {
+                throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(subjectName));
+            }
+
+            Fingerprint = fingerprint;
+            SubjectName = subjectName;
             FingerprintAlgorithm = algorithm;
             Priority = priority;
         }

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/CertificateTrustEntry.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/CertificateTrustEntry.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using NuGet.Common;
 using NuGet.Shared;
 
@@ -44,16 +43,15 @@ namespace NuGet.Configuration
                 return true;
             }
 
-            return FingerprintAlgorithm == other.FingerprintAlgorithm &&
-                string.Equals(Fingerprint, other.Fingerprint, StringComparison.Ordinal) &&
-                string.Equals(SubjectName, other.SubjectName, StringComparison.OrdinalIgnoreCase);
+            // If two fingerperints are same, then the entries represent the same certificate
+            return string.Equals(Fingerprint, other.Fingerprint, StringComparison.Ordinal);
         }
 
         public override int GetHashCode()
         {
             var hashCode = new HashCodeCombiner();
 
-            // certificate fingerprint is a good quick check for inequality
+            // certificate fingerprint is a good check for equality
             hashCode.AddObject(Fingerprint);
 
             return hashCode.CombinedHash;

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/ITrustEntry.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/ITrustEntry.cs
@@ -1,16 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace NuGet.Configuration
 {
     public interface ITrustEntry
     {
         /// <summary>
         /// The priority of this entry in the nuget.config hierarchy. Same as SettingValue.Priority.
-        /// Should be used only if this entry is read from a config file.
+        /// Null if this entry is not read from a config file.
         /// </summary>
-        int Priority { get; }
+        int? Priority { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/ITrustEntry.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/ITrustEntry.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Configuration
+{
+    public interface ITrustEntry
+    {
+        /// <summary>
+        /// The priority of this entry in the nuget.config hierarchy. Same as SettingValue.Priority.
+        /// Should be used only if this entry is read from a config file.
+        /// </summary>
+        int Priority { get; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/ITrustedSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/ITrustedSourceProvider.cs
@@ -15,12 +15,6 @@ namespace NuGet.Configuration
         IEnumerable<TrustedSource> LoadTrustedSources();
 
         /// <summary>
-        /// Saves trusted sources.
-        /// </summary>
-        /// <param name="sources">IEnumerable of TrustedSource to be saved.</param>
-        void SaveTrustedSources(IEnumerable<TrustedSource> sources);
-
-        /// <summary>
         /// Loads a trusted source corresponding to a package source.
         /// </summary>
         /// <param name="packageSourceName">Name of the PackageSource used for lookup.</param>
@@ -28,9 +22,21 @@ namespace NuGet.Configuration
         TrustedSource LoadTrustedSource(string packageSourceName);
 
         /// <summary>
-        /// Saves a trusted source.
+        /// Saves all trusted sources. Creates new entries or updates existing trusted source entries.
         /// </summary>
-        /// <param name="trustedSource">TrustedSource to be stored.</param>
-        void SaveTrustedSource(TrustedSource trustedSource);
+        /// <param name="sources">IEnumerable of TrustedSource to be saved.</param>
+        void SaveTrustedSources(IEnumerable<TrustedSource> sources);
+
+        /// <summary>
+        /// Saves a trusted sources. Creates new entry or updates existing trusted source entry.
+        /// </summary>
+        /// <param name="source">TrustedSource to be saved.</param>
+        void SaveTrustedSource(TrustedSource source);
+
+        /// <summary>
+        /// Deletes a trusted source.
+        /// </summary>
+        /// <param name="sourceName">Name of the TrustedSource to be deleted.</param>
+        void DeleteTrustedSource(string sourceName);
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/ITrustedSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/ITrustedSourceProvider.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.Configuration
+{
+    public interface ITrustedSourceProvider
+    {
+        /// <summary>
+        /// Loads all trusted sources.
+        /// </summary>
+        /// <returns>IEnumerable of TrustedSource.</returns>
+        IEnumerable<TrustedSource> LoadTrustedSources();
+
+        /// <summary>
+        /// Saves trusted sources.
+        /// </summary>
+        /// <param name="sources">IEnumerable of TrustedSource to be saved.</param>
+        void SaveTrustedSources(IEnumerable<TrustedSource> sources);
+
+        /// <summary>
+        /// Loads a trusted source corresponding to a package source.
+        /// </summary>
+        /// <param name="packageSourceName">Name of the PackageSource used for lookup.</param>
+        /// <returns>TrustedSource corresponding to the PackageSource. Null if none found.</returns>
+        TrustedSource LoadTrustedSource(string packageSourceName);
+
+        /// <summary>
+        /// Saves a trusted source.
+        /// </summary>
+        /// <param name="trustedSource">TrustedSource to be stored.</param>
+        void SaveTrustedSource(TrustedSource trustedSource);
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/ServiceIndexTrustEntry.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/ServiceIndexTrustEntry.cs
@@ -15,18 +15,23 @@ namespace NuGet.Configuration
 
         /// <summary>
         /// The priority of this entry in the nuget.config hierarchy. Same as SettingValue.Priority.
-        /// Should be used only if the ServiceIndexTrustEntry is read from a config file.
+        /// Null if this entry is not read from a config file.
         /// </summary>
-        public int Priority { get; }
+        public int? Priority { get; }
 
         public ServiceIndexTrustEntry(string serviceIndex)
-            : this(serviceIndex, priority: 0)
+            : this(serviceIndex, priority: null)
         {
         }
 
-        public ServiceIndexTrustEntry(string serviceIndex, int priority)
+        public ServiceIndexTrustEntry(string serviceIndex, int? priority)
         {
-            Value = serviceIndex ?? throw new ArgumentNullException(nameof(serviceIndex));
+            if (string.IsNullOrEmpty(serviceIndex))
+            {
+                throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(serviceIndex));
+            }
+
+            Value = serviceIndex;
             Priority = priority;
         }
 

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/ServiceIndexTrustEntry.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/ServiceIndexTrustEntry.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Shared;
+
+namespace NuGet.Configuration
+{
+    public class ServiceIndexTrustEntry : ITrustEntry, IEquatable<ServiceIndexTrustEntry>
+    {
+        /// <summary>
+        /// Service index uri.
+        /// </summary>
+        public string Value { get; }
+
+        /// <summary>
+        /// The priority of this entry in the nuget.config hierarchy. Same as SettingValue.Priority.
+        /// Should be used only if the ServiceIndexTrustEntry is read from a config file.
+        /// </summary>
+        public int Priority { get; }
+
+        public ServiceIndexTrustEntry(string serviceIndex)
+            : this(serviceIndex, priority: 0)
+        {
+        }
+
+        public ServiceIndexTrustEntry(string serviceIndex, int priority)
+        {
+            Value = serviceIndex ?? throw new ArgumentNullException(nameof(serviceIndex));
+            Priority = priority;
+        }
+
+        public bool Equals(ServiceIndexTrustEntry other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = new HashCodeCombiner();
+
+            hashCode.AddObject(Value);
+
+            return hashCode.CombinedHash;
+        }
+
+        public override bool Equals(object other)
+        {
+            return Equals(other as ServiceIndexTrustEntry);
+        }
+
+        internal ServiceIndexTrustEntry Clone()
+        {
+            return new ServiceIndexTrustEntry(Value, Priority);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSource.cs
@@ -3,10 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using NuGet.Shared;
 
 namespace NuGet.Configuration
 {
-    public class TrustedSource
+    public class TrustedSource : IEquatable<TrustedSource>
     {
         /// <summary>
         /// Name of the associated package source.
@@ -27,6 +28,52 @@ namespace NuGet.Configuration
         {
             SourceName = source ?? throw new ArgumentNullException(nameof(source));
             Certificates = new HashSet<CertificateTrustEntry>();
+        }
+
+        internal TrustedSource Clone()
+        {
+            var cloned = new TrustedSource(SourceName)
+            {
+                ServiceIndex = ServiceIndex
+            };
+
+            foreach (var entry in Certificates)
+            {
+                cloned.Certificates.Add(new CertificateTrustEntry(entry.Fingerprint, entry.SubjectName, entry.FingerprintAlgorithm));
+            }
+
+            return cloned;
+        }
+
+        public override int GetHashCode()
+        {
+            var combiner = new HashCodeCombiner();
+
+            combiner.AddObject(SourceName);
+
+            return combiner.GetHashCode();
+        }
+
+        public override bool Equals(object other)
+        {
+            return Equals(other as TrustedSource);
+        }
+
+        public bool Equals(TrustedSource other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return string.Equals(SourceName, other.SourceName, StringComparison.CurrentCultureIgnoreCase) &&
+                EqualityUtility.EqualsWithNullCheck(ServiceIndex, other.ServiceIndex, StringComparer.OrdinalIgnoreCase) &&
+                EqualityUtility.SetEqualsWithNullCheck(Certificates, other.Certificates);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSource.cs
@@ -24,25 +24,15 @@ namespace NuGet.Configuration
         /// </summary>
         public ISet<CertificateTrustEntry> Certificates { get; }
 
+        /// <summary>
+        /// Bool indicating if this trusted source has a corresponding package source.
+        /// </summary>
+        public bool HasPackageSource => !string.IsNullOrEmpty(ServiceIndex);
+
         public TrustedSource(string source)
         {
             SourceName = source ?? throw new ArgumentNullException(nameof(source));
             Certificates = new HashSet<CertificateTrustEntry>();
-        }
-
-        internal TrustedSource Clone()
-        {
-            var cloned = new TrustedSource(SourceName)
-            {
-                ServiceIndex = ServiceIndex
-            };
-
-            foreach (var entry in Certificates)
-            {
-                cloned.Certificates.Add(entry.Clone());
-            }
-
-            return cloned;
         }
 
         public override int GetHashCode()
@@ -74,6 +64,21 @@ namespace NuGet.Configuration
             return string.Equals(SourceName, other.SourceName, StringComparison.CurrentCultureIgnoreCase) &&
                 EqualityUtility.EqualsWithNullCheck(ServiceIndex, other.ServiceIndex, StringComparer.OrdinalIgnoreCase) &&
                 EqualityUtility.SetEqualsWithNullCheck(Certificates, other.Certificates);
+        }
+
+        internal TrustedSource Clone()
+        {
+            var cloned = new TrustedSource(SourceName)
+            {
+                ServiceIndex = ServiceIndex
+            };
+
+            foreach (var entry in Certificates)
+            {
+                cloned.Certificates.Add(entry.Clone());
+            }
+
+            return cloned;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSource.cs
@@ -17,17 +17,12 @@ namespace NuGet.Configuration
         /// <summary>
         /// Service index of the source.
         /// </summary>
-        public string ServiceIndex { get; set; }
+        public ServiceIndexTrustEntry ServiceIndex { get; set; }
 
         /// <summary>
         /// List of trusted certificates.
         /// </summary>
         public ISet<CertificateTrustEntry> Certificates { get; }
-
-        /// <summary>
-        /// Bool indicating if this trusted source has a corresponding package source.
-        /// </summary>
-        public bool HasPackageSource => !string.IsNullOrEmpty(ServiceIndex);
 
         public TrustedSource(string source)
         {
@@ -62,7 +57,7 @@ namespace NuGet.Configuration
             }
 
             return string.Equals(SourceName, other.SourceName, StringComparison.CurrentCultureIgnoreCase) &&
-                EqualityUtility.EqualsWithNullCheck(ServiceIndex, other.ServiceIndex, StringComparer.OrdinalIgnoreCase) &&
+                EqualityUtility.EqualsWithNullCheck(ServiceIndex, other.ServiceIndex) &&
                 EqualityUtility.SetEqualsWithNullCheck(Certificates, other.Certificates);
         }
 

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSource.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.Configuration
+{
+    public class TrustedSource
+    {
+        /// <summary>
+        /// Name of the associated package source.
+        /// </summary>
+        public string SourceName { get; }
+
+        /// <summary>
+        /// Service index of the source.
+        /// </summary>
+        public string ServiceIndex { get; set; }
+
+        /// <summary>
+        /// List of trusted certificates.
+        /// </summary>
+        public ISet<CertificateTrustEntry> Certificates { get; }
+
+        public TrustedSource(string source)
+        {
+            SourceName = source ?? throw new ArgumentNullException(nameof(source));
+            Certificates = new HashSet<CertificateTrustEntry>();
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSource.cs
@@ -39,7 +39,7 @@ namespace NuGet.Configuration
 
             foreach (var entry in Certificates)
             {
-                cloned.Certificates.Add(new CertificateTrustEntry(entry.Fingerprint, entry.SubjectName, entry.FingerprintAlgorithm));
+                cloned.Certificates.Add(entry.Clone());
             }
 
             return cloned;

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSourceProvider.cs
@@ -98,7 +98,7 @@ namespace NuGet.Configuration
             if (source.ServiceIndex != null)
             {
                 // use existing priority if present
-                var priority = matchingSource?.ServiceIndex?.Priority ?? source.ServiceIndex.Priority;
+                var priority = matchingSource?.ServiceIndex?.Priority ?? source.ServiceIndex.Priority ?? 0;
 
                 var settingValue = new SettingValue(ConfigurationConstants.ServiceIndex, source.ServiceIndex.Value, isMachineWide: false, priority: priority);
                 settingValues.Add(settingValue);
@@ -107,7 +107,7 @@ namespace NuGet.Configuration
             foreach (var cert in source.Certificates)
             {
                 // use existing priority if present
-                var priority = matchingSource?.Certificates.FirstOrDefault(c => c.Fingerprint == cert.Fingerprint)?.Priority ?? cert.Priority;
+                var priority = matchingSource?.Certificates.FirstOrDefault(c => c.Fingerprint == cert.Fingerprint)?.Priority ?? cert.Priority ?? 0;
 
                 // cant save to machine wide settings
                 var settingValue = new SettingValue(cert.Fingerprint, cert.SubjectName, isMachineWide: false, priority: priority);

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSourceProvider.cs
@@ -40,7 +40,7 @@ namespace NuGet.Configuration
             TrustedSource trustedSource = null;
             var settingValues = _settings.GetNestedSettingValues(ConfigurationConstants.TrustedSources, packageSourceName);
 
-            if (settingValues.Count > 0)
+            if (settingValues?.Count > 0)
             {
                 trustedSource = new TrustedSource(packageSourceName);
                 foreach (var settingValue in settingValues)

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSourceProvider.cs
@@ -50,7 +50,7 @@ namespace NuGet.Configuration
                 {
                     if (string.Equals(settingValue.Key, ConfigurationConstants.ServiceIndex, StringComparison.OrdinalIgnoreCase))
                     {
-                        trustedSource.ServiceIndex = settingValue.Value;
+                        trustedSource.ServiceIndex = new ServiceIndexTrustEntry(settingValue.Value, settingValue.Priority);
                     }
                     else
                     {
@@ -95,6 +95,15 @@ namespace NuGet.Configuration
 
             var settingValues = new List<SettingValue>();
 
+            if (source.ServiceIndex != null)
+            {
+                // use existing priority if present
+                var priority = matchingSource?.ServiceIndex?.Priority ?? source.ServiceIndex.Priority;
+
+                var settingValue = new SettingValue(ConfigurationConstants.ServiceIndex, source.ServiceIndex.Value, isMachineWide: false, priority: priority);
+                settingValues.Add(settingValue);
+            }
+
             foreach (var cert in source.Certificates)
             {
                 // use existing priority if present
@@ -104,13 +113,6 @@ namespace NuGet.Configuration
                 var settingValue = new SettingValue(cert.Fingerprint, cert.SubjectName, isMachineWide: false, priority: priority);
 
                 settingValue.AdditionalData.Add(ConfigurationConstants.FingerprintAlgorithm, cert.FingerprintAlgorithm.ToString());
-                settingValues.Add(settingValue);
-            }
-
-            if (!string.IsNullOrEmpty(source.ServiceIndex))
-            {
-                // TODO pass priority
-                var settingValue = new SettingValue(ConfigurationConstants.ServiceIndex, source.ServiceIndex, isMachineWide: false);
                 settingValues.Add(settingValue);
             }
 

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSourceProvider.cs
@@ -1,0 +1,82 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NuGet.Common;
+
+namespace NuGet.Configuration
+{
+    public class TrustedSourceProvider : ITrustedSourceProvider
+    {
+        private ISettings _settings;
+
+        public TrustedSourceProvider(ISettings settings)
+        {
+            _settings = settings;
+        }
+
+        public IEnumerable<TrustedSource> LoadTrustedSources()
+        {
+            var trustedSources = new List<TrustedSource>();
+            var trustedSourceNames = _settings.GetAllSubsections(ConfigurationConstants.TrustedSources);
+
+            foreach (var trustedSourceName in trustedSourceNames)
+            {
+                var trustedSource = LoadTrustedSource(trustedSourceName);
+
+                if (trustedSource != null)
+                {
+                    trustedSources.Add(trustedSource);
+                }
+            }
+
+            return trustedSources;
+        }
+
+        public TrustedSource LoadTrustedSource(string packageSourceName)
+        {
+            TrustedSource trustedSource = null;
+            var settingValues = _settings.GetNestedSettingValues(ConfigurationConstants.TrustedSources, packageSourceName);
+
+            if (settingValues.Count > 0)
+            {
+                trustedSource = new TrustedSource(packageSourceName);
+                foreach (var settingValue in settingValues)
+                {
+                    if (string.Equals(settingValue.Key, ConfigurationConstants.ServiceIndex, StringComparison.OrdinalIgnoreCase))
+                    {
+                        trustedSource.ServiceIndex = settingValue.Value;
+                    }
+                    else
+                    {
+                        var fingerprint = settingValue.Key;
+                        var subjectName = settingValue.Value;
+                        var algorithm = HashAlgorithmName.SHA256;
+
+                        if (settingValue.AdditionalData.TryGetValue(ConfigurationConstants.FingerprintAlgorithm, out var algorithmString) &&
+                            CryptoHashUtility.GetHashAlgorithmName(algorithmString) != HashAlgorithmName.Unknown)
+                        {
+                            algorithm = CryptoHashUtility.GetHashAlgorithmName(algorithmString);
+                        }
+
+                        trustedSource.Certificates.Add(new CertificateTrustEntry(fingerprint, subjectName, algorithm));
+                    }
+                }
+            }
+
+            return trustedSource;
+        }
+
+        public void SaveTrustedSources(IEnumerable<TrustedSource> sources)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SaveTrustedSource(TrustedSource trustedSource)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/TrustedSource/TrustedSourceProvider.cs
@@ -107,6 +107,13 @@ namespace NuGet.Configuration
                 settingValues.Add(settingValue);
             }
 
+            if (!string.IsNullOrEmpty(source.ServiceIndex))
+            {
+                // TODO pass priority
+                var settingValue = new SettingValue(ConfigurationConstants.ServiceIndex, source.ServiceIndex, isMachineWide: false);
+                settingValues.Add(settingValue);
+            }
+
             if (matchingSource != null)
             {
                 _settings.UpdateSubsections(ConfigurationConstants.TrustedSources, source.SourceName, settingValues);

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace NuGet.Configuration
@@ -10,6 +10,8 @@ namespace NuGet.Configuration
         public static readonly string DisabledPackageSources = "disabledPackageSources";
 
         public static readonly string PackageSources = "packageSources";
+
+        public static readonly string TrustedSources = "trustedSources";
 
         public static readonly string DefaultPushSource = "DefaultPushSource";
 
@@ -37,7 +39,7 @@ namespace NuGet.Configuration
 
         public static readonly string PasswordKey = "http_proxy.password";
         
-        public static readonly string NoProxy     = "no_proxy";
+        public static readonly string NoProxy = "no_proxy";
 
         public static readonly string KeyAttribute = "key";
 
@@ -46,8 +48,13 @@ namespace NuGet.Configuration
         public static readonly string ProtocolVersionAttribute = "protocolVersion";
 
         public static readonly string BeginIgnoreMarker = "NUGET: BEGIN LICENSE TEXT";
+
         public static readonly string EndIgnoreMarker = "NUGET: END LICENSE TEXT";
 
         public static readonly string FallbackPackageFolders = "fallbackPackageFolders";
+
+        public static readonly string FingerprintAlgorithm = "fingerprintAlgorithm";
+
+        public static readonly string ServiceIndex = "serviceIndex";
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/CertificateTrustEntryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/CertificateTrustEntryTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace NuGet.Configuration.Test
 {
-    public class TrustedCertificateEntryTests
+    public class CertificateTrustEntryTests
     {
         [Fact]
         public void EqualsReturnsTrueForSameObject()

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -183,7 +183,7 @@ namespace NuGet.Configuration.Test
 </configuration>";
 
             var expectedValue = new TrustedSource("NuGet.org");
-            expectedValue.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA512));
+            expectedValue.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA512, priority: 0));
 
             using (var mockBaseDirectory = TestDirectory.Create())
             {
@@ -257,7 +257,7 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void LoadPackageSources_LoadsTrustedSourceAndCredentails()
+        public void LoadPackageSources_LoadsTrustedSourceAndCredentials()
         {
             // Arrange
             var nugetConfigFilePath = "NuGet.Config";
@@ -321,11 +321,11 @@ namespace NuGet.Configuration.Test
 </configuration>";
 
             var expectedValue1 = new TrustedSource("NuGet.org");
-            expectedValue1.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA512));
-            expectedValue1.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA256));
+            expectedValue1.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA512, priority: 0));
+            expectedValue1.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA256, priority: 0));
 
             var expectedValue2 = new TrustedSource("CompanyFeed");
-            expectedValue2.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA384));
+            expectedValue2.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA384, priority: 0));
 
             using (var mockBaseDirectory = TestDirectory.Create())
             {

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using FluentAssertions;
 using Xunit;
 
 namespace NuGet.Configuration
@@ -22,11 +23,18 @@ namespace NuGet.Configuration
             var result = source.Clone();
 
             // Assert
+
+            // source data
             Assert.Equal(source.Source, result.Source);
             Assert.Equal(source.Name, result.Name);
             Assert.Equal(source.IsEnabled, result.IsEnabled);
             Assert.Equal(source.ProtocolVersion, result.ProtocolVersion);
-            Assert.Same(source.Credentials, result.Credentials);
+
+            // source credential
+            result.Credentials.Should().NotBeNull();
+            result.Credentials.Source.ShouldBeEquivalentTo(source.Credentials.Source);
+            result.Credentials.Username.ShouldBeEquivalentTo(source.Credentials.Username);
+            result.Credentials.IsPasswordClearText.ShouldBeEquivalentTo(source.Credentials.IsPasswordClearText);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/ServiceIndexTrustEntryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/ServiceIndexTrustEntryTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace NuGet.Configuration.Test
+{
+    public class ServiceIndexTrustEntryTests
+    {
+        [Fact]
+        public void EqualsReturnsTrueForSameObject()
+        {
+            var value = "SERVICE_INDEX";
+            var entry = new ServiceIndexTrustEntry(value);
+
+            entry.Equals(entry).Should().BeTrue();
+        }
+
+        [Fact]
+        public void EqualsReturnsTrueForIndenticalObjects()
+        {
+            var value = "SERVICE_INDEX";       
+            var entry1 = new ServiceIndexTrustEntry(value);
+            var entry2 = new ServiceIndexTrustEntry(value);
+
+            entry1.Equals(entry2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void EqualsReturnsTrueForEquivalentObjects()
+        {
+            var value1 = "SERVICE_INDEX";
+            var value2 = "service_index";
+            var entry1 = new ServiceIndexTrustEntry(value1);
+            var entry2 = new ServiceIndexTrustEntry(value2);
+
+            entry1.Equals(entry2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void EqualsReturnsFalseForNullOtherObject()
+        {
+            var value = "SERVICE_INDEX";
+            var entry = new ServiceIndexTrustEntry(value);
+
+            entry.Equals(null).Should().BeFalse();
+        }
+
+        [Fact]
+        public void EqualsReturnsFalseForDifferentValues()
+        {
+            var value1 = "SERVICE_INDEX";
+            var value2 = "service_index2";
+            var entry1 = new ServiceIndexTrustEntry(value1);
+            var entry2 = new ServiceIndexTrustEntry(value2);
+
+            entry1.Equals(entry2).Should().BeFalse();
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -41,7 +41,7 @@ namespace NuGet.Configuration.Test
             // Arrange
 #if IS_CORECLR
             var programFilesX86Data = Environment.GetEnvironmentVariable("PROGRAMFILES(X86)");
-            
+
             if (string.IsNullOrEmpty(programFilesX86Data))
             {
                 programFilesX86Data = Environment.GetEnvironmentVariable("PROGRAMFILES");
@@ -1626,6 +1626,855 @@ namespace NuGet.Configuration.Test
 </configuration>";
 
                 Assert.Equal(result.Replace("\r\n", "\n"), File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
+            }
+        }
+
+        [Fact]
+        public void CallingGetAllSubsectionsReturnsSubsections()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection>
+    <subsection1>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection1>
+    <subsection2>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection2>
+    <subsection3>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection3>
+  </section>
+</configuration>";
+            var expectedValues = new List<string>()
+            {
+                "subsection",
+                "subsection1",
+                "subsection2",
+                "subsection3",
+            };
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+
+                // Act
+                var subsections = settings.GetAllSubsections("section");
+
+                // Assert
+                subsections.Should().NotBeNull();
+                subsections.ShouldBeEquivalentTo(expectedValues);
+            }
+        }
+
+        [Fact]
+        public void CallingGetAllSubsectionsWithNonePresentReturnsEmptyList()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>";
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+
+                // Act
+                var subsections = settings.GetAllSubsections("section");
+
+                // Assert
+                subsections.Should().NotBeNull();
+                subsections.Should().BeEmpty();
+            }
+        }
+
+        [Fact]
+        public void CallingGetAllSubsectionsReturnsSubsectionsFromNestedSettings()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection>
+    <subsection1>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection1>
+    <subsection2>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection2>
+    <subsection3>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection3>
+  </section>
+</configuration>";
+
+            var config2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection4>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection4>
+    <subsection5>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection5>
+  </section>
+</configuration>";
+            var expectedValues = new List<string>()
+            {
+                "subsection",
+                "subsection1",
+                "subsection2",
+                "subsection3",
+                "subsection4",
+                "subsection5",
+            };
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockChildDirectory = TestDirectory.Create(mockBaseDirectory))
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config1);
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockChildDirectory, config2);
+
+                var configPaths = new List<string> { Path.Combine(mockChildDirectory, nugetConfigPath), Path.Combine(mockBaseDirectory, nugetConfigPath) };
+                var settings = Settings.LoadSettingsGivenConfigPaths(configPaths);
+
+                // Act
+                var subsections = settings.GetAllSubsections("section");
+
+                // Assert
+                subsections.Should().NotBeNull();
+                subsections.ShouldBeEquivalentTo(expectedValues);
+            }
+        }
+
+        [Fact]
+        public void CallingGetAllSubsectionsReturnsSubsectionsFromNestedSettingsWhenPresent()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection>
+    <subsection1>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection1>
+    <subsection2>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection2>
+    <subsection3>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection3>
+  </section>
+</configuration>";
+
+            var config2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section2>
+    <subsection4>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection4>
+  </section2>
+</configuration>";
+            var expectedValues = new List<string>()
+            {
+                "subsection",
+                "subsection1",
+                "subsection2",
+                "subsection3"
+            };
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockChildDirectory = TestDirectory.Create(mockBaseDirectory))
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config1);
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockChildDirectory, config2);
+
+                var configPaths = new List<string> { Path.Combine(mockChildDirectory, nugetConfigPath), Path.Combine(mockBaseDirectory, nugetConfigPath) };
+                var settings = Settings.LoadSettingsGivenConfigPaths(configPaths);
+
+                // Act
+                var subsections = settings.GetAllSubsections("section");
+
+                // Assert
+                subsections.Should().NotBeNull();
+                subsections.ShouldBeEquivalentTo(expectedValues);
+            }
+        }
+
+        [Fact]
+        public void CallingUpdateSubsectionsUpdatesSubsectionIfPresent()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key1"" value=""value1"" meta1=""data1"" />
+    </subsection>
+  </section>
+</configuration>";
+            var valueLookUp = new Dictionary<string, SettingValue>()
+            {
+                { "key1", new SettingValue("key1", "value1", isMachineWide: false) },
+                { "key2", new SettingValue("key2", "value2", isMachineWide: false) },
+                { "key3", new SettingValue("key3", "value3", isMachineWide: false) }
+            };
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+
+                // Act
+                settings.UpdateSubsections("section", "subsection", valueLookUp.Values.ToList());
+                var settingValues = settings.GetNestedSettingValues("section", "subsection");
+
+                // Assert
+                settingValues.Should().NotBeNull();
+                settingValues.Count.Should().Be(valueLookUp.Count);
+                foreach (var settingValue in settingValues)
+                {
+                    var matchingValue = valueLookUp[settingValue.Key];
+                    matchingValue.Should().NotBeNull();
+                    settingValue.Value.ShouldBeEquivalentTo(matchingValue.Value);
+                    settingValue.AdditionalData.ShouldBeEquivalentTo(matchingValue.AdditionalData);
+                }
+            }
+        }
+
+        [Fact]
+        public void CallingUpdateSubsectionsUpdatesSubsectionSettingMetadata()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key1"" value=""value1"" meta1=""data1"" />
+    </subsection>
+  </section>
+</configuration>";
+
+            var settingValue = new SettingValue("key2", "value2", isMachineWide: false);
+            settingValue.AdditionalData.Add("meta1", "data1");
+            settingValue.AdditionalData.Add("meta2", "data2");
+
+            var valueLookUp = new Dictionary<string, SettingValue>()
+            {
+                { "key2",  settingValue}
+            };
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+
+                // Act
+                settings.UpdateSubsections("section", "subsection", valueLookUp.Values.ToList());
+                var settingValues = settings.GetNestedSettingValues("section", "subsection");
+
+                // Assert
+                settingValues.Should().NotBeNull();
+                settingValues.Count.Should().Be(valueLookUp.Count);
+                foreach (var value in settingValues)
+                {
+                    var matchingValue = valueLookUp[value.Key];
+                    matchingValue.Should().NotBeNull();
+                    value.Value.ShouldBeEquivalentTo(matchingValue.Value);
+                    value.AdditionalData.ShouldBeEquivalentTo(matchingValue.AdditionalData);
+                }
+            }
+        }
+
+        [Fact]
+        public void CallingUpdateSubsectionsRemovesSubsectionSettingMetadata()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key1"" value=""value1"" meta1=""data1"" />
+    </subsection>
+  </section>
+</configuration>";
+
+            var settingValue = new SettingValue("key2", "value2", isMachineWide: false);
+
+            var valueLookUp = new Dictionary<string, SettingValue>()
+            {
+                { "key2",  settingValue}
+            };
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+
+                // Act
+                settings.UpdateSubsections("section", "subsection", valueLookUp.Values.ToList());
+                var settingValues = settings.GetNestedSettingValues("section", "subsection");
+
+                // Assert
+                settingValues.Should().NotBeNull();
+                settingValues.Count.Should().Be(valueLookUp.Count);
+                foreach (var value in settingValues)
+                {
+                    var matchingValue = valueLookUp[value.Key];
+                    matchingValue.Should().NotBeNull();
+                    value.Value.ShouldBeEquivalentTo(matchingValue.Value);
+                    value.AdditionalData.ShouldBeEquivalentTo(matchingValue.AdditionalData);
+                }
+            }
+        }
+
+        [Fact]
+        public void CallingUpdateSubsectionsRemovesSubsectionAndSectionIfEmpty()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key1"" value=""value1"" meta1=""data1"" />
+    </subsection>
+  </section>
+</configuration>";
+            var valueLookUp = new Dictionary<string, SettingValue>();
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+
+                // Act
+                settings.UpdateSubsections("section", "subsection", valueLookUp.Values.ToList());
+                var settingValues = settings.GetNestedSettingValues("section", "subsection");
+
+                // Assert
+                settingValues.Should().NotBeNull();
+                settingValues.Should().BeEmpty();
+            }
+        }
+
+        [Fact]
+        public void CallingUpdateSubsectionsRemovesSubsectionButLeavesOtherSubsections()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key1"" value=""value1"" meta1=""data1"" />
+    </subsection>
+    <subsection2>
+      <add key=""key2"" value=""value2"" meta1=""data1"" />
+    </subsection2>
+  </section>
+</configuration>";
+
+            var settingValue = new SettingValue("key2", "value2", isMachineWide: false);
+            settingValue.AdditionalData.Add("meta1", "data1");
+
+            var valueLookUp = new Dictionary<string, SettingValue>()
+            {
+                { "key2",  settingValue}
+            };
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+
+                // Act
+                settings.UpdateSubsections("section", "subsection", valueLookUp.Values.ToList());
+                var settingValues = settings.GetNestedSettingValues("section", "subsection2");
+
+                // Assert
+                settingValues.Should().NotBeNull();
+                settingValues.Count.Should().Be(valueLookUp.Count);
+                foreach (var value in settingValues)
+                {
+                    var matchingValue = valueLookUp[value.Key];
+                    matchingValue.Should().NotBeNull();
+                    value.Value.ShouldBeEquivalentTo(matchingValue.Value);
+                    value.AdditionalData.ShouldBeEquivalentTo(matchingValue.AdditionalData);
+                }
+            }
+        }
+
+        [Fact]
+        public void CallingUpdateSubsectionsRemovesSubsectionButLeavesOtherSections()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key1"" value=""value1"" meta1=""data1"" />
+    </subsection>
+  </section>
+  <section2>
+    <subsection2>
+      <add key=""key2"" value=""value2"" meta1=""data1"" />
+    </subsection2>
+  </section2>
+</configuration>";
+
+            var settingValue = new SettingValue("key2", "value2", isMachineWide: false);
+            settingValue.AdditionalData.Add("meta1", "data1");
+
+            var valueLookUp = new Dictionary<string, SettingValue>()
+            {
+                { "key2",  settingValue}
+            };
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+
+                // Act
+                settings.UpdateSubsections("section", "subsection", valueLookUp.Values.ToList());
+                var settingValues = settings.GetNestedSettingValues("section2", "subsection2");
+
+                // Assert
+                settingValues.Should().NotBeNull();
+                settingValues.Count.Should().Be(valueLookUp.Count);
+                foreach (var value in settingValues)
+                {
+                    var matchingValue = valueLookUp[value.Key];
+                    matchingValue.Should().NotBeNull();
+                    value.Value.ShouldBeEquivalentTo(matchingValue.Value);
+                    value.AdditionalData.ShouldBeEquivalentTo(matchingValue.AdditionalData);
+                }
+            }
+        }
+
+        [Fact]
+        public void CallingUpdateSubsectionsRemovesSubsectionAndSectionInConfigFileIfEmpty()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key1"" value=""value1"" meta1=""data1"" />
+    </subsection>
+  </section>
+</configuration>";
+            var valueLookUp = new Dictionary<string, SettingValue>();
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+
+                // Act
+                settings.UpdateSubsections("section", "subsection", valueLookUp.Values.ToList());
+                var settingValues = settings.GetNestedSettingValues("section", "subsection");
+
+                // Assert
+                var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>";
+
+                Assert.Equal(result.Replace("\r\n", "\n"), File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
+            }
+        }
+
+        [Fact]
+        public void CallingUpdateSubsectionsRemovesSubsectionAndSectionInConfigFileButLeavesOtherSections()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key1"" value=""value1"" meta1=""data1"" />
+    </subsection>
+  </section>
+  <section2>
+    <subsection2>
+      <add key=""key1"" value=""value1"" meta1=""data1"" />
+    </subsection2>
+  </section2>
+</configuration>";
+            var valueLookUp = new Dictionary<string, SettingValue>();
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+
+                // Act
+                settings.UpdateSubsections("section", "subsection", valueLookUp.Values.ToList());
+                var settingValues = settings.GetNestedSettingValues("section", "subsection");
+
+                // Assert
+                var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section2>
+    <subsection2>
+      <add key=""key1"" value=""value1"" meta1=""data1"" />
+    </subsection2>
+  </section2>
+</configuration>";
+
+                Assert.Equal(result.Replace("\r\n", "\n"), File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
+            }
+        }
+
+        [Fact]
+        public void CallingUpdateSubsectionsRemovesSubsectionAndSectionInConfigFileButLeavesOtherSubsections()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key1"" value=""value1"" meta1=""data1"" />
+    </subsection>
+    <subsection2>
+      <add key=""key1"" value=""value1"" meta1=""data1"" />
+    </subsection2>
+  </section>
+</configuration>";
+            var valueLookUp = new Dictionary<string, SettingValue>();
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+
+                // Act
+                settings.UpdateSubsections("section", "subsection", valueLookUp.Values.ToList());
+                var settingValues = settings.GetNestedSettingValues("section", "subsection");
+
+                // Assert
+                var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection2>
+      <add key=""key1"" value=""value1"" meta1=""data1"" />
+    </subsection2>
+  </section>
+</configuration>";
+
+                Assert.Equal(result.Replace("\r\n", "\n"), File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
+            }
+        }
+
+        [Fact]
+        public void CallingUpdateSubsectionsUpdatesSubsectionsIntoNestedSettingsWhenPresent()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection>
+  </section>
+</configuration>";
+
+            var config2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key2"" value=""value2"" meta1=""data1"" />
+    </subsection>
+  </section>
+</configuration>";
+
+            var settingValue1 = new SettingValue("key1", "value1", isMachineWide: false);
+            settingValue1.AdditionalData.Add("meta1", "data1");
+            settingValue1.AdditionalData.Add("meta2", "data2");
+
+            var settingValue2 = new SettingValue("key2", "value2", isMachineWide: false);
+            settingValue2.AdditionalData.Add("meta1", "data1");
+
+            var valueLookUp = new Dictionary<string, SettingValue>()
+            {
+                { "key1",  settingValue1},
+                { "key2",  settingValue2}
+            };
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockChildDirectory = TestDirectory.Create(mockBaseDirectory))
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config1);
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockChildDirectory, config2);
+
+                var configPaths = new List<string> { Path.Combine(mockChildDirectory, nugetConfigPath), Path.Combine(mockBaseDirectory, nugetConfigPath) };
+                var settings = Settings.LoadSettingsGivenConfigPaths(configPaths);
+
+                // Act
+                settings.UpdateSubsections("section", "subsection", valueLookUp.Values.ToList());
+                var settingValues = settings.GetNestedSettingValues("section", "subsection");
+
+                // Assert
+                settingValues.Should().NotBeNull();
+                settingValues.Count.Should().Be(valueLookUp.Count);
+                foreach (var settingValue in settingValues)
+                {
+                    var matchingValue = valueLookUp[settingValue.Key];
+                    matchingValue.Should().NotBeNull();
+                    settingValue.Value.ShouldBeEquivalentTo(matchingValue.Value);
+                    settingValue.AdditionalData.ShouldBeEquivalentTo(matchingValue.AdditionalData);
+                }
+            }
+        }
+
+        [Fact]
+        public void CallingUpdateSubsectionsRemovesSubsectionsFromNestedSettingsWhenEmpty()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection>
+  </section>
+</configuration>";
+
+            var config2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key2"" value=""value2"" meta1=""data1"" />
+    </subsection>
+  </section>
+</configuration>";
+
+            var valueLookUp = new Dictionary<string, SettingValue>();
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockChildDirectory = TestDirectory.Create(mockBaseDirectory))
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config1);
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockChildDirectory, config2);
+
+                var configPaths = new List<string> { Path.Combine(mockChildDirectory, nugetConfigPath), Path.Combine(mockBaseDirectory, nugetConfigPath) };
+                var settings = Settings.LoadSettingsGivenConfigPaths(configPaths);
+
+                // Act
+                settings.UpdateSubsections("section", "subsection", valueLookUp.Values.ToList());
+                var settingValues = settings.GetNestedSettingValues("section", "subsection");
+
+                // Assert
+                settingValues.Should().NotBeNull();
+                settingValues.Should().BeEmpty();
+            }
+        }
+
+        [Fact]
+        public void CallingUpdateSubsectionsRemovesSubsectionsFromNestedSettingsInConfigFileWhenEmpty()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection>
+  </section>
+</configuration>";
+
+            var config2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key2"" value=""value2"" meta1=""data1"" />
+    </subsection>
+  </section>
+</configuration>";
+
+            var valueLookUp = new Dictionary<string, SettingValue>();
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockChildDirectory = TestDirectory.Create(mockBaseDirectory))
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config1);
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockChildDirectory, config2);
+
+                var configPaths = new List<string> { Path.Combine(mockChildDirectory, nugetConfigPath), Path.Combine(mockBaseDirectory, nugetConfigPath) };
+                var settings = Settings.LoadSettingsGivenConfigPaths(configPaths);
+
+                // Act
+                settings.UpdateSubsections("section", "subsection", valueLookUp.Values.ToList());
+                var settingValues = settings.GetNestedSettingValues("section", "subsection");
+
+                // Assert
+                var result1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>";
+
+                var result2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>";
+
+                Assert.Equal(result1.Replace("\r\n", "\n"), File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
+                Assert.Equal(result2.Replace("\r\n", "\n"), File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
+            }
+        }
+
+        [Fact]
+        public void CallingUpdateSubsectionsRemovesSubsectionsFromNestedSettingsInConfigFileButLeavesOtherSubsections()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection>
+    <subsection1>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection1>
+  </section>
+</configuration>";
+
+            var config2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key2"" value=""value2"" meta1=""data1"" />
+    </subsection>
+  </section>
+</configuration>";
+
+            var valueLookUp = new Dictionary<string, SettingValue>();
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockChildDirectory = TestDirectory.Create(mockBaseDirectory))
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config1);
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockChildDirectory, config2);
+
+                var configPaths = new List<string> { Path.Combine(mockChildDirectory, nugetConfigPath), Path.Combine(mockBaseDirectory, nugetConfigPath) };
+                var settings = Settings.LoadSettingsGivenConfigPaths(configPaths);
+
+                // Act
+                settings.UpdateSubsections("section", "subsection", valueLookUp.Values.ToList());
+                var settingValues = settings.GetNestedSettingValues("section", "subsection");
+
+                // Assert
+                var result1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection1>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection1>
+  </section>
+</configuration>";
+
+                var result2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>";
+
+                Assert.Equal(result1.Replace("\r\n", "\n"), File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
+                Assert.Equal(result2.Replace("\r\n", "\n"), File.ReadAllText(Path.Combine(mockChildDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
+            }
+        }
+
+        [Fact]
+        public void CallingUpdateSubsectionsRemovesSubsectionsFromNestedSettingsInConfigFileButLeavesOtherSections()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection>
+  </section>
+  <section3>
+    <subsection4>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection4>
+  </section3>
+</configuration>";
+
+            var config2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section>
+    <subsection>
+      <add key=""key2"" value=""value2"" meta1=""data1"" />
+    </subsection>
+  </section>
+  <section2>
+    <subsection3>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection3>
+  </section2>
+</configuration>";
+
+            var valueLookUp = new Dictionary<string, SettingValue>();
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockChildDirectory = TestDirectory.Create(mockBaseDirectory))
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config1);
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockChildDirectory, config2);
+
+                var configPaths = new List<string> { Path.Combine(mockChildDirectory, nugetConfigPath), Path.Combine(mockBaseDirectory, nugetConfigPath) };
+                var settings = Settings.LoadSettingsGivenConfigPaths(configPaths);
+
+                // Act
+                settings.UpdateSubsections("section", "subsection", valueLookUp.Values.ToList());
+                var settingValues = settings.GetNestedSettingValues("section", "subsection");
+
+                // Assert
+                var result1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section3>
+    <subsection4>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection4>
+  </section3>
+</configuration>";
+
+                var result2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <section2>
+    <subsection3>
+      <add key=""key1"" value=""value1"" meta1=""data1"" meta2=""data2"" />
+    </subsection3>
+  </section2>
+</configuration>";
+
+                Assert.Equal(result1.Replace("\r\n", "\n"), File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
+                Assert.Equal(result2.Replace("\r\n", "\n"), File.ReadAllText(Path.Combine(mockChildDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/TrustedCertificateEntryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/TrustedCertificateEntryTests.cs
@@ -88,33 +88,5 @@ namespace NuGet.Configuration.Test
 
             entry1.Equals(entry2).Should().BeFalse();
         }
-
-        [Fact]
-        public void EqualsReturnsFalseForDifferentSubjectNames()
-        {
-            var fingerprint = "hash";
-            var subjectName1 = "subjectname";
-            var subjectName2 = "other subjectname";
-            var algorithm = HashAlgorithmName.SHA256;
-
-            var entry1 = new CertificateTrustEntry(fingerprint, subjectName1, algorithm);
-            var entry2 = new CertificateTrustEntry(fingerprint, subjectName2, algorithm);
-
-            entry1.Equals(entry2).Should().BeFalse();
-        }
-
-        [Fact]
-        public void EqualsReturnsFalseForDifferentAlgorithms()
-        {
-            var fingerprint = "hash";
-            var subjectName = "subjectname";
-            var algorithm1 = HashAlgorithmName.SHA256;
-            var algorithm2 = HashAlgorithmName.SHA512;
-
-            var entry1 = new CertificateTrustEntry(fingerprint, subjectName, algorithm1);
-            var entry2 = new CertificateTrustEntry(fingerprint, subjectName, algorithm2);
-
-            entry1.Equals(entry2).Should().BeFalse();
-        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/TrustedCertificateEntryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/TrustedCertificateEntryTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using FluentAssertions;
+using NuGet.Common;
+using Xunit;
+
+namespace NuGet.Configuration.Test
+{
+    public class TrustedCertificateEntryTests
+    {
+        [Fact]
+        public void EqualsReturnsTrueForSameObject()
+        {
+            var fingerprint = "hash";
+            var subjectName = "subjectname";
+            var algorithm = HashAlgorithmName.SHA256;
+
+            var entry = new CertificateTrustEntry(fingerprint, subjectName, algorithm);
+
+            entry.Equals(entry).Should().BeTrue();
+        }
+
+        [Fact]
+        public void EqualsReturnsTrueForIndenticalObjects()
+        {
+            var fingerprint = "hash";
+            var subjectName = "subjectname";
+            var algorithm = HashAlgorithmName.SHA256;
+
+            var entry1 = new CertificateTrustEntry(fingerprint, subjectName, algorithm);
+            var entry2 = new CertificateTrustEntry(fingerprint, subjectName, algorithm);
+
+            entry1.Equals(entry2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void EqualsReturnsTrueForEquivalentObjects()
+        {
+            var fingerprint = "hash";
+            var subjectName1 = "subjectname";
+            var subjectName2 = "subjectName";
+            var algorithm = HashAlgorithmName.SHA256;
+
+            var entry1 = new CertificateTrustEntry(fingerprint, subjectName1, algorithm);
+            var entry2 = new CertificateTrustEntry(fingerprint, subjectName2, algorithm);
+
+            entry1.Equals(entry2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void EqualsReturnsFalseForNullOtherObject()
+        {
+            var fingerprint = "hash";
+            var subjectName = "subjectname";
+            var algorithm = HashAlgorithmName.SHA256;
+
+            var entry = new CertificateTrustEntry(fingerprint, subjectName, algorithm);
+
+            entry.Equals(null).Should().BeFalse();
+        }
+
+        [Fact]
+        public void EqualsReturnsFalseForDifferentFingerprintCase()
+        {
+            var fingerprint1 = "hash";
+            var fingerprint2 = "HASH";
+            var subjectName = "subjectname";
+            var algorithm = HashAlgorithmName.SHA256;
+
+            var entry1 = new CertificateTrustEntry(fingerprint1, subjectName, algorithm);
+            var entry2 = new CertificateTrustEntry(fingerprint2, subjectName, algorithm);
+
+            entry1.Equals(entry2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void EqualsReturnsFalseForDifferentFingerprints()
+        {
+            var fingerprint1 = "hash";
+            var fingerprint2 = "other hash";
+            var subjectName = "subjectname";
+            var algorithm = HashAlgorithmName.SHA256;
+
+            var entry1 = new CertificateTrustEntry(fingerprint1, subjectName, algorithm);
+            var entry2 = new CertificateTrustEntry(fingerprint2, subjectName, algorithm);
+
+            entry1.Equals(entry2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void EqualsReturnsFalseForDifferentSubjectNames()
+        {
+            var fingerprint = "hash";
+            var subjectName1 = "subjectname";
+            var subjectName2 = "other subjectname";
+            var algorithm = HashAlgorithmName.SHA256;
+
+            var entry1 = new CertificateTrustEntry(fingerprint, subjectName1, algorithm);
+            var entry2 = new CertificateTrustEntry(fingerprint, subjectName2, algorithm);
+
+            entry1.Equals(entry2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void EqualsReturnsFalseForDifferentAlgorithms()
+        {
+            var fingerprint = "hash";
+            var subjectName = "subjectname";
+            var algorithm1 = HashAlgorithmName.SHA256;
+            var algorithm2 = HashAlgorithmName.SHA512;
+
+            var entry1 = new CertificateTrustEntry(fingerprint, subjectName, algorithm1);
+            var entry2 = new CertificateTrustEntry(fingerprint, subjectName, algorithm2);
+
+            entry1.Equals(entry2).Should().BeFalse();
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/TrustedSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/TrustedSourceProviderTests.cs
@@ -1,0 +1,241 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using FluentAssertions;
+using NuGet.Common;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Configuration.Test
+{
+    public class TrustedSourceProviderTests
+    {
+        [Fact]
+        public void ReturnsTrustedSourceForPackageSourceIfPresent()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+        <add key=""nuget.org"" value=""https://nuget.org"" />
+        <add key=""test.org"" value=""Packages"" />
+    </packageSources>
+    <trustedSources>
+        <nuget.org>
+            <add key=""HASH"" value=""SUBJECT_NAME"" fingerprintAlgorithm=""SHA256"" />
+        </nuget.org>
+    </trustedSources>
+</configuration>
+";
+            var expectedValues = new List<CertificateTrustEntry>
+            {
+                new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256)
+            };
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+                var trustedSourceProvider = new TrustedSourceProvider(settings);
+
+                // Act
+                var trustedSource = trustedSourceProvider.LoadTrustedSource("nuget.org");
+
+                // Assert
+                trustedSource.Should().NotBeNull();
+                trustedSource.SourceName.Should().Be("nuget.org");
+                trustedSource.ServiceIndex.Should().BeNull();
+                trustedSource.Certificates.Should().BeEquivalentTo(expectedValues);
+            }
+        }
+
+        [Fact]
+        public void ReturnsTrustedSourceWithMultipleCertificatesForPackageSourceIfPresent()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+        <add key=""nuget.org"" value=""https://nuget.org"" />
+        <add key=""test.org"" value=""Packages"" />
+    </packageSources>
+    <trustedSources>
+        <nuget.org>
+            <add key=""HASH"" value=""SUBJECT_NAME"" fingerprintAlgorithm=""SHA256"" />
+            <add key=""HASH2"" value=""SUBJECT_NAME"" fingerprintAlgorithm=""SHA512"" />
+        </nuget.org>
+    </trustedSources>
+</configuration>
+";
+            var expectedValues = new List<CertificateTrustEntry>
+            {
+                new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256),
+                new CertificateTrustEntry("HASH2", "SUBJECT_NAME", HashAlgorithmName.SHA512)
+            };
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+                var trustedSourceProvider = new TrustedSourceProvider(settings);
+
+                // Act
+                var trustedSource = trustedSourceProvider.LoadTrustedSource("nuget.org");
+
+                // Assert
+                trustedSource.Should().NotBeNull();
+                trustedSource.SourceName.Should().Be("nuget.org");
+                trustedSource.ServiceIndex.Should().BeNull();
+                trustedSource.Certificates.Should().BeEquivalentTo(expectedValues);
+            }
+        }
+
+        [Fact]
+        public void ReturnsNullTrustedSourceForPackageSourceIfAbsent()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+        <add key=""nuget.org"" value=""https://nuget.org"" />
+        <add key=""test.org"" value=""Packages"" />
+    </packageSources>
+    <trustedSources>
+        <nuget.org>
+            <add key=""HASH"" value=""SUBJECT_NAME"" fingerprintAlgorithm=""SHA256"" />
+        </nuget.org>
+    </trustedSources>
+</configuration>
+";
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+                var trustedSourceProvider = new TrustedSourceProvider(settings);
+
+                // Act
+                var trustedSource = trustedSourceProvider.LoadTrustedSource("test.org");
+
+                // Assert
+                trustedSource.Should().BeNull();
+            }
+        }
+
+        [Fact]
+        public void ReturnsNullTrustedSourceForPackageSourceIfEmpty()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+        <add key=""nuget.org"" value=""https://nuget.org"" />
+    </packageSources>
+    <trustedSources>
+        <nuget.org>
+        </nuget.org>
+    </trustedSources>
+</configuration>
+";
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+                var trustedSourceProvider = new TrustedSourceProvider(settings);
+
+                // Act
+                var trustedSource = trustedSourceProvider.LoadTrustedSource("nuget.org");
+
+                // Assert
+                trustedSource.Should().BeNull();
+            }
+        }
+
+        [Fact]
+        public void ReturnsNullTrustedSourceForPackageSourceIfCleared()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+        <add key=""nuget.org"" value=""https://nuget.org"" />
+    </packageSources>
+    <trustedSources>
+        <nuget.org>
+            <add key=""HASH"" value=""SUBJECT_NAME"" fingerprintAlgorithm=""SHA256"" />
+            <clear />
+        </nuget.org>
+    </trustedSources>
+</configuration>
+";
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+                var trustedSourceProvider = new TrustedSourceProvider(settings);
+
+                // Act
+                var trustedSource = trustedSourceProvider.LoadTrustedSource("nuget.org");
+
+                // Assert
+                trustedSource.Should().BeNull();
+            }
+        }
+
+        [Fact]
+        public void ReturnsAllTrustedSourceIfPresent()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+        <add key=""nuget.org"" value=""https://nuget.org"" />
+        <add key=""test.org"" value=""Packages"" />
+    </packageSources>
+    <trustedSources>
+        <nuget.org>
+            <add key=""HASH"" value=""SUBJECT_NAME"" fingerprintAlgorithm=""SHA256"" />
+            <add key=""HASH512"" value=""SUBJECT_NAME"" fingerprintAlgorithm=""SHA512"" />
+        </nuget.org>
+        <test.org>
+            <add key=""HASH"" value=""SUBJECT_NAME"" fingerprintAlgorithm=""SHA512"" />
+        </test.org>
+    </trustedSources>
+</configuration>
+";
+            var trustedSource1 = new TrustedSource("nuget.org");
+            trustedSource1.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256));
+            trustedSource1.Certificates.Add(new CertificateTrustEntry("HASH512", "SUBJECT_NAME", HashAlgorithmName.SHA512));
+            var trustedSource2 = new TrustedSource("test.org");
+            trustedSource2.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA512));
+
+            var expectedValues = new List<TrustedSource>
+            {
+                trustedSource1,
+                trustedSource2
+            };
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+                var trustedSourceProvider = new TrustedSourceProvider(settings);
+
+                // Act
+                var trustedSources = trustedSourceProvider.LoadTrustedSources();
+
+                // Assert
+                trustedSources.Should().NotBeNull();
+                trustedSources.ShouldBeEquivalentTo(expectedValues);
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/TrustedSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/TrustedSourceProviderTests.cs
@@ -406,10 +406,10 @@ namespace NuGet.Configuration.Test
 </configuration>";
 
             var trustedSource1 = new TrustedSource("nuget.org");
-            trustedSource1.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256));
-            trustedSource1.Certificates.Add(new CertificateTrustEntry("HASH512", "SUBJECT_NAME", HashAlgorithmName.SHA512));
+            trustedSource1.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256, priority: 0));
+            trustedSource1.Certificates.Add(new CertificateTrustEntry("HASH512", "SUBJECT_NAME", HashAlgorithmName.SHA512, priority: 0));
             var trustedSource2 = new TrustedSource("test.org");
-            trustedSource2.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA512));
+            trustedSource2.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA512, priority: 0));
 
             var expectedValues = new List<TrustedSource>
             {
@@ -814,10 +814,10 @@ namespace NuGet.Configuration.Test
                 var trustedSourceProvider = new TrustedSourceProvider(settings);
 
                 var trustedSource1 = new TrustedSource("nuget.org");
-                trustedSource1.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256));
+                trustedSource1.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256, priority: 0));
 
                 var trustedSource2 = new TrustedSource("temp.org");
-                trustedSource2.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA384));
+                trustedSource2.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA384, priority: 0));
 
                 var trustedSources = new List<TrustedSource>
                 {
@@ -854,13 +854,13 @@ namespace NuGet.Configuration.Test
                 var trustedSourceProvider = new TrustedSourceProvider(settings);
 
                 var trustedSource1 = new TrustedSource("nuget.org");
-                trustedSource1.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256));
-                trustedSource1.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA512));
-                trustedSource1.ServiceIndex = new ServiceIndexTrustEntry("SERVICE_INDEX");
+                trustedSource1.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256, priority: 0));
+                trustedSource1.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA512, priority: 0));
+                trustedSource1.ServiceIndex = new ServiceIndexTrustEntry("SERVICE_INDEX", priority: 0);
 
                 var trustedSource2 = new TrustedSource("temp.org");
-                trustedSource2.Certificates.Add(new CertificateTrustEntry("HASH3", "SUBJECT_NAME3", HashAlgorithmName.SHA384));
-                trustedSource2.Certificates.Add(new CertificateTrustEntry("HASH4", "SUBJECT_NAME4", HashAlgorithmName.SHA512));
+                trustedSource2.Certificates.Add(new CertificateTrustEntry("HASH3", "SUBJECT_NAME3", HashAlgorithmName.SHA384, priority: 0));
+                trustedSource2.Certificates.Add(new CertificateTrustEntry("HASH4", "SUBJECT_NAME4", HashAlgorithmName.SHA512, priority: 0));
 
                 var trustedSources = new List<TrustedSource>
                 {
@@ -1278,7 +1278,7 @@ namespace NuGet.Configuration.Test
                 var settings = new Settings(mockBaseDirectory);
                 var trustedSourceProvider = new TrustedSourceProvider(settings);
                 var trustedSource = new TrustedSource("nuget.org");
-                trustedSource.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256));
+                trustedSource.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256, priority: 0));
 
                 // Act
                 trustedSourceProvider.DeleteTrustedSource("temp.org");

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/TrustedSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/TrustedSourceProviderTests.cs
@@ -19,7 +19,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <packageSources>
         <add key='nuget.org' value='https://nuget.org' />
@@ -59,7 +59,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config1 = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config1 = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <packageSources>
         <add key='nuget.org' value='https://nuget.org' />
@@ -72,7 +72,7 @@ namespace NuGet.Configuration.Test
     </trustedSources>
 </configuration>";
 
-            var config2 = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config2 = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <trustedSources>
         <nuget.org>
@@ -113,7 +113,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config1 = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config1 = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <packageSources>
         <add key='nuget.org' value='https://nuget.org' />
@@ -126,7 +126,7 @@ namespace NuGet.Configuration.Test
     </trustedSources>
 </configuration>";
 
-            var config2 = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config2 = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <trustedSources>
         <nuget.org>
@@ -168,7 +168,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <packageSources>
         <add key='nuget.org' value='https://nuget.org' />
@@ -210,7 +210,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <packageSources>
         <add key='nuget.org' value='https://nuget.org' />
@@ -253,7 +253,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <packageSources>
         <add key='nuget.org' value='https://nuget.org' />
@@ -285,7 +285,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <packageSources>
         <add key='nuget.org' value='https://nuget.org' />
@@ -315,7 +315,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <packageSources>
         <add key='nuget.org' value='https://nuget.org' />
@@ -347,7 +347,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <packageSources>
         <add key='nuget.org' value='https://nuget.org' />
@@ -388,7 +388,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <packageSources>
         <add key='nuget.org' value='https://nuget.org' />
@@ -437,11 +437,8 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
-  <packageSources>
-    <add key=""nuget.org"" value=""https://nuget.org"" />
-  </packageSources>
 </configuration>";
 
             using (var mockBaseDirectory = TestDirectory.Create())
@@ -451,18 +448,16 @@ namespace NuGet.Configuration.Test
                 var trustedSourceProvider = new TrustedSourceProvider(settings);
                 var trustedSource = new TrustedSource("nuget.org");
                 trustedSource.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256));
-
+                trustedSource.ServiceIndex = new ServiceIndexTrustEntry(@"https://nuget.org");
                 // Act
                 trustedSourceProvider.SaveTrustedSource(trustedSource);
 
                 // Assert
                 var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-  <packageSources>
-    <add key=""nuget.org"" value=""https://nuget.org"" />
-  </packageSources>
   <trustedSources>
     <nuget.org>
+      <add key=""serviceIndex"" value=""https://nuget.org"" />
       <add key=""HASH"" value=""SUBJECT_NAME"" fingerprintAlgorithm=""SHA256"" />
     </nuget.org>
   </trustedSources>
@@ -478,7 +473,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
   <packageSources>
     <add key=""nuget.org"" value=""https://nuget.org"" />
@@ -510,6 +505,49 @@ namespace NuGet.Configuration.Test
   <trustedSources>
     <nuget.org>
       <add key=""HASH2"" value=""SUBJECT_NAME2"" fingerprintAlgorithm=""SHA384"" />
+    </nuget.org>
+  </trustedSources>
+</configuration>";
+
+                Assert.Equal(result.Replace("\r\n", "\n"),
+                    File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
+            }
+        }
+
+        [Fact]
+        public void WritesUpdatedTrustedSourceWithReplacedServiceIndex()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
+<configuration>
+  <trustedSources>
+    <nuget.org>
+      <add key=""serviceIndex"" value=""SERVICE_INDEX"" />
+      <add key=""HASH"" value=""SUBJECT_NAME"" fingerprintAlgorithm=""SHA256"" />
+    </nuget.org>
+  </trustedSources>
+</configuration>";
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+                var trustedSourceProvider = new TrustedSourceProvider(settings);
+                var trustedSource = new TrustedSource("nuget.org");
+                trustedSource.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA384));
+                trustedSource.ServiceIndex = new ServiceIndexTrustEntry("SERVICE_INDEX2");
+
+                // Act
+                trustedSourceProvider.SaveTrustedSource(trustedSource);
+
+                // Assert
+                var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <trustedSources>
+    <nuget.org>
+      <add key=""serviceIndex"" value=""SERVICE_INDEX2"" />
+      <add key=""HASH"" value=""SUBJECT_NAME"" fingerprintAlgorithm=""SHA384"" />
     </nuget.org>
   </trustedSources>
 </configuration>";
@@ -524,7 +562,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
   <packageSources>
     <add key=""nuget.org"" value=""https://nuget.org"" />
@@ -568,63 +606,113 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void WritesUpdatedTrustedSourceWithAddedServiceIndex()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
+<configuration>
+  <trustedSources>
+    <nuget.org>
+      <add key=""HASH"" value=""SUBJECT_NAME"" fingerprintAlgorithm=""SHA256"" />
+    </nuget.org>
+  </trustedSources>
+</configuration>";
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+                var settings = new Settings(mockBaseDirectory);
+                var trustedSourceProvider = new TrustedSourceProvider(settings);
+                var trustedSource = new TrustedSource("nuget.org");
+                trustedSource.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256));
+                trustedSource.ServiceIndex = new ServiceIndexTrustEntry("SERVICE_INDEX");
+
+                // Act
+                trustedSourceProvider.SaveTrustedSource(trustedSource);
+
+                // Assert
+                var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <trustedSources>
+    <nuget.org>
+      <add key=""serviceIndex"" value=""SERVICE_INDEX"" />
+      <add key=""HASH"" value=""SUBJECT_NAME"" fingerprintAlgorithm=""SHA256"" />
+    </nuget.org>
+  </trustedSources>
+</configuration>";
+
+                Assert.Equal(result.Replace("\r\n", "\n"),
+                    File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
+            }
+        }
+
+        [Fact]
         public void SavesNewTrustedSourceWithOneCertificate()
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
   <packageSources>
     <add key=""nuget.org"" value=""https://nuget.org"" />
   </packageSources>
 </configuration>";
 
+            var trustedSource = new TrustedSource("nuget.org");
+            trustedSource.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256));
+            trustedSource.ServiceIndex = new ServiceIndexTrustEntry("SERVICE_INDEX");
+
+            var expectedTrustedSources = new List<TrustedSource>()
+            {
+                trustedSource
+            };
+
             using (var mockBaseDirectory = TestDirectory.Create())
             {
                 ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
                 var settings = new Settings(mockBaseDirectory);
                 var trustedSourceProvider = new TrustedSourceProvider(settings);
-                var trustedSource = new TrustedSource("nuget.org");
-                trustedSource.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256));
+
 
                 // Act
                 trustedSourceProvider.SaveTrustedSource(trustedSource);
 
                 // Assert
-                var actualTrustedSources = trustedSourceProvider.LoadTrustedSources();
-                actualTrustedSources.Count().Should().Be(1);
-                actualTrustedSources.Should().Contain(trustedSource);
+                AssertTrustedSources(trustedSourceProvider.LoadTrustedSources(), expectedTrustedSources);
             }
         }
 
         [Fact]
-        public void SavesNewTrustedSourceWithMultipleCertificate()
+        public void SavesNewTrustedSourceWithMultipleCertificatesAndServiceIndex()
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
-  <packageSources>
-    <add key='nuget.org' value='https://nuget.org' />
-  </packageSources>
 </configuration>";
+
+            var trustedSource = new TrustedSource("nuget.org");
+            trustedSource.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256));
+            trustedSource.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA384));
+            trustedSource.ServiceIndex = new ServiceIndexTrustEntry("SERVICE_INDEX");
+
+            var expectedTrustedSources = new List<TrustedSource>()
+            {
+                trustedSource
+            };
 
             using (var mockBaseDirectory = TestDirectory.Create())
             {
                 ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
                 var settings = new Settings(mockBaseDirectory);
                 var trustedSourceProvider = new TrustedSourceProvider(settings);
-                var trustedSource = new TrustedSource("nuget.org");
-                trustedSource.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256));
-                trustedSource.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA384));
 
                 // Act
                 trustedSourceProvider.SaveTrustedSource(trustedSource);
 
                 // Assert
-                var actualTrustedSources = trustedSourceProvider.LoadTrustedSources();
-                actualTrustedSources.Count().Should().Be(1);
-                actualTrustedSources.Should().Contain(trustedSource);
+                AssertTrustedSources(trustedSourceProvider.LoadTrustedSources(), expectedTrustedSources);
             }
         }
 
@@ -633,7 +721,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
   <packageSources>
     <add key='nuget.org' value='https://nuget.org' />
@@ -645,21 +733,25 @@ namespace NuGet.Configuration.Test
   </trustedSources>
 </configuration>";
 
+            var trustedSource = new TrustedSource("nuget.org");
+            trustedSource.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA384));
+
+            var expectedTrustedSources = new List<TrustedSource>()
+            {
+                trustedSource
+            };
+
             using (var mockBaseDirectory = TestDirectory.Create())
             {
                 ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
                 var settings = new Settings(mockBaseDirectory);
                 var trustedSourceProvider = new TrustedSourceProvider(settings);
-                var trustedSource = new TrustedSource("nuget.org");
-                trustedSource.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA384));
 
                 // Act
                 trustedSourceProvider.SaveTrustedSource(trustedSource);
 
                 // Assert
-                var actualTrustedSources = trustedSourceProvider.LoadTrustedSources();
-                actualTrustedSources.Count().Should().Be(1);
-                actualTrustedSources.Should().Contain(trustedSource);
+                AssertTrustedSources(trustedSourceProvider.LoadTrustedSources(), expectedTrustedSources);
             }
         }
 
@@ -668,7 +760,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
   <packageSources>
     <add key='nuget.org' value='https://nuget.org' />
@@ -680,22 +772,26 @@ namespace NuGet.Configuration.Test
   </trustedSources>
 </configuration>";
 
+            var trustedSource = new TrustedSource("nuget.org");
+            trustedSource.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA384));
+            trustedSource.Certificates.Add(new CertificateTrustEntry("HASH3", "SUBJECT_NAME3", HashAlgorithmName.SHA512));
+
+            var expectedTrustedSources = new List<TrustedSource>()
+            {
+                trustedSource
+            };
+
             using (var mockBaseDirectory = TestDirectory.Create())
             {
                 ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
                 var settings = new Settings(mockBaseDirectory);
                 var trustedSourceProvider = new TrustedSourceProvider(settings);
-                var trustedSource = new TrustedSource("nuget.org");
-                trustedSource.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA384));
-                trustedSource.Certificates.Add(new CertificateTrustEntry("HASH3", "SUBJECT_NAME3", HashAlgorithmName.SHA512));
 
                 // Act
                 trustedSourceProvider.SaveTrustedSource(trustedSource);
 
                 // Assert
-                var actualTrustedSources = trustedSourceProvider.LoadTrustedSources();
-                actualTrustedSources.Count().Should().Be(1);
-                actualTrustedSources.Should().Contain(trustedSource);
+                AssertTrustedSources(trustedSourceProvider.LoadTrustedSources(), expectedTrustedSources);
             }
         }
 
@@ -704,7 +800,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
   <packageSources>
     <add key=""nuget.org"" value=""https://nuget.org"" />
@@ -740,11 +836,11 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void SavesMultpleTrustedSourcesWithMultipleCertificate()
+        public void SavesMultpleTrustedSourcesWithMultipleCertificates()
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
   <packageSources>
     <add key=""nuget.org"" value=""https://nuget.org"" />
@@ -760,6 +856,7 @@ namespace NuGet.Configuration.Test
                 var trustedSource1 = new TrustedSource("nuget.org");
                 trustedSource1.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256));
                 trustedSource1.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA512));
+                trustedSource1.ServiceIndex = new ServiceIndexTrustEntry("SERVICE_INDEX");
 
                 var trustedSource2 = new TrustedSource("temp.org");
                 trustedSource2.Certificates.Add(new CertificateTrustEntry("HASH3", "SUBJECT_NAME3", HashAlgorithmName.SHA384));
@@ -786,7 +883,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config1 = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config1 = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <packageSources>
         <add key='nuget.org' value='https://nuget.org' />
@@ -794,9 +891,19 @@ namespace NuGet.Configuration.Test
     </packageSources>
 </configuration>";
 
-            var config2 = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config2 = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
 </configuration>";
+
+            var trustedSource = new TrustedSource("nuget.org");
+            trustedSource.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA384));
+            trustedSource.Certificates.Add(new CertificateTrustEntry("HASH3", "SUBJECT_NAME3", HashAlgorithmName.SHA512));
+            trustedSource.ServiceIndex = new ServiceIndexTrustEntry("SERVICE_INDEX");
+
+            var expectedTrustedSources = new List<TrustedSource>
+            {
+                trustedSource
+            };
 
             using (var mockBaseDirectory = TestDirectory.Create())
             using (var mockChildDirectory = TestDirectory.Create(mockBaseDirectory))
@@ -807,17 +914,74 @@ namespace NuGet.Configuration.Test
                 var configPaths = new List<string> { Path.Combine(mockBaseDirectory, nugetConfigPath), Path.Combine(mockChildDirectory, nugetConfigPath) };
                 var settings = Settings.LoadSettingsGivenConfigPaths(configPaths);
                 var trustedSourceProvider = new TrustedSourceProvider(settings);
-                var trustedSource = new TrustedSource("nuget.org");
-                trustedSource.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA384));
-                trustedSource.Certificates.Add(new CertificateTrustEntry("HASH3", "SUBJECT_NAME3", HashAlgorithmName.SHA512));
 
                 // Act
                 trustedSourceProvider.SaveTrustedSource(trustedSource);
 
                 // Assert
-                var actualTrustedSources = trustedSourceProvider.LoadTrustedSources();
-                actualTrustedSources.Count().Should().Be(1);
-                actualTrustedSources.Should().Contain(trustedSource);
+                AssertTrustedSources(trustedSourceProvider.LoadTrustedSources(), expectedTrustedSources);
+            }
+        }
+
+        [Fact]
+        public void SavesNewTrustedSourceIntoConfigFiles()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""nuget.org"" value=""https://nuget.org"" />
+    <add key=""test.org"" value=""Packages"" />
+  </packageSources>
+</configuration>";
+
+            var config2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>";
+
+            var trustedSource = new TrustedSource("nuget.org");
+            trustedSource.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA384));
+            trustedSource.Certificates.Add(new CertificateTrustEntry("HASH3", "SUBJECT_NAME3", HashAlgorithmName.SHA512));
+            trustedSource.ServiceIndex = new ServiceIndexTrustEntry("SERVICE_INDEX");
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockChildDirectory = TestDirectory.Create(mockBaseDirectory))
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config1);
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockChildDirectory, config2);
+
+                var configPaths = new List<string> { Path.Combine(mockChildDirectory, nugetConfigPath), Path.Combine(mockBaseDirectory, nugetConfigPath) };
+                var settings = Settings.LoadSettingsGivenConfigPaths(configPaths);
+                var trustedSourceProvider = new TrustedSourceProvider(settings);
+
+                // Act
+                trustedSourceProvider.SaveTrustedSource(trustedSource);
+
+                // Assert
+                var result1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""nuget.org"" value=""https://nuget.org"" />
+    <add key=""test.org"" value=""Packages"" />
+  </packageSources>
+  <trustedSources>
+    <nuget.org>
+      <add key=""serviceIndex"" value=""SERVICE_INDEX"" />
+      <add key=""HASH2"" value=""SUBJECT_NAME2"" fingerprintAlgorithm=""SHA384"" />
+      <add key=""HASH3"" value=""SUBJECT_NAME3"" fingerprintAlgorithm=""SHA512"" />
+    </nuget.org>
+  </trustedSources>
+</configuration>";
+
+                var result2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>";
+
+                Assert.Equal(result1.Replace("\r\n", "\n"),
+                    File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
+                Assert.Equal(result2.Replace("\r\n", "\n"),
+                    File.ReadAllText(Path.Combine(mockChildDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
             }
         }
 
@@ -827,27 +991,38 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config1 = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <packageSources>
-        <add key='nuget.org' value='https://nuget.org' />
-        <add key='test.org' value='Packages' />
-    </packageSources>
-    <trustedSources>
-        <nuget.org>
-            <add key='HASH' value='SUBJECT_NAME' fingerprintAlgorithm='SHA256' />
-        </nuget.org>
-    </trustedSources>
+  <packageSources>
+    <add key=""nuget.org"" value=""https://nuget.org"" />
+    <add key=""test.org"" value=""Packages"" />
+  </packageSources>
+  <trustedSources>
+    <nuget.org>
+      <add key=""serviceIndex"" value=""SERVICE_INDEX"" />
+      <add key=""HASH"" value=""SUBJECT_NAME"" fingerprintAlgorithm=""SHA256"" />
+    </nuget.org>
+  </trustedSources>
 </configuration>";
 
-            var config2 = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
-    <trustedSources>
-        <nuget.org>
-            <add key='HASH2' value='SUBJECT_NAME2' fingerprintAlgorithm='SHA512' />
-        </nuget.org>
-    </trustedSources>
+  <trustedSources>
+    <nuget.org>
+      <add key=""HASH2"" value=""SUBJECT_NAME2"" fingerprintAlgorithm=""SHA512"" />
+    </nuget.org>
+  </trustedSources>
 </configuration>";
+
+            var trustedSource = new TrustedSource("nuget.org");
+            trustedSource.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA512));
+            trustedSource.Certificates.Add(new CertificateTrustEntry("HASH3", "SUBJECT_NAME3", HashAlgorithmName.SHA512));
+            trustedSource.ServiceIndex = new ServiceIndexTrustEntry("SERVICE_INDEX2");
+
+            var expectedTrustedSources = new List<TrustedSource>
+            {
+                trustedSource
+            };
 
             using (var mockBaseDirectory = TestDirectory.Create())
             using (var mockChildDirectory = TestDirectory.Create(mockBaseDirectory))
@@ -858,17 +1033,96 @@ namespace NuGet.Configuration.Test
                 var configPaths = new List<string> { Path.Combine(mockChildDirectory, nugetConfigPath), Path.Combine(mockBaseDirectory, nugetConfigPath) };
                 var settings = Settings.LoadSettingsGivenConfigPaths(configPaths);
                 var trustedSourceProvider = new TrustedSourceProvider(settings);
-                var trustedSource = new TrustedSource("nuget.org");
-                trustedSource.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA512));
-                trustedSource.Certificates.Add(new CertificateTrustEntry("HASH3", "SUBJECT_NAME3", HashAlgorithmName.SHA512));
+
 
                 // Act
                 trustedSourceProvider.SaveTrustedSource(trustedSource);
 
                 // Assert
-                var actualTrustedSources = trustedSourceProvider.LoadTrustedSources();
-                actualTrustedSources.Count().Should().Be(1);
-                actualTrustedSources.Should().Contain(trustedSource);
+                AssertTrustedSources(trustedSourceProvider.LoadTrustedSources(), expectedTrustedSources);
+            }
+        }
+
+        [Fact]
+        public void SavesUpdatedTrustedSourceIntoConfigFiles()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""nuget.org"" value=""https://nuget.org"" />
+    <add key=""test.org"" value=""Packages"" />
+  </packageSources>
+  <trustedSources>
+    <nuget.org>
+      <add key=""HASH"" value=""SUBJECT_NAME"" fingerprintAlgorithm=""SHA256"" />
+    </nuget.org>
+  </trustedSources>
+</configuration>";
+
+            var config2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <trustedSources>
+    <nuget.org>
+      <add key=""serviceIndex"" value=""SERVICE_INDEX"" />
+      <add key=""HASH2"" value=""SUBJECT_NAME2"" fingerprintAlgorithm=""SHA512"" />
+    </nuget.org>
+  </trustedSources>
+</configuration>";
+
+            var trustedSource = new TrustedSource("nuget.org");
+            trustedSource.Certificates.Add(new CertificateTrustEntry("HASH2", "SUBJECT_NAME2", HashAlgorithmName.SHA512));
+            trustedSource.Certificates.Add(new CertificateTrustEntry("HASH3", "SUBJECT_NAME3", HashAlgorithmName.SHA512));
+            trustedSource.ServiceIndex = new ServiceIndexTrustEntry("SERVICE_INDEX2");
+
+            var expectedTrustedSources = new List<TrustedSource>
+            {
+                trustedSource
+            };
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockChildDirectory = TestDirectory.Create(mockBaseDirectory))
+            {
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config1);
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockChildDirectory, config2);
+
+                var configPaths = new List<string> { Path.Combine(mockChildDirectory, nugetConfigPath), Path.Combine(mockBaseDirectory, nugetConfigPath) };
+                var settings = Settings.LoadSettingsGivenConfigPaths(configPaths);
+                var trustedSourceProvider = new TrustedSourceProvider(settings);
+
+
+                // Act
+                trustedSourceProvider.SaveTrustedSource(trustedSource);
+
+                // Assert
+                var result1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""nuget.org"" value=""https://nuget.org"" />
+    <add key=""test.org"" value=""Packages"" />
+  </packageSources>
+  <trustedSources>
+    <nuget.org>
+      <add key=""HASH3"" value=""SUBJECT_NAME3"" fingerprintAlgorithm=""SHA512"" />
+    </nuget.org>
+  </trustedSources>
+</configuration>";
+
+                var result2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <trustedSources>
+    <nuget.org>
+      <add key=""serviceIndex"" value=""SERVICE_INDEX2"" />
+      <add key=""HASH2"" value=""SUBJECT_NAME2"" fingerprintAlgorithm=""SHA512"" />
+    </nuget.org>
+  </trustedSources>
+</configuration>";
+
+                Assert.Equal(result1.Replace("\r\n", "\n"),
+                    File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
+                Assert.Equal(result2.Replace("\r\n", "\n"),
+                    File.ReadAllText(Path.Combine(mockChildDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
             }
         }
 
@@ -877,7 +1131,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config1 = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config1 = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <packageSources>
         <add key='nuget.org' value='https://nuget.org' />
@@ -890,7 +1144,7 @@ namespace NuGet.Configuration.Test
     </trustedSources>
 </configuration>";
 
-            var config2 = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config2 = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <trustedSources>
         <nuget.org>
@@ -898,6 +1152,14 @@ namespace NuGet.Configuration.Test
         </nuget.org>
     </trustedSources>
 </configuration>";
+
+            var trustedSource = new TrustedSource("nuget.org");
+            trustedSource.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256));
+
+            var expectedTrustedSources = new List<TrustedSource>
+            {
+                trustedSource
+            };
 
             using (var mockBaseDirectory = TestDirectory.Create())
             using (var mockChildDirectory = TestDirectory.Create(mockBaseDirectory))
@@ -908,16 +1170,12 @@ namespace NuGet.Configuration.Test
                 var configPaths = new List<string> { Path.Combine(mockChildDirectory, nugetConfigPath), Path.Combine(mockBaseDirectory, nugetConfigPath) };
                 var settings = Settings.LoadSettingsGivenConfigPaths(configPaths);
                 var trustedSourceProvider = new TrustedSourceProvider(settings);
-                var trustedSource = new TrustedSource("nuget.org");
-                trustedSource.Certificates.Add(new CertificateTrustEntry("HASH", "SUBJECT_NAME", HashAlgorithmName.SHA256));
 
                 // Act
                 trustedSourceProvider.SaveTrustedSource(trustedSource);
 
                 // Assert
-                var actualTrustedSources = trustedSourceProvider.LoadTrustedSources();
-                actualTrustedSources.Count().Should().Be(1);
-                actualTrustedSources.Should().Contain(trustedSource);
+                AssertTrustedSources(trustedSourceProvider.LoadTrustedSources(), expectedTrustedSources);
             }
         }
 
@@ -926,7 +1184,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
   <packageSources>
     <add key='nuget.org' value='https://nuget.org' />
@@ -959,7 +1217,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>
     <add key=""nuget.org"" value=""https://nuget.org"" />
@@ -998,7 +1256,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
   <packageSources>
     <add key='nuget.org' value='https://nuget.org' />
@@ -1038,7 +1296,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>
     <add key=""nuget.org"" value=""https://nuget.org"" />
@@ -1089,7 +1347,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config1 = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config1 = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <packageSources>
         <add key='nuget.org' value='https://nuget.org' />
@@ -1102,7 +1360,7 @@ namespace NuGet.Configuration.Test
     </trustedSources>
 </configuration>";
 
-            var config2 = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config2 = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <trustedSources>
         <nuget.org>
@@ -1136,7 +1394,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config1 = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+            var config1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
         <add key=""nuget.org"" value=""https://nuget.org"" />
@@ -1149,7 +1407,7 @@ namespace NuGet.Configuration.Test
     </trustedSources>
 </configuration>";
 
-            var config2 = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+            var config2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <trustedSources>
         <nuget.org>
@@ -1196,7 +1454,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config1 = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config1 = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <packageSources>
         <add key='nuget.org' value='https://nuget.org' />
@@ -1212,7 +1470,7 @@ namespace NuGet.Configuration.Test
     </trustedSources>
 </configuration>";
 
-            var config2 = $@"<?xml version='1.0' encoding='utf-8'?>
+            var config2 = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <trustedSources>
         <nuget.org>
@@ -1253,7 +1511,7 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
-            var config1 = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+            var config1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
         <add key=""nuget.org"" value=""https://nuget.org"" />
@@ -1269,7 +1527,7 @@ namespace NuGet.Configuration.Test
     </trustedSources>
 </configuration>";
 
-            var config2 = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+            var config2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <trustedSources>
         <nuget.org>
@@ -1295,7 +1553,7 @@ namespace NuGet.Configuration.Test
                 trustedSourceProvider.DeleteTrustedSource("temp.org");
 
                 // Assert
-                var result1 = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+                var result1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
         <add key=""nuget.org"" value=""https://nuget.org"" />
@@ -1308,7 +1566,7 @@ namespace NuGet.Configuration.Test
     </trustedSources>
 </configuration>";
 
-                var result2 = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+                var result2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <trustedSources>
         <nuget.org>
@@ -1321,6 +1579,35 @@ namespace NuGet.Configuration.Test
                     File.ReadAllText(Path.Combine(mockBaseDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
                 Assert.Equal(result2.Replace("\r\n", "\n"),
                     File.ReadAllText(Path.Combine(mockChildDirectory, nugetConfigPath)).Replace("\r\n", "\n"));
+            }
+        }
+
+        private void AssertTrustedSources(IEnumerable<TrustedSource> actual, IEnumerable<TrustedSource> expected)
+        {
+            actual.Should().NotBeNull();
+            expected.Should().NotBeNull();
+            actual.Count().Should().Be(expected.Count());
+
+            var expectedLookUp = expected.ToLookup(s => s.SourceName, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var source in actual)
+            {
+                var matchingValues = expectedLookUp[source.SourceName];
+                matchingValues.Count().Should().Be(1);
+
+                var matchingValue = matchingValues.FirstOrDefault();
+                matchingValue.Should().NotBeNull();
+
+                if (matchingValue.ServiceIndex != null)
+                {
+                    source.ServiceIndex.Should().NotBeNull();
+                    string.Equals(source.ServiceIndex.Value, matchingValue.ServiceIndex.Value, StringComparison.OrdinalIgnoreCase).Should().BeTrue();
+                }
+
+                foreach (var cert in source.Certificates)
+                {
+                    matchingValue.Certificates.Should().Contain(cert);
+                }
             }
         }
     }

--- a/test/TestUtilities/Test.Utility/TestDirectory.cs
+++ b/test/TestUtilities/Test.Utility/TestDirectory.cs
@@ -54,7 +54,7 @@ namespace NuGet.Test.Utility
             return Create(root);
         }
 
-        private static TestDirectory Create(string root)
+        public static TestDirectory Create(string root)
         {
             string parentPath = null;
 


### PR DESCRIPTION
## Bug
Addresses most of https://github.com/NuGet/Home/issues/6525
Spec detailing the proposed schema changes is [here](https://github.com/NuGet/Home/wiki/%5BSpec%5D-NuGet-Config-schema-changes-to-enable-repository-signatures)
Regression: No  

## Fix
Details: This PR adds supporting API to allow read/write operations of `TrustedSource` into NuGet.Config files. main point of entry is `TrustedSourceProvider` which allows loading, saving and deleting of trusted sources. Further, Changes have been made to `PackageSource` and `PackageSourceProvider` to allow saving and loading of trusted sources contained within package sources.

Most of the changes are for adding tests for new and old code.

This PR will be followed by a much smaller PR to allow untrusting of sources.

## Testing/Validation
Tests Added: Yes  
