### PR TITLE
Bump microsoft.web.xdt package version to 2.1.2

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -13,7 +13,7 @@
   <package id="Microsoft.VSSDK.BuildTools" version="15.1.192" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net40" />
-  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net40" />
+  <package id="Microsoft.Web.Xdt" version="2.1.2" targetFramework="net40" />
   <package id="NuGet.Core" version="2.14.0-rtm-832" targetFramework="net45"/>
   <package id="NuGet.MsBuild.Integration" version="3.1.0-beta-001" targetFramework="net45" />
   <package id="VSLangProj140" version="14.0.25029" targetFramework="net46" />

--- a/build/loc.proj
+++ b/build/loc.proj
@@ -17,8 +17,8 @@
 
   <Target Name="LocalizeNonProjectFiles"  Condition="'$(BuildRTM)' != 'true'">
     <ItemGroup>
-      <NonProjectFilesToMove Include="$(SolutionPackagesFolder)Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll">
-        <DestinationDir>$(ArtifactsDirectory)Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</DestinationDir>
+      <NonProjectFilesToMove Include="$(SolutionPackagesFolder)Microsoft.Web.Xdt.2.1.2\lib\net40\Microsoft.Web.XmlTransform.dll">
+        <DestinationDir>$(ArtifactsDirectory)Microsoft.Web.Xdt.2.1.2\lib\net40\Microsoft.Web.XmlTransform.dll</DestinationDir>
       </NonProjectFilesToMove>
       <NonProjectFilesToMove Include="$(NuGetClientsSrcDirectory)NuGet.VisualStudio.Client\extension.vsixlangpack">
         <DestinationDir>$(ArtifactsDirectory)vsixlangpack\extension.vsixlangpack</DestinationDir>

--- a/build/sign.proj
+++ b/build/sign.proj
@@ -26,7 +26,7 @@
       <FilesToSign Include="$(SolutionPackagesFolder)Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll">
         <Authenticode>3PartySHA2</Authenticode>
       </FilesToSign>
-      <FilesToSign Include="$(ArtifactsDirectory)Microsoft.Web.Xdt.2.1.1\lib\net40\**\Microsoft.Web.XmlTransform.resources.dll">
+      <FilesToSign Include="$(ArtifactsDirectory)Microsoft.Web.Xdt.2.1.2\lib\net40\**\Microsoft.Web.XmlTransform.resources.dll">
         <Authenticode>Microsoft</Authenticode>
         <StrongName>67</StrongName>
       </FilesToSign>

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <ReferenceOutputPath>$(ArtifactsDirectory)NuGet.VisualStudio.Client\15.0\bin\$(Configuration)\</ReferenceOutputPath>
     <NuGetTargetsPath>$(RepositoryRootDirectory)src\NuGet.Core\NuGet.Build.Tasks\NuGet.targets</NuGetTargetsPath>
-    <XmlTransformPath>$(ArtifactsDirectory)Microsoft.Web.Xdt.2.1.1\lib\net40\</XmlTransformPath>
+    <XmlTransformPath>$(ArtifactsDirectory)Microsoft.Web.Xdt.2.1.2\lib\net40\</XmlTransformPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -64,7 +64,7 @@
       <Link>Newtonsoft.Json.dll</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="$(SolutionPackagesFolder)Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll">
+    <Content Include="$(SolutionPackagesFolder)Microsoft.Web.Xdt.2.1.2\lib\net40\Microsoft.Web.XmlTransform.dll">
       <Link>Microsoft.Web.XmlTransform.dll</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -367,7 +367,7 @@
     </MSBuild>
     <ItemGroup>
       <VSIXSourceItem Include="@(LocalizedFilesForVsix)" />
-      <_LocalizedFiles Include="$(ArtifactsDirectory)Microsoft.Web.Xdt.2.1.1\lib\net40\**\Microsoft.Web.XmlTransform.resources.dll" />
+      <_LocalizedFiles Include="$(ArtifactsDirectory)Microsoft.Web.Xdt.2.1.2\lib\net40\**\Microsoft.Web.XmlTransform.resources.dll" />
       <_LocalizedFiles Include="$(ArtifactsDirectory)vsixlangpack\**\extension.vsixlangpack" />
       <_LocalizedFiles Include="$(ArtifactsDirectory)eulas\**\eula.rtf" />
       <_VsixLocFiles Include="@(_LocalizedFiles)">

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">


### PR DESCRIPTION
## Bug
Fixes: None
Regression:No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
Our old version of the web xdt package fails the symbol check during VS insertions. 
For that purpsoe, a new version was shipped that has it's symbols archived. 

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  
Validation done:  
