### PR TITLE
pass source to PackageExtractor and create RepoSignInfoProvider

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/OriginalCaseGlobalPackageFolder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/OriginalCaseGlobalPackageFolder.cs
@@ -84,11 +84,11 @@ namespace NuGet.Commands
                         continue;
                     }
 
-                    var localPackageFilePath = GetLocalPackageFilePath(remoteMatch);
+                    var localPackageSourceInfo = GetLocalPackageSourceInfo(remoteMatch);
                     var packageIdentity = new PackageIdentity(remoteMatch.Library.Name, remoteMatch.Library.Version);
                     IPackageDownloader packageDependency = null;
 
-                    if (string.IsNullOrEmpty(localPackageFilePath))
+                    if (string.IsNullOrEmpty(localPackageSourceInfo?.Package.ZipPath))
                     {
                         packageDependency = await remoteMatch.Provider.GetPackageDownloaderAsync(
                             packageIdentity,
@@ -99,7 +99,8 @@ namespace NuGet.Commands
                     else
                     {
                         packageDependency = new LocalPackageArchiveDownloader(
-                            localPackageFilePath,
+                            localPackageSourceInfo.Repository.RepositoryRoot,
+                            localPackageSourceInfo.Package.ZipPath,
                             packageIdentity,
                             _request.Log);
                     }
@@ -160,7 +161,7 @@ namespace NuGet.Commands
                 remoteMatch.Library.Version);
         }
 
-        private string GetLocalPackageFilePath(RemoteMatch remoteMatch)
+        private LocalPackageSourceInfo GetLocalPackageSourceInfo(RemoteMatch remoteMatch)
         {
             var library = remoteMatch.Library;
 
@@ -172,7 +173,7 @@ namespace NuGet.Commands
 
             if (localPackage != null && File.Exists(localPackage.Package.ZipPath))
             {
-                return localPackage.Package.ZipPath;
+                return localPackage;
             }
 
             return null;

--- a/src/NuGet.Core/NuGet.PackageManagement/PackagePreFetcherResult.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/PackagePreFetcherResult.cs
@@ -182,12 +182,13 @@ namespace NuGet.PackageManagement
             TelemetryActivity.EmitTelemetryEvent(telemetryEvent);
         }
 
-        private static DownloadResourceResult GetPackagesFolderResult(string nupkgPath)
+        private DownloadResourceResult GetPackagesFolderResult(string nupkgPath)
         {
             // Create a download result for the package that already exists
             return new DownloadResourceResult(
                 File.OpenRead(nupkgPath),
-                new PackageArchiveReader(nupkgPath))
+                new PackageArchiveReader(nupkgPath),
+                Source?.Source)
             { SignatureVerified = true };
         }
     }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/FolderNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/FolderNuGetProject.cs
