### PR TITLE
Signing:  change SigningOptions to use streams

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/SigningOptions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/SigningOptions.cs
@@ -8,19 +8,43 @@ using NuGet.Common;
 
 namespace NuGet.Packaging.Signing
 {
-    public sealed class SigningOptions
+    public sealed class SigningOptions : IDisposable
     {
-        /// <summary>
-        /// Path to the package file that will be used as an input for any signer operation.
-        /// <remarks>Signer operations cannot be done in place, therefore this value should be different than OutputFilePath.</remarks>
-        /// </summary>
-        public string PackageFilePath { get; }
+        private readonly Lazy<Stream> _inputPackageStream;
+        private readonly Lazy<Stream> _outputPackageStream;
+        private bool _isDisposed;
 
         /// <summary>
-        /// Path to the file that will be used as an output for any signer operation.
-        /// <remarks>Signer operations cannot be done in place, therefore this value should be different than PackageFilePath.</remarks>
+        /// Readable stream for the package that will be used as an input for any signing operation.
         /// </summary>
-        public string OutputFilePath { get; }
+        public Stream InputPackageStream
+        {
+            get
+            {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(SigningOptions));
+                }
+
+                return _inputPackageStream.Value;
+            }
+        }
+
+        /// <summary>
+        /// Readable and writeable stream for the output package for any signing operation.
+        /// </summary>
+        public Stream OutputPackageStream
+        {
+            get
+            {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(SigningOptions));
+                }
+
+                return _outputPackageStream.Value;
+            }
+        }
 
         /// <summary>
         /// Switch used to indicate if an existing signature should be overwritten.
@@ -33,23 +57,119 @@ namespace NuGet.Packaging.Signing
         public ISignatureProvider SignatureProvider { get; }
 
         /// <summary>
-        /// Logger to be used to display the logs during the execution of signer actions.
+        /// Logger to be used to display the logs during the execution of signing actions.
         /// </summary>
         public ILogger Logger { get; }
 
