### PR TITLE
Issues: 5893 and 5850 for dotnet.exe

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Build.Framework;
@@ -31,6 +31,7 @@ namespace NuGet.Build.Tasks.Pack
         bool IncludeBuildOutput { get; }
         bool IncludeSource { get; }
         bool IncludeSymbols { get; }
+        bool InstallPackageToOutputPath { get; }
         bool IsTool { get; }
         string LicenseUrl { get; }
         ILogger Logger { get; }
@@ -41,6 +42,7 @@ namespace NuGet.Build.Tasks.Pack
         string NuspecFile { get; }
         string[] NuspecProperties { get; }
         string NuspecOutputPath { get; }
+        bool OutputFileNamesWithoutVersion { get; }
         TItem[] PackageFiles { get; }
         TItem[] PackageFilesToExclude { get; }
         string PackageId { get; }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -1,4 +1,4 @@
-
+﻿
 <!--
 ***********************************************************************************************
 NuGet.targets
@@ -243,7 +243,9 @@ Copyright (c) .NET Foundation. All rights reserved.
               AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder="$(AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder)"
               NoWarn="$(NoWarn)"
               WarningsAsErrors="$(WarningsAsErrors)"
-              TreatWarningsAsErrors="$(TreatWarningsAsErrors)"/>
+              TreatWarningsAsErrors="$(TreatWarningsAsErrors)"
+              OutputFileNamesWithoutVersion="$(OutputFileNamesWithoutVersion)"
+              InstallPackageToOutputPath="$(InstallPackageToOutputPath)"/>
   </Target>
 
   <!--

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -42,6 +42,8 @@ namespace NuGet.Build.Tasks.Pack
         public bool IsTool { get; set; }
         public bool IncludeSymbols { get; set; }
         public bool IncludeSource { get; set; }
+        public bool InstallPackageToOutputPath { get; set; }
+        public bool OutputFileNamesWithoutVersion { get; set; }
         public string RepositoryUrl { get; set; }
         public string RepositoryType { get; set; }
         public string RepositoryBranch { get; set; }
@@ -162,6 +164,7 @@ namespace NuGet.Build.Tasks.Pack
                 IncludeBuildOutput = IncludeBuildOutput,
                 IncludeSource = IncludeSource,
                 IncludeSymbols = IncludeSymbols,
+                InstallPackageToOutputPath = InstallPackageToOutputPath,
                 IsTool = IsTool,
                 LicenseUrl = MSBuildStringUtility.TrimAndGetNullForEmpty(LicenseUrl),
                 Logger = Logger,
@@ -171,6 +174,7 @@ namespace NuGet.Build.Tasks.Pack
                 NuspecFile = MSBuildStringUtility.TrimAndGetNullForEmpty(NuspecFile),
                 NuspecOutputPath = MSBuildStringUtility.TrimAndGetNullForEmpty(NuspecOutputPath),
                 NuspecProperties = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(NuspecProperties),
+                OutputFileNamesWithoutVersion = OutputFileNamesWithoutVersion,
                 PackageFiles = MSBuildUtility.WrapMSBuildItem(PackageFiles),
                 PackageFilesToExclude = MSBuildUtility.WrapMSBuildItem(PackageFilesToExclude),
                 PackageId = MSBuildStringUtility.TrimAndGetNullForEmpty(PackageId),

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -24,6 +24,8 @@ namespace NuGet.Build.Tasks.Pack
         {
             var packArgs = new PackArgs
             {
+                InstallPackageToOutputPath = request.InstallPackageToOutputPath,
+                OutputFileNamesWithoutVersion = request.OutputFileNamesWithoutVersion,
                 OutputDirectory = request.PackageOutputPath,
                 Serviceable = request.Serviceable,
                 Tool = request.IsTool,

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -25,6 +25,7 @@ namespace NuGet.Build.Tasks.Pack
         public bool IncludeBuildOutput { get; set; }
         public bool IncludeSource { get; set; }
         public bool IncludeSymbols { get; set; }
+        public bool InstallPackageToOutputPath { get; set; }
         public bool IsTool { get; set; }
         public string LicenseUrl { get; set; }
         public ILogger Logger { get; set; }
@@ -43,6 +44,7 @@ namespace NuGet.Build.Tasks.Pack
         public string ProjectUrl { get; set; }
         public string NuspecBasePath { get; set; }
         public string[] NuspecProperties { get; set; }
+        public bool OutputFileNamesWithoutVersion { get; set; }
         public string ReleaseNotes { get; set; }
         public string RepositoryType { get; set; }
         public string RepositoryUrl { get; set; }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -692,7 +692,7 @@ namespace Dotnet.Integration.Test
 
                 var nuspecFilePath = Path.Combine(workingDirectory, "PackedFromNuspec.nuspec");
                 var nupackageFilePath = Path.Combine(workingDirectory, "PackedFromNuspec.nupkg");
-                var nupackageSha512FilePath = Path.Combine(workingDirectory, "PackedFromNuspec.sha512");
+                var nupackageSha512FilePath = Path.Combine(workingDirectory, "PackedFromNuspec.nupkg.sha512");
                 Assert.True(File.Exists(nuspecFilePath), "The output .nuspec is not in the expected place: " + nuspecFilePath);
                 Assert.True(File.Exists(nupackageFilePath), "The output .nupkg is not in the expected place: " + nupackageFilePath);
                 Assert.True(File.Exists(nupackageSha512FilePath), "The output .sha512 is not in the expected place: " + nupackageSha512FilePath);

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -230,8 +230,10 @@ namespace NuGet.Build.Tasks.Pack.Test
                 IncludeBuildOutput = value,
                 IncludeSource = value,
                 IncludeSymbols = value,
+                InstallPackageToOutputPath = value,
                 IsTool = value,
                 NoPackageAnalysis = value,
+                OutputFileNamesWithoutVersion = value,
                 RequireLicenseAcceptance = value,
                 DevelopmentDependency = value,
                 Serviceable = value
@@ -245,8 +247,10 @@ namespace NuGet.Build.Tasks.Pack.Test
             Assert.Equal(value, actual.IncludeBuildOutput);
             Assert.Equal(value, actual.IncludeSource);
             Assert.Equal(value, actual.IncludeSymbols);
+            Assert.Equal(value, actual.InstallPackageToOutputPath);
             Assert.Equal(value, actual.IsTool);
             Assert.Equal(value, actual.NoPackageAnalysis);
+            Assert.Equal(value, actual.OutputFileNamesWithoutVersion);
             Assert.Equal(value, actual.RequireLicenseAcceptance);
             Assert.Equal(value, actual.DevelopmentDependency);
             Assert.Equal(value, actual.Serviceable);


### PR DESCRIPTION
## Bug
Fixes: 

Issue 5893: Feature Request: Need the ability for NuGet.exe pack to create a nupkg without the version in the package name

Issue 5850: Feature Request: NuGet.exe pack should drop resolved nuspec to support network share hosted Package Source

Regression: No  

## Fix
Added features for dotnet.exe. These were already added to nuget.exe

## Testing/Validation
Tests Added: Yes
Validation done: Unit tests
