### PR TITLE
Invalidate http cache to hit http source to get refresh package's metdata

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/InstalledPackageFeed.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/InstalledPackageFeed.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -100,7 +100,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return result;
         }
 
-        private async Task<IPackageSearchMetadata> GetPackageMetadataAsync(PackageIdentity identity, bool includePrerelease, CancellationToken cancellationToken)
+        public async Task<IPackageSearchMetadata> GetPackageMetadataAsync(PackageIdentity identity, bool includePrerelease, CancellationToken cancellationToken)
         {
             // first we try and load the metadata from a local package
             var packageMetadata = await _metadataProvider.GetLocalPackageMetadataAsync(identity, includePrerelease, cancellationToken);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/SourceRepositoryExtensions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/SourceRepositoryExtensions.cs
@@ -88,6 +88,10 @@ namespace NuGet.PackageManagement.VisualStudio
 
             using (var sourceCacheContext = new SourceCacheContext())
             {
+                // Update http source cache context MaxAge so that it can always go online to fetch
+                // latest version of packages.
+                sourceCacheContext.MaxAge = DateTimeOffset.UtcNow;
+
                 var packages = await metadataResource?.GetMetadataAsync(
                     identity.Id,
                     includePrerelease: true,
@@ -142,6 +146,10 @@ namespace NuGet.PackageManagement.VisualStudio
 
             using (var sourceCacheContext = new SourceCacheContext())
             {
+                // Update http source cache context MaxAge so that it can always go online to fetch
+                // latest version of packages.
+                sourceCacheContext.MaxAge = DateTimeOffset.UtcNow;
+
                 var packages = await metadataResource?.GetMetadataAsync(
                     packageId,
                     includePrerelease,

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedUtilities.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -36,6 +37,10 @@ namespace NuGet.Protocol
 
             using (var sourceCacheContext = new SourceCacheContext())
             {
+                // Update http source cache context MaxAge so that it can always go online to fetch
+                // latest version of packages.
+                sourceCacheContext.MaxAge = DateTimeOffset.UtcNow;
+
                 // apply the filters to the version list returned
                 var packages = await feedParser.FindPackagesByIdAsync(
                     package.Id,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Feeds/InstalledPackageFeedTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Feeds/InstalledPackageFeedTests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.PackageManagement.VisualStudio.Test
+{
+    public class InstalledPackageFeedTests
+    {
+        private readonly MultiSourcePackageMetadataProvider _metadataProvider;
+        private readonly PackageMetadataResource _metadataResource;
+
+        public InstalledPackageFeedTests()
+        {
+            // dependencies and data
+            _metadataResource = Mock.Of<PackageMetadataResource>();
+
+            var provider = Mock.Of<INuGetResourceProvider>();
+            Mock.Get(provider)
+                .Setup(x => x.TryCreate(It.IsAny<SourceRepository>(), It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult(Tuple.Create(true, (INuGetResource)_metadataResource)));
+            Mock.Get(provider)
+                .Setup(x => x.ResourceType)
+                .Returns(typeof(PackageMetadataResource));
+
+            var logger = new TestLogger();
+            var packageSource = new Configuration.PackageSource("http://fake-source");
+            var source = new SourceRepository(packageSource, new[] { provider });
+
+            // target
+            _metadataProvider = new MultiSourcePackageMetadataProvider(
+                new[] { source },
+                optionalLocalRepository: null,
+                optionalGlobalLocalRepositories: null,
+                logger: logger);
+        }
+
+        [Fact]
+        public async Task GetPackagesWithUpdatesAsync_WithHttpCache()
+        {
+            // Arrange
+            var testPackageIdentity = new PackageCollectionItem("FakePackage", new NuGetVersion("1.0.0"), null);
+
+            var packageIdentity = new PackageIdentity("FakePackage", new NuGetVersion("1.0.0"));
+
+            SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.0");
+
+            var _target = new InstalledPackageFeed(new[] { testPackageIdentity }, _metadataProvider, new TestLogger());
+
+            // Act
+            var package = await _target.GetPackageMetadataAsync(
+                packageIdentity, false, CancellationToken.None);
+
+            Assert.NotNull(package);
+            Assert.Equal("1.0.0", package.Identity.Version.ToString());
+            var allVersions = await package.GetVersionsAsync();
+            Assert.NotEmpty(allVersions);
+            Assert.Equal(
+                new[] { "2.0.0", "1.0.0", "0.0.1" },
+                allVersions.Select(v => v.Version.ToString()).ToArray());
+
+            SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
+
+            package = await _target.GetPackageMetadataAsync(
+                packageIdentity, false, CancellationToken.None);
+
+            Assert.NotNull(package);
+            Assert.Equal("1.0.0", package.Identity.Version.ToString());
+
+            allVersions = await package.GetVersionsAsync();
+            Assert.NotEmpty(allVersions);
+            Assert.Equal(
+                new[] { "2.0.1", "2.0.0", "1.0.1", "1.0.0", "0.0.1" },
+                allVersions.Select(v => v.Version.ToString()).ToArray());
+        }
+
+        private void SetupRemotePackageMetadata(string id, params string[] versions)
+        {
+            var metadata = versions
+                .Select(v => PackageSearchMetadataBuilder
+                    .FromIdentity(new PackageIdentity(id, new NuGetVersion(v)))
+                    .Build());
+
+            Mock.Get(_metadataResource)
+                .Setup(x => x.GetMetadataAsync(id, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<SourceCacheContext>(), It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(metadata));
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
@@ -26,6 +26,7 @@
     <Compile Include="DispatcherThreadCollection.cs" />
     <Compile Include="Feeds\MultiSourcePackageMetadataProviderTests.cs" />
     <Compile Include="Feeds\UpdatePackageFeedTests.cs" />
+    <Compile Include="Feeds\InstalledPackageFeedTests.cs" />
     <Compile Include="FrameworkAssemblyResolverTests.cs" />
     <Compile Include="ProjectSystems\ProjectKNuGetProjectTests.cs" />
     <Compile Include="ProjectSystems\ProjectSystemCacheTests.cs" />


### PR DESCRIPTION
When clicking refresh on install/ update tabs, client is not hitting http sources to get refresh metadata for packages so customer has to wait until 30 mins or manually clear cache to get updates. This PR invalidate http cache for these refresh just like for search.

Working on adding tests to cover missing scenarios.

fixes https://github.com/NuGet/Home/issues/6657

@rrelyea 