### PR TITLE
fix recursive dir for tfmspecificpackagefile

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -378,7 +378,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="_GetTfmSpecificContentForPackage"
           DependsOnTargets="$(TargetsForTfmSpecificContentInPackage)"
-          Returns="@(TfmSpecificPackageFile)">
+          Returns="@(TfmSpecificPackageFileWithRecursiveDir)">
+    <!-- The below workaround needs to be done due to msbuild bug https://github.com/Microsoft/msbuild/issues/3121 -->
+    <ItemGroup>
+      <TfmSpecificPackageFileWithRecursiveDir Include="@(TfmSpecificPackageFile)">
+        <NuGetRecursiveDir>%(TfmSpecificPackageFile.RecursiveDir)</NuGetRecursiveDir>
+      </TfmSpecificPackageFileWithRecursiveDir>
+    </ItemGroup>
   </Target>
 
   <Target Name="_GetDebugSymbolsWithTfm"

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -435,6 +435,8 @@ namespace NuGet.Build.Tasks.Pack
                     .ToList();
 
                 var recursiveDir = packageFile.GetProperty("RecursiveDir");
+                // The below NuGetRecursiveDir workaround needs to be done due to msbuild bug https://github.com/Microsoft/msbuild/issues/3121
+                recursiveDir = string.IsNullOrEmpty(recursiveDir) ? packageFile.GetProperty("NuGetRecursiveDir") : string.Empty;
                 if (!string.IsNullOrEmpty(recursiveDir))
                 {
                     var newTargetPaths = new List<string>();

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -436,7 +436,7 @@ namespace NuGet.Build.Tasks.Pack
 
                 var recursiveDir = packageFile.GetProperty("RecursiveDir");
                 // The below NuGetRecursiveDir workaround needs to be done due to msbuild bug https://github.com/Microsoft/msbuild/issues/3121
-                recursiveDir = string.IsNullOrEmpty(recursiveDir) ? packageFile.GetProperty("NuGetRecursiveDir") : string.Empty;
+                recursiveDir = string.IsNullOrEmpty(recursiveDir) ? packageFile.GetProperty("NuGetRecursiveDir") : recursiveDir;
                 if (!string.IsNullOrEmpty(recursiveDir))
                 {
                     var newTargetPaths = new List<string>();

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -1712,9 +1712,10 @@ namespace ClassLibrary
                 var projectName = "ClassLibrary1";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
                 var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
-                Directory.CreateDirectory(Path.Combine(workingDirectory, "Extensions"));
+                Directory.CreateDirectory(Path.Combine(workingDirectory, "Extensions", "cs"));
                 File.WriteAllText(Path.Combine(workingDirectory, "abc.txt"), "hello world");
                 File.WriteAllText(Path.Combine(workingDirectory, "Extensions", "ext.txt"), "hello world again");
+                File.WriteAllText(Path.Combine(workingDirectory, "Extensions", "cs", "ext.cs.txt"), "hello world again");
 
                 msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
 
@@ -1727,6 +1728,9 @@ namespace ClassLibrary
         <PackagePath>mycontent/$(TargetFramework)</PackagePath>
       </TfmSpecificPackageFile>
       <TfmSpecificPackageFile Include=""Extensions/ext.txt"" Condition=""'$(TargetFramework)' == 'net46'"">
+        <PackagePath>net46content</PackagePath>
+      </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include=""Extensions/**/ext.cs.txt"" Condition=""'$(TargetFramework)' == 'net46'"">
         <PackagePath>net46content</PackagePath>
       </TfmSpecificPackageFile>  
     </ItemGroup>
@@ -1758,8 +1762,9 @@ namespace ClassLibrary
                         var net46files = nupkgReader.GetFiles("net46content");
                         if (tfms.Length > 1)
                         {
-                            Assert.Equal(1, net46files.Count());
+                            Assert.Equal(2, net46files.Count());
                             Assert.Contains("net46content/ext.txt", net46files);
+                            Assert.Contains("net46content/cs/ext.cs.txt", net46files);
                         }
                         else
                         {


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/6726

This PR works around an existing msbuild bug: https://github.com/Microsoft/msbuild/issues/3121 

Scenario being fixed:

``` 
<TfmSpecificPackageFile Include=""Extensions/**/ext.cs.txt"" Condition=""'$(TargetFramework)' == 'net46'"">
        <PackagePath>net46content</PackagePath>
      </TfmSpecificPackageFile>  
```
Expected:
The final target path for ext.cs.txt in your package should be ``` net46content\<expanded ** >\ext.cs.txt ```

Actual:
The final target path ext.cs.txt is ``` net46content\ext.cs.txt ```
