### PR TITLE
Print warning if pack excludes a file because of default exclude wildcards

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -862,7 +862,21 @@ namespace NuGet.Commands
             if (!_packArgs.NoDefaultExcludes)
             {
                 // The user has not explicitly disabled default filtering.
-                wildCards = wildCards.Concat(_defaultExcludes);
+                var excludedFiles = PathResolver.FilterPackageFiles(packageFiles, ResolvePath, _defaultExcludes);
+                if(excludedFiles != null)
+                {
+                    foreach (var file in excludedFiles)
+                    {
+                        if(file is PhysicalPackageFile)
+                        {
+                            var physicalPackageFile = file as PhysicalPackageFile;
+                            _packArgs.Logger.Log(PackLogMessage.CreateWarning(
+                                String.Format(CultureInfo.CurrentCulture, Strings.Warning_FileExcludedByDefault, physicalPackageFile.SourcePath),
+                                NuGetLogCode.NU5119));
+
+                        }
+                    }
+                }
             }
             wildCards = wildCards.Concat(_packArgs.Exclude);
 

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1557,6 +1557,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to File &apos;{0}&apos; was not added to the package. Files and folders starting with &apos;.&apos; or ending with &apos;.nupkg&apos; are excluded by default. To include this file, use -NoDefaultExcludes from the commandline.
+        /// </summary>
+        internal static string Warning_FileExcludedByDefault {
+            get {
+                return ResourceManager.GetString("Warning_FileExcludedByDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} depends on {1} but {2} was not found. An approximate best match of {3} was resolved..
         /// </summary>
         internal static string Warning_MinVersionDoesNotExist {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -694,4 +694,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="Error_UnableToSignPackage" xml:space="preserve">
     <value>Unable to sign package.</value>
   </data>
+  <data name="Warning_FileExcludedByDefault" xml:space="preserve">
+    <value>File '{0}' was not added to the package. Files and folders starting with '.' or ending with '.nupkg' are excluded by default. To include this file, use -NoDefaultExcludes from the commandline</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -631,6 +631,11 @@ namespace NuGet.Common
         NU5118 = 5118,
 
         /// <summary>
+        /// Warning_FileExcludedByDefault
+        /// </summary>
+        NU5119 = 5119,
+
+        /// <summary>
         /// Undefined package warning
         /// </summary>
         NU5500 = 5500,

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
@@ -31,7 +31,8 @@ namespace NuGet.Common
         /// <summary>
         /// Removes files from the source that match any wildcard.
         /// </summary>
-        public static void FilterPackageFiles<T>(ICollection<T> source, Func<T, string> getPath, IEnumerable<string> wildcards)
+        public static IEnumerable<T> FilterPackageFiles<T>(ICollection<T> source,
+            Func<T, string> getPath, IEnumerable<string> wildcards)
         {
             var matchedFiles = new HashSet<T>(GetMatches(source, getPath, wildcards));
 
@@ -40,6 +41,8 @@ namespace NuGet.Common
             {
                 source.Remove(item);
             }
+
+            return toRemove;
         }
 
         public static string NormalizeWildcardForExcludedFiles(string basePath, string wildcard)


### PR DESCRIPTION
Fixes:  https://github.com/NuGet/Home/issues/3308