### PR TITLE
changes for verify reposign during package extraction

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2913,7 +2913,9 @@ namespace NuGet.PackageManagement
                         var packagePath = PackagesFolderNuGetProject.GetInstalledPackageFilePath(nuGetProjectAction.PackageIdentity);
                         if (File.Exists(packagePath))
                         {
-                            using (var downloadResourceResult = new DownloadResourceResult(File.OpenRead(packagePath), nuGetProjectAction.SourceRepository?.PackageSource?.Source))
+                            var packageStream = File.OpenRead(packagePath);
+                            using (var downloadResourceResult = new DownloadResourceResult(
+                                File.OpenRead(packagePath), new PackageArchiveReader(packageStream, leaveStreamOpen: true, packageSignatureVerified: true), nuGetProjectAction.SourceRepository?.PackageSource?.Source))
                             {
                                 await ExecuteInstallAsync(nuGetProject, nuGetProjectAction.PackageIdentity, downloadResourceResult, packageWithDirectoriesToBeDeleted, nuGetProjectContext, token);
                             }

--- a/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
@@ -309,23 +309,10 @@ namespace NuGet.PackageManagement
                     sourceRepository.PackageSource.Source));
             }
 
-            if (result.PackageReader == null)
-            {
-                result.PackageStream.Seek(0, SeekOrigin.Begin);
-                var packageReader = new PackageArchiveReader(result.PackageStream);
-                result.PackageStream.Seek(0, SeekOrigin.Begin);
-                result = new DownloadResourceResult(result.PackageStream, packageReader, sourceRepository.PackageSource.Source)
-                {
-                    SignatureVerified = result.SignatureVerified
-                };
-            }
-            else if (result.Status != DownloadResourceResultStatus.AvailableWithoutStream)
+            if (result.Status != DownloadResourceResultStatus.AvailableWithoutStream)
             {
                 // bind the source
-                result = new DownloadResourceResult(result.PackageStream, result.PackageReader, sourceRepository.PackageSource.Source)
-                {
-                    SignatureVerified = result.SignatureVerified
-                };
+                result = new DownloadResourceResult(result.PackageStream, result.PackageReader, sourceRepository.PackageSource.Source);
             }
 
             return result;

--- a/src/NuGet.Core/NuGet.PackageManagement/PackagePreFetcherResult.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/PackagePreFetcherResult.cs
@@ -187,8 +187,7 @@ namespace NuGet.PackageManagement
             // Create a download result for the package that already exists
             return new DownloadResourceResult(
                 File.OpenRead(nupkgPath),
-                new PackageArchiveReader(nupkgPath))
-            { SignatureVerified = true };
+                new PackageArchiveReader(nupkgPath, packageSignatureVerified: true));
         }
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/FolderNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/FolderNuGetProject.cs
@@ -148,9 +148,9 @@ namespace NuGet.ProjectManagement
 
                     if (packageExtractionContext == null)
                     {
-                        var signedPackageVerifier = !downloadResourceResult.SignatureVerified ? new PackageSignatureVerifier(
+                        var signedPackageVerifier = new PackageSignatureVerifier(
                             SignatureVerificationProviderFactory.GetSignatureVerificationProviders(),
-                            SignedPackageVerifierSettings.Default) : null;
+                            SignedPackageVerifierSettings.Default);
 
                         packageExtractionContext = new PackageExtractionContext(
                             PackageSaveMode.Defaultv2,
@@ -175,34 +175,21 @@ namespace NuGet.ProjectManagement
                     }
                     var addedPackageFilesList = new List<string>();
 
-                    if (downloadResourceResult.PackageReader != null)
+                    if (downloadResourceResult.Status == DownloadResourceResultStatus.AvailableWithoutStream)
                     {
-                        if (downloadResourceResult.Status == DownloadResourceResultStatus.AvailableWithoutStream)
-                        {
-                            addedPackageFilesList.AddRange(
-                                await PackageExtractor.ExtractPackageAsync(
-                                    downloadResourceResult.PackageReader,
-                                    PackagePathResolver,
-                                    packageExtractionContext,
-                                    cancellationToken,
-                                    nuGetProjectContext.OperationId));
-                        }
-                        else
-                        {
-                            addedPackageFilesList.AddRange(
-                                await PackageExtractor.ExtractPackageAsync(
-                                    downloadResourceResult.PackageReader,
-                                    downloadResourceResult.PackageStream,
-                                    PackagePathResolver,
-                                    packageExtractionContext,
-                                    cancellationToken,
-                                    nuGetProjectContext.OperationId));
-                        }
+                        addedPackageFilesList.AddRange(
+                            await PackageExtractor.ExtractPackageAsync(
+                                downloadResourceResult.PackageReader,
+                                PackagePathResolver,
+                                packageExtractionContext,
+                                cancellationToken,
+                                nuGetProjectContext.OperationId));
                     }
                     else
                     {
                         addedPackageFilesList.AddRange(
                             await PackageExtractor.ExtractPackageAsync(
+                                downloadResourceResult.PackageReader,
                                 downloadResourceResult.PackageStream,
                                 PackagePathResolver,
                                 packageExtractionContext,

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -178,10 +178,8 @@ namespace NuGet.ProjectManagement
             }
 
             // These casts enforce use of -Async(...) methods.
-            var packageReader = downloadResourceResult.PackageReader
-                ?? new PackageArchiveReader(downloadResourceResult.PackageStream, leaveStreamOpen: true);
-            IAsyncPackageContentReader packageContentReader = packageReader;
-            IAsyncPackageCoreReader packageCoreReader = packageReader;
+            IAsyncPackageContentReader packageContentReader = downloadResourceResult.PackageReader;
+            IAsyncPackageCoreReader packageCoreReader = downloadResourceResult.PackageReader;
 
             var libItemGroups = await packageContentReader.GetLibItemsAsync(token);
             var referenceItemGroups = await packageContentReader.GetReferenceItemsAsync(token);

--- a/src/NuGet.Core/NuGet.Packaging/Definitions/IPackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Definitions/IPackageDownloader.cs
@@ -26,6 +26,9 @@ namespace NuGet.Packaging
         /// <exception cref="ObjectDisposedException">Thrown if this object is disposed.</exception>
         IAsyncPackageCoreReader CoreReader { get; }
 
+        /// <summary>
+        /// Gets a signed package reader.
+        /// </summary>
         ISignedPackageReader SignedPackageReader { get; }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -40,7 +40,7 @@ namespace NuGet.Packaging
 
         public override bool PackageSignatureVerified { get; }
 
-        public override IEnumerable<IRepositoryCertInfo> RepositoryCertInfos { get; }
+        public override IEnumerable<IRepositoryCertificateInfo> RepositoryCertificateInfos { get; }
 
         /// <summary>
         /// Nupkg package reader
@@ -51,8 +51,8 @@ namespace NuGet.Packaging
                 Stream stream,
                 bool packageSignatureVerified = false,
                 bool requiredRepoSign = false,
-                IEnumerable<IRepositoryCertInfo> repositoryCertInfos = null)
-                : this(stream, false, DefaultFrameworkNameProvider.Instance, DefaultCompatibilityProvider.Instance, packageSignatureVerified, requiredRepoSign, repositoryCertInfos)
+                IEnumerable<IRepositoryCertificateInfo> RepositoryCertificateInfos = null)
+                : this(stream, false, DefaultFrameworkNameProvider.Instance, DefaultCompatibilityProvider.Instance, packageSignatureVerified, requiredRepoSign, RepositoryCertificateInfos)
         {
         }
 
@@ -69,8 +69,8 @@ namespace NuGet.Packaging
             IFrameworkCompatibilityProvider compatibilityProvider,
             bool packageSignatureVerified = false,
             bool requiredRepoSign = false,
-            IEnumerable<IRepositoryCertInfo> repositoryCertInfos = null)
-            : this(stream, false, packageSignatureVerified, requiredRepoSign, repositoryCertInfos)
+            IEnumerable<IRepositoryCertificateInfo> RepositoryCertificateInfos = null)
+            : this(stream, false, packageSignatureVerified, requiredRepoSign, RepositoryCertificateInfos)
         {
         }
 
@@ -84,18 +84,18 @@ namespace NuGet.Packaging
             bool leaveStreamOpen,
             bool packageSignatureVerified = false,
             bool requiredRepoSign = false,
-            IEnumerable<IRepositoryCertInfo> repositoryCertInfos = null)
+            IEnumerable<IRepositoryCertificateInfo> RepositoryCertificateInfos = null)
             : this(new ZipArchive(stream, ZipArchiveMode.Read, leaveStreamOpen),
                   DefaultFrameworkNameProvider.Instance,
                   DefaultCompatibilityProvider.Instance,
                   packageSignatureVerified,
                   requiredRepoSign,
-                  repositoryCertInfos)
+                  RepositoryCertificateInfos)
         {
             ZipReadStream = stream;
             PackageSignatureVerified = packageSignatureVerified;
             RequiredRepoSign = requiredRepoSign;
-            RepositoryCertInfos = repositoryCertInfos;
+            RepositoryCertificateInfos = RepositoryCertificateInfos;
         }
 
         /// <summary>
@@ -112,13 +112,13 @@ namespace NuGet.Packaging
             IFrameworkCompatibilityProvider compatibilityProvider,
             bool packageSignatureVerified = false,
             bool requiredRepoSign = false,