-        public SigningOptions(string packageFilePath, string outputFilePath, bool overwrite, ISignatureProvider signatureProvider, ILogger logger)
+        /// <summary>Instantiates a new <see cref="SigningOptions" /> object.</summary>
+        /// <param name="inputPackageStream">A readable stream for the package that will be used as input for any
+        /// signing operation.</param>
+        /// <param name="outputPackageStream">A readable and writeable stream for the output package for any signing
+        /// operation.</param>
+        /// <param name="overwrite">A flag indicating if an existing signature should be overwritten.</param>
+        /// <param name="signatureProvider">A provider to create a Signature that can be added to the package.</param>
+        /// <param name="logger">A logger.</param>
+        /// <remarks>Signing operations cannot be done in place; therefore, <paramref name="inputPackageStream"/>
+        /// and <paramref name="outputPackageStream" /> should be different streams.</remarks>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="inputPackageStream" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="outputPackageStream" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="signatureProvider" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="inputPackageStream" /> and
+        /// <paramref name="outputPackageStream"/> are the same object.</exception>
+        public SigningOptions(
+            Lazy<Stream> inputPackageStream,
+            Lazy<Stream> outputPackageStream,
+            bool overwrite,
+            ISignatureProvider signatureProvider,
+            ILogger logger)
         {
-            PackageFilePath = packageFilePath ?? throw new ArgumentNullException(nameof(packageFilePath));
-            OutputFilePath = outputFilePath ?? throw new ArgumentNullException(nameof(outputFilePath));
-
-            if (StringComparer.OrdinalIgnoreCase.Equals(NormalizeFilePath(packageFilePath), NormalizeFilePath(outputFilePath)))
-            {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.SigningCannotBeDoneInPlace, nameof(packageFilePath), nameof(outputFilePath)));
-            }
-
+            _inputPackageStream = inputPackageStream ?? throw new ArgumentNullException(nameof(inputPackageStream));
+            _outputPackageStream = outputPackageStream ?? throw new ArgumentNullException(nameof(outputPackageStream));
             SignatureProvider = signatureProvider ?? throw new ArgumentNullException(nameof(signatureProvider));
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             Overwrite = overwrite;
+        }
+
+        /// <summary>Creates a new <see cref="SigningOptions" /> object from file paths.</summary>
+        /// <param name="inputPackageFilePath">The file path of the package that will be used as input for any
+        /// signing operation.</param>
+        /// <param name="outputPackageFilePath">The file path of the package that will be the output for any signing
+        /// operation.</param>
+        /// <param name="overwrite">A flag indicating if an existing signature should be overwritten.</param>
+        /// <param name="signatureProvider">A provider to create a Signature that can be added to the package.</param>
+        /// <param name="logger">A logger.</param>
+        /// <remarks>Signing operations cannot be done in place; therefore, <paramref name="inputPackageFilePath"/>
+        /// and <paramref name="outputPackageFilePath" /> should be different file paths.</remarks>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="inputPackageFilePath" /> is <c>null</c>,
+        /// an empty string, or equivalent to <paramref name="outputPackageFilePath" />.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="inputPackageFilePath" /> is <c>null</c>,
+        /// an empty string, or equivalent to <paramref name="outputPackageFilePath" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="signatureProvider" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
+        public static SigningOptions CreateFromFilePaths(
+            string inputPackageFilePath,
+            string outputPackageFilePath,
+            bool overwrite,
+            ISignatureProvider signatureProvider,
+            ILogger logger)
+        {
+            if (string.IsNullOrEmpty(inputPackageFilePath))
+            {
+                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(inputPackageFilePath));
+            }
+
+            if (string.IsNullOrEmpty(outputPackageFilePath))
+            {
+                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(outputPackageFilePath));
+            }
+
+            if (StringComparer.OrdinalIgnoreCase.Equals(NormalizeFilePath(inputPackageFilePath), NormalizeFilePath(outputPackageFilePath)))
+            {
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.SigningCannotBeDoneInPlace,
+                        nameof(inputPackageFilePath),
+                        nameof(outputPackageFilePath)));
+            }
+
+            if (signatureProvider == null)
+            {
+                throw new ArgumentNullException(nameof(signatureProvider));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            return new SigningOptions(
+                new Lazy<Stream>(() => File.OpenRead(inputPackageFilePath)),
+                new Lazy<Stream>(() => File.Open(outputPackageFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite)),
+                overwrite,
+                signatureProvider,
+                logger);
+        }
+
+        public void Dispose()
+        {
+            if (!_isDisposed)
+            {
+                if (_inputPackageStream.IsValueCreated)
+                {
+                    _inputPackageStream.Value.Dispose();
+                }
+
+                if (_outputPackageStream.IsValueCreated)
+                {
+                    _outputPackageStream.Value.Dispose();
+                }
+
+                GC.SuppressFinalize(this);
+
+                _isDisposed = true;
+            }
         }
 
         private static string NormalizeFilePath(string filePath)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SigningUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SigningUtility.cs
@@ -247,10 +247,6 @@ namespace NuGet.Packaging.Signing
             return new SignatureContent(SigningSpecifications.V1, hashAlgorithmName, base64ZipArchiveHash);
         }
 #else
