### PR TITLE
Avoid throwing NotSupportedException from NetCore project system service

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/NuGetProjectUpgradeUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/NuGetProjectUpgradeUtility.cs
@@ -56,11 +56,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
             }
 
-            if (!nuGetProject.ProjectServices.Capabilities.SupportsPackageReferences)
-            {
-                return false;
-            }
-
             var msBuildNuGetProject = nuGetProject as MSBuildNuGetProject;
             if (msBuildNuGetProject == null || !msBuildNuGetProject.PackagesConfigNuGetProject.PackagesConfigExists())
             {


### PR DESCRIPTION
This PR removes unnecessary code to check if project system service supports PackageReference capability, which throws NotSupportedException for net core projects. We don't need this check since we already typecast NuGetProject project to MSBuildNuGetProject which ensures that we don't fault into other project systems.

@rrelyea 