-            IEnumerable<IRepositoryCertInfo> repositoryCertInfos = null)
-            : this(new ZipArchive(stream, ZipArchiveMode.Read, leaveStreamOpen), frameworkProvider, compatibilityProvider, packageSignatureVerified, requiredRepoSign, repositoryCertInfos)
+            IEnumerable<IRepositoryCertificateInfo> RepositoryCertificateInfos = null)
+            : this(new ZipArchive(stream, ZipArchiveMode.Read, leaveStreamOpen), frameworkProvider, compatibilityProvider, packageSignatureVerified, requiredRepoSign, RepositoryCertificateInfos)
         {
             ZipReadStream = stream;
             PackageSignatureVerified = packageSignatureVerified;
             RequiredRepoSign = requiredRepoSign;
-            RepositoryCertInfos = repositoryCertInfos;
+            RepositoryCertificateInfos = RepositoryCertificateInfos;
         }
 
         /// <summary>
@@ -126,8 +126,8 @@ namespace NuGet.Packaging
         /// </summary>
         /// <param name="zipArchive">ZipArchive containing the nupkg data.</param>
         /// <param name="requiredRepoSign">Set to true if the package is needed to be repository signed.</param>
-        public PackageArchiveReader(ZipArchive zipArchive, bool packageSignatureVerified = false, bool requiredRepoSign = false, IEnumerable<IRepositoryCertInfo> repositoryCertInfos = null)
-            : this(zipArchive, DefaultFrameworkNameProvider.Instance, DefaultCompatibilityProvider.Instance, packageSignatureVerified, requiredRepoSign, repositoryCertInfos)
+        public PackageArchiveReader(ZipArchive zipArchive, bool packageSignatureVerified = false, bool requiredRepoSign = false, IEnumerable<IRepositoryCertificateInfo> RepositoryCertificateInfos = null)
+            : this(zipArchive, DefaultFrameworkNameProvider.Instance, DefaultCompatibilityProvider.Instance, packageSignatureVerified, requiredRepoSign, RepositoryCertificateInfos)
         {
         }
 
@@ -144,13 +144,13 @@ namespace NuGet.Packaging
             IFrameworkCompatibilityProvider compatibilityProvider,
             bool packageSignatureVerified = false,
             bool requiredRepoSign = false,