@@ -181,6 +181,7 @@ namespace NuGet.ProjectManagement
                         {
                             addedPackageFilesList.AddRange(
                                 await PackageExtractor.ExtractPackageAsync(
+                                    downloadResourceResult.PackageSource,
                                     downloadResourceResult.PackageReader,
                                     PackagePathResolver,
                                     packageExtractionContext,
@@ -191,6 +192,7 @@ namespace NuGet.ProjectManagement
                         {
                             addedPackageFilesList.AddRange(
                                 await PackageExtractor.ExtractPackageAsync(
+                                    downloadResourceResult.PackageSource,
                                     downloadResourceResult.PackageReader,
                                     downloadResourceResult.PackageStream,
                                     PackagePathResolver,
@@ -203,6 +205,7 @@ namespace NuGet.ProjectManagement
                     {
                         addedPackageFilesList.AddRange(
                             await PackageExtractor.ExtractPackageAsync(
+                                downloadResourceResult.PackageSource,
                                 downloadResourceResult.PackageStream,
                                 PackagePathResolver,
                                 packageExtractionContext,

--- a/src/NuGet.Core/NuGet.Packaging/Definitions/IPackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Definitions/IPackageDownloader.cs
@@ -28,6 +28,8 @@ namespace NuGet.Packaging
 
         ISignedPackageReader SignedPackageReader { get; }
 
+        string Source { get; }
+
         /// <summary>
         /// Asynchronously copies a .nupkg to a target file path.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
@@ -64,9 +64,12 @@ namespace NuGet.Packaging
             }
         }
 
+        public string Source { get; }
+
         /// <summary>
         /// Initializes a new <see cref="LocalPackageArchiveDownloader" /> class.
         /// </summary>
+        /// <param name="source">A package source.</param>
         /// <param name="packageFilePath">A source package archive file path.</param>
         /// <param name="packageIdentity">A package identity.</param>
         /// <param name="logger">A logger.</param>
@@ -77,6 +80,7 @@ namespace NuGet.Packaging
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
         /// is either <c>null</c> or an empty string.</exception>
         public LocalPackageArchiveDownloader(
+            string source,
             string packageFilePath,
             PackageIdentity packageIdentity,
             ILogger logger)
@@ -104,6 +108,7 @@ namespace NuGet.Packaging
             _packageReader = new Lazy<PackageArchiveReader>(GetPackageReader);
             _sourceStream = new Lazy<FileStream>(GetSourceStream);
             _handleExceptionAsync = exception => Task.FromResult(false);
+            Source = source;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -17,6 +17,7 @@ namespace NuGet.Packaging
     public static class PackageExtractor
     {
         public static async Task<IEnumerable<string>> ExtractPackageAsync(
+            string source,
             Stream packageStream,
             PackagePathResolver packagePathResolver,
             PackageExtractionContext packageExtractionContext,
@@ -145,6 +146,7 @@ namespace NuGet.Packaging
         }
 
         public static async Task<IEnumerable<string>> ExtractPackageAsync(
+            string source,
             PackageReaderBase packageReader,
             Stream packageStream,
             PackagePathResolver packagePathResolver,
@@ -253,6 +255,7 @@ namespace NuGet.Packaging
         }
 
         public static async Task<IEnumerable<string>> ExtractPackageAsync(
+            string source,
             PackageReaderBase packageReader,
             PackagePathResolver packagePathResolver,
             PackageExtractionContext packageExtractionContext,
@@ -367,6 +370,7 @@ namespace NuGet.Packaging
         /// resulted in no copy operation.
         /// </returns>
         public static async Task<bool> InstallFromSourceAsync(
+            string source,
             PackageIdentity packageIdentity,
             Func<Stream, Task> copyToAsync,
             VersionFolderPathResolver versionFolderPathResolver,

--- a/src/NuGet.Core/NuGet.Packaging/Signing/RepositorySignatureInfo.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/RepositorySignatureInfo.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Packaging.Core;
+
+namespace NuGet.Packaging
+{
+    public class RepositorySignatureInfo
+    {
+        public bool AllRepositorySigned { get; }
+
+        public IEnumerable<IRepositoryCertificateInfo> RepositoryCertificateInfos { get; }
+
+        public RepositorySignatureInfo(bool allRepositorySigned, IEnumerable<IRepositoryCertificateInfo> repositoryCertificateInfos)
+        {
+            AllRepositorySigned = allRepositorySigned;
+            RepositoryCertificateInfos = repositoryCertificateInfos;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Signing/RepositorySignatureInfoProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/RepositorySignatureInfoProvider.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System;
+
+namespace NuGet.Packaging
+{
+    /// <summary>
+    /// RepositorySignatureInfoProvdier is a static cache for repository signature information for package source.
+    /// </summary>
+    public class RepositorySignatureInfoProvider
+    {
+        private ConcurrentDictionary<string, RepositorySignatureInfo> _dict = new ConcurrentDictionary<string, RepositorySignatureInfo>();
+
+        public static RepositorySignatureInfoProvider Instance { get; } = new RepositorySignatureInfoProvider();
+
+        private RepositorySignatureInfoProvider()
+        {
+        }
+
+        /// <summary>
+        /// Try to get repository signature information for the source.
+        /// </summary>
+        /// <param name="source"></param>
+        /// <returns>Null if can't find the repository signature information for the source.</returns>
+        public RepositorySignatureInfo TryGetRepositorySignatureInfo(string source)
+        {
+            RepositorySignatureInfo repositorySignatureInfo = null;
+
+            _dict.TryGetValue(source, out repositorySignatureInfo);
+
+            return repositorySignatureInfo;
+        }
+
+        /// <summary>
+        /// Add or update the repository signature information for the source.
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="repositorySignatureInfo"></param>
+        public void AddOrUpdateRepositorySignatureInfo(string source, RepositorySignatureInfo repositorySignatureInfo)
+        {
+            _dict[source] = repositorySignatureInfo ?? throw new ArgumentNullException(nameof(repositorySignatureInfo));
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/DownloadResourceResult.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DownloadResourceResult.cs
@@ -58,16 +58,6 @@ namespace NuGet.Protocol.Core.Types
         /// Initializes a new <see cref="DownloadResourceResult" /> class.
         /// </summary>
         /// <param name="stream">A package stream.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="stream" /> is <c>null</c>.</exception>
-        public DownloadResourceResult(Stream stream)
-            : this(stream, source: null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new <see cref="DownloadResourceResult" /> class.
-        /// </summary>
-        /// <param name="stream">A package stream.</param>
         /// <param name="packageReader">A package reader.</param>
         /// <param name="source">A package source.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="stream" /> is <c>null</c>.</exception>
@@ -75,17 +65,6 @@ namespace NuGet.Protocol.Core.Types
             : this(stream, source)
         {
             _packageReader = packageReader;
-        }
-
-        /// <summary>
-        /// Initializes a new <see cref="DownloadResourceResult" /> class.
-        /// </summary>
-        /// <param name="stream">A package stream.</param>
-        /// <param name="packageReader">A package reader.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="stream" /> is <c>null</c>.</exception>
-        public DownloadResourceResult(Stream stream, PackageReaderBase packageReader)
-            : this(stream, packageReader, source: null)
-        {
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
@@ -32,6 +32,8 @@ namespace NuGet.Protocol
         /// <summary>This API is intended only for testing purposes and should not be used in product code.</summary>
         public IHttpRetryHandler RetryHandler { get; set; } = new HttpRetryHandler();
 
+        public string PackageSource => _packageSource.Source;
+
         public HttpSource(
             PackageSource packageSource,
             Func<Task<HttpHandlerResource>> messageHandlerFactory,

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalDownloadResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalDownloadResource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -61,7 +61,7 @@ namespace NuGet.Protocol
             if (packageInfo != null)
             {
                 var stream = File.OpenRead(packageInfo.Path);
-                return Task.FromResult(new DownloadResourceResult(stream, packageInfo.GetReader()));
+                return Task.FromResult(new DownloadResourceResult(stream, packageInfo.GetReader(), _localResource.Root));
             }
             else
             {

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV2FindPackageByIdResource.cs
@@ -269,7 +269,7 @@ namespace NuGet.Protocol
 
             if (packageInfo != null)
             {
-                packageDownloader = new LocalPackageArchiveDownloader(packageInfo.Path, packageInfo.Identity, logger);
+                packageDownloader = new LocalPackageArchiveDownloader(_source, packageInfo.Path, packageInfo.Identity, logger);
             }
 
             return Task.FromResult(packageDownloader);

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV3FindPackageByIdResource.cs
@@ -295,7 +295,7 @@ namespace NuGet.Protocol
                 var packagePath = _resolver.GetPackageFilePath(packageIdentity.Id, matchedVersion);
                 var matchedPackageIdentity = new PackageIdentity(packageIdentity.Id, matchedVersion);
 
-                packageDependency = new LocalPackageArchiveDownloader(packagePath, matchedPackageIdentity, logger);
+                packageDependency = new LocalPackageArchiveDownloader(_source, packagePath, matchedPackageIdentity, logger);
             }
 
             return Task.FromResult(packageDependency);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageDownloader.cs
@@ -60,6 +60,8 @@ namespace NuGet.Protocol.Plugins
             }
         }
 
+        public string Source => _packageSourceRepository;
+
         /// <summary>
         /// Initializes a new <see cref="PluginPackageDownloader" /> class.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Protocol/Providers/DownloadResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/DownloadResourceV3Provider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -26,6 +26,10 @@ namespace NuGet.Protocol
             {
                 var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
                 var client = httpSourceResource.HttpSource;
+
+                // Repository signature information init
+                var repositorySignatureResource = await source.GetResourceAsync<RepositorySignatureResource>(token);
+                repositorySignatureResource?.UpdateRepositorySignatureInfo();
 
                 // If index.json contains a flat container resource use that to directly
                 // construct package download urls.

--- a/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
@@ -66,9 +66,12 @@ namespace NuGet.Protocol
             }
         }
 
+        public string Source { get; }
+
         /// <summary>
         /// Initializes a new <see cref="RemotePackageArchiveDownloader" /> class.
         /// </summary>
+        /// <param name="source">A package source.</param>
         /// <param name="resource">A <see cref="FindPackageByIdResource" /> resource.</param>
         /// <param name="packageIdentity">A package identity.</param>
         /// <param name="cacheContext">A source cache context.</param>
@@ -80,6 +83,7 @@ namespace NuGet.Protocol
         /// is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
         public RemotePackageArchiveDownloader(
+            string source,
             FindPackageByIdResource resource,
             PackageIdentity packageIdentity,
             SourceCacheContext cacheContext,
@@ -111,6 +115,7 @@ namespace NuGet.Protocol
             _logger = logger;
             _packageReader = new Lazy<PackageArchiveReader>(GetPackageReader);
             _handleExceptionAsync = exception => Task.FromResult(false);
+            Source = source;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
@@ -295,7 +295,7 @@ namespace NuGet.Protocol
             PackageInfo packageInfo;
             if (packageInfos.TryGetValue(packageIdentity.Version, out packageInfo))
             {
-                return new RemotePackageArchiveDownloader(this, packageInfo.Identity, cacheContext, logger);
+                return new RemotePackageArchiveDownloader(_httpSource.PackageSource, this, packageInfo.Identity, cacheContext, logger);
             }
 
             return null;

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -26,6 +26,10 @@ namespace NuGet.Protocol
             if (packageBaseAddress != null
                 && packageBaseAddress.Count > 0)
             {
+                //Repository signature information init
+                var repositorySignatureResource = await sourceRepository.GetResourceAsync<RepositorySignatureResource>(token);
+                repositorySignatureResource?.UpdateRepositorySignatureInfo();
+
                 var httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>(token);
 
                 resource = new HttpFileSystemBasedFindPackageByIdResource(

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -302,7 +302,7 @@ namespace NuGet.Protocol
                 return null;
             }
 
-            return new RemotePackageArchiveDownloader(this, packageInfo.Identity, cacheContext, logger);
+            return new RemotePackageArchiveDownloader(PackageSource.Source, this, packageInfo.Identity, cacheContext, logger);
         }
 
         private async Task<PackageInfo> GetPackageInfoAsync(

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
@@ -287,7 +287,7 @@ namespace NuGet.Protocol
                 return null;
             }
 
-            return new RemotePackageArchiveDownloader(this, packageInfo.Identity, cacheContext, logger);
+            return new RemotePackageArchiveDownloader(SourceRepository.PackageSource.Source, this, packageInfo.Identity, cacheContext, logger);
         }
 
         private async Task<RemoteSourceDependencyInfo> GetPackageInfoAsync(

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResourceProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -25,6 +25,9 @@ namespace NuGet.Protocol
 
             if (serviceIndexResource != null)
             {
+                //Repository signature information init
+                var repositorySignatureResource = await sourceRepository.GetResourceAsync<RepositorySignatureResource>(token);
+                repositorySignatureResource?.UpdateRepositorySignatureInfo();
                 var httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>(token);
 
                 resource = new RemoteV3FindPackageByIdResource(

--- a/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Newtonsoft.Json.Linq;
+using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 
@@ -12,6 +13,7 @@ namespace NuGet.Protocol
 {
     public class RepositorySignatureResource : INuGetResource
     {
+        public string Source { get; }
 
         public bool AllRepositorySigned { get; }
 
@@ -26,6 +28,7 @@ namespace NuGet.Protocol
 
             AllRepositorySigned = allRepositorySigned;
             RepositoryCertificateInfos = data.OfType<JObject>().Select(p => p.FromJToken<RepositoryCertificateInfo>());
+            Source = source.PackageSource.Source;
         }
 
         // Test only.
@@ -33,6 +36,12 @@ namespace NuGet.Protocol
         {
             AllRepositorySigned = allRepositorySigned;
             RepositoryCertificateInfos = repositoryCertInfos;
+        }
+
+        public void UpdateRepositorySignatureInfo()
+        {
+            RepositorySignatureInfoProvider.Instance.AddOrUpdateRepositorySignatureInfo
+                (Source, new RepositorySignatureInfo(AllRepositorySigned, RepositoryCertificateInfos));
         }
 
     }

--- a/src/NuGet.Core/NuGet.Protocol/SourceRepository.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SourceRepository.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/NuGet.Core/NuGet.Protocol/Utility/GetDownloadResultUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/GetDownloadResultUtility.cs
@@ -79,6 +79,7 @@ namespace NuGet.Protocol
                             if (directDownload)
                             {
                                 return await DirectDownloadAsync(
+                                    client.PackageSource,
                                     identity,
                                     packageStream,
                                     downloadContext,
@@ -87,6 +88,7 @@ namespace NuGet.Protocol
                             else
                             {
                                 return await GlobalPackagesFolderUtility.AddPackageAsync(
+                                    client.PackageSource,
                                     identity,
                                     packageStream,
                                     globalPackagesFolder,
@@ -152,6 +154,7 @@ namespace NuGet.Protocol
         }
 
         private static async Task<DownloadResourceResult> DirectDownloadAsync(
+            string source,
             PackageIdentity packageIdentity,
             Stream packageStream,
             PackageDownloadContext downloadContext,
@@ -204,7 +207,7 @@ namespace NuGet.Protocol
 
                 fileStream.Seek(0, SeekOrigin.Begin);
 
-                return new DownloadResourceResult(fileStream);
+                return new DownloadResourceResult(fileStream, source);
             }
             catch
             {

--- a/src/NuGet.Core/NuGet.Protocol/Utility/GlobalPackagesFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/GlobalPackagesFolderUtility.cs
@@ -52,7 +52,7 @@ namespace NuGet.Protocol
                 {
                     stream = File.Open(nupkgPath, FileMode.Open, FileAccess.Read, FileShare.Read);
                     packageReader = new PackageFolderReader(installPath);
-                    return new DownloadResourceResult(stream, packageReader) { SignatureVerified = true };
+                    return new DownloadResourceResult(stream, packageReader, source: null) { SignatureVerified = true };
                 }
                 catch
                 {
@@ -74,6 +74,7 @@ namespace NuGet.Protocol
         }
 
         public static async Task<DownloadResourceResult> AddPackageAsync(
+            string source,
             PackageIdentity packageIdentity,
             Stream packageStream,
             string globalPackagesFolder,
@@ -113,6 +114,7 @@ namespace NuGet.Protocol
             var versionFolderPathResolver = new VersionFolderPathResolver(globalPackagesFolder);
 
             await PackageExtractor.InstallFromSourceAsync(
+                source,
                 packageIdentity,
                 stream => packageStream.CopyToAsync(stream, BufferSize, token),
                 versionFolderPathResolver,

--- a/src/NuGet.Core/NuGet.Protocol/Utility/OfflineFeedUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/OfflineFeedUtility.cs
@@ -208,9 +208,10 @@ namespace NuGet.Protocol.Core.Types
                         var versionFolderPathResolver = new VersionFolderPathResolver(source);
 
                         using (var packageDownloader = new LocalPackageArchiveDownloader(
-                            packagePath,
-                            packageIdentity,
-                            logger))
+                            source: null,
+                            packageFilePath: packagePath,
+                            packageIdentity: packageIdentity,
+                            logger: logger))
                         {
                             // Set Empty parentId here.
                             await PackageExtractor.InstallFromSourceAsync(

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
@@ -315,12 +315,13 @@ namespace NuGet.CommandLine.Test.Caching
             using (var fileStream = new FileStream(packagePath, FileMode.Open, FileAccess.Read))
             {
                 using (await GlobalPackagesFolderUtility.AddPackageAsync(
-                    identity,
-                    fileStream,
-                    GlobalPackagesPath,
-                    Guid.Empty,
-                    Common.NullLogger.Instance,
-                    CancellationToken.None))
+                    source: null,
+                    packageIdentity: identity,
+                    packageStream: fileStream,
+                    globalPackagesFolder: GlobalPackagesPath,
+                    parentId: Guid.Empty,
+                    logger: Common.NullLogger.Instance,
+                    token: CancellationToken.None))
                 {
                 }
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -88,7 +88,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -98,7 +98,7 @@ namespace NuGet.CommandLine.Test
 
                 using (var stream = File.OpenRead(b1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject.InstallPackageAsync(
                         b1,
                         downloadResult,
@@ -180,7 +180,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -286,7 +286,7 @@ namespace NuGet.CommandLine.Test
 
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject1.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -296,7 +296,7 @@ namespace NuGet.CommandLine.Test
 
                 using (var stream = File.OpenRead(b1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject2.InstallPackageAsync(
                         b1,
                         downloadResult,
@@ -388,7 +388,7 @@ namespace NuGet.CommandLine.Test
 
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject1.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -484,7 +484,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -563,7 +563,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -651,7 +651,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -742,7 +742,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a2Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject.InstallPackageAsync(
                         a2,
                         downloadResult,
@@ -826,7 +826,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -906,7 +906,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -987,7 +987,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -1105,7 +1105,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject1 = new MSBuildNuGetProject(projectSystem1, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject1.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -1195,7 +1195,7 @@ namespace NuGet.CommandLine.Test
                 var msBuildProject1 = new MSBuildNuGetProject(projectSystem1, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject1.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -1315,7 +1315,7 @@ namespace NuGet.CommandLine.Test
 
                 using (var stream = File.OpenRead(a1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject1.InstallPackageAsync(
                         a1,
                         downloadResult,
@@ -1325,7 +1325,7 @@ namespace NuGet.CommandLine.Test
 
                 using (var stream = File.OpenRead(b1Package))
                 {
-                    var downloadResult = new DownloadResourceResult(stream);
+                    var downloadResult = new DownloadResourceResult(stream, packagesSourceDirectory);
                     await msBuildProject2.InstallPackageAsync(
                         b1,
                         downloadResult,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectKNuGetProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectKNuGetProjectTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -178,7 +178,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     TestDirectory,
                     context);
 
-                return new DownloadResourceResult(package.OpenRead());
+                return new DownloadResourceResult(package.OpenRead(), TestDirectory.Path);
             }
         }
     }

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -443,6 +443,7 @@ namespace NuGet.Commands.FuncTest
                 var packageIdentity = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
 
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    workingDir,
                     packagePath,
                     packageIdentity,
                     logger))

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/OriginalCaseGlobalPackageFolderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/OriginalCaseGlobalPackageFolderTests.cs
@@ -42,7 +42,7 @@ namespace NuGet.Commands.Test
                     identity.Version.ToString());
 
                 var logger = new TestLogger();
-                var graph = GetRestoreTargetGraph(identity, packagePath, logger);
+                var graph = GetRestoreTargetGraph(sourceDirectory,identity, packagePath, logger);
 
                 var request = GetRestoreRequest(packagesDirectory, logger);
                 var resolver = new VersionFolderPathResolver(packagesDirectory, isLowercase: false);
@@ -79,7 +79,7 @@ namespace NuGet.Commands.Test
 
                 var logger = new TestLogger();
                 var identityB = new PackageIdentity("PackageB", NuGetVersion.Parse("2.0.0-Beta"));
-                var graph = GetRestoreTargetGraph(identityB, packagePath, logger);
+                var graph = GetRestoreTargetGraph(sourceDirectory, identityB, packagePath, logger);
 
                 // Add the package to the fallback directory.
                 await SimpleTestPackageUtility.CreateFolderFeedV3(fallbackDirectory, identityB);
@@ -117,7 +117,7 @@ namespace NuGet.Commands.Test
                     identity.Version.ToString());
 
                 var logger = new TestLogger();
-                var graph = GetRestoreTargetGraph(identity, packagePath, logger);
+                var graph = GetRestoreTargetGraph(sourceDirectory, identity, packagePath, logger);
 
                 var request = GetRestoreRequest(packagesDirectory, logger);
                 var resolver = new VersionFolderPathResolver(packagesDirectory, isLowercase: false);
@@ -157,8 +157,8 @@ namespace NuGet.Commands.Test
                     identity.Version.ToString());
 
                 var logger = new TestLogger();
-                var graphA = GetRestoreTargetGraph(identity, packagePath, logger);
-                var graphB = GetRestoreTargetGraph(identity, packagePath, logger);
+                var graphA = GetRestoreTargetGraph(sourceDirectory, identity, packagePath, logger);
+                var graphB = GetRestoreTargetGraph(sourceDirectory, identity, packagePath, logger);
 
                 var request = GetRestoreRequest(packagesDirectory, logger);
                 var resolver = new VersionFolderPathResolver(packagesDirectory, isLowercase: false);
@@ -225,6 +225,7 @@ namespace NuGet.Commands.Test
         }
 
         private static RestoreTargetGraph GetRestoreTargetGraph(
+            string source,
             PackageIdentity identity,
             FileInfo packagePath,
             TestLogger logger)
@@ -245,6 +246,7 @@ namespace NuGet.Commands.Test
                     (callbackIdentity, sourceCacheContext, callbackLogger, cancellationToken) =>
                     {
                         packageDependency = new LocalPackageArchiveDownloader(
+                            source,
                             packagePath.FullName,
                             callbackIdentity,
                             callbackLogger);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/InstallationCompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/InstallationCompatibilityTests.cs
@@ -86,7 +86,7 @@ namespace NuGet.PackageManagement.Test
             // Arrange
             var tc = new TestContext();
             tc.MinClientVersion = new NuGetVersion("10.0.0");
-            var result = new DownloadResourceResult(Stream.Null, tc.PackageReader.Object);
+            var result = new DownloadResourceResult(Stream.Null, tc.PackageReader.Object, string.Empty);
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<MinClientVersionException>(() =>
@@ -409,7 +409,7 @@ namespace NuGet.PackageManagement.Test
                 string expected)
             {
                 // Arrange
-                var result = new DownloadResourceResult(Stream.Null, PackageReader.Object);
+                var result = new DownloadResourceResult(Stream.Null, PackageReader.Object, string.Empty);
 
                 // Act & Assert
                 var ex = await Assert.ThrowsAsync<PackagingException>(() =>
@@ -429,7 +429,7 @@ namespace NuGet.PackageManagement.Test
             public async Task VerifySuccessAsync(NuGetProject nugetProject)
             {
                 // Arrange
-                var result = new DownloadResourceResult(Stream.Null, PackageReader.Object);
+                var result = new DownloadResourceResult(Stream.Null, PackageReader.Object, string.Empty);
 
                 // Act & Assert
                 await Target.EnsurePackageCompatibilityAsync(

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -46,7 +46,7 @@ namespace NuGet.Test
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var token = CancellationToken.None;
 
-                using (var packageStream = GetDownloadResult(packageFileInfo))
+                using (var packageStream = GetDownloadResult(randomPackageSourcePath.Path, packageFileInfo))
                 {
                     // Act
                     await projectA.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -183,7 +183,7 @@ namespace NuGet.Test
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var token = CancellationToken.None;
 
-                using (var packageStream = GetDownloadResult(packageFileInfo))
+                using (var packageStream = GetDownloadResult(randomPackageSourcePath.Path, packageFileInfo))
                 {
                     // Act
                     await projectA.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -314,7 +314,7 @@ namespace NuGet.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackage(randomTestPackageSourcePath,
                     testPackage1.Id, testPackage1.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResult(packageFileInfo))
+                using (var packageStream = GetDownloadResult(randomTestPackageSourcePath.Path, packageFileInfo))
                 {
                     // Act
                     await projectB.InstallPackageAsync(testPackage1, packageStream, testNuGetProjectContext, token);
@@ -323,7 +323,7 @@ namespace NuGet.Test
 
                 packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackage(randomTestPackageSourcePath,
                     testPackage2.Id, testPackage2.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResult(packageFileInfo))
+                using (var packageStream = GetDownloadResult(randomTestPackageSourcePath.Path, packageFileInfo))
                 {
                     // Act
                     await projectA.InstallPackageAsync(testPackage2, packageStream, testNuGetProjectContext, token);
@@ -393,9 +393,9 @@ namespace NuGet.Test
             }
         }
 
-        private static DownloadResourceResult GetDownloadResult(FileInfo packageFileInfo)
+        private static DownloadResourceResult GetDownloadResult(string source, FileInfo packageFileInfo)
         {
-            return new DownloadResourceResult(packageFileInfo.OpenRead());
+            return new DownloadResourceResult(packageFileInfo.OpenRead(), source);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/BuildIntegratedNuGetProjectTests.cs
@@ -252,7 +252,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyContentPackage(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath.Path, packageFileInfo))
                 {
                     // Act
                     await buildIntegratedProject.InstallPackageAsync(
@@ -298,7 +298,7 @@ namespace ProjectManagement.Test
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
                 var packageFileInfo2 = TestPackagesGroupedByFolder.GetLegacyContentPackage(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath.Path, packageFileInfo))
                 {
                     await buildIntegratedProject.InstallPackageAsync(
                         packageIdentity.Id,
@@ -352,7 +352,7 @@ namespace ProjectManagement.Test
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
                 var packageFileInfo2 = TestPackagesGroupedByFolder.GetLegacyContentPackage(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath.Path, packageFileInfo))
                 {
                     await buildIntegratedProject.InstallPackageAsync(
                         packageIdentity.Id,
@@ -497,9 +497,9 @@ namespace ProjectManagement.Test
             }
         }
 
-        private static DownloadResourceResult GetDownloadResourceResult(FileInfo fileInfo)
+        private static DownloadResourceResult GetDownloadResourceResult(string source, FileInfo fileInfo)
         {
-            return new DownloadResourceResult(fileInfo.OpenRead());
+            return new DownloadResourceResult(fileInfo.OpenRead(), source);
         }
 
         private static JObject BasicConfig

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/FolderNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/FolderNuGetProjectTests.cs
@@ -105,7 +105,7 @@ namespace NuGet.ProjectManagement.Test
                 var nupkgFilePath = Path.Combine(packageInstallPath, packagePathResolver.GetPackageFileName(packageIdentity));
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var token = CancellationToken.None;
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestSourcePath, packageFileInfo))
                 {
                     // Act
                     await folderNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -183,7 +183,7 @@ namespace NuGet.ProjectManagement.Test
                 var nupkgFilePath = Path.Combine(packageInstallPath, packagePathResolver.GetPackageFileName(packageIdentity));
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var token = CancellationToken.None;
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestSourcePath, packageFileInfo))
                 {
                     // Act
                     await folderNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -240,7 +240,7 @@ namespace NuGet.ProjectManagement.Test
                 var nupkgFilePath = Path.Combine(packageInstallPath, packagePathResolver.GetPackageFileName(packageIdentity));
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var token = CancellationToken.None;
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestSourcePath, packageFileInfo))
                 {
                     // Act
                     await folderNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -333,7 +333,7 @@ namespace NuGet.ProjectManagement.Test
                 var nupkgFilePath = Path.Combine(packageInstallPath, packagePathResolver.GetPackageFileName(packageIdentity));
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var token = CancellationToken.None;
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestSourcePath, packageFileInfo))
                 {
                     // Act
                     await folderNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -613,7 +613,7 @@ namespace NuGet.ProjectManagement.Test
                 var nupkgFilePath = Path.Combine(packageInstallPath, packagePathResolver.GetPackageFileName(packageIdentity));
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var token = CancellationToken.None;
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestSourcePath, packageFileInfo))
                 {
                     // Act
                     await folderNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -671,7 +671,7 @@ namespace NuGet.ProjectManagement.Test
                 };
 
                 var token = CancellationToken.None;
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestSourcePath, packageFileInfo))
                 {
                     // Act
                     await folderNuGetProject.InstallPackageAsync(
@@ -738,7 +738,7 @@ namespace NuGet.ProjectManagement.Test
                 };
 
                 var token = CancellationToken.None;
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestSourcePath, packageFileInfo))
                 {
                     // Act
                     await folderNuGetProject.InstallPackageAsync(
@@ -848,9 +848,9 @@ namespace NuGet.ProjectManagement.Test
             }
         }
 
-        private static DownloadResourceResult GetDownloadResourceResult(FileInfo fileInfo)
+        private static DownloadResourceResult GetDownloadResourceResult(string source, FileInfo fileInfo)
         {
-            return new DownloadResourceResult(fileInfo.OpenRead());
+            return new DownloadResourceResult(fileInfo.OpenRead(), source);
         }
 
         private sealed class FolderNuGetProjectTest : IDisposable
@@ -862,6 +862,8 @@ namespace NuGet.ProjectManagement.Test
             internal PackagePathResolver Resolver { get; }
             internal TestDirectory TestDirectory { get; }
 
+            internal string Source { get; }
+
             internal FolderNuGetProjectTest(bool useSideBySidePaths = true)
             {
                 PackageIdentity = new PackageIdentity(id: "a", version: NuGetVersion.Parse("1.0.0"));
@@ -870,12 +872,12 @@ namespace NuGet.ProjectManagement.Test
                 Resolver = new PackagePathResolver(ProjectDirectory.FullName, useSideBySidePaths);
                 Project = new FolderNuGetProject(ProjectDirectory.FullName, Resolver);
 
-                var sourcePackageDirectoryPath = Path.Combine(TestDirectory.Path, "source");
+                Source = Path.Combine(TestDirectory.Path, "source");
 
-                Directory.CreateDirectory(sourcePackageDirectoryPath);
+                Directory.CreateDirectory(Source);
 
                 Package = TestPackagesGroupedByFolder.GetLegacyTestPackage(
-                    sourcePackageDirectoryPath,
+                    Source,
                     PackageIdentity.Id,
                     PackageIdentity.Version.ToNormalizedString());
             }
@@ -898,7 +900,7 @@ namespace NuGet.ProjectManagement.Test
 
             internal async Task InstallAsync(PackageSaveMode packageSaveMode)
             {
-                using (var result = GetDownloadResourceResult(Package))
+                using (var result = GetDownloadResourceResult(Source, Package))
                 {
                     var projectContext = new TestNuGetProjectContext();
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/MSBuildNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/MSBuildNuGetProjectTests.cs
@@ -95,7 +95,7 @@ namespace ProjectManagement.Test
                 var packageFileInfo = TestPackagesGroupedByFolder.GetPackageWithEmptyFolders(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
 
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(
@@ -153,7 +153,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackage(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -203,7 +203,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackage(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -256,7 +256,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackageWithMultipleReferences(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -298,7 +298,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackageWithMultipleReferences(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -332,7 +332,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackageWithMultipleReferences(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
                 }
@@ -369,7 +369,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackageWithMultipleReferences(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
                 }
@@ -416,7 +416,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackage(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -467,7 +467,7 @@ namespace ProjectManagement.Test
                 Exception exception = null;
                 try
                 {
-                    using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                    using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                     {
                         // Act
                         await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -518,7 +518,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetPackageWithFrameworkReference(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -570,7 +570,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyContentPackage(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -622,7 +622,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetContentPackageWithTargetFramework(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -674,7 +674,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyContentPackage(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -738,7 +738,7 @@ namespace ProjectManagement.Test
                 var packageFileInfo = TestPackagesGroupedByFolder.GetPackageWithPPFiles(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
 
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -789,7 +789,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetPackageWithPPFiles(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -874,7 +874,7 @@ namespace ProjectManagement.Test
     </system.webServer>
 </configuration>
 ");
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -953,7 +953,7 @@ namespace ProjectManagement.Test
     </system.web>
 </configuration>
 ");
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -1040,7 +1040,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetPackageWithBuildFiles(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -1089,7 +1089,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetPackageWithBuildFiles(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -1155,7 +1155,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetPackageWithPowershellScripts(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -1207,7 +1207,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetPackageWithPowershellScripts(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     testNuGetProjectContext.ActionType = NuGetActionType.Uninstall;
@@ -1283,7 +1283,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacySolutionLevelPackage(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -1331,7 +1331,7 @@ namespace ProjectManagement.Test
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacySolutionLevelPackage(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
 
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     testNuGetProjectContext.ActionType = NuGetActionType.Install;
@@ -1399,7 +1399,7 @@ namespace ProjectManagement.Test
 
                 try
                 {
-                    using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                    using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                     {
                         // Act
                         await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -1451,7 +1451,7 @@ namespace ProjectManagement.Test
                 Exception exception = null;
                 try
                 {
-                    using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                    using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                     {
                         // Act
                         await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -1498,7 +1498,7 @@ namespace ProjectManagement.Test
                 var packageFileInfo = TestPackagesGroupedByFolder.GetEmptyPackageWithDependencies(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
 
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -1538,7 +1538,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackage(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -1588,7 +1588,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackage(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -1655,7 +1655,7 @@ namespace ProjectManagement.Test
                     packageIdentity.Id,
                     packageIdentity.Version.ToNormalizedString());
 
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act Install
                     await
@@ -1737,7 +1737,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackage(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     testNuGetProjectContext.ActionType = NuGetActionType.Install;
@@ -1802,7 +1802,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackage(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     testNuGetProjectContext.ActionType = NuGetActionType.Install;
@@ -1838,7 +1838,7 @@ namespace ProjectManagement.Test
                 // since the last package was uninstalled
                 Assert.False(File.Exists(packagesProjectNameConfigPath));
 
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     testNuGetProjectContext.ActionType = NuGetActionType.Uninstall;
@@ -1886,7 +1886,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetNet45TestPackageWithDummyFile(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -1931,7 +1931,7 @@ namespace ProjectManagement.Test
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetTestPackageWithDummyFile(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
-                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
                 {
                     // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
@@ -1958,9 +1958,9 @@ namespace ProjectManagement.Test
             Assert.Equal(expected, actual);
         }
 
-        private static DownloadResourceResult GetDownloadResourceResult(FileInfo fileInfo)
+        private static DownloadResourceResult GetDownloadResourceResult(string source, FileInfo fileInfo)
         {
-            return new DownloadResourceResult(fileInfo.OpenRead());
+            return new DownloadResourceResult(fileInfo.OpenRead(), source);
         }
 
         private class TestMSBuildNuGetProject

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/PackagesConfigNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/PackagesConfigNuGetProjectTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -318,7 +318,7 @@ namespace ProjectManagement.Test
 
         private static DownloadResourceResult GetDownloadResourceResult()
         {
-            return new DownloadResourceResult(Stream.Null);
+            return new DownloadResourceResult(Stream.Null, null);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/LocalPackageArchiveDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/LocalPackageArchiveDownloaderTests.cs
@@ -23,9 +23,10 @@ namespace NuGet.Packaging.Test
         {
             var exception = Assert.Throws<ArgumentException>(
                 () => new LocalPackageArchiveDownloader(
-                    packageFilePath,
-                    new PackageIdentity(id: "a", version: NuGetVersion.Parse("1.0.0")),
-                    NullLogger.Instance));
+                    source: null,
+                    packageFilePath: packageFilePath,
+                    packageIdentity: new PackageIdentity(id: "a", version: NuGetVersion.Parse("1.0.0")),
+                    logger: NullLogger.Instance));
 
             Assert.Equal("packageFilePath", exception.ParamName);
         }
@@ -35,6 +36,7 @@ namespace NuGet.Packaging.Test
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new LocalPackageArchiveDownloader(
+                    source: null,
                     packageFilePath: "a",
                     packageIdentity: null,
                     logger: NullLogger.Instance));
@@ -47,6 +49,7 @@ namespace NuGet.Packaging.Test
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new LocalPackageArchiveDownloader(
+                    source: null,
                     packageFilePath: "a",
                     packageIdentity: new PackageIdentity(id: "a", version: NuGetVersion.Parse("1.0.0")),
                     logger: null));
@@ -412,6 +415,7 @@ namespace NuGet.Packaging.Test
                     $"{packageIdentity.Id}.{packageIdentity.Version.ToNormalizedString()}.nupkg");
 
                 var downloader = new LocalPackageArchiveDownloader(
+                    testDirectory.Path,
                     sourcePackageFilePath,
                     packageIdentity,
                     NullLogger.Instance);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
@@ -44,6 +44,7 @@ namespace Commands.Test
 
                 // Act
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    null,
                     package.File.FullName,
                     identity,
                     logger))
@@ -91,6 +92,7 @@ namespace Commands.Test
 
                 // Act
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    null,
                     package.File.FullName,
                     identity,
                     logger))
@@ -149,6 +151,7 @@ namespace Commands.Test
 
                 // Act
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    null,
                     package.File.FullName,
                     identity,
                     logger))
@@ -209,6 +212,7 @@ namespace Commands.Test
 
                 // Act
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    null,
                     package.File.FullName,
                     identity,
                     logger))
@@ -261,6 +265,7 @@ namespace Commands.Test
 
                 // Act
                 using (var packageDownloader = new ThrowingPackageArchiveDownloader(
+                    null,
                     package.File.FullName,
                     identity,
                     logger))
@@ -279,6 +284,7 @@ namespace Commands.Test
                 Assert.NotEmpty(Directory.EnumerateFiles(packageDir));
 
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    packagesDir,
                     package.File.FullName,
                     identity,
                     logger))
@@ -328,6 +334,7 @@ namespace Commands.Test
 
                 // Act
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    null,
                     package.File.FullName,
                     identity,
                     logger))
@@ -355,6 +362,7 @@ namespace Commands.Test
                 Assert.NotEmpty(Directory.EnumerateFiles(packageDir));
 
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    null,
                     package.File.FullName,
                     identity,
                     logger))
@@ -400,6 +408,7 @@ namespace Commands.Test
 
                 // Act
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    null,
                     packageFileInfo,
                     packageIdentity,
                     NullLogger.Instance))
@@ -443,6 +452,7 @@ namespace Commands.Test
 
                 // Act
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    null,
                     packageFileInfo,
                     packageIdentity,
                     NullLogger.Instance))
@@ -489,6 +499,7 @@ namespace Commands.Test
                 var versionFolderPathResolver = new VersionFolderPathResolver(packagesDirectory);
                 // Act
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    null,
                     packageFileInfo.FullName,
                     packageIdentity,
                     NullLogger.Instance))
@@ -548,6 +559,7 @@ namespace Commands.Test
 
                 // Act
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    null,
                     packageFileInfo.FullName,
                     packageIdentity,
                     NullLogger.Instance))
@@ -605,6 +617,7 @@ namespace Commands.Test
 
                 // Act
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    null,
                     packageFileInfo.FullName,
                     packageIdentity,
                     NullLogger.Instance))
@@ -647,6 +660,7 @@ namespace Commands.Test
 
                 // Act
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    null,
                     packageFileInfo,
                     packageIdentity,
                     NullLogger.Instance))
@@ -779,7 +793,10 @@ namespace Commands.Test
 
             public ISignedPackageReader SignedPackageReader => _packageReader.Value;
 
+            public string Source { get; }
+
             internal ThrowingPackageArchiveDownloader(
+                string source,
                 string packageFilePath,
                 PackageIdentity packageIdentity,
                 ILogger logger)
@@ -789,6 +806,7 @@ namespace Commands.Test
                 _logger = logger;
                 _packageReader = new Lazy<PackageArchiveReader>(GetPackageReader);
                 _sourceStream = new Lazy<FileStream>(GetSourceStream);
+                Source = source;
             }
 
             public void Dispose()

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -62,6 +62,7 @@ namespace NuGet.Packaging.Test
                             sem.Wait();
 
                             using (var packageDownloader = new LocalPackageArchiveDownloader(
+                                sourcePath,
                                 sourcePathResolver.GetPackageFilePath(identity.Id, identity.Version),
                                 identity,
                                 NullLogger.Instance))
@@ -118,6 +119,7 @@ namespace NuGet.Packaging.Test
                 var pathResolver = new VersionFolderPathResolver(packagesPath);
 
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    sourcePath,
                     packageFileInfo.FullName,
                     identity,
                     NullLogger.Instance))
@@ -161,6 +163,7 @@ namespace NuGet.Packaging.Test
                 var pathResolver = new VersionFolderPathResolver(packagesPath);
 
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    sourcePath,
                     packageFileInfo.FullName,
                     identity,
                     NullLogger.Instance))
@@ -206,6 +209,7 @@ namespace NuGet.Packaging.Test
                 var pathResolver = new VersionFolderPathResolver(packagesPath, isLowercase);
 
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    sourcePath,
                     packageFileInfo.FullName,
                     identity,
                     NullLogger.Instance))
@@ -265,6 +269,7 @@ namespace NuGet.Packaging.Test
                 var pathResolver = new VersionFolderPathResolver(root);
 
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    root,
                     packageFile,
                     packageIdentity,
                     NullLogger.Instance))
@@ -310,6 +315,7 @@ namespace NuGet.Packaging.Test
                 var pathResolver = new VersionFolderPathResolver(root);
 
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    root,
                     packageFile,
                     packageIdentity,
                     NullLogger.Instance))
@@ -346,6 +352,7 @@ namespace NuGet.Packaging.Test
 
                 // Act
                 var files = await PackageExtractor.ExtractPackageAsync(
+                    null,
                     packageReader,
                     packageStream,
                     resolver,
@@ -381,7 +388,9 @@ namespace NuGet.Packaging.Test
                     using (var folderReader = new PackageFolderReader(packageFolder))
                     {
                         // Act
-                        var files = await PackageExtractor.ExtractPackageAsync(folderReader,
+                        var files = await PackageExtractor.ExtractPackageAsync(
+                            packageFolder.Path,
+                            folderReader,
                             stream,
                             new PackagePathResolver(root),
                             new PackageExtractionContext(
@@ -423,6 +432,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        root,
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -456,11 +466,12 @@ namespace NuGet.Packaging.Test
                         signedPackageVerifier: null);
 
                     // Act
-                    var files = await PackageExtractor.ExtractPackageAsync(folderReader,
-                                                                         packageStream,
-                                                                         new PackagePathResolver(root),
-                                                                         packageExtractionContext,
-                                                                         CancellationToken.None);
+                    var files = await PackageExtractor.ExtractPackageAsync(packageFolder,
+                                                                           folderReader,
+                                                                           packageStream,
+                                                                           new PackagePathResolver(root),
+                                                                           packageExtractionContext,
+                                                                           CancellationToken.None);
 
                     // Assert
                     Assert.True(files.Any(p => p.EndsWith(".nupkg")));
@@ -490,7 +501,8 @@ namespace NuGet.Packaging.Test
                         signedPackageVerifier: null);
 
                     // Act
-                    var files = await PackageExtractor.ExtractPackageAsync(folderReader,
+                    var files = await PackageExtractor.ExtractPackageAsync(packageFolder,
+                                                                         folderReader,
                                                                          packageStream,
                                                                          new PackagePathResolver(root),
                                                                          packageExtractionContext,
@@ -524,7 +536,8 @@ namespace NuGet.Packaging.Test
                         signedPackageVerifier: null);
 
                     // Act
-                    var files = await PackageExtractor.ExtractPackageAsync(folderReader,
+                    var files = await PackageExtractor.ExtractPackageAsync(packageFolder,
+                                                                         folderReader,
                                                                          packageStream,
                                                                          new PackagePathResolver(root),
                                                                          packageExtractionContext,
@@ -559,12 +572,14 @@ namespace NuGet.Packaging.Test
                                 signedPackageVerifier: null);
 
                     // Act
-                    var packageFiles = PackageExtractor.ExtractPackageAsync(packageStream,
+                    var packageFiles = PackageExtractor.ExtractPackageAsync(root,
+                                                                     packageStream,
                                                                      resolver,
                                                                      packageExtractionContext,
                                                                      CancellationToken.None);
 
-                    var satellitePackageFiles = PackageExtractor.ExtractPackageAsync(satellitePackageStream,
+                    var satellitePackageFiles = PackageExtractor.ExtractPackageAsync(root,
+                                                                     satellitePackageStream,
                                                                      resolver,
                                                                      packageExtractionContext,
                                                                      CancellationToken.None);
@@ -607,6 +622,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        root,
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -648,6 +664,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        root,
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -701,6 +718,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        root,
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -744,6 +762,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        root,
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -788,6 +807,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        root,
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -843,12 +863,14 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        root,
                         packageStream,
                         resolver,
                         packageExtractionContext,
                         CancellationToken.None);
 
                     var satellitePackageFiles = PackageExtractor.ExtractPackageAsync(
+                        root,
                         satellitePackageStream,
                         resolver,
                         packageExtractionContext,
@@ -894,6 +916,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        root,
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -936,6 +959,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        root,
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -975,6 +999,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        root,
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -1016,6 +1041,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        root,
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -1057,6 +1083,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        root,
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -1098,6 +1125,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        root,
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -1139,6 +1167,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackageAsync(
+                        root,
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -1182,6 +1211,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     await PackageExtractor.ExtractPackageAsync(
+                        root,
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -1227,6 +1257,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     await PackageExtractor.ExtractPackageAsync(
+                        root,
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -1273,6 +1304,7 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     await PackageExtractor.ExtractPackageAsync(
+                        root,
                         packageStream,
                         resolver,
                         packageExtractionContext,
@@ -1294,6 +1326,7 @@ namespace NuGet.Packaging.Test
             {
                 var exception = await Assert.ThrowsAsync<ArgumentNullException>(
                     () => PackageExtractor.ExtractPackageAsync(
+                        null,
                         packageReader: null,
                         packagePathResolver: test.Resolver,
                         packageExtractionContext: test.Context,
@@ -1310,6 +1343,7 @@ namespace NuGet.Packaging.Test
             {
                 var exception = await Assert.ThrowsAsync<ArgumentNullException>(
                     () => PackageExtractor.ExtractPackageAsync(
+                        null,
                         test.Reader,
                         packagePathResolver: null,
                         packageExtractionContext: test.Context,
@@ -1326,6 +1360,7 @@ namespace NuGet.Packaging.Test
             {
                 var exception = await Assert.ThrowsAsync<ArgumentNullException>(
                     () => PackageExtractor.ExtractPackageAsync(
+                        null,
                         test.Reader,
                         test.Resolver,
                         packageExtractionContext: null,
@@ -1342,6 +1377,7 @@ namespace NuGet.Packaging.Test
             {
                 await Assert.ThrowsAsync<OperationCanceledException>(
                     () => PackageExtractor.ExtractPackageAsync(
+                        null,
                         test.Reader,
                         test.Resolver,
                         test.Context,
@@ -1357,6 +1393,7 @@ namespace NuGet.Packaging.Test
                 test.Context.PackageSaveMode = PackageSaveMode.None;
 
                 var files = await PackageExtractor.ExtractPackageAsync(
+                    test.Source,
                     test.Reader,
                     test.Resolver,
                     test.Context,
@@ -1392,6 +1429,7 @@ namespace NuGet.Packaging.Test
                 test.Context.PackageSaveMode = PackageSaveMode.Files;
 
                 var files = await PackageExtractor.ExtractPackageAsync(
+                    test.Source,
                     test.Reader,
                     test.Resolver,
                     test.Context,
@@ -1427,6 +1465,7 @@ namespace NuGet.Packaging.Test
                 test.Context.PackageSaveMode = PackageSaveMode.Nuspec;
 
                 var files = await PackageExtractor.ExtractPackageAsync(
+                    test.Source,
                     test.Reader,
                     test.Resolver,
                     test.Context,
@@ -1462,6 +1501,7 @@ namespace NuGet.Packaging.Test
                 test.Context.PackageSaveMode = PackageSaveMode.Nupkg;
 
                 var files = await PackageExtractor.ExtractPackageAsync(
+                    test.Source,
                     test.Reader,
                     test.Resolver,
                     test.Context,
@@ -1497,6 +1537,7 @@ namespace NuGet.Packaging.Test
                 test.Context.PackageSaveMode = PackageSaveMode.Defaultv2;
 
                 var files = await PackageExtractor.ExtractPackageAsync(
+                    test.Source,
                     test.Reader,
                     test.Resolver,
                     test.Context,
@@ -1532,6 +1573,7 @@ namespace NuGet.Packaging.Test
                 test.Context.PackageSaveMode = PackageSaveMode.Defaultv3;
 
                 var files = await PackageExtractor.ExtractPackageAsync(
+                    test.Source,
                     test.Reader,
                     test.Resolver,
                     test.Context,
@@ -1568,6 +1610,7 @@ namespace NuGet.Packaging.Test
                 test.Context.XmlDocFileSaveMode = XmlDocFileSaveMode.None;
 
                 var files = await PackageExtractor.ExtractPackageAsync(
+                    test.Source,
                     test.Reader,
                     test.Resolver,
                     test.Context,
@@ -1596,6 +1639,7 @@ namespace NuGet.Packaging.Test
                 test.Context.XmlDocFileSaveMode = XmlDocFileSaveMode.Skip;
 
                 var files = await PackageExtractor.ExtractPackageAsync(
+                    test.Source,
                     test.Reader,
                     test.Resolver,
                     test.Context,
@@ -1624,6 +1668,7 @@ namespace NuGet.Packaging.Test
                 test.Context.XmlDocFileSaveMode = XmlDocFileSaveMode.Compress;
 
                 var files = await PackageExtractor.ExtractPackageAsync(
+                    test.Source,
                     test.Reader,
                     test.Resolver,
                     test.Context,
@@ -1661,6 +1706,7 @@ namespace NuGet.Packaging.Test
                 var pathResolver = new VersionFolderPathResolver(root);
 
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    root,
                     packageFileInfo.FullName,
                     identity,
                     NullLogger.Instance))
@@ -1702,6 +1748,7 @@ namespace NuGet.Packaging.Test
                 var pathResolver = new VersionFolderPathResolver(root);
 
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    root,
                     packageFileInfo.FullName,
                     identity,
                     NullLogger.Instance))
@@ -1744,6 +1791,7 @@ namespace NuGet.Packaging.Test
                 var pathResolver = new VersionFolderPathResolver(root);
 
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    root,
                     packageFileInfo.FullName,
                     identity,
                     NullLogger.Instance))
@@ -1801,7 +1849,7 @@ namespace NuGet.Packaging.Test
                     {
                         var copiedFilePath = Path.Combine(destination, nuspecFileName);
 
-                        File.WriteAllText(copiedFilePath, string.Empty);
+                        File.WriteAllText(copiedFilePath, null);
 
                         copiedFilePaths = new[] { copiedFilePath };
                     })
@@ -1870,7 +1918,7 @@ namespace NuGet.Packaging.Test
                     {
                         var copiedFilePath = Path.Combine(destination, actualNuspecFileName);
 
-                        File.WriteAllText(copiedFilePath, string.Empty);
+                        File.WriteAllText(copiedFilePath, null);
 
                         copiedFilePaths = new[] { copiedFilePath };
                     })
@@ -1927,6 +1975,7 @@ namespace NuGet.Packaging.Test
                 var identity = new PackageIdentity("A", new NuGetVersion("1.0.0"));
 
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    root,
                     packageFileInfo.FullName,
                     identity,
                     NullLogger.Instance))
@@ -1971,6 +2020,7 @@ namespace NuGet.Packaging.Test
                 var identity = new PackageIdentity("A", new NuGetVersion("1.0.0"));
 
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    root,
                     packageFileInfo.FullName,
                     identity,
                     NullLogger.Instance))
@@ -2012,6 +2062,7 @@ namespace NuGet.Packaging.Test
                 var identity = new PackageIdentity("A", new NuGetVersion("1.0.0"));
 
                 using (var packageDownloader = new LocalPackageArchiveDownloader(
+                    root,
                     packageFileInfo.FullName,
                     identity,
                     NullLogger.Instance))
@@ -2060,6 +2111,7 @@ namespace NuGet.Packaging.Test
                 {
                     // Act
                     await PackageExtractor.InstallFromSourceAsync(
+                        root,
                         identity,
                         (stream) => fileStream.CopyToAsync(stream, 4096, CancellationToken.None),
                         resolver,
@@ -2102,6 +2154,7 @@ namespace NuGet.Packaging.Test
                 {
                     // Act
                     await PackageExtractor.InstallFromSourceAsync(
+                        root,
                         identity,
                         (stream) => fileStream.CopyToAsync(stream, 4096, CancellationToken.None),
                         resolver,
@@ -2145,6 +2198,7 @@ namespace NuGet.Packaging.Test
                     // Act & Assert
                     await Assert.ThrowsAsync<SignatureException>(
                      () => PackageExtractor.InstallFromSourceAsync(
+                         root,
                          identity,
                         (stream) => fileStream.CopyToAsync(stream, 4096, CancellationToken.None),
                         resolver,
@@ -2186,7 +2240,8 @@ namespace NuGet.Packaging.Test
                         signedPackageVerifier.Object);
 
                     // Act
-                    var packageFiles = await PackageExtractor.ExtractPackageAsync(packageStream,
+                    var packageFiles = await PackageExtractor.ExtractPackageAsync(root,
+                                                                     packageStream,
                                                                      resolver,
                                                                      packageExtractionContext,
                                                                      CancellationToken.None);
@@ -2230,6 +2285,7 @@ namespace NuGet.Packaging.Test
                     // Act & Assert
                     await Assert.ThrowsAsync<SignatureException>(
                         () => PackageExtractor.ExtractPackageAsync(
+                            root,
                             packageStream,
                             resolver,
                             packageExtractionContext,
@@ -2267,7 +2323,8 @@ namespace NuGet.Packaging.Test
                         signedPackageVerifier.Object);
 
                     // Act
-                    var packageFiles = await PackageExtractor.ExtractPackageAsync(packageReader,
+                    var packageFiles = await PackageExtractor.ExtractPackageAsync(root,
+                                                                     packageReader,
                                                                      resolver,
                                                                      packageExtractionContext,
                                                                      CancellationToken.None);
@@ -2311,6 +2368,7 @@ namespace NuGet.Packaging.Test
                     // Act & Assert
                     await Assert.ThrowsAsync<SignatureException>(
                         () => PackageExtractor.ExtractPackageAsync(
+                            root,
                             packageReader,
                             resolver,
                             packageExtractionContext,
@@ -2348,7 +2406,8 @@ namespace NuGet.Packaging.Test
                         signedPackageVerifier.Object);
 
                     // Act
-                    var packageFiles = await PackageExtractor.ExtractPackageAsync(packageReader,
+                    var packageFiles = await PackageExtractor.ExtractPackageAsync(root,
+                                                                     packageReader,
                                                                      packageStream,
                                                                      resolver,
                                                                      packageExtractionContext,
@@ -2395,6 +2454,7 @@ namespace NuGet.Packaging.Test
                     // Act & Assert
                     await Assert.ThrowsAsync<SignatureException>(
                         () => PackageExtractor.ExtractPackageAsync(
+                            root,
                             packageReader,
                             packageStream,
                             resolver,
@@ -2584,6 +2644,8 @@ namespace NuGet.Packaging.Test
             internal PackageReader Reader { get; }
             internal PackagePathResolver Resolver { get; }
 
+            internal string Source { get; }
+
             internal ExtractPackageAsyncTest()
             {
                 Context = new PackageExtractionContext(
@@ -2594,13 +2656,13 @@ namespace NuGet.Packaging.Test
                 PackageIdentity = new PackageIdentity(id: "a", version: NuGetVersion.Parse("1.0.0"));
                 _testDirectory = TestDirectory.Create();
 
-                var sourceDirectory = Path.Combine(_testDirectory.Path, "source");
+                var Source = Path.Combine(_testDirectory.Path, "source");
 
-                Directory.CreateDirectory(sourceDirectory);
+                Directory.CreateDirectory(Source);
 
                 DestinationDirectory = Directory.CreateDirectory(Path.Combine(_testDirectory.Path, "destination"));
 
-                Package = CreatePackage(PackageIdentity, sourceDirectory);
+                Package = CreatePackage(PackageIdentity, Source);
                 Reader = new PackageReader(File.OpenRead(Package.FullName));
                 Resolver = new PackagePathResolver(DestinationDirectory.FullName);
             }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageHelperTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageHelperTests.cs
@@ -208,6 +208,7 @@ namespace NuGet.Packaging.Test
             using (var test = PackageHelperTest.Create(TestPackagesCore.GetPackageContentReaderTestPackage()))
             {
                 await PackageExtractor.ExtractPackageAsync(
+                    test.Root,
                     test.Reader,
                     test.GetPackageStream(),
                     test.Resolver,
@@ -338,6 +339,7 @@ namespace NuGet.Packaging.Test
                     using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                     {
                         await PackageExtractor.ExtractPackageAsync(
+                            test.Root,
                             packageReader,
                             packageStream,
                             packagePathResolver,
@@ -390,7 +392,7 @@ namespace NuGet.Packaging.Test
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 {
                     await PackageExtractor.ExtractPackageAsync(
-                        packageReader,
+                        testDirectory.Path,
                         packageStream,
                         packagePathResolver,
                         new PackageExtractionContext(
@@ -406,6 +408,7 @@ namespace NuGet.Packaging.Test
                 using (var packageStream = File.OpenRead(satellitePackageInfo.FullName))
                 {
                     await PackageExtractor.ExtractPackageAsync(
+                        testDirectory.Path,
                         packageReader,
                         packageStream,
                         packagePathResolver,

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
@@ -82,7 +82,7 @@ namespace NuGet.Protocol.Tests
         public void Constructor_Stream_ThrowsForNullStream()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new DownloadResourceResult(stream: null));
+                () => new DownloadResourceResult(stream: null, source: null));
 
             Assert.Equal("stream", exception.ParamName);
         }
@@ -90,7 +90,7 @@ namespace NuGet.Protocol.Tests
         [Fact]
         public void Constructor_Stream_InitializesProperties()
         {
-            using (var result = new DownloadResourceResult(Stream.Null))
+            using (var result = new DownloadResourceResult(Stream.Null, source: null))
             {
                 Assert.Null(result.PackageReader);
                 Assert.Null(result.PackageSource);
@@ -135,7 +135,7 @@ namespace NuGet.Protocol.Tests
             using (var packageReader = new TestPackageReader())
             {
                 var exception = Assert.Throws<ArgumentNullException>(
-                    () => new DownloadResourceResult(stream: null, packageReader: packageReader));
+                    () => new DownloadResourceResult(stream: null, packageReader: packageReader, source: null));
 
                 Assert.Equal("stream", exception.ParamName);
             }
@@ -144,7 +144,7 @@ namespace NuGet.Protocol.Tests
         [Fact]
         public void Constructor_StreamPackageReaderBase_AllowsNullPackageReader()
         {
-            using (var result = new DownloadResourceResult(Stream.Null, packageReader: null))
+            using (var result = new DownloadResourceResult(Stream.Null, packageReader: null, source: null))
             {
                 Assert.Null(result.PackageReader);
             }
@@ -154,7 +154,7 @@ namespace NuGet.Protocol.Tests
         public void Constructor_StreamPackageReaderBase_InitializesProperties()
         {
             using (var packageReader = new TestPackageReader())
-            using (var result = new DownloadResourceResult(Stream.Null, packageReader))
+            using (var result = new DownloadResourceResult(Stream.Null, packageReader, source: null))
             {
                 Assert.Same(packageReader, result.PackageReader);
                 Assert.Null(result.PackageSource);
@@ -202,7 +202,7 @@ namespace NuGet.Protocol.Tests
         public void Dispose_IsIdempotent()
         {
             using (var stream = new TestStream())
-            using (var result = new DownloadResourceResult(stream))
+            using (var result = new DownloadResourceResult(stream, source: null))
             {
                 result.Dispose();
                 result.Dispose();

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemotePackageArchiveDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemotePackageArchiveDownloaderTests.cs
@@ -32,6 +32,7 @@ namespace NuGet.Protocol.Tests
             {
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => new RemotePackageArchiveDownloader(
+                        null,
                         resource: null,
                         packageIdentity: _packageIdentity,
                         cacheContext: sourceCacheContext,
@@ -48,6 +49,7 @@ namespace NuGet.Protocol.Tests
             {
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => new RemotePackageArchiveDownloader(
+                        null,
                         Mock.Of<FindPackageByIdResource>(),
                         packageIdentity: null,
                         cacheContext: sourceCacheContext,
@@ -62,6 +64,7 @@ namespace NuGet.Protocol.Tests
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new RemotePackageArchiveDownloader(
+                    null,
                     Mock.Of<FindPackageByIdResource>(),
                     _packageIdentity,
                     cacheContext: null,
@@ -77,6 +80,7 @@ namespace NuGet.Protocol.Tests
             {
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => new RemotePackageArchiveDownloader(
+                        null,
                         Mock.Of<FindPackageByIdResource>(),
                         _packageIdentity,
                         sourceCacheContext,
@@ -518,6 +522,7 @@ namespace NuGet.Protocol.Tests
                 var resource = new Mock<FindPackageByIdResource>(MockBehavior.Strict);
 
                 var downloader = new RemotePackageArchiveDownloader(
+                    testDirectory.Path,
                     resource.Object,
                     _packageIdentity,
                     sourceCacheContext,

--- a/test/TestUtilities/Test.Utility/GlobalFolderUtility.cs
+++ b/test/TestUtilities/Test.Utility/GlobalFolderUtility.cs
@@ -41,7 +41,9 @@ namespace NuGet.Test.Utility
 
                 using (var stream = File.OpenRead(packagePath))
                 {
-                    await PackageExtractor.InstallFromSourceAsync(reader.GetIdentity(),
+                    await PackageExtractor.InstallFromSourceAsync(
+                        null,
+                        reader.GetIdentity(),
                         async (d) => await stream.CopyToAsync(d),
                         versionFolderPathResolver,
                         pathContext,

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
@@ -460,6 +460,7 @@ namespace NuGet.Test.Utility
                     using (var fileStream = File.OpenRead(file))
                     {
                         await PackageExtractor.InstallFromSourceAsync(
+                            null,
                             identity,
                             (stream) => fileStream.CopyToAsync(stream, 4096, CancellationToken.None),
                             new VersionFolderPathResolver(root),
@@ -513,7 +514,7 @@ namespace NuGet.Test.Utility
             {
                 using (var stream = File.OpenRead(path))
                 {
-                    await PackageExtractor.ExtractPackageAsync(stream, resolver, context, CancellationToken.None);
+                    await PackageExtractor.ExtractPackageAsync(string.Empty, stream, resolver, context, CancellationToken.None);
                 }
             }
         }


### PR DESCRIPTION
Changes in this PR，

1. PackageExtractor accepts source as parameter.
2. DownloadResouceResult have to have source.
3. Create a static instance which stores Repo sign information for each source.
4. update the repo sign information for each source when v3 findPackageByIdResource and DownloadResource created.
5. expose source from IPackageDownloader.
