### PR TITLE
Fixed permission issue with multiple users using dotnet restore on linux

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpCacheUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpCacheUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -9,6 +9,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 
 namespace NuGet.Protocol
@@ -110,7 +111,7 @@ namespace NuGet.Protocol
             var cacheFileDirectory = Path.GetDirectoryName(result.CacheFile);
 
             // Make sure the new cache file directory is created before writing a file to it.
-            Directory.CreateDirectory(newCacheFileDirectory);
+            DirectoryUtility.CreateSharedDirectory(newCacheFileDirectory);
 
             // The update of a cached file is divided into two steps:
             // 1) Delete the old file.
@@ -147,7 +148,7 @@ namespace NuGet.Protocol
             // Make sure the cache file directory is created before moving or writing a file to it.
             if (cacheFileDirectory != newCacheFileDirectory)
             {
-                Directory.CreateDirectory(cacheFileDirectory);
+                DirectoryUtility.CreateSharedDirectory(cacheFileDirectory);
             }
 
             // If the destination file doesn't exist, we can safely perform moving operation.

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpSourceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;


### PR DESCRIPTION
Fixed permission issue with multiple users using dotnet restore on linux.

Fixes https://github.com/NuGet/Home/issues/6647

@rrelyea 