### PR TITLE
Check hash of lock files before writing file to disk

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/IRestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/IRestoreResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -25,6 +25,11 @@ namespace NuGet.Commands
         /// The existing lock file. This is null if no lock file was provided on the <see cref="RestoreRequest"/>.
         /// </summary>
         LockFile PreviousLockFile { get; }
+
+        /// <summary>
+        /// The SHA256 hash of the existing lock file. This is null if there is no previous lock file.
+        /// </summary>
+        byte[] PreviousLockFileHash { get; }
 
         /// <summary>
         /// Props and targets files to be written to disk.

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/NoOpRestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/NoOpRestoreResult.cs
@@ -15,10 +15,10 @@ namespace NuGet.Commands
 {
     public class NoOpRestoreResult : RestoreResult
     {
-        public NoOpRestoreResult(bool success, LockFile lockFile, LockFile previousLockFile, string lockFilePath, CacheFile cacheFile, string cacheFilePath, ProjectStyle projectStyle, TimeSpan elapsedTime) :
+        public NoOpRestoreResult(bool success, LockFile lockFile, LockFile previousLockFile, byte[] previousLockFileHash, string lockFilePath, CacheFile cacheFile, string cacheFilePath, ProjectStyle projectStyle, TimeSpan elapsedTime) :
             base(success : success, restoreGraphs : null, compatibilityCheckResults : new List<CompatibilityCheckResult>() , 
-                msbuildFiles : null, lockFile : lockFile, previousLockFile : previousLockFile, lockFilePath: lockFilePath,
-                cacheFile: cacheFile, cacheFilePath: cacheFilePath, projectStyle: projectStyle, elapsedTime: elapsedTime)
+                msbuildFiles : null, lockFile : lockFile, previousLockFile : previousLockFile, previousLockFileHash : previousLockFileHash,
+                lockFilePath: lockFilePath, cacheFile: cacheFile, cacheFilePath: cacheFilePath, projectStyle: projectStyle, elapsedTime: elapsedTime)
         {
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -101,6 +101,7 @@ namespace NuGet.Commands
                                 _success,
                                 _request.ExistingLockFile,
                                 _request.ExistingLockFile,
+                                _request.ExistingLockFileHash,
                                 _request.ExistingLockFile.Path,
                                 cacheFile,
                                 _request.Project.RestoreMetadata.CacheFilePath,
@@ -202,6 +203,7 @@ namespace NuGet.Commands
                     msbuildOutputFiles,
                     assetsFile,
                     _request.ExistingLockFile,
+                    _request.ExistingLockFileHash,
                     assetsFilePath,
                     cacheFile,
                     cacheFilePath,
@@ -248,7 +250,8 @@ namespace NuGet.Commands
             {
                 if (noOp) // Only if the hash matches, then load the lock file. This is a performance hit, so we need to delay it as much as possible.
                 {
-                    _request.ExistingLockFile = LockFileUtilities.GetLockFile(_request.LockFilePath, _logger);
+                    var existingLockFile = LockFileUtilities.GetLockFile(_request.LockFilePath, _logger, out var existingLockFileHash);
+                    _request.SetExistingLockFile(existingLockFile, existingLockFileHash);
                 }
                 else
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
@@ -79,7 +79,12 @@ namespace NuGet.Commands
         /// (or, if that property is not specified, from the default location of the lock file, as specified in the
         /// description for <see cref="LockFilePath"/>)
         /// </summary>
-        public LockFile ExistingLockFile { get; set; }
+        public LockFile ExistingLockFile { get; private set; }
+
+        /// <summary>
+        /// The SHA256 hash of the existing lock file, if it exists.
+        /// </summary>
+        public byte[] ExistingLockFileHash { get; private set; }
 
         /// <summary>
         /// The number of concurrent tasks to run during installs. Defaults to
@@ -160,5 +165,11 @@ namespace NuGet.Commands
                             SignedPackageVerifierSettings.Default);
 
         public Guid ParentId { get; set;}
+
+        public void SetExistingLockFile(LockFile existingLockFile, byte[] existingLockFileHash)
+        {
+            ExistingLockFile = existingLockFile;
+            ExistingLockFileHash = existingLockFileHash;
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -256,7 +256,8 @@ namespace NuGet.Commands
             // how long it takes to load the lock file.
             if (request.ExistingLockFile == null)
             {
-                request.ExistingLockFile = LockFileUtilities.GetLockFile(request.LockFilePath, log);
+                var existingLockFile = LockFileUtilities.GetLockFile(request.LockFilePath, log, out var existingLogFileHash);
+                request.SetExistingLockFile(existingLockFile, existingLogFileHash);
             }
 
             var command = new RestoreCommand(request);

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileUtilities.cs
@@ -1,26 +1,42 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
+using System.Security.Cryptography;
+using System.Text;
 using NuGet.Common;
 
 namespace NuGet.ProjectModel
 {
     public static class LockFileUtilities
     {
-        public static LockFile GetLockFile(string lockFilePath, Common.ILogger logger)
+        public static LockFile GetLockFile(string lockFilePath, Common.ILogger logger, out byte[] hash)
         {
             LockFile lockFile = null;
+            hash = null;
 
             if (File.Exists(lockFilePath))
             {
                 var format = new LockFileFormat();
 
                 // A corrupt lock file will log errors and return null
-                lockFile = FileUtility.SafeRead(filePath: lockFilePath,read: (stream, path) => format.Read(stream, logger, path));
+                var lockFileContents = FileUtility.SafeRead(filePath: lockFilePath, read: (stream, path) =>
+                {
+                    using (var streamReader = new StreamReader(stream))
+                    {
+                        return streamReader.ReadToEnd();
+                    }
+                });
+
+                using (var sha = SHA256.Create())
+                {
+                    hash = sha.ComputeHash(Encoding.ASCII.GetBytes(lockFileContents));
+                }
+
+                using (var stringReader = new StringReader(lockFileContents))
+                {
+                    lockFile = format.Read(stringReader, logger, lockFilePath);
+                }
             }
 
             return lockFile;

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
@@ -111,7 +111,7 @@ namespace Dotnet.Integration.Test
                 // Assert
                 Assert.True(result.Item1 == 0, result.AllOutput);
                 // Verify the assets file
-                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
+                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance, out var hash);
                 Assert.NotNull(lockFile);
                 Assert.Equal(2, lockFile.Targets.Count);
                 var ridTargets = lockFile.Targets.Where(e => e.RuntimeIdentifier != null ? e.RuntimeIdentifier.Equals(rid, StringComparison.CurrentCultureIgnoreCase) : false);
@@ -195,7 +195,7 @@ namespace Dotnet.Integration.Test
                 // Assert
                 Assert.True(result.Item1 == 0, result.AllOutput);
                 // Verify the assets file
-                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
+                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance, out var hash);
                 Assert.NotNull(lockFile);
                 Assert.Equal(2, lockFile.Targets.Count);
                 var ridTargets = lockFile.Targets.Where(e => e.RuntimeIdentifier != null ? e.RuntimeIdentifier.Equals(rid, StringComparison.CurrentCultureIgnoreCase) : false);
@@ -243,7 +243,7 @@ namespace Dotnet.Integration.Test
                 // Assert
                 Assert.True(result.Item1 == 0, result.AllOutput);
                 // Verify the assets file
-                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
+                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance, out var hash);
                 Assert.NotNull(lockFile);
                 Assert.Equal(2, lockFile.Targets.Count);
                 var ridTargets = lockFile.Targets.Where(e => e.RuntimeIdentifier != null ? e.RuntimeIdentifier.Equals(projectRID, StringComparison.CurrentCultureIgnoreCase) : false);
@@ -384,7 +384,7 @@ namespace Dotnet.Integration.Test
 
                 // Assert
                 Assert.True(result.Item1 == 0, result.AllOutput);
-                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
+                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance, out var hash);
                 Assert.NotNull(lockFile);
                 Assert.Equal(2, lockFile.Targets.Count);
                 var ridTargets = lockFile.Targets.Where(e => e.RuntimeIdentifier != null ? e.RuntimeIdentifier.Equals(projectRid, StringComparison.CurrentCultureIgnoreCase) : false);
@@ -504,7 +504,7 @@ namespace Dotnet.Integration.Test
                 // Assert
                 Assert.True(result.Item1 == 0, result.AllOutput);
                 // Verify the assets file
-                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
+                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance, out var hash);
                 Assert.NotNull(lockFile);
                 Assert.Equal(2, lockFile.Targets.Count);
                 var ridTargets = lockFile.Targets.Where(e => e.RuntimeIdentifier != null ? e.RuntimeIdentifier.Equals(rid, StringComparison.CurrentCultureIgnoreCase) : false);
@@ -559,7 +559,7 @@ namespace Dotnet.Integration.Test
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
                 // Assert
-                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
+                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance, out var hash);
                 Assert.NotNull(lockFile);
                 Assert.Equal(2, lockFile.Targets.Count);
                 var ridTargets = lockFile.Targets.Where(e => e.RuntimeIdentifier != null ? e.RuntimeIdentifier.Equals(rid, StringComparison.CurrentCultureIgnoreCase) : false);
