### PR TITLE
Fix Net Core projects UI hang

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetLockService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetLockService.cs
@@ -44,9 +44,9 @@ namespace NuGet.PackageManagement.VisualStudio
         /// </summary>
         public async Task<T> ExecuteNuGetOperationAsync<T>(Func<Task<T>> action, CancellationToken token)
         {
-            if (_lockCount.Value == 0)
+            return await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                return await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                if (_lockCount.Value == 0)
                 {
                     return await _joinableTaskFactory.RunAsync(async delegate
                     {
@@ -73,12 +73,13 @@ namespace NuGet.PackageManagement.VisualStudio
                             _lockCount.Value--;
                         }
                     });
-                });
-            }
-            else
-            {
-                return await action();
-            }
+                
+                }
+                else
+                {
+                    return await action();
+                }
+            });
         }
 
         public Task ExecuteNuGetOperationAsync(Func<Task> action, CancellationToken token)


### PR DESCRIPTION
Based on internal customer solution, VS UI hanged during updating NuGet packages, because while update was still in progress, auto restore was started in the operation which was okay but since there were not sharing the same JoinableTaskContext so both were deadlocked.

So this PR fixes this issue, make sure all these actions shares the same JTF context.

Issue# [591458](https://devdiv.visualstudio.com/DevDiv/NuGet/_workitems/edit/591458) [Feedback] Visual Studio Hang during nuget package update

@rrelyea 