-            IEnumerable<IRepositoryCertInfo> repositoryCertInfos = null)
+            IEnumerable<IRepositoryCertificateInfo> RepositoryCertificateInfos = null)
             : base(frameworkProvider, compatibilityProvider)
         {
             _zipArchive = zipArchive ?? throw new ArgumentNullException(nameof(zipArchive));
             PackageSignatureVerified = packageSignatureVerified;
             RequiredRepoSign = requiredRepoSign;
-            RepositoryCertInfos = repositoryCertInfos;
+            RepositoryCertificateInfos = RepositoryCertificateInfos;
         }
 
         public PackageArchiveReader(
@@ -159,7 +159,7 @@ namespace NuGet.Packaging
             IFrameworkCompatibilityProvider compatibilityProvider = null,
             bool packageSignatureVerified = false,
             bool requiredRepoSign = false,
-            IEnumerable<IRepositoryCertInfo> repositoryCertInfos = null)
+            IEnumerable<IRepositoryCertificateInfo> RepositoryCertificateInfos = null)
             : base(frameworkProvider ?? DefaultFrameworkNameProvider.Instance, compatibilityProvider ?? DefaultCompatibilityProvider.Instance)
         {
             if (filePath == null)
@@ -169,7 +169,7 @@ namespace NuGet.Packaging
 
             PackageSignatureVerified = packageSignatureVerified;
             RequiredRepoSign = requiredRepoSign;
-            RepositoryCertInfos = repositoryCertInfos;
+            RepositoryCertificateInfos = RepositoryCertificateInfos;
 
             // Since this constructor owns the stream, the responsibility falls here to dispose the stream of an
             // invalid .zip archive. If this constructor succeeds, the disposal of the stream is handled by the

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -17,134 +17,6 @@ namespace NuGet.Packaging
     public static class PackageExtractor
     {
         public static async Task<IEnumerable<string>> ExtractPackageAsync(
-            Stream packageStream,
-            PackagePathResolver packagePathResolver,
-            PackageExtractionContext packageExtractionContext,
-            CancellationToken token,
-            Guid parentId = default(Guid))
-        {
-            if (packageStream == null)
-            {
-                throw new ArgumentNullException(nameof(packageStream));
-            }
-
-            if (!packageStream.CanSeek)
-            {
-                throw new ArgumentException(Strings.PackageStreamShouldBeSeekable);
-            }
-
-            if (packagePathResolver == null)
-            {
-                throw new ArgumentNullException(nameof(packagePathResolver));
-            }
-
-            if (packageExtractionContext == null)
-            {
-                throw new ArgumentNullException(nameof(packageExtractionContext));
-            }
-
-            var packageSaveMode = packageExtractionContext.PackageSaveMode;
-            var filesAdded = new List<string>();
-            var nupkgStartPosition = packageStream.Position;
-
-            using (var telemetry = TelemetryActivity.CreateTelemetryActivityWithNewOperationId(parentId))
-            {
-                using (var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true))
-                {
-                    var packageIdentityFromNuspec = await packageReader.GetIdentityAsync(CancellationToken.None);
-
-                    var installPath = packagePathResolver.GetInstallPath(packageIdentityFromNuspec);
-                    var packageDirectoryInfo = Directory.CreateDirectory(installPath);
-                    var packageDirectory = packageDirectoryInfo.FullName;
-
-                    try
-                    {
-                        telemetry.StartIntervalMeasure();
-
-                        await VerifyPackageSignatureAsync(
-                         telemetry.OperationId,
-                         packageIdentityFromNuspec,
-                         packageExtractionContext,
-                         packageReader,
-                         token);
-
-                        telemetry.EndIntervalMeasure(PackagingConstants.PackageVerifyDurationName);
-                    }
-                    catch (SignatureException)
-                    {
-                        telemetry.TelemetryEvent = new PackageExtractionTelemetryEvent(
-                                       packageExtractionContext.PackageSaveMode,
-                                       NuGetOperationStatus.Failed,
-                                       ExtractionSource.NuGetFolderProject,
-                                       packageIdentityFromNuspec);
-                        throw;
-                    }
-
-                    var packageFiles = await packageReader.GetPackageFilesAsync(packageSaveMode, token);
-
-                    if ((packageSaveMode & PackageSaveMode.Nuspec) == PackageSaveMode.Nuspec)
-                    {
-                        var sourceNuspecFile = packageFiles.Single(p => PackageHelper.IsManifest(p));
-
-                        var targetNuspecPath = Path.Combine(
-                            packageDirectory,
-                            packagePathResolver.GetManifestFileName(packageIdentityFromNuspec));
-
-                        // Extract the .nuspec file with a well known file name.
-                        filesAdded.Add(packageReader.ExtractFile(
-                            sourceNuspecFile,
-                            targetNuspecPath,
-                            packageExtractionContext.Logger));
-
-                        packageFiles = packageFiles.Except(new[] { sourceNuspecFile });
-                    }
-
-                    var packageFileExtractor = new PackageFileExtractor(packageFiles, packageExtractionContext.XmlDocFileSaveMode);
-
-                    filesAdded.AddRange(await packageReader.CopyFilesAsync(
-                        packageDirectory,
-                        packageFiles,
-                        packageFileExtractor.ExtractPackageFile,
-                        packageExtractionContext.Logger,
-                        token));
-
-                    if ((packageSaveMode & PackageSaveMode.Nupkg) == PackageSaveMode.Nupkg)
-                    {
-                        // During package extraction, nupkg is the last file to be created
-                        // Since all the packages are already created, the package stream is likely positioned at its end
-                        // Reset it to the nupkgStartPosition
-                        packageStream.Seek(nupkgStartPosition, SeekOrigin.Begin);
-
-                        var nupkgFilePath = Path.Combine(
-                            packageDirectory,
-                            packagePathResolver.GetPackageFileName(packageIdentityFromNuspec));
-
-                        filesAdded.Add(packageStream.CopyToFile(nupkgFilePath));
-                    }
-
-                    // Now, copy satellite files unless requested to not copy them
-                    if (packageExtractionContext.CopySatelliteFiles)
-                    {
-                        filesAdded.AddRange(await CopySatelliteFilesAsync(
-                            packageReader,
-                            packagePathResolver,
-                            packageSaveMode,
-                            packageExtractionContext,
-                            token));
-                    }
-                    telemetry.TelemetryEvent = new PackageExtractionTelemetryEvent(
-                                      packageExtractionContext.PackageSaveMode,
-                                      NuGetOperationStatus.Succeeded,
-                                      ExtractionSource.NuGetFolderProject,
-                                      packageIdentityFromNuspec);
-
-                }
-
-                return filesAdded;
-            }
-        }
-
-        public static async Task<IEnumerable<string>> ExtractPackageAsync(
             PackageReaderBase packageReader,
             Stream packageStream,
             PackagePathResolver packagePathResolver,
@@ -371,6 +243,9 @@ namespace NuGet.Packaging
             Func<Stream, Task> copyToAsync,
             VersionFolderPathResolver versionFolderPathResolver,
             PackageExtractionContext packageExtractionContext,
+            bool packageSignatureVerified,
+            bool requiredRepoSign,
+            IEnumerable<IRepositoryCertInfo> repositoryCertInfos,
             CancellationToken token,
             Guid parentId = default(Guid))
         {
@@ -459,7 +334,7 @@ namespace NuGet.Packaging
                                     await copyToAsync(nupkgStream);
                                     nupkgStream.Seek(0, SeekOrigin.Begin);
 
-                                    using (var packageReader = new PackageArchiveReader(nupkgStream))
+                                    using (var packageReader = new PackageArchiveReader(nupkgStream, packageSignatureVerified, requiredRepoSign, repositoryCertInfos))
                                     {
                                         if (packageSaveMode.HasFlag(PackageSaveMode.Nuspec) || packageSaveMode.HasFlag(PackageSaveMode.Files))
                                         {
@@ -972,7 +847,7 @@ namespace NuGet.Packaging
             ISignedPackageReader signedPackageReader,
             CancellationToken token)
         {
-            if (packageExtractionContext.SignedPackageVerifier != null)
+            if (packageExtractionContext.SignedPackageVerifier != null && !signedPackageReader.PackageSignatureVerified)
             {
                 var verifyResult = await packageExtractionContext.SignedPackageVerifier.VerifySignaturesAsync(
                        signedPackageReader,

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -245,7 +245,7 @@ namespace NuGet.Packaging
             PackageExtractionContext packageExtractionContext,
             bool packageSignatureVerified,
             bool requiredRepoSign,
-            IEnumerable<IRepositoryCertInfo> repositoryCertInfos,
+            IEnumerable<IRepositoryCertificateInfo> RepositoryCertificateInfos,
             CancellationToken token,
             Guid parentId = default(Guid))
         {
@@ -334,7 +334,7 @@ namespace NuGet.Packaging
                                     await copyToAsync(nupkgStream);
                                     nupkgStream.Seek(0, SeekOrigin.Begin);
 
-                                    using (var packageReader = new PackageArchiveReader(nupkgStream, packageSignatureVerified, requiredRepoSign, repositoryCertInfos))
+                                    using (var packageReader = new PackageArchiveReader(nupkgStream, packageSignatureVerified, requiredRepoSign, RepositoryCertificateInfos))
                                     {
                                         if (packageSaveMode.HasFlag(PackageSaveMode.Nuspec) || packageSaveMode.HasFlag(PackageSaveMode.Files))
                                         {

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -25,7 +25,7 @@ namespace NuGet.Packaging
 
         public override bool PackageSignatureVerified => true;
 
-        public override IEnumerable<IRepositoryCertInfo> RepositoryCertInfos => null;
+        public override IEnumerable<IRepositoryCertificateInfo> RepositoryCertificateInfos => null;
 
         /// <summary>
         /// Package folder reader

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -21,6 +21,12 @@ namespace NuGet.Packaging
     {
         private readonly DirectoryInfo _root;
 
+        public override bool RequiredRepoSign => false;
+
+        public override bool PackageSignatureVerified => true;
+
+        public override IEnumerable<IRepositoryCertInfo> RepositoryCertInfos => null;
+
         /// <summary>
         /// Package folder reader
         /// </summary>

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -352,7 +352,7 @@ namespace NuGet.Packaging
 
         public abstract bool PackageSignatureVerified { get; }
 
-        public abstract IEnumerable<IRepositoryCertInfo> RepositoryCertInfos { get; }
+        public abstract IEnumerable<IRepositoryCertificateInfo> RepositoryCertificateInfos { get; }
 
         /// <summary>
         /// Frameworks mentioned in the package.

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -46,20 +46,12 @@ namespace NuGet.Packaging
         /// <param name="compatibilityProvider">A framework compatibility provider.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="frameworkProvider" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="compatibilityProvider" /> is <c>null</c>.</exception>
-        public PackageReaderBase(IFrameworkNameProvider frameworkProvider, IFrameworkCompatibilityProvider compatibilityProvider)
+        public PackageReaderBase(
+            IFrameworkNameProvider frameworkProvider,
+            IFrameworkCompatibilityProvider compatibilityProvider)
         {
-            if (frameworkProvider == null)
-            {
-                throw new ArgumentNullException(nameof(frameworkProvider));
-            }
-
-            if (compatibilityProvider == null)
-            {
-                throw new ArgumentNullException(nameof(compatibilityProvider));
-            }
-
-            FrameworkProvider = frameworkProvider;
-            CompatibilityProvider = compatibilityProvider;
+            FrameworkProvider = frameworkProvider ?? throw new ArgumentNullException(nameof(frameworkProvider));
+            CompatibilityProvider = compatibilityProvider ?? throw new ArgumentNullException(nameof(compatibilityProvider));
         }
 
         #region IPackageCoreReader implementation
@@ -121,7 +113,6 @@ namespace NuGet.Packaging
                 return _nuspecReader;
             }
         }
-
         #endregion
 
         #region IAsyncPackageCoreReader implementation
@@ -356,6 +347,12 @@ namespace NuGet.Packaging
         }
 
         #endregion
+
+        public abstract bool RequiredRepoSign { get; }
+
+        public abstract bool PackageSignatureVerified { get; }
+
+        public abstract IEnumerable<IRepositoryCertInfo> RepositoryCertInfos { get; }
 
         /// <summary>
         /// Frameworks mentioned in the package.

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
+using NuGet.Packaging.Core;
 
 namespace NuGet.Packaging.Signing
 {
@@ -13,6 +15,15 @@ namespace NuGet.Packaging.Signing
     /// </summary>
     public interface ISignedPackageReader : IDisposable
     {
+        /// <summary>
+        /// Return true if the package is needed to be repository signed.
+        /// </summary>
+        bool RequiredRepoSign { get; }
+
+        bool PackageSignatureVerified { get; }
+
+        IEnumerable<IRepositoryCertInfo> RepositoryCertInfos { get; }
+
         /// <summary>
         /// Get package signature.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
@@ -22,7 +22,7 @@ namespace NuGet.Packaging.Signing
 
         bool PackageSignatureVerified { get; }
 
-        IEnumerable<IRepositoryCertInfo> RepositoryCertInfos { get; }
+        IEnumerable<IRepositoryCertificateInfo> RepositoryCertificateInfos { get; }
 
         /// <summary>
         /// Get package signature.

--- a/src/NuGet.Core/NuGet.Protocol/DownloadResourceResult.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DownloadResourceResult.cs
@@ -42,38 +42,22 @@ namespace NuGet.Protocol.Core.Types
         /// <param name="stream">A package stream.</param>
         /// <param name="source">A package source.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="stream" /> is <c>null</c>.</exception>
-        public DownloadResourceResult(Stream stream, string source)
+        public DownloadResourceResult(Stream stream, PackageReaderBase packageReader, string source)
         {
             if (stream == null)
             {
                 throw new ArgumentNullException(nameof(stream));
             }
 
+            if (packageReader == null)
+            {
+                throw new ArgumentNullException(nameof(packageReader));
+            }
+
             Status = DownloadResourceResultStatus.Available;
             _stream = stream;
+            _stream.Seek(0, SeekOrigin.Begin);
             _packageSource = source;
-        }
-
-        /// <summary>
-        /// Initializes a new <see cref="DownloadResourceResult" /> class.
-        /// </summary>
-        /// <param name="stream">A package stream.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="stream" /> is <c>null</c>.</exception>
-        public DownloadResourceResult(Stream stream)
-            : this(stream, source: null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new <see cref="DownloadResourceResult" /> class.
-        /// </summary>
-        /// <param name="stream">A package stream.</param>
-        /// <param name="packageReader">A package reader.</param>
-        /// <param name="source">A package source.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="stream" /> is <c>null</c>.</exception>
-        public DownloadResourceResult(Stream stream, PackageReaderBase packageReader, string source)
-            : this(stream, source)
-        {
             _packageReader = packageReader;
         }
 
@@ -107,8 +91,6 @@ namespace NuGet.Protocol.Core.Types
         }
 
         public DownloadResourceResultStatus Status { get; }
-
-        public bool SignatureVerified { get; set; }
 
         /// <summary>
         /// Gets the package <see cref="PackageStream"/>.

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedParser.cs
@@ -277,8 +277,9 @@ namespace NuGet.Protocol
                 downloadUri,
                 downloadContext,
                 globalPackagesFolder,
-                log,
-                token);
+                repositorySignatureResource: null,
+                logger: log,
+                token: token);
         }
 
         public async Task<DownloadResourceResult> DownloadFromIdentity(
@@ -302,8 +303,9 @@ namespace NuGet.Protocol
                 new Uri(packageInfo.DownloadUrl),
                 downloadContext,
                 globalPackagesFolder,
-                log,
-                token);
+                repositorySignatureResource: null,
+                logger: log,
+                token: token);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV2FindPackageByIdResource.cs
@@ -29,6 +29,8 @@ namespace NuGet.Protocol
 
         private readonly string _source;
 
+        public override RepositorySignatureResource RepositorySignatureResource => null;
+
         /// <summary>
         /// Initializes a new <see cref="LocalV2FindPackageByIdResource" /> class.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV3FindPackageByIdResource.cs
@@ -52,6 +52,8 @@ namespace NuGet.Protocol
             set => _packageFileCache = value;
         }
 
+        public override RepositorySignatureResource RepositorySignatureResource => null;
+
         /// <summary>
         /// Initializes a new <see cref="LocalV3FindPackageByIdResource" /> class.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -458,7 +458,7 @@ namespace NuGet.Protocol.Plugins
 
         public override bool PackageSignatureVerified => true;
 
-        public override IEnumerable<IRepositoryCertInfo> RepositoryCertInfos => null;
+        public override IEnumerable<IRepositoryCertificateInfo> RepositoryCertificateInfos => null;
 
         /// <summary>
         /// Asynchronously gets the .nuspec reader.

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -454,6 +454,12 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         public override NuspecReader NuspecReader => throw new NotSupportedException();
 
+        public override bool RequiredRepoSign => false;
+
+        public override bool PackageSignatureVerified => true;
+
+        public override IEnumerable<IRepositoryCertInfo> RepositoryCertInfos => null;
+
         /// <summary>
         /// Asynchronously gets the .nuspec reader.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Protocol/Providers/DownloadResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/DownloadResourceV3Provider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -30,17 +30,18 @@ namespace NuGet.Protocol
                 // If index.json contains a flat container resource use that to directly
                 // construct package download urls.
                 var packageBaseAddress = serviceIndex.GetServiceEntryUri(ServiceTypes.PackageBaseAddress)?.AbsoluteUri;
+                var repositorySignatureResource = await source.GetResourceAsync<RepositorySignatureResource>(token);
 
                 if (packageBaseAddress != null)
                 {
-                    curResource = new DownloadResourceV3(client, packageBaseAddress);
+                    curResource = new DownloadResourceV3(client, packageBaseAddress, repositorySignatureResource);
                 }
                 else
                 {
                     // If there is no flat container resource fall back to using the registration resource to find
                     // the download url.
                     var registrationResource = await source.GetResourceAsync<RegistrationResourceV3>(token);
-                    curResource = new DownloadResourceV3(client, registrationResource);
+                    curResource = new DownloadResourceV3(client, registrationResource, repositorySignatureResource);
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
@@ -268,7 +268,7 @@ namespace NuGet.Protocol
                 stream,
                 packageSignatureVerified: false,
                 requiredRepoSign: _resource.RepositorySignatureResource?.AllRepositorySigned ?? false,
-                repositoryCertInfos: _resource.RepositorySignatureResource?.RepositoryCertInfos);
+                RepositoryCertificateInfos: _resource.RepositorySignatureResource?.RepositoryCertificateInfos);
         }
 
         private FileStream GetDestinationStream()

--- a/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
@@ -264,7 +264,11 @@ namespace NuGet.Protocol
         {
             var stream = GetDestinationStream();
 
-            return new PackageArchiveReader(stream);
+            return new PackageArchiveReader(
+                stream,
+                packageSignatureVerified: false,
+                requiredRepoSign: _resource.RepositorySignatureResource?.AllRepositorySigned ?? false,
+                repositoryCertInfos: _resource.RepositorySignatureResource?.RepositoryCertInfos);
         }
 
         private FileStream GetDestinationStream()

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
@@ -36,6 +36,8 @@ namespace NuGet.Protocol
         private readonly IReadOnlyList<Uri> _baseUris;
         private readonly FindPackagesByIdNupkgDownloader _nupkgDownloader;
 
+        public override RepositorySignatureResource RepositorySignatureResource { get; }
+
         /// <summary>
         /// Initializes a new <see cref="HttpFileSystemBasedFindPackageByIdResource" /> class.
         /// </summary>
@@ -46,7 +48,8 @@ namespace NuGet.Protocol
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="httpSource" /> is <c>null</c>.</exception>
         public HttpFileSystemBasedFindPackageByIdResource(
             IReadOnlyList<Uri> baseUris,
-            HttpSource httpSource)
+            HttpSource httpSource,
+            RepositorySignatureResource repositorySignatureResource)
         {
             if (baseUris == null)
             {
@@ -58,18 +61,14 @@ namespace NuGet.Protocol
                 throw new ArgumentException(Strings.OneOrMoreUrisMustBeSpecified, nameof(baseUris));
             }
 
-            if (httpSource == null)
-            {
-                throw new ArgumentNullException(nameof(httpSource));
-            }
-
             _baseUris = baseUris
                 .Take(MaxRetries)
                 .Select(uri => uri.OriginalString.EndsWith("/", StringComparison.Ordinal) ? uri : new Uri(uri.OriginalString + "/"))
                 .ToList();
 
-            _httpSource = httpSource;
+            _httpSource = httpSource ?? throw new ArgumentNullException(nameof(httpSource));
             _nupkgDownloader = new FindPackagesByIdNupkgDownloader(httpSource);
+            RepositorySignatureResource = repositorySignatureResource;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -27,10 +27,12 @@ namespace NuGet.Protocol
                 && packageBaseAddress.Count > 0)
             {
                 var httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>(token);
+                var repositorySignatureResource = await sourceRepository.GetResourceAsync<RepositorySignatureResource>(token);
 
                 resource = new HttpFileSystemBasedFindPackageByIdResource(
                     packageBaseAddress,
-                    httpSourceResource.HttpSource);
+                    httpSourceResource.HttpSource,
+                    repositorySignatureResource);
             }
 
             return Tuple.Create(resource != null, resource);

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/PluginFindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/PluginFindPackageByIdResource.cs
@@ -29,6 +29,8 @@ namespace NuGet.Protocol.Core.Types
         private readonly IPlugin _plugin;
         private readonly IPluginMulticlientUtilities _utilities;
 
