### PR TITLE
IVsSolutionRestoreStatusProvider and Apex fixes

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsSolutionRestoreStatusProvider.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsSolutionRestoreStatusProvider.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.SolutionRestoreManager
+{
+    /// <summary>
+    /// Provides the status of IVsSolutionRestore.
+    /// </summary>
+    [ComImport]
+    [Guid("BEEE8F17-2174-4380-AE77-C428ACDF07E5")]
+    public interface IVsSolutionRestoreStatusProvider
+    {
+        /// <summary>
+        /// IsRestoreCompleteAsync indicates whether or not automatic package restore has pending work.
+        /// Automatic package restore applies for both packages.config and PackageReference projects.
+        /// 
+        /// Returns true if all projects in the solution that require nomination have been nominated for restore and all pending restores have completed.
+        /// The result does not indicate that restore completed successfully, a failed restore will still return true.
+        /// </summary>
+        /// <remarks>
+        /// Special cases:
+        /// * An empty solution will return true.
+        /// * If no solution is open this will true.
+        /// * An invalid project that does not provide restore details will cause this to return false since restore will not run for that project.
+        ///
+        /// Restores running due to Install/Update/Uninstall operations are NOT included in this status. Status here is limited to IVsSolutionRestoreService.
+        /// </remarks>
+        Task<bool> IsRestoreCompleteAsync(CancellationToken token);
+    }
+}

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
@@ -62,6 +62,7 @@
     <Compile Include="VerbosityLevel.cs" />
     <Compile Include="VsSolutionRestoreService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="VsSolutionRestoreStatusProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuGet.PackageManagement.VisualStudio\NuGet.PackageManagement.VisualStudio.csproj">

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreStatusProvider.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreStatusProvider.cs
@@ -1,0 +1,91 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.PackageManagement.VisualStudio;
+using NuGet.ProjectManagement;
+using NuGet.ProjectManagement.Projects;
+using NuGet.Shared;
+using NuGet.VisualStudio;
+
+namespace NuGet.SolutionRestoreManager
+{
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    [Export(typeof(IVsSolutionRestoreStatusProvider))]
+    public class VsSolutionRestoreStatusProvider : IVsSolutionRestoreStatusProvider
+    {
+        private readonly Lazy<ISolutionRestoreWorker> _restoreWorker;
+        private readonly Lazy<IVsSolutionManager> _solutionManager;
+
+        [ImportingConstructor]
+        public VsSolutionRestoreStatusProvider(
+            Lazy<ISolutionRestoreWorker> restoreWorker,
+            Lazy<IVsSolutionManager> solutionManager)
+        {
+            _restoreWorker = restoreWorker;
+            _solutionManager = solutionManager;
+        }
+
+        /// <summary>
+        /// True if all projects have been nominated and the restore worker has completed all work.
+        /// </summary>
+        public async Task<bool> IsRestoreCompleteAsync(CancellationToken token)
+        {
+            var complete = true;
+
+            // Check if the solution is open, if there are no projects then consider it restored.
+            if (_solutionManager.Value.IsSolutionOpen)
+            {
+                var graphContext = new DependencyGraphCacheContext();
+                var projects = (await _solutionManager.Value.GetNuGetProjectsAsync()).AsList();
+
+                // Empty solutions with no projects are considered restored.
+                foreach (var project in projects)
+                {
+                    token.ThrowIfCancellationRequested();
+
+                    // Check if the project has a spec to see if nomination is complete.
+                    complete &= await HasSpecAsync(project, graphContext);
+                }
+
+                // Check if the restore worker is currently active.
+                complete &= !_restoreWorker.Value.IsRunning;
+            }
+
+            return complete;
+        }
+
+        /// <summary>
+        /// True if the project has a spec available for restore.
+        /// </summary>
+        private static async Task<bool> HasSpecAsync(NuGetProject project, DependencyGraphCacheContext graphContext)
+        {
+            var buildProject = project as BuildIntegratedNuGetProject;
+
+            if (buildProject != null)
+            {
+                try
+                {
+                    var specs = await buildProject.GetPackageSpecsAsync(graphContext);
+
+                    if (specs?.Count < 1)
+                    {
+                        // Spec has not been loaded
+                        return false;
+                    }
+                }
+                catch (InvalidOperationException)
+                {
+                    // This is thrown if a project has not yet been nominated.
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/SolutionRestore/ISolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/SolutionRestore/ISolutionRestoreWorker.cs
@@ -23,6 +23,11 @@ namespace NuGet.VisualStudio
         bool IsBusy { get; }
 
         /// <summary>
+        /// Returns true when restore is running or additional restores are pending.
+        /// </summary>
+        bool IsRunning { get; }
+
+        /// <summary>
         /// Joinable task factory to synchronize with the worker.
         /// </summary>
         JoinableTaskFactory JoinableTaskFactory { get; }

--- a/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/ApexTestUIProject.cs
+++ b/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/ApexTestUIProject.cs
@@ -72,23 +72,6 @@ namespace NuGet.PackageManagement.UI.TestContract
             UIInvoke(() => _packageManagerControl.UpdatePackage(packages));
         }
 
-        public bool IsPackageInstalled(PackageIdentity package)
-        {
-            var nugetProject = _packageManagerControl._detailModel.NuGetProjects.FirstOrDefault();
-
-            if (nugetProject == null)
-            {
-                return false;
-            }
-
-            var installedPackage = NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
-            {
-                return await nugetProject.GetInstalledPackagesAsync(CancellationToken.None);
-            });
-
-            return installedPackage.Any(p => p.PackageIdentity.Equals(package));
-        }
-
         public bool WaitForActionComplete(Action action, TimeSpan timeout)
         {
             var taskCompletionSource = new TaskCompletionSource<bool>();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetUIProjectTestExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetUIProjectTestExtension.cs
@@ -60,10 +60,5 @@ namespace NuGet.Tests.Apex
             _uiproject.ActiveFilter = ItemFilter.UpdatesAvailable;
         }
 
-        public bool IsPackageInstalled(string packageId, string version)
-        {
-            return _uiproject.IsPackageInstalled(new PackageIdentity(packageId, NuGetVersion.Parse(version)));
-        }
-
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/SharedVisualStudioHostTestClass.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/SharedVisualStudioHostTestClass.cs
@@ -6,7 +6,9 @@ using FluentAssertions;
 using Microsoft.Test.Apex;
 using Microsoft.Test.Apex.VisualStudio;
 using Microsoft.Test.Apex.VisualStudio.Solution;
+using Test.Utility;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.Tests.Apex
 {
@@ -25,8 +27,14 @@ namespace NuGet.Tests.Apex
         private readonly IVisualStudioHostFixtureFactory _contextFixtureFactory;
         private readonly Lazy<VisualStudioHostFixture> _hostFixture;
 
-        protected SharedVisualStudioHostTestClass(IVisualStudioHostFixtureFactory contextFixtureFactory)
+        /// <summary>
+        /// ITestOutputHelper wrapper
+        /// </summary>
+        public XunitLogger XunitLogger { get; }
+
+        protected SharedVisualStudioHostTestClass(IVisualStudioHostFixtureFactory contextFixtureFactory, ITestOutputHelper output)
         {
+            XunitLogger = new XunitLogger(output);
             _contextFixtureFactory = contextFixtureFactory;
 
             _hostFixture = new Lazy<VisualStudioHostFixture>(() =>
@@ -54,11 +62,19 @@ namespace NuGet.Tests.Apex
 
         protected NuGetConsoleTestExtension GetConsole(ProjectTestExtension project)
         {
+            XunitLogger.LogInformation("GetConsole");
             VisualStudio.ClearWindows();
-
             var nugetTestService = GetNuGetTestService();
+
+            XunitLogger.LogInformation("EnsurePackageManagerConsoleIsOpen");
             nugetTestService.EnsurePackageManagerConsoleIsOpen().Should().BeTrue("Console was opened");
+
+            XunitLogger.LogInformation("GetPackageManagerConsole");
             var nugetConsole = nugetTestService.GetPackageManagerConsole(project.Name);
+
+            nugetTestService.WaitForAutoRestore();
+
+            XunitLogger.LogInformation("GetConsole complete");
 
             return nugetConsole;
         }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
@@ -61,6 +61,9 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.SolutionRestoreManager.Interop\NuGet.SolutionRestoreManager.Interop.csproj">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.VisualStudio\NuGet.VisualStudio.csproj">
       <Project>{e5556bc6-a7fd-4d8e-8a7d-7648df1d7471}</Project>
       <Name>NuGet.VisualStudio</Name>

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/IVsPackageInstallerTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/IVsPackageInstallerTestCase.cs
@@ -3,13 +3,14 @@
 
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.Tests.Apex
 {
     public class IVsPackageInstallerTestCase : SharedVisualStudioHostTestClass, IClassFixture<VisualStudioHostFixtureFactory>
     {
-        public IVsPackageInstallerTestCase(VisualStudioHostFixtureFactory visualStudioHostFixtureFactory) 
-            : base(visualStudioHostFixtureFactory)
+        public IVsPackageInstallerTestCase(VisualStudioHostFixtureFactory visualStudioHostFixtureFactory, ITestOutputHelper output)
+            : base(visualStudioHostFixtureFactory, output)
         {
         }
 
@@ -23,7 +24,7 @@ namespace NuGet.Tests.Apex
             var nugetTestService = GetNuGetTestService();
 
             solutionService.CreateEmptySolution();
-            solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject"); 
+            var projExt = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
 
             var project = dte.Solution.Projects.Item(1);
 
@@ -31,7 +32,7 @@ namespace NuGet.Tests.Apex
             nugetTestService.InstallPackage(project.UniqueName, "newtonsoft.json");
 
             // Assert
-            nugetTestService.Verify.PackageIsInstalled(project.UniqueName, "newtonsoft.json");
+            Utils.AssetPackageInPackagesConfig(VisualStudio, projExt, "newtonsoft.json", XunitLogger);
         }
 
         [StaFact]
@@ -42,17 +43,16 @@ namespace NuGet.Tests.Apex
             var solutionService = VisualStudio.Get<SolutionService>();
             var nugetTestService = GetNuGetTestService();
             solutionService.CreateEmptySolution();
-            solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary,ProjectTargetFramework.V46, "TestProject");
+            var projExt = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
             var dte = VisualStudio.Dte;
             var project = dte.Solution.Projects.Item(1);
-
-            // Act & Assert
             nugetTestService.InstallPackage(project.UniqueName, "newtonsoft.json");
-            nugetTestService.Verify.PackageIsInstalled(project.UniqueName, "newtonsoft.json");
 
-            // Act & Assert
+            // Act
             nugetTestService.UninstallPackage(project.UniqueName, "newtonsoft.json");
-            nugetTestService.Verify.PackageIsNotInstalled(project.UniqueName, "newtonsoft.json");
+
+            // Assert
+            Utils.AssetPackageNotInPackagesConfig(VisualStudio, projExt, "newtonsoft.json", XunitLogger);
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NetCoreProjectTestCase.cs
@@ -1,15 +1,15 @@
 using System.Collections.Generic;
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using NuGet.StaFact;
-using NuGet.Test.Utility;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.Tests.Apex
 {
     public class NetCoreProjectTestCase : SharedVisualStudioHostTestClass, IClassFixture<VisualStudioHostFixtureFactory>
     {
-        public NetCoreProjectTestCase(VisualStudioHostFixtureFactory visualStudioHostFixtureFactory)
-            : base(visualStudioHostFixtureFactory)
+        public NetCoreProjectTestCase(VisualStudioHostFixtureFactory visualStudioHostFixtureFactory, ITestOutputHelper output)
+            : base(visualStudioHostFixtureFactory, output)
         {
         }
 
@@ -21,7 +21,7 @@ namespace NuGet.Tests.Apex
             // Arrange
             EnsureVisualStudioHost();
 
-            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate))
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
             {
                 VisualStudio.AssertNoErrors();
             }
@@ -35,7 +35,7 @@ namespace NuGet.Tests.Apex
             // Arrange
             EnsureVisualStudioHost();
 
-            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate))
+            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
             {
                 var project2 = testContext.SolutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject2");
                 project2.Build();
@@ -44,9 +44,9 @@ namespace NuGet.Tests.Apex
                 testContext.SolutionService.SaveAll();
 
                 testContext.SolutionService.Build();
+                testContext.NuGetApexTestService.WaitForAutoRestore();
 
-                Assert.True(testContext.Project.References.TryFindReferenceByName("TestProject2", out var result));
-                VisualStudio.AssertNoErrors();
+                Utils.AssertPackageInAssetsFile(VisualStudio, testContext.Project, "TestProject2", "1.0.0", XunitLogger);
             }
         }
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetUITestCase.cs
@@ -3,13 +3,14 @@
 
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.Tests.Apex
 {
     public class NuGetUITestCase : SharedVisualStudioHostTestClass, IClassFixture<VisualStudioHostFixtureFactory>
     {
-        public NuGetUITestCase(VisualStudioHostFixtureFactory visualStudioHostFixtureFactory) 
-            : base(visualStudioHostFixtureFactory)
+        public NuGetUITestCase(VisualStudioHostFixtureFactory visualStudioHostFixtureFactory, ITestOutputHelper output)
+            : base(visualStudioHostFixtureFactory, output)
         {
         }
 
@@ -52,12 +53,10 @@ namespace NuGet.Tests.Apex
             dte.ExecuteCommand("Project.ManageNuGetPackages");
             var nugetTestService = GetNuGetTestService();
             var uiwindow = nugetTestService.GetUIWindowfromProject(project);
-            uiwindow.InstallPackageFromUI("newtonsoft.json","9.0.1");
-            project.Build();
+            uiwindow.InstallPackageFromUI("newtonsoft.json", "9.0.1");
 
             // Assert
-            Assert.True(uiwindow.IsPackageInstalled("newtonsoft.json", "9.0.1"));
-            VisualStudio.AssertNoErrors();
+            Utils.AssetPackageInPackagesConfig(VisualStudio, project, "newtonsoft.json", "9.0.1", XunitLogger);
         }
 
         [StaFact]
@@ -71,29 +70,22 @@ namespace NuGet.Tests.Apex
             solutionService.CreateEmptySolution();
             var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
             var nuProject = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "NuProject");
-            VisualStudio.ClearOutputWindow();
 
             // Act
             dte.ExecuteCommand("Project.ManageNuGetPackages");
             var nugetTestService = GetNuGetTestService();
             var uiwindow = nugetTestService.GetUIWindowfromProject(nuProject);
             uiwindow.InstallPackageFromUI("newtonsoft.json", "9.0.1");
-            project.Build();
-
-            // Assert
-            VisualStudio.AssertNoErrors();
-
-            VisualStudio.ClearOutputWindow();
             VisualStudio.SelectProjectInSolutionExplorer(project.Name);
             dte.ExecuteCommand("Project.ManageNuGetPackages");
+
+            VisualStudio.ClearOutputWindow();
             var uiwindow2 = nugetTestService.GetUIWindowfromProject(project);
             uiwindow2.InstallPackageFromUI("newtonsoft.json", "9.0.1");
-            project.Build();
 
             // Assert
-            Assert.True(uiwindow.IsPackageInstalled("newtonsoft.json", "9.0.1"));
-            Assert.True(uiwindow2.IsPackageInstalled("newtonsoft.json", "9.0.1"));
-            VisualStudio.AssertNoErrors();
+            Utils.AssetPackageInPackagesConfig(VisualStudio, project, "newtonsoft.json", "9.0.1", XunitLogger);
+            Utils.AssetPackageInPackagesConfig(VisualStudio, nuProject, "newtonsoft.json", "9.0.1", XunitLogger);
         }
 
         [StaFact]
@@ -106,25 +98,17 @@ namespace NuGet.Tests.Apex
 
             solutionService.CreateEmptySolution();
             var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
-            VisualStudio.ClearWindows();
-
-            // Act
             dte.ExecuteCommand("Project.ManageNuGetPackages");
             var nugetTestService = GetNuGetTestService();
             var uiwindow = nugetTestService.GetUIWindowfromProject(project);
             uiwindow.InstallPackageFromUI("newtonsoft.json", "9.0.1");
-            project.Build();
-
-            // Assert
-            Assert.True(uiwindow.IsPackageInstalled("newtonsoft.json", "9.0.1"));
+            VisualStudio.ClearWindows();
 
             // Act
             uiwindow.UninstallPackageFromUI("newtonsoft.json");
-            project.Build();
 
             // Assert
-            Assert.False(uiwindow.IsPackageInstalled("newtonsoft.json", "9.0.1"));
-            VisualStudio.AssertNoErrors();
+            Utils.AssetPackageNotInPackagesConfig(VisualStudio, project, "newtonsoft.json", XunitLogger);
         }
 
         [StaFact]
@@ -144,20 +128,13 @@ namespace NuGet.Tests.Apex
             var nugetTestService = GetNuGetTestService();
             var uiwindow = nugetTestService.GetUIWindowfromProject(project);
             uiwindow.InstallPackageFromUI("newtonsoft.json", "9.0.1");
-            project.Build();
-
-            // Assert
-            Assert.True(uiwindow.IsPackageInstalled("newtonsoft.json", "9.0.1"));
-            VisualStudio.AssertNoErrors();
 
             // Act
             VisualStudio.ClearWindows();
             uiwindow.UpdatePackageFromUI("newtonsoft.json", "10.0.3");
-            project.Build();
 
             // Assert
-            Assert.True(uiwindow.IsPackageInstalled("newtonsoft.json", "10.0.3"));
-            VisualStudio.AssertNoErrors();
+            Utils.AssetPackageInPackagesConfig(VisualStudio, project, "newtonsoft.json", "10.0.3", XunitLogger);
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/Utils.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/Utils.cs
@@ -2,14 +2,18 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.Versioning;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
+using System.Xml.Linq;
 using FluentAssertions;
+using Microsoft.Test.Apex.VisualStudio;
 using Microsoft.Test.Apex.VisualStudio.Solution;
+using NuGet.Common;
+using NuGet.LibraryModel;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -31,7 +35,8 @@ namespace NuGet.Tests.Apex
             SimpleTestPackageUtility.CreatePackages(packageSource, package);
         }
 
