### PR TITLE
Fix hang when creating PCL project

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -18,6 +18,7 @@ using Microsoft;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.PackageManagement.Telemetry;
@@ -40,7 +41,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private static readonly INuGetProjectContext EmptyNuGetProjectContext = new EmptyNuGetProjectContext();
         private static readonly string VSNuGetClientName = "NuGet VS VSIX";
 
-        private readonly INuGetLockService _initLock = new NuGetLockService();
+        private readonly INuGetLockService _initLock;
 
         private SolutionEvents _solutionEvents;
         private CommandEvents _solutionSaveEvent;
@@ -128,7 +129,8 @@ namespace NuGet.PackageManagement.VisualStudio
             IVsProjectAdapterProvider vsProjectAdapterProvider,
             [Import("VisualStudioActivityLogger")]
             Common.ILogger logger,
-            Lazy<ISettings> settings)
+            Lazy<ISettings> settings,
+            JoinableTaskContext joinableTaskContext)
         {
             Assumes.Present(serviceProvider);
             Assumes.Present(projectSystemCache);
@@ -137,6 +139,7 @@ namespace NuGet.PackageManagement.VisualStudio
             Assumes.Present(vsProjectAdapterProvider);
             Assumes.Present(logger);
             Assumes.Present(settings);
+            Assumes.Present(joinableTaskContext);
 
             _serviceProvider = serviceProvider;
             _projectSystemCache = projectSystemCache;
@@ -145,6 +148,7 @@ namespace NuGet.PackageManagement.VisualStudio
             _vsProjectAdapterProvider = vsProjectAdapterProvider;
             _logger = logger;
             _settings = settings;
+            _initLock = new NuGetLockService(joinableTaskContext);
         }
 
         private async Task InitializeAsync()

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
@@ -479,6 +479,7 @@ namespace NuGet.VisualStudio
                 var packageManager = CreatePackageManager(repoProvider);
 
                 // find the project
+                await _solutionManager.InitializationTask;
                 var nuGetProject = await _solutionManager.GetOrCreateProjectAsync(project, projectContext);
 
                 // install the package

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
@@ -478,12 +478,6 @@ namespace NuGet.VisualStudio
 
                 var packageManager = CreatePackageManager(repoProvider);
 
-                // await for any outstanding initialization task
-                if (_solutionManager.InitializationTask != null)
-                {
-                    await _solutionManager.InitializationTask;
-                }
-
                 // find the project
                 var nuGetProject = await _solutionManager.GetOrCreateProjectAsync(project, projectContext);
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
@@ -478,8 +478,13 @@ namespace NuGet.VisualStudio
 
                 var packageManager = CreatePackageManager(repoProvider);
 
+                // await for any outstanding initialization task
+                if (_solutionManager.InitializationTask != null)
+                {
+                    await _solutionManager.InitializationTask;
+                }
+
                 // find the project
-                await _solutionManager.InitializationTask;
                 var nuGetProject = await _solutionManager.GetOrCreateProjectAsync(project, projectContext);
 
                 // install the package

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetLockServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetLockServiceTests.cs
@@ -26,7 +26,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             _jtf = fixture.JoinableTaskFactory;
 
-            _lockService = new NuGetLockService();
+            _lockService = new NuGetLockService(fixture.JoinableTaskFactory.Context);
             Assert.False(_lockService.IsLockHeld);
         }
 


### PR DESCRIPTION
Fixes `VSTS 567587 and 508282` work items.

There is a hang when creating a PCL project for the first time. 

Repro:
1.	Tools > Option > Nuget > Clear all Cache
2.	File > new project > Visual C# > Class library (Legacy Portable)
3.	Select ASP.NET Core 1.0 and Windows Universal 10.0
4.	Click OK
5.	Close solution
6.	Repeat steps 1 to 4
7.	It will hang here and the project will never finish creating.