-        /// <summary>
-        /// Remove a signature from a package.
-        /// </summary>
-        public static Task RemoveSignatureAsync(string packageFilePath, string outputFilePath, CancellationToken token) => throw new NotImplementedException();
 
         /// <summary>
         /// Add a signature to a package.

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageArchiveTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageArchiveTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if IS_DESKTOP
+
+using System;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using NuGet.Test.Utility;
+using Test.Utility.Signing;
+using Xunit;
+
+namespace NuGet.Packaging.FuncTest
+{
+    [Collection(SigningTestCollection.Name)]
+    public class SignedPackageArchiveTests
+    {
+        private readonly SigningTestFixture _fixture;
+
+        public SignedPackageArchiveTests(SigningTestFixture fixture)
+        {
+             _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+        }
+
+        [CIOnlyFact]
+        public async Task RemoveSignatureAsync_RemovesPackageSignatureAsync()
+        {
+            using (var directory = TestDirectory.Create())
+            using (var certificate = new X509Certificate2(_fixture.TrustedTestCertificate.Source.Cert))
+            {
+                var signedPackageFile = await CreateSignedPackageAsync(directory, certificate);
+
+                using (var test = new Test(signedPackageFile.FullName))
+                {
+                    using (var package = new SignedPackageArchive(test.InputPackageStream, test.OutputPackageStream))
+                    {
+                        await package.RemoveSignatureAsync(CancellationToken.None);
+                    }
+
+                    var isSigned = await SignedArchiveTestUtility.IsSignedAsync(test.OutputPackageStream);
+
+                    Assert.False(isSigned);
+                }
+            }
+        }
+
+        private static async Task<FileInfo> CreateSignedPackageAsync(TestDirectory directory, X509Certificate2 certificate)
+        {
+            var packageContext = new SimpleTestPackageContext();
+            var packageFileName = Guid.NewGuid().ToString();
+            var package = packageContext.CreateAsFile(directory, packageFileName);
+            var signatureProvider = new X509SignatureProvider(timestampProvider: null);
+            var overwrite = true;
+            var outputFile = new FileInfo(Path.Combine(directory, Guid.NewGuid().ToString()));
+
+            using (var request = new AuthorSignPackageRequest(certificate, HashAlgorithmName.SHA256))
+            using (var options = SigningOptions.CreateFromFilePaths(
+                package.FullName,
+                outputFile.FullName,
+                overwrite,
+                signatureProvider,
+                NullLogger.Instance))
+            {
+                await SigningUtility.SignAsync(options, request, CancellationToken.None);
+
+                var isSigned = await SignedArchiveTestUtility.IsSignedAsync(options.OutputPackageStream);
+
+                Assert.True(isSigned);
+            }
+
+            return outputFile;
+        }
+
+        private sealed class Test : IDisposable
+        {
+            private readonly TestDirectory _directory;
+
+            internal Stream InputPackageStream { get; }
+            internal Stream OutputPackageStream { get; }
+
+            private bool _isDisposed;
+
+            internal Test(string packageFilePath)
+            {
+                _directory = TestDirectory.Create();
+
+                var outputPath = Path.Combine(_directory, Guid.NewGuid().ToString());
+
+                InputPackageStream = File.OpenRead(packageFilePath);
+                OutputPackageStream = File.Open(outputPath, FileMode.OpenOrCreate, FileAccess.ReadWrite);
+            }
+
+            public void Dispose()
+            {
+                if (!_isDisposed)
+                {
+                    _directory?.Dispose();
+
+                    InputPackageStream.Dispose();
+                    OutputPackageStream.Dispose();
+
+                    GC.SuppressFinalize(this);
+
+                    _isDisposed = true;
+                }
+            }
+        }
+    }
+}
+#endif

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningOptionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningOptionsTests.cs
@@ -3,10 +3,11 @@
 
 #if NET46
 using System;
-using System.Security.Cryptography.X509Certificates;
+using System.IO;
 using Moq;
 using NuGet.Common;
 using NuGet.Packaging.Signing;
+using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.Packaging.Test
@@ -14,53 +15,43 @@ namespace NuGet.Packaging.Test
     public class SigningOptionsTests
     {
         [Fact]
-        public void Constructor_WhenPackagePathIsNull_Throws()
+        public void Constructor_WhenInputPackageStreamIsNull_Throws()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new SigningOptions(packageFilePath: null,
-                                        outputFilePath: "outputPath",
-                                        overwrite: true,
-                                        signatureProvider: Mock.Of<ISignatureProvider>(),
-                                        logger: Mock.Of<ILogger>()));
+                () => new SigningOptions(
+                    inputPackageStream: null,
+                    outputPackageStream: new Lazy<Stream>(() => Stream.Null),
+                    overwrite: true,
+                    signatureProvider: Mock.Of<ISignatureProvider>(),
+                    logger: Mock.Of<ILogger>()));
 
-            Assert.Equal("packageFilePath", exception.ParamName);
+            Assert.Equal("inputPackageStream", exception.ParamName);
         }
 
         [Fact]
-        public void Constructor_WhenOutputPathIsNull_Throws()
+        public void Constructor_WhenOutputPackageStreamIsNull_Throws()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new SigningOptions(packageFilePath: "packagePath",
-                                        outputFilePath: null,
-                                        overwrite: true,
-                                        signatureProvider: Mock.Of<ISignatureProvider>(),
-                                        logger: Mock.Of<ILogger>()));
+                () => new SigningOptions(
+                    inputPackageStream: new Lazy<Stream>(() => Stream.Null),
+                    outputPackageStream: null,
+                    overwrite: true,
+                    signatureProvider: Mock.Of<ISignatureProvider>(),
+                    logger: Mock.Of<ILogger>()));
 