+        public override RepositorySignatureResource RepositorySignatureResource => null;
+
         /// <summary>
         /// Instantiates a new <see cref="PluginFindPackageByIdResource" /> class.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -75,6 +75,8 @@ namespace NuGet.Protocol
         /// </summary>
         public PackageSource PackageSource { get; }
 
+        public override RepositorySignatureResource RepositorySignatureResource => null;
+
         /// <summary>
         /// Asynchronously gets all package versions for a package ID.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
@@ -39,20 +39,11 @@ namespace NuGet.Protocol
         /// is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="httpSource" />
         /// is <c>null</c>.</exception>
-        public RemoteV3FindPackageByIdResource(SourceRepository sourceRepository, HttpSource httpSource)
+        public RemoteV3FindPackageByIdResource(SourceRepository sourceRepository, HttpSource httpSource, RepositorySignatureResource repositorySignatureResource)
         {
-            if (sourceRepository == null)
-            {
-                throw new ArgumentNullException(nameof(sourceRepository));
-            }
-
-            if (httpSource == null)
-            {
-                throw new ArgumentNullException(nameof(httpSource));
-            }
-
-            SourceRepository = sourceRepository;
-            _httpSource = httpSource;
+            SourceRepository = sourceRepository ?? throw new ArgumentNullException(nameof(sourceRepository));
+            _httpSource = httpSource ?? throw new ArgumentNullException(nameof(httpSource));
+            RepositorySignatureResource = repositorySignatureResource;
             _nupkgDownloader = new FindPackagesByIdNupkgDownloader(httpSource);
         }
 
@@ -60,6 +51,8 @@ namespace NuGet.Protocol
         /// Gets the source repository.
         /// </summary>
         public SourceRepository SourceRepository { get; }
+
+        public override RepositorySignatureResource RepositorySignatureResource { get; }
 
         /// <summary>
         /// Asynchronously gets all package versions for a package ID.

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResourceProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -26,10 +26,12 @@ namespace NuGet.Protocol
             if (serviceIndexResource != null)
             {
                 var httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>(token);
+                var repositorySignatureResource = await sourceRepository.GetResourceAsync<RepositorySignatureResource>(token);
 
                 resource = new RemoteV3FindPackageByIdResource(
                     sourceRepository,
-                    httpSourceResource.HttpSource);
+                    httpSourceResource.HttpSource,
+                    repositorySignatureResource);
             }
 
             return Tuple.Create(resource != null, resource);

--- a/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourceV3.cs
@@ -18,11 +18,11 @@ namespace NuGet.Protocol
         private readonly RegistrationResourceV3 _regResource;
         private readonly HttpSource _client;
         private readonly string _packageBaseAddressUrl;
-
+        private readonly RepositorySignatureResource _repositorySignatureResource;
         /// <summary>
         /// Download packages using the download url found in the registration resource.
         /// </summary>
-        public DownloadResourceV3(HttpSource client, RegistrationResourceV3 regResource)
+        public DownloadResourceV3(HttpSource client, RegistrationResourceV3 regResource, RepositorySignatureResource repositorySignatureResource)
             : this(client)
         {
             if (regResource == null)
@@ -31,12 +31,13 @@ namespace NuGet.Protocol
             }
 
             _regResource = regResource;
+            _repositorySignatureResource = repositorySignatureResource;
         }
 
         /// <summary>
         /// Download packages using the package base address container resource.
         /// </summary>
-        public DownloadResourceV3(HttpSource client, string packageBaseAddress)
+        public DownloadResourceV3(HttpSource client, string packageBaseAddress, RepositorySignatureResource repositorySignatureResource)
             : this(client)
         {
             if (packageBaseAddress == null)
@@ -45,6 +46,7 @@ namespace NuGet.Protocol
             }
 
             _packageBaseAddressUrl = packageBaseAddress.TrimEnd('/');
