### PR TITLE
Rename verification results to be more explanatory

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
@@ -122,13 +122,13 @@ namespace NuGet.Packaging.Signing
             }
             settings = settings ?? SignedPackageVerifierSettings.Default;
 
-            var treatIssueAsError = !settings.AllowUntrusted;
+            var treatIssueAsError = !settings.AllowIllegal;
             var certificate = SignerInfo.Certificate;
             if (certificate == null)
             {
                 issues.Add(SignatureLog.Issue(treatIssueAsError, NuGetLogCode.NU3010, Strings.ErrorNoCertificate));
 
-                return SignatureVerificationStatus.Invalid;
+                return SignatureVerificationStatus.Illegal;
             }
 
             issues.Add(SignatureLog.InformationLog(string.Format(CultureInfo.CurrentCulture,
@@ -144,7 +144,7 @@ namespace NuGet.Packaging.Signing
                 issues.Add(SignatureLog.Issue(treatIssueAsError, NuGetLogCode.NU3012, Strings.ErrorSignatureVerificationFailed));
                 issues.Add(SignatureLog.DebugLog(e.ToString()));
 
-                return SignatureVerificationStatus.Invalid;
+                return SignatureVerificationStatus.Illegal;
             }
 
             if (VerificationUtility.IsSigningCertificateValid(certificate, treatIssueAsError, issues))
@@ -166,7 +166,7 @@ namespace NuGet.Packaging.Signing
 
                         if (chainBuildingSucceed)
                         {
-                            return SignatureVerificationStatus.Trusted;
+                            return SignatureVerificationStatus.Valid;
                         }
 
                         var chainBuildingHasIssues = false;
@@ -199,7 +199,7 @@ namespace NuGet.Packaging.Signing
 
                             issues.Add(SignatureLog.Error(NuGetLogCode.NU3012, status.StatusInformation));
 
-                            return SignatureVerificationStatus.Invalid;
+                            return SignatureVerificationStatus.Suspect;
                         }
 
                         if (isSelfSignedCertificate &&
@@ -209,7 +209,7 @@ namespace NuGet.Packaging.Signing
 
                             if (!chainBuildingHasIssues && settings.AllowUntrustedSelfIssuedCertificate)
                             {
-                                return SignatureVerificationStatus.Trusted;
+                                return SignatureVerificationStatus.Valid;
                             }
                         }
 
@@ -226,7 +226,7 @@ namespace NuGet.Packaging.Signing
 
                             if (!chainBuildingHasIssues && settings.AllowUnknownRevocation)
                             {
-                                return SignatureVerificationStatus.Trusted;
+                                return SignatureVerificationStatus.Valid;
                             }
 
                             chainBuildingHasIssues = true;
@@ -246,7 +246,7 @@ namespace NuGet.Packaging.Signing
                 }
             }
 
-            return SignatureVerificationStatus.Untrusted;
+            return SignatureVerificationStatus.Illegal;
         }
 
         private void VerifySigningTimeAttribute(SignerInfo signerInfo)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/AllowListVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/AllowListVerificationProvider.cs
