### PR TITLE
Adding placeholder to InvalidPackageSignatureFileEntry to improve errors

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -521,7 +521,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package signature file entry is invalid..
+        ///   Looks up a localized string similar to The package signature file entry is invalid. {0}.
         /// </summary>
         internal static string InvalidPackageSignatureFileEntry {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -420,7 +420,8 @@ Valid from:</comment>
     <value>The timestamp signing certificate is not yet valid.</value>
   </data>
   <data name="InvalidPackageSignatureFileEntry" xml:space="preserve">
-    <value>The package signature file entry is invalid.</value>
+    <value>The package signature file entry is invalid. {0}</value>
+    <comment>{0} - error message suffix containing the reason for failure.</comment>
   </data>
   <data name="InvalidPrimarySignature" xml:space="preserve">
     <value>The primary signature is invalid.</value>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveUtilityTests.cs
@@ -70,7 +70,7 @@ namespace NuGet.Packaging.Test
                 var exception = Assert.Throws<SignatureException>(
                     () => SignedPackageArchiveUtility.OpenPackageSignatureFileStream(test.Reader));
 
-                Assert.Equal("The package signature file entry is invalid.", exception.Message);
+                Assert.Equal("The package signature file entry is invalid. The central directory header field 'compression method' has an invalid value (8).", exception.Message);
                 Assert.Equal(NuGetLogCode.NU3005, exception.Code);
             }
         }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6712
Regression: No

## Fix
Adds a placeholder to the `InvalidPackageSignatureFileEntry ` resource so that error messages get correctly displayed. Hence in the call [here](https://github.com/NuGet/NuGet.Client/blob/0f6d609e9767dc58c519914e255993642ef48228/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveIOUtility.cs#L334-L340) the error suffix will be correctly propagated to the exception and improve user experience.
