### PR TITLE
Add countersignature verification to allowListVerificationProvider

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/VerifyCommand/VerifyCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/VerifyCommand/VerifyCommandRunner.cs
@@ -40,7 +40,11 @@ namespace NuGet.Commands
                 LocalFolderUtility.EnsurePackageFileExists(verifyArgs.PackagePath, packagesToVerify);
 
                 var allowListEntries = verifyArgs.CertificateFingerprint.Select(fingerprint =>
-                    new CertificateHashAllowListEntry(VerificationTarget.Primary, fingerprint, _defaultFingerprintAlgorithm)).ToList();
+                    new CertificateHashAllowListEntry(
+                        VerificationTarget.Author | VerificationTarget.Repository,
+                        SignaturePlacement.PrimarySignature,
+                        fingerprint,
+                        _defaultFingerprintAlgorithm)).ToList();
 
                 var verifierSettings = SignedPackageVerifierSettings.GetVerifyCommandDefaultPolicy(clientAllowListEntries: allowListEntries);
                 var verificationProviders = SignatureVerificationProviderFactory.GetSignatureVerificationProviders();

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/SignaturePlacement.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/SignaturePlacement.cs
@@ -1,21 +1,24 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace NuGet.Packaging.Signing
 {
     /// <summary>
     /// Indicates signature placement.
     /// </summary>
+    [Flags]
     public enum SignaturePlacement
     {
         /// <summary>
         /// The primary signature.
         /// </summary>
-        PrimarySignature = 1,
+        PrimarySignature = 0x01,
 
         /// <summary>
         /// A countersignature on the primary signature.
         /// </summary>
-        Countersignature = 2
+        Countersignature = 0x10
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/RepositorySignatureInfoUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/RepositorySignatureInfoUtility.cs
@@ -66,10 +66,11 @@ namespace NuGet.Packaging.Signing
                 foreach (var certInfo in repositoryCertificateInfos)
                 {
                     var verificationTarget = VerificationTarget.Repository;
+                    var signaturePlacement = SignaturePlacement.PrimarySignature | SignaturePlacement.Countersignature;
 
-                    AddCertificateFingerprintIntoAllowList(verificationTarget, HashAlgorithmName.SHA256, certInfo, repositoryAllowList);
-                    AddCertificateFingerprintIntoAllowList(verificationTarget, HashAlgorithmName.SHA384, certInfo, repositoryAllowList);
-                    AddCertificateFingerprintIntoAllowList(verificationTarget, HashAlgorithmName.SHA512, certInfo, repositoryAllowList);
+                    AddCertificateFingerprintIntoAllowList(verificationTarget, signaturePlacement, HashAlgorithmName.SHA256, certInfo, repositoryAllowList);
+                    AddCertificateFingerprintIntoAllowList(verificationTarget, signaturePlacement, HashAlgorithmName.SHA384, certInfo, repositoryAllowList);
+                    AddCertificateFingerprintIntoAllowList(verificationTarget, signaturePlacement, HashAlgorithmName.SHA512, certInfo, repositoryAllowList);
                 }
             }
 
@@ -78,6 +79,7 @@ namespace NuGet.Packaging.Signing
 
         private static void AddCertificateFingerprintIntoAllowList(
             VerificationTarget target,
+            SignaturePlacement placement,
             HashAlgorithmName algorithm,
             IRepositoryCertificateInfo certInfo,
             List<CertificateHashAllowListEntry> allowList)
@@ -86,7 +88,7 @@ namespace NuGet.Packaging.Signing
 
             if (!string.IsNullOrEmpty(fingerprint))
             {
-                allowList.Add(new CertificateHashAllowListEntry(target, fingerprint, algorithm));
+                allowList.Add(new CertificateHashAllowListEntry(target, placement, fingerprint, algorithm));
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/RepositorySignatureInfoUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/RepositorySignatureInfoUtility.cs
@@ -68,9 +68,10 @@ namespace NuGet.Packaging.Signing
                     var verificationTarget = VerificationTarget.Repository;
                     var signaturePlacement = SignaturePlacement.PrimarySignature | SignaturePlacement.Countersignature;
 
-                    AddCertificateFingerprintIntoAllowList(verificationTarget, signaturePlacement, HashAlgorithmName.SHA256, certInfo, repositoryAllowList);
-                    AddCertificateFingerprintIntoAllowList(verificationTarget, signaturePlacement, HashAlgorithmName.SHA384, certInfo, repositoryAllowList);
-                    AddCertificateFingerprintIntoAllowList(verificationTarget, signaturePlacement, HashAlgorithmName.SHA512, certInfo, repositoryAllowList);
+                    foreach (var hashAlgorithm in SigningSpecifications.V1.AllowedHashAlgorithms)
+                    {
+                        AddCertificateFingerprintIntoAllowList(verificationTarget, signaturePlacement, hashAlgorithm, certInfo, repositoryAllowList);
+                    }
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/AllowListVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/AllowListVerificationProvider.cs
@@ -49,6 +49,12 @@ namespace NuGet.Packaging.Signing
             return new SignedPackageVerificationResult(GetValidity(allowListResults), signature, allowListResults.SelectMany(r => r.Issues));
         }
 
+        /// <summary>
+        /// Verify an allow list with a given request
+        /// </summary>
+        /// <param name="request">Information about the allow list verification to perform</param>
+        /// <remarks>This method should never return a status unknown. Min is used to take the most severe status in <see cref="GetValidity"/>
+        /// therefore, if unknown is returned the verification process will return an unknown status for the whole operation</remarks>
         private Task<SignedPackageVerificationResult> VerifyAllowList(CertificateListVerificationRequest request)
         {
             var status = SignatureVerificationStatus.Valid;

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/CertificateHashAllowListEntry.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/CertificateHashAllowListEntry.cs
@@ -11,8 +11,8 @@ namespace NuGet.Packaging.Signing
 
         public HashAlgorithmName FingerprintAlgorithm { get; }
 
-        public CertificateHashAllowListEntry(VerificationTarget target, string fingerprint, HashAlgorithmName algorithm)
-            : base(target)
+        public CertificateHashAllowListEntry(VerificationTarget target, SignaturePlacement placement, string fingerprint, HashAlgorithmName algorithm)
+            : base(target, placement)
         {
             Fingerprint = fingerprint;
             FingerprintAlgorithm = algorithm;

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureVerificationStatus.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureVerificationStatus.cs
@@ -1,12 +1,15 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 namespace NuGet.Packaging.Signing
 {
     /// <summary>
     /// Represents the trust result of a signature.
     /// </summary>
+    /// <remarks>The order of the elements on this enum is important.
+    /// It should be ordered from most severe to valid.
+    /// When a verification with multiple steps wants to be strict it should take the min
+    /// out of each step as the status for the whole verification.</remarks>
     public enum SignatureVerificationStatus
     {
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/VerificationAllowListEntry.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/VerificationAllowListEntry.cs
@@ -1,15 +1,31 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace NuGet.Packaging.Signing
 {
     public abstract class VerificationAllowListEntry
     {
-        public VerificationTarget VerificationTarget { get; }
+        /// <summary>
+        /// Target type of signature to verify.
+        /// </summary>
+        public VerificationTarget Target { get; }
 
-        public VerificationAllowListEntry(VerificationTarget target)
+        /// <summary>
+        /// Signature placement to verify.
+        /// </summary>
+        public SignaturePlacement Placement { get; }
+
+        public VerificationAllowListEntry(VerificationTarget target, SignaturePlacement placement)
         {
-            VerificationTarget = target;
+            if (target == VerificationTarget.Author && placement.HasFlag(SignaturePlacement.Countersignature))
+            {
+                throw new ArgumentException(Strings.ErrorAuthorTargetCannotBeACountersignature);
+            }
+
+            Target = target;
+            Placement = placement;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/VerificationTarget.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/VerificationTarget.cs
@@ -5,10 +5,23 @@ using System;
 
 namespace NuGet.Packaging.Signing
 {
+    /// <summary>
+    /// Indicates the type of signature a verification is targeting
+    /// </summary>
+    /// <remarks>This target makes no assumption about the placement of the signature.
+    /// It only refers to author or repository type of signature.
+    /// If a specific placement is needed use the SignaturePlacement class.</remarks>
     [Flags]
     public enum VerificationTarget
     {
-        Primary     = 0x000001,
-        Repository  = 0x000010
+        /// <summary>
+        /// Target Author signatures
+        /// </summary>
+        Author      = 0x01,
+
+        /// <summary>
+        /// Target Repository signatures
+        /// </summary>
+        Repository  = 0x10
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/VerificationTarget.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/VerificationTarget.cs
@@ -10,7 +10,7 @@ namespace NuGet.Packaging.Signing
     /// </summary>
     /// <remarks>This target makes no assumption about the placement of the signature.
     /// It only refers to author or repository type of signature.
-    /// If a specific placement is needed use the SignaturePlacement class.</remarks>
+    /// If a specific placement is needed use the <see cref="SignaturePlacement" /> enum.</remarks>
     [Flags]
     public enum VerificationTarget
     {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -188,7 +188,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package signature certificate cannot be trusted as no client allow list found..
+        ///   Looks up a localized string similar to The client allow list is required and was empty or not found..
         /// </summary>
         internal static string Error_NoClientAllowList {
             get {
@@ -215,7 +215,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package signature certificate cannot be trusted as no repository allow list found..
+        ///   Looks up a localized string similar to The repository allow list is required and was empty or not found..
         /// </summary>
         internal static string Error_NoRepoAllowList {
             get {
@@ -247,6 +247,15 @@ namespace NuGet.Packaging {
         internal static string Error_RepositorySignatureMustNotHaveARepositoryCountersignature {
             get {
                 return ResourceManager.GetString("Error_RepositorySignatureMustNotHaveARepositoryCountersignature", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot target author signatures that are countersignatures..
+        /// </summary>
+        internal static string ErrorAuthorTargetCannotBeACountersignature {
+            get {
+                return ResourceManager.GetString("ErrorAuthorTargetCannotBeACountersignature", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -188,7 +188,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The client allow list is required and was empty or not found..
+        ///   Looks up a localized string similar to A list of trusted signers is required by the client but none was found..
         /// </summary>
         internal static string Error_NoClientAllowList {
             get {
@@ -215,7 +215,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The repository allow list is required and was empty or not found..
+        ///   Looks up a localized string similar to A repository announced that their packages should be signed but an empty list of trusted certificates was found..
         /// </summary>
         internal static string Error_NoRepoAllowList {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -593,10 +593,10 @@ Valid from:</comment>
     <value>The primary signature and repository countersignature are unrelated.</value>
   </data>
   <data name="Error_NoRepoAllowList" xml:space="preserve">
-    <value>The package signature certificate cannot be trusted as no repository allow list found.</value>
+    <value>The repository allow list is required and was empty or not found.</value>
   </data>
   <data name="Error_NoClientAllowList" xml:space="preserve">
-    <value>The package signature certificate cannot be trusted as no client allow list found.</value>
+    <value>The client allow list is required and was empty or not found.</value>
   </data>
   <data name="Error_NoMatchingRepositoryCertificate" xml:space="preserve">
     <value>The package signature certificate fingerprint does not match any certificate fingerprint in repository allow list.</value>
@@ -655,5 +655,8 @@ Valid from:</comment>
   </data>
   <data name="SignError_TimestampUnsupportedSignatureAlgorithm" xml:space="preserve">
     <value>The timestamp certificate has an unsupported signature algorithm.</value>
+  </data>
+  <data name="ErrorAuthorTargetCannotBeACountersignature" xml:space="preserve">
+    <value>Cannot target author signatures that are countersignatures.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -593,10 +593,10 @@ Valid from:</comment>
     <value>The primary signature and repository countersignature are unrelated.</value>
   </data>
   <data name="Error_NoRepoAllowList" xml:space="preserve">
-    <value>The repository allow list is required and was empty or not found.</value>
+    <value>A repository announced that their packages should be signed but an empty list of trusted certificates was found.</value>
   </data>
   <data name="Error_NoClientAllowList" xml:space="preserve">
-    <value>The client allow list is required and was empty or not found.</value>
+    <value>A list of trusted signers is required by the client but none was found.</value>
   </data>
   <data name="Error_NoMatchingRepositoryCertificate" xml:space="preserve">
     <value>The package signature certificate fingerprint does not match any certificate fingerprint in repository allow list.</value>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -3028,6 +3028,7 @@ namespace NuGet.Packaging.Test
         private static Tuple<RepositorySignatureInfo, List<CertificateHashAllowListEntry>> CreateTestRepositorySignatureInfoAndExpectedAllowList()
         {
             var target = VerificationTarget.Repository;
+            var placement = SignaturePlacement.PrimarySignature | SignaturePlacement.Countersignature;
             var allSigned = true;
             var firstCertFingerprints = new Dictionary<string, string>()
             {
@@ -3067,10 +3068,10 @@ namespace NuGet.Packaging.Test
 
             var expectedAllowList = new List<CertificateHashAllowListEntry>()
             {
-                new CertificateHashAllowListEntry(target, $"{HashAlgorithmName.SHA256.ToString()}_first", HashAlgorithmName.SHA256),
-                new CertificateHashAllowListEntry(target, $"{HashAlgorithmName.SHA384.ToString()}_first", HashAlgorithmName.SHA384),
-                new CertificateHashAllowListEntry(target, $"{HashAlgorithmName.SHA512.ToString()}_first", HashAlgorithmName.SHA512),
-                new CertificateHashAllowListEntry(target, $"{HashAlgorithmName.SHA256.ToString()}_second", HashAlgorithmName.SHA256)
+                new CertificateHashAllowListEntry(target, placement, $"{HashAlgorithmName.SHA256.ToString()}_first", HashAlgorithmName.SHA256),
+                new CertificateHashAllowListEntry(target, placement, $"{HashAlgorithmName.SHA384.ToString()}_first", HashAlgorithmName.SHA384),
+                new CertificateHashAllowListEntry(target, placement, $"{HashAlgorithmName.SHA512.ToString()}_first", HashAlgorithmName.SHA512),
+                new CertificateHashAllowListEntry(target, placement, $"{HashAlgorithmName.SHA256.ToString()}_second", HashAlgorithmName.SHA256)
             };
 
             return Tuple.Create(repositorySignatureInfo, expectedAllowList);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/RepositorySignatureInfoUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/RepositorySignatureInfoUtilityTests.cs
@@ -113,6 +113,8 @@ namespace NuGet.Packaging.Test
         {
             // Arrange
             var target = VerificationTarget.Repository;
+            var placement = SignaturePlacement.PrimarySignature | SignaturePlacement.Countersignature;
+
             var allSigned = true;
             var certFingerprints = new Dictionary<string, string>()
             {
@@ -139,9 +141,9 @@ namespace NuGet.Packaging.Test
 
             var expectedAllowList = new List<CertificateHashAllowListEntry>()
             {
-                new CertificateHashAllowListEntry(target, HashAlgorithmName.SHA256.ToString(), HashAlgorithmName.SHA256),
-                new CertificateHashAllowListEntry(target, HashAlgorithmName.SHA384.ToString(), HashAlgorithmName.SHA384),
-                new CertificateHashAllowListEntry(target, HashAlgorithmName.SHA512.ToString(), HashAlgorithmName.SHA512)
+                new CertificateHashAllowListEntry(target, placement, HashAlgorithmName.SHA256.ToString(), HashAlgorithmName.SHA256),
+                new CertificateHashAllowListEntry(target, placement, HashAlgorithmName.SHA384.ToString(), HashAlgorithmName.SHA384),
+                new CertificateHashAllowListEntry(target, placement, HashAlgorithmName.SHA512.ToString(), HashAlgorithmName.SHA512)
             };
 
             var repoSignatureInfo = new RepositorySignatureInfo(allSigned, repoCertificateInfo);
@@ -162,6 +164,7 @@ namespace NuGet.Packaging.Test
         {
             // Arrange
             var target = VerificationTarget.Repository;
+            var placement = SignaturePlacement.PrimarySignature | SignaturePlacement.Countersignature;
             var allSigned = true;
             var firstCertFingerprints = new Dictionary<string, string>()
             {
@@ -199,10 +202,10 @@ namespace NuGet.Packaging.Test
 
             var expectedAllowList = new List<CertificateHashAllowListEntry>()
             {
-                new CertificateHashAllowListEntry(target, $"{HashAlgorithmName.SHA256.ToString()}_first", HashAlgorithmName.SHA256),
-                new CertificateHashAllowListEntry(target, $"{HashAlgorithmName.SHA384.ToString()}_first", HashAlgorithmName.SHA384),
-                new CertificateHashAllowListEntry(target, $"{HashAlgorithmName.SHA512.ToString()}_first", HashAlgorithmName.SHA512),
-                new CertificateHashAllowListEntry(target, $"{HashAlgorithmName.SHA256.ToString()}_second", HashAlgorithmName.SHA256)
+                new CertificateHashAllowListEntry(target, placement, $"{HashAlgorithmName.SHA256.ToString()}_first", HashAlgorithmName.SHA256),
+                new CertificateHashAllowListEntry(target, placement, $"{HashAlgorithmName.SHA384.ToString()}_first", HashAlgorithmName.SHA384),
+                new CertificateHashAllowListEntry(target, placement, $"{HashAlgorithmName.SHA512.ToString()}_first", HashAlgorithmName.SHA512),
+                new CertificateHashAllowListEntry(target, placement, $"{HashAlgorithmName.SHA256.ToString()}_second", HashAlgorithmName.SHA256)
             };
 
             var repoSignatureInfo = new RepositorySignatureInfo(allSigned, repoCertificateInfo);
@@ -223,6 +226,7 @@ namespace NuGet.Packaging.Test
         {
             // Arrange
             var target = VerificationTarget.Repository;
+            var placement = SignaturePlacement.PrimarySignature | SignaturePlacement.Countersignature;
             var allSigned = true;
             var certFingerprints = new Dictionary<string, string>()
             {
@@ -249,15 +253,15 @@ namespace NuGet.Packaging.Test
 
             var expectedClientAllowList = new List<CertificateHashAllowListEntry>()
             {
-                new CertificateHashAllowListEntry(target, HashAlgorithmName.SHA256.ToString(), HashAlgorithmName.SHA256)
+                new CertificateHashAllowListEntry(target, placement, HashAlgorithmName.SHA256.ToString(), HashAlgorithmName.SHA256)
             };
 
 
             var expectedRepoAllowList = new List<CertificateHashAllowListEntry>()
             {
-                new CertificateHashAllowListEntry(target, HashAlgorithmName.SHA256.ToString(), HashAlgorithmName.SHA256),
-                new CertificateHashAllowListEntry(target, HashAlgorithmName.SHA384.ToString(), HashAlgorithmName.SHA384),
-                new CertificateHashAllowListEntry(target, HashAlgorithmName.SHA512.ToString(), HashAlgorithmName.SHA512)
+                new CertificateHashAllowListEntry(target, placement, HashAlgorithmName.SHA256.ToString(), HashAlgorithmName.SHA256),
+                new CertificateHashAllowListEntry(target, placement, HashAlgorithmName.SHA384.ToString(), HashAlgorithmName.SHA384),
+                new CertificateHashAllowListEntry(target, placement, HashAlgorithmName.SHA512.ToString(), HashAlgorithmName.SHA512)
             };
 
             var repoSignatureInfo = new RepositorySignatureInfo(allSigned, repoCertificateInfo);

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -580,7 +580,7 @@ namespace Test.Utility.Signing
                     return false;
                 }
 
-                return x.VerificationTarget == y.VerificationTarget &&
+                return x.Target == y.Target &&
                     x.FingerprintAlgorithm == y.FingerprintAlgorithm &&
                     string.Equals(x.Fingerprint, y.Fingerprint, StringComparison.Ordinal);
             }
@@ -594,7 +594,7 @@ namespace Test.Utility.Signing
 
                 var combiner = new HashCodeCombiner();
 
-                combiner.AddObject(obj.VerificationTarget);
+                combiner.AddObject(obj.Target);
                 combiner.AddObject(obj.Fingerprint);
                 combiner.AddObject(obj.FingerprintAlgorithm);
 

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -582,7 +582,7 @@ namespace Test.Utility.Signing
 
                 return x.Target == y.Target &&
                     x.FingerprintAlgorithm == y.FingerprintAlgorithm &&
-                    string.Equals(x.Fingerprint, y.Fingerprint, StringComparison.Ordinal);
+                    string.Equals(x.Fingerprint, y.Fingerprint, StringComparison.OrdinalIgnoreCase);
             }
 
             public int GetHashCode(CertificateHashAllowListEntry obj)


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/6807

Currently when we check the `RepositorySignatureInformation` on a signature it is only aware of primary signatures.

This PR makes the `AllowListVerificationProvider` to be aware of different signature placements apart from signature targets, and makes sure that the current inputs to this provider pass the appropriate targets and placements.