@@ -36,7 +36,7 @@ namespace NuGet.Packaging.Signing
             if (_allowList.Count() > 0 && !IsSignatureAllowed(signature))
             {
                 status = SignatureVerificationStatus.Untrusted;
-                issues.Add(SignatureLog.Issue(fatal: true, code: NuGetLogCode.NU3003, message: string.Format(CultureInfo.CurrentCulture, Strings.Error_NoMatchingCertificate, _fingerprintAlgorithm.ToString())));
+                issues.Add(SignatureLog.Issue(fatal: !settings.AllowUntrusted, code: NuGetLogCode.NU3003, message: string.Format(CultureInfo.CurrentCulture, Strings.Error_NoMatchingCertificate, _fingerprintAlgorithm.ToString())));
             }
 
             return new SignedPackageVerificationResult(status, signature, issues);

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/AllowListVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/AllowListVerificationProvider.cs
@@ -30,12 +30,12 @@ namespace NuGet.Packaging.Signing
 #if IS_DESKTOP
         private PackageVerificationResult VerifyAllowList(ISignedPackageReader package, PrimarySignature signature, SignedPackageVerifierSettings settings)
         {
-            var status = SignatureVerificationStatus.Trusted;
+            var status = SignatureVerificationStatus.Valid;
             var issues = new List<SignatureLog>();
 
             if (_allowList.Count() > 0 && !IsSignatureAllowed(signature))
             {
-                status = SignatureVerificationStatus.Invalid;
+                status = SignatureVerificationStatus.Untrusted;
                 issues.Add(SignatureLog.Issue(fatal: true, code: NuGetLogCode.NU3003, message: string.Format(CultureInfo.CurrentCulture, Strings.Error_NoMatchingCertificate, _fingerprintAlgorithm.ToString())));
             }
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/IntegrityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/IntegrityVerificationProvider.cs
@@ -21,7 +21,7 @@ namespace NuGet.Packaging.Signing
 #if IS_DESKTOP
         private async Task<PackageVerificationResult> VerifyPackageIntegrityAsync(ISignedPackageReader package, PrimarySignature signature, SignedPackageVerifierSettings settings)
         {
-            var status = SignatureVerificationStatus.Untrusted;
+            var status = SignatureVerificationStatus.Illegal;
             var issues = new List<SignatureLog>();
 
             var validHashOids = SigningSpecifications.V1.AllowedHashAlgorithmOids;
@@ -33,18 +33,18 @@ namespace NuGet.Packaging.Signing
                 try
                 {
                     await package.ValidateIntegrityAsync(signature.SignatureContent, CancellationToken.None);
-                    status = SignatureVerificationStatus.Trusted;
+                    status = SignatureVerificationStatus.Valid;
                 }
                 catch (Exception e)
                 {
-                    status = SignatureVerificationStatus.Invalid;
+                    status = SignatureVerificationStatus.Suspect;
                     issues.Add(SignatureLog.Error(NuGetLogCode.NU3008, Strings.SignaturePackageIntegrityFailure));
                     issues.Add(SignatureLog.DebugLog(e.ToString()));
                 }
             }
             else
             {
-                issues.Add(SignatureLog.Issue(!settings.AllowUntrusted, NuGetLogCode.NU3016, Strings.SignatureFailureInvalidHashAlgorithmOid));
+                issues.Add(SignatureLog.Issue(!settings.AllowIllegal, NuGetLogCode.NU3016, Strings.SignatureFailureInvalidHashAlgorithmOid));
                 issues.Add(SignatureLog.DebugLog(string.Format(CultureInfo.CurrentCulture, Strings.SignatureDebug_HashOidFound, signatureHashOid)));
             }
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
@@ -46,7 +46,7 @@ namespace NuGet.Packaging.Signing
             }
             catch (TimestampException)
             {
-                return new SignedPackageVerificationResult(SignatureVerificationStatus.Invalid, signature, timestampIssues);
+                return new SignedPackageVerificationResult(SignatureVerificationStatus.Illegal, signature, timestampIssues);
             }
 
             var certificateExtraStore = signature.SignedCms.Certificates;

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureVerificationStatus.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureVerificationStatus.cs
@@ -15,13 +15,13 @@ namespace NuGet.Packaging.Signing
         Unknown = 0,
 
         /// <summary>
-        /// Invalid signature.
+        /// Invalid package signature.
         /// </summary>
         /// <remarks>This could happen because the package integrity check fails or the certificate is revoked.</remarks>
         Suspect = 1,
 
         /// <summary>
-        /// Signature does not conform with the specification.
+        /// Signature does not conform with NuGet signing specification.
         /// </summary>
         Illegal = 2,
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureVerificationStatus.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureVerificationStatus.cs
@@ -21,7 +21,7 @@ namespace NuGet.Packaging.Signing
         Suspect = 1,
 
         /// <summary>
-        /// Signature does not conform with the spec.
+        /// Signature does not conform with the specification.
         /// </summary>
         Illegal = 2,
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureVerificationStatus.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureVerificationStatus.cs
@@ -17,17 +17,23 @@ namespace NuGet.Packaging.Signing
         /// <summary>
         /// Invalid signature.
         /// </summary>
