### PR TITLE
fix validation issues directory separator char issue

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Rules/InitScriptNotUnderToolsRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/InitScriptNotUnderToolsRule.cs
@@ -15,8 +15,8 @@ namespace NuGet.Packaging.Rules
         {
             foreach (var file in builder.GetFiles())
             {
-                string name = Path.GetFileName(file);
-                string dirName = Path.GetFileName(Path.GetDirectoryName(file));
+                var name = Path.GetFileName(file);
+                var dirName = Path.GetFileName(Path.GetDirectoryName(file));
                 if (name.Equals("init.ps1", StringComparison.OrdinalIgnoreCase) && !dirName.Equals(PackagingConstants.Folders.Tools, StringComparison.OrdinalIgnoreCase))
                 {
                     yield return CreatePackageIssue(file);

--- a/src/NuGet.Core/NuGet.Packaging/Rules/InvalidFrameworkFolderRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/InvalidFrameworkFolderRule.cs
@@ -18,7 +18,7 @@ namespace NuGet.Packaging.Rules
         public IEnumerable<PackLogMessage> Validate(PackageArchiveReader builder)
         {
             var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var file in builder.GetFiles())
+            foreach (var file in builder.GetFiles().Select(t => PathUtility.GetPathWithDirectorySeparator(t)))
             {
                 string[] parts = file.Split(Path.DirectorySeparatorChar);
                 if (parts.Length >= 3 && parts[0].Equals(LibDirectory, StringComparison.OrdinalIgnoreCase))

--- a/src/NuGet.Core/NuGet.Packaging/Rules/MisplacedScriptFileRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/MisplacedScriptFileRule.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using NuGet.Common;
 
 namespace NuGet.Packaging.Rules
@@ -16,7 +17,7 @@ namespace NuGet.Packaging.Rules
 
         public IEnumerable<PackLogMessage> Validate(PackageArchiveReader builder)
         {
-            foreach (var file in builder.GetFiles())
+            foreach (var file in builder.GetFiles().Select(t => PathUtility.GetPathWithDirectorySeparator(t)))
             {
                 if (!file.EndsWith(ScriptExtension, StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/NuGet.Core/NuGet.Packaging/Rules/MisplacedTransformFileRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/MisplacedTransformFileRule.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using NuGet.Common;
 
 namespace NuGet.Packaging.Rules
@@ -18,7 +19,7 @@ namespace NuGet.Packaging.Rules
 
         public IEnumerable<PackLogMessage> Validate(PackageArchiveReader builder)
         {
-            foreach (var file in builder.GetFiles())
+            foreach (var file in builder.GetFiles().Select(t => PathUtility.GetPathWithDirectorySeparator(t)))
             {
                 // if not a .transform file, ignore
                 if (!file.EndsWith(CodeTransformExtension, StringComparison.OrdinalIgnoreCase) &&

--- a/src/NuGet.Core/NuGet.Packaging/Rules/WinRTNameIsObsoleteRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/WinRTNameIsObsoleteRule.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using NuGet.Common;
 
 namespace NuGet.Packaging.Rules
@@ -15,11 +16,11 @@ namespace NuGet.Packaging.Rules
 
         public IEnumerable<PackLogMessage> Validate(PackageArchiveReader builder)
         {
-            foreach (var file in builder.GetFiles())
+            foreach (var file in builder.GetFiles().Select(t => PathUtility.GetPathWithDirectorySeparator(t)))
             {
-                foreach (string prefix in Prefixes)
+                foreach (var prefix in Prefixes)
                 {
-                    if (file.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    if (file.StartsWith(PathUtility.GetPathWithDirectorySeparator(prefix), StringComparison.OrdinalIgnoreCase))
                     {
                         yield return CreateIssue(file);
                     }


### PR DESCRIPTION
One of the side-effect of changing the validation API to use ``` PackageArchiveReader``` instead of ``` PackageBuilder``` was that the directory separator char in ``` PackageArchiveReader``` is always ``` / ``` while in ``` PackageBuilder``` it is equal to the value of ```Path.DirectorySeparatorChar```.  This PR fixes this by converting all paths to paths with ``` Path.DirectorySeparatorChar``` .