### PR TITLE
update to preview3 release label

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -13,7 +13,7 @@
     <CliTargetBranch>master</CliTargetBranch>
     <!-- We need to update this netcoreassembly build number with every milestone to workaround any breaking api
     changes we might have made-->
-    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">1</NetCoreAssemblyBuildNumber>
+    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">3</NetCoreAssemblyBuildNumber>
     <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview$(NetCoreAssemblyBuildNumber)</ReleaseLabel>
   </PropertyGroup>
 


### PR DESCRIPTION
since our current insertions are targeted to preview3, updating the release label to preview3.

CC: @joelverhagen  - this should fix the latest available commandline package on dist.