-        /// <remarks>This could happen for many reasons such as a tampered with package, invalid hash algorithm, or invalid signing data.</remarks>
-        Invalid = 1,
+        /// <remarks>This could happen because the package integrity check fails or the certificate is revoked.</remarks>
+        Suspect = 1,
 
         /// <summary>
-        /// Signature is NOT trusted.
+        /// Signature does not conform with the spec.
         /// </summary>
-        Untrusted = 2,
+        Illegal = 2,
+
 
         /// <summary>
-        /// Signature is trusted.
+        /// Signature is not explicitly trusted by the consumer. 
         /// </summary>
-        Trusted = 3
+        Untrusted = 3,
+
+        /// <summary>
+        /// Signature is valid for the verification step.
+        /// </summary>
+        Valid = 4
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifierSettings.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifierSettings.cs
@@ -14,7 +14,12 @@ namespace NuGet.Packaging.Signing
         public bool AllowUnsigned { get; }
 
         /// <summary>
-        /// Allow packages that are not trusted.
+        /// Treat illegal packages as unsigned
+        /// </summary>
+        public bool AllowIllegal { get; }
+
+        /// <summary>
+        /// Allow packages that have not been explicitly trusted by the consumer.
         /// </summary>
         public bool AllowUntrusted { get; }
 
