### PR TITLE
 fix remaining migrator issues

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PackagesConfigToPackageReferenceMigrator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/PackagesConfigToPackageReferenceMigrator.cs
@@ -188,7 +188,7 @@ namespace NuGet.PackageManagement.UI
         private static string CreateBackup(MSBuildNuGetProject msBuildNuGetProject, string solutionDirectory)
         {
             var guid = Guid.NewGuid().ToString().Split('-').First();
-            var backupPath = Path.Combine(solutionDirectory, $"Backup_{guid}", NuGetProject.GetUniqueNameOrName(msBuildNuGetProject));
+            var backupPath = Path.Combine(solutionDirectory, "MigrationBackup", guid, NuGetProject.GetUniqueNameOrName(msBuildNuGetProject));
             Directory.CreateDirectory(backupPath);
 
             // Backup packages.config

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/NuGetProjectUpgradeWindowModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/NuGetProjectUpgradeWindowModel.cs
@@ -70,7 +70,7 @@ namespace NuGet.PackageManagement.UI
         {
             get
             {
-                if(_notFoundPackages == null)
+                if (_notFoundPackages == null)
                 {
                     GetUpgradeDependencyItems();
                 }
@@ -129,8 +129,30 @@ namespace NuGet.PackageManagement.UI
                         }
                         issues.AddRange(foundIssues);
                     }
+
+                    if(!package.InstallAsTopLevel)
+                    {
+                        PromoteToTopLevelIfNeeded(reader, package);
+                    }
                 }
             }
+        }
+
+        /* The package will be installed as top level if :
+         * 1) The package contains build, buildCrossTargeting, contentFiles or analyzers folder.
+         * 2) The package has developmentDependency set to true.
+         */         
+        private void PromoteToTopLevelIfNeeded(PackageArchiveReader reader, NuGetProjectUpgradeDependencyItem item)
+        {
+            if(reader.GetDevelopmentDependency() ||
+                reader.GetFiles(PackagingConstants.Folders.Build).Any() ||
+                reader.GetFiles(PackagingConstants.Folders.BuildCrossTargeting).Any() ||
+                reader.GetFiles(PackagingConstants.Folders.ContentFiles).Any() ||
+                reader.GetFiles(PackagingConstants.Folders.Analyzers).Any())
+            {
+                item.InstallAsTopLevel = true;
+            }
+
         }
 
         private ObservableCollection<NuGetProjectUpgradeDependencyItem> GetUpgradeDependencyItems()

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/UpgradeReport.xslt
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/UpgradeReport.xslt
@@ -142,7 +142,7 @@
         <meta content="en-us" http-equiv="Content-Language" />
         <meta content="text/html; charset=utf-16" http-equiv="Content-Type" />
         <title _locID="NuGetUpgradeReportTitle">
-          NuGet Upgrade Report
+          NuGetMigrationLog
         </title>
         <style>
           <xsl:text disable-output-escaping="yes">
@@ -316,16 +316,16 @@
             </a>
           </div>
           <div class="info-text">
-            <a href="https://aka.ms/nugetupgraderevertv1">Help me revert the NuGet project migration</a>
+            <a href="https://aka.ms/nuget-pc2pr-migrator-rollback">Help me rollback to packages.config</a>
           </div>
 
-          <h2 _locID="PackagesTitle">Packages Processed</h2>
-          <h3 _locID="IncludePackagesTitle">Top-level Dependencies:</h3>
+          <h2 _locID="PackagesTitle">Packages processed</h2>
+          <h3 _locID="IncludePackagesTitle">Top-level dependencies:</h3>
           <div class="issues">
             <xsl:apply-templates select="Projects" mode="IncludedPackages" />
           </div>
           <p />
-          <h3 _locID="IncludePackagesTitle">Transitive Dependencies:</h3>
+          <h3 _locID="IncludePackagesTitle">Transitive dependencies:</h3>
           <div class="issues">
             <xsl:apply-templates select="Projects" mode="ExcludedPackages" />
           </div>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PRMigratorBar.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PRMigratorBar.xaml
@@ -9,6 +9,9 @@
       <ResourceDictionary.MergedDictionaries>
         <nuget:SharedResources />
       </ResourceDictionary.MergedDictionaries>