@@ -613,7 +613,7 @@ namespace Dotnet.Integration.Test
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
                 // Assert
-                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
+                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance, out var hash);
                 Assert.NotNull(lockFile);
                 Assert.Equal(2, lockFile.Targets.Count);
                 var ridTargets = lockFile.Targets.Where(e => e.RuntimeIdentifier != null ? e.RuntimeIdentifier.Equals(rid, StringComparison.CurrentCultureIgnoreCase) : false);
@@ -665,7 +665,7 @@ namespace Dotnet.Integration.Test
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
                 // Assert
-                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
+                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance, out var hash);
                 Assert.NotNull(lockFile);
                 Assert.Equal(2, lockFile.Targets.Count);
                 var ridTargets = lockFile.Targets.Where(e => e.RuntimeIdentifier != null ? e.RuntimeIdentifier.Equals(rid, StringComparison.CurrentCultureIgnoreCase) : false);
@@ -723,7 +723,7 @@ namespace Dotnet.Integration.Test
                 var result = _msbuildFixture.RestoreToolProject(workingDirectory, projectName, string.Empty);
 
                 // Assert
-                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
+                var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance, out var hash);
                 Assert.NotNull(lockFile);
                 Assert.Equal(2, lockFile.Targets.Count);
                 var ridTargets = lockFile.Targets.Where(e => e.RuntimeIdentifier != null ? e.RuntimeIdentifier.Equals(rid, StringComparison.CurrentCultureIgnoreCase) : false);

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -637,7 +637,7 @@ namespace NuGet.Commands.FuncTest
                 request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
