### PR TITLE
updating build scripts to use tls 1.2

### DIFF
--- a/scripts/utils/InsertNuGetIntoSdkAndCli.ps1
+++ b/scripts/utils/InsertNuGetIntoSdkAndCli.ps1
@@ -41,6 +41,9 @@ param
     [string]$BuildOutputPath
 )
 
+# set security protocol for Invoke-RestMethod
+. "$PSScriptRoot\SetSecurityProtocol.ps1"
+
 $repoOwner = "dotnet"
 $Base64Token = [System.Convert]::ToBase64String([char[]]$PersonalAccessToken)
 

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -6,6 +6,9 @@ https://developer.github.com/v3/repos/statuses/
 .DESCRIPTION
 Uses the Personal Access Token of NuGetLurker to post status of tests and build to GitHub.
 #>
+# set security protocol for Invoke-RestMethod
+. "$PSScriptRoot\SetSecurityProtocol.ps1"
+
 Function Update-GitCommitStatus {
     param(
         [Parameter(Mandatory = $True)]
@@ -39,7 +42,6 @@ Function Update-GitCommitStatus {
     } | ConvertTo-Json;
 
     Write-Host $Body
-
     $r1 = Invoke-RestMethod -Headers $Headers -Method Post -Uri "https://api.github.com/repos/nuget/nuget.client/statuses/$CommitSha" -Body $Body
 
     Write-Host $r1
@@ -120,6 +122,7 @@ function Get-TestRun {
     $Headers = @{
         Authorization = 'Basic {0}' -f $Base64Token;
     }
+    
     $testRuns = Invoke-RestMethod -Uri $url -Method GET -Headers $Headers
     Write-Host $testRuns
     $matchingRun = $testRuns.value | where { $_.name -ieq $TestName }

--- a/scripts/utils/SetSecurityProtocol.ps1
+++ b/scripts/utils/SetSecurityProtocol.ps1
@@ -1,0 +1,2 @@
+# Set security protol to tls1.2 for Invoke-RestMethod powershell cmdlet
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12

--- a/scripts/utils/TagNuGetClientGitRepostoryOnRelease.ps1
+++ b/scripts/utils/TagNuGetClientGitRepostoryOnRelease.ps1
@@ -26,7 +26,8 @@ param
     [string]$BuildOutputPath
 )
 
-
+# set security protocol for Invoke-RestMethod
+. "$PSScriptRoot\SetSecurityProtocol.ps1"
 
 # These environment variables are set on the VSTS Release Definition agents.
 $Branch = ${env:BUILD_SOURCEBRANCHNAME}


### PR DESCRIPTION
github [deprecated ](https://githubengineering.com/crypto-removal-notice/)tls 1.0 as of today 11am. 

This PR updates our build scripts to use tls 1.2 instead.