+      <BitmapImage
+        x:Key="BitmapImageInformation"
+        UriSource="/NuGet.PackageManagement.UI;component/Resources/statusinformation.16.16.png" />
     </ResourceDictionary>
   </UserControl.Resources>
   <Border x:Name="MigratorBar" VerticalAlignment="Center" Visibility="Collapsed">
@@ -18,6 +21,12 @@
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
       <StackPanel Margin="0,4,0,6" Grid.Column="0" Orientation="Horizontal">
+        <Image
+          Margin="3,0,0,0"
+          Source="{StaticResource BitmapImageInformation}"
+          Height="16"
+          Width="16"
+          VerticalAlignment="Center"/>
         <TextBlock
         x:Name="UpgradeMessage"
         Margin="5,0,5,0"

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
@@ -116,7 +116,7 @@ namespace NuGet.Packaging.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The assembly &apos;{0}&apos; is placed directly under the &apos;lib&apos; folder. This assembly won&apos;t be referenced by the project after migration..
+        ///   Looks up a localized string similar to The assembly &apos;lib\{0}&apos; will be ignored when the package is installed after the migration..
         /// </summary>
         public static string Migrator_AssemblyDirectlyUnderLibWarning {
             get {
@@ -125,7 +125,7 @@ namespace NuGet.Packaging.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package &apos;{0}&apos; contains &apos;content&apos; folder which will not be copied to the project directory after migration. The package may not work as expected after migration..
+        ///   Looks up a localized string similar to The package &apos;{0}&apos; contains &apos;content&apos; folder which will not be available when the package is installed after the migration..
         /// </summary>
         public static string Migrator_PackageHasContentFolder {
             get {
@@ -134,7 +134,7 @@ namespace NuGet.Packaging.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package &apos;{0}&apos; contains an install.ps1 script that will not be applied after migration..
+        ///   Looks up a localized string similar to The package &apos;{0}&apos; contains install.ps1 script which will be ignored when the package is installed after the migration..
         /// </summary>
         public static string Migrator_PackageHasInstallScript {
             get {
@@ -143,7 +143,7 @@ namespace NuGet.Packaging.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package &apos;{0}&apos; contains an xdt transform which will not be applied to the project after migration..
+        ///   Looks up a localized string similar to The XDT transform file &apos;{0}&apos; will not be applied when the package is installed after the migration..
         /// </summary>
         public static string Migrator_XdtTransformInPackage {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
@@ -136,16 +136,16 @@
     <value>The package version '{0}' uses SemVer 2.0.0 or components of SemVer 1.0.0 that are not supported on legacy clients. Change the package version to a SemVer 1.0.0 string. If the version contains a release label it must start with a letter. This message can be ignored if the package is not intended for older clients.</value>
   </data>
   <data name="Migrator_AssemblyDirectlyUnderLibWarning" xml:space="preserve">
-    <value>The assembly '{0}' is placed directly under the 'lib' folder. This assembly won't be referenced by the project after migration.</value>
+    <value>The assembly 'lib\{0}' will be ignored when the package is installed after the migration.</value>
   </data>
   <data name="Migrator_PackageHasContentFolder" xml:space="preserve">
-    <value>The package '{0}' contains 'content' folder which will not be copied to the project directory after migration. The package may not work as expected after migration.</value>
+    <value>The package '{0}' contains 'content' folder which will not be available when the package is installed after the migration.</value>
   </data>
   <data name="Migrator_PackageHasInstallScript" xml:space="preserve">
-    <value>The package '{0}' contains an install.ps1 script that will not be applied after migration.</value>
+    <value>The package '{0}' contains install.ps1 script which will be ignored when the package is installed after the migration.</value>
   </data>
   <data name="Migrator_XdtTransformInPackage" xml:space="preserve">
-    <value>The package '{0}' contains an xdt transform which will not be applied to the project after migration.</value>
+    <value>The XDT transform file '{0}' will not be applied when the package is installed after the migration.</value>
   </data>
   <data name="MisplacedInitScriptWarning" xml:space="preserve">
     <value>The file '{0}' will be ignored by NuGet because it is not directly under 'tools' folder. Place the file directly under 'tools' folder.</value>


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/6666

In addition, adds logic to mark a package as Top Level (but still in Transitive Dependencies list) if it has developmentDependency set to true, or contains build, analyzers or contentFiles.