### PR TITLE
copy public key file locally for functional tests

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -349,6 +349,16 @@ phases:
         Write-Host "##vso[build.updatebuildnumber]$env:BuildNumber"
         gci env:* | sort-object name
 
+  - task: CopyFiles@2
+    displayName: "Copy Public Key Files"
+    inputs:
+      SourceFolder: "$(NuGetSharePublicKeys)"
+      Contents: "*.snk"
+      TargetFolder: "$(Build.Repository.LocalPath)\\keys"
+      CleanTargetFolder: "true"
+      OverWrite: "true"
+      flattenFolders: "true"
+
   - task: PowerShell@1
     displayName: "Download Config Files"
     enabled: "false"
@@ -381,7 +391,7 @@ phases:
       solution: "build\\build.proj"
       msbuildVersion: "15.0"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:CoreFuncTests  /p:BuildRTM=false  /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml"
+      msbuildArguments: "/t:CoreFuncTests  /p:BuildRTM=false  /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:NUGET_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\NuGetKey.snk /p:MS_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\35MSSharedLib1024.snk"
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"


### PR DESCRIPTION
For some weird reason, functional tests are failling at the ilmerge step because they are trying to reference the public key directly from the network share.

Copying the public key locally to the repo root seems to fix the problem. 

No clue why though.