### PR TITLE
fix hash of build tools vsix

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -201,7 +201,7 @@ phases:
       solution: "setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
       msbuildVersion: "15.0"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/p:BuildNumber=$(BuildNumber)"
+      msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true"
     condition: " and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
   - task: MSBuild@1
@@ -220,9 +220,17 @@ phases:
       TargetFolder: "$(BuildOutputTargetPath)\\artifacts\\$(VsixPublishDir)\\$(NupkgOutputDir)"
 
   - task: MSBuild@1
-    displayName: "Generate VSMAN file for VSIX"
+    displayName: "Generate VSMAN file for NuGet Core VSIX"
     inputs:
       solution: "setup\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
+      msbuildVersion: "15.0"
+      configuration: "$(BuildConfiguration)"
+    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+
+  - task: MSBuild@1
+    displayName: "Generate VSMAN file for Build Tools VSIX"
+    inputs:
+      solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
       msbuildVersion: "15.0"
       configuration: "$(BuildConfiguration)"
     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
@@ -10,6 +10,10 @@
     <BuildNumber>$(SemanticVersion).$(BuildNumber)</BuildNumber>
     <TargetName>$(MSBuildProjectName)</TargetName>
     <DropFolder>$(VsixPublishDestination)</DropFolder>
+    <OutputPath Condition="'$(IsVsixBuild)' != 'true'">$(DropFolder)</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsVsixBuild)' == 'true'">
     <IsPackage>true</IsPackage>
     <FinalizeValidate>false</FinalizeValidate>
     <ValidateManifest>false</ValidateManifest>
@@ -17,7 +21,7 @@
     <MicroBuild_SigningEnabled>false</MicroBuild_SigningEnabled>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(IsVsixBuild)' == 'true'">
     <ProjectReference Include="Microsoft.VisualStudio.NuGet.BuildTools.swixproj" SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
 
@@ -25,14 +29,12 @@
     <MergeManifest Include="$(OutputPath)$(MSBuildProjectName).json" />
   </ItemGroup>
 
-  <Target Name="CopyToDropFolder" AfterTargets="Build">
+  <Target Name="CopyToDropFolder" AfterTargets="Build" Condition="'$(IsVsixBuild)' == 'true'">
     <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).vsix" DestinationFolder="$(DropFolder)" />
     <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).json" DestinationFolder="$(DropFolder)" />
-    <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).vsman" DestinationFolder="$(DropFolder)" />
-    <Copy SourceFiles="$(OutputPath)$(MSBuildProjectName).vsmand" DestinationFolder="$(DropFolder)" />
   </Target>
 
   <Import Project="$(MicroBuildDirectory)MicroBuild.Core.targets" />
 
-  <Target Name="ValidateManifest" />
+  <Target Name="ValidateManifest" Condition="'$(IsVsixBuild)' == 'true'"/>
 </Project>


### PR DESCRIPTION
my recent check-in to combine multiple signing requests into one ended up signing the build tools vsix after it generated the vsman file, leading to an invalid hash in the vsman file.

This fixes it by doing the vsman generation as a post signing step so that the hash is consistent.