### PR TITLE
Make NuGet.Credentials XPLAT, cleanup the dependency graph

### DIFF
--- a/src/NuGet.Clients/NuGet.Credentials/NuGet.Credentials.csproj
+++ b/src/NuGet.Clients/NuGet.Credentials/NuGet.Credentials.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <Shipping>true</Shipping>
     <PackProject>true</PackProject>
     <IncludeInVsix>true</IncludeInVsix>
@@ -22,7 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(NuGetCoreSrcDirectory)\NuGet.PackageManagement\NuGet.PackageManagement.csproj" />
+    <ProjectReference Include="$(NuGetCoreSrcDirectory)\NuGet.Protocol\NuGet.Protocol.csproj" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" Condition=" '$(TargetFramework)' == 'netstandard1.3'" />
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" Condition=" '$(TargetFramework)' == 'netstandard1.3'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Clients/NuGet.Credentials/PluginCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/PluginCredentialProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -182,13 +182,15 @@ namespace NuGet.Credentials
             {
                 FileName = Path,
                 Arguments = argumentString,
+#if IS_DESKTOP                
                 WindowStyle = ProcessWindowStyle.Hidden,
+                ErrorDialog = false,
+#endif
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 StandardOutputEncoding = Encoding.UTF8,
                 StandardErrorEncoding = Encoding.UTF8,
-                ErrorDialog = false
             };
 
             string stdOut = null;

--- a/src/NuGet.Clients/NuGet.Credentials/PluginException.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/PluginException.cs
@@ -17,12 +17,12 @@ namespace NuGet.Credentials
         public PluginException(string message) : base(message) { }
 
         public PluginException(string message, Exception inner) : base(message, inner) { }
-
+#if NET46
         protected PluginException(
           System.Runtime.Serialization.SerializationInfo info,
           System.Runtime.Serialization.StreamingContext context) : base(info, context)
         { }
