### PR TITLE
Enable repository signatures as primary signature

### DIFF
--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignAbstract.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignAbstract.cs
@@ -1,0 +1,180 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using NuGet.CommandLine;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using NuGet.Protocol;
+
+namespace NuGet.MSSigning.Extensions
+{
+    public abstract class MSSignAbstract : Command
+    {
+        [Option(typeof(NuGetMSSignCommand), "MSSignCommandCSPNameDescription")]
+        public string CSPName { get; set; }
+
+        [Option(typeof(NuGetMSSignCommand), "MSSignCommandKeyContainerDescription")]
+        public string KeyContainer { get; set; }
+
+        [Option(typeof(NuGetMSSignCommand), "MSSignCommandHashAlgorithmDescription")]
+        public string HashAlgorithm { get; set; }
+
+        [Option(typeof(NuGetMSSignCommand), "MSSignCommandTimestamperDescription")]
+        public string Timestamper { get; set; }
+
+        [Option(typeof(NuGetMSSignCommand), "MSSignCommandTimestampHashAlgorithmDescription")]
+        public string TimestampHashAlgorithm { get; set; }
+
+        [Option(typeof(NuGetMSSignCommand), "MSSignCommandCertificateFingerprintDescription")]
+        public string CertificateFingerprint { get; set; }
+
+        [Option(typeof(NuGetMSSignCommand), "MSSignCommandCertificateFileDescription")]
+        public string CertificateFile { get; set; }
+
+        [Option(typeof(NuGetMSSignCommand), "MSSignCommandOutputDirectoryDescription")]
+        public string OutputDirectory { get; set; }
+
+        protected IEnumerable<string> GetPackages()
+        {
+            // resolve path into multiple packages if needed.
+            var packagesToSign = LocalFolderUtility.ResolvePackageFromPath(Arguments[0]);
+            LocalFolderUtility.EnsurePackageFileExists(Arguments[0], packagesToSign);
+
+            return packagesToSign;
+        }
+
+        protected CngKey GetPrivateKey(X509Certificate2 cert)
+        {
+            var rsakey = cert.GetRSAPrivateKey() as RSACng;
+
+            if (rsakey != null)
+            {
+                return rsakey.Key;
+            }
+
+            var provider = new CngProvider(CSPName);
+            var cngkey = CngKey.Open(KeyContainer, provider, CngKeyOpenOptions.MachineKey);
+
+            if (cngkey == null)
+            {
+                throw new InvalidOperationException(NuGetMSSignCommand.MSSignCommandNoCngKeyException);
+            }
+
+            if (cngkey.AlgorithmGroup != CngAlgorithmGroup.Rsa)
+            {
+                throw new InvalidOperationException(NuGetMSSignCommand.MSSignCommandInvalidCngKeyException);
+            }
+
+            return cngkey;
+        }
+
+        protected X509Certificate2 GetCertificate(X509Certificate2Collection certCollection)
+        {
+            var matchingCertCollection = certCollection.Find(X509FindType.FindByThumbprint, CertificateFingerprint, validOnly: false);
+
+            if (matchingCertCollection == null || matchingCertCollection.Count == 0)
+            {
+                throw new InvalidOperationException(NuGetMSSignCommand.MSSignCommandNoCertException);
+            }
+
+            return matchingCertCollection[0];
+        }
+
+        protected X509Certificate2Collection GetCertificateCollection()
+        {
+            var certCollection = new X509Certificate2Collection();
+            certCollection.Import(CertificateFile);
+
+            return certCollection;
+        }
+
+        protected void ValidatePackagePath()
+        {
+            // Assert mandatory argument
+            if (Arguments.Count < 1 ||
+                string.IsNullOrEmpty(Arguments[0]))
+            {
+                throw new ArgumentException(NuGetMSSignCommand.MSSignCommandNoPackageException);
+            }
+        }
+
+        protected void WarnIfNoTimestamper(ILogger logger)
+        {
+            if (string.IsNullOrEmpty(Timestamper))
+            {
+                logger.Log(LogMessage.CreateWarning(NuGetLogCode.NU3002, NuGetMSSignCommand.MSSignCommandNoTimestamperWarning));
+            }
+        }
+
+        protected void EnsureOutputDirectory()
+        {
+            if (!string.IsNullOrEmpty(OutputDirectory))
+            {
+                Directory.CreateDirectory(OutputDirectory);
+            }
+        }
+
+        protected void ValidateCertificateInputs()
+        {
+            if (string.IsNullOrEmpty(CertificateFile))
+            {
+                // Throw if user gave no certificate input
+                throw new ArgumentException(NuGetMSSignCommand.MSSignCommandNoValidCertificateFileException);
+            }
+
+            if (string.IsNullOrEmpty(CSPName))
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
+                        NuGetMSSignCommand.MSSignCommandInvalidArgumentException,
+                        nameof(CSPName)));
+            }
+
+            if (string.IsNullOrEmpty(KeyContainer))
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
+                        NuGetMSSignCommand.MSSignCommandInvalidArgumentException,
+                        nameof(KeyContainer)));
+            }
+
+            if (string.IsNullOrEmpty(CertificateFingerprint))
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
+                        NuGetMSSignCommand.MSSignCommandInvalidArgumentException,
+                        nameof(CertificateFingerprint)));
+            }
+        }
+
+        protected Common.HashAlgorithmName ValidateAndParseHashAlgorithm(string value, string name, SigningSpecifications spec)
+        {
+            var hashAlgorithm = Common.HashAlgorithmName.SHA256;
+
+            if (!string.IsNullOrEmpty(value))
+            {
+                hashAlgorithm = CryptoHashUtility.GetHashAlgorithmName(value);
+
+                if (!spec.AllowedHashAlgorithms.Contains(hashAlgorithm))
+                {
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
+                        NuGetMSSignCommand.MSSignCommandInvalidArgumentException,
+                        name));
+                }
+            }
+
+            if (hashAlgorithm == Common.HashAlgorithmName.Unknown)
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
+                        NuGetMSSignCommand.MSSignCommandInvalidArgumentException,
+                        name));
+            }
+
+            return hashAlgorithm;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignCommand.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignCommand.cs
@@ -1,20 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.CommandLine;
 using NuGet.Commands;
