### PR TITLE
Removed PC to PR migrator option from Project context menu

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -233,13 +233,13 @@ namespace NuGetVSExtension
             _mcs = await GetServiceAsync(typeof(IMenuCommandService)) as OleMenuCommandService;
             if (null != _mcs)
             {
-                // menu command for upgrading packages.config files to project.json - Project menu, Project context menu, References context menu
+                // menu command for upgrading packages.config files to PackageReference - References context menu
                 var upgradeNuGetProjectCommandID = new CommandID(GuidList.guidNuGetDialogCmdSet, PkgCmdIDList.cmdidUpgradeNuGetProject);
                 var upgradeNuGetProjectCommand = new OleMenuCommand(ExecuteUpgradeNuGetProjectCommandAsync, null,
                     BeforeQueryStatusForUpgradeNuGetProject, upgradeNuGetProjectCommandID);
                 _mcs.AddCommand(upgradeNuGetProjectCommand);
 
-                // menu command for upgrading packages.config files to project.json - packages.config context menu
+                // menu command for upgrading packages.config files to PackageReference - packages.config context menu
                 var upgradePackagesConfigCommandID = new CommandID(GuidList.guidNuGetDialogCmdSet, PkgCmdIDList.cmdidUpgradePackagesConfig);
                 var upgradePackagesConfigCommand = new OleMenuCommand(ExecuteUpgradeNuGetProjectCommandAsync, null,
                     BeforeQueryStatusForUpgradePackagesConfig, upgradePackagesConfigCommandID);

--- a/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
@@ -205,13 +205,7 @@
       <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_ITEM_OPEN"/>
     </CommandPlacement>
     <CommandPlacement guid="guidDialogCmdSet" id="cmdidUpgradeNuGetProject" priority="0xF101">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_ADD"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidDialogCmdSet" id="cmdidUpgradeNuGetProject" priority="0xF101">
       <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_REFROOT_ADD"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidDialogCmdSet" id="cmdidUpgradeNuGetProject" priority="0xF101">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_PROJ_OPTIONS"/>
     </CommandPlacement>
     <CommandPlacement guid="guidDialogCmdSet" id="cmdidRestorePackages" priority="0xF101">
       <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_SOLUTION_BUILD" />


### PR DESCRIPTION
This option will only be available on References context menu.

Fix part of https://github.com/NuGet/Home/issues/6530

@rrelyea 