### PR TITLE
Signing: improve testability of signing infrastructure

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -133,8 +133,9 @@ namespace NuGet.Packaging.FuncTest
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
             var keyPair = SigningTestUtility.GenerateKeyPair(publicKeyLength: 2048);
             var now = DateTimeOffset.UtcNow;
-            var issueOptions = new IssueCertificateOptions(keyPair.Public)
+            var issueOptions = new IssueCertificateOptions()
                 {
+                    KeyPair = keyPair,
                     NotAfter = now.AddSeconds(10),
                     NotBefore = now.AddSeconds(-2),
                     SubjectName = new X509Name("CN=NuGet Test Expired Certificate")
@@ -187,8 +188,9 @@ namespace NuGet.Packaging.FuncTest
             var timestampService = TimestampService.Create(ca, serviceOptions);
             var keyPair = SigningTestUtility.GenerateKeyPair(publicKeyLength: 2048);
             var now = DateTimeOffset.UtcNow;
-            var issueOptions = new IssueCertificateOptions(keyPair.Public)
+            var issueOptions = new IssueCertificateOptions()
             {
+                KeyPair = keyPair,
                 NotAfter = now.AddSeconds(10),
                 NotBefore = now.AddSeconds(-2),
                 SubjectName = new X509Name("CN=NuGet Test Expired Certificate")

--- a/test/TestUtilities/Test.Utility/Signing/CertificateUtilities.cs
+++ b/test/TestUtilities/Test.Utility/Signing/CertificateUtilities.cs
@@ -12,11 +12,11 @@ namespace Test.Utility.Signing
 {
     internal static class CertificateUtilities
     {
-        internal static AsymmetricCipherKeyPair CreateKeyPair()
+        internal static AsymmetricCipherKeyPair CreateKeyPair(int strength = 2048)
         {
             var generator = new RsaKeyPairGenerator();
 
-            generator.Init(new KeyGenerationParameters(new SecureRandom(), strength: 2048));
+            generator.Init(new KeyGenerationParameters(new SecureRandom(), strength));
 
             return generator.GenerateKeyPair();
         }
@@ -29,6 +29,11 @@ namespace Test.Utility.Signing
 
                 return BitConverter.ToString(hash).Replace("-", "");
             }
+        }
+
+        internal static string GenerateRandomId()
+        {
+            return Guid.NewGuid().ToString();
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/Signing/OcspResponderOptions.cs
+++ b/test/TestUtilities/Test.Utility/Signing/OcspResponderOptions.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Test.Utility.Signing
+{
+    public sealed class OcspResponderOptions
+    {
+        public DateTimeOffset? ThisUpdate { get; set; }
+        public DateTimeOffset? NextUpdate { get; set; }
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/TimestampService.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TimestampService.cs
@@ -105,8 +105,9 @@ namespace Test.Utility.Signing
                     extensionValue: ExtendedKeyUsage.GetInstance(new DerSequence(KeyPurposeID.IdKPTimeStamping)));
             };
 
-            var issueOptions = new IssueCertificateOptions(keyPair.Public)
+            var issueOptions = new IssueCertificateOptions()
                 {
+                    KeyPair = keyPair,
                     SubjectName = subjectName,
                     CustomizeCertificate = customizeCertificate
                 };


### PR DESCRIPTION
Resolve https://github.com/NuGet/Home/issues/6569.

Adding some test functionality for Loic.

* Enable customization of root and intermediate certificates (without duplicating the certificate generator lambda).  For example, with this change the public key length for root and intermediate certificates can easily be varied.
* Add `OcspResponder.Create(...)` method with `OcspResponderOptions` parameter for customizing OCSP responses.