### PR TITLE
disable publishing symbols nupkg to myget

### DIFF
--- a/scripts/cibuild/PublishArtifactsFromVsts.ps1
+++ b/scripts/cibuild/PublishArtifactsFromVsts.ps1
@@ -65,10 +65,9 @@ $NuGetExe = Join-Path $env:BUILD_REPOSITORY_LOCALPATH .nuget\nuget.exe
 
 if(Test-Path $NupkgsDir)
 {
-    Write-Output "Publishing nupkgs from '$Nupkgs'"
     # Push all nupkgs to the nuget-build feed on myget.
-    Get-Item "$NupkgsDir\*.nupkg" -Exclude "Test.*.nupkg" | Push-ToMyGet -ApiKey $NuGetBuildFeedApiKey -BuildFeed $NuGetBuildFeedUrl -SymbolSource $NuGetBuildSymbolsFeedUrl
+    Get-Item "$NupkgsDir\*.nupkg" -Exclude "Test.*.nupkg", "*.symbols.nupkg" | Push-ToMyGet -ApiKey $NuGetBuildFeedApiKey -BuildFeed $NuGetBuildFeedUrl -SymbolSource $NuGetBuildSymbolsFeedUrl
     # We push NuGet.Build.Tasks.Pack nupkg to dotnet-core feed as per the request of the CLI team.
-    Get-Item "$NupkgsDir\NuGet.Build.Tasks.Pack*.nupkg" | Push-ToMyGet -ApiKey $DotnetCoreFeedApiKey -BuildFeed $DotnetCoreFeedUrl -SymbolSource $DotnetCoreSymbolsFeedUrl
+    Get-Item "$NupkgsDir\NuGet.Build.Tasks.Pack*.nupkg" -Exclude "*.symbols.nupkg" | Push-ToMyGet -ApiKey $DotnetCoreFeedApiKey -BuildFeed $DotnetCoreFeedUrl -SymbolSource $DotnetCoreSymbolsFeedUrl
 }
 


### PR DESCRIPTION
myget doesn't accept symbol packages which does not have both src and pdb for semver2 packages.