-
+#endif
         public static PluginException Create(string path, Exception inner)
         {
             return new PluginException(

--- a/src/NuGet.Clients/NuGet.Credentials/PluginException.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/PluginException.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Credentials;
@@ -17,7 +17,7 @@ namespace NuGet.Credentials
         public PluginException(string message) : base(message) { }
 
         public PluginException(string message, Exception inner) : base(message, inner) { }
-#if NET46
+#if IS_DESKTOP
         protected PluginException(
           System.Runtime.Serialization.SerializationInfo info,
           System.Runtime.Serialization.StreamingContext context) : base(info, context)

--- a/src/NuGet.Clients/NuGet.Credentials/PluginUnexpectedStatusException.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/PluginUnexpectedStatusException.cs
@@ -19,12 +19,12 @@ namespace NuGet.Credentials
         public PluginUnexpectedStatusException(string message) : base(message) { }
 
         public PluginUnexpectedStatusException(string message, Exception inner) : base(message, inner) { }
-
+#if IS_DESKTOP
         protected PluginUnexpectedStatusException(
           SerializationInfo info,
           StreamingContext context) : base(info, context)
         { }
-
+#endif
         public static PluginException CreateUnexpectedStatusMessage(
             string path, PluginCredentialResponseExitCode status)
         {

--- a/src/NuGet.Clients/NuGet.Credentials/ProviderException.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/ProviderException.cs
@@ -20,11 +20,12 @@ namespace NuGet.Credentials
         public ProviderException(string message, Exception inner) : base(message, inner)
         {
         }
-
+#if IS_DESKTOP
         protected ProviderException(
             SerializationInfo info,
             StreamingContext context) : base(info, context)
         {
         }
+#endif
     }
 }

--- a/src/NuGet.Clients/NuGet.Credentials/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/Resources.Designer.cs
@@ -10,6 +10,7 @@
 
 namespace NuGet.Credentials {
     using System;
+    using System.Reflection;
     
     
     /// <summary>
@@ -19,7 +20,7 @@ namespace NuGet.Credentials {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -39,7 +40,7 @@ namespace NuGet.Credentials {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.Credentials.Resources", typeof(Resources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.Credentials.Resources", typeof(Resources).GetTypeInfo().Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
+++ b/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\NuGet.Frameworks\NuGet.Frameworks.csproj" />
     <ProjectReference Include="..\NuGet.ProjectModel\NuGet.ProjectModel.csproj" />
     <ProjectReference Include="..\NuGet.Configuration\NuGet.Configuration.csproj" />
     <ProjectReference Include="..\NuGet.DependencyResolver.Core\NuGet.DependencyResolver.Core.csproj" />

--- a/src/NuGet.Core/NuGet.LibraryModel/NuGet.LibraryModel.csproj
+++ b/src/NuGet.Core/NuGet.LibraryModel/NuGet.LibraryModel.csproj
@@ -21,7 +21,6 @@
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Common\NuGet.Common.csproj" />
     <ProjectReference Include="..\NuGet.Versioning\NuGet.Versioning.csproj" />
-    <ProjectReference Include="..\NuGet.Frameworks\NuGet.Frameworks.csproj" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets" />

--- a/src/NuGet.Core/NuGet.Packaging.Core/NuGet.Packaging.Core.csproj
+++ b/src/NuGet.Core/NuGet.Packaging.Core/NuGet.Packaging.Core.csproj
@@ -20,7 +20,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Frameworks\NuGet.Frameworks.csproj" />
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Versioning\NuGet.Versioning.csproj" />
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Common\NuGet.Common.csproj" />
   </ItemGroup>

--- a/src/NuGet.Core/NuGet.ProjectModel/NuGet.ProjectModel.csproj
+++ b/src/NuGet.Core/NuGet.ProjectModel/NuGet.ProjectModel.csproj
@@ -22,12 +22,7 @@
     <ProjectReference Include="..\NuGet.DependencyResolver.Core\NuGet.DependencyResolver.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
     <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
   </ItemGroup>

--- a/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
@@ -44,7 +44,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
@@ -53,7 +52,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
   </ItemGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -109,7 +109,7 @@ namespace NuGet.Test
 
                         configs.Add(config);
 
-                        CreateConfigJsonNet452(config);
+                        BasicConfigNet46(config);
 
                         var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
                             projectTargetFramework,
@@ -251,7 +251,7 @@ namespace NuGet.Test
 
                         configs.Add(config);
 
-                        CreateConfigJsonNet452(config);
+                        BasicConfigNet46(config);
 
                         var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
                             projectTargetFramework,
@@ -378,7 +378,7 @@ namespace NuGet.Test
                 var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
                 var token = CancellationToken.None;
 
-                CreateConfigJsonNet452(randomConfig);
+                BasicConfigNet46(randomConfig);
 
                 var projectTargetFramework = NuGetFramework.Parse("net452");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -483,7 +483,7 @@ namespace NuGet.Test
                 var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
                 var token = CancellationToken.None;
 
-                CreateConfigJsonNet452(randomConfig);
+                BasicConfigNet46(randomConfig);
 
                 var projectTargetFramework = NuGetFramework.Parse("net45");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -548,7 +548,7 @@ namespace NuGet.Test
                 var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
                 var token = CancellationToken.None;
 
-                CreateConfigJsonNet452(randomConfig);
+                BasicConfigNet46(randomConfig);
 
                 var projectTargetFramework = NuGetFramework.Parse("net45");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -615,7 +615,7 @@ namespace NuGet.Test
                 var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
                 var token = CancellationToken.None;
 
-                CreateConfigJsonNet452(randomConfig);
+                BasicConfigNet46(randomConfig);
 
                 var projectTargetFramework = NuGetFramework.Parse("net45");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -790,9 +790,9 @@ namespace NuGet.Test
                 var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
                 var token = CancellationToken.None;
 
-                CreateConfigJsonNet452(randomConfig);
+                BasicConfigNet46(randomConfig);
 
-                var projectTargetFramework = NuGetFramework.Parse("net45");
+                var projectTargetFramework = NuGetFramework.Parse("net46");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
                 var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
@@ -941,9 +941,9 @@ namespace NuGet.Test
                 var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
                 var token = CancellationToken.None;
 
-                CreateConfigJsonNet452(randomConfig);
+                BasicConfigNet46(randomConfig);
 
-                var projectTargetFramework = NuGetFramework.Parse("net45");
+                var projectTargetFramework = NuGetFramework.Parse("net46");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
                 var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
@@ -1035,9 +1035,9 @@ namespace NuGet.Test
                 var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
                 var token = CancellationToken.None;
 
-                CreateConfigJsonNet452(randomConfig);
+                BasicConfigNet46(randomConfig);
 
-                var projectTargetFramework = NuGetFramework.Parse("net45");
+                var projectTargetFramework = NuGetFramework.Parse("net46");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
                 var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
@@ -1529,7 +1529,7 @@ namespace NuGet.Test
                 var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
                 var token = CancellationToken.None;
 
-                CreateConfigJsonNet452(randomConfig);
+                BasicConfigNet46(randomConfig);
 
                 var projectTargetFramework = NuGetFramework.Parse("net452");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -1600,7 +1600,7 @@ namespace NuGet.Test
                 var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
                 var token = CancellationToken.None;
 
-                CreateConfigJsonNet452(randomConfig);
+                BasicConfigNet46(randomConfig);
 
                 var projectTargetFramework = NuGetFramework.Parse("net452");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -1639,7 +1639,7 @@ namespace NuGet.Test
                 var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
                 var token = CancellationToken.None;
 
-                CreateConfigJsonNet452(randomConfig);
+                BasicConfigNet46(randomConfig);
 
                 var projectTargetFramework = NuGetFramework.Parse("net452");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -1681,7 +1681,7 @@ namespace NuGet.Test
                 var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
                 var token = CancellationToken.None;
 
-                CreateConfigJsonNet452(randomConfig);
+                BasicConfigNet46(randomConfig);
 
                 var projectTargetFramework = NuGetFramework.Parse("net452");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -1735,7 +1735,7 @@ namespace NuGet.Test
 
                     var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
 
-                    CreateConfigJsonNet452(randomConfig);
+                    BasicConfigNet46(randomConfig);
 
                     var projectTargetFramework = NuGetFramework.Parse("net452");
                     var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
@@ -1796,22 +1796,22 @@ namespace NuGet.Test
             }
         }
 
-        private static void CreateConfigJsonNet452(string path)
+        private static void BasicConfigNet46(string path)
         {
             using (var writer = new StreamWriter(path))
             {
-                writer.Write(BasicConfigNet452.ToString());
+                writer.Write(BasicConfigNet460.ToString());
             }
         }
 
-        private static JObject BasicConfigNet452
+        private static JObject BasicConfigNet460
         {
             get
             {
                 var json = new JObject();
 
                 var frameworks = new JObject();
-                frameworks["net452"] = new JObject();
+                frameworks["net46"] = new JObject();
 
                 json["dependencies"] = new JObject();
 


### PR DESCRIPTION
## Bug
Fixes: 
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
As part of the cross-plat auth plugin work, we'd need NuGet.Credentials to be XPLAT. 
I've changed around a couple of dependencies.  NuGet.Credentials in reality needs only NuGet.Configuration, but I've made it depend on Nuget.Protocol, as that's where the Plugin code is. 

I've also cleaned up a bunch of the redundant dependencies.
Extra dependencies to NuGet.Frameworks and newtonsoft.json.

I will comment on each one, why each change is made here in the PR.

I want to do this change early, because it's isolated. It'll also make it easier to review other PRs with the needless fluff from 10 extra files. 

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  
Validation done:  
Built. Existing tests are the only thing that need to work.