### PR TITLE
Fix casing of System.Xml reference in NuGet.CommandLine.csproj

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -29,7 +29,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.XML" />
+    <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.VisualStudio.Setup.Configuration.Interop">
       <HintPath>$(SolutionPackagesFolder)Microsoft.VisualStudio.Setup.Configuration.Interop.1.1.142-preview4-29265\lib\net35\Microsoft.VisualStudio.Setup.Configuration.Interop.dll</HintPath>


### PR DESCRIPTION
Fixes build issues on case sensitive file system, like in https://github.com/NuGet/Home/issues/6604#issuecomment-372711971
