### PR TITLE
Initialize RepositoryUrl and RepositoryCommit properties from source control info

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -192,7 +192,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
   </Target>
 
-  <Target Name="GenerateNuspec" DependsOnTargets="$(GenerateNuspecDependsOn);_CalculateInputsOutputsForPack;_GetProjectReferenceVersions" Condition="$(IsPackable) == 'true'"
+  <Target Name="GenerateNuspec" DependsOnTargets="$(GenerateNuspecDependsOn);_CalculateInputsOutputsForPack;_GetProjectReferenceVersions;_InitializeNuspecRepositoryInformationProperties" Condition="$(IsPackable) == 'true'"
           Inputs="@(NuGetPackInput)" Outputs="@(NuGetPackOutput)">
     <!-- Call Pack -->
     <PackTask PackItem="$(PackProjectInputFile)"
@@ -244,6 +244,19 @@ Copyright (c) .NET Foundation. All rights reserved.
               NoWarn="$(NoWarn)"
               WarningsAsErrors="$(WarningsAsErrors)"
               TreatWarningsAsErrors="$(TreatWarningsAsErrors)"/>
+  </Target>
+
+  <!--
+    Initialize Repository* properties from properties set by a source control package, if available in the project.
+  -->
+  <Target Name="_InitializeNuspecRepositoryInformationProperties"
+          DependsOnTargets="InitializeSourceControlInformation"
+          Condition="'$(SourceControlInformationFeatureSupported)' == 'true'">
+    <PropertyGroup>
+      <!-- The project must specify PublishRepositoryUrl=true in order to publish the URL, in order to prevent inadvertent leak of internal URL. -->
+      <RepositoryUrl Condition="'$(RepositoryUrl)' == '' and '$(PublishRepositoryUrl)' == 'true'">$(PrivateRepositoryUrl)</RepositoryUrl>
+      <RepositoryCommit Condition="'$(RepositoryCommit)' == ''">$(SourceRevisionId)</RepositoryCommit>
+    </PropertyGroup>
   </Target>
 
   <!--

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -2316,7 +2316,7 @@ namespace ClassLibrary
         }
 
         [PlatformFact(Platform.Windows)]
