### PR TITLE
Updated existing telemetry event to include upgradable project information

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -701,9 +701,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 // This ensures we do not emit the events over and over while the solution is
                 // open.
                 TelemetryActivity.EmitTelemetryEvent(await VSTelemetryServiceUtility.GetProjectTelemetryEventAsync(nuGetProject));
-
-                // Emit telemetry event which tells if the current project is upgradable or not.
-                TelemetryActivity.EmitTelemetryEvent(await VSTelemetryServiceUtility.GetUpgradableProjectTelemetryEvent(nuGetProject));
             }
 
             if (string.IsNullOrEmpty(DefaultNuGetProjectName) ||

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/ProjectTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/ProjectTelemetryEvent.cs
@@ -12,18 +12,21 @@ namespace NuGet.PackageManagement.Telemetry
             string nuGetVersion,
             string projectId,
             NuGetProjectType nuGetProjectType,
-            int installedPackageCount) :
+            int installedPackageCount,
+            bool isPRUpgradable) :
             base(ProjectInformationEventName, new Dictionary<string, object>
                 {
                     { nameof(InstalledPackageCount), installedPackageCount },
                     { nameof(NuGetProjectType), nuGetProjectType },
                     { nameof(NuGetVersion), nuGetVersion },
-                    { nameof(ProjectId), projectId.ToString() }
+                    { nameof(ProjectId), projectId.ToString() },
+                    { IsPRUpgradable, isPRUpgradable }
                 })
         {
         }
 
         public const string ProjectInformationEventName = "ProjectInformation";
+        public const string IsPRUpgradable = "IsPRUpgradable";
 
         /// <summary>
         /// The version of NuGet that emitted this event.
@@ -44,5 +47,10 @@ namespace NuGet.PackageManagement.Telemetry
         /// The number of NuGet packages installed to this project.
         /// </summary>
         public int InstalledPackageCount => (int)base[nameof(InstalledPackageCount)];
+
+        /// <summary>
+        /// True, if project can be upgraded to PackageReference.
+        /// </summary>
+        public bool IsProjectPRUpgradable => (bool)base[IsPRUpgradable];
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/VSTelemetryServiceUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/VSTelemetryServiceUtility.cs
@@ -106,11 +106,14 @@ namespace NuGet.PackageManagement.Telemetry
                     0 :
                     (await nuGetProject.GetInstalledPackagesAsync(CancellationToken.None)).Count();
 
+                var isUpgradable = await NuGetProjectUpgradeUtility.IsNuGetProjectUpgradeableAsync(nuGetProject);
+
                 return new ProjectTelemetryEvent(
                     NuGetVersion.Value,
                     projectId,
                     projectType,
-                    installedPackagesCount);
+                    installedPackagesCount,
+                    isUpgradable);
             }
             catch (Exception ex)
             {
@@ -123,19 +126,6 @@ namespace NuGet.PackageManagement.Telemetry
                 Debug.Fail(message);
                 return null;
             }
-        }
-
-        public static async Task<TelemetryEvent> GetUpgradableProjectTelemetryEvent(NuGetProject project)
-        {
-            var telemetryEvent = new TelemetryEvent("ProjectUpgradable");
-
-            var projectId = project.GetMetadata<string>(NuGetProjectMetadataKeys.ProjectId);
-            var isUpgradable = await NuGetProjectUpgradeUtility.IsNuGetProjectUpgradeableAsync(project);
-
-            telemetryEvent["ProjectId"] = projectId;
-            telemetryEvent["IsUpgradable"] = isUpgradable;
-
-            return telemetryEvent;
         }
 
         public static TelemetryEvent GetUpgradeTelemetryEvent(

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
@@ -33,7 +33,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 "3.5.0-beta2",
                 "15e9591f-9391-4ddf-a246-ca9e0351277d",
                 projectType,
-                3);
+                3,
+                true);
             var target = new NuGetVSTelemetryService(telemetrySession.Object);
 
             // Act
@@ -43,7 +44,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             telemetrySession.Verify(x => x.PostEvent(It.IsAny<TelemetryEvent>()), Times.Once);
             Assert.NotNull(lastTelemetryEvent);
             Assert.Equal("ProjectInformation", lastTelemetryEvent.Name);
-            Assert.Equal(4, lastTelemetryEvent.Count);
+            Assert.Equal(5, lastTelemetryEvent.Count);
 
             var nuGetVersion = lastTelemetryEvent["NuGetVersion"];
             Assert.NotNull(nuGetVersion);
@@ -64,6 +65,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.NotNull(installedPackageCount);
             Assert.IsType<int>(installedPackageCount);
             Assert.Equal(projectInformation.InstalledPackageCount, installedPackageCount);
+
+            var isPRUpgradable = lastTelemetryEvent["IsPRUpgradable"];
+            Assert.NotNull(isPRUpgradable);
+            Assert.IsType<bool>(isPRUpgradable);
+            Assert.Equal(projectInformation.IsProjectPRUpgradable, isPRUpgradable);
         }
     }
 }


### PR DESCRIPTION
Based on discussion with DoRon, we want to move to RawClient telemetry tables to write our kusto queries and generate reports instead of using our own custom tables. In that case, it's easy to add more data to existing telemetry event schema and directly update query to include the added field.

@rrelyea @DoRonMotter 