+            _repositorySignatureResource = repositorySignatureResource;
         }
 
         private DownloadResourceV3(HttpSource client)
@@ -132,6 +134,7 @@ namespace NuGet.Protocol
                     uri,
                     downloadContext,
                     globalPackagesFolder,
+                    _repositorySignatureResource,
                     logger,
                     token);
             }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/FindPackageByIdResource.cs
@@ -18,6 +18,8 @@ namespace NuGet.Protocol.Core.Types
     /// </summary>
     public abstract class FindPackageByIdResource : INuGetResource
     {
+        public abstract RepositorySignatureResource RepositorySignatureResource { get; }
+
         /// <summary>
         /// Asynchronously gets all package versions for a package ID.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
@@ -29,10 +29,10 @@ namespace NuGet.Protocol
         }
 
         // Test only.
-        public RepositorySignatureResource(bool allRepositorySigned, IEnumerable<IRepositoryCertificateInfo> repositoryCertInfos)
+        public RepositorySignatureResource(bool allRepositorySigned, IEnumerable<IRepositoryCertificateInfo> RepositoryCertificateInfos)
         {
             AllRepositorySigned = allRepositorySigned;
-            RepositoryCertificateInfos = repositoryCertInfos;
+            RepositoryCertificateInfos = RepositoryCertificateInfos;
         }
 
     }

--- a/src/NuGet.Core/NuGet.Protocol/Utility/GetDownloadResultUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/GetDownloadResultUtility.cs
@@ -216,7 +216,7 @@ namespace NuGet.Protocol
                         leaveStreamOpen: true,
                         packageSignatureVerified: false,
                         requiredRepoSign: repositorySignatureResource?.AllRepositorySigned?? false,
-                        repositoryCertInfos: repositorySignatureResource?.RepositoryCertInfos?? null));
+                        RepositoryCertificateInfos: repositorySignatureResource?.RepositoryCertificateInfos?? null));
             }
             catch
             {

--- a/src/NuGet.Core/NuGet.Protocol/Utility/GlobalPackagesFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/GlobalPackagesFolderUtility.cs
@@ -120,7 +120,7 @@ namespace NuGet.Protocol
                 packageExtractionContext,
                 packageSignatureVerified: true,
                 requiredRepoSign: repositorySignatureResource?.AllRepositorySigned?? false,
-                repositoryCertInfos: repositorySignatureResource?.RepositoryCertInfos?? null,
+                RepositoryCertificateInfos: repositorySignatureResource?.RepositoryCertificateInfos?? null,
                 token: token,
                 parentId: parentId);
 

--- a/src/NuGet.Core/NuGet.Protocol/Utility/GlobalPackagesFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/GlobalPackagesFolderUtility.cs
@@ -52,7 +52,7 @@ namespace NuGet.Protocol
                 {
                     stream = File.Open(nupkgPath, FileMode.Open, FileAccess.Read, FileShare.Read);
                     packageReader = new PackageFolderReader(installPath);
-                    return new DownloadResourceResult(stream, packageReader) { SignatureVerified = true };
+                    return new DownloadResourceResult(stream, packageReader);
                 }
                 catch
                 {
@@ -77,6 +77,7 @@ namespace NuGet.Protocol
             PackageIdentity packageIdentity,
             Stream packageStream,
             string globalPackagesFolder,
+            RepositorySignatureResource repositorySignatureResource,
             Guid parentId,
             ILogger logger,
             CancellationToken token)
@@ -117,8 +118,11 @@ namespace NuGet.Protocol
                 stream => packageStream.CopyToAsync(stream, BufferSize, token),
                 versionFolderPathResolver,
                 packageExtractionContext,
-                token,
-                parentId);
+                packageSignatureVerified: true,
+                requiredRepoSign: repositorySignatureResource?.AllRepositorySigned?? false,
+                repositoryCertInfos: repositorySignatureResource?.RepositoryCertInfos?? null,
+                token: token,
+                parentId: parentId);
 
             var package = GetPackage(packageIdentity, globalPackagesFolder);
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
@@ -318,6 +318,7 @@ namespace NuGet.CommandLine.Test.Caching
                     identity,
                     fileStream,
                     GlobalPackagesPath,
+                    null,
                     Guid.Empty,
                     Common.NullLogger.Instance,
                     CancellationToken.None))

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -88,7 +88,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, new PackageArchiveReader(stream, leaveStreamOpen: true));
                     await msBuildProject.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -98,7 +98,7 @@ namespace NuGet.CommandLine.Test
 
                 using (var stream = File.OpenRead(b1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, new PackageArchiveReader(stream, leaveStreamOpen: true));
                     await msBuildProject.InstallPackageAsync(
                         b1,
                         downloadResult,
@@ -180,7 +180,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, new PackageArchiveReader(stream, leaveStreamOpen: true));
                     await msBuildProject.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -286,7 +286,7 @@ namespace NuGet.CommandLine.Test
 
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, new PackageArchiveReader(stream, leaveStreamOpen: true));
                     await msBuildProject1.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -296,7 +296,7 @@ namespace NuGet.CommandLine.Test
 
                 using (var stream = File.OpenRead(b1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, new PackageArchiveReader(stream, leaveStreamOpen: true));
                     await msBuildProject2.InstallPackageAsync(
                         b1,
                         downloadResult,
@@ -388,7 +388,7 @@ namespace NuGet.CommandLine.Test
 
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, new PackageArchiveReader(stream, leaveStreamOpen: true));
                     await msBuildProject1.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -484,7 +484,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, new PackageArchiveReader(stream, leaveStreamOpen: true));
                     await msBuildProject.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -563,7 +563,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, new PackageArchiveReader(stream, leaveStreamOpen: true));
                     await msBuildProject.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -651,7 +651,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, new PackageArchiveReader(stream, leaveStreamOpen: true));
                     await msBuildProject.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -742,7 +742,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a2Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, new PackageArchiveReader(stream, leaveStreamOpen: true));
                     await msBuildProject.InstallPackageAsync(
                         a2,
                         downloadResult,
@@ -826,7 +826,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, new PackageArchiveReader(stream, leaveStreamOpen: true));
                     await msBuildProject.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -906,7 +906,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, new PackageArchiveReader(stream, leaveStreamOpen: true));
                     await msBuildProject.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -987,7 +987,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, new PackageArchiveReader(stream, leaveStreamOpen: true));
                     await msBuildProject.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -1105,7 +1105,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject1 = new MSBuildNuGetProject(projectSystem1, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, new PackageArchiveReader(stream, leaveStreamOpen: true));
                     await msBuildProject1.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -1195,7 +1195,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject1 = new MSBuildNuGetProject(projectSystem1, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, new PackageArchiveReader(stream, leaveStreamOpen: true));
                     await msBuildProject1.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -1315,7 +1315,7 @@ namespace NuGet.CommandLine.Test
 
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, new PackageArchiveReader(stream, leaveStreamOpen: true));
                     await msBuildProject1.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -1325,7 +1325,7 @@ namespace NuGet.CommandLine.Test
 
                 using (var stream = File.OpenRead(b1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, new PackageArchiveReader(stream, leaveStreamOpen: true));
                     await msBuildProject2.InstallPackageAsync(
                         b1,
                         downloadResult,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectKNuGetProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectKNuGetProjectTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -178,7 +178,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     TestDirectory,
                     context);
 
-                return new DownloadResourceResult(package.OpenRead());
+                var packageStream = package.OpenRead();
+                return new DownloadResourceResult(packageStream, new PackageArchiveReader(packageStream, leaveStreamOpen: true));
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -395,7 +395,8 @@ namespace NuGet.Test
 
         private static DownloadResourceResult GetDownloadResult(FileInfo packageFileInfo)
         {
-            return new DownloadResourceResult(packageFileInfo.OpenRead());
+            var packageStream = packageFileInfo.OpenRead();
+            return new DownloadResourceResult(packageStream, new PackageArchiveReader(packageStream, leaveStreamOpen: true));
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/BuildIntegratedNuGetProjectTests.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json.Linq;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
@@ -499,7 +500,9 @@ namespace ProjectManagement.Test
 
         private static DownloadResourceResult GetDownloadResourceResult(FileInfo fileInfo)
         {
-            return new DownloadResourceResult(fileInfo.OpenRead());
+            var packageStream = fileInfo.OpenRead();
+
+            return new DownloadResourceResult(packageStream, new PackageArchiveReader(packageStream, leaveStreamOpen: true));
         }
 
         private static JObject BasicConfig

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/FolderNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/FolderNuGetProjectTests.cs
@@ -850,7 +850,9 @@ namespace NuGet.ProjectManagement.Test
 
         private static DownloadResourceResult GetDownloadResourceResult(FileInfo fileInfo)
         {
-            return new DownloadResourceResult(fileInfo.OpenRead());
+            var packageStream = fileInfo.OpenRead();
+
+            return new DownloadResourceResult(packageStream, new PackageArchiveReader(packageStream, leaveStreamOpen: true));
         }
 
         private sealed class FolderNuGetProjectTest : IDisposable

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/MSBuildNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/MSBuildNuGetProjectTests.cs
@@ -1960,7 +1960,9 @@ namespace ProjectManagement.Test
 
         private static DownloadResourceResult GetDownloadResourceResult(FileInfo fileInfo)
         {
-            return new DownloadResourceResult(fileInfo.OpenRead());
+            var packageStream = fileInfo.OpenRead();
+
+            return new DownloadResourceResult(packageStream, new PackageArchiveReader(packageStream, leaveStreamOpen: true));
         }
 
         private class TestMSBuildNuGetProject

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/PackagesConfigNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/PackagesConfigNuGetProjectTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -14,6 +14,7 @@ using NuGet.Versioning;
 using NuGet.Test.Utility;
 using Test.Utility;
 using Xunit;
+using NuGet.Packaging;
 
 namespace ProjectManagement.Test
 {
@@ -318,7 +319,7 @@ namespace ProjectManagement.Test
 
         private static DownloadResourceResult GetDownloadResourceResult()
         {
-            return new DownloadResourceResult(Stream.Null);
+            return new DownloadResourceResult(DownloadResourceResultStatus.NotFound);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -2090,7 +2090,7 @@ namespace NuGet.Packaging.Test
                             signedPackageVerifier: signedPackageVerifier.Object),
                             packageSignatureVerified: false,
                             requiredRepoSign: false,
-                            repositoryCertInfos: null,
+                            RepositoryCertificateInfos: null,
                             token: CancellationToken.None);
 
                     // Assert
@@ -2135,7 +2135,7 @@ namespace NuGet.Packaging.Test
                             signedPackageVerifier: signedPackageVerifier.Object),
                             packageSignatureVerified: false,
                             requiredRepoSign: false,
-                            repositoryCertInfos: null,
+                            RepositoryCertificateInfos: null,
                             token: CancellationToken.None);
 
                     // Assert
