### PR TITLE
Allow the DotnetToolReference restore style to add a Microsoft.NET.Platforms reference

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
@@ -67,7 +67,8 @@ namespace NuGet.Commands
 
             if (packageSpec.RestoreMetadata?.ProjectStyle == ProjectStyle.DotnetToolReference)
             {
-                if (packageSpec.GetAllPackageDependencies().Count() != 1)
+                // Autoreferenced packages are allowed. Currently they're using Microsoft.NET.Platforms as an auto-ref package
+                if (packageSpec.GetAllPackageDependencies().Where(e => !e.AutoReferenced).Count() != 1)
                 {
                     // Create issue
                     var issue = CompatibilityIssue.IncompatibleProjectType(
@@ -382,7 +383,8 @@ namespace NuGet.Commands
 
             if (ProjectStyle.DotnetToolReference == compatibilityData.PackageSpec.RestoreMetadata?.ProjectStyle)
             {
-                if (!containsDotnetToolPackageType && compatibilityData.PackageSpec.GetAllPackageDependencies().Any(e => e.Name.Equals(compatibilityData.TargetLibrary.Name, StringComparison.OrdinalIgnoreCase)))
+                // If the package is not autoreferenced or a tool package
+                if (!containsDotnetToolPackageType && compatibilityData.PackageSpec.GetAllPackageDependencies().Where(e => !e.AutoReferenced).Any(e => e.Name.Equals(compatibilityData.TargetLibrary.Name, StringComparison.OrdinalIgnoreCase)))
                 {
                     var issue = CompatibilityIssue.IncompatiblePackageWithDotnetTool(new PackageIdentity(node.Key.Name, node.Key.Version));
                     issues.Add(issue);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
@@ -633,9 +633,9 @@ namespace Dotnet.Integration.Test
                 var workingDirectory = Path.Combine(testDirectory, projectName);
                 var localSource = Path.Combine(testDirectory, "packageSource");
                 var source = "https://api.nuget.org/v3/index.json" + ";" + localSource;
-                var rid = "any";
-                var packageRid = "win-x64";
-                var packageName = string.Join("ToolPackage-", tfm, rid);
+                var rid = "win-x64";
+                var packageRid = "any";
+                var packageName = string.Join("ToolPackage-", tfm, packageRid);
                 var autoReferencePackageName = "Microsoft.NETCore.Platforms";
                 var packageVersion = NuGetVersion.Parse("1.0.0");
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
@@ -517,6 +517,68 @@ namespace Dotnet.Integration.Test
             }
         }
 
+        [PlatformTheory(Platform.Windows)]
+        [InlineData("net461")]
+        [InlineData("netcoreapp1.0")]
+        public void DotnetToolTests_AutoreferencedDependencyAndToolPackagToolRestore_Succeeds(string tfm)
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ToolRestoreProject";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var localSource = Path.Combine(testDirectory, "packageSource");
+                var source = "https://api.nuget.org/v3/index.json" + ";" + localSource;
+                var rid = "win-x64";
+                var packageName = string.Join("ToolPackage-", tfm, rid);
+                var autoReferencePackageName = "Microsoft.NETCore.Platforms";
+                var packageVersion = NuGetVersion.Parse("1.0.0");
+
+                var package = new SimpleTestPackageContext(packageName, packageVersion.OriginalVersion);
+                package.Files.Clear();
+                package.AddFile($"tools/{tfm}/{rid}/a.dll");
+                package.AddFile($"tools/{tfm}/{rid}/Settings.json");
+
+                package.PackageType = PackageType.DotnetTool;
+                package.UseDefaultRuntimeAssemblies = false;
+                package.PackageTypes.Add(PackageType.DotnetTool);
+                SimpleTestPackageUtility.CreatePackages(localSource, package);
+
+                var packages = new List<PackageIdentity>() {
+                    new PackageIdentity(packageName, packageVersion),
+                    new PackageIdentity(autoReferencePackageName, NuGetVersion.Parse("2.0.1"))
+                };
+
+                _msbuildFixture.CreateDotnetToolProject(solutionRoot: testDirectory.Path,
+                    projectName: projectName, targetFramework: tfm, rid: rid,
+                    source: source, packages: packages);
+
+                var fullProjectPath = Path.Combine(workingDirectory, $"{projectName}.csproj");
+                MakePackageReferenceImplicitlyDefined(fullProjectPath, autoReferencePackageName);
+
+                // Act
+                var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
+
+                // Assert
+                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
+                Assert.NotNull(lockFile);
+                Assert.Equal(2, lockFile.Targets.Count);
+                var ridTargets = lockFile.Targets.Where(e => e.RuntimeIdentifier != null ? e.RuntimeIdentifier.Equals(rid, StringComparison.CurrentCultureIgnoreCase) : false);
+                Assert.Equal(1, ridTargets.Count());
+                Assert.Equal(2, ridTargets.First().Libraries.Count);
+                Assert.DoesNotContain("NU12", result.AllOutput); // Output has no errors
+            }
+        }
+
+        private static void MakePackageReferenceImplicitlyDefined(string fullProjectPath, string packageName)
+        {
+            var searchString = $"\"{packageName}\" ";
+            var text = File.ReadAllText(fullProjectPath);
+
+            var referenceElement = text.IndexOf(searchString) + searchString.Length;
+            text = text.Substring(0, referenceElement) + " IsImplicitlyDefined=\"true\" " + text.Substring(referenceElement);
+            File.WriteAllText(fullProjectPath, text);
+        }
+
         public static string GetResource(string name, Type type)
         {
             using (var reader = new StreamReader(type.GetTypeInfo().Assembly.GetManifestResourceStream(name)))


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6559
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
In order to make portable tools forward compatible, we need to allow the dotnettoolreference project to reference certain packages. 
Namely Microsoft.NET.Platforms. 
The CLI team will autoreference the package above.

The change here allows autoreferenced packages in the tools project graph. 

## Testing/Validation
Tests Added: Yes
Reason for not adding tests:  
Validation done:  Manual

//cc @wli3 
