### PR TITLE
Fix lockfile comparison

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -161,7 +161,7 @@ namespace NuGet.ProjectModel
                    OutputPath == other.OutputPath &&
                    ProjectName == other.ProjectName &&
                    ProjectUniqueName == other.ProjectUniqueName &&
-                   Sources.OrderedEquals(other.Sources, source => source.Source, StringComparer.Ordinal) &&
+                   Sources.OrderedEquals(other.Sources.Distinct(), source => source.Source, StringComparer.Ordinal) &&
                    PackagesPath == other.PackagesPath &&
                    EqualityUtility.SequenceEqualWithNullCheck(ConfigFilePaths, other.ConfigFilePaths) &&
                    EqualityUtility.SequenceEqualWithNullCheck(FallbackFolders, other.FallbackFolders) &&

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFrameworkInfo.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFrameworkInfo.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Shared;
 
@@ -63,7 +64,7 @@ namespace NuGet.ProjectModel
             }
 
             return EqualityUtility.EqualsWithNullCheck(FrameworkName, other.FrameworkName) &&
-                   EqualityUtility.SequenceEqualWithNullCheck(ProjectReferences, other.ProjectReferences);
+                   ProjectReferences.OrderedEquals(other.ProjectReferences, e => e.ProjectPath, PathUtility.GetStringComparerBasedOnOS());
         }
 
         public ProjectRestoreMetadataFrameworkInfo Clone()


### PR DESCRIPTION
## Bug
Fixes: https://developercommunity.visualstudio.com/content/problem/200708/when-running-a-fully-built-solution-the-build-just.html
Regression: No

## Fix
Details: The customer is seeing delays after a build because the build is causing a NuGet restore and bugs in the lock file comparison code causes NuGet to write out an unchanged lockfile. This causes the compiler to run a design-time build, thinking that a reference has changed. 

The fix to ProjectRestoreMetadata is due to the fact that sources are written out as a JSON object. So if the Source list has duplicate entries, then they will be squashed down to a single entry. So we need to take that into account when comparing.

The fix to ProjectRestoreMetadataFrameworkInfo is that we need to make sure ProjectReferences are compared in the same order.

## Testing/Validation
Tests Added: No
Reason for not adding tests: There don't seem to be any tests at all for cache file comparison. This seems like a comprehensive test hole that needs to be addressed separately from these targeted fixes. But let me know.
Validation done:  Ran tests.
