### PR TITLE
Signing:  disable signed package verification under Mono on non-Windows platforms

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -264,14 +264,17 @@ namespace NuGet.Packaging
             var isSigned = false;
 
 #if IS_DESKTOP
-            using (var zip = new ZipArchive(ZipReadStream, ZipArchiveMode.Read, leaveOpen: true))
+            if (RuntimeEnvironmentHelper.IsWindows)
             {
-                var signatureEntry = zip.GetEntry(SigningSpecifications.SignaturePath);
-
-                if (signatureEntry != null &&
-                    string.Equals(signatureEntry.Name, SigningSpecifications.SignaturePath, StringComparison.Ordinal))
+                using (var zip = new ZipArchive(ZipReadStream, ZipArchiveMode.Read, leaveOpen: true))
                 {
-                    isSigned = true;
+                    var signatureEntry = zip.GetEntry(SigningSpecifications.SignaturePath);
+
+                    if (signatureEntry != null &&
+                        string.Equals(signatureEntry.Name, SigningSpecifications.SignaturePath, StringComparison.Ordinal))
+                    {
+                        isSigned = true;
+                    }
                 }
             }
 #endif

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetVerifyCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetVerifyCommandTest.cs
@@ -81,7 +81,7 @@ namespace NuGet.CommandLine.Test
                 {
                     Assert.True(_failureCode == result.ExitCode, result.AllOutput);
                     Assert.False(result.Success);
-                    Assert.Contains("The package signature is invalid or cannot be verified on this platform.", result.AllOutput);
+                    Assert.Contains("NU3004: The package is not signed.", result.AllOutput);
                 }
                 else
                 {


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/6652.

Disable verification of signed packages under Mono on non-Windows platforms until we know it should work.