### PR TITLE
nuget.configuration needs to have XPLATProject set

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/NuGet.Configuration.csproj
+++ b/src/NuGet.Core/NuGet.Configuration/NuGet.Configuration.csproj
@@ -10,6 +10,7 @@
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>
+    <XPLATProject>true</XPLATProject>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6818
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details:

This was somehow missed in the patch work, and never fixed on NuGet side, but rather on source-build side. 

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  
Validation done:  Automated tests