-        public void PackCommand_PackWithSourceControlInformationVerifyNuspec()
+        public void PackCommand_PackWithSourceControlInformation_Unsupported_VerifyNuspec()
         {
             using (var testDirectory = TestDirectory.Create())
             {
@@ -2332,15 +2332,73 @@ namespace ClassLibrary
                     var xml = XDocument.Load(stream);
                     var ns = xml.Root.Name.Namespace;
 
+                    ProjectFileUtils.AddProperty(xml, "RepositoryType", "git");
+
                     // mock implementation of InitializeSourceControlInformation common targets:
-                    xml.Add(
+                    xml.Root.Add(
                         new XElement(ns + "Target",
                             new XAttribute("Name", "InitializeSourceControlInformation"),
                             new XElement(ns + "PropertyGroup",
-                                new XElement("SourceRevisionId", "e1c65e4524cd70ee6e22abe33e6cb6ec73938cb3"),
+                                new XElement("SourceRevisionId", "e1c65e4524cd70ee6e22abe33e6cb6ec73938cb1"),
                                 new XElement("PrivateRepositoryUrl", "https://github.com/NuGet/NuGet.Client.git"))));
 
-                    xml.Add(
+                    xml.Root.Add(
+                        new XElement(ns + "PropertyGroup",
+                            new XElement("SourceControlInformationFeatureSupported", "false")));
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory}");
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var nuspecReader = nupkgReader.NuspecReader;
+
+                    // Validate the output .nuspec.
+                    var repositoryMetadata = nuspecReader.GetRepositoryMetadata();
+                    repositoryMetadata.Type.Should().Be("git");
+                    repositoryMetadata.Url.Should().Be("");
+                    repositoryMetadata.Branch.Should().Be("");
+                    repositoryMetadata.Commit.Should().Be("");
+                }
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void PackCommand_PackWithSourceControlInformation_PrivateUrl_VerifyNuspec()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                // Act
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    var ns = xml.Root.Name.Namespace;
+
+                    ProjectFileUtils.AddProperty(xml, "RepositoryType", "git");
+
+                    // mock implementation of InitializeSourceControlInformation common targets:
+                    xml.Root.Add(
+                        new XElement(ns + "Target",
+                            new XAttribute("Name", "InitializeSourceControlInformation"),
+                            new XElement(ns + "PropertyGroup",
+                                new XElement("SourceRevisionId", "e1c65e4524cd70ee6e22abe33e6cb6ec73938cb1"),
+                                new XElement("PrivateRepositoryUrl", "https://github.com/NuGet/NuGet.Client.git"))));
+
+                    xml.Root.Add(
                         new XElement(ns + "PropertyGroup",
                             new XElement("SourceControlInformationFeatureSupported", "true")));
 
@@ -2360,10 +2418,127 @@ namespace ClassLibrary
                     var nuspecReader = nupkgReader.NuspecReader;
 
                     // Validate the output .nuspec.
-                    nuspecReader.GetRepositoryMetadata().Type.Should().Be("");
-                    nuspecReader.GetRepositoryMetadata().Url.Should().Be("https://github.com/NuGet/NuGet.Client.git");
-                    nuspecReader.GetRepositoryMetadata().Branch.Should().Be("");
-                    nuspecReader.GetRepositoryMetadata().Commit.Should().Be("e1c65e4524cd70ee6e22abe33e6cb6ec73938cb3");
+                    var repositoryMetadata = nuspecReader.GetRepositoryMetadata();
+                    repositoryMetadata.Type.Should().Be("git");
+                    repositoryMetadata.Url.Should().Be("");
+                    repositoryMetadata.Branch.Should().Be("");
+                    repositoryMetadata.Commit.Should().Be("e1c65e4524cd70ee6e22abe33e6cb6ec73938cb1");
+                }
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void PackCommand_PackWithSourceControlInformation_PublishedUrl_VerifyNuspec()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                // Act
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    var ns = xml.Root.Name.Namespace;
+
+                    ProjectFileUtils.AddProperty(xml, "RepositoryType", "git");
+                    ProjectFileUtils.AddProperty(xml, "PublishRepositoryUrl", "true");
+
+                    // mock implementation of InitializeSourceControlInformation common targets:
+                    xml.Root.Add(
+                        new XElement(ns + "Target",
+                            new XAttribute("Name", "InitializeSourceControlInformation"),
+                            new XElement(ns + "PropertyGroup",
+                                new XElement("SourceRevisionId", "e1c65e4524cd70ee6e22abe33e6cb6ec73938cb1"),
+                                new XElement("PrivateRepositoryUrl", "https://github.com/NuGet/NuGet.Client.git"))));
+
+                    xml.Root.Add(
+                        new XElement(ns + "PropertyGroup",
+                            new XElement("SourceControlInformationFeatureSupported", "true")));
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory}");
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var nuspecReader = nupkgReader.NuspecReader;
+
+                    // Validate the output .nuspec.
+                    var repositoryMetadata = nuspecReader.GetRepositoryMetadata();
+                    repositoryMetadata.Type.Should().Be("git");
+                    repositoryMetadata.Url.Should().Be("https://github.com/NuGet/NuGet.Client.git");
+                    repositoryMetadata.Branch.Should().Be("");
+                    repositoryMetadata.Commit.Should().Be("e1c65e4524cd70ee6e22abe33e6cb6ec73938cb1");
+                }
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void PackCommand_PackWithSourceControlInformation_ProjectOverride_VerifyNuspec()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                // Act
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    var ns = xml.Root.Name.Namespace;
+
+                    ProjectFileUtils.AddProperty(xml, "RepositoryType", "git");
+                    ProjectFileUtils.AddProperty(xml, "PublishRepositoryUrl", "true");
+                    ProjectFileUtils.AddProperty(xml, "RepositoryCommit", "1111111111111111111111111111111111111111");
+                    ProjectFileUtils.AddProperty(xml, "RepositoryUrl", "https://github.com/Overridden");
+
+                    // mock implementation of InitializeSourceControlInformation common targets:
+                    xml.Root.Add(
+                        new XElement(ns + "Target",
+                            new XAttribute("Name", "InitializeSourceControlInformation"),
+                            new XElement(ns + "PropertyGroup",
+                                new XElement("SourceRevisionId", "e1c65e4524cd70ee6e22abe33e6cb6ec73938cb1"),
+                                new XElement("PrivateRepositoryUrl", "https://github.com/NuGet/NuGet.Client"))));
+
+                    xml.Root.Add(
+                        new XElement(ns + "PropertyGroup",
+                            new XElement("SourceControlInformationFeatureSupported", "true")));
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory}");
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var nuspecReader = nupkgReader.NuspecReader;
+
+                    // Validate the output .nuspec.
+                    var repositoryMetadata = nuspecReader.GetRepositoryMetadata();
+                    repositoryMetadata.Type.Should().Be("git");
+                    repositoryMetadata.Url.Should().Be("https://github.com/Overridden");
+                    repositoryMetadata.Branch.Should().Be("");
+                    repositoryMetadata.Commit.Should().Be("1111111111111111111111111111111111111111");
                 }
             }
         }


### PR DESCRIPTION
Initialize `RepositoryUrl` and `RepositoryCommit` properties from values set by source control provider package referenced by the project.
See https://github.com/tmat/repository-info/tree/master/docs for details.

The added initialization target depends on `InitializeSourceControlInformation` target, which is now defined in `Microsoft.Common.targets` like so:

```xml
  <!--
    Target that allows targets consuming source control confirmation to establish a dependency
    on the targets producing this information.
    Any target that reads SourceRevisionId, PrivateRepositoryUrl, and other source control related
    properties and items should depend on this target.
    Source control information provider that sets these properties and items shall execute before
    this target (by including InitializeSourceControlInformation in its BeforeTargets) and set
    source control properties and items that haven't been initialized yet.
  -->
  <Target Name="InitializeSourceControlInformation" />
```
