### PR TITLE
remove unnecesary async read to project json get json

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
@@ -10,6 +10,7 @@ using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Commands;
 using NuGet.Common;
@@ -301,8 +302,9 @@ namespace NuGet.ProjectManagement.Projects
                 return FileUtility.SafeRead(JsonConfigPath, (stream, filePath) =>
                 {
                     using (var reader = new StreamReader(stream))
+                    using (var jsonReader = new JsonTextReader(reader))
                     {
-                        return JObject.Parse(reader.ReadToEnd());
+                        return JObject.Load(jsonReader);
                     }
                 });
             }
@@ -321,7 +323,7 @@ namespace NuGet.ProjectManagement.Projects
                 {
                     using (var reader = new StreamReader(stream))
                     {
-                        return JObject.Parse(await reader.ReadToEndAsync());
+                        return JObject.Parse(reader.ReadToEnd());
                     }
                 });
             }


### PR DESCRIPTION
This async operation was causing a hang when creating a new PCL project.

It is not needed because JObject.Parse runs sync therefore the use of a async read method becomes unnecessary.

cc. @rrelyea 