### PR TITLE
Guarding Project updates with writer lock

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
@@ -285,26 +285,35 @@ namespace NuGet.PackageManagement.VisualStudio
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 var relativeTargetPath = PathUtility.GetRelativePath(PathUtility.EnsureTrailingSlash(ProjectFullPath), targetFullPath);
-                AddImportStatement(relativeTargetPath, location);
-                await SaveProjectAsync();
-
-                // notify the project system of the change
-                UpdateImportStamp(VsProjectAdapter);
+                await AddImportStatement(relativeTargetPath, location);
             });
         }
 
-        private void AddImportStatement(string targetsPath, ImportLocation location)
+        private async Task AddImportStatement(string targetsPath, ImportLocation location)
         {
-            // Need NOT be on the UI Thread
-            MicrosoftBuildEvaluationProjectUtility.AddImportStatement(
-                EnvDTEProjectUtility.AsMSBuildEvaluationProject(VsProjectAdapter.FullName), targetsPath, location);
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            // running inside a writer lock to avoid MSBuild throwing "this collection is read-only" error
+            await ProjectHelper.DoWorkInWriterLockAsync(
+                VsProjectAdapter.Project,
+                VsProjectAdapter.VsHierarchy,
+                buildProject => MicrosoftBuildEvaluationProjectUtility.AddImportStatement(buildProject, targetsPath, location));
+
+            // notify the project system of the change
+            UpdateImportStamp(VsProjectAdapter);
         }
 
-        private void RemoveImportStatement(string targetsPath)
+        private async Task RemoveImportStatement(string targetsPath)
         {
-            // Need NOT be on the UI Thread
-            MicrosoftBuildEvaluationProjectUtility.RemoveImportStatement(
-                EnvDTEProjectUtility.AsMSBuildEvaluationProject(VsProjectAdapter.FullName), targetsPath);
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            await ProjectHelper.DoWorkInWriterLockAsync(
+                VsProjectAdapter.Project,
+                VsProjectAdapter.VsHierarchy,
+                buildProject => MicrosoftBuildEvaluationProjectUtility.RemoveImportStatement(buildProject, targetsPath));
+
+            // notify the project system of the change
+            UpdateImportStamp(VsProjectAdapter);
         }
 
         private static bool IsSamePath(string path1, string path2)
@@ -371,12 +380,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 var relativeTargetPath = PathUtility.GetRelativePath(PathUtility.EnsureTrailingSlash(ProjectFullPath), targetFullPath);
-                RemoveImportStatement(relativeTargetPath);
-
-                await SaveProjectAsync();
-
-                // notify the project system of the change
-                UpdateImportStamp(VsProjectAdapter);
+                await RemoveImportStatement(relativeTargetPath);
             });
         }
 


### PR DESCRIPTION
Guarding these operations (adding/ removing project imports, and reevaluation) with projectLockService writer lock so that it doesn't throw on a read-only access. We already safeguard it for js/ native projects.

Fixes https://github.com/NuGet/Home/issues/6468

@rrelyea 