### PR TITLE
Consume new `References3.AddFiles` API

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.legacy.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -310,6 +310,9 @@
     </PackageReference>
     <PackageReference Include="VSLangProj2">
       <Version>7.0.5000</Version>
+    </PackageReference>
+    <PackageReference Include="VSLangProj157">
+      <Version>15.7.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
@@ -16,6 +16,7 @@ using Microsoft.CSharp.RuntimeBinder;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.ProjectManagement;
 using NuGet.VisualStudio;
@@ -816,8 +817,16 @@ namespace NuGet.PackageManagement.VisualStudio
                         var references = (VSLangProj.Reference[])referencesArray;
                         reference = references[0];
                     }
-                    catch (Exception)
+                    catch (Exception e)
                     {
+                        if (e is InvalidCastException)
+                        {
+                            // We've encountered a project system that doesn't implement References3, or
+                            // there's some sort of setup issue such that we can't find the library with
+                            // the References3 type. Send a report about this.
+                            TelemetryActivity.EmitTelemetryEvent(new TelemetryEvent("References3InvalidCastException"));
+                        }
+
                         // If that didn't work, fall back to References.Add.
                         reference = References.Add(assemblyFullPath);
                     }


### PR DESCRIPTION
## Bug
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/572174
Regression: No
If Regression then when did it last work:  N/A
If Regression then how are we preventing it in future:   N/A

## Fix
Details:

This change adds basic usage of the new `References3.AddFiles` API when
adding references in a packages.config-based project. The current API
used for this purposes, `References.Add`, can trigger multiple
design-time builds per call and may not set all the right metadata on
the resulting `<Reference>` element in the project file. This can
require further calls to update that metadata, which can in turn trigger
further design-time builds.

`AddFiles` on the other hand creates `<Reference>` items with all the
proper metadata--notable, the `<Private>` metadata is set appropriately,
and it specifies an explicit version of the given assembly. And since it
is explicitly about adding files as references and does not need to
support short or full assembly names it can skip several of the
design-time builds run by `Add`. Use of `AddFiles` instead of `Add`
eliminates up to 75% of the design-time builds incurred while adding a
new package.

For the time being, if `AddFiles` fails we will fall back to calling
`Add`. This way adding a new package is not completely broken in case
there are bugs in the `AddFiles` implementation. If the new API proves
reliable, then the fallback can be removed later.

`AddFiles` can also take multiple file paths, and resolve all the
assemblies with a single design-time build. However, using the API in
that manner will require some refactoring of the client code; it is an
option for the future but is not pursued here.

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  Change concerns integration with Visual Studio
Validation done:  Manually verified that with the right changes in place to both the NuGet client and the underlying project system adding new packages works end-to-end.
