### PR TITLE
Moved Capability check after checking current project is packages.config based

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/NuGetProjectUpgradeUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/NuGetProjectUpgradeUtility.cs
@@ -56,8 +56,16 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
             }
 
+            // check if current project is packages.config based or not
             var msBuildNuGetProject = nuGetProject as MSBuildNuGetProject;
             if (msBuildNuGetProject == null || !msBuildNuGetProject.PackagesConfigNuGetProject.PackagesConfigExists())
+            {
+                return false;
+            }
+
+            // this further check if current project system supports VSProject4 or not which is essential to skip
+            // projects like c++ which currently doesn't support VSProject4 implementation for PackageReference
+            if (!msBuildNuGetProject.ProjectServices.Capabilities.SupportsPackageReferences)
             {
                 return false;
             }


### PR DESCRIPTION
This PR is on top of https://github.com/NuGet/NuGet.Client/pull/2146 to rightly place Capability check. We need this capability check even for packages.config based projects to figure out if they even supports `VSProject4`. 

@rrelyea 