### PR TITLE
TFM mappings for WebAssembly and MonoUE

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
@@ -93,6 +93,8 @@ namespace NuGet.Frameworks
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.WinRT, "winrt"), // legacy
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.UAP, "uap"),
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.Tizen, "tizen"),
+                            new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.WebAssembly, "wasm"),
+                            new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.MonoUE, "monoue"),
                         };
                 }
 
@@ -506,6 +508,16 @@ namespace NuGet.Frameworks
 
                             CreateGenerationAndStandardMappingForAllVersions(
                                 FrameworkConstants.FrameworkIdentifiers.XamarinWatchOS,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard20),
+
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.WebAssembly,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard20),
+
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.MonoUE,
                                 FrameworkConstants.CommonFrameworks.DotNet56,
                                 FrameworkConstants.CommonFrameworks.NetStandard20)
                         }.SelectMany(mappings => mappings))

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
@@ -68,6 +68,8 @@ namespace NuGet.Frameworks
             public const string XamarinXboxOne = "Xamarin.XboxOne";
             public const string UAP = "UAP";
             public const string Tizen = "Tizen";
+            public const string WebAssembly = "WebAssembly";
+            public const string MonoUE = "MonoUE";
         }
 
         /// <summary>

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityListProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityListProviderTests.cs
@@ -48,6 +48,8 @@ namespace NuGet.Frameworks.Test
             Assert.Contains("Xamarin.Xbox360,Version=v0.0", actual);
             Assert.Contains("Xamarin.XboxOne,Version=v0.0", actual);
             Assert.Contains("Tizen,Version=v3.0", actual);
+            Assert.Contains("WebAssembly,Version=v0.0", actual);
+            Assert.Contains("MonoUE,Version=v0.0", actual);
 
             // negative
             Assert.DoesNotContain(".NETFramework,Version=v4.6", actual); // only the minimum support version is returned
@@ -55,7 +57,7 @@ namespace NuGet.Frameworks.Test
             Assert.DoesNotContain(".NETPlatform,Version=v5.3", actual); // frameworks with no relationship are not returned
 
             // count
-            Assert.Equal(26, actual.Length);
+            Assert.Equal(28, actual.Length);
         }
 
         [Fact]
@@ -92,6 +94,8 @@ namespace NuGet.Frameworks.Test
             Assert.Contains("Xamarin.XboxOne,Version=v0.0", actual);
             Assert.Contains("Tizen,Version=v3.0", actual);
             Assert.Contains("UAP,Version=v10.0.15064", actual);
+            Assert.Contains("WebAssembly,Version=v0.0", actual);
+            Assert.Contains("MonoUE,Version=v0.0", actual);
 
             // negative
             Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // only the minimum support version is returned
@@ -99,7 +103,7 @@ namespace NuGet.Frameworks.Test
             Assert.DoesNotContain(".NETPlatform,Version=v5.6", actual); // frameworks with no relationship are not returned
 
             // count
-            Assert.Equal(20, actual.Length);
+            Assert.Equal(22, actual.Length);
         }
 
         [Fact]
@@ -135,6 +139,8 @@ namespace NuGet.Frameworks.Test
             Assert.Contains("Xamarin.XboxOne,Version=v0.0", actual);
             Assert.Contains("Tizen,Version=v3.0", actual);
             Assert.Contains("UAP,Version=v10.0.15064", actual);
+            Assert.Contains("WebAssembly,Version=v0.0", actual);
+            Assert.Contains("MonoUE,Version=v0.0", actual);
 
             // negative
             Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // only the minimum support version is returned
@@ -143,7 +149,7 @@ namespace NuGet.Frameworks.Test
             Assert.DoesNotContain("DNXCore,Version=v5.0", actual);
 
             // count
-            Assert.Equal(19, actual.Length);
+            Assert.Equal(21, actual.Length);
         }
 
         [Fact]
@@ -179,6 +185,8 @@ namespace NuGet.Frameworks.Test
             Assert.Contains("Xamarin.XboxOne,Version=v0.0", actual);
             Assert.Contains("Tizen,Version=v4.0", actual);
             Assert.Contains("UAP,Version=v10.0.15064", actual);
+            Assert.Contains("WebAssembly,Version=v0.0", actual);
+            Assert.Contains("MonoUE,Version=v0.0", actual);
 
             // negative
             Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // only the minimum support version is returned
@@ -187,7 +195,7 @@ namespace NuGet.Frameworks.Test
             Assert.DoesNotContain("DNXCore,Version=v5.0", actual);
 
             // count
-            Assert.Equal(19, actual.Length);
+            Assert.Equal(21, actual.Length);
         }
 
         [Fact]
@@ -222,6 +230,8 @@ namespace NuGet.Frameworks.Test
             Assert.Contains("Xamarin.XboxOne,Version=v0.0", actual);
             Assert.Contains("Tizen,Version=v4.0", actual);
             Assert.Contains("UAP,Version=v10.0.15064", actual);
+            Assert.Contains("WebAssembly,Version=v0.0", actual);
+            Assert.Contains("MonoUE,Version=v0.0", actual);
 
             // negative
             Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // only the minimum support version is returned
@@ -230,7 +240,7 @@ namespace NuGet.Frameworks.Test
             Assert.DoesNotContain("DNXCore,Version=v5.0", actual);
 
             // count
-            Assert.Equal(19, actual.Length);
+            Assert.Equal(21, actual.Length);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
@@ -904,6 +904,8 @@ namespace NuGet.Test
         [InlineData("xamarinxboxthreesixty")]
         [InlineData("xamarinwatchos")]
         [InlineData("xamarinxboxone")]
+        [InlineData("wasm")]
+        [InlineData("monoue")]
         public void Compatibility_ProjectCanInstallGenerationLibraries(string framework)
         {
             // Arrange


### PR DESCRIPTION
Added TFMs for WebAssembly and Mono for Unreal Engine.

Like other Mono-based frameworks, these are compatible with netstandard 2.0.