-        public static SimpleTestPackageContext CreateSignedPackage(string packageName, string packageVersion, X509Certificate2 testCertificate) {
+        public static SimpleTestPackageContext CreateSignedPackage(string packageName, string packageVersion, X509Certificate2 testCertificate)
+        {
             var package = CreatePackage(packageName, packageVersion);
             package.AuthorSignatureCertificate = testCertificate;
 
@@ -48,33 +53,149 @@ namespace NuGet.Tests.Apex
             return package;
         }
 
-        public static void AssertPackageIsInstalled(NuGetApexTestService testService, ProjectTestExtension project, string packageName, string packageVersion)
+        public static void AssertPackageReferenceExists(VisualStudioHost visualStudio, ProjectTestExtension project, string packageName, string packageVersion, ILogger logger)
         {
-            var assetsFilePath = GetAssetsFilePath(project.FullPath);
-            if (File.Exists(assetsFilePath))
-            {
-                // Project has an assets file, let's look there to assert
-                var inAssetsFile = IsPackageInstalledInAssetsFile(assetsFilePath, packageName, packageVersion);
-                inAssetsFile.Should().BeTrue($"{packageName}-{packageVersion} should be installed in {project.Name}");
-                return;
-            }
-            // Project has not assets file, let's use IVS API to assert
-            testService.Verify.PackageIsInstalled(project.UniqueName, packageName, packageVersion);
+            logger.LogInformation($"Checking for PackageReference {packageName} {packageVersion}");
+
+            var matches = GetPackageReferences(project)
+                .Where(e => e.Name.Equals(packageName, StringComparison.OrdinalIgnoreCase)
+                        && e.LibraryRange.VersionRange.MinVersion.Equals(NuGetVersion.Parse(packageVersion)))
+                .ToList();
+
+            logger.LogInformation($"Matches: {matches.Count}");
+
+            matches.Any().Should().BeTrue($"A PackageReference with {packageName}/{packageVersion} was not found in {project.FullPath}");
         }
 
-        public static void AssertPackageIsNotInstalled(NuGetApexTestService testService, ProjectTestExtension project, string packageName, string packageVersion)
+        public static void AssertPackageReferenceDoesNotExist(VisualStudioHost visualStudio, ProjectTestExtension project, string packageName, string packageVersion, ILogger logger)
         {
-            var assetsFilePath = GetAssetsFilePath(project.FullPath);
-            if (File.Exists(assetsFilePath))
-            {
-                // Project has an assets file, let's look there to assert
-                var inAssetsFile = IsPackageInstalledInAssetsFile(assetsFilePath, packageName, packageVersion);
-                inAssetsFile.Should().BeFalse($"{packageName}-{packageVersion} should not be installed in {project.Name}");
-                return;
-            }
-            // Project has not assets file, let's use IVS API to assert
-            testService.Verify.PackageIsNotInstalled(project.UniqueName, packageName, packageVersion);
+            logger.LogInformation($"Checking for PackageReference {packageName} {packageVersion}");
+
+            var matches = GetPackageReferences(project)
+                .Where(e => e.Name.Equals(packageName, StringComparison.OrdinalIgnoreCase)
+                        && e.LibraryRange.VersionRange.MinVersion.Equals(NuGetVersion.Parse(packageVersion)))
+                .ToList();
+
+            logger.LogInformation($"Matches: {matches.Count}");
+
+            matches.Any().Should().BeFalse($"A PackageReference with {packageName}/{packageVersion} was not found in {project.FullPath}");
         }
+
+        public static void AssertPackageReferenceDoesNotExist(VisualStudioHost visualStudio, ProjectTestExtension project, string packageName, ILogger logger)
+        {
+            logger.LogInformation($"Checking for PackageReference {packageName}");
+
+            var matches = GetPackageReferences(project)
+                .Where(e => e.Name.Equals(packageName, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            logger.LogInformation($"Matches: {matches.Count}");
+
+            matches.Any().Should().BeFalse($"A PackageReference for {packageName} was not found in {project.FullPath}");
+        }
+
+        public static List<LibraryDependency> GetPackageReferences(ProjectTestExtension project)
+        {
+            project.Save();
+            var doc = XDocument.Load(project.FullPath);
+
+            return doc.Root.Descendants()
+                .Where(e => e.Name.LocalName.Equals("PackageReference", StringComparison.OrdinalIgnoreCase))
+                .Select(e => new LibraryDependency(
+                    new LibraryRange(e.Attribute(XName.Get("Include")).Value,
+                        VersionRange.Parse(e.Attribute(XName.Get("Version")).Value),
+                        LibraryDependencyTarget.Package),
+                        LibraryDependencyType.Default,
+                        LibraryIncludeFlags.All,
+                        LibraryIncludeFlags.None,
+                        new List<NuGetLogCode>(),
+                        autoReferenced: false))
+                .ToList();
+        }
+
+        public static void AssertPackageInAssetsFile(VisualStudioHost visualStudio, ProjectTestExtension project, string packageName, string packageVersion, ILogger logger)
+        {
+            logger.LogInformation($"Checking assets file for {packageName}");
+
+            var testService = visualStudio.Get<NuGetApexTestService>();
+            testService.WaitForAutoRestore();
+
+            var assetsFilePath = GetAssetsFilePath(project.FullPath);
+            File.Exists(assetsFilePath).Should().BeTrue(AppendErrors($"File does not exist: {assetsFilePath}", visualStudio));
+
+            // Project has an assets file, let's look there to assert
+            var inAssetsFile = IsPackageInstalledInAssetsFile(assetsFilePath, packageName, packageVersion);
+
+            logger.LogInformation($"Exists: {inAssetsFile}");
+
+            inAssetsFile.Should().BeTrue(AppendErrors($"{packageName}/{packageVersion} should be installed in {project.Name}", visualStudio));
+        }
+
+        public static void AssetPackageInPackagesConfig(VisualStudioHost visualStudio, ProjectTestExtension project, string packageName, string packageVersion, ILogger logger)
+        {
+            logger.LogInformation($"Checking project {packageName}");
+            var testService = visualStudio.Get<NuGetApexTestService>();
+
+            // Check using the IVs APIs
+            var exists = testService.IsPackageInstalled(project.UniqueName, packageName, packageVersion);
+
+            logger.LogInformation($"Exists: {exists}");
+
+            exists.Should().BeTrue(AppendErrors($"{packageName}/{packageVersion} should be installed in {project.Name}", visualStudio));
+        }
+
+        public static void AssetPackageInPackagesConfig(VisualStudioHost visualStudio, ProjectTestExtension project, string packageName, ILogger logger)
+        {
+            logger.LogInformation($"Checking project {packageName}");
+            var testService = visualStudio.Get<NuGetApexTestService>();
+
+            // Check using the IVs APIs
+            var exists = testService.IsPackageInstalled(project.UniqueName, packageName);
+            logger.LogInformation($"Exists: {exists}");
+
+            exists.Should().BeTrue(AppendErrors($"{packageName} should be installed in {project.Name}", visualStudio));
+        }
+
+        public static void AssertPackageNotInAssetsFile(VisualStudioHost visualStudio, ProjectTestExtension project, string packageName, string packageVersion, ILogger logger)
+        {
+            logger.LogInformation($"Checking assets file for {packageName}");
+            var testService = visualStudio.Get<NuGetApexTestService>();
+            testService.WaitForAutoRestore();
+
+            var assetsFilePath = GetAssetsFilePath(project.FullPath);
+            File.Exists(assetsFilePath).Should().BeTrue(AppendErrors($"File does not exist: {assetsFilePath}", visualStudio));
+
+            // Project has an assets file, let's look there to assert
+            var inAssetsFile = IsPackageInstalledInAssetsFile(assetsFilePath, packageName, packageVersion);
+            logger.LogInformation($"Exists: {inAssetsFile}");
+
+            inAssetsFile.Should().BeFalse(AppendErrors($"{packageName}/{packageVersion} should be installed in {project.Name}", visualStudio));
+        }
+
+        public static void AssetPackageNotInPackagesConfig(VisualStudioHost visualStudio, ProjectTestExtension project, string packageName, string packageVersion, ILogger logger)
+        {
+            logger.LogInformation($"Checking project for {packageName}");
+            var testService = visualStudio.Get<NuGetApexTestService>();
+
+            // Check using the IVs APIs
+            var exists = testService.IsPackageInstalled(project.UniqueName, packageName, packageVersion);
+            logger.LogInformation($"Exists: {exists}");
+
+            exists.Should().BeFalse(AppendErrors($"{packageName}/{packageVersion} should NOT be in {project.Name}", visualStudio));
+        }
+
+        public static void AssetPackageNotInPackagesConfig(VisualStudioHost visualStudio, ProjectTestExtension project, string packageName, ILogger logger)
+        {
+            logger.LogInformation($"Checking project for {packageName}");
+            var testService = visualStudio.Get<NuGetApexTestService>();
+
+            // Check using the IVs APIs
+            var exists = testService.IsPackageInstalled(project.UniqueName, packageName);
+            logger.LogInformation($"Exists: {exists}");
+
+            exists.Should().BeFalse(AppendErrors($"{packageName} should NOT be in {project.Name}", visualStudio));
+        }
+
 
         public static bool IsPackageInstalledInAssetsFile(string assetsFilePath, string packageName, string packageVersion)
         {
@@ -170,14 +291,33 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        internal static ProjectTestExtension CreateAndInitProject(ProjectTemplate projectTemplate, SimpleTestPathContext pathContext, SolutionService solutionService)
+        internal static ProjectTestExtension CreateAndInitProject(ProjectTemplate projectTemplate, SimpleTestPathContext pathContext, SolutionService solutionService, ILogger logger)
         {
+            logger.LogInformation("Creating solution");
             solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
+
+            logger.LogInformation("Adding project");
             var project = solutionService.AddProject(ProjectLanguage.CSharp, projectTemplate, ProjectTargetFramework.V46, "TestProject");
+
+            logger.LogInformation("Saving solution");
             solutionService.Save();
+
+            logger.LogInformation("Building solution");
             project.Build();
 
             return project;
+        }
+
+        public static string AppendErrors(string s, VisualStudioHost visualStudio)
+        {
+            var errors = visualStudio.GetErrorsInOutputWindows();
+
+            if (errors.Any())
+            {
+                s += Environment.NewLine + string.Join("\n\t error: ", errors);
+            }
+
+            return s;
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/xunit.runner.json
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/xunit.runner.json
@@ -1,6 +1,6 @@
 {
   "methodDisplay": "classAndMethod",
-  "longRunningTestSeconds": 120,
+  "longRunningTestSeconds": 300,
   "diagnosticMessages": true,
   "preEnumerateTheories": false
 }

--- a/test/TestUtilities/Test.Utility/XunitLogger.cs
+++ b/test/TestUtilities/Test.Utility/XunitLogger.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using NuGet.Common;
+using Xunit.Abstractions;
+
+namespace Test.Utility
+{
+    /// <summary>
+    /// ILogger -> Xunit
+    /// </summary>
+    public class XunitLogger : LoggerBase
+    {
+        public XunitLogger(ITestOutputHelper output)
+        {
+            Output = output;
+            VerbosityLevel = LogLevel.Information;
+        }
+
+        /// <summary>
+        /// Xunit output
+        /// </summary>
+        public ITestOutputHelper Output { get; }
+
+        public override void Log(ILogMessage message)
+        {
+            var level = message.Level.ToString().ToLowerInvariant();
+            level = level.Substring(0, Math.Min(level.Length, 4));
+
+            Output.WriteLine($"[test] {level}: {message.Message}");
+        }
+
+        public override Task LogAsync(ILogMessage message)
+        {
+            Log(message);
+            return Task.FromResult(true);
+        }
+    }
+}


### PR DESCRIPTION
IsRestoreCompleteAsync allows callers to check if auto restore is running or contains pending work. It also enables checking if nominations exist for all projects, until this happens restore will fail.

* Add xunit logging to apex tests
* Wait until all auto restores complete before verification
* Check csproj files for PackageReferences
* Unify installed package checks across tests

Fixes https://github.com/NuGet/Home/issues/6029