### PR TITLE
fix symbol collection target and disable flaky mono tests

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -265,6 +265,7 @@ phases:
       solution: "build\\symbols.proj"
       msbuildVersion: "15.0"
       configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/p:IsSymbolBuild=true"
     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
     
   - task: CopyFiles@2

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -103,8 +103,8 @@
   <Import Project="$(BuildCommonDirectory)common.targets" />
   
   <PropertyGroup>
-    <SignTargetsForRealSigning>GetIlmergeBuildOutput</SignTargetsForRealSigning>
-    <SymbolTargetsToGetPdbs>GetIlmergeSymbolOutput</SymbolTargetsToGetPdbs>
+    <SignTargetsForRealSigning Condition="'$(IsSymbolsBuild)' != 'true'">GetIlmergeBuildOutput</SignTargetsForRealSigning>
+    <SymbolTargetsToGetPdbs>GetIlmergeSymbolOutput;GetFinalBuildOutput</SymbolTargetsToGetPdbs>
   </PropertyGroup>
   
   <!--These targets help get all the DLLs that are packed in the nuspec to be sent for signing.-->
@@ -127,6 +127,12 @@
   <Target Name="GetIlmergeSymbolOutput" Returns="@(SymbolsToIndex)">
     <ItemGroup>
       <SymbolsToIndex Include="$(OutputPath)ilmerge\*.pdb" KeepDuplicates="false" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GetFinalBuildOutput" Returns="@(DllsToIndex)">
+    <ItemGroup>
+      <DllsToIndex Include="$(OutputPath)ilmerge\NuGet.Build.Tasks.Pack.dll"/>
     </ItemGroup>
   </Target>
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -953,7 +953,7 @@ namespace NuGet.CommandLine.Test
         }
 
         // Test push command to a server using Plugin credential provider
-        [Fact]
+        [SkipMono]
         public void PushCommand_PushToServer_GetCredentialFromPlugin()
         {
             var nugetexe = Util.GetNuGetExePath();
@@ -1021,7 +1021,7 @@ namespace NuGet.CommandLine.Test
 
         // Test push command to a server, plugin provider does not provide credentials
         // so fallback to console provider
-        [Fact]
+        [SkipMono]
         public void PushCommand_PushToServer_WhenPluginReturnsNoCredentials_FallBackToConsoleProvider()
         {
             var nugetexe = Util.GetNuGetExePath();


### PR DESCRIPTION
the symbol collection target was unnecessarily invoking ILMerge on pack DLLs due to a target chaining issue, which I have fixed here using a property to detect that it's running symbol collection.

also disabled a couple of flaky mono tests