-                request.ExistingLockFile = result.LockFile;
+                request.SetExistingLockFile(result.LockFile, null);
                 command = new RestoreCommand(request);
                 result = await command.ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
@@ -993,7 +993,7 @@ namespace NuGet.Commands.FuncTest
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 // Act
-                request.ExistingLockFile = modifiedLockFile;
+                request.SetExistingLockFile(modifiedLockFile, null);
 
                 command = new RestoreCommand(request);
                 result = await command.ExecuteAsync();
@@ -1041,7 +1041,7 @@ namespace NuGet.Commands.FuncTest
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
                 var previousLockFile = result.LockFile;
-                request.ExistingLockFile = result.LockFile;
+                request.SetExistingLockFile(result.LockFile, null);
 
                 // Act 2
                 // Read the file from disk to verify the reader
@@ -1437,7 +1437,7 @@ namespace NuGet.Commands.FuncTest
                 var logger = new TestLogger();
                 var requestB = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 requestB.LockFilePath = Path.Combine(projectDir, "project.lock.json");
-                requestB.ExistingLockFile = resultA.LockFile;
+                requestB.SetExistingLockFile(resultA.LockFile, null);
                 var commandB = new RestoreCommand(requestB);
 
                 // Act
@@ -1791,7 +1791,7 @@ namespace NuGet.Commands.FuncTest
                 var logger = new TestLogger();
                 var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
