### PR TITLE
Skipping Mono type check if current process is devenv

### DIFF
--- a/src/NuGet.Core/NuGet.Common/RuntimeEnvironmentHelper.cs
+++ b/src/NuGet.Core/NuGet.Common/RuntimeEnvironmentHelper.cs
@@ -2,13 +2,26 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace NuGet.Common
 {
     public static class RuntimeEnvironmentHelper
     {
+        private static readonly string[] VisualStudioProcesses = { "DEVENV"};
+
         private static Lazy<bool> _isMono = new Lazy<bool>(() => Type.GetType("Mono.Runtime") != null);
+
+        private static Lazy<bool> _isRunningInVisualStudio = new Lazy<bool>(() =>
+        {
+            var currentProcessName = Path.GetFileNameWithoutExtension(GetCurrentProcessFilePath());
+
+            return VisualStudioProcesses.Any(
+                process => process.Equals(currentProcessName, StringComparison.OrdinalIgnoreCase));
+        });
 
         [DllImport("libc")]
         static extern int uname(IntPtr buf);
@@ -36,7 +49,32 @@ namespace NuGet.Common
 
         public static bool IsMono
         {
-            get { return _isMono.Value; }
+            get
+            {
+                if (IsRunningInVisualStudio)
+                {
+                    // skip Mono type check if current process is Devenv
+                    return false;
+                }
+
+                return _isMono.Value;
+            }
+        }
+
+        public static bool IsRunningInVisualStudio
+        {
+            get
+            {
+                return _isRunningInVisualStudio.Value;
+            }
+        }
+
+        private static string GetCurrentProcessFilePath()
+        {
+            using (var process = Process.GetCurrentProcess())
+            {
+                return process.MainModule.FileName;
+            }
         }
 
         public static bool IsMacOSX


### PR DESCRIPTION
`VSTypeResolutionService` throws COM exception when checking for `Mono.Runtime` inside Visual Studio. Since Mono check is irrelevant inside VS so we'll now always return `false` for `isMono` when NuGet is running inside VS.

Fixes [568283](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/568283) 

@rrelyea 