### PR TITLE
dispose packageArchiveReader properly when symbols package is created

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -768,6 +768,10 @@ namespace NuGet.Commands
                 {
                     return packageArchiveReader;
                 }
+                else
+                {
+                    packageArchiveReader?.Dispose();
+                }
             }
 
             if (_packArgs.Symbols)
@@ -940,7 +944,7 @@ namespace NuGet.Commands
             string outputPath = GetOutputPath(symbolsBuilder, _packArgs, symbols: true);
 
             InitCommonPackageBuilderProperties(symbolsBuilder);
-            BuildPackage(symbolsBuilder, outputPath);
+            BuildPackage(symbolsBuilder, outputPath)?.Dispose();
         }
 
         internal void AnalyzePackage(PackageArchiveReader package)

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -647,7 +647,7 @@ namespace NuGet.Commands
             }
             else
             {
-                if (_packArgs.Symbols)
+                if (_packArgs.Symbols && packageBuilder.Files.Any())
                 {
                     // remove source related files when building the lib package
                     ExcludeFilesForLibPackage(packageBuilder.Files);

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -87,6 +87,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                     OutputDirectory = dir,
                     Path = nuspecPath,
                     Exclude = Array.Empty<string>(),
+                    Symbols = true,
                     Logger = NullLogger.Instance
                 },
                 MSBuildProjectFactory.ProjectCreator,


### PR DESCRIPTION
completing the fix for : https://github.com/NuGet/Home/issues/6165 

6165 was partially fixed by https://github.com/NuGet/NuGet.Client/pull/1808 but didn't cover the case of disposing PackageArchiveReader when IncludeSymbols=true .