### PR TITLE
fix the invalid prerelease dependency rule

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Rules/InvalidPrereleaseDependencyRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/InvalidPrereleaseDependencyRule.cs
@@ -27,7 +27,8 @@ namespace NuGet.Packaging.Rules
                 yield break;
             }
 
-            if (nuspecReader.GetVersion().IsPrerelease)
+            // If the package is stable, and has a prerelease dependency.
+            if (!nuspecReader.GetVersion().IsPrerelease)
             {
                 // If we are creating a production package, do not allow any of the dependencies to be a prerelease version.
                 var prereleaseDependency = nuspecReader.GetDependencyGroups().SelectMany(set => set.Packages).FirstOrDefault(IsPrereleaseDependency);


### PR DESCRIPTION
fixes a regression (caught by CLI insertion PR) where the InvalidPrereleaseDependency rule was throwing a warning on a prerelease package with prerelease dependency instead of a stable package with prerelease dependency.

