### PR TITLE
add commit hash to informational version

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -138,6 +138,7 @@
 
   <PropertyGroup Condition=" '$(Version)' == '' ">
     <Version>$(SemanticVersion)$(PreReleaseInformationVersion)</Version>
+    <Version Condition="'$(BUILD_SOURCEVERSION)' != ''">$(SemanticVersion)$(PreReleaseInformationVersion)+$(BUILD_SOURCEVERSION)</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -125,7 +125,7 @@
     <!-- If we aren't excluding the build number, use the release label and the build number. -->
     <When Condition="'$(BuildRTM)' != 'true' AND '$(PreReleaseVersion)' != '' AND '$(PreReleaseVersion)' != '0' ">
       <PropertyGroup>
-        <PreReleaseInformationVersion>-$(ReleaseLabel)-$(PreReleaseVersion)</PreReleaseInformationVersion>
+        <PreReleaseInformationVersion>-$(ReleaseLabel).$(PreReleaseVersion)</PreReleaseInformationVersion>
       </PropertyGroup>
     </When>
     <!-- If we are excluding the build number, show the release label unless we are RTM. -->
@@ -177,7 +177,8 @@
       <_Parameter1>$(SemanticVersion).$(PreReleaseVersion)</_Parameter1>
     </AssemblyAttributes>
     <AssemblyAttributes Include="AssemblyInformationalVersion">
-      <_Parameter1>$(SemanticVersion)$(PreReleaseInformationVersion)</_Parameter1>
+      <_Parameter1 Condition="'$(BUILD_SOURCEVERSION)' == ''">$(SemanticVersion)$(PreReleaseInformationVersion)</_Parameter1>
+      <_Parameter1 Condition="'$(BUILD_SOURCEVERSION)' != ''">$(SemanticVersion)$(PreReleaseInformationVersion)+$(BUILD_SOURCEVERSION)</_Parameter1>
     </AssemblyAttributes>
     <AssemblyAttributes Include="AssemblyCompany">
       <_Parameter1>Microsoft Corporation</_Parameter1>
@@ -197,7 +198,8 @@
     <!-- Assembly attributes for net core projects -->
     <AssemblyVersion>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</AssemblyVersion>
     <FileVersion>$(SemanticVersion).$(PreReleaseVersion)</FileVersion>
-    <InformationalVersion>$(SemanticVersion)$(PreReleaseInformationVersion)</InformationalVersion>
+    <InformationalVersion Condition="'$(BUILD_SOURCEVERSION)' == ''">$(SemanticVersion)$(PreReleaseInformationVersion)</InformationalVersion>
+    <InformationalVersion Condition="'$(BUILD_SOURCEVERSION)' != ''">$(SemanticVersion)$(PreReleaseInformationVersion)+$(BUILD_SOURCEVERSION)</InformationalVersion>
     <Company>Microsoft Corporation</Company>
     <Product>NuGet</Product>
     <Copyright>Microsoft Corporation. All rights reserved.</Copyright>


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/6492 

adds commit hash (set as env variable in VSTS) in the informational version following semver2 guidelines.