-                request.ExistingLockFile = lockFile;
+                request.SetExistingLockFile(lockFile, null);
 
                 // Act
                 var command = new RestoreCommand(request);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -382,9 +382,9 @@ namespace NuGet.Commands.Test
                     logger)
                 {
                     LockFilePath = lockFilePath,
-                    IsLowercasePackagesDirectory = isLowercase,
-                    ExistingLockFile = lockFileFormat.Read(lockFilePath)
+                    IsLowercasePackagesDirectory = isLowercase
                 };
+                requestB.SetExistingLockFile(lockFileFormat.Read(lockFilePath), null);
                 var commandB = new RestoreCommand(requestB);
                 var resultB = await commandB.ExecuteAsync();
                 await resultB.CommitAsync(logger, CancellationToken.None);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
@@ -29,6 +29,7 @@ namespace NuGet.Commands.Test
                     compatibilityCheckResults: null,
                     lockFile: new LockFile(),
                     previousLockFile: null, // different lock file
+                    previousLockFileHash: null,
                     lockFilePath: path,
                     msbuildFiles: Enumerable.Empty<MSBuildOutputFile>(),
                     cacheFile: null,
@@ -62,6 +63,7 @@ namespace NuGet.Commands.Test
                     compatibilityCheckResults: null,
                     lockFile: new LockFile(),
                     previousLockFile: new LockFile(), // same lock file
+                    previousLockFileHash: null,
                     lockFilePath: path,
                     msbuildFiles: Enumerable.Empty<MSBuildOutputFile>(),
                     cacheFile: null,
@@ -96,6 +98,7 @@ namespace NuGet.Commands.Test
                     compatibilityCheckResults: null,
                     lockFile: new LockFile(),
                     previousLockFile: null, // different lock file
+                    previousLockFileHash: null,
                     lockFilePath: path,
                     msbuildFiles: Enumerable.Empty<MSBuildOutputFile>(),
                     cacheFile: new CacheFile("NotSoRandomString"),
@@ -134,6 +137,7 @@ namespace NuGet.Commands.Test
                     success: true,
                     lockFile: new LockFile(),
                     previousLockFile: new LockFile(),
+                    previousLockFileHash: null,
                     lockFilePath: path,
                     cacheFile: new CacheFile("NotSoRandomString"),
                     cacheFilePath: cachePath,

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/InstallationCompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/InstallationCompatibilityTests.cs
@@ -508,6 +508,7 @@ namespace NuGet.PackageManagement.Test
                     null,
                     null,
                     null,
+                    null,
                     ProjectStyle.Unknown,
                     TimeSpan.MinValue);
             }


### PR DESCRIPTION
I realize this may require some discussion, but I wanted to get the PR started so people can look at what I'm proposing.

I'm currently working with several large customers who are reporting hangs in Visual Studio after doing a NuGet restore where nothing has changed (usually after solution open or build of a .NET Core project, both of which do automatic restores). What is happening is that projects' lock files are being written to disk even though they are not dirty, which is causing the compiler to kick off unnecessary design-time builds.

The core problem is that the logic that NuGet uses to compare a new lock file to an existing lock file to determine whether or not the lock file has changed is fragile and broken in places. I have already fixed at least 4-5 instances of places where the comparison logic wasn't taking into account sorting, wasn't handling duplicates correctly, or was just plain wrong. But even after those fixes, we're still seeing persistent issues with customers, many of whom cannot provide their solutions for us to debug against. Clearly, there are still issues lurking in that code.

It has gotten bad enough that the CPS-based project system has already implemented defensive measures where it hashes the lock file so that it can determine if a lock file has "really" changed when it gets a file change notification. And now I'm at the point where I need to add the same defensive measures to the original project system so that I can address real (and urgent) customer issues. But now it start to get ridiculous -- other people besides the C#/VB project system depend on the lock file write time, and it doesn't make sense that everyone who cares about lock files has to implement their own version of this hash check.

So, instead of implementing this hashing over and over, I am proposing that we fix everyone in one fell swoop by moving the check directly into NuGet. Clearly, this is a workaround -- in an ideal world, the lock file comparison logic would have extensive tests written for it and all bugs flushed out. However, until such time as the NuGet team gets the resources to demonstrate that their lock file comparison logic is fully sound, this code would provide immediate relief to customers suffering from UI delays due to bugs in that logic.

I'm certainly open to other solutions, though.