@@ -2181,7 +2181,7 @@ namespace NuGet.Packaging.Test
                             signedPackageVerifier: signedPackageVerifier.Object),
                             packageSignatureVerified: false,
                             requiredRepoSign: false,
-                            repositoryCertInfos: null,
+                            RepositoryCertificateInfos: null,
                             token: CancellationToken.None));
                 }
             }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -423,6 +423,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(packageStream),
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -559,12 +560,14 @@ namespace NuGet.Packaging.Test
                                 signedPackageVerifier: null);
 
                     // Act
-                    var packageFiles = PackageExtractor.ExtractPackageAsync(packageStream,
+                    var packageFiles = PackageExtractor.ExtractPackageAsync(new PackageArchiveReader(packageStream),
+                                                                     packageStream,
                                                                      resolver,
                                                                      packageExtractionContext,
                                                                      CancellationToken.None);
 
-                    var satellitePackageFiles = PackageExtractor.ExtractPackageAsync(satellitePackageStream,
+                    var satellitePackageFiles = PackageExtractor.ExtractPackageAsync(new PackageArchiveReader(satellitePackageStream),
+                                                                     satellitePackageStream,
                                                                      resolver,
                                                                      packageExtractionContext,
                                                                      CancellationToken.None);
@@ -607,6 +610,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(packageStream),
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -648,6 +652,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(packageStream),
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -701,6 +706,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(packageStream),
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -744,6 +750,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(packageStream),
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -788,6 +795,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(packageStream),
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -843,12 +851,14 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(packageStream),
                         packageStream,
                         resolver,
                         packageExtractionContext,
                         CancellationToken.None);
 
                     var satellitePackageFiles = PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(satellitePackageStream),
                         satellitePackageStream,
                         resolver,
                         packageExtractionContext,
@@ -894,6 +904,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(packageStream),
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -936,6 +947,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(packageStream),
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -975,6 +987,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(packageStream),
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -1016,6 +1029,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(packageStream),
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -1057,6 +1071,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(packageStream),
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -1098,6 +1113,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(packageStream),
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -1139,6 +1155,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(packageStream),
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -1182,6 +1199,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     await PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(packageStream),
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -1227,6 +1245,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     await PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(packageStream),
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -1273,6 +1292,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     await PackageExtractor.ExtractPackageAsync(
+                        new PackageArchiveReader(packageStream),
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -2068,7 +2088,10 @@ namespace NuGet.Packaging.Test
                             xmlDocFileSaveMode: XmlDocFileSaveMode.None,
                             logger: NullLogger.Instance,
                             signedPackageVerifier: signedPackageVerifier.Object),
-                        CancellationToken.None);
+                            packageSignatureVerified: false,
+                            requiredRepoSign: false,
+                            repositoryCertInfos: null,
+                            token: CancellationToken.None);
 
                     // Assert
                     Assert.False(File.Exists(resolver.GetPackageFilePath(identity.Id, identity.Version)), "The .nupkg should not exist.");
@@ -2110,7 +2133,10 @@ namespace NuGet.Packaging.Test
                             xmlDocFileSaveMode: XmlDocFileSaveMode.None,
                             logger: NullLogger.Instance,
                             signedPackageVerifier: signedPackageVerifier.Object),
-                        CancellationToken.None);
+                            packageSignatureVerified: false,
+                            requiredRepoSign: false,
+                            repositoryCertInfos: null,
+                            token: CancellationToken.None);
 
                     // Assert
                     Assert.True(File.Exists(resolver.GetPackageFilePath(identity.Id, identity.Version)), "The .nupkg should not exist.");
@@ -2153,87 +2179,10 @@ namespace NuGet.Packaging.Test
                             xmlDocFileSaveMode: XmlDocFileSaveMode.None,
                             logger: NullLogger.Instance,
                             signedPackageVerifier: signedPackageVerifier.Object),
-                        CancellationToken.None));
-                }
-            }
-        }
-
-        [Fact]
-        public async Task ExtractPackageAsyncByStream_TrustedSignPackage()
-        {
-            // Arrange
-            using (var root = TestDirectory.Create())
-            {
-                var nupkg = new SimpleTestPackageContext("A", "1.0.0");
-
-                var signedPackageVerifier = new Mock<IPackageSignatureVerifier>(MockBehavior.Strict);
-
-                signedPackageVerifier.Setup(x => x.VerifySignaturesAsync(It.IsAny<ISignedPackageReader>(),
-                    It.IsAny<CancellationToken>(), It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(true));
-
-                var resolver = new PackagePathResolver(root);
-                var identity = new PackageIdentity("A", new NuGetVersion("1.0.0"));
-
-                var packageFileInfo = SimpleTestPackageUtility.CreateFullPackage(root, nupkg);
-
-                using (var packageStream = File.OpenRead(packageFileInfo.FullName))
-                {
-                    var packageExtractionContext = new PackageExtractionContext(
-                        PackageSaveMode.Nuspec | PackageSaveMode.Files,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        NullLogger.Instance,
-                        signedPackageVerifier.Object);
-
-                    // Act
-                    var packageFiles = await PackageExtractor.ExtractPackageAsync(packageStream,
-                                                                     resolver,
-                                                                     packageExtractionContext,
-                                                                     CancellationToken.None);
-
-                    // Assert
-                    var installPath = resolver.GetInstallPath(identity);
-                    Assert.False(File.Exists(Path.Combine(installPath, resolver.GetPackageFileName(identity))));
-                    Assert.True(File.Exists(Path.Combine(installPath, resolver.GetManifestFileName(identity))));
-                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "a.dll")));
-                }
-            }
-        }
-
-        [Fact]
-        public async Task ExtractPackageAsyncByStream_InvalidSignPackageWithUnzip()
-        {
-            // Arrange
-            using (var root = TestDirectory.Create())
-            {
-                var nupkg = new SimpleTestPackageContext("A", "1.0.0");
-
-                var signedPackageVerifier = new Mock<IPackageSignatureVerifier>(MockBehavior.Strict);
-
-                signedPackageVerifier.Setup(x => x.VerifySignaturesAsync(It.IsAny<ISignedPackageReader>(),
-                    It.IsAny<CancellationToken>(), It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(false));
-
-                var resolver = new PackagePathResolver(root);
-                var identity = new PackageIdentity("A", new NuGetVersion("1.0.0"));
-
-                var packageFileInfo = SimpleTestPackageUtility.CreateFullPackage(root, nupkg);
-
-                using (var packageStream = File.OpenRead(packageFileInfo.FullName))
-                {
-                    var packageExtractionContext = new PackageExtractionContext(
-                        PackageSaveMode.Nupkg,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        NullLogger.Instance,
-                        signedPackageVerifier.Object);
-
-                    // Act & Assert
-                    await Assert.ThrowsAsync<SignatureException>(
-                        () => PackageExtractor.ExtractPackageAsync(
-                            packageStream,
-                            resolver,
-                            packageExtractionContext,
-                            CancellationToken.None));
+                            packageSignatureVerified: false,
+                            requiredRepoSign: false,
+                            repositoryCertInfos: null,
+                            token: CancellationToken.None));
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
@@ -153,7 +153,7 @@ namespace NuGet.Protocol.Tests
 
             public override bool PackageSignatureVerified => true;
 
-            public override IEnumerable<IRepositoryCertInfo> RepositoryCertInfos => null;
+            public override IEnumerable<IRepositoryCertificateInfo> RepositoryCertificateInfos => null;
 
             public override IEnumerable<string> CopyFiles(
                 string destination,

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
@@ -79,57 +79,6 @@ namespace NuGet.Protocol.Tests
         }
 
         [Fact]
-        public void Constructor_Stream_ThrowsForNullStream()
-        {
-            var exception = Assert.Throws<ArgumentNullException>(
-                () => new DownloadResourceResult(stream: null));
-
-            Assert.Equal("stream", exception.ParamName);
-        }
-
-        [Fact]
-        public void Constructor_Stream_InitializesProperties()
-        {
-            using (var result = new DownloadResourceResult(Stream.Null))
-            {
-                Assert.Null(result.PackageReader);
-                Assert.Null(result.PackageSource);
-                Assert.Same(Stream.Null, result.PackageStream);
-                Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
-            }
-        }
-
-        [Fact]
-        public void Constructor_StreamSource_ThrowsForNullStream()
-        {
-            var exception = Assert.Throws<ArgumentNullException>(
-                () => new DownloadResourceResult(stream: null, source: "a"));
-
-            Assert.Equal("stream", exception.ParamName);
-        }
-
-        [Fact]
-        public void Constructor_StreamSource_AllowsNullSource()
-        {
-            using (var result = new DownloadResourceResult(Stream.Null, source: null))
-            {
-                Assert.Null(result.PackageSource);
-            }
-        }
-
-        [Fact]
-        public void Constructor_StreamSource_InitializesProperties()
-        {
-            using (var result = new DownloadResourceResult(Stream.Null, source: "a"))
-            {
-                Assert.Null(result.PackageReader);
-                Assert.Equal("a", result.PackageSource);
-                Assert.Same(Stream.Null, result.PackageStream);
-                Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
-            }
-        }
-
-        [Fact]
         public void Constructor_StreamPackageReaderBase_ThrowsForNullStream()
         {
             using (var packageReader = new TestPackageReader())
@@ -138,15 +87,6 @@ namespace NuGet.Protocol.Tests
                     () => new DownloadResourceResult(stream: null, packageReader: packageReader));
 
                 Assert.Equal("stream", exception.ParamName);
-            }
-        }
-
-        [Fact]
-        public void Constructor_StreamPackageReaderBase_AllowsNullPackageReader()
-        {
-            using (var result = new DownloadResourceResult(Stream.Null, packageReader: null))
-            {
-                Assert.Null(result.PackageReader);
             }
         }
 
