### PR TITLE
Fix adding separate fields for package id and versions in extraction telemetry

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Telemetry/PackageExtractionTelemetryEvent.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Telemetry/PackageExtractionTelemetryEvent.cs
@@ -19,6 +19,7 @@ namespace NuGet.Packaging
         public ExtractionSource ExtractionSource => (ExtractionSource)base[nameof(ExtractionSource)];
 
         public string PackageId => (string)base[nameof(PackageId)];
+        public string PackageVersion => (string)base[nameof(PackageVersion)];
 
         public PackageExtractionTelemetryEvent(
             PackageSaveMode packageSaveMode,
@@ -32,7 +33,8 @@ namespace NuGet.Packaging
                     { nameof(PackageSaveMode), packageSaveMode }
                 })
         {
-            AddPiiData(nameof(PackageId), packageId.ToString());
+            AddPiiData(nameof(PackageId), packageId.Id.ToLowerInvariant());
+            AddPiiData(nameof(PackageVersion), packageId.Version.ToNormalizedString().ToLowerInvariant());
         }
     }
 }


### PR DESCRIPTION
Currently package id and version are being logged as a single telemetry data point but since package id could also have numbers so it makes it difficult to separate both to understand. So logging package id and version as separate data points.

@rrelyea 