-            Assert.Equal("outputFilePath", exception.ParamName);
-        }
-
-        [Fact]
-        public void Constructor_WhenOutputPathAndPackagePathAreEqual_Throws()
-        {
-            var exception = Assert.Throws<ArgumentException>(
-                () => new SigningOptions(packageFilePath: "packagePath",
-                                        outputFilePath: "packagePath",
-                                        overwrite: true,
-                                        signatureProvider: Mock.Of<ISignatureProvider>(),
-                                        logger: Mock.Of<ILogger>()));
-
-            Assert.Equal("packageFilePath and outputFilePath should be different. Package signing cannot be done in place.", exception.Message);
+            Assert.Equal("outputPackageStream", exception.ParamName);
         }
 
         [Fact]
         public void Constructor_WhenSignatureProviderIsNull_Throws()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new SigningOptions(packageFilePath: "packagePath",
-                                        outputFilePath: "outputPath",
-                                        overwrite: true,
-                                        signatureProvider: null,
-                                        logger: Mock.Of<ILogger>()));
+                () => new SigningOptions(
+                    inputPackageStream: new Lazy<Stream>(() => Stream.Null),
+                    outputPackageStream: new Lazy<Stream>(() => Stream.Null),
+                    overwrite: true,
+                    signatureProvider: null,
+                    logger: Mock.Of<ILogger>()));
 
             Assert.Equal("signatureProvider", exception.ParamName);
         }
