### PR TITLE
Signing:  enable sign command to use untrusted self-issued certificates in certificate store

### DIFF
--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTestFixture.cs
@@ -28,6 +28,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         private TrustedTestCert<TestCertificate> _trustedTestCertExpired;
         private TrustedTestCert<TestCertificate> _trustedTestCertNotYetValid;
         private TrustedTestCert<X509Certificate2> _trustedTimestampRoot;
+        private TrustedTestCert<X509Certificate2> _untrustedSelfIssuedCertificateInCertificateStore;
         private TrustedTestCertificateChain _trustedTestCertChain;
         private TrustedTestCertificateChain _revokedTestCertChain;
         private TrustedTestCertificateChain _revocationUnknownTestCertChain;
@@ -174,6 +175,24 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 }
 
                 return _revocationUnknownTestCertChain.Leaf;
+            }
+        }
+
+        public X509Certificate2 UntrustedSelfIssuedCertificateInCertificateStore
+        {
+            get
+            {
+                if (_untrustedSelfIssuedCertificateInCertificateStore == null)
+                {
+                    var certificate = SigningTestUtility.GenerateSelfIssuedCertificate(isCa: false);
+
+                    _untrustedSelfIssuedCertificateInCertificateStore = TrustedTestCert.Create(
+                        certificate,
+                        StoreName.My,
+                        StoreLocation.CurrentUser);
+                }
+
+                return new X509Certificate2(_untrustedSelfIssuedCertificateInCertificateStore.Source);
             }
         }
 
@@ -324,6 +343,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             _trustedTestCertExpired?.Dispose();
             _trustedTestCertNotYetValid?.Dispose();
             _trustedTimestampRoot?.Dispose();
+            _untrustedSelfIssuedCertificateInCertificateStore?.Dispose();
             _trustedTestCertChain?.Dispose();
             _revokedTestCertChain?.Dispose();
             _revocationUnknownTestCertChain?.Dispose();

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -633,5 +633,27 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 firstResult.AllOutput.Should().Contain(string.Format(_invalidPasswordErrorCode, pfxPath));
             }
         }
+
+        [CIOnlyFact]
+        public void SignCommand_SignPackageWithUntrustedSelfIssuedCertificateInCertificateStore()
+        {
+            using (var directory = TestDirectory.Create())
+            {
+                var packageContext = new SimpleTestPackageContext();
+                var packageFile = packageContext.CreateAsFile(directory, fileName: Guid.NewGuid().ToString());
+
+                using (var certificate = _testFixture.UntrustedSelfIssuedCertificateInCertificateStore)
+                {
+                    var result = CommandRunner.Run(
+                        _nugetExePath,
+                        directory,
+                        $"sign {packageFile.FullName} -CertificateFingerprint {certificate.Thumbprint}",
+                        waitForExit: true);
+
+                    Assert.True(result.Success);
+                    Assert.Contains(_noTimestamperWarningCode, result.AllOutput);
+                }
+            }
+        }
     }
 }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -94,8 +94,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 // Assert
                 result.Success.Should().BeFalse();
                 result.AllOutput.Should().Contain(_noTimestamperWarningCode);
-                result.AllOutput.Should().Contain(_chainBuildFailureErrorCode);
-                result.AllOutput.Should().Contain("The certificate is not valid for the requested usage");
             }
         }
 
@@ -253,8 +251,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 // Assert
                 result.Success.Should().BeFalse();
                 result.AllOutput.Should().Contain(_noTimestamperWarningCode);
-                result.AllOutput.Should().Contain(_chainBuildFailureErrorCode);
-                result.AllOutput.Should().Contain("The certificate is revoked");
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
@@ -114,7 +114,7 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
-        public void GetCertificateChain_WithUntrustedSelfSignedCertificate_ReturnsChain()
+        public void GetCertificateChain_WithUntrustedSelfIssuedCertificate_ReturnsChain()
         {
             using (var certificate = _fixture.GetDefaultCertificate())
             {

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -396,9 +396,15 @@ namespace Test.Utility.Signing
             generator.SetPublicKey(keyPair.Public);
 
             var signatureFactory = new Asn1SignatureFactory("SHA256WITHRSA", keyPair.Private);
-            var certificate = generator.Generate(signatureFactory);
+            var bcCertificate = generator.Generate(signatureFactory);
 
-            return new X509Certificate2(certificate.GetEncoded());
+            var certificate = new X509Certificate2(bcCertificate.GetEncoded());
+
+#if IS_DESKTOP
+            certificate.PrivateKey = DotNetUtilities.ToRSA(keyPair.Private as RsaPrivateCrtKeyParameters);
+#endif
+
+            return certificate;
         }
 
         private static X509SubjectKeyIdentifierExtension GetSubjectKeyIdentifier(X509Certificate2 issuer)

--- a/test/TestUtilities/Test.Utility/Signing/TrustedTestCert.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TrustedTestCert.cs
@@ -96,9 +96,6 @@ namespace Test.Utility.Signing
             using (_store)
             {
                 _store.Remove(TrustedCert);
-#if IS_DESKTOP
-                _store.Close();
-#endif
             }
 
             DisposeCrl();


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/6616.

CC @rido-min