### PR TITLE
add migrator validation

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -214,7 +214,7 @@ namespace NuGet.CommandLine
 
             if (!string.IsNullOrEmpty(TargetPath))
             {
-                Logger.Log(PackLogMessage.CreateMessage(string.Format(
+                Logger.Log(PackagingLogMessage.CreateMessage(string.Format(
                         CultureInfo.CurrentCulture,
                         LocalizedResourceManager.GetString("PackagingFilesFromOutputPath"),
                         Path.GetFullPath(Path.GetDirectoryName(TargetPath))), LogLevel.Minimal));
@@ -228,17 +228,17 @@ namespace NuGet.CommandLine
             }
             catch (Exception ex)
             {
-                Logger.Log(PackLogMessage.CreateError(string.Format(
+                Logger.Log(PackagingLogMessage.CreateError(string.Format(
                         CultureInfo.CurrentCulture,
                         LocalizedResourceManager.GetString("UnableToExtractAssemblyMetadata"),
                         Path.GetFileName(TargetPath)), NuGetLogCode.NU5011));
                 if (LogLevel == LogLevel.Verbose)
                 {
-                    Logger.Log(PackLogMessage.CreateError(ex.ToString(), NuGetLogCode.NU5011));
+                    Logger.Log(PackagingLogMessage.CreateError(ex.ToString(), NuGetLogCode.NU5011));
                 }
                 else
                 {
-                    Logger.Log(PackLogMessage.CreateError(ex.Message, NuGetLogCode.NU5011));
+                    Logger.Log(PackagingLogMessage.CreateError(ex.Message, NuGetLogCode.NU5011));
                 }
 
                 return null;
@@ -311,7 +311,7 @@ namespace NuGet.CommandLine
             if (String.IsNullOrEmpty(builder.Description))
             {
                 builder.Description = "Description";
-                Logger.Log(PackLogMessage.CreateWarning(string.Format(
+                Logger.Log(PackagingLogMessage.CreateWarning(string.Format(
                         CultureInfo.CurrentCulture,
                         LocalizedResourceManager.GetString("Warning_UnspecifiedField"),
                         "Description",
@@ -321,7 +321,7 @@ namespace NuGet.CommandLine
             if (!builder.Authors.Any())
             {
                 builder.Authors.Add(Environment.UserName);
-                Logger.Log(PackLogMessage.CreateWarning(string.Format(
+                Logger.Log(PackagingLogMessage.CreateWarning(string.Format(
                         CultureInfo.CurrentCulture,
                         LocalizedResourceManager.GetString("Warning_UnspecifiedField"),
                         "Author",
@@ -399,7 +399,7 @@ namespace NuGet.CommandLine
             {
                 if (TargetFramework != null)
                 {
-                    Logger.Log(PackLogMessage.CreateMessage(string.Format(
+                    Logger.Log(PackagingLogMessage.CreateMessage(string.Format(
                             CultureInfo.CurrentCulture,
                             LocalizedResourceManager.GetString("BuildingProjectTargetingFramework"),
                             _project.FullPath,
@@ -979,7 +979,7 @@ namespace NuGet.CommandLine
             {
                 return;
             }
-            Logger.Log(PackLogMessage.CreateMessage(LocalizedResourceManager.GetString("UsingPackagesConfigForDependencies"), LogLevel.Minimal));
+            Logger.Log(PackagingLogMessage.CreateMessage(LocalizedResourceManager.GetString("UsingPackagesConfigForDependencies"), LogLevel.Minimal));
 
             var references = packagesProject.GetInstalledPackagesAsync(CancellationToken.None).Result;
 
@@ -1137,7 +1137,7 @@ namespace NuGet.CommandLine
             {
                 if (ProjectProperties.ContainsKey("SolutionDir"))
                 {
-                    Logger.Log(PackLogMessage.CreateWarning(string.Format(
+                    Logger.Log(PackagingLogMessage.CreateWarning(string.Format(
                             CultureInfo.CurrentCulture,
                             LocalizedResourceManager.GetString("Warning_DuplicatePropertyKey"),
                             "SolutionDir"), NuGetLogCode.NU5114));
@@ -1161,7 +1161,7 @@ namespace NuGet.CommandLine
                 return null;
             }
 
-            Logger.Log(PackLogMessage.CreateMessage(string.Format(
+            Logger.Log(PackagingLogMessage.CreateMessage(string.Format(
                     CultureInfo.CurrentCulture,
                     LocalizedResourceManager.GetString("UsingNuspecForMetadata"),
                     Path.GetFileName(nuspecFile)), LogLevel.Minimal));
@@ -1243,7 +1243,7 @@ namespace NuGet.CommandLine
 
                 if (!File.Exists(fullPath))
                 {
-                    Logger.Log(PackLogMessage.CreateWarning(string.Format(
+                    Logger.Log(PackagingLogMessage.CreateWarning(string.Format(
                             CultureInfo.CurrentCulture,
                             LocalizedResourceManager.GetString("Warning_FileDoesNotExist"),
                             targetFilePath), NuGetLogCode.NU5116));
@@ -1254,7 +1254,7 @@ namespace NuGet.CommandLine
                 // These are show up in shared files found in universal apps.
                 if (targetFilePath.IndexOf("$(MSBuild", StringComparison.OrdinalIgnoreCase) > -1)
                 {
-                    Logger.Log(PackLogMessage.CreateWarning(string.Format(
+                    Logger.Log(PackagingLogMessage.CreateWarning(string.Format(
                             CultureInfo.CurrentCulture,
                             LocalizedResourceManager.GetString("Warning_UnresolvedFilePath"),
                             targetFilePath), NuGetLogCode.NU5117));
@@ -1275,14 +1275,14 @@ namespace NuGet.CommandLine
                     var isEqual = ContentEquals(targetFile, fullPath);
                     if (isEqual)
                     {
-                        Logger.Log(PackLogMessage.CreateMessage(string.Format(
+                        Logger.Log(PackagingLogMessage.CreateMessage(string.Format(
                                 CultureInfo.CurrentCulture,
                                 LocalizedResourceManager.GetString("PackageCommandFileFromDependencyIsNotChanged"),
                                 targetFilePath), LogLevel.Minimal));
                         continue;
                     }
 
-                    Logger.Log(PackLogMessage.CreateMessage(string.Format(
+                    Logger.Log(PackagingLogMessage.CreateMessage(string.Format(
                             CultureInfo.CurrentCulture,
                             LocalizedResourceManager.GetString("PackageCommandFileFromDependencyIsChanged"),
                             targetFilePath), LogLevel.Minimal));
@@ -1306,7 +1306,7 @@ namespace NuGet.CommandLine
             }
             else
             {
-                Logger.Log(PackLogMessage.CreateWarning(string.Format(
+                Logger.Log(PackagingLogMessage.CreateWarning(string.Format(
                         CultureInfo.CurrentCulture,
                         LocalizedResourceManager.GetString("FileNotAddedToPackage"),
                         packageFile.SourcePath,
@@ -1318,7 +1318,7 @@ namespace NuGet.CommandLine
         {
             if (LogLevel == LogLevel.Verbose)
             {
-                Logger.Log(PackLogMessage.CreateMessage(string.Format(format, args), LogLevel.Verbose));
+                Logger.Log(PackagingLogMessage.CreateMessage(string.Format(format, args), LogLevel.Verbose));
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UpgradeLogger.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UpgradeLogger.cs
@@ -114,7 +114,7 @@ namespace NuGet.PackageManagement.UI
             _propertiesElement.AppendChild(propertyElement);
         }
 
-        internal void RegisterPackage(string projectName, string name, string version, IList<PackLogMessage> issues, bool included)
+        internal void RegisterPackage(string projectName, string name, string version, IList<PackagingLogMessage> issues, bool included)
         {
             var packageElement = _xmlDocument.CreateElement(PackageString);
             packageElement.SetAttribute(NameString, name);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/NuGetProjectUpgradeDependencyItem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/NuGetProjectUpgradeDependencyItem.cs
@@ -17,7 +17,7 @@ namespace NuGet.PackageManagement.UI
         public PackageIdentity Package { get; }
         public IList<PackageIdentity> DependingPackages { get; }
 
-        public IList<PackLogMessage> Issues { get; }
+        public IList<PackagingLogMessage> Issues { get; }
 
         public string Id { get; }
 
@@ -49,7 +49,7 @@ namespace NuGet.PackageManagement.UI
             Id = package.Id;
             Version = package.Version.ToNormalizedString();
             DependingPackages = dependingPackages ?? new List<PackageIdentity>();
-            Issues = new List<PackLogMessage>();
+            Issues = new List<PackagingLogMessage>();
         }
 
         public override string ToString()

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/NuGetProjectUpgradeWindowModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/NuGetProjectUpgradeWindowModel.cs
@@ -109,7 +109,7 @@ namespace NuGet.PackageManagement.UI
                 HasIssues = true;
                 HasNotFoundPackages = true;
                 _notFoundPackages.Add(packageIdentity);
-                package.Issues.Add(PackLogMessage.CreateWarning(
+                package.Issues.Add(PackagingLogMessage.CreateWarning(
                     string.Format(CultureInfo.CurrentCulture, Resources.Upgrader_PackageNotFound, packageIdentity.Id),
                     NuGetLogCode.NU5500));
             }
@@ -117,8 +117,7 @@ namespace NuGet.PackageManagement.UI
             {
                 using (var reader = new PackageArchiveReader(packagePath))
                 {
-                    // TODO: Create the right set of rules here.
-                    var packageRules = PackageCreationRuleSet.Rules;
+                    var packageRules = RuleSet.PackagesConfigToPackageReferenceMigrationRuleSet;
                     var issues = package.Issues;
 
                     foreach (var rule in packageRules)

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -75,7 +75,7 @@ namespace NuGet.Commands
         {
             this._createProjectFactory = createProjectFactory;
             this._packArgs = packArgs;
-            Rules = PackageCreationRuleSet.Rules;
+            Rules = RuleSet.PackageCreationRuleSet;
             GenerateNugetPackage = true;
         }
 
@@ -128,12 +128,12 @@ namespace NuGet.Commands
 
             if (_packArgs.InstallPackageToOutputPath)
             {
-                _packArgs.Logger.Log(PackLogMessage.CreateMessage(string.Format(CultureInfo.CurrentCulture, Strings.Log_PackageCommandInstallPackageToOutputPath, "Package", outputPath), LogLevel.Minimal));
+                _packArgs.Logger.Log(PackagingLogMessage.CreateMessage(string.Format(CultureInfo.CurrentCulture, Strings.Log_PackageCommandInstallPackageToOutputPath, "Package", outputPath), LogLevel.Minimal));
                 WriteResolvedNuSpecToPackageOutputDirectory(builder);
                 WriteSHA512PackageHash(builder);
             }
 
-            _packArgs.Logger.Log(PackLogMessage.CreateMessage(String.Format(CultureInfo.CurrentCulture, Strings.Log_PackageCommandSuccess, outputPath), LogLevel.Minimal));
+            _packArgs.Logger.Log(PackagingLogMessage.CreateMessage(String.Format(CultureInfo.CurrentCulture, Strings.Log_PackageCommandSuccess, outputPath), LogLevel.Minimal));
             return new PackageArchiveReader(outputPath);
         }
 
@@ -150,7 +150,7 @@ namespace NuGet.Commands
                 Path.GetDirectoryName(outputPath), 
                 new VersionFolderPathResolver(outputPath).GetManifestFileName(builder.Id, builder.Version));
 
-            _packArgs.Logger.Log(PackLogMessage.CreateMessage(string.Format(CultureInfo.CurrentCulture, Strings.Log_PackageCommandInstallPackageToOutputPath, "NuSpec", resolvedNuSpecOutputPath), LogLevel.Minimal));
+            _packArgs.Logger.Log(PackagingLogMessage.CreateMessage(string.Format(CultureInfo.CurrentCulture, Strings.Log_PackageCommandInstallPackageToOutputPath, "NuSpec", resolvedNuSpecOutputPath), LogLevel.Minimal));
 
             if (string.Equals(_packArgs.Path, resolvedNuSpecOutputPath, StringComparison.OrdinalIgnoreCase))
             {
@@ -182,7 +182,7 @@ namespace NuGet.Commands
             // We must use the Path.GetTempPath() which NuGetFolderPath.Temp uses as a root because writing temp files to the package directory with a guid would break some build tools caching
             var tempOutputPath = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp), Path.GetFileName(sha512OutputPath));
 
-            _packArgs.Logger.Log(PackLogMessage.CreateMessage(string.Format(CultureInfo.CurrentCulture, Strings.Log_PackageCommandInstallPackageToOutputPath, "SHA512", sha512OutputPath), LogLevel.Minimal));
+            _packArgs.Logger.Log(PackagingLogMessage.CreateMessage(string.Format(CultureInfo.CurrentCulture, Strings.Log_PackageCommandInstallPackageToOutputPath, "SHA512", sha512OutputPath), LogLevel.Minimal));
 
             byte[] sha512hash;
             var cryptoHashProvider = new CryptoHashProvider("SHA512");
@@ -721,7 +721,7 @@ namespace NuGet.Commands
             {
                 if (factory.GetProjectProperties().ContainsKey(property.Key))
                 {
-                    _packArgs.Logger.Log(PackLogMessage.CreateWarning(
+                    _packArgs.Logger.Log(PackagingLogMessage.CreateWarning(
                         String.Format(CultureInfo.CurrentCulture, Strings.Warning_DuplicatePropertyKey, property.Key),
                         NuGetLogCode.NU5114));
                 }
@@ -870,7 +870,7 @@ namespace NuGet.Commands
                         if(file is PhysicalPackageFile)
                         {
                             var physicalPackageFile = file as PhysicalPackageFile;
-                            _packArgs.Logger.Log(PackLogMessage.CreateWarning(
+                            _packArgs.Logger.Log(PackagingLogMessage.CreateWarning(
                                 String.Format(CultureInfo.CurrentCulture, Strings.Warning_FileExcludedByDefault, physicalPackageFile.SourcePath),
                                 NuGetLogCode.NU5119));
 
@@ -946,12 +946,12 @@ namespace NuGet.Commands
         internal void AnalyzePackage(PackageArchiveReader package)
         {
             IEnumerable<IPackageRule> packageRules = Rules;
-            IList<PackLogMessage> issues = new List<PackLogMessage>();
+            IList<PackagingLogMessage> issues = new List<PackagingLogMessage>();
             NuGetVersion version;
 
             if (!NuGetVersion.TryParseStrict(package.GetIdentity().Version.ToString(), out version))
             {
-                issues.Add(PackLogMessage.CreateWarning(
+                issues.Add(PackagingLogMessage.CreateWarning(
                     String.Format(CultureInfo.CurrentCulture, Strings.Warning_SemanticVersion, package.GetIdentity().Version),
                     NuGetLogCode.NU5113));
             }
@@ -970,7 +970,7 @@ namespace NuGet.Commands
             }
         }
 
-        private void PrintPackageIssue(PackLogMessage issue)
+        private void PrintPackageIssue(PackagingLogMessage issue)
         {
             if (!String.IsNullOrEmpty(issue.Message))
             {
@@ -1131,7 +1131,7 @@ namespace NuGet.Commands
 
         private void WriteLine(string message, object arg = null)
         {
-            _packArgs.Logger.Log(PackLogMessage.CreateMessage(String.Format(CultureInfo.CurrentCulture, message, arg?.ToString()), LogLevel.Information));
+            _packArgs.Logger.Log(PackagingLogMessage.CreateMessage(String.Format(CultureInfo.CurrentCulture, message, arg?.ToString()), LogLevel.Information));
         }
 
         public static void AddLibraryDependency(LibraryDependency dependency, ISet<LibraryDependency> list)

--- a/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
@@ -156,7 +156,7 @@ namespace NuGet.Commands
             }
             else
             {
-                Logger.Log(PackLogMessage.CreateWarning(string.Format(
+                Logger.Log(PackagingLogMessage.CreateWarning(string.Format(
                         CultureInfo.CurrentCulture,
                         Strings.FileNotAddedToPackage,
                         packageFile.Source,

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -636,8 +636,24 @@ namespace NuGet.Common
         NU5119 = 5119,
 
         /// <summary>
+        /// Migrator_PackageHasInstallScript
+        /// </summary>
+        NU5120 = 5120,
+
+        /// <summary>
+        /// Migrator_PackageHasContentFolder
+        /// </summary>
+        NU5121 = 5121,
+
+        /// <summary>
+        /// Migrator_XdtTransformInPackage
+        /// </summary>
+        NU5122 = 5122,
+
+        /// <summary>
         /// Undefined package warning
         /// </summary>
-        NU5500 = 5500,
+        NU5500 = 5500
+
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/PackagingLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/PackagingLogMessage.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace NuGet.Common
 {
-    public class PackLogMessage : IPackLogMessage
+    public class PackagingLogMessage : IPackLogMessage
     {
         public LogLevel Level { get; set; }
         public NuGetLogCode Code { get; set; }
@@ -25,7 +25,7 @@ namespace NuGet.Common
         /// <param name="logLevel">The log level</param>
         /// <param name="logCode">The NuGet log code</param>
         /// <param name="message">The log message</param>
-        private PackLogMessage(LogLevel logLevel, NuGetLogCode logCode, string message)
+        private PackagingLogMessage(LogLevel logLevel, NuGetLogCode logCode, string message)
         {
             Level = logLevel;
             Code = logCode;
@@ -33,7 +33,7 @@ namespace NuGet.Common
             Time = DateTimeOffset.UtcNow;
         }
 
-        private PackLogMessage(LogLevel logLevel, string message)
+        private PackagingLogMessage(LogLevel logLevel, string message)
         {
             Message = message;
             Code = NuGetLogCode.Undefined;
@@ -46,19 +46,19 @@ namespace NuGet.Common
         /// </summary>
         /// <param name="code">The logging code</param>
         /// <param name="message">The log message</param>
-        public static PackLogMessage CreateError(string message, NuGetLogCode code)
+        public static PackagingLogMessage CreateError(string message, NuGetLogCode code)
         {
-            return new PackLogMessage(LogLevel.Error, code, message);
+            return new PackagingLogMessage(LogLevel.Error, code, message);
         }
 
-        public static PackLogMessage CreateWarning(string message, NuGetLogCode code)
+        public static PackagingLogMessage CreateWarning(string message, NuGetLogCode code)
         {
-            return new PackLogMessage(LogLevel.Warning, code, message);
+            return new PackagingLogMessage(LogLevel.Warning, code, message);
         }
 
-        public static PackLogMessage CreateMessage(string message, LogLevel logLevel)
+        public static PackagingLogMessage CreateMessage(string message, LogLevel logLevel)
         {
-            return new PackLogMessage(logLevel, message);
+            return new PackagingLogMessage(logLevel, message);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging.Core/PackagingException.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/PackagingException.cs
@@ -13,25 +13,25 @@ namespace NuGet.Packaging.Core
         public PackagingException(string message)
             : base(message)
         {
-            _logMessage = PackLogMessage.CreateError(message, NuGetLogCode.NU5000);
+            _logMessage = PackagingLogMessage.CreateError(message, NuGetLogCode.NU5000);
         }
 
         public PackagingException(NuGetLogCode logCode, string message)
             : base(message)
         {
-            _logMessage = PackLogMessage.CreateError(message, logCode);
+            _logMessage = PackagingLogMessage.CreateError(message, logCode);
         }
 
         public PackagingException(NuGetLogCode logCode, string message, Exception innerException)
             : base(message, innerException)
         {
-            _logMessage = PackLogMessage.CreateError(message, logCode);
+            _logMessage = PackagingLogMessage.CreateError(message, logCode);
         }
 
         public PackagingException(string message, Exception innerException)
             : base(message, innerException)
         {
-            _logMessage = PackLogMessage.CreateError(message, NuGetLogCode.NU5000);
+            _logMessage = PackagingLogMessage.CreateError(message, NuGetLogCode.NU5000);
         }
 
         public virtual ILogMessage AsLogMessage()

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
@@ -116,6 +116,42 @@ namespace NuGet.Packaging.Rules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The assembly &apos;{0}&apos; is placed directly under the &apos;lib&apos; folder. This assembly won&apos;t be referenced by the project after migration..
+        /// </summary>
+        public static string Migrator_AssemblyDirectlyUnderLibWarning {
+            get {
+                return ResourceManager.GetString("Migrator_AssemblyDirectlyUnderLibWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The package &apos;{0}&apos; contains &apos;content&apos; folder which will not be copied to the project directory after migration. The package may not work as expected after migration..
+        /// </summary>
+        public static string Migrator_PackageHasContentFolder {
+            get {
+                return ResourceManager.GetString("Migrator_PackageHasContentFolder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The package &apos;{0}&apos; contains an install.ps1 script that will not be applied after migration..
+        /// </summary>
+        public static string Migrator_PackageHasInstallScript {
+            get {
+                return ResourceManager.GetString("Migrator_PackageHasInstallScript", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The package &apos;{0}&apos; contains an xdt transform which will not be applied to the project after migration..
+        /// </summary>
+        public static string Migrator_XdtTransformInPackage {
+            get {
+                return ResourceManager.GetString("Migrator_XdtTransformInPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The file &apos;{0}&apos; will be ignored by NuGet because it is not directly under &apos;tools&apos; folder. Place the file directly under &apos;tools&apos; folder..
         /// </summary>
         public static string MisplacedInitScriptWarning {

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
@@ -135,6 +135,18 @@
   <data name="LegacyVersionWarning" xml:space="preserve">
     <value>The package version '{0}' uses SemVer 2.0.0 or components of SemVer 1.0.0 that are not supported on legacy clients. Change the package version to a SemVer 1.0.0 string. If the version contains a release label it must start with a letter. This message can be ignored if the package is not intended for older clients.</value>
   </data>
+  <data name="Migrator_AssemblyDirectlyUnderLibWarning" xml:space="preserve">
+    <value>The assembly '{0}' is placed directly under the 'lib' folder. This assembly won't be referenced by the project after migration.</value>
+  </data>
+  <data name="Migrator_PackageHasContentFolder" xml:space="preserve">
+    <value>The package '{0}' contains 'content' folder which will not be copied to the project directory after migration. The package may not work as expected after migration.</value>
+  </data>
+  <data name="Migrator_PackageHasInstallScript" xml:space="preserve">
+    <value>The package '{0}' contains an install.ps1 script that will not be applied after migration.</value>
+  </data>
+  <data name="Migrator_XdtTransformInPackage" xml:space="preserve">
+    <value>The package '{0}' contains an xdt transform which will not be applied to the project after migration.</value>
+  </data>
   <data name="MisplacedInitScriptWarning" xml:space="preserve">
     <value>The file '{0}' will be ignored by NuGet because it is not directly under 'tools' folder. Place the file directly under 'tools' folder.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Packaging/Rules/ContentFolderInPackageReferenceProjectRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/ContentFolderInPackageReferenceProjectRule.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.Common;
+
+namespace NuGet.Packaging.Rules
+{
+    class ContentFolderInPackageReferenceProjectRule : IPackageRule
+    {
+        public string MessageFormat
+        {
+            get;
+        }
+
+        public ContentFolderInPackageReferenceProjectRule(string messageFormat)
+        {
+            MessageFormat = messageFormat;
+        }
+
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
+        {
+            if (builder.GetFiles()
+                .Select(t => PathUtility.GetPathWithDirectorySeparator(t))
+                .Any(t => t.StartsWith
+                    (PackagingConstants.Folders.Content + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)))
+            {
+                // if package has content folder but no contentFiles folder
+                if(!builder.GetFiles()
+                .Select(t => PathUtility.GetPathWithDirectorySeparator(t))
+                .Any(t => t.StartsWith
+                    (PackagingConstants.Folders.ContentFiles + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)))
+                {
+                    var issue = new List<PackagingLogMessage>();
+                    issue.Add(PackagingLogMessage.CreateWarning(
+                        string.Format(MessageFormat, builder.GetIdentity().Id), NuGetLogCode.NU5121));
+                    return issue;
+                }
+            }
+
+            return new List<PackagingLogMessage>();
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Rules/DefaultManifestValuesRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/DefaultManifestValuesRule.cs
@@ -28,7 +28,7 @@ namespace NuGet.Packaging.Rules
             MessageFormat = messageFormat;
         }
 
-        public IEnumerable<PackLogMessage> Validate(PackageArchiveReader builder)
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
         {
             if(builder == null)
             {
@@ -70,9 +70,9 @@ namespace NuGet.Packaging.Rules
             }
         }
 
-        private PackLogMessage CreateIssueFor(string field, string value)
+        private PackagingLogMessage CreateIssueFor(string field, string value)
         {
-            return PackLogMessage.CreateWarning(
+            return PackagingLogMessage.CreateWarning(
                 string.Format(CultureInfo.CurrentCulture, MessageFormat, value, field),
                 NuGetLogCode.NU5102);
         }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/IPackageRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/IPackageRule.cs
@@ -9,7 +9,7 @@ namespace NuGet.Packaging.Rules
 {
     public interface IPackageRule
     {
-        IEnumerable<PackLogMessage> Validate(PackageArchiveReader builder);
+        IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder);
         string MessageFormat { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/InitScriptNotUnderToolsRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/InitScriptNotUnderToolsRule.cs
@@ -17,7 +17,7 @@ namespace NuGet.Packaging.Rules
         {
             MessageFormat = messageFormat;
         }
-        public IEnumerable<PackLogMessage> Validate(PackageArchiveReader builder)
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
         {
             foreach (var file in builder.GetFiles())
             {
@@ -30,9 +30,9 @@ namespace NuGet.Packaging.Rules
             }
         }
 
-        private PackLogMessage CreatePackageIssue(string file)
+        private PackagingLogMessage CreatePackageIssue(string file)
         {
-            return PackLogMessage.CreateWarning(
+            return PackagingLogMessage.CreateWarning(
                 string.Format(CultureInfo.CurrentCulture, MessageFormat, file),
                 NuGetLogCode.NU5107);
         }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/InstallScriptInPackageReferenceProjectRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/InstallScriptInPackageReferenceProjectRule.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.Common;
+
+namespace NuGet.Packaging.Rules
+{
+    class InstallScriptInPackageReferenceProjectRule : IPackageRule
+    {
+        public string MessageFormat { get; }
+
+        public InstallScriptInPackageReferenceProjectRule(string messageFormat)
+        {
+            MessageFormat = messageFormat;
+        }
+
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
+        {
+            foreach (var toolItem in builder.GetFiles()
+                .Select(t => PathUtility.GetPathWithDirectorySeparator(t))
+                .Where(t =>
+                    t.StartsWith(PackagingConstants.Folders.Tools + Path.DirectorySeparatorChar,
+                    StringComparison.OrdinalIgnoreCase)))
+            {
+                if(toolItem.EndsWith("install.ps1", StringComparison.OrdinalIgnoreCase))
+                {
+                    var issue = new List<PackagingLogMessage>();
+                    issue.Add(PackagingLogMessage.CreateWarning(
+                        string.Format(MessageFormat, builder.GetIdentity().Id), NuGetLogCode.NU5120));
+                    return issue;
+                }
+            }
+
+            return new List<PackagingLogMessage>();
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Rules/InvalidFrameworkFolderRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/InvalidFrameworkFolderRule.cs
@@ -22,7 +22,7 @@ namespace NuGet.Packaging.Rules
             MessageFormat = messageFormat;
         }
 
-        public IEnumerable<PackLogMessage> Validate(PackageArchiveReader builder)
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
         {
             var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var file in builder.GetFiles().Select(t => PathUtility.GetPathWithDirectorySeparator(t)))
@@ -68,9 +68,9 @@ namespace NuGet.Packaging.Rules
             return name.Equals(nuspecReader.GetLanguage(), StringComparison.OrdinalIgnoreCase);
         }
 
-        private PackLogMessage CreatePackageIssue(string target)
+        private PackagingLogMessage CreatePackageIssue(string target)
         {
-            return PackLogMessage.CreateWarning(
+            return PackagingLogMessage.CreateWarning(
                 string.Format(CultureInfo.CurrentCulture, MessageFormat, target),
                 NuGetLogCode.NU5103);
         }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/InvalidPlaceholderFileRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/InvalidPlaceholderFileRule.cs
@@ -19,7 +19,7 @@ namespace NuGet.Packaging.Rules
         {
             MessageFormat = messageFormat;
         }
-        public IEnumerable<PackLogMessage> Validate(PackageArchiveReader builder)
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
         {
             foreach (var file in builder.GetFiles())
             {
@@ -34,9 +34,9 @@ namespace NuGet.Packaging.Rules
             }
         }
 
-        private PackLogMessage CreatePackageIssueForPlaceholderFile(string target)
+        private PackagingLogMessage CreatePackageIssueForPlaceholderFile(string target)
         {
-            return PackLogMessage.CreateWarning(
+            return PackagingLogMessage.CreateWarning(
                 String.Format(CultureInfo.CurrentCulture, MessageFormat, target),
                 NuGetLogCode.NU5109);
         }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/InvalidPrereleaseDependencyRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/InvalidPrereleaseDependencyRule.cs
@@ -18,7 +18,7 @@ namespace NuGet.Packaging.Rules
         {
             MessageFormat = messageFormat;
         }
-        public IEnumerable<PackLogMessage> Validate(PackageArchiveReader builder)
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
         {
             var nuspecReader = builder?.NuspecReader;
             if (nuspecReader.GetDependencyGroups() == null)
@@ -44,9 +44,9 @@ namespace NuGet.Packaging.Rules
                    dependency.VersionRange.MaxVersion?.IsPrerelease == true;
         }
 
-        private PackLogMessage CreatePackageIssueForPrereleaseDependency(string dependency)
+        private PackagingLogMessage CreatePackageIssueForPrereleaseDependency(string dependency)
         {
-            return PackLogMessage.CreateWarning(
+            return PackagingLogMessage.CreateWarning(
                 String.Format(CultureInfo.CurrentCulture, MessageFormat, dependency),
                 NuGetLogCode.NU5104);
         }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/LegacyVersionRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/LegacyVersionRule.cs
@@ -23,13 +23,13 @@ namespace NuGet.Packaging.Rules
         // NuGet 2.12 regex for version parsing.
         private const string LegacyRegex = @"^(?<Version>\d+(\s*\.\s*\d+){0,3})(?<Release>-[a-z][0-9a-z-]*)?$";
 
-        public IEnumerable<PackLogMessage> Validate(PackageArchiveReader builder)
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
         {
             var regex = new Regex(LegacyRegex, RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
             var nuspecReader = builder.NuspecReader;
             if (!regex.IsMatch(nuspecReader.GetVersion().ToFullString()))
             {
-                yield return PackLogMessage.CreateWarning(
+                yield return PackagingLogMessage.CreateWarning(
                     string.Format(CultureInfo.CurrentCulture, MessageFormat, nuspecReader.GetVersion().ToFullString()),
                     NuGetLogCode.NU5105);
             }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/MisplaceAssemblyOutsideLibRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/MisplaceAssemblyOutsideLibRule.cs
@@ -18,7 +18,7 @@ namespace NuGet.Packaging.Rules
         {
             MessageFormat = messageFormat;
         }
-        public IEnumerable<PackLogMessage> Validate(PackageArchiveReader builder)
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
         {
             foreach (var packageFile in builder.GetFiles())
             {
@@ -38,9 +38,9 @@ namespace NuGet.Packaging.Rules
             }
         }
 
-        private PackLogMessage CreatePackageIssueForAssembliesOutsideLib(string target)
+        private PackagingLogMessage CreatePackageIssueForAssembliesOutsideLib(string target)
         {
-            return PackLogMessage.CreateWarning(
+            return PackagingLogMessage.CreateWarning(
                 string.Format(CultureInfo.CurrentCulture, MessageFormat, target),
                 NuGetLogCode.NU5100);
         }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/MisplacedAssemblyUnderLibRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/MisplacedAssemblyUnderLibRule.cs
@@ -18,7 +18,7 @@ namespace NuGet.Packaging.Rules
         {
             MessageFormat = messageFormat;
         }
-        public IEnumerable<PackLogMessage> Validate(PackageArchiveReader builder)
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
         {
             foreach (var packageFile in builder.GetFiles())
             {
@@ -36,16 +36,16 @@ namespace NuGet.Packaging.Rules
             }
         }
 
-        private PackLogMessage CreatePackageIssueForAssembliesUnderLib(string target)
+        private PackagingLogMessage CreatePackageIssueForAssembliesUnderLib(string target)
         {
-            return PackLogMessage.CreateWarning(
+            return PackagingLogMessage.CreateWarning(
                 String.Format(CultureInfo.CurrentCulture, MessageFormat, target),
                 NuGetLogCode.NU5101);
         }
 
-        private static PackLogMessage CreatePackageIssueForAssembliesOutsideLib(string target)
+        private static PackagingLogMessage CreatePackageIssueForAssembliesOutsideLib(string target)
         {
-            return PackLogMessage.CreateWarning(
+            return PackagingLogMessage.CreateWarning(
                 String.Format(CultureInfo.CurrentCulture, AnalysisResources.AssemblyOutsideLibWarning, target),
                 NuGetLogCode.NU5100);
         }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/MisplacedScriptFileRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/MisplacedScriptFileRule.cs
@@ -22,7 +22,7 @@ namespace NuGet.Packaging.Rules
             MessageFormat = messageFormat;
         }
 
-        public IEnumerable<PackLogMessage> Validate(PackageArchiveReader builder)
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
         {
             foreach (var file in builder.GetFiles().Select(t => PathUtility.GetPathWithDirectorySeparator(t)))
             {
@@ -38,9 +38,9 @@ namespace NuGet.Packaging.Rules
             }
         }
 
-        private PackLogMessage CreatePackageIssueForMisplacedScript(string target)
+        private PackagingLogMessage CreatePackageIssueForMisplacedScript(string target)
         {
-            return PackLogMessage.CreateWarning(
+            return PackagingLogMessage.CreateWarning(
                 string.Format(CultureInfo.CurrentCulture, MessageFormat, target),
                 NuGetLogCode.NU5110);
         }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/RuleSet.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/RuleSet.cs
@@ -7,9 +7,9 @@ using System.Collections.ObjectModel;
 
 namespace NuGet.Packaging.Rules
 {
-    public static class PackageCreationRuleSet
+    public static class RuleSet
     {
-        private static readonly ReadOnlyCollection<IPackageRule> _rules = new ReadOnlyCollection<IPackageRule>(
+        private static readonly ReadOnlyCollection<IPackageRule> _packageCreationRules = new ReadOnlyCollection<IPackageRule>(
             new IPackageRule[] {
                 new InvalidFrameworkFolderRule(AnalysisResources.InvalidFrameworkWarning),
                 new MisplacedAssemblyUnderLibRule(AnalysisResources.AssemblyDirectlyUnderLibWarning),
@@ -27,11 +27,28 @@ namespace NuGet.Packaging.Rules
             }
         );
 
-        public static IEnumerable<IPackageRule> Rules
+        private static readonly ReadOnlyCollection<IPackageRule> _packagesConfigToPackageReferenceMigrationRuleSet = new ReadOnlyCollection<IPackageRule>(
+            new IPackageRule[] {
+                new MisplacedAssemblyUnderLibRule(AnalysisResources.Migrator_AssemblyDirectlyUnderLibWarning),
+                new InstallScriptInPackageReferenceProjectRule(AnalysisResources.Migrator_PackageHasInstallScript),
+                new ContentFolderInPackageReferenceProjectRule(AnalysisResources.Migrator_PackageHasContentFolder),
+                new XdtTransformInPackageReferenceProjectRule(AnalysisResources.Migrator_XdtTransformInPackage)
+            }
+        );
+
+        public static IEnumerable<IPackageRule> PackageCreationRuleSet
         {
             get
             {
-                return _rules;
+                return _packageCreationRules;
+            }
+        }
+
+        public static IEnumerable<IPackageRule> PackagesConfigToPackageReferenceMigrationRuleSet
+        {
+            get
+            {
+                return _packagesConfigToPackageReferenceMigrationRuleSet;
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/UnrecognizedScriptFileRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/UnrecognizedScriptFileRule.cs
@@ -22,7 +22,7 @@ namespace NuGet.Packaging.Rules
             MessageFormat = messageFormat;
         }
 
-        public IEnumerable<PackLogMessage> Validate(PackageArchiveReader builder)
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
         {
             foreach (var file in builder.GetFiles().Select(t => PathUtility.GetPathWithDirectorySeparator(t)))
             {
@@ -43,9 +43,9 @@ namespace NuGet.Packaging.Rules
             }
         }
 
-        private PackLogMessage CreatePackageIssueForUnrecognizedScripts(string target)
+        private PackagingLogMessage CreatePackageIssueForUnrecognizedScripts(string target)
         {
-            return PackLogMessage.CreateWarning(
+            return PackagingLogMessage.CreateWarning(
                 String.Format(CultureInfo.CurrentCulture, MessageFormat, target),
                 NuGetLogCode.NU5111);
         }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/UnspecifiedDependencyVersionRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/UnspecifiedDependencyVersionRule.cs
@@ -19,7 +19,7 @@ namespace NuGet.Packaging.Rules
             MessageFormat = messageFormat;
         }
 
-        public IEnumerable<PackLogMessage> Validate(PackageArchiveReader builder)
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
         {
             if (builder == null)
             {
@@ -31,7 +31,7 @@ namespace NuGet.Packaging.Rules
 
             if (dependency != null && dependency.VersionRange == VersionRange.All)
             {
-                var issue = PackLogMessage.CreateWarning(String.Format(
+                var issue = PackagingLogMessage.CreateWarning(String.Format(
                     CultureInfo.CurrentCulture,
                     AnalysisResources.UnspecifiedDependencyVersionWarning,
                     dependency.Id),
@@ -40,9 +40,9 @@ namespace NuGet.Packaging.Rules
             }
         }
 
-        private PackLogMessage CreateIssueFor(string field, string value)
+        private PackagingLogMessage CreateIssueFor(string field, string value)
         {
-            return PackLogMessage.CreateWarning(
+            return PackagingLogMessage.CreateWarning(
                 String.Format(CultureInfo.CurrentCulture, MessageFormat, value, field),
                 NuGetLogCode.NU5102);
         }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/WinRTNameIsObsoleteRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/WinRTNameIsObsoleteRule.cs
@@ -20,7 +20,7 @@ namespace NuGet.Packaging.Rules
         {
             MessageFormat = messageFormat;
         }
-        public IEnumerable<PackLogMessage> Validate(PackageArchiveReader builder)
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
         {
             foreach (var file in builder.GetFiles().Select(t => PathUtility.GetPathWithDirectorySeparator(t)))
             {
@@ -34,9 +34,9 @@ namespace NuGet.Packaging.Rules
             }
         }
 
-        private PackLogMessage CreateIssue(string file)
+        private PackagingLogMessage CreateIssue(string file)
         {
-            return PackLogMessage.CreateWarning(
+            return PackagingLogMessage.CreateWarning(
                 string.Format(CultureInfo.CurrentCulture, MessageFormat, file),
                 NuGetLogCode.NU5106);
         }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/XdtTransformsInPackageReferenceProjectRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/XdtTransformsInPackageReferenceProjectRule.cs
@@ -10,16 +10,15 @@ using NuGet.Common;
 
 namespace NuGet.Packaging.Rules
 {
-    internal class MisplacedTransformFileRule : IPackageRule
+    internal class XdtTransformInPackageReferenceProjectRule : IPackageRule
     {
-        private const string CodeTransformExtension = ".pp";
         private const string ConfigTransformExtension = ".transform";
         private const string ContentDirectory = "content";
         private const string ContentFilesDirectory = "contentFiles";
 
         public string MessageFormat { get; }
 
-        public MisplacedTransformFileRule(string messageFormat)
+        public XdtTransformInPackageReferenceProjectRule(string messageFormat)
         {
             MessageFormat = messageFormat;
         }
@@ -29,28 +28,27 @@ namespace NuGet.Packaging.Rules
             foreach (var file in builder.GetFiles().Select(t => PathUtility.GetPathWithDirectorySeparator(t)))
             {
                 // if not a .transform file, ignore
-                if (!file.EndsWith(CodeTransformExtension, StringComparison.OrdinalIgnoreCase) &&
-                    !file.EndsWith(ConfigTransformExtension, StringComparison.OrdinalIgnoreCase))
+                if (!file.EndsWith(ConfigTransformExtension, StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }
 
-                // if not inside 'content' folder, warn
-                if (!file.StartsWith(ContentDirectory + Path.DirectorySeparatorChar,
+                // if inside content or contentFiles folder then warn.
+                if (file.StartsWith(ContentDirectory + Path.DirectorySeparatorChar,
                     StringComparison.OrdinalIgnoreCase)
-                    && !file.StartsWith(ContentFilesDirectory + Path.DirectorySeparatorChar,
+                    || file.StartsWith(ContentFilesDirectory + Path.DirectorySeparatorChar,
                     StringComparison.OrdinalIgnoreCase))
                 {
-                    yield return CreatePackageIssueForMisplacedContent(file);
+                    yield return CreatePackageIssueForTransformFiles(file);
                 }
             }
         }
 
-        private PackagingLogMessage CreatePackageIssueForMisplacedContent(string path)
+        private PackagingLogMessage CreatePackageIssueForTransformFiles(string path)
         {
             return PackagingLogMessage.CreateWarning(
                 String.Format(CultureInfo.CurrentCulture, MessageFormat, path),
-                NuGetLogCode.NU5108);
+                NuGetLogCode.NU5122);
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/6632 

Adds the following 4 rules for validating packages during migration:


•	package contains a dll file at the root of the lib folder and not a TFM specific folder. For example - lib\foo.dll
•	package contains install.ps1
•	package contains xdt transforms
•	package contains content but no contentFiles
