### PR TITLE
AddProjectRestoreInfo does not update the existing projectNames

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/ProjectSystemCache.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/ProjectSystemCache.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -284,7 +284,10 @@ namespace NuGet.PackageManagement.VisualStudio
 
             try
             {
-                UpdateProjectNamesCache(projectNames);
+                if (!_projectNamesCache.ContainsKey(projectNames.FullName))
+                {
+                    UpdateProjectNamesCache(projectNames);
+                }
 
                 AddOrUpdateCacheEntry(
                     projectNames.FullName,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectSystemCacheTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectSystemCacheTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Moq;
@@ -152,16 +152,16 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo);
 
             // Assert
-            DependencyGraphSpec actual;
-            ProjectNames names;
-
-            var getPackageSpecSuccess = target.TryGetProjectRestoreInfo(projectNames.FullName, out actual);
-            var getProjectNameSuccess = target.TryGetProjectNames(projectNames.UniqueName, out names);
+            var getPackageSpecSuccess = target.TryGetProjectRestoreInfo(projectNames.FullName, out var actual);
+            var getProjectNameFromUniqueNameSuccess = target.TryGetProjectNames(projectNames.UniqueName, out var names1);
+            var getProjectNameFromFullNameSuccess = target.TryGetProjectNames(projectNames.FullName, out var names2);
 
             Assert.True(getPackageSpecSuccess);
-            Assert.True(getProjectNameSuccess);
+            Assert.True(getProjectNameFromUniqueNameSuccess);
+            Assert.True(getProjectNameFromFullNameSuccess);
             Assert.Same(projectRestoreInfo, actual);
-            Assert.Equal(@"folder\project", names.CustomUniqueName);
+            Assert.Equal(@"folder\project", names1.CustomUniqueName);
+            Assert.Equal(@"folder\project", names2.CustomUniqueName);
         }
 
         [Fact]


### PR DESCRIPTION
## Bug
Fixes: VSTS 584687
Regression: Yes 
If Regression then when did it last work:  15.7 preview 1 or 2.
If Regression then how are we preventing it in future:   unit test
Details:

Rename a .net core project, PMC default project becomes null.

Root Cause:
In current code, Nomination always add restoreInfo with a temp ProjectNames to ProjectSystemCache,
Then the real ProjectNames will be updated by SolutionManager during Init.
This design depends on the order of AddedProjectEvent and nomination Event, it only works when Nomination happens before AddedProjectEvent, otherwise the temp ProjectNames replaces real projectNames.


## Fix
Details: 

Since Nomination always add temp ProjectNames to ProjectSystemCache, it should not update the ProjectName cache if the real ProjectName already exists.

The fix is skip ProjectName update if real ProjectName already exists in AddProjectRestoreInfo() method

actually this is the origin design for ProjectSystemCache, we even have a test which test against this scenario, unfortunately that test didn't test correct thing,


## Testing/Validation
Tests Added: Yes  
Reason for not adding tests:  
Validation done:  manual validation