The callstack for this hang is shown below:
```
12f60620 <0> NuGet.ProjectManagement.Projects.ProjectJsonNuGetProject+<>c+<<GetJsonAsync>b__21_0>d
.12f606cc <0> NuGet.Common.FileUtility+<SafeReadAsync>d__11`1[[Newtonsoft.Json.Linq.JObject, Newtonsoft.Json]]
..12f6079c <0> NuGet.ProjectManagement.Projects.ProjectJsonNuGetProject+<GetJsonAsync>d__21
...12f6085c <0> NuGet.ProjectManagement.Projects.ProjectJsonNuGetProject+<GetInstalledPackagesAsync>d__13
....12f60920 <0> NuGet.PackageManagement.Telemetry.VSTelemetryServiceUtility+<GetProjectTelemetryEventAsync>d__2
.....12f609ec <1> NuGet.PackageManagement.VisualStudio.VSSolutionManager+<AddVsProjectAdapterToCacheAsync>d__94
......12f60abc <2> NuGet.PackageManagement.VisualStudio.VSSolutionManager+<<EnsureNuGetAndVsProjectAdapterCacheAsync>b__93_0>d
.......12f60b9c <0> NuGet.PackageManagement.VisualStudio.NuGetLockService+<>c__DisplayClass7_0+<<ExecuteNuGetOperationAsync>b__0>d
........12f60c5c <1> NuGet.PackageManagement.VisualStudio.NuGetLockService+<ExecuteNuGetOperationAsync>d__6`1[[System.Boolean, mscorlib]]
.........12f60d28 <0> NuGet.PackageManagement.VisualStudio.VSSolutionManager+<EnsureNuGetAndVsProjectAdapterCacheAsync>d__93
..........12f60de8 <1> NuGet.PackageManagement.VisualStudio.VSSolutionManager+<>c__DisplayClass91_0+<<OnEnvDTEProjectAdded>b__0>d

3753ce14 <0> NuGet.PackageManagement.VisualStudio.NuGetLockService+<ExecuteNuGetOperationAsync>d__6`1[[System.Boolean, mscorlib]]
.3753cee0 <0> NuGet.PackageManagement.VisualStudio.VSSolutionManager+<EnsureNuGetAndVsProjectAdapterCacheAsync>d__93
..3753cfa0 <4> NuGet.PackageManagement.VisualStudio.VSSolutionManager+<EnsureInitializeAsync>d__96
...3753d098 <0> NuGet.PackageManagement.VisualStudio.VSSolutionManager+<GetNuGetProjectAsync>d__70
....3754bb00 <2> NuGet.PackageManagement.VisualStudio.VSSolutionManager+<GetOrCreateProjectAsync>d__106
.....3753968c <2> NuGet.VisualStudio.VsPackageInstaller+<InstallInternalAsync>d__32
......37539788 <1> NuGet.VisualStudio.VsPackageInstaller+<>c__DisplayClass23_0+<<InstallPackagesFromRegistryRepository>b__0>d
```

`NuGetLockService` is facing a deadlock because it is taken in the UI thread (from a call to `OnEnvDTEProjectAdded`) and then, when this process goes off the UI thread (to `ReadJsonAsync`) a call to `InstallPackagesFromRegistryRepository` takes the UI thread and ends up waiting for `NuGetLockService` which is waiting on the UI thread to resume.

The deadlock is appearing because JTF does not have enough information about the processes waiting on the `NuGetLockService` so it can yield the UI thread if needed. This fix adds a `JoinableTaskCollection` to `NuGetLockService` so `JTF.RunAsync` will be able to yield if necessary.

As a followup we should also fix https://github.com/NuGet/Home/issues/6594 i.e. change the `NuGetLockService` instance in `VSSolutionManager` to be MEF imported instead of creating a new one, which is currently done [here](https://github.com/NuGet/NuGet.Client/blob/98fd6e140c80c3932d6e857b456ee5120751ae46/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs#L43).

cc. @rrelyea, @jainaashish 