### PR TITLE
Use correct JoinableTaskContext from CPS for .net core sdk projects

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGetUIThreadHelper.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGetUIThreadHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using Microsoft;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
@@ -91,6 +92,14 @@ namespace NuGet.VisualStudio
                 var joinableTaskContext = new JoinableTaskContext(mainThread, synchronizationContext);
                 return joinableTaskContext.Factory;
             });
+        }
+
+        public static void SetCustomJoinableTaskFactory(JoinableTaskFactory joinableTaskFactory)
+        {
+            Assumes.Present(joinableTaskFactory);
+
+            // This is really just a test-hook
+            _joinableTaskFactory = new Lazy<JoinableTaskFactory>(() => joinableTaskFactory);
         }
 
         private static JoinableTaskFactory GetThreadHelperJoinableTaskFactorySafe()

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetLockServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetLockServiceTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
+using NuGet.VisualStudio;
 using Test.Utility.Threading;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
@@ -27,6 +28,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             _jtf = fixture.JoinableTaskFactory;
 
             _lockService = new NuGetLockService(fixture.JoinableTaskFactory.Context);
+            NuGetUIThreadHelper.SetCustomJoinableTaskFactory(_jtf);
             Assert.False(_lockService.IsLockHeld);
         }
 


### PR DESCRIPTION
As per Lifeng's comment on https://github.com/NuGet/Home/issues/6733
`
The code need pick up JoinableTaskContext from CPS for .Net Core project system and it is used to do that before that refactoring. After the change, it picks up from VS Shell, and that context doesn't handle project lock dependencies, and can easily run into dead locks.
`

To mitigate deadlocks with CPS's lock, this PR will use CPS JTF specialized instance along with our own JoinableTaskCollection by creating two nested JTF.RunAsync calls, one using CPS and the other using our JTF instance.

Fixes https://github.com/NuGet/Home/issues/6733 and VSTS# 580160

@rrelyea @lifengl @AArnott 