@@ -69,13 +60,158 @@ namespace NuGet.Packaging.Test
         public void Constructor_WhenLoggerIsNull_Throws()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new SigningOptions(packageFilePath: "packagePath",
-                                        outputFilePath: "outputPath",
-                                        overwrite: true,
-                                        signatureProvider: Mock.Of<ISignatureProvider>(),
-                                        logger: null));
+                () => new SigningOptions(
+                    inputPackageStream: new Lazy<Stream>(() => Stream.Null),
+                    outputPackageStream: new Lazy<Stream>(() => Stream.Null),
+                    overwrite: true,
+                    signatureProvider: Mock.Of<ISignatureProvider>(),
+                    logger: null));
 
             Assert.Equal("logger", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WithValidInput_InitializesProperties()
+        {
+            var inputPackageStream = new Lazy<Stream>(() => Stream.Null);
+            var outputPackageStream = new Lazy<Stream>(() => Stream.Null);
+            var overwrite = true;
+            var signatureProvider = Mock.Of<ISignatureProvider>();
+            var logger = Mock.Of<ILogger>();
+
+            using (var options = new SigningOptions(inputPackageStream, outputPackageStream, overwrite, signatureProvider, logger))
+            {
+                Assert.Same(inputPackageStream.Value, options.InputPackageStream);
+                Assert.Same(outputPackageStream.Value, options.OutputPackageStream);
+                Assert.Equal(overwrite, options.Overwrite);
+                Assert.Same(signatureProvider, options.SignatureProvider);
+                Assert.Same(logger, options.Logger);
+            }
+        }
+
+        [Fact]
+        public void Dispose_DisposesStreams()
+        {
+            var inputPackageStream = new Lazy<Stream>(() => new MemoryStream());
+            var outputPackageStream = new Lazy<Stream>(() => new MemoryStream());
+            var overwrite = true;
+            var signatureProvider = Mock.Of<ISignatureProvider>();
+            var logger = Mock.Of<ILogger>();
+
+            using (var options = new SigningOptions(inputPackageStream, outputPackageStream, overwrite, signatureProvider, logger))
+            {
+                Assert.True(inputPackageStream.Value.CanWrite);
+                Assert.True(outputPackageStream.Value.CanWrite);
+            }
+
+            Assert.False(inputPackageStream.Value.CanWrite);
+            Assert.False(outputPackageStream.Value.CanWrite);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void CreateFromFilePaths_WhenInputPackageFilePathIsNullOrEmpty_Throws(string inputPackageFilePath)
+        {
+            var exception = Assert.Throws<ArgumentException>(
+                () => SigningOptions.CreateFromFilePaths(
+                    inputPackageFilePath,
+                    outputPackageFilePath: "a",
+                    overwrite: true,
+                    signatureProvider: Mock.Of<ISignatureProvider>(),
+                    logger: Mock.Of<ILogger>()));
+
+            Assert.Equal("inputPackageFilePath", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void CreateFromFilePaths_WhenOutputPackageFilePathIsNullOrEmpty_Throws(string outputPackageFilePath)
+        {
+            var exception = Assert.Throws<ArgumentException>(
+                () => SigningOptions.CreateFromFilePaths(
+                    inputPackageFilePath: "a",
+                    outputPackageFilePath: outputPackageFilePath,
+                    overwrite: true,
+                    signatureProvider: Mock.Of<ISignatureProvider>(),
+                    logger: Mock.Of<ILogger>()));
+
+            Assert.Equal("outputPackageFilePath", exception.ParamName);
+        }
+
+        [Fact]
+        public void CreateFromFilePaths_WhenInputPackageFilePathAndOutputPackageFilePathAreEquivalent_Throws()
+        {
+            var exception = Assert.Throws<ArgumentException>(
+                () => SigningOptions.CreateFromFilePaths(
+                    inputPackageFilePath: Path.Combine(Path.GetTempPath(), "file"),
+                    outputPackageFilePath: Path.Combine(Path.GetTempPath(), "FILE"),
+                    overwrite: true,
+                    signatureProvider: Mock.Of<ISignatureProvider>(),
+                    logger: Mock.Of<ILogger>()));
+
+            Assert.Equal("inputPackageFilePath and outputPackageFilePath should be different. Package signing cannot be done in place.", exception.Message);
+        }
+
+        [Fact]
+        public void CreateFromFilePaths_WhenSignatureProviderIsNull_Throws()
+        {
+            using (var directory = TestDirectory.Create())
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => SigningOptions.CreateFromFilePaths(
+                        inputPackageFilePath: Path.Combine(Path.GetTempPath(), "a"),
+                        outputPackageFilePath: Path.Combine(Path.GetTempPath(), "b"),
+                        overwrite: true,
+                        signatureProvider: null,
+                        logger: Mock.Of<ILogger>()));
+
+                Assert.Equal("signatureProvider", exception.ParamName);
+            }
+        }
+
+        [Fact]
+        public void CreateFromFilePaths_WhenLoggerIsNull_Throws()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => SigningOptions.CreateFromFilePaths(
+                    inputPackageFilePath: Path.Combine(Path.GetTempPath(), "a"),
+                    outputPackageFilePath: Path.Combine(Path.GetTempPath(), "b"),
+                    overwrite: true,
+                    signatureProvider: Mock.Of<ISignatureProvider>(),
+                    logger: null));
+
+            Assert.Equal("logger", exception.ParamName);
+        }
+
+        [Fact]
+        public void CreateFromFilePaths_WithValidInput_InitializesProperties()
+        {
+            using (var directory = TestDirectory.Create())
+            {
+                var inputPackageFilePath = Path.Combine(Path.GetTempPath(), "a");
+                var outputPackageFilePath = Path.Combine(Path.GetTempPath(), "b");
+                var overwrite = false;
+                var signatureProvider = Mock.Of<ISignatureProvider>();
+                var logger = Mock.Of<ILogger>();
+
+                File.WriteAllBytes(inputPackageFilePath, Array.Empty<byte>());
+
+                using (var options = SigningOptions.CreateFromFilePaths(
+                    inputPackageFilePath,
+                    outputPackageFilePath,
+                    overwrite,
+                    signatureProvider,
+                    logger))
+                {
+                    Assert.NotNull(options.InputPackageStream);
+                    Assert.NotNull(options.OutputPackageStream);
+                    Assert.Equal(overwrite, options.Overwrite);
+                    Assert.Same(signatureProvider, options.SignatureProvider);
+                    Assert.Same(logger, options.Logger);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Change `SigningOptions` to use streams instead of file paths to provide greater flexibility than file system paths alone.