@@ -176,16 +116,6 @@ namespace NuGet.Protocol.Tests
         }
 
         [Fact]
-        public void Constructor_StreamPackageReaderBaseSource_AllowsNullPackageReaderAndSource()
-        {
-            using (var result = new DownloadResourceResult(Stream.Null, packageReader: null, source: null))
-            {
-                Assert.Null(result.PackageReader);
-                Assert.Null(result.PackageSource);
-            }
-        }
-
-        [Fact]
         public void Constructor_StreamPackageReaderBaseSource_InitializesProperties()
         {
             using (var packageReader = new TestPackageReader())
@@ -202,7 +132,8 @@ namespace NuGet.Protocol.Tests
         public void Dispose_IsIdempotent()
         {
             using (var stream = new TestStream())
-            using (var result = new DownloadResourceResult(stream))
+            using (var packageReader = new TestPackageReader())
+            using (var result = new DownloadResourceResult(stream, packageReader))
             {
                 result.Dispose();
                 result.Dispose();
@@ -217,6 +148,12 @@ namespace NuGet.Protocol.Tests
                 : base(DefaultFrameworkNameProvider.Instance, DefaultCompatibilityProvider.Instance)
             {
             }
+
+            public override bool RequiredRepoSign => false;
+
+            public override bool PackageSignatureVerified => true;
+
+            public override IEnumerable<IRepositoryCertInfo> RepositoryCertInfos => null;
 
             public override IEnumerable<string> CopyFiles(
                 string destination,

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemotePackageArchiveDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemotePackageArchiveDownloaderTests.cs
@@ -516,7 +516,7 @@ namespace NuGet.Protocol.Tests
                 var packageReader = test.Downloader.SignedPackageReader;
                 Assert.False(packageReader.RequiredRepoSign);
 
-                var certInfo = packageReader.RepositoryCertInfos.FirstOrDefault();
+                var certInfo = packageReader.RepositoryCertificateInfos.FirstOrDefault();
                 RepositorySignatureResourceTests.VerifyCertInfo(certInfo);
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemotePackageArchiveDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemotePackageArchiveDownloaderTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
@@ -466,6 +467,60 @@ namespace NuGet.Protocol.Tests
             }
         }
 
+        [Fact]
+        public async Task RepositorySign_Basic()
+        {
+            using (var test = RemotePackageArchiveDownloaderTest.Create())
+            {
+                test.Resource.Setup(x => x.CopyNupkgToStreamAsync(
+                        It.IsNotNull<string>(),
+                        It.IsNotNull<NuGetVersion>(),
+                        It.IsNotNull<Stream>(),
+                        It.IsNotNull<SourceCacheContext>(),
+                        It.IsNotNull<ILogger>(),
+                        It.IsAny<CancellationToken>()))
+                    .Callback<string, NuGetVersion, Stream, SourceCacheContext, ILogger, CancellationToken>(
+                        (id, version, stream, cacheContext, logger, cancellationToken) =>
+                        {
+                            var remoteDirectoryPath = Path.Combine(test.TestDirectory.Path, "remote");
+
+                            Directory.CreateDirectory(remoteDirectoryPath);
+
+                            var packageContext = new SimpleTestPackageContext()
+                            {
+                                Id = test.PackageIdentity.Id,
+                                Version = test.PackageIdentity.Version.ToNormalizedString()
+                            };
+
+                            packageContext.AddFile($"lib/net45/{test.PackageIdentity.Id}.dll");
+
+                            SimpleTestPackageUtility.CreatePackages(remoteDirectoryPath, packageContext);
+
+                            var sourcePackageFilePath = Path.Combine(
+                                remoteDirectoryPath,
+                                $"{test.PackageIdentity.Id}.{test.PackageIdentity.Version.ToNormalizedString()}.nupkg");
+
+                            using (var remoteStream = File.OpenRead(sourcePackageFilePath))
+                            {
+                                remoteStream.CopyTo(stream);
+                            }
+                        })
+                    .ReturnsAsync(true);
+
+                var destinationFilePath = Path.Combine(test.TestDirectory.Path, "a");
+
+                await test.Downloader.CopyNupkgFileToAsync(
+                    destinationFilePath,
+                    CancellationToken.None);
+
+                var packageReader = test.Downloader.SignedPackageReader;
+                Assert.False(packageReader.RequiredRepoSign);
+
+                var certInfo = packageReader.RepositoryCertInfos.FirstOrDefault();
+                RepositorySignatureResourceTests.VerifyCertInfo(certInfo);
+            }
+        }
+
         private sealed class RemotePackageArchiveDownloaderTest : IDisposable
         {
             internal RemotePackageArchiveDownloader Downloader { get; }
@@ -516,6 +571,7 @@ namespace NuGet.Protocol.Tests
                     $"{_packageIdentity.Id}.{_packageIdentity.Version.ToNormalizedString()}.nupkg");
 
                 var resource = new Mock<FindPackageByIdResource>(MockBehavior.Strict);
+                resource.SetupGet(p => p.RepositorySignatureResource).Returns(RepositorySignatureResourceTests.GetRepositorySignatureResource());
 
                 var downloader = new RemotePackageArchiveDownloader(
                     resource.Object,

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceTests.cs
@@ -580,7 +580,7 @@ namespace NuGet.Protocol.Tests
 
                 Assert.False(repoSignInfo.AllRepositorySigned);
 
-                var certInfo = repoSignInfo.RepositoryCertInfos.FirstOrDefault();
+                var certInfo = repoSignInfo.RepositoryCertificateInfos.FirstOrDefault();
                 RepositorySignatureResourceTests.VerifyCertInfo(certInfo);
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -28,7 +29,8 @@ namespace NuGet.Protocol.Tests
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new HttpFileSystemBasedFindPackageByIdResource(
                     baseUris: null,
-                    httpSource: CreateDummyHttpSource()));
+                    httpSource: CreateDummyHttpSource(),
+                    repositorySignatureResource: null));
 
             Assert.Equal("baseUris", exception.ParamName);
         }
@@ -39,7 +41,8 @@ namespace NuGet.Protocol.Tests
             var exception = Assert.Throws<ArgumentException>(
                 () => new HttpFileSystemBasedFindPackageByIdResource(
                     new List<Uri>(),
-                    CreateDummyHttpSource()));
+                    CreateDummyHttpSource(),
+                    repositorySignatureResource: null));
 
             Assert.Equal("baseUris", exception.ParamName);
         }
@@ -50,7 +53,8 @@ namespace NuGet.Protocol.Tests
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new HttpFileSystemBasedFindPackageByIdResource(
                     new List<Uri>() { new Uri("https://unit.test") },
-                    httpSource: null));
+                    httpSource: null,
+                    repositorySignatureResource: null));
 
             Assert.Equal("httpSource", exception.ParamName);
         }
@@ -567,6 +571,20 @@ namespace NuGet.Protocol.Tests
             }
         }
 
