### PR TITLE
Don't send projectinformation project count for project.json due to concurrency issues

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/VSTelemetryServiceUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/VSTelemetryServiceUtility.cs
@@ -100,9 +100,11 @@ namespace NuGet.PackageManagement.Telemetry
                     projectType = NuGetProjectType.XProjProjectJson;
                 }
 
-                // Get package count.
-                var installedPackages = await nuGetProject.GetInstalledPackagesAsync(CancellationToken.None);
-                var installedPackagesCount = installedPackages.Count();
+                // Get package count - don't attempt to get the project.json package count, because it fails on PCL project creation due to concurrency issue 
+                var installedPackagesCount =
+                    projectType == NuGetProjectType.UwpProjectJson ?
+                    0 :
+                    (await nuGetProject.GetInstalledPackagesAsync(CancellationToken.None)).Count();
 
                 return new ProjectTelemetryEvent(
                     NuGetVersion.Value,


### PR DESCRIPTION
## Bug
Fixes: Internal bug [570450](https://devdiv.visualstudio.com/DevDiv/NuGet/_workitems/edit/570450)
Regression: Yes  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 

Bug:
Create an Empty Solution. Add two Portable Class Librarys The Second Portable class Library created will result in a "Cannot create a file when that files already exists" error dialog.

More details from the bug itself.

I've narrowed down the [changeset ](https://github.com/NuGet/NuGet.Client/commit/98fd6e140c80c3932d6e857b456ee5120751ae46)where this problem started occuring.
This is a critical telemetry work though. 
 
There's a threading issue, which we're likely to attempt to solve later. 

Until then, we won't send data for the package count for PJ (not that important really). 
This was determined in an internal discussion

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  
Validation done: Manual, vendors.   