@@ -33,6 +38,7 @@ namespace NuGet.Packaging.Signing
 
         public SignedPackageVerifierSettings(
             bool allowUnsigned,
+            bool allowIllegal,
             bool allowUntrusted,
             bool allowUntrustedSelfIssuedCertificate,
             bool allowIgnoreTimestamp,
@@ -41,6 +47,7 @@ namespace NuGet.Packaging.Signing
             bool allowUnknownRevocation)
         {
             AllowUnsigned = allowUnsigned;
+            AllowIllegal = allowIllegal;
             AllowUntrusted = allowUntrusted;
             AllowUntrustedSelfIssuedCertificate = allowUntrustedSelfIssuedCertificate;
             AllowIgnoreTimestamp = allowIgnoreTimestamp;
@@ -54,6 +61,7 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         public static SignedPackageVerifierSettings AllowAll { get; } = new SignedPackageVerifierSettings(
             allowUnsigned: true,
+            allowIllegal: true,
             allowUntrusted: true,
             allowUntrustedSelfIssuedCertificate: true,
             allowIgnoreTimestamp: true,
@@ -71,6 +79,7 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         public static SignedPackageVerifierSettings VSClientDefaultPolicy { get; } = new SignedPackageVerifierSettings(
             allowUnsigned: true,
+            allowIllegal: true,
             allowUntrusted: true,
             allowUntrustedSelfIssuedCertificate: true,
             allowIgnoreTimestamp: true,
@@ -83,6 +92,7 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         public static SignedPackageVerifierSettings VerifyCommandDefaultPolicy { get; } = new SignedPackageVerifierSettings(
             allowUnsigned: false,
+            allowIllegal: false,
             allowUntrusted: false,
             allowUntrustedSelfIssuedCertificate: true,
             allowIgnoreTimestamp: false,

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifierSettings.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifierSettings.cs
@@ -14,7 +14,7 @@ namespace NuGet.Packaging.Signing
         public bool AllowUnsigned { get; }
 
         /// <summary>
-        /// Treat illegal packages as unsigned
+        /// Allow packages with signatures that do not conform to the specification.
         /// </summary>
         public bool AllowIllegal { get; }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -248,6 +248,7 @@ namespace NuGet.Packaging.FuncTest
             var settings = new SignedPackageVerifierSettings(
                 allowUnsigned: false,
                 allowIllegal: false,
+                allowUntrusted: false,
                 allowUntrustedSelfIssuedCertificate: false,
                 allowIgnoreTimestamp: false,
                 allowMultipleTimestamps: true,
@@ -294,6 +295,7 @@ namespace NuGet.Packaging.FuncTest
             var setting = new SignedPackageVerifierSettings(
                 allowUnsigned: false,
                 allowIllegal: false,
+                allowUntrusted: false,
                 allowUntrustedSelfIssuedCertificate: false,
                 allowIgnoreTimestamp: false,
                 allowMultipleTimestamps: true,
@@ -390,12 +392,13 @@ namespace NuGet.Packaging.FuncTest
         }
 
         [CIOnlyFact]
-        public async Task GetTrustResultAsync_WithUnavailableRevocationInformationAndAllowUntrusted_Warns()
+        public async Task GetTrustResultAsync_WithUnavailableRevocationInformationAndAllowIllegal_Warns()
         {
             // Arrange
             var setting = new SignedPackageVerifierSettings(
                 allowUnsigned: false,
                 allowIllegal: true,
+                allowUntrusted: false,
                 allowUntrustedSelfIssuedCertificate: false,
                 allowIgnoreTimestamp: false,
                 allowMultipleTimestamps: false,
@@ -418,6 +421,7 @@ namespace NuGet.Packaging.FuncTest
             var setting = new SignedPackageVerifierSettings(
                 allowUnsigned: false,
                 allowIllegal: false,
+                allowUntrusted: false,
                 allowUntrustedSelfIssuedCertificate: false,
                 allowIgnoreTimestamp: false,
                 allowMultipleTimestamps: false,
@@ -481,6 +485,7 @@ namespace NuGet.Packaging.FuncTest
             var setting = new SignedPackageVerifierSettings(
                 allowUnsigned: false,
                 allowIllegal: false,
+                allowUntrusted: false,
                 allowUntrustedSelfIssuedCertificate: false,
                 allowIgnoreTimestamp: false,
                 allowMultipleTimestamps: false,
@@ -517,6 +522,7 @@ namespace NuGet.Packaging.FuncTest
             var settings = new SignedPackageVerifierSettings(
                 allowUnsigned: false,
                 allowIllegal: false,
+                allowUntrusted: false,
                 allowUntrustedSelfIssuedCertificate: false,
                 allowIgnoreTimestamp: false,
                 allowMultipleTimestamps: false,
@@ -542,6 +548,7 @@ namespace NuGet.Packaging.FuncTest
             var settings = new SignedPackageVerifierSettings(
                 allowUnsigned: false,
                 allowIllegal: false,
+                allowUntrusted: false,
                 allowUntrustedSelfIssuedCertificate: true,
                 allowIgnoreTimestamp: false,
                 allowMultipleTimestamps: false,
@@ -567,6 +574,7 @@ namespace NuGet.Packaging.FuncTest
             var settings = new SignedPackageVerifierSettings(
                allowUnsigned: false,
                allowIllegal: false,
+                allowUntrusted: false,
                allowUntrustedSelfIssuedCertificate: false,
                allowIgnoreTimestamp: false,
                allowMultipleTimestamps: false,

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -171,7 +171,7 @@ namespace NuGet.Packaging.FuncTest
                     var trustProvider = result.Results.Single();
 
                     Assert.True(result.Valid);
-                    Assert.Equal(SignatureVerificationStatus.Trusted, trustProvider.Trust);
+                    Assert.Equal(SignatureVerificationStatus.Valid, trustProvider.Trust);
                     Assert.Equal(0, trustProvider.Issues.Count(issue => issue.Level == LogLevel.Error));
                     Assert.Equal(0, trustProvider.Issues.Count(issue => issue.Level == LogLevel.Warning));
                 }
@@ -228,7 +228,7 @@ namespace NuGet.Packaging.FuncTest
                     var result = results.Results.Single();
 
                     Assert.False(results.Valid);
-                    Assert.Equal(SignatureVerificationStatus.Untrusted, result.Trust);
+                    Assert.Equal(SignatureVerificationStatus.Illegal, result.Trust);
                     Assert.Equal(1, result.Issues.Count(issue => issue.Level == LogLevel.Error));
                     Assert.Equal(0, result.Issues.Count(issue => issue.Level == LogLevel.Warning));
 
@@ -247,7 +247,7 @@ namespace NuGet.Packaging.FuncTest
         {
             var settings = new SignedPackageVerifierSettings(
                 allowUnsigned: false,
-                allowUntrusted: false,
+                allowIllegal: false,
                 allowUntrustedSelfIssuedCertificate: false,
                 allowIgnoreTimestamp: false,
                 allowMultipleTimestamps: true,
@@ -293,7 +293,7 @@ namespace NuGet.Packaging.FuncTest
             var nupkg = new SimpleTestPackageContext();
             var setting = new SignedPackageVerifierSettings(
                 allowUnsigned: false,
-                allowUntrusted: false,
+                allowIllegal: false,
                 allowUntrustedSelfIssuedCertificate: false,
                 allowIgnoreTimestamp: false,
                 allowMultipleTimestamps: true,
@@ -364,7 +364,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Act & Assert
             var matchingIssues = await VerifyUnavailableRevocationInfo(
-                SignatureVerificationStatus.Trusted,
+                SignatureVerificationStatus.Valid,
                 LogLevel.Warning,
                 setting);
 
@@ -379,7 +379,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Act & Assert
             var matchingIssues = await VerifyUnavailableRevocationInfo(
-                SignatureVerificationStatus.Trusted,
+                SignatureVerificationStatus.Valid,
                 LogLevel.Warning,
                 setting);
 
@@ -395,7 +395,7 @@ namespace NuGet.Packaging.FuncTest
             // Arrange
             var setting = new SignedPackageVerifierSettings(
                 allowUnsigned: false,
-                allowUntrusted: true,
+                allowIllegal: true,
                 allowUntrustedSelfIssuedCertificate: false,
                 allowIgnoreTimestamp: false,
                 allowMultipleTimestamps: false,
@@ -404,7 +404,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Act & Assert
             var matchingIssues = await VerifyUnavailableRevocationInfo(
-                SignatureVerificationStatus.Trusted,
+                SignatureVerificationStatus.Valid,
                 LogLevel.Warning,
                 setting);
 
@@ -417,7 +417,7 @@ namespace NuGet.Packaging.FuncTest
             // Arrange
             var setting = new SignedPackageVerifierSettings(
                 allowUnsigned: false,
-                allowUntrusted: false,
+                allowIllegal: false,
                 allowUntrustedSelfIssuedCertificate: false,
                 allowIgnoreTimestamp: false,
                 allowMultipleTimestamps: false,
@@ -426,7 +426,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Act & Assert
             var matchingIssues = await VerifyUnavailableRevocationInfo(
-                SignatureVerificationStatus.Trusted,
+                SignatureVerificationStatus.Valid,
                 LogLevel.Warning,
                 setting);
 
@@ -480,7 +480,7 @@ namespace NuGet.Packaging.FuncTest
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
             var setting = new SignedPackageVerifierSettings(
                 allowUnsigned: false,
-                allowUntrusted: false,
+                allowIllegal: false,
                 allowUntrustedSelfIssuedCertificate: false,
                 allowIgnoreTimestamp: false,
                 allowMultipleTimestamps: false,
@@ -505,7 +505,7 @@ namespace NuGet.Packaging.FuncTest
                 var totalErrorIssues = result.GetErrorIssues();
 
                 // Assert
-                result.Trust.Should().Be(SignatureVerificationStatus.Invalid);
+                result.Trust.Should().Be(SignatureVerificationStatus.Illegal);
                 totalErrorIssues.Count().Should().Be(1);
                 totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3000);
             }
@@ -516,7 +516,7 @@ namespace NuGet.Packaging.FuncTest
         {
             var settings = new SignedPackageVerifierSettings(
                 allowUnsigned: false,
-                allowUntrusted: false,
+                allowIllegal: false,
                 allowUntrustedSelfIssuedCertificate: false,
                 allowIgnoreTimestamp: false,
                 allowMultipleTimestamps: false,
@@ -527,7 +527,7 @@ namespace NuGet.Packaging.FuncTest
             {
                 var result = await test.Provider.GetTrustResultAsync(test.Package, test.PrimarySignature, settings, CancellationToken.None);
 
-                Assert.Equal(SignatureVerificationStatus.Untrusted, result.Trust);
+                Assert.Equal(SignatureVerificationStatus.Illegal, result.Trust);
                 Assert.Equal(1, result.Issues.Count(issue => issue.Level == LogLevel.Error));
                 Assert.Equal(1, result.Issues.Count(issue => issue.Level == LogLevel.Warning));
 
@@ -541,7 +541,7 @@ namespace NuGet.Packaging.FuncTest
         {
             var settings = new SignedPackageVerifierSettings(
                 allowUnsigned: false,
-                allowUntrusted: false,
+                allowIllegal: false,
                 allowUntrustedSelfIssuedCertificate: true,
                 allowIgnoreTimestamp: false,
                 allowMultipleTimestamps: false,
@@ -552,7 +552,7 @@ namespace NuGet.Packaging.FuncTest
             {
                 var result = await test.Provider.GetTrustResultAsync(test.Package, test.PrimarySignature, settings, CancellationToken.None);
 
-                Assert.Equal(SignatureVerificationStatus.Trusted, result.Trust);
+                Assert.Equal(SignatureVerificationStatus.Valid, result.Trust);
                 Assert.Equal(0, result.Issues.Count(issue => issue.Level == LogLevel.Error));
                 Assert.Equal(2, result.Issues.Count(issue => issue.Level == LogLevel.Warning));
 
@@ -566,7 +566,7 @@ namespace NuGet.Packaging.FuncTest
         {
             var settings = new SignedPackageVerifierSettings(
                allowUnsigned: false,
-               allowUntrusted: false,
+               allowIllegal: false,
                allowUntrustedSelfIssuedCertificate: false,
                allowIgnoreTimestamp: false,
                allowMultipleTimestamps: false,
@@ -577,7 +577,7 @@ namespace NuGet.Packaging.FuncTest
             {
                 var result = await test.Provider.GetTrustResultAsync(test.Package, test.PrimarySignature, settings, CancellationToken.None);
 
-                Assert.Equal(SignatureVerificationStatus.Trusted, result.Trust);
+                Assert.Equal(SignatureVerificationStatus.Valid, result.Trust);
                 Assert.Equal(0, result.Issues.Count(issue => issue.Level == LogLevel.Error));
                 Assert.Equal(1, result.Issues.Count(issue => issue.Level == LogLevel.Warning));
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
@@ -46,7 +46,7 @@ namespace NuGet.Packaging.FuncTest
 
             _settings = new SignedPackageVerifierSettings(
                 allowUnsigned: true,
-                allowUntrusted: false,
+                allowIllegal: false,
                 allowUntrustedSelfIssuedCertificate: true,
                 allowIgnoreTimestamp: true,
                 allowMultipleTimestamps: true,

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
@@ -47,6 +47,7 @@ namespace NuGet.Packaging.FuncTest
             _settings = new SignedPackageVerifierSettings(
                 allowUnsigned: true,
                 allowIllegal: false,
+                allowUntrusted: false,
                 allowUntrustedSelfIssuedCertificate: true,
                 allowIgnoreTimestamp: true,
                 allowMultipleTimestamps: true,


### PR DESCRIPTION
Part of https://github.com/NuGet/Home/issues/6276

The naming of the VerificationResults where confusing with how the spec treated errors. This PR intends to improve the naming strategy. It follows the next criteria:

- A package is `suspect` when we know it is bad and should not be used. i.e. Integrity check fails, revoked certificate.
- A package is `illegal` when it does not conform with the NuGet Package Signing spec. e.g. hash algorithm unsupported, public key unsupported, etc. Some policies allow illegal packages with the same guaranties as unsigned packages.
- A package is `untrusted` when the consumer did not provide explicit trust for the signer. i.e. a list of trusted sources or package author was given but the package being verified did not match any in the list. Some policies allow untrusted packages with the same guaranties as unsigned packages.
- A package is `valid` when it successfully passes all verification checks in the NuGet Package Signing Spec. 