### PR TITLE
set security protocol in the script itself so it works in the release def

### DIFF
--- a/scripts/utils/InsertNuGetIntoSdkAndCli.ps1
+++ b/scripts/utils/InsertNuGetIntoSdkAndCli.ps1
@@ -41,8 +41,8 @@ param
     [string]$BuildOutputPath
 )
 
-# set security protocol for Invoke-RestMethod
-. "$PSScriptRoot\SetSecurityProtocol.ps1"
+# Set security protocol to tls1.2 for Invoke-RestMethod powershell cmdlet
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 $repoOwner = "dotnet"
 $Base64Token = [System.Convert]::ToBase64String([char[]]$PersonalAccessToken)

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -6,8 +6,8 @@ https://developer.github.com/v3/repos/statuses/
 .DESCRIPTION
 Uses the Personal Access Token of NuGetLurker to post status of tests and build to GitHub.
 #>
-# set security protocol for Invoke-RestMethod
-. "$PSScriptRoot\SetSecurityProtocol.ps1"
+# Set security protocol to tls1.2 for Invoke-RestMethod powershell cmdlet
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 Function Update-GitCommitStatus {
     param(

--- a/scripts/utils/SetSecurityProtocol.ps1
+++ b/scripts/utils/SetSecurityProtocol.ps1
@@ -1,2 +1,0 @@
-# Set security protol to tls1.2 for Invoke-RestMethod powershell cmdlet
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12

--- a/scripts/utils/TagNuGetClientGitRepostoryOnRelease.ps1
+++ b/scripts/utils/TagNuGetClientGitRepostoryOnRelease.ps1
@@ -26,8 +26,8 @@ param
     [string]$BuildOutputPath
 )
 
-# set security protocol for Invoke-RestMethod
-. "$PSScriptRoot\SetSecurityProtocol.ps1"
+# Set security protocol to tls1.2 for Invoke-RestMethod powershell cmdlet
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 # These environment variables are set on the VSTS Release Definition agents.
 $Branch = ${env:BUILD_SOURCEBRANCHNAME}


### PR DESCRIPTION
This change removes the extra setsecurityprotocol.ps1 script because the release definition just downloads a single script and executes it - therefore it makes sense that all the logic be contained in the same script itself.