### PR TITLE
Assemblies that ended with ".resources" are not processed. 

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildToolset.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildToolset.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.ComTypes;
@@ -134,7 +135,7 @@ namespace NuGet.CommandLine
         {
             var dirName = new DirectoryInfo(directoryName).Name;
             float dirValue;
-            if (float.TryParse(dirName, out dirValue))
+            if (float.TryParse(dirName, NumberStyles.Float, CultureInfo.InvariantCulture, out dirValue))
             {
                 return dirValue;
             }

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildToolset.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildToolset.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.ComTypes;
@@ -135,7 +134,7 @@ namespace NuGet.CommandLine
         {
             var dirName = new DirectoryInfo(directoryName).Name;
             float dirValue;
-            if (float.TryParse(dirName, NumberStyles.Float, CultureInfo.InvariantCulture, out dirValue))
+            if (float.TryParse(dirName, out dirValue))
             {
                 return dirValue;
             }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
@@ -628,7 +628,7 @@ namespace NuGet.ProjectManagement
             {
                 // Assembly name can be ended as ".resources" by itself. 
                 // We should check full name + resources.dll postfix here.
-                if (filePath.EndsWith(packageIdentity.Id+Constants.ResourceAssemblyExtension, StringComparison.OrdinalIgnoreCase))
+                if (filePath.EndsWith(packageIdentity.Id + Constants.ResourceAssemblyExtension, StringComparison.OrdinalIgnoreCase))
                 {
                     return false;
                 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -500,7 +501,9 @@ namespace NuGet.Packaging
 
             if (StringComparer.OrdinalIgnoreCase.Equals(extension, ".dll"))
             {
-                if (!path.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
+                // Resource assembly suppose to be located in the culture folder.
+                // In other case proper assemblies that are ended with "resources" can be filtered.
+                if (!Regex.IsMatch(path, @"[\\\/](\w{2}|\w{2}[-]\w{2})[\\\/].+[.]resources[.]dll$", RegexOptions.IgnoreCase))
                 {
                     result = true;
                 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -26,7 +26,7 @@ namespace NuGet.Packaging
     public abstract class PackageReaderBase : IPackageCoreReader, IPackageContentReader, IAsyncPackageCoreReader, IAsyncPackageContentReader, ISignedPackageReader
     {
         private NuspecReader _nuspecReader;
-
+        private static readonly Regex _resourceDllRegex = new Regex(@"[\\\/](\w{2}|\w{2}[-]\w{2})[\\\/].+[.]resources[.]dll$", RegexOptions.IgnoreCase);
         protected IFrameworkNameProvider FrameworkProvider { get; set; }
         protected IFrameworkCompatibilityProvider CompatibilityProvider { get; set; }
 
@@ -503,7 +503,7 @@ namespace NuGet.Packaging
             {
                 // Resource assembly suppose to be located in the culture folder.
                 // In other case proper assemblies that are ended with "resources" can be filtered.
-                if (!Regex.IsMatch(path, @"[\\\/](\w{2}|\w{2}[-]\w{2})[\\\/].+[.]resources[.]dll$", RegexOptions.IgnoreCase))
+                if (!_resourceDllRegex.IsMatch(path))
                 {
                     result = true;
                 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -821,7 +821,7 @@ namespace NuGet.Protocol.Plugins
             // filter out non reference assemblies
             foreach (var group in await GetLibItemsAsync(cancellationToken))
             {
-                fileGroups.Add(new FrameworkSpecificGroup(group.TargetFramework, group.Items.Where(e => IsReferenceAssembly(e))));
+                fileGroups.Add(new FrameworkSpecificGroup(group.TargetFramework, group.Items.Where(e => IsAssemblyReference(e))));
             }
 
             // results

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/MSBuildNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/MSBuildNuGetProjectTests.cs
@@ -11,8 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Frameworks;
-using NuGet.LibraryModel;
-using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
@@ -172,6 +170,60 @@ namespace ProjectManagement.Test
                 Assert.Equal("test45.dll", msBuildNuGetProjectSystem.References.First().Key);
                 Assert.Equal(Path.Combine(msBuildNuGetProject.FolderNuGetProject.GetInstalledPath(packageIdentity),
                     "lib\\net45\\test45.dll"), msBuildNuGetProjectSystem.References.First().Value);
+            }
+        }
+
+        [Fact]
+        public async Task TestMSBuildNuGetProjectDontIgnoreResourceAssembly()
+        {
+            // Sattelite assemblies should be ignored, but not the main assemblies ended up with 'resources' title.
+            // Arrange
+            var packageIdentity = new PackageIdentity("packageA", new NuGetVersion("1.0.0"));
+
+            using (var randomTestPackageSourcePath = TestDirectory.Create())
+            using (var randomPackagesFolderPath = TestDirectory.Create())
+            using (var randomPackagesConfigFolderPath = TestDirectory.Create())
+            {
+                var randomPackagesConfigPath = Path.Combine(randomPackagesConfigFolderPath, "packages.config");
+                var token = CancellationToken.None;
+
+                var projectTargetFramework = NuGetFramework.Parse("net45");
+                var testNuGetProjectContext = new TestNuGetProjectContext();
+                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext);
+                var msBuildNuGetProject = new MSBuildNuGetProject(msBuildNuGetProjectSystem, randomPackagesFolderPath, randomPackagesConfigFolderPath);
+
+                // Pre-Assert
+                // Check that the packages.config file does not exist
+                Assert.False(File.Exists(randomPackagesConfigPath));
+                // Check that there are no packages returned by PackagesConfigProject
+                var packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+                Assert.Equal(0, packagesInPackagesConfig.Count);
+                Assert.Equal(0, msBuildNuGetProjectSystem.References.Count);
+
+                var assemblyName = "solution.resources";
+                var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackageWithSatellites(randomTestPackageSourcePath,
+                    packageIdentity.Id,
+                    assemblyName,
+                    packageIdentity.Version.ToNormalizedString());
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
+                {
+                    // Act
+                    await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
+                }
+
+                // Assert
+                // Check that the packages.config file exists after the installation
+                Assert.True(File.Exists(randomPackagesConfigPath));
+                // Check the number of packages and packages returned by PackagesConfigProject after the installation
+                packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+                Assert.Equal(1, packagesInPackagesConfig.Count);
+                Assert.Equal(packageIdentity, packagesInPackagesConfig[0].PackageIdentity);
+                Assert.Equal(projectTargetFramework, packagesInPackagesConfig[0].TargetFramework);
+                // Check that the reference has been added to MSBuildNuGetProjectSystem
+                Assert.Equal(1, msBuildNuGetProjectSystem.References.Count);
+                Assert.Equal(assemblyName + ".dll", msBuildNuGetProjectSystem.References.First().Key);
+                Assert.Equal(Path.Combine(msBuildNuGetProject.FolderNuGetProject.GetInstalledPath(packageIdentity),
+                    "lib\\net45\\" + assemblyName + ".dll"), msBuildNuGetProjectSystem.References.First().Value);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
@@ -46,7 +46,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        // verify that assemblies ended with "resources" still processed.
+        // verify that assemblies titles ended up with the "resources.dll" are still processed.
         [Fact]
         public void PackagesEndedWithResourcesShouldBeProcessed()
         {

--- a/test/TestUtilities/Test.Utility/TestPackages.cs
+++ b/test/TestUtilities/Test.Utility/TestPackages.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -47,6 +48,27 @@ namespace Test.Utility
                     "lib/net40/test40b.dll",
                     "lib/net45/test45.dll"
                 });
+        }
+
+        public static FileInfo GetLegacyTestPackageWithSatellites(string path,
+           string packageId = "packageA",
+           string packageAssemblyName = "solution.resources",
+           string packageVersion = "2.0.3")
+        {
+            var libs = new System.Collections.Generic.List<string>()
+                {
+                    "lib/" + packageAssemblyName + ".dll",
+                    "lib/net40/" + packageAssemblyName + ".dll",
+                    "lib/net40/" + packageAssemblyName + "a.dll",
+                    "lib/net40/" + packageAssemblyName + "b.dll",
+                    "lib/net45/" + packageAssemblyName + ".dll"
+                };
+
+            libs.Add("lib/net45/de/" + packageAssemblyName + ".resources.dll");
+            libs.Add("lib/net45/zh-Hans/" + packageAssemblyName + ".resources.dll");
+            libs.Add("lib/net45/abc/" + packageAssemblyName + ".resources.dll");
+    
+            return GeneratePackage(path, packageId, packageVersion, libs.ToArray());
         }
 
         public static FileInfo GetLegacyTestPackageWithMultipleReferences(string path,

--- a/test/TestUtilities/Test.Utility/TestPackagesCore.cs
+++ b/test/TestUtilities/Test.Utility/TestPackagesCore.cs
@@ -174,7 +174,7 @@ namespace NuGet.Test.Utility
             return file;
         }
 
-        public static TempFile GetLegacyTestPackage(string packageName="test")
+        public static TempFile GetLegacyResourcesPackage(string packageName)
         {
             var file = new TempFile();
 
@@ -182,10 +182,54 @@ namespace NuGet.Test.Utility
             {
                 zip.AddEntry("lib/"+ packageName + ".dll", ZeroContent);
                 zip.AddEntry("lib/net40/"+ packageName + "40.dll", ZeroContent);
-                zip.AddEntry("lib/net40/"+ packageName + "40b.dll", ZeroContent);
-                zip.AddEntry("lib/net45/"+ packageName + "45.dll", ZeroContent);
-                zip.AddEntry("lib/net40/en/" + packageName + ".resources.dll", ZeroContent);
-                zip.AddEntry("lib/net45/en-GB/" + packageName + ".resources.dll", ZeroContent);
+                zip.AddEntry("lib/net40/" + packageName + "40b.dll", ZeroContent);
+                zip.AddEntry("lib/net45/" + packageName + "45.dll", ZeroContent);
+                foreach (var culture in CultureInfo.GetCultures(CultureTypes.AllCultures).Where(p => !string.IsNullOrEmpty(p.Name)).Select(c => c.Name))
+                {
+                    zip.AddEntry("lib/net40/" + culture + "/" + packageName + ".resources.dll", ZeroContent);
+                    zip.AddEntry("lib/net45/" + culture + "/" + packageName + ".resources.dll", ZeroContent);
+                }
+
+                zip.AddEntry("packageA.nuspec", @"<?xml version=""1.0"" encoding=""utf-8""?>
+                            <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+                              <metadata>
+                                <id>packageA</id>
+                                <version>2.0.3</version>
+                                <authors>Author1, author2</authors>
+                                <description>Sample description</description>
+                                <language>en-US</language>
+                                <projectUrl>http://www.nuget.org/</projectUrl>
+                                <licenseUrl>http://www.nuget.org/license</licenseUrl>
+                                <dependencies>
+                                   <group>
+                                      <dependency id=""RouteMagic"" version=""1.1.0"" />
+                                   </group>
+                                   <group targetFramework=""net40"">
+                                      <dependency id=""jQuery"" />
+                                      <dependency id=""WebActivator"" />
+                                   </group>
+                                   <group targetFramework=""sl30"">
+                                   </group>
+                                </dependencies>
+                              </metadata>
+                            </package>", Encoding.UTF8);
+            }
+
+            return file;
+        }
+
+        public static TempFile GetLegacyTestPackage()
+        {
+            var file = new TempFile();
+
+            using (var zip = new ZipArchive(File.Create(file), ZipArchiveMode.Create))
+            {
+                zip.AddEntry("lib/test.dll", ZeroContent);
+                zip.AddEntry("lib/net40/test40.dll", ZeroContent);
+                zip.AddEntry("lib/net40/test40b.dll", ZeroContent);
+                zip.AddEntry("lib/net45/test45.dll", ZeroContent);
+                zip.AddEntry("lib/net40/en/test.resources.dll", ZeroContent);
+                zip.AddEntry("lib/net45/en-GB/test.resources.dll", ZeroContent);
 
                 zip.AddEntry("packageA.nuspec", @"<?xml version=""1.0"" encoding=""utf-8""?>
                             <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">

--- a/test/TestUtilities/Test.Utility/TestPackagesCore.cs
+++ b/test/TestUtilities/Test.Utility/TestPackagesCore.cs
@@ -174,16 +174,18 @@ namespace NuGet.Test.Utility
             return file;
         }
 
-        public static TempFile GetLegacyTestPackage()
+        public static TempFile GetLegacyTestPackage(string packageName="test")
         {
             var file = new TempFile();
 
             using (var zip = new ZipArchive(File.Create(file), ZipArchiveMode.Create))
             {
-                zip.AddEntry("lib/test.dll", ZeroContent);
-                zip.AddEntry("lib/net40/test40.dll", ZeroContent);
-                zip.AddEntry("lib/net40/test40b.dll", ZeroContent);
-                zip.AddEntry("lib/net45/test45.dll", ZeroContent);
+                zip.AddEntry("lib/"+ packageName + ".dll", ZeroContent);
+                zip.AddEntry("lib/net40/"+ packageName + "40.dll", ZeroContent);
+                zip.AddEntry("lib/net40/"+ packageName + "40b.dll", ZeroContent);
+                zip.AddEntry("lib/net45/"+ packageName + "45.dll", ZeroContent);
+                zip.AddEntry("lib/net40/en/" + packageName + ".resources.dll", ZeroContent);
+                zip.AddEntry("lib/net45/en-GB/" + packageName + ".resources.dll", ZeroContent);
 
                 zip.AddEntry("packageA.nuspec", @"<?xml version=""1.0"" encoding=""utf-8""?>
                             <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">


### PR DESCRIPTION
An assembly that has a name like "lib.resources" is not properly updated with Nuget. 
Packages config are updated but csproj files are skipped. 
Check\suggestion is added that resource files should be located in a folder with a culture name.
Example:
net\en\lib.resources.resources.dll
net\en-GB\lib.resources.resources.dll
Those are satellite assemblies files.

But this one should be processed: 
net\lib.resources.dll

Related issue:
https://github.com/NuGet/Home/issues/6686