-using NuGet.Common;
 using NuGet.Packaging.Signing;
-using NuGet.Protocol;
 
 namespace NuGet.MSSigning.Extensions
 {
@@ -24,43 +15,19 @@ namespace NuGet.MSSigning.Extensions
        UsageSummaryResourceName = "MSSignCommandUsageSummary",
        UsageExampleResourceName = "MSSignCommandUsageExamples",
        UsageDescriptionResourceName = "MSSignCommandUsageDescription")]
-    public class MSSignCommand : Command
+    public class MSSignCommand : MSSignAbstract
     {
         // Default constructor used only for testing, since the Command Default Constructor is protected
         public MSSignCommand() : base()
         {
         }
 
-        [Option(typeof(NuGetMSSignCommand), "MSSignCommandCSPNameDescription")]
-        public string CSPName { get; set; }
-
-        [Option(typeof(NuGetMSSignCommand), "MSSignCommandKeyContainerDescription")]
-        public string KeyContainer { get; set; }
-
-        [Option(typeof(NuGetMSSignCommand), "MSSignCommandHashAlgorithmDescription")]
-        public string HashAlgorithm { get; set; }
-
-        [Option(typeof(NuGetMSSignCommand), "MSSignCommandTimestamperDescription")]
-        public string Timestamper { get; set; }
-
-        [Option(typeof(NuGetMSSignCommand), "MSSignCommandTimestampHashAlgorithmDescription")]
-        public string TimestampHashAlgorithm { get; set; }
-
-        [Option(typeof(NuGetMSSignCommand), "MSSignCommandCertificateFingerprintDescription")]
-        public string CertificateFingerprint { get; set; }
-
-        [Option(typeof(NuGetMSSignCommand), "MSSignCommandCertificateFileDescription")]
-        public string CertificateFile { get; set; }
-
-        [Option(typeof(NuGetMSSignCommand), "MSSignCommandOutputDirectoryDescription")]
-        public string OutputDirectory { get; set; }
-
         [Option(typeof(NuGetMSSignCommand), "MSSignCommandOverwriteDescription")]
         public bool Overwrite { get; set; }
 
         public override async Task ExecuteCommandAsync()
         {
-            using (var signRequest = GetSignRequest())
+            using (var signRequest = GetAuthorSignRequest())
             {
                 var packages = GetPackages();
                 var signCommandRunner = new SignCommandRunner();
@@ -74,7 +41,7 @@ namespace NuGet.MSSigning.Extensions
             }
         }
 
-        public AuthorSignPackageRequest GetSignRequest()
+        private AuthorSignPackageRequest GetAuthorSignRequest()
         {
             ValidatePackagePath();
             WarnIfNoTimestamper(Console);
@@ -91,148 +58,13 @@ namespace NuGet.MSSigning.Extensions
             var request = new AuthorSignPackageRequest(
                 certificate,
                 signatureHashAlgorithm,
-                timestampHashAlgorithm);
-
-            request.PrivateKey = privateKey;
+                timestampHashAlgorithm)
+            {
+                PrivateKey = privateKey
+            };
             request.AdditionalCertificates.AddRange(certCollection);
 
             return request;
-        }
-
-        private IEnumerable<string> GetPackages()
-        {
-            // resolve path into multiple packages if needed.
-            var packagesToSign = LocalFolderUtility.ResolvePackageFromPath(Arguments[0]);
-            LocalFolderUtility.EnsurePackageFileExists(Arguments[0], packagesToSign);
-
-            return packagesToSign;
-        }
-
-        private CngKey GetPrivateKey(X509Certificate2 cert)
-        {
-            var rsakey = cert.GetRSAPrivateKey() as RSACng;
-
-            if (rsakey != null)
-            {
-                return rsakey.Key;
-            }
-
-            var provider = new CngProvider(CSPName);
-            var cngkey = CngKey.Open(KeyContainer, provider, CngKeyOpenOptions.MachineKey);
-
-            if (cngkey == null)
-            {
-                throw new InvalidOperationException(NuGetMSSignCommand.MSSignCommandNoCngKeyException);
-            }
-
-            if (cngkey.AlgorithmGroup != CngAlgorithmGroup.Rsa)
-            {
-                throw new InvalidOperationException(NuGetMSSignCommand.MSSignCommandInvalidCngKeyException);
-            }
-
-            return cngkey;
-        }
-
-        private X509Certificate2 GetCertificate(X509Certificate2Collection certCollection)
-        {
-            var matchingCertCollection = certCollection.Find(X509FindType.FindByThumbprint, CertificateFingerprint, validOnly: false);
-
-            if (matchingCertCollection == null || matchingCertCollection.Count == 0)
-            {
-                throw new InvalidOperationException(NuGetMSSignCommand.MSSignCommandNoCertException);
-            }
-
-            return matchingCertCollection[0];
-        }
-
-        private X509Certificate2Collection GetCertificateCollection()
-        {
-            var certCollection = new X509Certificate2Collection();
-            certCollection.Import(CertificateFile);
-
-            return certCollection;
-        }
-
-        private void ValidatePackagePath()
-        {
-            // Assert mandatory argument
-            if (Arguments.Count < 1 ||
-                string.IsNullOrEmpty(Arguments[0]))
-            {
-                throw new ArgumentException(NuGetMSSignCommand.MSSignCommandNoPackageException);
-            }
-        }
-
-        private void WarnIfNoTimestamper(ILogger logger)
-        {
-            if (string.IsNullOrEmpty(Timestamper))
-            {
-                logger.Log(LogMessage.CreateWarning(NuGetLogCode.NU3002, NuGetMSSignCommand.MSSignCommandNoTimestamperWarning));
-            }
-        }
-
-        private void EnsureOutputDirectory()
-        {
-            if (!string.IsNullOrEmpty(OutputDirectory))
-            {
-                Directory.CreateDirectory(OutputDirectory);
-            }
-        }
-
-        private void ValidateCertificateInputs()
-        {
-            if (string.IsNullOrEmpty(CertificateFile))
-            {
-                // Throw if user gave no certificate input
-                throw new ArgumentException(NuGetMSSignCommand.MSSignCommandNoValidCertificateFileException);
-            }
-
-            if (string.IsNullOrEmpty(CSPName))
-            {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
-                        NuGetMSSignCommand.MSSignCommandInvalidArgumentException,
-                        nameof(CSPName)));
-            }
-
-            if (string.IsNullOrEmpty(KeyContainer))
-            {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
-                        NuGetMSSignCommand.MSSignCommandInvalidArgumentException,
-                        nameof(KeyContainer)));
-            }
-
-            if (string.IsNullOrEmpty(CertificateFingerprint))
-            {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
-                        NuGetMSSignCommand.MSSignCommandInvalidArgumentException,
-                        nameof(CertificateFingerprint)));
-            }
-        }
-
-        private Common.HashAlgorithmName ValidateAndParseHashAlgorithm(string value, string name, SigningSpecifications spec)
-        {
-            var hashAlgorithm = Common.HashAlgorithmName.SHA256;
-
-            if (!string.IsNullOrEmpty(value))
-            {
-                hashAlgorithm = CryptoHashUtility.GetHashAlgorithmName(value);
-
-                if (!spec.AllowedHashAlgorithms.Contains(hashAlgorithm))
-                {
-                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
-                        NuGetMSSignCommand.MSSignCommandInvalidArgumentException,
-                        name));
-                }
-            }
-
-            if (hashAlgorithm == Common.HashAlgorithmName.Unknown)
-            {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
-                        NuGetMSSignCommand.MSSignCommandInvalidArgumentException,
-                        name));
-            }
-
-            return hashAlgorithm;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignCommand.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignCommand.cs
@@ -17,11 +17,6 @@ namespace NuGet.MSSigning.Extensions
        UsageDescriptionResourceName = "MSSignCommandUsageDescription")]
     public class MSSignCommand : MSSignAbstract
     {
-        // Default constructor used only for testing, since the Command Default Constructor is protected
-        public MSSignCommand() : base()
-        {
-        }
-
         [Option(typeof(NuGetMSSignCommand), "MSSignCommandOverwriteDescription")]
         public bool Overwrite { get; set; }
 

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.Designer.cs
@@ -241,5 +241,61 @@ namespace NuGet.MSSigning.Extensions {
                 return ResourceManager.GetString("MSSignCommandUsageSummary", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sign a NuGet package by adding repository signature with specified p7b file..
+        /// </summary>
+        internal static string RepoSignCommandDescription {
+            get {
+                return ResourceManager.GetString("RepoSignCommandDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Semicolon separated list of package owners..
+        /// </summary>
+        internal static string RepoSignCommandOwnersDescription {
+            get {
+                return ResourceManager.GetString("RepoSignCommandOwnersDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sign a NuGet package with repository signature..
+        /// </summary>
+        internal static string RepoSignCommandUsageDescription {
+            get {
+                return ResourceManager.GetString("RepoSignCommandUsageDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nuget reposign MyPackage.nupkg -Timestamper https://foo.bar -CertificateFile foo.p7b -CSPName &quot;Cryptographic Service Provider&quot;  -KeyContainer &quot;4003d786-cc37-4004-bfdf-c4f3e8ef9b3a&quot; -CertificateFingerprint &quot;4003d786cc374004bfdfc4f3e8ef9b3a&quot;  -Owners bar;foo -V3ServiceIndexUrl https://v3.index
+        ///
+        ///nuget reposign MyPackage.nupkg -Timestamper https://foo.bar -CertificateFile foo.p7b -CSPName &quot;Cryptographic Service Provider&quot;  -KeyContainer &quot;4003d786-cc37-4004-bfdf-c4f3e8ef9b3a&quot; -CertificateFingerprint &quot;4003d786cc [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string RepoSignCommandUsageExamples {
+            get {
+                return ResourceManager.GetString("RepoSignCommandUsageExamples", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;package_path&gt; -Timestamper &lt;timestamp_server_url&gt; -CertificateFile &lt;p7b_file_path&gt; -CSPName &lt;cryptographic_service_provider_name&gt; -KeyContainer &lt;key_container_guid&gt; -CertificateFingerprint &lt;certificate_fingerprint&gt; -Owners &lt;package_owners&gt; -V3ServiceIndexUrl &lt;v3_service_index_url&gt;.
+        /// </summary>
+        internal static string RepoSignCommandUsageSummary {
+            get {
+                return ResourceManager.GetString("RepoSignCommandUsageSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Repository v3 service index url..
+        /// </summary>
+        internal static string RepoSignCommandV3ServiceIndexUrlDescription {
+            get {
+                return ResourceManager.GetString("RepoSignCommandV3ServiceIndexUrlDescription", resourceCulture);
+            }
+        }
     }
 }

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.Designer.cs
@@ -252,11 +252,11 @@ namespace NuGet.MSSigning.Extensions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Semicolon separated list of package owners..
+        ///   Looks up a localized string similar to Semicolon-separated list of package owners..
         /// </summary>
-        internal static string RepoSignCommandOwnersDescription {
+        internal static string RepoSignCommandPackageOwnersDescription {
             get {
-                return ResourceManager.GetString("RepoSignCommandOwnersDescription", resourceCulture);
+                return ResourceManager.GetString("RepoSignCommandPackageOwnersDescription", resourceCulture);
             }
         }
         
@@ -270,9 +270,9 @@ namespace NuGet.MSSigning.Extensions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to nuget reposign MyPackage.nupkg -Timestamper https://foo.bar -CertificateFile foo.p7b -CSPName &quot;Cryptographic Service Provider&quot;  -KeyContainer &quot;4003d786-cc37-4004-bfdf-c4f3e8ef9b3a&quot; -CertificateFingerprint &quot;4003d786cc374004bfdfc4f3e8ef9b3a&quot;  -Owners bar;foo -V3ServiceIndexUrl https://v3.index
+        ///   Looks up a localized string similar to nuget reposign MyPackage.nupkg -Timestamper http://timestamper.test -CertificateFile certificates.p7b -CSPName &quot;Cryptographic Service Provider&quot; -KeyContainer 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -CertificateFingerprint 8599ADD1C62EE42E315EA887FF60908B7A7C6E9B -V3ServiceIndexUrl https://v3.index.test
         ///
-        ///nuget reposign MyPackage.nupkg -Timestamper https://foo.bar -CertificateFile foo.p7b -CSPName &quot;Cryptographic Service Provider&quot;  -KeyContainer &quot;4003d786-cc37-4004-bfdf-c4f3e8ef9b3a&quot; -CertificateFingerprint &quot;4003d786cc [rest of string was truncated]&quot;;.
+        ///nuget reposign MyPackage.nupkg -Timestamper http://timestamper.test -CertificateFile certificates.p7b -CSPName &quot;Cryptographic Service Provider&quot; -KeyContainer 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -CertificateF [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string RepoSignCommandUsageExamples {
             get {
@@ -281,7 +281,7 @@ namespace NuGet.MSSigning.Extensions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;package_path&gt; -Timestamper &lt;timestamp_server_url&gt; -CertificateFile &lt;p7b_file_path&gt; -CSPName &lt;cryptographic_service_provider_name&gt; -KeyContainer &lt;key_container_guid&gt; -CertificateFingerprint &lt;certificate_fingerprint&gt; -Owners &lt;package_owners&gt; -V3ServiceIndexUrl &lt;v3_service_index_url&gt;.
+        ///   Looks up a localized string similar to &lt;package_path&gt; -Timestamper &lt;timestamp_server_url&gt; -CertificateFile &lt;p7b_file_path&gt; -CSPName &lt;cryptographic_service_provider_name&gt; -KeyContainer &lt;key_container_guid&gt; -CertificateFingerprint &lt;certificate_fingerprint&gt; -PackageOwners &lt;package_owners&gt; -V3ServiceIndexUrl &lt;v3_service_index_url&gt;.
         /// </summary>
         internal static string RepoSignCommandUsageSummary {
             get {
@@ -290,7 +290,7 @@ namespace NuGet.MSSigning.Extensions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Repository v3 service index url..
+        ///   Looks up a localized string similar to Repository V3 service index URL..
         /// </summary>
         internal static string RepoSignCommandV3ServiceIndexUrlDescription {
             get {

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.resx
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.resx
@@ -182,4 +182,24 @@ nuget mssign MyPackage.nupkg -Timestamper https://foo.bar -CertificateFile foo.p
   <data name="MSSignCommandOverwriteDescription" xml:space="preserve">
     <value>Switch to indicate if the current signature should be overwritten. By default the command will fail if the package already has a signature.</value>
   </data>
+  <data name="RepoSignCommandDescription" xml:space="preserve">
+    <value>Sign a NuGet package by adding repository signature with specified p7b file.</value>
+  </data>
+  <data name="RepoSignCommandOwnersDescription" xml:space="preserve">
+    <value>Semicolon separated list of package owners.</value>
+  </data>
+  <data name="RepoSignCommandUsageDescription" xml:space="preserve">
+    <value>Sign a NuGet package with repository signature.</value>
+  </data>
+  <data name="RepoSignCommandUsageExamples" xml:space="preserve">
+    <value>nuget reposign MyPackage.nupkg -Timestamper https://foo.bar -CertificateFile foo.p7b -CSPName "Cryptographic Service Provider"  -KeyContainer "4003d786-cc37-4004-bfdf-c4f3e8ef9b3a" -CertificateFingerprint "4003d786cc374004bfdfc4f3e8ef9b3a"  -Owners bar;foo -V3ServiceIndexUrl https://v3.index
+
+nuget reposign MyPackage.nupkg -Timestamper https://foo.bar -CertificateFile foo.p7b -CSPName "Cryptographic Service Provider"  -KeyContainer "4003d786-cc37-4004-bfdf-c4f3e8ef9b3a" -CertificateFingerprint "4003d786cc374004bfdfc4f3e8ef9b3a" -OutputDirectory .\..\Signed -Owners bar;foo -V3ServiceIndexUrl https://v3.index</value>
+  </data>
+  <data name="RepoSignCommandUsageSummary" xml:space="preserve">
+    <value>&lt;package_path&gt; -Timestamper &lt;timestamp_server_url&gt; -CertificateFile &lt;p7b_file_path&gt; -CSPName &lt;cryptographic_service_provider_name&gt; -KeyContainer &lt;key_container_guid&gt; -CertificateFingerprint &lt;certificate_fingerprint&gt; -Owners &lt;package_owners&gt; -V3ServiceIndexUrl &lt;v3_service_index_url&gt;</value>
+  </data>
+  <data name="RepoSignCommandV3ServiceIndexUrlDescription" xml:space="preserve">
+    <value>Repository v3 service index url.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.resx
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.resx
@@ -185,21 +185,21 @@ nuget mssign MyPackage.nupkg -Timestamper https://foo.bar -CertificateFile foo.p
   <data name="RepoSignCommandDescription" xml:space="preserve">
     <value>Sign a NuGet package by adding repository signature with specified p7b file.</value>
   </data>
-  <data name="RepoSignCommandOwnersDescription" xml:space="preserve">
-    <value>Semicolon separated list of package owners.</value>
+  <data name="RepoSignCommandPackageOwnersDescription" xml:space="preserve">
+    <value>Semicolon-separated list of package owners.</value>
   </data>
   <data name="RepoSignCommandUsageDescription" xml:space="preserve">
     <value>Sign a NuGet package with repository signature.</value>
   </data>
   <data name="RepoSignCommandUsageExamples" xml:space="preserve">
-    <value>nuget reposign MyPackage.nupkg -Timestamper https://foo.bar -CertificateFile foo.p7b -CSPName "Cryptographic Service Provider"  -KeyContainer "4003d786-cc37-4004-bfdf-c4f3e8ef9b3a" -CertificateFingerprint "4003d786cc374004bfdfc4f3e8ef9b3a"  -Owners bar;foo -V3ServiceIndexUrl https://v3.index
+    <value>nuget reposign MyPackage.nupkg -Timestamper http://timestamper.test -CertificateFile certificates.p7b -CSPName "Cryptographic Service Provider" -KeyContainer 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -CertificateFingerprint 8599ADD1C62EE42E315EA887FF60908B7A7C6E9B -V3ServiceIndexUrl https://v3.index.test
 
-nuget reposign MyPackage.nupkg -Timestamper https://foo.bar -CertificateFile foo.p7b -CSPName "Cryptographic Service Provider"  -KeyContainer "4003d786-cc37-4004-bfdf-c4f3e8ef9b3a" -CertificateFingerprint "4003d786cc374004bfdfc4f3e8ef9b3a" -OutputDirectory .\..\Signed -Owners bar;foo -V3ServiceIndexUrl https://v3.index</value>
+nuget reposign MyPackage.nupkg -Timestamper http://timestamper.test -CertificateFile certificates.p7b -CSPName "Cryptographic Service Provider" -KeyContainer 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -CertificateFingerprint 8599ADD1C62EE42E315EA887FF60908B7A7C6E9B -OutputDirectory .\..\Signed -PackageOwners owner1;owner2 -V3ServiceIndexUrl https://v3.index.test</value>
   </data>
   <data name="RepoSignCommandUsageSummary" xml:space="preserve">
-    <value>&lt;package_path&gt; -Timestamper &lt;timestamp_server_url&gt; -CertificateFile &lt;p7b_file_path&gt; -CSPName &lt;cryptographic_service_provider_name&gt; -KeyContainer &lt;key_container_guid&gt; -CertificateFingerprint &lt;certificate_fingerprint&gt; -Owners &lt;package_owners&gt; -V3ServiceIndexUrl &lt;v3_service_index_url&gt;</value>
+    <value>&lt;package_path&gt; -Timestamper &lt;timestamp_server_url&gt; -CertificateFile &lt;p7b_file_path&gt; -CSPName &lt;cryptographic_service_provider_name&gt; -KeyContainer &lt;key_container_guid&gt; -CertificateFingerprint &lt;certificate_fingerprint&gt; -PackageOwners &lt;package_owners&gt; -V3ServiceIndexUrl &lt;v3_service_index_url&gt;</value>
   </data>
   <data name="RepoSignCommandV3ServiceIndexUrlDescription" xml:space="preserve">
-    <value>Repository v3 service index url.</value>
+    <value>Repository V3 service index URL.</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/RepoSignCommand.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/RepoSignCommand.cs
@@ -1,0 +1,114 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.CommandLine;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+
+namespace NuGet.MSSigning.Extensions
+{
+    [Command(typeof(NuGetMSSignCommand), "reposign", "RepoSignCommandDescription",
+       MinArgs = 1,
+       MaxArgs = 1,
+       UsageSummaryResourceName = "RepoSignCommandUsageSummary",
+       UsageExampleResourceName = "RepoSignCommandUsageExamples",
+       UsageDescriptionResourceName = "RepoSignCommandUsageDescription")]
+    public class RepoSignCommand : MSSignAbstract
+    {
+        // Default constructor used only for testing, since the Command Default Constructor is protected
+        public RepoSignCommand() : base()
+        {
+        }
+
+        private readonly List<string> _owners = new List<string>();
+
+        [Option(typeof(NuGetMSSignCommand), "RepoSignCommandOwnersDescription")]
+        public IList<string> Owners => _owners;
+
+        [Option(typeof(NuGetMSSignCommand), "RepoSignCommandV3ServiceIndexUrlDescription")]
+        public string V3ServiceIndexUrl { get; set; }
+
+        public override async Task ExecuteCommandAsync()
+        {
+            using (var signRequest = GetRepositorySignRequest())
+            {
+                var packages = GetPackages();
+                var signCommandRunner = new SignCommandRunner();
+                var result = await signCommandRunner.ExecuteCommandAsync(
+                    packages, signRequest, Timestamper, Console, OutputDirectory, false, CancellationToken.None);
+
+                if (result != 0)
+                {
+                    throw new ExitCodeException(exitCode: result);
+                }
+            }
+        }
+
+        private RepositorySignPackageRequest GetRepositorySignRequest()
+        {
+            ValidatePackagePath();
+            WarnIfNoTimestamper(Console);
+            ValidateCertificateInputs();
+            EnsureOutputDirectory();
+            ValidatePackageOwners();
+
+            var signingSpec = SigningSpecifications.V1;
+            var signatureHashAlgorithm = ValidateAndParseHashAlgorithm(HashAlgorithm, nameof(HashAlgorithm), signingSpec);
+            var timestampHashAlgorithm = ValidateAndParseHashAlgorithm(TimestampHashAlgorithm, nameof(TimestampHashAlgorithm), signingSpec);
+            var certCollection = GetCertificateCollection();
+            var certificate = GetCertificate(certCollection);
+            var privateKey = GetPrivateKey(certificate);
+            var v3ServiceIndexUri = ValidateAndParseV3ServiceIndexUrl();
+
+            var request = new RepositorySignPackageRequest(
+                certificate,
+                signatureHashAlgorithm,
+                timestampHashAlgorithm,
+                v3ServiceIndexUri,
+                new ReadOnlyCollection<string>(Owners))
+            {
+                PrivateKey = privateKey
+            };
+
+            request.AdditionalCertificates.AddRange(certCollection);
+
+            return request;
+        }
+
+        private Uri ValidateAndParseV3ServiceIndexUrl()
+        {
+            // Assert mandatory argument
+            if (!string.IsNullOrEmpty(V3ServiceIndexUrl) ||
+                Uri.IsWellFormedUriString(V3ServiceIndexUrl, UriKind.Absolute))
+            {
+                var uri = UriUtility.CreateSourceUri(V3ServiceIndexUrl, UriKind.Absolute);
+                if (uri.Scheme == Uri.UriSchemeHttps)
+                {
+                    return uri;
+                }
+            }
+
+            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
+                    NuGetMSSignCommand.MSSignCommandInvalidArgumentException,
+                    nameof(V3ServiceIndexUrl)));
+        }
+
+        private void ValidatePackageOwners()
+        {
+            if (Owners.Any(packageOwner => string.IsNullOrWhiteSpace(packageOwner)))
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
+                    NuGetMSSignCommand.MSSignCommandInvalidArgumentException,
+                    nameof(Owners)));
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
+using NuGet.Packaging;
 using NuGet.Packaging.Signing;
 using NuGet.Protocol;
 
@@ -57,7 +58,7 @@ namespace NuGet.Commands
 
         public async Task<int> ExecuteCommandAsync(
             IEnumerable<string> packagesToSign,
-            AuthorSignPackageRequest signPackageRequest,
+            SignPackageRequest signPackageRequest,
             string timestamper,
             ILogger logger,
             string outputDirectory,

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/AuthorSignPackageRequest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/AuthorSignPackageRequest.cs
@@ -29,8 +29,7 @@ namespace NuGet.Packaging.Signing
             : base(
                   certificate,
                   hashAlgorithm,
-                  hashAlgorithm,
-                  SignaturePlacement.PrimarySignature)
+                  hashAlgorithm)
         {
         }
 
@@ -53,8 +52,7 @@ namespace NuGet.Packaging.Signing
             : base(
                   certificate,
                   signatureHashAlgorithm,
-                  timestampHashAlgorithm,
-                  SignaturePlacement.PrimarySignature)
+                  timestampHashAlgorithm)
         {
         }
     }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/RepositorySignPackageRequest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/RepositorySignPackageRequest.cs
@@ -32,7 +32,6 @@ namespace NuGet.Packaging.Signing
         /// <param name="certificate">The signing certificate.</param>
         /// <param name="signatureHashAlgorithm">The signature hash algorithm.</param>
         /// <param name="timestampHashAlgorithm">The timestamp hash algorithm.</param>
-        /// <param name="signaturePlacement">The signature placement.</param>
         /// <param name="v3ServiceIndexUrl">The V3 service index URL.</param>
         /// <param name="packageOwners">A read-only list of package owners.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="certificate" />
@@ -40,8 +39,6 @@ namespace NuGet.Packaging.Signing
         /// <exception cref="ArgumentException">Thrown if <paramref name="signatureHashAlgorithm" />
         /// is invalid.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="timestampHashAlgorithm" />
-        /// is invalid.</exception>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="signaturePlacement" />
         /// is invalid.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="v3ServiceIndexUrl" />
         /// is <c>null</c>.</exception>
@@ -53,14 +50,12 @@ namespace NuGet.Packaging.Signing
             X509Certificate2 certificate,
             HashAlgorithmName signatureHashAlgorithm,
             HashAlgorithmName timestampHashAlgorithm,
-            SignaturePlacement signaturePlacement,
             Uri v3ServiceIndexUrl,
             IReadOnlyList<string> packageOwners)
             : base(
                   certificate,
                   signatureHashAlgorithm,
-                  timestampHashAlgorithm,
-                  signaturePlacement)
+                  timestampHashAlgorithm)
         {
             if (v3ServiceIndexUrl == null)
             {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/SignPackageRequest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/SignPackageRequest.cs
@@ -40,10 +40,6 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         public abstract SignatureType SignatureType { get; }
 
-        /// <summary>
-        /// Gets the signature placement.
-        /// </summary>
-        public SignaturePlacement SignaturePlacement { get; }
 
         internal IReadOnlyList<X509Certificate2> Chain { get; private set; }
 
@@ -57,8 +53,7 @@ namespace NuGet.Packaging.Signing
         protected SignPackageRequest(
             X509Certificate2 certificate,
             HashAlgorithmName signatureHashAlgorithm,
-            HashAlgorithmName timestampHashAlgorithm,
-            SignaturePlacement signaturePlacement)
+            HashAlgorithmName timestampHashAlgorithm)
         {
             if (certificate == null)
             {
@@ -77,15 +72,9 @@ namespace NuGet.Packaging.Signing
                 throw new ArgumentException(Strings.InvalidArgument, nameof(timestampHashAlgorithm));
             }
 
-            if (!Enum.IsDefined(typeof(SignaturePlacement), signaturePlacement))
-            {
-                throw new ArgumentException(Strings.InvalidArgument, nameof(signaturePlacement));
-            }
-
             Certificate = certificate;
             SignatureHashAlgorithm = signatureHashAlgorithm;
             TimestampHashAlgorithm = timestampHashAlgorithm;
-            SignaturePlacement = signaturePlacement;
             AdditionalCertificates = new X509Certificate2Collection();
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/RepositoryCountersignatureTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/RepositoryCountersignatureTests.cs
@@ -146,7 +146,6 @@ namespace NuGet.Packaging.FuncTest
                     new X509Certificate2(certificate),
                     HashAlgorithmName.SHA256,
                     HashAlgorithmName.SHA256,
-                    SignaturePlacement.Countersignature,
                     v3ServiceIndexUrl,
                     packageOwners);
                 var cmsSigner = SigningUtility.CreateCmsSigner(request, NullLogger.Instance);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
@@ -37,15 +37,50 @@ namespace NuGet.Packaging.FuncTest
         }
 
         [CIOnlyFact]
-        public async Task SignAsync_AddsPackageSignatureAsync()
+        public async Task SignAsync_AddsPackageAuthorSignatureAsync()
         {
             using (var test = new Test(_testFixture.TrustedTestCertificate.Source.Cert))
             {
-                await SigningUtility.SignAsync(test.Options, test.Request, CancellationToken.None);
+                await SigningUtility.SignAsync(test.Options, test.AuthorRequest, CancellationToken.None);
 
                 var isSigned = await SignedArchiveTestUtility.IsSignedAsync(test.Options.OutputPackageStream);
 
                 Assert.True(isSigned);
+            }
+        }
+        [CIOnlyFact]
+        public async Task SignAsync_AddsPackageRepositorySignatureAsync()
+        {
+            using (var test = new Test(_testFixture.TrustedTestCertificate.Source.Cert))
+            {
+                await SigningUtility.SignAsync(test.Options, test.RepositoryRequest, CancellationToken.None);
+
+                var isSigned = await IsSignedAsync(test.Options.OutputFilePath);
+
+                Assert.True(isSigned);
+            }
+        }
+
+
+        [CIOnlyFact]
+        public async Task RemoveSignaturesAsync_RemovesPackageSignatureAsync()
+        {
+            using (var signTest = new Test(_testFixture.TrustedTestCertificate.Source.Cert))
+            {
+                await SigningUtility.SignAsync(signTest.Options, signTest.AuthorRequest, CancellationToken.None);
+
+                var isSigned = await IsSignedAsync(signTest.Options.OutputFilePath);
+
+                Assert.True(isSigned);
+
+                using (var unsignTest = new Test(signTest.Options.OutputFilePath))
+                {
+                    await SigningUtility.RemoveSignatureAsync(unsignTest.Options.PackageFilePath, unsignTest.Options.OutputFilePath, CancellationToken.None);
+
+                    isSigned = await IsSignedAsync(unsignTest.Options.OutputFilePath);
+
+                    Assert.False(isSigned);
+                }
             }
         }
 
@@ -55,7 +90,7 @@ namespace NuGet.Packaging.FuncTest
             using (var test = new Test(_testFixture.TrustedTestCertificateExpired.Source.Cert))
             {
                 var exception = await Assert.ThrowsAsync<SignatureException>(
-                    () => SigningUtility.SignAsync(test.Options, test.Request, CancellationToken.None));
+                    () => SigningUtility.SignAsync(test.Options, test.AuthorRequest, CancellationToken.None));
 
                 Assert.Equal(NuGetLogCode.NU3018, exception.Code);
                 Assert.Contains("Certificate chain validation failed.", exception.Message);
@@ -73,7 +108,7 @@ namespace NuGet.Packaging.FuncTest
             using (var test = new Test(_testFixture.TrustedTestCertificateNotYetValid.Source.Cert))
             {
                 var exception = await Assert.ThrowsAsync<SignatureException>(
-                    () => SigningUtility.SignAsync(test.Options, test.Request, CancellationToken.None));
+                    () => SigningUtility.SignAsync(test.Options, test.AuthorRequest, CancellationToken.None));
 
                 Assert.Equal(NuGetLogCode.NU3017, exception.Code);
                 Assert.Contains("The signing certificate is not yet valid", exception.Message);
@@ -87,19 +122,23 @@ namespace NuGet.Packaging.FuncTest
 
         private sealed class Test : IDisposable
         {
-            private readonly X509Certificate2 _certificate;
+            private readonly X509Certificate2 _authorCertificate;
+            private readonly X509Certificate2 _repositoryCertificate;
+
             private readonly TestDirectory _directory;
 
             internal SigningOptions Options { get; }
-            internal SignPackageRequest Request { get; }
             internal FileInfo OutputFile { get; }
+            internal AuthorSignPackageRequest AuthorRequest { get; }
+            internal RepositorySignPackageRequest RepositoryRequest { get; }
 
             private bool _isDisposed;
 
             internal Test(X509Certificate2 certificate)
             {
                 _directory = TestDirectory.Create();
-                _certificate = new X509Certificate2(certificate);
+                _authorCertificate = new X509Certificate2(certificate);
+                _repositoryCertificate = new X509Certificate2(certificate);
 
                 var outputPath = Path.Combine(_directory, Guid.NewGuid().ToString());
 
@@ -110,25 +149,31 @@ namespace NuGet.Packaging.FuncTest
                 var package = packageContext.CreateAsFile(_directory, packageFileName);
                 var signatureProvider = new X509SignatureProvider(timestampProvider: null);
 
-                Request = new AuthorSignPackageRequest(_certificate, HashAlgorithmName.SHA256);
+                AuthorRequest = new AuthorSignPackageRequest(_authorCertificate, HashAlgorithmName.SHA256);
+                RepositoryRequest = new RepositorySignPackageRequest(_repositoryCertificate, HashAlgorithmName.SHA256, HashAlgorithmName.SHA256, new Uri("https://test/api/index.json"), null);
+                Options = new SigningOptions(packageFilePath: package.FullName, outputFilePath: outputPath, overwrite: true, signatureProvider: signatureProvider, logger: NullLogger.Instance);
+            }
+
+            internal Test(string packageFilePath)
+            {
+                _directory = TestDirectory.Create();
+                _authorCertificate = new X509Certificate2();
+                _repositoryCertificate = new X509Certificate2();
 
                 var overwrite = true;
 
-                Options = SigningOptions.CreateFromFilePaths(
-                    package.FullName,
-                    OutputFile.FullName,
-                    overwrite,
-                    signatureProvider,
-                    NullLogger.Instance);
+                AuthorRequest = new AuthorSignPackageRequest(_authorCertificate, HashAlgorithmName.SHA256);
+                RepositoryRequest = new RepositorySignPackageRequest(_repositoryCertificate, HashAlgorithmName.SHA256, HashAlgorithmName.SHA256, new Uri("https://test/api/index.json"), null);
+                Options = new SigningOptions(packageFilePath: packageFilePath, outputFilePath: outputPath, overwrite: true, signatureProvider: signatureProvider, logger: NullLogger.Instance);
             }
 
             public void Dispose()
             {
                 if (!_isDisposed)
                 {
-                    Request?.Dispose();
-                    _certificate?.Dispose();
-                    Options.Dispose();
+                    AuthorRequest?.Dispose();
+                    _authorCertificate?.Dispose();
+                    _repositoryCertificate?.Dispose();
                     _directory?.Dispose();
 
                     GC.SuppressFinalize(this);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/AuthorSignPackageRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/AuthorSignPackageRequestTests.cs
@@ -51,7 +51,6 @@ namespace NuGet.Packaging.Test
                 var request = new AuthorSignPackageRequest(certificate, HashAlgorithmName.SHA512);
 
                 Assert.Equal(SignatureType.Author, request.SignatureType);
-                Assert.Equal(SignaturePlacement.PrimarySignature, request.SignaturePlacement);
                 Assert.Same(certificate, request.Certificate);
                 Assert.Equal(HashAlgorithmName.SHA512, request.SignatureHashAlgorithm);
                 Assert.Equal(HashAlgorithmName.SHA512, request.TimestampHashAlgorithm);
@@ -110,7 +109,6 @@ namespace NuGet.Packaging.Test
                 var request = new AuthorSignPackageRequest(certificate, HashAlgorithmName.SHA512, HashAlgorithmName.SHA256);
 
                 Assert.Equal(SignatureType.Author, request.SignatureType);
-                Assert.Equal(SignaturePlacement.PrimarySignature, request.SignaturePlacement);
                 Assert.Same(certificate, request.Certificate);
                 Assert.Equal(HashAlgorithmName.SHA512, request.SignatureHashAlgorithm);
                 Assert.Equal(HashAlgorithmName.SHA256, request.TimestampHashAlgorithm);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/RepositorySignPackageRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/RepositorySignPackageRequestTests.cs
@@ -36,7 +36,6 @@ namespace NuGet.Packaging.Test
                     certificate,
                     HashAlgorithmName.SHA256,
                     HashAlgorithmName.SHA256,
-                    SignaturePlacement.PrimarySignature,
                     new Uri("https://test.test"),
                     packageOwners: null));
 
@@ -55,7 +54,6 @@ namespace NuGet.Packaging.Test
                         certificate,
                         signatureHashAlgorithm,
                         HashAlgorithmName.SHA256,
-                        SignaturePlacement.PrimarySignature,
                         _validV3ServiceIndexUrl,
                         _validPackageOwners));
 
@@ -75,7 +73,6 @@ namespace NuGet.Packaging.Test
                         certificate,
                         HashAlgorithmName.SHA256,
                         timestampHashAlgorithm,
-                        SignaturePlacement.PrimarySignature,
                         _validV3ServiceIndexUrl,
                         _validPackageOwners));
 
@@ -83,23 +80,6 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [Fact]
-        public void Constructor_WithInvalidSignaturePlacement_Throws()
-        {
-            using (var certificate = new X509Certificate2())
-            {
-                var exception = Assert.Throws<ArgumentException>(
-                    () => new RepositorySignPackageRequest(
-                        certificate,
-                        HashAlgorithmName.SHA256,
-                        HashAlgorithmName.SHA256,
-                        (SignaturePlacement)int.MinValue,
-                        _validV3ServiceIndexUrl,
-                        _validPackageOwners));
-
-                Assert.Equal("signaturePlacement", exception.ParamName);
-            }
-        }
 
         [Fact]
         public void Constructor_WhenV3ServiceIndexUrlNull_Throws()
@@ -111,7 +91,6 @@ namespace NuGet.Packaging.Test
                         certificate,
                         HashAlgorithmName.SHA256,
                         HashAlgorithmName.SHA256,
-                        SignaturePlacement.PrimarySignature,
                         v3ServiceIndexUrl: null,
                         packageOwners: _validPackageOwners));
 
@@ -129,7 +108,6 @@ namespace NuGet.Packaging.Test
                         certificate,
                         HashAlgorithmName.SHA256,
                         HashAlgorithmName.SHA256,
-                        SignaturePlacement.PrimarySignature,
                         new Uri("/", UriKind.Relative),
                         _validPackageOwners));
 
@@ -148,7 +126,6 @@ namespace NuGet.Packaging.Test
                         certificate,
                         HashAlgorithmName.SHA256,
                         HashAlgorithmName.SHA256,
-                        SignaturePlacement.PrimarySignature,
                         new Uri("http://test.test", UriKind.Absolute),
                         _validPackageOwners));
 
@@ -170,7 +147,6 @@ namespace NuGet.Packaging.Test
                         certificate,
                         HashAlgorithmName.SHA256,
                         HashAlgorithmName.SHA256,
-                        SignaturePlacement.PrimarySignature,
                         _validV3ServiceIndexUrl,
                         new string[] { packageOwner }));
 
@@ -187,12 +163,10 @@ namespace NuGet.Packaging.Test
                 certificate,
                 HashAlgorithmName.SHA256,
                 HashAlgorithmName.SHA384,
-                SignaturePlacement.Countersignature,
                 _validV3ServiceIndexUrl,
                 _validPackageOwners))
             {
                 Assert.Equal(SignatureType.Repository, request.SignatureType);
-                Assert.Equal(SignaturePlacement.Countersignature, request.SignaturePlacement);
                 Assert.Same(certificate, request.Certificate);
                 Assert.Equal(HashAlgorithmName.SHA256, request.SignatureHashAlgorithm);
                 Assert.Equal(HashAlgorithmName.SHA384, request.TimestampHashAlgorithm);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
@@ -344,7 +344,6 @@ namespace NuGet.Packaging.Test
                 certificate,
                 Common.HashAlgorithmName.SHA256,
                 Common.HashAlgorithmName.SHA256,
-                SignaturePlacement.PrimarySignature,
                 v3ServiceIndexUrl,
                 packageOwners))
             {
@@ -700,7 +699,6 @@ namespace NuGet.Packaging.Test
                 certificate,
                 Common.HashAlgorithmName.SHA256,
                 Common.HashAlgorithmName.SHA256,
-                SignaturePlacement.PrimarySignature,
                 v3ServiceIndexUrl,
                 packageOwners);
         }


### PR DESCRIPTION
## Bug
First part of: https://github.com/NuGet/Home/issues/6619

## Fix
This PR is the first part for support for repository signatures and countersignatures. This only enables the use of the `reposing` command to create repository primary signatures. The logic for countersignatures will come in a later PR.

## Testing/Validation
Tests Added: Yes