### PR TITLE
Refactored and cleaned up SignedArchiveTestUtility

### DIFF
--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/VerifyCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/VerifyCommandTests.cs
@@ -221,8 +221,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 signResult.Success.Should().BeTrue();
 
-                var certificateFingerprint = CertificateUtility.GetHash(cert.Source.Cert, HashAlgorithmName.SHA256);
-                var certificateFingerprintString = BitConverter.ToString(certificateFingerprint).Replace("-", "");
+                var certificateFingerprintString = SignatureTestUtility.GetFingerprint(cert.Source.Cert, HashAlgorithmName.SHA256);
 
                 // Act
                 var verifyResult = CommandRunner.Run(

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
@@ -40,9 +40,9 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
+                var certificateFingerprintString = SignatureTestUtility.GetFingerprint(testCertificate, HashAlgorithmName.SHA256);
+
                 var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
-                var certificateFingerprint = CertificateUtility.GetHash(testCertificate, HashAlgorithmName.SHA256);
-                var certificateFingerprintString = BitConverter.ToString(certificateFingerprint).Replace("-", "");
 
                 var allowListHashes = new[] { certificateFingerprintString, "abc" };
                 var allowList = allowListHashes.Select(hash => new CertificateHashAllowListEntry(VerificationTarget.Primary, hash)).ToList();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
@@ -40,7 +40,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
                 var certificateFingerprint = CertificateUtility.GetHash(testCertificate, HashAlgorithmName.SHA256);
                 var certificateFingerprintString = BitConverter.ToString(certificateFingerprint).Replace("-", "");
 
@@ -74,7 +74,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 var allowListHashes = new[] { "abc" };
                 var allowList = allowListHashes.Select(hash => new CertificateHashAllowListEntry(VerificationTarget.Primary, hash)).ToList();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/IntegrityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/IntegrityVerificationProviderTests.cs
@@ -71,7 +71,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
                 var verifier = new PackageSignatureVerifier(_trustProviders, policy);
 
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
@@ -97,7 +97,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
                 SignedArchiveTestUtility.TamperWithPackage(signedPackagePath);
 
                 var verifier = new PackageSignatureVerifier(_trustProviders, policy);
@@ -133,7 +133,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 // tamper with the package
                 using (var stream = File.Open(signedPackagePath, FileMode.Open))
@@ -177,7 +177,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 // tamper with the package
                 using (var stream = File.Open(signedPackagePath, FileMode.Open))
@@ -220,7 +220,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 // tamper with the package
                 using (var stream = File.Open(signedPackagePath, FileMode.Open))
@@ -261,7 +261,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 // tamper with the package
                 using (var stream = File.Open(signedPackagePath, FileMode.Open))
@@ -305,7 +305,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 // unsign the package
                 using (var stream = File.Open(signedPackagePath, FileMode.Open))
@@ -349,7 +349,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 TamperSignature(signedPackagePath);
 
@@ -386,7 +386,7 @@ namespace NuGet.Packaging.FuncTest
             }
 
             var fileBytes = File.ReadAllBytes(packageFilePath);
