### PR TITLE
remove breaking api change in PathResolver.FilterPackageFiles

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -862,7 +862,7 @@ namespace NuGet.Commands
             if (!_packArgs.NoDefaultExcludes)
             {
                 // The user has not explicitly disabled default filtering.
-                var excludedFiles = PathResolver.FilterPackageFiles(packageFiles, ResolvePath, _defaultExcludes);
+                var excludedFiles = PathResolver.GetFilteredPackageFiles(packageFiles, ResolvePath, _defaultExcludes);
                 if(excludedFiles != null)
                 {
                     foreach (var file in excludedFiles)

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
@@ -31,7 +31,13 @@ namespace NuGet.Common
         /// <summary>
         /// Removes files from the source that match any wildcard.
         /// </summary>
-        public static IEnumerable<T> FilterPackageFiles<T>(ICollection<T> source,
+        public static void FilterPackageFiles<T>(ICollection<T> source,
+            Func<T, string> getPath, IEnumerable<string> wildcards)
+        {
+            GetFilteredPackageFiles<T>(source, getPath, wildcards);
+        }
+
+        public static IEnumerable<T> GetFilteredPackageFiles<T>(ICollection<T> source,
             Func<T, string> getPath, IEnumerable<string> wildcards)
         {
             var matchedFiles = new HashSet<T>(GetMatches(source, getPath, wildcards));


### PR DESCRIPTION
A breaking change in a PathResolver API was introduced in the PR https://github.com/NuGet/NuGet.Client/pull/2033 as part of the commit https://github.com/NuGet/NuGet.Client/commit/0e0d851abc9c4b0ef38871069b767b052bbb8695#diff-1931ada13864530e9b62f5d98db0a303R34 

This change reverts the break and adds a new api to get the list of filtered files.

CC: @rrelyea @Petermarcu