### PR TITLE
Fix throwing package not found exception even before actual preview restore

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -1553,18 +1553,7 @@ namespace NuGet.PackageManagement
 
             if (nuGetProject is INuGetIntegratedProject)
             {
-                SourceRepository sourceRepository;
-                if (primarySources.Count() > 1)
-                {
-                    var logger = new ProjectContextLogger(nuGetProjectContext);
-                    sourceRepository = await GetSourceRepository(packageIdentity, primarySources, resolutionContext.SourceCacheContext, logger);
-                }
-                else
-                {
-                    sourceRepository = primarySources.First();
-                }
-
-                var action = NuGetProjectAction.CreateInstallProjectAction(packageIdentity, sourceRepository, nuGetProject);
+                var action = NuGetProjectAction.CreateInstallProjectAction(packageIdentity, primarySources.First(), nuGetProject);
                 var actions = new[] { action };
 
                 var buildIntegratedProject = nuGetProject as BuildIntegratedNuGetProject;


### PR DESCRIPTION
Currently we throw package not found exception for build integrated projects (Project.json and PackageReference) when the package is not available from any online feed. This happens while creating simple `NuGetProjectAction` to run actual preview restore, where actual preview restore will anyways take care of this including first checking through fallback folders.

Fixes [595963](https://devdiv.visualstudio.com/DevDiv/NuGet/_workitems/edit/595963) Failure to install package with IVsPackageInstaller api when package version is available in the NuGetFallbackFolder but not on the enabled online feed.