### PR TITLE
support IsListed in V3 GetMetadataAsync

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Converters/ParserConstants.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/ParserConstants.cs
@@ -1,4 +1,4 @@
-﻿ // Copyright (c) .NET Foundation. All rights reserved.
+ // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -50,5 +50,6 @@ namespace NuGet.Protocol
         public const string PackageContent = "packageContent";
         public const string Versions = "versions";
         public const string PrefixReserved = "verified";
+        public const string Listed = "listed";
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -103,7 +103,7 @@ namespace NuGet.Protocol
 
         public Task<IEnumerable<VersionInfo>> GetVersionsAsync() => Task.FromResult<IEnumerable<VersionInfo>>(ParsedVersions);
 
-        // The V3 source currently does not return a listed property
-        public bool IsListed => true;
+        [JsonProperty(PropertyName = JsonProperties.Listed)]
+        public bool IsListed { get; private set; } = true;
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
@@ -51,6 +51,30 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(result.Description, result.Summary);
                 Assert.Equal(string.Join(", ", "deepequal", "deep", "equal"), result.Tags);
                 Assert.Equal("DeepEqual", result.Title);
+                Assert.True(result.IsListed);
+            }
+        }
+
+        [Fact]
+        public async Task PackageMetadataResourceV3_GetMetadataAsync_Unlisted()
+        {
+            var responses = new Dictionary<string, string>();
+            responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
+            responses.Add("https://api.nuget.org/v3/registration0/unlistedpackagea/index.json", JsonData.UnlistedPackageARegistration);
+
+            var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
+
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>();
+
+            var package = new PackageIdentity("unlistedpackagea", NuGetVersion.Parse("1.0.0"));
+
+            // Act
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var result = (PackageSearchMetadataRegistration)await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
+
+                // Assert
+                Assert.False(result.IsListed);
             }
         }
 


### PR DESCRIPTION
## Fix
`PackageMetadataResource` and `PackageSearchResource` are both returning `IPackageSearchMetadata`.
`IsListed` is supported by `PackageMetadataResource` but not by `PackageSearchResource`.

## Testing
Tests Added: Yes