### PR TITLE
Set semVerLevel=2.0.0 in RemoteV2FindPackageByIdResource

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -39,6 +39,7 @@ namespace NuGet.Protocol
         private readonly HttpSource _httpSource;
         private readonly Dictionary<string, Task<IEnumerable<PackageInfo>>> _packageVersionsCache = new Dictionary<string, Task<IEnumerable<PackageInfo>>>(StringComparer.OrdinalIgnoreCase);
         private readonly FindPackagesByIdNupkgDownloader _nupkgDownloader;
+        private readonly V2FeedQueryBuilder _queryBuilder;
 
         /// <summary>
         /// Initializes a new <see cref="RemoteV2FindPackageByIdResource" /> class.
@@ -64,6 +65,7 @@ namespace NuGet.Protocol
             _baseUri = packageSource.Source.EndsWith("/") ? packageSource.Source : (packageSource.Source + "/");
             _httpSource = httpSource;
             _nupkgDownloader = new FindPackagesByIdNupkgDownloader(_httpSource);
+            _queryBuilder = new V2FeedQueryBuilder();
 
             PackageSource = packageSource;
         }
@@ -342,7 +344,8 @@ namespace NuGet.Protocol
         {
             for (var retry = 0; retry < 3; ++retry)
             {
-                var uri = _baseUri + "FindPackagesById()?id='" + id + "'";
+                var relativeUri = _queryBuilder.BuildFindPackagesByIdUri(id).TrimStart('/');
+                var uri = _baseUri + relativeUri;
                 var httpSourceCacheContext = HttpSourceCacheContext.Create(cacheContext, retry);
 
                 try

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
@@ -138,7 +138,7 @@ namespace NuGet.CommandLine.Test.Caching
                     });
                 });
 
-            // Add the /nuget/FindPackagesById()?id='' endpoint.
+            // Add the /nuget/FindPackagesById()?id=''&semVerLevel=2.0.0 endpoint.
             MockServer.Get.Add(
                 builder.GetFindPackagesByIdPath(identity.Id),
                 request =>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/MockResponses/MockResponseBuilder.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/MockResponses/MockResponseBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
@@ -51,7 +51,7 @@ namespace NuGet.CommandLine.Test.Caching
 
         public string GetFindPackagesByIdPath(string id)
         {
-            return $"/nuget/FindPackagesById()?id='{id}'";
+            return $"/nuget/FindPackagesById()?id='{id}'&semVerLevel=2.0.0";
         }
 
         public string GetODataUrl(PackageIdentity identity)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreRetryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreRetryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -195,7 +195,7 @@ namespace NuGet.CommandLine.Test
                                 }
                             });
                         }
-                        else if (path == "/nuget/FindPackagesById()?id='testPackage1'")
+                        else if (path == "/nuget/FindPackagesById()?id='testPackage1'&semVerLevel=2.0.0")
                         {
                             return new Action<HttpListenerResponse>(response =>
                             {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DependencyInfoResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DependencyInfoResourceV2FeedTests.cs
@@ -51,8 +51,6 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
-                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress + "Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')",
                  ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV2FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV2FindPackageByIdResourceTests.cs
@@ -201,7 +201,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='a'", "204");
+            responses.Add(serviceAddress + "FindPackagesById()?id='a'&semVerLevel=2.0.0", "204");
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
             var logger = new TestLogger();
@@ -344,7 +344,7 @@ namespace NuGet.Protocol.Tests
                         })
                     },
                     {
-                        serviceAddress + "FindPackagesById()?id='XUNIT'",
+                        serviceAddress + "FindPackagesById()?id='XUNIT'&semVerLevel=2.0.0",
                         _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new TestContent(ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()))
@@ -402,7 +402,7 @@ namespace NuGet.Protocol.Tests
                         })
                     },
                     {
-                        serviceAddress + "FindPackagesById()?id='WINDOWSAZURE.STORAGE'",
+                        serviceAddress + "FindPackagesById()?id='WINDOWSAZURE.STORAGE'&semVerLevel=2.0.0",
                         _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new TestContent(ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()))
@@ -749,7 +749,7 @@ namespace NuGet.Protocol.Tests
                         })
                     },
                     {
-                        serviceAddress + $"FindPackagesById()?id='{packageIdentity.Id}'",
+                        serviceAddress + $"FindPackagesById()?id='{packageIdentity.Id}'&semVerLevel=2.0.0",
                         request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new TestContent(
@@ -759,7 +759,7 @@ namespace NuGet.Protocol.Tests
                         })
                     },
                     {
-                        serviceAddress + $"FindPackagesById()?id='{packageIdentity.Id.ToUpper()}'",
+                        serviceAddress + $"FindPackagesById()?id='{packageIdentity.Id.ToUpper()}'&semVerLevel=2.0.0",
                         request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new TestContent(
@@ -776,7 +776,7 @@ namespace NuGet.Protocol.Tests
                         })
                     },
                     {
-                        serviceAddress + $"FindPackagesById()?id='a'",
+                        serviceAddress + $"FindPackagesById()?id='a'&semVerLevel=2.0.0",
                         request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent))
                     }
                 };

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV3FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV3FindPackageByIdResourceTests.cs
@@ -151,35 +151,6 @@ namespace NuGet.Protocol.Tests
             }
         }
 
-        [Fact]
-        public async Task GetAllVersionsAsync_NoErrorsOnNoContent()
-        {
-            // Arrange
-            var serviceAddress = ProtocolUtility.CreateServiceAddress();
-
-            var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='a'", "204");
-
-            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
-            var logger = new TestLogger();
-
-            using (var cacheContext = new SourceCacheContext())
-            {
-                var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
-
-                // Act
-                var versions = await resource.GetAllVersionsAsync(
-                    "a",
-                    cacheContext,
-                    logger,
-                    CancellationToken.None);
-
-                // Assert
-                // Verify no items returned, and no exceptions were thrown above
-                Assert.Equal(0, versions.Count());
-            }
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("")]
@@ -677,35 +648,11 @@ namespace NuGet.Protocol.Tests
                         })
                     },
                     {
-                        serviceAddress + $"FindPackagesById()?id='{packageIdentity.Id}'",
-                        request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                        {
-                            Content = new TestContent(
-                                ProtocolUtility.GetResource(
-                                    "NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml",
-                                    typeof(RemoteV3FindPackageByIdResourceTest)))
-                        })
-                    },
-                    {
-                        serviceAddress + $"FindPackagesById()?id='{packageIdentity.Id.ToUpper()}'",
-                        request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                        {
-                            Content = new TestContent(
-                                ProtocolUtility.GetResource(
-                                    "NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml",
-                                    typeof(RemoteV3FindPackageByIdResourceTest)))
-                        })
-                    },
-                    {
                         serviceAddress + "api/v2/package/xunit/2.2.0-beta1-build3239",
                         request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new ByteArrayContent(packageBytes)
                         })
-                    },
-                    {
-                        serviceAddress + $"FindPackagesById()?id='a'",
-                        request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent))
                     }
                 };
 


### PR DESCRIPTION
Address https://github.com/NuGet/Home/issues/6625

Notes:

- I chose not to use `V2FeedParser`. This would be a more thorough change but is more risky. I may do a follow-up PR if I can be confident of no behavior changes. Right now, we basically have a ton of duplicated code between `RemoteV2FindPackageByIdResource` and `V2FeedParser`.
- There was some unnecessary test setup in `RemoteV3FindPackageByIdResourceTests`... it looks like the V2 and V3 test suites have a lot of copied code.
- I removed a V2 test from `RemoteV3FindPackageByIdResourceTests`.
