### PR TITLE
Make sure to not modify the original package if signing operation fails

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
@@ -138,9 +138,14 @@ namespace NuGet.Commands
             {
                 await SigningUtility.SignAsync(signingOptions, signRequest, token);
 
-                if (File.Exists(signingOptions.OutputFilePath))
+                var outputPathInfo = new FileInfo(signingOptions.OutputFilePath);
+                if (outputPathInfo.Exists && outputPathInfo.Length > 0)
                 {
                     FileUtility.Replace(signingOptions.OutputFilePath, packageOutputPath);
+                }
+                else if (outputPathInfo.Length == 0)
+                {
+                    throw new SignatureException(Strings.Error_UnableToSignPackage);
                 }
             }
             catch

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
@@ -137,13 +137,19 @@ namespace NuGet.Commands
             try
             {
                 await SigningUtility.SignAsync(signingOptions, signRequest, token);
-            }
-            finally
-            {
+
                 if (File.Exists(signingOptions.OutputFilePath))
                 {
                     FileUtility.Replace(signingOptions.OutputFilePath, packageOutputPath);
                 }
+            }
+            catch
+            {
+                if (File.Exists(signingOptions.OutputFilePath))
+                {
+                    FileUtility.Delete(signingOptions.OutputFilePath);
+                }
+                throw;
             }
         }
 

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -332,6 +332,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to sign package..
+        /// </summary>
+        internal static string Error_UnableToSignPackage {
+            get {
+                return ResourceManager.GetString("Error_UnableToSignPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package &apos;{0}&apos; specifies an invalid build action &apos;{1}&apos; for file &apos;{2}&apos;..
         /// </summary>
         internal static string Error_UnknownBuildAction {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -691,4 +691,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="Error_InvalidDependencyVersionConstraints" xml:space="preserve">
     <value>Package version constraints for '{0}' return a version range that is empty.</value>
   </data>
+  <data name="Error_UnableToSignPackage" xml:space="preserve">
+    <value>Unable to sign package.</value>
+  </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -667,14 +667,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             {
                 var packageContext = new SimpleTestPackageContext();
                 var packageFile = packageContext.CreateAsFile(directory, fileName: Guid.NewGuid().ToString());
-
-                byte[] originalFile;
-                using (var packageStream = packageFile.OpenRead())
-                using(var ms = new MemoryStream())
-                {
-                    packageStream.CopyTo(ms);
-                    originalFile = ms.ToArray();
-                }
+                var originalFile = File.ReadAllBytes(packageFile.FullName);
 
                 using (var certificate = _testFixture.UntrustedSelfIssuedCertificateInCertificateStore)
                 {
@@ -686,13 +679,9 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                     Assert.False(result.Success);
                     Assert.Contains("The timestamp certificate has an unsupported signature algorithm.", result.AllOutput);
-                    using (var packageStream = packageFile.OpenRead())
-                    using (var ms = new MemoryStream())
-                    {
-                        packageStream.CopyTo(ms);
-                        var newFile = ms.ToArray();
-                        Assert.Equal(newFile, originalFile);
-                    }
+
+                    var resultingFile = File.ReadAllBytes(packageFile.FullName);
+                    Assert.Equal(resultingFile, originalFile);
                 }
             }
         }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6627

## Fix
When `SignAsync` failed we were still replacing the output path with the temp file created. This PR makes sure to only do that if `SignAsync` succeds, if not just delete the temp file that was previously created.

## Testing/Validation
Tests Added: Yes

/cc @rrelyea 
