### PR TITLE
Signing:  fix incorrect encoding

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -296,7 +296,7 @@ namespace NuGet.Packaging
             }
 
 #if IS_DESKTOP
-            using (var reader = new BinaryReader(ZipReadStream, SigningSpecifications.Encoding, leaveOpen: true))
+            using (var reader = new BinaryReader(ZipReadStream, new UTF8Encoding(), leaveOpen: true))
             using (var hashAlgorithm = signatureContent.HashAlgorithm.GetHashProvider())
             {
                 var expectedHash = Convert.FromBase64String(signatureContent.HashValue);

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Content/KeyPairFileReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Content/KeyPairFileReader.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace NuGet.Packaging.Signing
@@ -14,14 +15,19 @@ namespace NuGet.Packaging.Signing
 
         private readonly StreamReader _reader;
 
-        public KeyPairFileReader(Stream stream)
+        public KeyPairFileReader(Stream stream, Encoding encoding)
         {
             if (stream == null)
             {
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            _reader = new StreamReader(stream, KeyPairFileUtility.Encoding, detectEncodingFromByteOrderMarks: false);
+            if (encoding == null)
+            {
+                throw new ArgumentNullException(nameof(encoding));
+            }
+
+            _reader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks: false);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Content/KeyPairFileUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Content/KeyPairFileUtility.cs
@@ -2,17 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Text;
 
 namespace NuGet.Packaging.Signing
 {
     public static class KeyPairFileUtility
     {
-        /// <summary>
-        /// File encoding.
-        /// </summary>
-        public static readonly Encoding Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-
         /// <summary>
         /// Throw if the expected value does not exist.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Content/KeyPairFileWriter.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Content/KeyPairFileWriter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Text;
 
 namespace NuGet.Packaging.Signing
 {
@@ -10,14 +11,19 @@ namespace NuGet.Packaging.Signing
     {
         private readonly StreamWriter _writer;
 
-        public KeyPairFileWriter(Stream stream, bool leaveOpen)
+        public KeyPairFileWriter(Stream stream, Encoding encoding, bool leaveOpen)
         {
             if (stream == null)
             {
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            _writer = new StreamWriter(stream, KeyPairFileUtility.Encoding, bufferSize: 8192, leaveOpen: leaveOpen);
+            if (encoding == null)
+            {
+                throw new ArgumentNullException(nameof(encoding));
+            }
+
+            _writer = new StreamWriter(stream, encoding, bufferSize: 8192, leaveOpen: leaveOpen);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Content/SignatureContent.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Content/SignatureContent.cs
@@ -50,7 +50,7 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         private void Save(Stream stream)
         {
-            using (var writer = new KeyPairFileWriter(stream, leaveOpen: true))
+            using (var writer = new KeyPairFileWriter(stream, _signingSpecifications.Encoding, leaveOpen: true))
             {
                 writer.WritePair("Version", _signingSpecifications.Version);
                 writer.WriteSectionBreak();
@@ -102,7 +102,7 @@ namespace NuGet.Packaging.Signing
             var hashAlgorithm = HashAlgorithmName.Unknown;
             string hash = null;
 
-            using (var reader = new KeyPairFileReader(stream))
+            using (var reader = new KeyPairFileReader(stream, signingSpecifications.Encoding))
             {
                 // Read header-section.
                 var properties = reader.ReadSection();

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Specifications/SigningSpecificationsV1.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Specifications/SigningSpecificationsV1.cs
@@ -11,7 +11,7 @@ namespace NuGet.Packaging.Signing
     {
         private const string _signaturePath = ".signature.p7s";
         private const int _rsaPublicKeyMinLength = 2048;
-        private static readonly Encoding _encoding = Encoding.UTF8;
+        private static readonly Encoding _encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
         /// <summary>
         /// Allowed digest algorithms for signature and timestamp hashing.
@@ -42,7 +42,7 @@ namespace NuGet.Packaging.Signing
         public override int RSAPublicKeyMinLength => _rsaPublicKeyMinLength;
 
         public override Encoding Encoding => _encoding;
-        
+
         public SigningSpecificationsV1()
             : base()
         {

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -23,6 +24,9 @@ namespace NuGet.Packaging.FuncTest
     [Collection(SigningTestCollection.Name)]
     public class SignedPackageIntegrityVerificationTests
     {
+        private readonly UTF8Encoding _readerEncoding = new UTF8Encoding();
+        private readonly UTF8Encoding _writerEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
         private SigningSpecifications _specification => SigningSpecifications.V1;
 
         private SigningTestFixture _testFixture;
@@ -343,8 +347,8 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(packageStream, _specification.Encoding, leaveOpen: true))
-                    using (var writer = new BinaryWriter(packageStream, _specification.Encoding, leaveOpen: true))
+                    using (var reader = new BinaryReader(packageStream, _readerEncoding, leaveOpen: true))
+                    using (var writer = new BinaryWriter(packageStream, _writerEncoding, leaveOpen: true))
                     {
                         var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
                         metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);
@@ -374,8 +378,8 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
-                    using (var writer = new BinaryWriter(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
+                    using (var reader = new BinaryReader(packageWriteStream, _readerEncoding, leaveOpen: true))
+                    using (var writer = new BinaryWriter(packageWriteStream, _writerEncoding, leaveOpen: true))
                     {
                         var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
                         metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);
@@ -419,8 +423,8 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
-                    using (var writer = new BinaryWriter(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
+                    using (var reader = new BinaryReader(packageWriteStream, _readerEncoding, leaveOpen: true))
+                    using (var writer = new BinaryWriter(packageWriteStream, _writerEncoding, leaveOpen: true))
                     {
                         var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
                         metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);
@@ -452,8 +456,8 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
-                    using (var writer = new BinaryWriter(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
+                    using (var reader = new BinaryReader(packageWriteStream, _readerEncoding, leaveOpen: true))
+                    using (var writer = new BinaryWriter(packageWriteStream, _writerEncoding, leaveOpen: true))
                     {
                         var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
                         metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);
@@ -485,8 +489,8 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
-                    using (var writer = new BinaryWriter(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
+                    using (var reader = new BinaryReader(packageWriteStream, _readerEncoding, leaveOpen: true))
+                    using (var writer = new BinaryWriter(packageWriteStream, _writerEncoding, leaveOpen: true))
                     {
                         var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
                         metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);
@@ -530,8 +534,8 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
-                    using (var writer = new BinaryWriter(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
+                    using (var reader = new BinaryReader(packageWriteStream, _readerEncoding, leaveOpen: true))
+                    using (var writer = new BinaryWriter(packageWriteStream, _writerEncoding, leaveOpen: true))
                     {
                         var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
                         metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);
@@ -563,8 +567,8 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
-                    using (var writer = new BinaryWriter(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
+                    using (var reader = new BinaryReader(packageWriteStream, _readerEncoding, leaveOpen: true))
+                    using (var writer = new BinaryWriter(packageWriteStream, _writerEncoding, leaveOpen: true))
                     {
                         var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
                         metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);
@@ -608,8 +612,8 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
-                    using (var writer = new BinaryWriter(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
+                    using (var reader = new BinaryReader(packageWriteStream, _readerEncoding, leaveOpen: true))
+                    using (var writer = new BinaryWriter(packageWriteStream, _writerEncoding, leaveOpen: true))
                     {
                         var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
                         metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);
@@ -641,8 +645,8 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
-                    using (var writer = new BinaryWriter(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
+                    using (var reader = new BinaryReader(packageWriteStream, _readerEncoding, leaveOpen: true))
+                    using (var writer = new BinaryWriter(packageWriteStream, _writerEncoding, leaveOpen: true))
                     {
                         var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
                         metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);
@@ -686,8 +690,8 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
-                    using (var writer = new BinaryWriter(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
+                    using (var reader = new BinaryReader(packageWriteStream, _readerEncoding, leaveOpen: true))
+                    using (var writer = new BinaryWriter(packageWriteStream, _writerEncoding, leaveOpen: true))
                     {
                         var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
                         metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);
@@ -719,8 +723,8 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
-                    using (var writer = new BinaryWriter(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
+                    using (var reader = new BinaryReader(packageWriteStream, _readerEncoding, leaveOpen: true))
+                    using (var writer = new BinaryWriter(packageWriteStream, _writerEncoding, leaveOpen: true))
                     {
                         var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
                         metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);
@@ -764,8 +768,8 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
-                    using (var writer = new BinaryWriter(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
+                    using (var reader = new BinaryReader(packageWriteStream, _readerEncoding, leaveOpen: true))
+                    using (var writer = new BinaryWriter(packageWriteStream, _writerEncoding, leaveOpen: true))
                     {
                         var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
                         metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);
@@ -797,8 +801,8 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
-                    using (var writer = new BinaryWriter(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
+                    using (var reader = new BinaryReader(packageWriteStream, _readerEncoding, leaveOpen: true))
+                    using (var writer = new BinaryWriter(packageWriteStream, _writerEncoding, leaveOpen: true))
                     {
                         var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
                         metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);
@@ -842,8 +846,8 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
-                    using (var writer = new BinaryWriter(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
+                    using (var reader = new BinaryReader(packageWriteStream, _readerEncoding, leaveOpen: true))
+                    using (var writer = new BinaryWriter(packageWriteStream, _writerEncoding, leaveOpen: true))
                     {
                         var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
                         metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);
@@ -875,8 +879,8 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
-                    using (var writer = new BinaryWriter(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
+                    using (var reader = new BinaryReader(packageWriteStream, _readerEncoding, leaveOpen: true))
+                    using (var writer = new BinaryWriter(packageWriteStream, _writerEncoding, leaveOpen: true))
                     {
                         var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
                         metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);
@@ -922,8 +926,8 @@ namespace NuGet.Packaging.FuncTest
                 var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
-                    using (var writer = new BinaryWriter(packageWriteStream, encoding: _specification.Encoding, leaveOpen: true))
+                    using (var reader = new BinaryReader(packageWriteStream, _readerEncoding, leaveOpen: true))
+                    using (var writer = new BinaryWriter(packageWriteStream, _writerEncoding, leaveOpen: true))
                     {
                         var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
                         metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);
@@ -944,7 +948,7 @@ namespace NuGet.Packaging.FuncTest
 
         private void AssertSignatureEntryMetadataThrowsException(Stream packageStream)
         {
-            using (var reader = new BinaryReader(packageStream, encoding: _specification.Encoding, leaveOpen: true))
+            using (var reader = new BinaryReader(packageStream, _readerEncoding, leaveOpen: true))
             {
                 var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
                 metadata.SignatureCentralDirectoryHeaderIndex = SignedArchiveTestUtility.GetSignatureCentralDirectoryIndex(metadata, _specification);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/KeyPairFileReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/KeyPairFileReaderTests.cs
@@ -11,19 +11,31 @@ namespace NuGet.Packaging.Test
 {
     public class KeyPairFileReaderTests
     {
+        private static readonly Encoding _encoding = new UTF8Encoding();
+
         [Fact]
         public void Constructor_IfStreamIsNull_Throws()
         {
-            var exception = Assert.Throws<ArgumentNullException>(() => new KeyPairFileReader(stream: null));
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new KeyPairFileReader(stream: null, encoding: _encoding));
 
             Assert.Equal("stream", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_IfEncodingIsNull_Throws()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new KeyPairFileReader(Stream.Null, encoding: null));
+
+            Assert.Equal("encoding", exception.ParamName);
         }
 
         [Fact]
         public void ReadSection_IfContentEmpty_ReturnsEmptyResult()
         {
             using (var stream = new MemoryStream())
-            using (var reader = new KeyPairFileReader(stream))
+            using (var reader = new KeyPairFileReader(stream, _encoding))
             {
                 var section = reader.ReadSection();
 
@@ -41,7 +53,7 @@ namespace NuGet.Packaging.Test
         {
             var bytes = Encoding.UTF8.GetBytes(content);
             using (var stream = new MemoryStream(bytes))
-            using (var reader = new KeyPairFileReader(stream))
+            using (var reader = new KeyPairFileReader(stream, _encoding))
             {
                 var exception = Assert.Throws<SignatureException>(() => reader.ReadSection());
 
@@ -57,7 +69,7 @@ namespace NuGet.Packaging.Test
             var bytes = Encoding.UTF8.GetBytes(content);
 
             using (var stream = new MemoryStream(bytes))
-            using (var reader = new KeyPairFileReader(stream))
+            using (var reader = new KeyPairFileReader(stream, _encoding))
             {
                 var exception = Assert.Throws<SignatureException>(() => reader.ReadSection());
 
@@ -71,7 +83,7 @@ namespace NuGet.Packaging.Test
             var bytes = Encoding.UTF8.GetBytes("a:b\r\n\r\nc:d\r\n\r\n");
 
             using (var stream = new MemoryStream(bytes))
-            using (var reader = new KeyPairFileReader(stream))
+            using (var reader = new KeyPairFileReader(stream, _encoding))
             {
                 var headerSection = reader.ReadSection();
 
@@ -96,7 +108,7 @@ namespace NuGet.Packaging.Test
             {
                 Assert.True(stream.CanRead);
 
-                using (var reader = new KeyPairFileReader(stream))
+                using (var reader = new KeyPairFileReader(stream, _encoding))
                 {
                 }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/KeyPairFileUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/KeyPairFileUtilityTests.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class KeyPairFileUtilityTests
+    {
+        private readonly Dictionary<string, string> _dictionary = new Dictionary<string, string>() { { "a", "b" } };
+
+        [Fact]
+        public void GetValueOrThrow_WhenKeyDoesNotExist_Throws()
+        {
+            var exception = Assert.Throws<SignatureException>(
+                () => KeyPairFileUtility.GetValueOrThrow(_dictionary, key: "c"));
+
+            Assert.Equal(NuGetLogCode.NU3000, exception.Code);
+            Assert.Equal("Missing expected key: c", exception.Message);
+        }
+
+        [Fact]
+        public void GetValueOrThrow_WhenKeyExists_ReturnsValue()
+        {
+            var value = KeyPairFileUtility.GetValueOrThrow(_dictionary, key: "a");
+
+            Assert.Equal("b", value);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/KeyPairFileWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/KeyPairFileWriterTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text;
+using NuGet.Packaging.Signing;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class KeyPairFileWriterTests
+    {
+        private static readonly Encoding _encoding = new UTF8Encoding();
+
+        [Fact]
+        public void Constructor_IfStreamIsNull_Throws()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new KeyPairFileWriter(stream: null, encoding: _encoding, leaveOpen: true));
+
+            Assert.Equal("stream", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_IfEncodingIsNull_Throws()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new KeyPairFileWriter(Stream.Null, encoding: null, leaveOpen: true));
+
+            Assert.Equal("encoding", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Constructor_WithLeaveOpen_TogglesStreamDisposal(bool leaveOpen)
+        {
+            using (var stream = new MemoryStream())
+            {
+                Assert.True(stream.CanWrite);
+
+                using (var writer = new KeyPairFileWriter(stream, _encoding, leaveOpen))
+                {
+                }
+
+                Assert.Equal(leaveOpen, stream.CanWrite);
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void WritePair_WhenKeyNullOrEmpty_Throws(string key)
+        {
+            using (var stream = new MemoryStream())
+            using (var writer = new KeyPairFileWriter(stream, _encoding, leaveOpen: true))
+            {
+                var exception = Assert.Throws<ArgumentException>(
+                    () => writer.WritePair(key, "b"));
+
+                Assert.Equal("key", exception.ParamName);
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void WritePair_WhenValueNull_Throws(string value)
+        {
+            using (var stream = new MemoryStream())
+            using (var writer = new KeyPairFileWriter(stream, _encoding, leaveOpen: true))
+            {
+                var exception = Assert.Throws<ArgumentException>(
+                    () => writer.WritePair("a", value));
+
+                Assert.Equal("value", exception.ParamName);
+            }
+        }
+
+        [Fact]
+        public void WritePair_WithValidInput_WritesContent()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new KeyPairFileWriter(stream, _encoding, leaveOpen: true))
+                {
+                    writer.WritePair("a", "b");
+                }
+
+                Assert.Equal(_encoding.GetBytes("a:b\n"), stream.ToArray());
+            }
+        }
+
+        [Fact]
+        public void WriteSectionBreak_WritesEol()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new KeyPairFileWriter(stream, _encoding, leaveOpen: true))
+                {
+                    writer.WriteSectionBreak();
+                }
+
+                Assert.Equal(_encoding.GetBytes("\n"), stream.ToArray());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/6600.

[`SigningSpecifications.Encoding`](https://github.com/NuGet/NuGet.Client/blob/e2fb49fed454bcdd48c53efcb40ba26a50be761e/src/NuGet.Core/NuGet.Packaging/Signing/Specifications/SigningSpecifications.cs#L47) should only be used for encoding/decoding the signature content (`SignedCms.ContentInfo.Content`).  However, it's generally used in `BinaryReader`/`BinaryWriter` construction.  This is incorrect.  Although both `BinaryReader` and `BinaryWriter` default to some variation of `UTF8Encoding`, the `UTF8Encoding` constructor flags are different and more importantly independent of `SigningSpecifications.Encoding`.

`BinaryReader` and `BinaryWriter` instances are used to read/write packages (ZIP files).  Since we have no need to read/write characters (`System.Char`) or strings (`System.String`) directly from/to a package byte stream, the `BinaryReader`/`BinaryWriter` encoding is unimportant.  However, in order to set the `BinaryReader`/`BinaryWriter` `leaveOpen` constructor parameter, we need to pass some `Encoding` instance, so it might as well match what other constructors use by default.