+        [Fact]
+        public void GetPackageRepoSignInfo()
+        {
+            using (var test = HttpFileSystemBasedFindPackageByIdResourceTest.Create())
+            {
+                var repoSignInfo = test.Resource.RepositorySignatureResource;
+
+                Assert.False(repoSignInfo.AllRepositorySigned);
+
+                var certInfo = repoSignInfo.RepositoryCertInfos.FirstOrDefault();
+                RepositorySignatureResourceTests.VerifyCertInfo(certInfo);
+            }
+        }
+
         private static HttpSource CreateDummyHttpSource()
         {
             var packageSource = new PackageSource("https://unit.test");
@@ -648,7 +666,8 @@ namespace NuGet.Protocol.Tests
                 var httpSource = new TestHttpSource(packageSource, responses);
                 var resource = new HttpFileSystemBasedFindPackageByIdResource(
                     baseUris,
-                    httpSource);
+                    httpSource,
+                    repositorySignatureResource: RepositorySignatureResourceTests.GetRepositorySignatureResource());
 
                 return new HttpFileSystemBasedFindPackageByIdResourceTest(
                     resource,

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV3FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV3FindPackageByIdResourceTests.cs
@@ -30,7 +30,8 @@ namespace NuGet.Protocol.Tests
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new RemoteV3FindPackageByIdResource(
                     sourceRepository: null,
-                    httpSource: CreateDummyHttpSource()));
+                    httpSource: CreateDummyHttpSource(),
+                    repositorySignatureResource: null));
 
             Assert.Equal("sourceRepository", exception.ParamName);
         }
@@ -43,7 +44,8 @@ namespace NuGet.Protocol.Tests
                     new SourceRepository(
                         new PackageSource("https://unit.test"),
                         Enumerable.Empty<INuGetResourceProvider>()),
-                    httpSource: null));
+                    httpSource: null,
+                    repositorySignatureResource: null));
 
             Assert.Equal("httpSource", exception.ParamName);
         }
@@ -546,6 +548,20 @@ namespace NuGet.Protocol.Tests
             }
         }
 
+        [Fact]
+        public void GetPackageRepoSignInfo()
+        {
+            using (var test = RemoteV3FindPackageByIdResourceTest.Create())
+            {
+                var repoSignInfo = test.Resource.RepositorySignatureResource;
+
+                Assert.False(repoSignInfo.AllRepositorySigned);
+
+                var certInfo = repoSignInfo.RepositoryCertInfos.FirstOrDefault();
+                RepositorySignatureResourceTests.VerifyCertInfo(certInfo);
+            }
+        }
+
         private static HttpSource CreateDummyHttpSource()
         {
             var packageSource = new PackageSource("https://unit.test");
@@ -657,9 +673,11 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var httpSource = new TestHttpSource(packageSource, responses);
+
                 var resource = new RemoteV3FindPackageByIdResource(
                     sourceRepository,
-                    httpSource);
+                    httpSource,
+                    repositorySignatureResource: RepositorySignatureResourceTests.GetRepositorySignatureResource());
 
                 return new RemoteV3FindPackageByIdResourceTest(
                     resource,

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV3FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV3FindPackageByIdResourceTests.cs
@@ -557,7 +557,7 @@ namespace NuGet.Protocol.Tests
 
                 Assert.False(repoSignInfo.AllRepositorySigned);
 
-                var certInfo = repoSignInfo.RepositoryCertInfos.FirstOrDefault();
+                var certInfo = repoSignInfo.RepositoryCertificateInfos.FirstOrDefault();
                 RepositorySignatureResourceTests.VerifyCertInfo(certInfo);
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/RepositorySignatureResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/RepositorySignatureResourceTests.cs
@@ -102,7 +102,7 @@ namespace NuGet.Protocol.Tests
             certInfo.SetupGet(p => p.ContentUrl).Returns(_contentUrl);
 
             var certInfos = new List<IRepositoryCertificateInfo>() { certInfo.Object };
-            return new RepositorySignatureResource(allRepositorySigned: false, repositoryCertInfos: certInfos);
+            return new RepositorySignatureResource(allRepositorySigned: false, RepositoryCertificateInfos: certInfos);
         }
 
         public static void VerifyCertInfo(IRepositoryCertificateInfo certInfo)

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Utility/GetDownloadResultUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Utility/GetDownloadResultUtilityTests.cs
@@ -84,7 +84,7 @@ namespace NuGet.Protocol.Tests
                         Assert.Equal(identity.ToString(), id.ToString());
 
                         Assert.False(packageReader.RequiredRepoSign);
-                        var certInfo = packageReader.RepositoryCertInfos.FirstOrDefault();
+                        var certInfo = packageReader.RepositoryCertificateInfos.FirstOrDefault();
 
                         RepositorySignatureResourceTests.VerifyCertInfo(certInfo);
                     }

--- a/test/TestUtilities/Test.Utility/GlobalFolderUtility.cs
+++ b/test/TestUtilities/Test.Utility/GlobalFolderUtility.cs
@@ -15,27 +15,23 @@ namespace NuGet.Test.Utility
         /// <summary>
         /// Add a nupkg to the global package folder.
         /// </summary>
-        public static Task AddPackageToGlobalFolderAsync(FileInfo packagePath, DirectoryInfo globalFolder, bool requireSignVerify = false)
+        public static Task AddPackageToGlobalFolderAsync(FileInfo packagePath, DirectoryInfo globalFolder)
         {
-            return AddPackageToGlobalFolderAsync(packagePath.FullName, globalFolder.FullName, requireSignVerify);
+            return AddPackageToGlobalFolderAsync(packagePath.FullName, globalFolder.FullName);
         }
 
         /// <summary>
         /// Add a nupkg to the global package folder.
         /// </summary>
-        public static async Task AddPackageToGlobalFolderAsync(string packagePath, string globalFolder, bool requireSignVerify = false)
+        public static async Task AddPackageToGlobalFolderAsync(string packagePath, string globalFolder)
         {
             using (var reader = new PackageArchiveReader(packagePath))
             {
-                var signedPackageVerifier = requireSignVerify ? new PackageSignatureVerifier(
-                           SignatureVerificationProviderFactory.GetSignatureVerificationProviders(),
-                           SignedPackageVerifierSettings.Default) : null;
-
                 var pathContext = new PackageExtractionContext(
                     packageSaveMode: PackageSaveMode.Defaultv3,
                     xmlDocFileSaveMode: XmlDocFileSaveMode.None,
                     logger: Common.NullLogger.Instance,
-                    signedPackageVerifier: signedPackageVerifier);
+                    signedPackageVerifier: null);
 
                 var versionFolderPathResolver = new VersionFolderPathResolver(globalFolder);
 
@@ -45,7 +41,10 @@ namespace NuGet.Test.Utility
                         async (d) => await stream.CopyToAsync(d),
                         versionFolderPathResolver,
                         pathContext,
-                        CancellationToken.None);
+                        packageSignatureVerified: true,
+                        requiredRepoSign: false,
+                        repositoryCertInfos: null,
+                        token: CancellationToken.None);
                 }
             }
         }

--- a/test/TestUtilities/Test.Utility/GlobalFolderUtility.cs
+++ b/test/TestUtilities/Test.Utility/GlobalFolderUtility.cs
@@ -43,7 +43,7 @@ namespace NuGet.Test.Utility
                         pathContext,
                         packageSignatureVerified: true,
                         requiredRepoSign: false,
-                        repositoryCertInfos: null,
+                        RepositoryCertificateInfos: null,
                         token: CancellationToken.None);
                 }
             }

--- a/test/TestUtilities/Test.Utility/Protocol/TestContent.cs
+++ b/test/TestUtilities/Test.Utility/Protocol/TestContent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
@@ -11,11 +11,17 @@ namespace Test.Utility
 {
     public class TestContent : HttpContent
     {
-        private MemoryStream _stream;
+        private Stream _stream;
 
         public TestContent(string s)
         {
             _stream = new MemoryStream(Encoding.UTF8.GetBytes(s));
+            _stream.Seek(0, SeekOrigin.Begin);
+        }
+
+        public TestContent(Stream stream)
+        {
+            _stream = stream;
             _stream.Seek(0, SeekOrigin.Begin);
         }
 

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
@@ -436,7 +436,10 @@ namespace NuGet.Test.Utility
                                 XmlDocFileSaveMode.None,
                                 NullLogger.Instance,
                                 signedPackageVerifier: null),
-                            CancellationToken.None);
+                            packageSignatureVerified: true,
+                            requiredRepoSign: false,
+                            repositoryCertInfos: null,
+                            token: CancellationToken.None);
                     }
                 }
             }
@@ -481,7 +484,7 @@ namespace NuGet.Test.Utility
             {
                 using (var stream = File.OpenRead(path))
                 {
-                    await PackageExtractor.ExtractPackageAsync(stream, resolver, context, CancellationToken.None);
+                    await PackageExtractor.ExtractPackageAsync(new PackageArchiveReader(stream), stream, resolver, context, CancellationToken.None);
                 }
             }
         }

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
@@ -438,7 +438,7 @@ namespace NuGet.Test.Utility
                                 signedPackageVerifier: null),
                             packageSignatureVerified: true,
                             requiredRepoSign: false,
-                            repositoryCertInfos: null,
+                            RepositoryCertificateInfos: null,
                             token: CancellationToken.None);
                     }
                 }


### PR DESCRIPTION
1. protocol change
  talk to server and fetch repo sign information from server
2. PackageReader API change.
 added API for reading repo sign information in PackageReader
3. PackageExtractor change,
Removed API which accepts package stream.

Passing package stream in different layers is bad for package sign, we are losing all information about where the stream comes from, is it already verified...etc. In this changes, we should always pass packageReader in different layers.

Tests are failed due to some test issues, I'm fixing them, please review product change for now.