-            var newFileBytes = SignedArchiveTestUtility.FindAndReplaceSequence(
+            var newFileBytes = SignatureTestUtility.FindAndReplaceSequence(
                 fileBytes,
                 packageSignature,
                 randomBytes);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PrimarySignatureTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PrimarySignatureTests.cs
@@ -49,7 +49,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             {
                 // Act
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedAndTimeStampedPackageAsync(
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(
                     cert,
                     nupkg,
                     dir,
@@ -77,7 +77,7 @@ namespace NuGet.Packaging.FuncTest
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 // Act
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 // Assert
                 using (var stream = File.OpenRead(signedPackagePath))
@@ -99,7 +99,7 @@ namespace NuGet.Packaging.FuncTest
             using (var directory = TestDirectory.Create())
             using (var certificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var packageFilePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(
+                var packageFilePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(
                     certificate,
                     packageContext,
                     directory);
@@ -149,7 +149,7 @@ namespace NuGet.Packaging.FuncTest
             using (var certificate1 = new X509Certificate2(certificates[0].Source.Cert))
             using (var certificate2 = new X509Certificate2(certificates[1].Source.Cert))
             {
-                var packageFilePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(
+                var packageFilePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(
                     certificate1,
                     packageContext,
                     directory);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/RepositoryCountersignatureTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/RepositoryCountersignatureTests.cs
@@ -165,7 +165,7 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var directory = TestDirectory.Create())
                 {
-                    var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(
+                    var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(
                          new X509Certificate2(certificate),
                         packageContext,
                         directory);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -495,7 +495,7 @@ namespace NuGet.Packaging.FuncTest
             {
                 var signature = await SignedArchiveTestUtility.CreatePrimarySignatureForPackageAsync(package, signatureRequest);
                 var timestampedSignature = await SignedArchiveTestUtility.TimestampSignature(timestampProvider, signature, signatureRequest.TimestampHashAlgorithm, SignaturePlacement.PrimarySignature, testLogger);
-                var reTimestampedSignature = await SignedArchiveTestUtility.TimestampSignature(timestampProvider, signature, signatureRequest.TimestampHashAlgorithm, SignaturePlacement.PrimarySignature, testLogger);
+                var reTimestampedSignature = await SignedArchiveTestUtility.TimestampSignature(timestampProvider, timestampedSignature, signatureRequest.TimestampHashAlgorithm, SignaturePlacement.PrimarySignature, testLogger);
 
                 timestampedSignature.Timestamps.Count.Should().Be(1);
                 reTimestampedSignature.Timestamps.Count.Should().Be(2);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -54,7 +54,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
                 var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.VerifyCommandDefaultPolicy);
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -79,7 +79,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedAndTimeStampedPackageAsync(
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(
                     testCertificate,
                     nupkg,
                     dir,
@@ -107,23 +107,21 @@ namespace NuGet.Packaging.FuncTest
             using (var directory = TestDirectory.Create())
             using (var certificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                using (var request = new AuthorSignPackageRequest(certificate, HashAlgorithmName.SHA512, HashAlgorithmName.SHA256))
-                {
-                    var signedPackagePath = await SignedArchiveTestUtility.CreateSignedAndTimeStampedPackageAsync(
-                        certificate,
-                        packageContext,
-                        directory,
-                        timestampService.Url,
-                        request);
-                    var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.VerifyCommandDefaultPolicy);
-                    using (var packageReader = new PackageArchiveReader(signedPackagePath))
-                    {
-                        var result = await verifier.VerifySignaturesAsync(packageReader, CancellationToken.None);
-                        var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(
+                    certificate,
+                    packageContext,
+                    directory,
+                    timestampService.Url,
+                    signatureHashAlgorithm: HashAlgorithmName.SHA512);
 
-                        result.Valid.Should().BeTrue();
-                        resultsWithErrors.Count().Should().Be(0);
-                    }
+                var verifier = new PackageSignatureVerifier(_trustProviders, SignedPackageVerifierSettings.VerifyCommandDefaultPolicy);
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    var result = await verifier.VerifySignaturesAsync(packageReader, CancellationToken.None);
+                    var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
+
+                    result.Valid.Should().BeTrue();
+                    resultsWithErrors.Count().Should().Be(0);
                 }
             }
         }
@@ -148,15 +146,15 @@ namespace NuGet.Packaging.FuncTest
             using (var directory = TestDirectory.Create())
             {
                 certificate.PrivateKey = DotNetUtilities.ToRSA(keyPair.Private as RsaPrivateCrtKeyParameters);
+                var notAfter = certificate.NotAfter.ToUniversalTime();
 
                 var packageContext = new SimpleTestPackageContext();
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedAndTimeStampedPackageAsync(
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(
                     certificate,
                     packageContext,
                     directory,
                     timestampService.Url);
 
-                var notAfter = certificate.NotAfter.ToUniversalTime();
                 var waitDuration = (notAfter - DateTimeOffset.UtcNow).Add(TimeSpan.FromSeconds(1));
 
                 // Wait for the certificate to expire.  Trust of the signature will require a valid timestamp.
@@ -206,7 +204,7 @@ namespace NuGet.Packaging.FuncTest
                 certificate.PrivateKey = DotNetUtilities.ToRSA(keyPair.Private as RsaPrivateCrtKeyParameters);
 
                 var packageContext = new SimpleTestPackageContext();
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedAndTimeStampedPackageAsync(
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(
                     certificate,
                     packageContext,
                     directory,
@@ -305,7 +303,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
                 var verifier = new PackageSignatureVerifier(_trustProviders, setting);
                 using (var packageReader = new PackageArchiveReader(signedPackagePath))
                 {
@@ -332,7 +330,7 @@ namespace NuGet.Packaging.FuncTest
             using (var directory = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var packageFilePath = await SignedArchiveTestUtility.CreateSignedAndTimeStampedPackageAsync(
+                var packageFilePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(
                     testCertificate,
                     package,
                     directory,
@@ -341,7 +339,7 @@ namespace NuGet.Packaging.FuncTest
                 using (var packageReader = new PackageArchiveReader(packageFilePath))
                 {
                     var signature = await packageReader.GetPrimarySignatureAsync(CancellationToken.None);
-                    var invalidSignature = SignedArchiveTestUtility.GenerateInvalidPrimarySignature(signature);
+                    var invalidSignature = SignatureTestUtility.GenerateInvalidPrimarySignature(signature);
                     var provider = new SignatureTrustAndValidityVerificationProvider();
 
                     var result = await provider.GetTrustResultAsync(
@@ -488,7 +486,6 @@ namespace NuGet.Packaging.FuncTest
                 allowMultipleTimestamps: false,
                 allowNoTimestamp: false,
                 allowUnknownRevocation: false);
-            var signatureProvider = new X509SignatureProvider(timestampProvider: null);
             var timestampProvider = new Rfc3161TimestampProvider(timestampService.Url);
             var verificationProvider = new SignatureTrustAndValidityVerificationProvider();
 
@@ -496,9 +493,9 @@ namespace NuGet.Packaging.FuncTest
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             using (var signatureRequest = new AuthorSignPackageRequest(testCertificate, HashAlgorithmName.SHA256))
             {
-                var signature = await SignedArchiveTestUtility.CreatePrimarySignatureForPackageAsync(signatureProvider, package, signatureRequest, testLogger);
-                var timestampedSignature = await SignedArchiveTestUtility.TimestampPrimarySignature(timestampProvider, signatureRequest, signature, testLogger);
-                var reTimestampedSignature = await SignedArchiveTestUtility.TimestampPrimarySignature(timestampProvider, signatureRequest, timestampedSignature, testLogger);
+                var signature = await SignedArchiveTestUtility.CreatePrimarySignatureForPackageAsync(package, signatureRequest);
+                var timestampedSignature = await SignedArchiveTestUtility.TimestampSignature(timestampProvider, signature, signatureRequest.TimestampHashAlgorithm, SignaturePlacement.PrimarySignature, testLogger);
+                var reTimestampedSignature = await SignedArchiveTestUtility.TimestampSignature(timestampProvider, signature, signatureRequest.TimestampHashAlgorithm, SignaturePlacement.PrimarySignature, testLogger);
 
                 timestampedSignature.Timestamps.Count.Should().Be(1);
                 reTimestampedSignature.Timestamps.Count.Should().Be(2);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
@@ -62,7 +62,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
                 var entryCount = 0;
 
                 using (var stream = File.Open(signedPackagePath, FileMode.Open))
@@ -71,7 +71,7 @@ namespace NuGet.Packaging.FuncTest
                     entryCount = zip.Entries.Count;
                 }
 
-                await SignedArchiveTestUtility.ShiftSignatureMetadataAsync(_specification, signedPackagePath, dir, entryCount - 1, entryCount - 1);
+                await SignatureTestUtility.ShiftSignatureMetadataAsync(_specification, signedPackagePath, dir, entryCount - 1, entryCount - 1);
 
                 var verifier = new PackageSignatureVerifier(_trustProviders, _settings);
 
@@ -96,9 +96,9 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
-                await SignedArchiveTestUtility.ShiftSignatureMetadataAsync(_specification, signedPackagePath, dir, 0, 0);
+                await SignatureTestUtility.ShiftSignatureMetadataAsync(_specification, signedPackagePath, dir, 0, 0);
 
                 var verifier = new PackageSignatureVerifier(_trustProviders, _settings);
 
@@ -123,7 +123,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
                 var entryCount = 0;
 
                 using (var stream = File.Open(signedPackagePath, FileMode.Open))
@@ -132,7 +132,7 @@ namespace NuGet.Packaging.FuncTest
                     entryCount = zip.Entries.Count;
                 }
 
-                await SignedArchiveTestUtility.ShiftSignatureMetadataAsync(_specification, signedPackagePath, dir, entryCount - 1, 0);
+                await SignatureTestUtility.ShiftSignatureMetadataAsync(_specification, signedPackagePath, dir, entryCount - 1, 0);
 
                 var verifier = new PackageSignatureVerifier(_trustProviders, _settings);
 
@@ -157,7 +157,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
                 var entryCount = 0;
 
                 using (var stream = File.Open(signedPackagePath, FileMode.Open))
@@ -166,7 +166,7 @@ namespace NuGet.Packaging.FuncTest
                     entryCount = zip.Entries.Count;
                 }
 
-                await SignedArchiveTestUtility.ShiftSignatureMetadataAsync(_specification, signedPackagePath, dir, 0, entryCount - 1);
+                await SignatureTestUtility.ShiftSignatureMetadataAsync(_specification, signedPackagePath, dir, 0, entryCount - 1);
 
                 var verifier = new PackageSignatureVerifier(_trustProviders, _settings);
 
@@ -191,7 +191,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
                 var entryCount = 0;
 
                 using (var stream = File.Open(signedPackagePath, FileMode.Open))
@@ -201,7 +201,7 @@ namespace NuGet.Packaging.FuncTest
                 }
 
                 var middleEntry = (entryCount - 1) / 2;
-                await SignedArchiveTestUtility.ShiftSignatureMetadataAsync(_specification, signedPackagePath, dir, middleEntry - 1, middleEntry + 1);
+                await SignatureTestUtility.ShiftSignatureMetadataAsync(_specification, signedPackagePath, dir, middleEntry - 1, middleEntry + 1);
 
                 var verifier = new PackageSignatureVerifier(_trustProviders, _settings);
 
@@ -228,7 +228,7 @@ namespace NuGet.Packaging.FuncTest
             using (var packageStream = nupkg.CreateAsStream())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signarture = await SignedArchiveTestUtility.CreatePrimarySignatureForPackageAsync(testCertificate, packageStream);
+                var signarture = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
                 using (var package = new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: true))
                 {
                     var signatureEntry = package.CreateEntry(_specification.SignaturePath);
@@ -266,7 +266,7 @@ namespace NuGet.Packaging.FuncTest
             using (var packageStream = nupkg.CreateAsStream())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signarture = await SignedArchiveTestUtility.CreatePrimarySignatureForPackageAsync(testCertificate, packageStream);
+                var signarture = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
                 using (var package = new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: true))
                 {
                     var signatureEntry = package.CreateEntry(_specification.SignaturePath);
@@ -292,7 +292,7 @@ namespace NuGet.Packaging.FuncTest
             using (var packageStream = nupkg.CreateAsStream())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signarture = await SignedArchiveTestUtility.CreatePrimarySignatureForPackageAsync(testCertificate, packageStream);
+                var signarture = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
                 using (var package = new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: true))
                 {
                     var signatureEntry = package.CreateEntry(_specification.SignaturePath, CompressionLevel.Optimal);
@@ -330,7 +330,7 @@ namespace NuGet.Packaging.FuncTest
             using (var packageStream = nupkg.CreateAsStream())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signarture = await SignedArchiveTestUtility.CreatePrimarySignatureForPackageAsync(testCertificate, packageStream);
+                var signarture = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
                 using (var package = new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: true))
                 {
                     var signatureEntry = package.CreateEntry(_specification.SignaturePath, CompressionLevel.Optimal);
@@ -354,7 +354,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 using (var packageStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
@@ -384,7 +384,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
@@ -428,7 +428,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
@@ -460,7 +460,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
@@ -492,7 +492,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
@@ -536,7 +536,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
@@ -568,7 +568,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
@@ -612,7 +612,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
@@ -644,7 +644,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
@@ -688,7 +688,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
@@ -720,7 +720,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
@@ -764,7 +764,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
@@ -796,7 +796,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
@@ -840,7 +840,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
@@ -872,7 +872,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
 
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
@@ -919,7 +919,7 @@ namespace NuGet.Packaging.FuncTest
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signedPackagePath = await SignedArchiveTestUtility.CreateSignedPackageAsync(testCertificate, nupkg, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, nupkg, dir);
                 using (var packageWriteStream = new FileStream(signedPackagePath, FileMode.Open))
                 {
                     using (var reader = new BinaryReader(packageWriteStream, _readerEncoding, leaveOpen: true))

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -81,7 +81,7 @@ namespace NuGet.Packaging.FuncTest
             using (var packageStream = nupkg.CreateAsStream())
             {
                 // Act
-                var signature = await SignedArchiveTestUtility.CreatePrimarySignatureForPackageAsync(authorCert, packageStream, timestampProvider);
+                var signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(authorCert, packageStream, timestampProvider);
                 var authorSignedCms = signature.SignedCms;
                 var timestamp = signature.Timestamps.First();
                 var timestampCms = timestamp.SignedCms;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureUtilityTests.cs
@@ -115,7 +115,7 @@ namespace NuGet.Packaging.Test
                 var packageContext = new SimpleTestPackageContext();
                 var unsignedPackageStream = packageContext.CreateAsStream();
 
-                var signature = await SignedArchiveTestUtility.CreatePrimarySignatureForPackageAsync(
+                var signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(
                     certificate,
                     unsignedPackageStream);
 
@@ -134,15 +134,19 @@ namespace NuGet.Packaging.Test
                 var packageContext = new SimpleTestPackageContext();
                 var unsignedPackageStream = packageContext.CreateAsStream();
 
-                var signature = await SignedArchiveTestUtility.CreatePrimarySignatureForPackageAsync(
+                var signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(
                     certificate,
                     unsignedPackageStream);
 
-                var reposignedSignature = await SignedArchiveTestUtility.RepositoryCountersignPrimarySignatureAsync(repositoryCertificate, signature);
+                var hashAlgorithm = Common.HashAlgorithmName.SHA256;
+                var v3ServiceIndexUri = new Uri("https://v3serviceIndex.test/api/index.json");
+                using (var request = new RepositorySignPackageRequest(repositoryCertificate, hashAlgorithm, hashAlgorithm, v3ServiceIndexUri, null))
+                {
+                    var reposignedSignature = await SignedArchiveTestUtility.RepositoryCountersignPrimarySignatureAsync(signature, request);
+                    var hasRepoCountersignature = SignatureUtility.HasRepositoryCountersignature(reposignedSignature);
 
-                var hasRepoCountersignature = SignatureUtility.HasRepositoryCountersignature(reposignedSignature);
-
-                Assert.True(hasRepoCountersignature);
+                    Assert.True(hasRepoCountersignature);
+                }
             }
         }
 

--- a/test/TestUtilities/Test.Utility/Signing/SignatureTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SignatureTestUtility.cs
@@ -1,0 +1,226 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+#if IS_DESKTOP
+using System.Security.Cryptography.Pkcs;
+#endif
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Packaging;
+using NuGet.Packaging.Signing;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace Test.Utility.Signing
+{
+    public class SignatureTestUtility
+    {
+#if IS_DESKTOP
+        // Central Directory file header size excluding signature, file name, extra field and file comment
+        private const uint CentralDirectoryFileHeaderSizeWithoutSignature = 46;
+
+        /// <summary>
+        /// Get the certificate fingerprint for a given hash algorithm
+        /// </summary>
+        /// <param name="cert">Certificate to calculate fingerprint</param>
+        /// <param name="hashAlgorithm">Hash algorithm to calculate fingerprint</param>
+        /// <returns></returns>
+        public static string GetFingerprint(X509Certificate2 cert, HashAlgorithmName hashAlgorithm)
+        {
+            var certificateFingerprint = CertificateUtility.GetHash(cert, hashAlgorithm);
+            return BitConverter.ToString(certificateFingerprint).Replace("-", "");
+        }
+
+        public static PrimarySignature GenerateInvalidPrimarySignature(PrimarySignature signature)
+        {
+            var hash = Encoding.UTF8.GetBytes(signature.SignatureContent.HashValue);
+            var newHash = Encoding.UTF8.GetBytes(new string('0', hash.Length));
+
+            var bytes = signature.SignedCms.Encode();
+            var newBytes = FindAndReplaceSequence(bytes, hash, newHash);
+
+            return PrimarySignature.Load(newBytes);
+        }
+
+        public static byte[] FindAndReplaceSequence(byte[] bytes, byte[] find, byte[] replace)
+        {
+            var found = false;
+            var from = -1;
+
+            for (var i = 0; !found && i < bytes.Length - find.Length; ++i)
+            {
+                for (var j = 0; j < find.Length; ++j)
+                {
+                    if (bytes[i + j] != find[j])
+                    {
+                        break;
+                    }
+
+                    if (j == find.Length - 1)
+                    {
+                        from = i;
+                        found = true;
+                    }
+                }
+            }
+
+            if (!found)
+            {
+                throw new Exception("Byte sequence not found.");
+            }
+
+            var byteList = new List<byte>(bytes);
+
+            byteList.RemoveRange(from, find.Length);
+            byteList.InsertRange(from, replace);
+
+            return byteList.ToArray();
+        }
+
+        /// <summary>
+        /// unsigns a package for test purposes.
+        /// This does not timestamp a signature and can be used outside corp network.
+        /// </summary>
+        public static async Task ShiftSignatureMetadataAsync(SigningSpecifications spec, string signedPackagePath, string dir, int centralDirectoryIndex, int fileHeaderIndex)
+        {
+            var testLogger = new TestLogger();
+            var testSignatureProvider = new X509SignatureProvider(timestampProvider: null);
+
+            // Create a temp path
+            var copiedSignedPackagePath = Path.Combine(dir, Guid.NewGuid().ToString());
+
+            using (var signedReadStream = File.OpenRead(signedPackagePath))
+            using (var signedPackage = new BinaryReader(signedReadStream))
+            using (var shiftedWriteStream = File.OpenWrite(copiedSignedPackagePath))
+            using (var shiftedPackage = new BinaryWriter(shiftedWriteStream))
+            {
+                await ShiftSignatureMetadata(spec, signedPackage, shiftedPackage, centralDirectoryIndex, fileHeaderIndex);
+            }
+
+            // Overwrite the original package with the shifted one
+            File.Copy(copiedSignedPackagePath, signedPackagePath, overwrite: true);
+        }
+
+        private static Task ShiftSignatureMetadata(SigningSpecifications spec, BinaryReader reader, BinaryWriter writer, int centralDirectoryIndex, int fileHeaderIndex)
+        {
+            var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
+
+            // Calculate new central directory record metadata with the the signature record and entry shifted
+            var shiftedCdr = ShiftMetadata(spec, metadata, newSignatureFileEntryIndex: fileHeaderIndex, newSignatureCentralDirectoryRecordIndex: centralDirectoryIndex);
+
+            // Order records by shifted ofset (new offset = old offset + change in offset).
+            // This is the order they will appear in the new shifted package, but not necesarily the same order they were in the old package
+            shiftedCdr.Sort((x, y) => (x.OffsetToLocalFileHeader + x.ChangeInOffset).CompareTo(y.OffsetToLocalFileHeader + y.ChangeInOffset));
+
+            // Write data from start of file to first file entry
+            reader.BaseStream.Seek(offset: 0, origin: SeekOrigin.Begin);
+            SignedPackageArchiveIOUtility.ReadAndWriteUntilPosition(reader, writer, metadata.StartOfLocalFileHeaders);
+
+            // Write all file entries in the new order
+            foreach (var entry in shiftedCdr)
+            {
+                // We need to read each entry from their position in the old package and write them sequencially to the new package
+                // The order in which they will appear in the new shited package is defined by the sorting done before starting to write
+                reader.BaseStream.Seek(offset: entry.OffsetToLocalFileHeader, origin: SeekOrigin.Begin);
+                SignedPackageArchiveIOUtility.ReadAndWriteUntilPosition(reader, writer, entry.OffsetToLocalFileHeader + entry.FileEntryTotalSize);
+            }
+
+            // Write all central directory records with updated offsets
+            // We first need to sort them in the order they will appear in the new shifted package
+            shiftedCdr.Sort((x, y) => x.IndexInHeaders.CompareTo(y.IndexInHeaders));
+            foreach (var entry in shiftedCdr)
+            {
+                reader.BaseStream.Seek(offset: entry.Position, origin: SeekOrigin.Begin);
+                // Read and write from the start of the central directory record until the relative offset of local file header (42 from the start of central directory record, incluing signature length)
+                SignedPackageArchiveIOUtility.ReadAndWriteUntilPosition(reader, writer, reader.BaseStream.Position + 42);
+
+                var relativeOffsetOfLocalFileHeader = (uint)(reader.ReadUInt32() + entry.ChangeInOffset);
+                writer.Write(relativeOffsetOfLocalFileHeader);
+
+                // We already read and hash the whole header, skip only filenameLength + extraFieldLength + fileCommentLength (46 is the size of the header without those lengths)
+                SignedPackageArchiveIOUtility.ReadAndWriteUntilPosition(reader, writer, reader.BaseStream.Position + entry.HeaderSize - CentralDirectoryFileHeaderSizeWithoutSignature);
+            }
+
+            // Write everything after central directory records
+            reader.BaseStream.Seek(offset: metadata.EndOfCentralDirectory, origin: SeekOrigin.Begin);
+            SignedPackageArchiveIOUtility.ReadAndWriteUntilPosition(reader, writer, reader.BaseStream.Length);
+
+            return Task.FromResult(0);
+        }
+
+        private static List<CentralDirectoryHeaderMetadata> ShiftMetadata(
+            SigningSpecifications spec,
+            SignedPackageArchiveMetadata metadata,
+            int newSignatureFileEntryIndex,
+            int newSignatureCentralDirectoryRecordIndex)
+        {
+            var shiftedCdr = new List<CentralDirectoryHeaderMetadata>(metadata.CentralDirectoryHeaders);
+
+            // Sort Central Directory records in the order the file entries appear  in the original archive
+            shiftedCdr.Sort((x, y) => x.OffsetToLocalFileHeader.CompareTo(y.OffsetToLocalFileHeader));
+
+            // Shift Central Directory records to the desired position.
+            // Because we sorted in the file entry order this will shift
+            // the file entries
+            ShiftSignatureToIndex(spec, shiftedCdr, newSignatureFileEntryIndex);
+
+            // Calculate the change in offsets for the shifted file entries
+            var lastEntryEnd = 0L;
+            foreach (var cdr in shiftedCdr)
+            {
+                cdr.ChangeInOffset = lastEntryEnd - cdr.OffsetToLocalFileHeader;
+
+                lastEntryEnd = cdr.OffsetToLocalFileHeader + cdr.FileEntryTotalSize + cdr.ChangeInOffset;
+            }
+
+            // Now we sort the central directory records in the order thecentral directory records appear in the original archive
+            shiftedCdr.Sort((x, y) => x.Position.CompareTo(y.Position));
+
+            // Shift Central Directory records to the desired position.
+            // Because we sorted in the central directory records order this will shift
+            // the central directory records
+            ShiftSignatureToIndex(spec, shiftedCdr, newSignatureCentralDirectoryRecordIndex);
+
+            // Calculate the new indexes for each central directory record
+            var lastIndex = 0;
+            foreach (var cdr in shiftedCdr)
+            {
+                cdr.IndexInHeaders = lastIndex;
+                lastIndex++;
+            }
+
+            return shiftedCdr;
+        }
+
+        private static void ShiftSignatureToIndex(
+            SigningSpecifications spec,
+            List<CentralDirectoryHeaderMetadata> cdr,
+            int index)
+        {
+            // Check for the signature object in the entries.
+            // We have to do a manual check because we have no context
+            // of the order in which the central directory records list is sorted.
+            var recordIndex = 0;
+            for (; recordIndex < cdr.Count; recordIndex++)
+            {
+                if (cdr[recordIndex].IsPackageSignatureFile)
+                {
+                    break;
+                }
+            }
+            // Remove the signature object and add it to the new index
+            var signatureCD = cdr[recordIndex];
+            cdr.RemoveAt(recordIndex);
+            cdr.Insert(index, signatureCD);
+        }
+#endif
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/SignedArchiveTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SignedArchiveTestUtility.cs
@@ -23,69 +23,24 @@ namespace Test.Utility.Signing
 {
     public static class SignedArchiveTestUtility
     {
-        // Central Directory file header size excluding signature, file name, extra field and file comment
-        private const uint CentralDirectoryFileHeaderSizeWithoutSignature = 46;
-
         /// <summary>
-        /// Generates a signed copy of a package and returns the path to that package
-        /// </summary>
-        /// <param name="testCert">Certificate to be used while signing the package</param>
-        /// <param name="nupkg">Package to be signed</param>
-        /// <param name="dir">Directory for placing the signed package</param>
-        /// <param name="name">Name of the signed package file to create.</param>
-        /// <returns>Path to the signed copy of the package</returns>
-        public static async Task<string> CreateSignedPackageAsync(X509Certificate2 testCert, SimpleTestPackageContext nupkg, string dir, string name = null)
-        {
-            var testLogger = new TestLogger();
-            var signedPackagePath = Path.Combine(dir, name ?? Guid.NewGuid().ToString());
-            var tempPath = Path.GetTempFileName();
-
-            using (var packageStream = nupkg.CreateAsStream())
-            using (var fileStream = File.OpenWrite(tempPath))
-            {
-                packageStream.CopyTo(fileStream);
-            }
-
-            await SignPackageAsync(testLogger, testCert, tempPath, signedPackagePath);
-
-            FileUtility.Delete(tempPath);
-
-            return signedPackagePath;
-        }
-
-        public static async Task CreateSignedPackageAsync(
-            SignPackageRequest request,
-            Stream packageReadStream,
-            Stream packageWriteStream)
-        {
-            using (var signedPackage = new SignedPackageArchive(packageReadStream, packageWriteStream))
-            using (var options = new SigningOptions(
-                new Lazy<Stream>(() => packageReadStream),
-                new Lazy<Stream>(() => packageWriteStream),
-                overwrite: false,
-                signatureProvider: new X509SignatureProvider(timestampProvider: null),
-                logger: NullLogger.Instance))
-            {
-                await SigningUtility.SignAsync(options, request, CancellationToken.None);
-            }
-        }
-
-        /// <summary>
-        /// Generates a signed copy of a package and returns the path to that package
-        /// This method timestamps a package and should only be used with tests marked with [CIOnlyFact]
+        /// Generates an author signed copy of a package and returns the path to that package
+        /// This method can timestamp a package and should only be used with tests marked with [CIOnlyFact]
         /// </summary>
         /// <param name="certificate">Certificate to be used while signing the package</param>
         /// <param name="nupkg">Package to be signed</param>
         /// <param name="dir">Directory for placing the signed package</param>
         /// <param name="timestampService">RFC 3161 timestamp service URL.</param>
-        /// <param name="request">An author signing request.</param>
+        /// <param name="signatureHashAlgorithm">Hash algorithm to be used in the signature. Defaults to SHA256</param>
+        /// <param name="timestampHashAlgorithm">Hash algorithm to be used in the timestamp. Defaults to SHA256</param>
         /// <returns>Path to the signed copy of the package</returns>
-        public static async Task<string> CreateSignedAndTimeStampedPackageAsync(
+        public static async Task<string> AuthorSignPackageAsync(
             X509Certificate2 certificate,
             SimpleTestPackageContext nupkg,
             string dir,
-            Uri timestampService,
-            AuthorSignPackageRequest request = null)
+            Uri timestampService = null,
+            HashAlgorithmName signatureHashAlgorithm = HashAlgorithmName.SHA256,
+            HashAlgorithmName timestampHashAlgorithm = HashAlgorithmName.SHA256)
         {
             var testLogger = new TestLogger();
             var signedPackagePath = Path.Combine(dir, Guid.NewGuid().ToString());
@@ -96,17 +51,126 @@ namespace Test.Utility.Signing
             {
                 packageStream.CopyTo(fileStream);
             }
-#if IS_DESKTOP
-            using (var cert = new X509Certificate2(certificate))
-            using (request = request ?? new AuthorSignPackageRequest(cert, HashAlgorithmName.SHA256))
+
+            using (var originalPackage = File.OpenRead(signedPackagePath))
+            using (var signedPackage = File.Open(tempPath, FileMode.OpenOrCreate, FileAccess.ReadWrite))
+            using (var request = new AuthorSignPackageRequest(certificate, signatureHashAlgorithm, timestampHashAlgorithm))
             {
-                await SignAndTimeStampPackageAsync(testLogger, tempPath, signedPackagePath, timestampService, request);
+                await CreateSignedPackageAsync(request, originalPackage, signedPackage, timestampService);
             }
-#endif
 
             FileUtility.Delete(tempPath);
 
             return signedPackagePath;
+        }
+
+        /// <summary>
+        /// Generates an repository signed copy of a package and returns the path to that package
+        /// This method can timestamp a package and should only be used with tests marked with [CIOnlyFact]
+        /// </summary>
+        /// <param name="certificate">Certificate to be used while signing the package</param>
+        /// <param name="nupkg">Package to be signed</param>
+        /// <param name="dir">Directory for placing the signed package</param>
+        /// <param name="timestampService">RFC 3161 timestamp service URL.</param>
+        /// <param name="v3ServiceIndex">Value for the V3ServiceIndex for the repository signature attribute</param>
+        /// <param name="packageOwners">List of package owners for teh repository signature attribute</param>
+        /// <param name="signatureHashAlgorithm">Hash algorithm to be used in the signature. Defaults to SHA256</param>
+        /// <param name="timestampHashAlgorithm">Hash algorithm to be used in the timestamp. Defaults to SHA256</param>
+        /// <returns>Path to the signed copy of the package</returns>
+        public static async Task<string> RepositorySignPackageAsync(
+            X509Certificate2 certificate,
+            SimpleTestPackageContext nupkg,
+            string dir,
+            Uri v3ServiceIndex,
+            Uri timestampService = null,
+            IReadOnlyList<string> packageOwners = null,
+            HashAlgorithmName signatureHashAlgorithm = HashAlgorithmName.SHA256,
+            HashAlgorithmName timestampHashAlgorithm = HashAlgorithmName.SHA256)
+        {
+            var testLogger = new TestLogger();
+            var signedPackagePath = Path.Combine(dir, Guid.NewGuid().ToString());
+            var tempPath = Path.GetTempFileName();
+
+            using (var packageStream = nupkg.CreateAsStream())
+            using (var fileStream = File.OpenWrite(tempPath))
+            {
+                packageStream.CopyTo(fileStream);
+            }
+
+            using (var originalPackage = File.OpenRead(signedPackagePath))
+            using (var signedPackage = File.Open(tempPath, FileMode.OpenOrCreate, FileAccess.ReadWrite))
+            using (var request = new RepositorySignPackageRequest(certificate, signatureHashAlgorithm, timestampHashAlgorithm, v3ServiceIndex, packageOwners))
+            {
+                await CreateSignedPackageAsync(request, originalPackage, signedPackage, timestampService);
+            }
+
+            FileUtility.Delete(tempPath);
+
+            return signedPackagePath;
+        }
+
+        /// <summary>
+        /// Generates an repository signed copy of a package and returns the path to that package
+        /// This method can timestamp a package and should only be used with tests marked with [CIOnlyFact]
+        /// </summary>
+        /// <remarks>If the package is already author signed this method will repository countersign it</remarks>
+        /// <param name="certificate">Certificate to be used while signing the package</param>
+        /// <param name="packagePath">Package to be signed</param>
+        /// <param name="outputDir">Directory for placing the signed package</param>
+        /// <param name="timestampService">RFC 3161 timestamp service URL.</param>
+        /// <param name="v3ServiceIndex">Value for the V3ServiceIndex for the repository signature attribute</param>
+        /// <param name="packageOwners">List of package owners for teh repository signature attribute</param>
+        /// <param name="signatureHashAlgorithm">Hash algorithm to be used in the signature. Defaults to SHA256</param>
+        /// <param name="timestampHashAlgorithm">Hash algorithm to be used in the timestamp. Defaults to SHA256</param>
+        /// <returns>Path to the signed copy of the package</returns>
+        public static async Task<string> RepositorySignPackageAsync(
+            X509Certificate2 certificate,
+            string packagePath,
+            string outputDir,
+            Uri v3ServiceIndex,
+            Uri timestampService = null,
+            IReadOnlyList<string> packageOwners = null,
+            HashAlgorithmName signatureHashAlgorithm = HashAlgorithmName.SHA256,
+            HashAlgorithmName timestampHashAlgorithm = HashAlgorithmName.SHA256)
+        {
+            var testLogger = new TestLogger();
+            var outputPackagePath = Path.Combine(outputDir, Guid.NewGuid().ToString());
+            var tempPath = Path.GetTempFileName();
+
+            using (var originalPackage = File.OpenRead(packagePath))
+            using (var signedPackage = File.Open(tempPath, FileMode.OpenOrCreate, FileAccess.ReadWrite))
+            using (var request = new RepositorySignPackageRequest(certificate, signatureHashAlgorithm, timestampHashAlgorithm, v3ServiceIndex, packageOwners))
+            {
+                await CreateSignedPackageAsync(request, originalPackage, signedPackage, timestampService);
+            }
+
+            FileUtility.Delete(tempPath);
+
+            return outputPackagePath;
+        }
+
+        public static async Task CreateSignedPackageAsync(
+            SignPackageRequest request,
+            Stream packageReadStream,
+            Stream packageWriteStream,
+            Uri timestampService = null)
+        {
+            Rfc3161TimestampProvider timestampProvider = null;
+            if (timestampService != null)
+            {
+                timestampProvider = new Rfc3161TimestampProvider(timestampService);
+            }
+
+            using (var signedPackage = new SignedPackageArchive(packageReadStream, packageWriteStream))
+            using (var options = new SigningOptions(
+                new Lazy<Stream>(() => packageReadStream),
+                new Lazy<Stream>(() => packageWriteStream),
+                overwrite: false,
+                signatureProvider: new X509SignatureProvider(timestampProvider),
+                logger: NullLogger.Instance))
+            {
+                await SigningUtility.SignAsync(options, request, CancellationToken.None);
+            }
         }
 
         /// <summary>
@@ -116,25 +180,121 @@ namespace Test.Utility.Signing
         /// <param name="packageStream">Package stream for which the signature has to be generated.</param>
         /// <param name="timestampProvider">An optional timestamp provider.</param>
         /// <returns>Signature for the package.</returns>
-        public static async Task<PrimarySignature> CreatePrimarySignatureForPackageAsync(
+        public static async Task<PrimarySignature> CreateAuthorSignatureForPackageAsync(
             X509Certificate2 testCert,
             Stream packageStream,
             ITimestampProvider timestampProvider = null)
         {
-            var testLogger = new TestLogger();
             var hashAlgorithm = HashAlgorithmName.SHA256;
-
             using (var request = new AuthorSignPackageRequest(testCert, hashAlgorithm))
             using (var package = new PackageArchiveReader(packageStream, leaveStreamOpen: true))
             {
-                var zipArchiveHash = await package.GetArchiveHashAsync(request.SignatureHashAlgorithm, CancellationToken.None);
-                var base64ZipArchiveHash = Convert.ToBase64String(zipArchiveHash);
-                var signatureContent = new SignatureContent(SigningSpecifications.V1, hashAlgorithm, base64ZipArchiveHash);
-                var testSignatureProvider = new X509SignatureProvider(timestampProvider);
-
-                return await testSignatureProvider.CreatePrimarySignatureAsync(request, signatureContent, testLogger, CancellationToken.None);
+                return await CreatePrimarySignatureForPackageAsync(package, request, timestampProvider);
             }
         }
+
+        /// <summary>
+        /// Generates a Signature for a given package for tests.
+        /// </summary>
+        /// <param name="package">Package to be used for the signature.</param>
+        /// <param name="request">Sign package request for primary signature</param>
+        /// <param name="timestampProvider">Provider to add timestamp to package. Defaults to null.</param>
+        /// <returns>Signature for the package.</returns>
+        public static async Task<PrimarySignature> CreatePrimarySignatureForPackageAsync(
+            PackageArchiveReader package,
+            SignPackageRequest request,
+            ITimestampProvider timestampProvider = null)
+        {
+            Assert.True(await package.IsSignedAsync(CancellationToken.None));
+
+            var testLogger = new TestLogger();
+            var signatureProvider = new X509SignatureProvider(timestampProvider);
+
+            var zipArchiveHash = await package.GetArchiveHashAsync(request.SignatureHashAlgorithm, CancellationToken.None);
+            var base64ZipArchiveHash = Convert.ToBase64String(zipArchiveHash);
+            var signatureContent = new SignatureContent(SigningSpecifications.V1, request.SignatureHashAlgorithm, base64ZipArchiveHash);
+
+            return await signatureProvider.CreatePrimarySignatureAsync(request, signatureContent, testLogger, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Adds a repository countersignature for a given primary signature for tests.
+        /// </summary>
+        /// <param name="signature">Primary signature to add the repository countersignature.</param>
+        /// <param name="request">RepositorySignPackageRequest containing the metadata for the signature request.</param>
+        /// <returns>Primary signature with a repository countersignature.</returns>
+        public static async Task<PrimarySignature> RepositoryCountersignPrimarySignatureAsync(PrimarySignature signature, RepositorySignPackageRequest request)
+        {
+            var testLogger = new TestLogger();
+            var signatureProvider = new X509SignatureProvider(timestampProvider: null);
+
+            return await signatureProvider.CreateRepositoryCountersignatureAsync(request, signature, testLogger, CancellationToken.None);
+        }
+
+#if IS_DESKTOP
+        // This generates a package with a basic signed CMS.
+        // The signature MUST NOT have any signed or unsigned attributes.
+        public static async Task<FileInfo> SignPackageFileWithBasicSignedCmsAsync(
+            TestDirectory directory,
+            FileInfo packageFile,
+            X509Certificate2 certificate)
+        {
+            SignatureContent signatureContent;
+
+            using (var stream = packageFile.OpenRead())
+            using (var hashAlgorithm = HashAlgorithmName.SHA256.GetHashProvider())
+            {
+                var hash = hashAlgorithm.ComputeHash(stream, leaveStreamOpen: false);
+                signatureContent = new SignatureContent(SigningSpecifications.V1, HashAlgorithmName.SHA256, Convert.ToBase64String(hash));
+            }
+
+            var signedPackageFile = new FileInfo(Path.Combine(directory, Guid.NewGuid().ToString()));
+            var cmsSigner = new CmsSigner(certificate)
+            {
+                DigestAlgorithm = HashAlgorithmName.SHA256.ConvertToOid(),
+                IncludeOption = X509IncludeOption.WholeChain
+            };
+
+            var contentInfo = new ContentInfo(signatureContent.GetBytes());
+            var signature = new SignedCms(contentInfo);
+
+            signature.ComputeSignature(cmsSigner);
+
+            Assert.Empty(signature.SignerInfos[0].SignedAttributes);
+            Assert.Empty(signature.SignerInfos[0].UnsignedAttributes);
+
+            using (var packageReadStream = packageFile.OpenRead())
+            using (var packageWriteStream = signedPackageFile.OpenWrite())
+            using (var package = new SignedPackageArchive(packageReadStream, packageWriteStream))
+            using (var signatureStream = new MemoryStream(signature.Encode()))
+            {
+                await package.AddSignatureAsync(signatureStream, CancellationToken.None);
+            }
+
+            return signedPackageFile;
+        }
+
+
+        public static Task<PrimarySignature> TimestampSignature(ITimestampProvider timestampProvider, PrimarySignature primarySignature, HashAlgorithmName hashAlgorithm, SignaturePlacement target, ILogger logger)
+        {
+            Signature signatureToTimestamp = primarySignature;
+            if (target == SignaturePlacement.Countersignature)
+            {
+                signatureToTimestamp = RepositoryCountersignature.GetRepositoryCountersignature(primarySignature);
+            }
+
+            var signatureValue = signatureToTimestamp.GetSignatureValue();
+            var messageHash = hashAlgorithm.ComputeHash(signatureValue);
+
+            var timestampRequest = new TimestampRequest(
+                SigningSpecifications.V1,
+                messageHash,
+                hashAlgorithm,
+                target);
+
+            return timestampProvider.TimestampSignatureAsync(primarySignature, timestampRequest, logger, CancellationToken.None);
+        }
+#endif
 
         public static async Task<bool> IsSignedAsync(Stream package)
         {
@@ -166,231 +326,6 @@ namespace Test.Utility.Signing
             }
         }
 
-
-        /// <summary>
-        /// Adds a Repository countersignature to a given primary signature
-        /// </summary>
-        /// <param name="testCert">Certificate to be used while generating the countersignature.</param>
-        /// <param name="primarySignature">Primary signature to add countersignature.</param>
-        /// <param name="timestampProvider">An optional timestamp provider.</param>
-        /// <returns></returns>
-        public static async Task<PrimarySignature> RepositoryCountersignPrimarySignatureAsync(
-            X509Certificate2 testCert,
-            PrimarySignature primarySignature,
-            ITimestampProvider timestampProvider = null)
-        {
-            var testLogger = new TestLogger();
-            var hashAlgorithm = HashAlgorithmName.SHA256;
-            var v3ServiceIndexUrl = new Uri("https://v3serviceIndex.test/api/index.json");
-
-            using (var request = new RepositorySignPackageRequest(testCert, hashAlgorithm, hashAlgorithm, v3ServiceIndexUrl, null))
-            {
-                var testSignatureProvider = new X509SignatureProvider(timestampProvider);
-
-                return await testSignatureProvider.CreateRepositoryCountersignatureAsync(request, primarySignature, testLogger, CancellationToken.None);
-            }
-        }
-
-        /// <summary>
-        /// Sign a package for test purposes.
-        /// This does not timestamp a signature and can be used outside corp network.
-        /// </summary>
-        private static async Task SignPackageAsync(TestLogger testLogger, X509Certificate2 certificate, string inputPackagePath, string outputPackagePath)
-        {
-#if IS_DESKTOP
-            var testSignatureProvider = new X509SignatureProvider(timestampProvider: null);
-            using (var cert = new X509Certificate2(certificate))
-            using (var request = new AuthorSignPackageRequest(cert, HashAlgorithmName.SHA256))
-            {
-                const bool overwrite = false;
-                using (var options = SigningOptions.CreateFromFilePaths(
-                    inputPackagePath,
-                    outputPackagePath,
-                    overwrite,
-                    testSignatureProvider,
-                    testLogger))
-                {
-                    await SigningUtility.SignAsync(options, request, CancellationToken.None);
-                }
-            }
-#endif
-        }
-
-        /// <summary>
-        /// Sign and timestamp a package for test purposes.
-        /// This method timestamps a package and should only be used with tests marked with [CIOnlyFact]
-        /// </summary>
-        private static async Task SignAndTimeStampPackageAsync(
-            TestLogger testLogger,
-            string inputPackagePath,
-            string outputPackagePath,
-            Uri timestampService,
-            AuthorSignPackageRequest request)
-        {
-            var testSignatureProvider = new X509SignatureProvider(new Rfc3161TimestampProvider(timestampService));
-            var overwrite = false;
-
-            using (var options = SigningOptions.CreateFromFilePaths(
-                inputPackagePath,
-                outputPackagePath,
-                overwrite,
-                testSignatureProvider,
-                testLogger))
-            {
-                await SigningUtility.SignAsync(options, request, CancellationToken.None);
-            }
-        }
-
-        public static async Task<VerifySignaturesResult> VerifySignatureAsync(SignedPackageArchive signPackage, SignedPackageVerifierSettings settings)
-        {
-            var verificationProviders = new[] { new SignatureTrustAndValidityVerificationProvider() };
-            var verifier = new PackageSignatureVerifier(verificationProviders, settings);
-            var result = await verifier.VerifySignaturesAsync(signPackage, CancellationToken.None);
-            return result;
-        }
-
-        /// <summary>
-        /// Generates a Signature for a given package for tests.
-        /// </summary>
-        /// <param name="signatureProvider">Signature proivider to create the signature.</param>
-        /// <param name="package">Package to be used for the signature.</param>
-        /// <param name="request">SignPackageRequest containing the metadata for the signature request.</param>
-        /// <param name="testLogger">ILogger.</param>
-        /// <returns>Signature for the package.</returns>
-        public static async Task<PrimarySignature> CreatePrimarySignatureForPackageAsync(ISignatureProvider signatureProvider, PackageArchiveReader package, SignPackageRequest request, TestLogger testLogger)
-        {
-            var zipArchiveHash = await package.GetArchiveHashAsync(request.SignatureHashAlgorithm, CancellationToken.None);
-            var base64ZipArchiveHash = Convert.ToBase64String(zipArchiveHash);
-            var signatureContent = new SignatureContent(SigningSpecifications.V1, request.SignatureHashAlgorithm, base64ZipArchiveHash);
-
-            return await signatureProvider.CreatePrimarySignatureAsync(request, signatureContent, testLogger, CancellationToken.None);
-        }
-
-        /// <summary>
-        /// Adds a repository countersignature for a given primary signature for tests.
-        /// </summary>
-        /// <param name="signatureProvider">Signature proivider to create the repository countersignature.</param>
-        /// <param name="signature">Primary signature to add the repository countersignature.</param>
-        /// <param name="request">RepositorySignPackageRequest containing the metadata for the signature request.</param>
-        /// <param name="testLogger">ILogger.</param>
-        /// <returns>Primary signature with a repository countersignature.</returns>
-        public static async Task<PrimarySignature> RepositoryCountersignPrimarySignatureAsync(ISignatureProvider signatureProvider, PrimarySignature signature, RepositorySignPackageRequest request, TestLogger testLogger)
-        {
-            return await signatureProvider.CreateRepositoryCountersignatureAsync(request, signature, testLogger, CancellationToken.None);
-        }
-
-#if IS_DESKTOP
-        private static SignatureContent CreateSignatureContent(FileInfo packageFile)
-        {
-            using (var stream = packageFile.OpenRead())
-            using (var hashAlgorithm = HashAlgorithmName.SHA256.GetHashProvider())
-            {
-                var hash = hashAlgorithm.ComputeHash(stream, leaveStreamOpen: false);
-
-                return new SignatureContent(SigningSpecifications.V1, HashAlgorithmName.SHA256, Convert.ToBase64String(hash));
-            }
-        }
-
-        private static SignedCms CreateSignature(SignatureContent signatureContent, X509Certificate2 certificate)
-        {
-            var cmsSigner = new CmsSigner(certificate);
-
-            cmsSigner.DigestAlgorithm = HashAlgorithmName.SHA256.ConvertToOid();
-            cmsSigner.IncludeOption = X509IncludeOption.WholeChain;
-
-            var contentInfo = new ContentInfo(signatureContent.GetBytes());
-            var signedCms = new SignedCms(contentInfo);
-
-            signedCms.ComputeSignature(cmsSigner);
-
-            Assert.Empty(signedCms.SignerInfos[0].SignedAttributes);
-            Assert.Empty(signedCms.SignerInfos[0].UnsignedAttributes);
-
-            return signedCms;
-        }
-
-        // This generates a package with a basic signed CMS.
-        // The signature MUST NOT have any signed or unsigned attributes.
-        public static async Task<FileInfo> SignPackageFileWithBasicSignedCmsAsync(
-            TestDirectory directory,
-            FileInfo packageFile,
-            X509Certificate2 certificate)
-        {
-            var signatureContent = CreateSignatureContent(packageFile);
-            var signedPackageFile = new FileInfo(Path.Combine(directory, Guid.NewGuid().ToString()));
-            var signature = CreateSignature(signatureContent, certificate);
-
-            using (var packageReadStream = packageFile.OpenRead())
-            using (var packageWriteStream = signedPackageFile.OpenWrite())
-            using (var package = new SignedPackageArchive(packageReadStream, packageWriteStream))
-            using (var signatureStream = new MemoryStream(signature.Encode()))
-            {
-                await package.AddSignatureAsync(signatureStream, CancellationToken.None);
-            }
-
-            return signedPackageFile;
-        }
-
-        /// <summary>
-        /// Timestamps a signature for tests.
-        /// </summary>
-        /// <param name="timestampProvider">Timestamp provider.</param>
-        /// <param name="signatureRequest">SignPackageRequest containing metadata for timestamp request.</param>
-        /// <param name="signature">Signature that needs to be timestamped.</param>
-        /// <param name="logger">ILogger.</param>
-        /// <returns>Timestamped Signature.</returns>
-        public static Task<PrimarySignature> TimestampPrimarySignature(ITimestampProvider timestampProvider, SignPackageRequest signatureRequest, PrimarySignature signature, ILogger logger)
-        {
-            var signatureValue = signature.GetSignatureValue();
-            var messageHash = signatureRequest.TimestampHashAlgorithm.ComputeHash(signatureValue);
-
-            var timestampRequest = new TimestampRequest(
-                signingSpecifications: SigningSpecifications.V1,
-                hashedMessage: messageHash,
-                hashAlgorithm: signatureRequest.TimestampHashAlgorithm,
-                target: SignaturePlacement.PrimarySignature
-            );
-
-            return TimestampPrimarySignature(timestampProvider, timestampRequest, signature, logger);
-        }
-#endif
-        /// <summary>
-        /// Timestamps a signature for tests.
-        /// </summary>
-        /// <param name="timestampProvider">Timestamp provider.</param>
-        /// <param name="signature">Signature that needs to be timestamped.</param>
-        /// <param name="logger">ILogger.</param>
-        /// <param name="timestampRequest">timestampRequest containing metadata for timestamp request.</param>
-        /// <returns>Timestamped Signature.</returns>
-        public static Task<PrimarySignature> TimestampPrimarySignature(ITimestampProvider timestampProvider, TimestampRequest timestampRequest, PrimarySignature signature, ILogger logger)
-        {
-            return timestampProvider.TimestampSignatureAsync(signature, timestampRequest, logger, CancellationToken.None);
-        }
-
-        /// <summary>
-        /// unsigns a package for test purposes.
-        /// This does not timestamp a signature and can be used outside corp network.
-        /// </summary>
-        public static async Task ShiftSignatureMetadataAsync(SigningSpecifications spec, string signedPackagePath, string dir, int centralDirectoryIndex, int fileHeaderIndex)
-        {
-            var testLogger = new TestLogger();
-            var testSignatureProvider = new X509SignatureProvider(timestampProvider: null);
-
-            // Create a temp path
-            var copiedSignedPackagePath = Path.Combine(dir, Guid.NewGuid().ToString());
-
-            using (var signedReadStream = File.OpenRead(signedPackagePath))
-            using (var signedPackage = new BinaryReader(signedReadStream))
-            using (var shiftedWriteStream = File.OpenWrite(copiedSignedPackagePath))
-            using (var shiftedPackage = new BinaryWriter(shiftedWriteStream))
-            {
-                await ShiftSignatureMetadata(spec, signedPackage, shiftedPackage, centralDirectoryIndex, fileHeaderIndex);
-            }
-
-            // Overwrite the original package with the shifted one
-            File.Copy(copiedSignedPackagePath, signedPackagePath, overwrite: true);
-        }
-
         public static void TamperWithPackage(string signedPackagePath)
         {
             using (var stream = File.Open(signedPackagePath, FileMode.Open))
@@ -398,168 +333,6 @@ namespace Test.Utility.Signing
             {
                 zip.Entries.First().Delete();
             }
-        }
-
-#if IS_DESKTOP
-
-        public static PrimarySignature GenerateInvalidPrimarySignature(PrimarySignature signature)
-        {
-            var hash = Encoding.UTF8.GetBytes(signature.SignatureContent.HashValue);
-            var newHash = Encoding.UTF8.GetBytes(new string('0', hash.Length));
-
-            var bytes = signature.SignedCms.Encode();
-            var newBytes = FindAndReplaceSequence(bytes, hash, newHash);
-
-            return PrimarySignature.Load(newBytes);
-        }
-#endif
-
-        public static byte[] FindAndReplaceSequence(byte[] bytes, byte[] find, byte[] replace)
-        {
-            var found = false;
-            var from = -1;
-
-            for (var i = 0; !found && i < bytes.Length - find.Length; ++i)
-            {
-                for (var j = 0; j < find.Length; ++j)
-                {
-                    if (bytes[i + j] != find[j])
-                    {
-                        break;
-                    }
-
-                    if (j == find.Length - 1)
-                    {
-                        from = i;
-                        found = true;
-                    }
-                }
-            }
-
-            if (!found)
-            {
-                throw new Exception("Byte sequence not found.");
-            }
-
-            var byteList = new List<byte>(bytes);
-
-            byteList.RemoveRange(from, find.Length);
-            byteList.InsertRange(from, replace);
-
-            return byteList.ToArray();
-        }
-
-        private static Task ShiftSignatureMetadata(SigningSpecifications spec, BinaryReader reader, BinaryWriter writer, int centralDirectoryIndex, int fileHeaderIndex)
-        {
-            var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
-
-            // Calculate new central directory record metadata with the the signature record and entry shifted
-            var shiftedCdr = ShiftMetadata(spec, metadata, newSignatureFileEntryIndex: fileHeaderIndex, newSignatureCentralDirectoryRecordIndex: centralDirectoryIndex);
-
-            // Order records by shifted ofset (new offset = old offset + change in offset).
-            // This is the order they will appear in the new shifted package, but not necesarily the same order they were in the old package
-            shiftedCdr.Sort((x, y) => (x.OffsetToLocalFileHeader + x.ChangeInOffset).CompareTo(y.OffsetToLocalFileHeader + y.ChangeInOffset));
-
-            // Write data from start of file to first file entry
-            reader.BaseStream.Seek(offset: 0, origin: SeekOrigin.Begin);
-            SignedPackageArchiveIOUtility.ReadAndWriteUntilPosition(reader, writer, metadata.StartOfLocalFileHeaders);
-
-            // Write all file entries in the new order
-            foreach (var entry in shiftedCdr)
-            {
-                // We need to read each entry from their position in the old package and write them sequencially to the new package
-                // The order in which they will appear in the new shited package is defined by the sorting done before starting to write
-                reader.BaseStream.Seek(offset: entry.OffsetToLocalFileHeader, origin: SeekOrigin.Begin);
-                SignedPackageArchiveIOUtility.ReadAndWriteUntilPosition(reader, writer, entry.OffsetToLocalFileHeader + entry.FileEntryTotalSize);
-            }
-
-            // Write all central directory records with updated offsets
-            // We first need to sort them in the order they will appear in the new shifted package
-            shiftedCdr.Sort((x, y) => x.IndexInHeaders.CompareTo(y.IndexInHeaders));
-            foreach (var entry in shiftedCdr)
-            {
-                reader.BaseStream.Seek(offset: entry.Position, origin: SeekOrigin.Begin);
-                // Read and write from the start of the central directory record until the relative offset of local file header (42 from the start of central directory record, incluing signature length)
-                SignedPackageArchiveIOUtility.ReadAndWriteUntilPosition(reader, writer, reader.BaseStream.Position + 42);
-
-                var relativeOffsetOfLocalFileHeader = (uint)(reader.ReadUInt32() + entry.ChangeInOffset);
-                writer.Write(relativeOffsetOfLocalFileHeader);
-
-                // We already read and hash the whole header, skip only filenameLength + extraFieldLength + fileCommentLength (46 is the size of the header without those lengths)
-                SignedPackageArchiveIOUtility.ReadAndWriteUntilPosition(reader, writer, reader.BaseStream.Position + entry.HeaderSize - CentralDirectoryFileHeaderSizeWithoutSignature);
-            }
-
-            // Write everything after central directory records
-            reader.BaseStream.Seek(offset: metadata.EndOfCentralDirectory, origin: SeekOrigin.Begin);
-            SignedPackageArchiveIOUtility.ReadAndWriteUntilPosition(reader, writer, reader.BaseStream.Length);
-
-            return Task.FromResult(0);
-        }
-
-        private static List<CentralDirectoryHeaderMetadata> ShiftMetadata(
-            SigningSpecifications spec,
-            SignedPackageArchiveMetadata metadata,
-            int newSignatureFileEntryIndex,
-            int newSignatureCentralDirectoryRecordIndex)
-        {
-            var shiftedCdr = new List<CentralDirectoryHeaderMetadata>(metadata.CentralDirectoryHeaders);
-
-            // Sort Central Directory records in the order the file entries appear  in the original archive
-            shiftedCdr.Sort((x, y) => x.OffsetToLocalFileHeader.CompareTo(y.OffsetToLocalFileHeader));
-
-            // Shift Central Directory records to the desired position.
-            // Because we sorted in the file entry order this will shift
-            // the file entries
-            ShiftSignatureToIndex(spec, shiftedCdr, newSignatureFileEntryIndex);
-
-            // Calculate the change in offsets for the shifted file entries
-            var lastEntryEnd = 0L;
-            foreach (var cdr in shiftedCdr)
-            {
-                cdr.ChangeInOffset = lastEntryEnd - cdr.OffsetToLocalFileHeader;
-
-                lastEntryEnd = cdr.OffsetToLocalFileHeader + cdr.FileEntryTotalSize + cdr.ChangeInOffset;
-            }
-
-            // Now we sort the central directory records in the order thecentral directory records appear in the original archive
-            shiftedCdr.Sort((x, y) => x.Position.CompareTo(y.Position));
-
-            // Shift Central Directory records to the desired position.
-            // Because we sorted in the central directory records order this will shift
-            // the central directory records
-            ShiftSignatureToIndex(spec, shiftedCdr, newSignatureCentralDirectoryRecordIndex);
-
-            // Calculate the new indexes for each central directory record
-            var lastIndex = 0;
-            foreach (var cdr in shiftedCdr)
-            {
-                cdr.IndexInHeaders = lastIndex;
-                lastIndex++;
-            }
-
-            return shiftedCdr;
-        }
-
-        private static void ShiftSignatureToIndex(
-            SigningSpecifications spec,
-            List<CentralDirectoryHeaderMetadata> cdr,
-            int index)
-        {
-            // Check for the signature object in the entries.
-            // We have to do a manual check because we have no context
-            // of the order in which the central directory records list is sorted.
-            var recordIndex = 0;
-            for (; recordIndex < cdr.Count; recordIndex++)
-            {
-                if (cdr[recordIndex].IsPackageSignatureFile)
-                {
-                    break;
-                }
-            }
-            // Remove the signature object and add it to the new index
-            var signatureCD = cdr[recordIndex];
-            cdr.RemoveAt(recordIndex);
-            cdr.Insert(index, signatureCD);
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/Signing/SignedArchiveTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SignedArchiveTestUtility.cs
@@ -52,8 +52,8 @@ namespace Test.Utility.Signing
                 packageStream.CopyTo(fileStream);
             }
 
-            using (var originalPackage = File.OpenRead(signedPackagePath))
-            using (var signedPackage = File.Open(tempPath, FileMode.OpenOrCreate, FileAccess.ReadWrite))
+            using (var originalPackage = File.OpenRead(tempPath))
+            using (var signedPackage = File.Open(signedPackagePath, FileMode.OpenOrCreate, FileAccess.ReadWrite))
             using (var request = new AuthorSignPackageRequest(certificate, signatureHashAlgorithm, timestampHashAlgorithm))
             {
                 await CreateSignedPackageAsync(request, originalPackage, signedPackage, timestampService);
@@ -97,8 +97,8 @@ namespace Test.Utility.Signing
                 packageStream.CopyTo(fileStream);
             }
 
-            using (var originalPackage = File.OpenRead(signedPackagePath))
-            using (var signedPackage = File.Open(tempPath, FileMode.OpenOrCreate, FileAccess.ReadWrite))
+            using (var originalPackage = File.OpenRead(tempPath))
+            using (var signedPackage = File.Open(signedPackagePath, FileMode.OpenOrCreate, FileAccess.ReadWrite))
             using (var request = new RepositorySignPackageRequest(certificate, signatureHashAlgorithm, timestampHashAlgorithm, v3ServiceIndex, packageOwners))
             {
                 await CreateSignedPackageAsync(request, originalPackage, signedPackage, timestampService);
@@ -135,16 +135,13 @@ namespace Test.Utility.Signing
         {
             var testLogger = new TestLogger();
             var outputPackagePath = Path.Combine(outputDir, Guid.NewGuid().ToString());
-            var tempPath = Path.GetTempFileName();
 
             using (var originalPackage = File.OpenRead(packagePath))
-            using (var signedPackage = File.Open(tempPath, FileMode.OpenOrCreate, FileAccess.ReadWrite))
+            using (var signedPackage = File.Open(outputPackagePath, FileMode.OpenOrCreate, FileAccess.ReadWrite))
             using (var request = new RepositorySignPackageRequest(certificate, signatureHashAlgorithm, timestampHashAlgorithm, v3ServiceIndex, packageOwners))
             {
                 await CreateSignedPackageAsync(request, originalPackage, signedPackage, timestampService);
             }
-
-            FileUtility.Delete(tempPath);
 
             return outputPackagePath;
         }
@@ -205,7 +202,7 @@ namespace Test.Utility.Signing
             SignPackageRequest request,
             ITimestampProvider timestampProvider = null)
         {
-            Assert.True(await package.IsSignedAsync(CancellationToken.None));
+            Assert.False(await package.IsSignedAsync(CancellationToken.None));
 
             var testLogger = new TestLogger();
             var signatureProvider = new X509SignatureProvider(timestampProvider);


### PR DESCRIPTION
`SignedArchiveTestUtility` was a mess it had different methods that did the same and there was no intuitive way to add countersignature methods for tests. This PR refactors and cleans up that code so it can be easy to use for tests.