### PR TITLE
Fixed refreshing http cache when update button clicked on browse tab

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/SourceRepositoryExtensions.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/SourceRepositoryExtensions.cs
@@ -176,6 +176,10 @@ namespace NuGet.PackageManagement.VisualStudio
 
             using (var sourceCacheContext = new SourceCacheContext())
             {
+                // Update http source cache context MaxAge so that it can always go online to fetch
+                // latest versions of the package.
+                sourceCacheContext.MaxAge = DateTimeOffset.UtcNow;
+
                 var packages = await metadataResource?.GetMetadataAsync(
                     packageId,
                     includePrerelease,


### PR DESCRIPTION
This PR is in continuation to https://github.com/NuGet/NuGet.Client/pull/2103 where refreshing http cache for update button on browse tab was missed. This will only happen when you're on browse tab, publish a new version of a package, and without switching any tab tries to update this package.

I've also created a tracking issue to add better tests for http caching from NuGet UI - https://github.com/NuGet/Home/issues/6787 

@rrelyea 
