### PR TITLE
Add e2e apex tests for repository signatures and countersignatures

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
@@ -37,7 +37,7 @@ namespace NuGet.Tests.Apex
             SolutionService = _visualStudio.Get<SolutionService>();
             NuGetApexTestService = _visualStudio.Get<NuGetApexTestService>();
 
-            Project = Utils.CreateAndInitProject(projectTemplate, _pathContext, SolutionService, logger);
+            Project = CommonUtility.CreateAndInitProject(projectTemplate, _pathContext, SolutionService, logger);
 
             NuGetApexTestService.WaitForAutoRestore();
         }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
@@ -10,6 +10,9 @@
 
   <ItemGroup>
     <None Remove="Apex\ApexTestContext.cs" />
+    <None Remove="NuGetPackageSigningTests\RepositoryCountersignedPackageTestCase.cs" />
+    <None Remove="NuGetPackageSigningTests\RepositorySignedPackageTestCase.cs" />
+    <None Remove="Utility\SigningUtility.cs" />
   </ItemGroup>
   
   <ItemGroup>
@@ -41,15 +44,20 @@
     <Compile Include="NuGetEndToEndTests\NuGetConsoleTestCase.cs" />
     <Compile Include="NuGetEndToEndTests\NetCoreProjectTestCase.cs" />
     <Compile Include="NuGetEndToEndTests\NuGetUITestCase.cs" />
-    <Compile Include="NuGetEndToEndTests\Utils.cs" />
+    <Compile Include="NuGetPackageSigningTests\RepositoryCountersignedPackageTestCase.cs" />
+    <Compile Include="Utility\CommonUtility.cs" />
     <Compile Include="Apex\NuGetTypeConstraint.cs" />
     <Compile Include="Apex\NuGetUIProjectTestExtensionVerifier.cs" />
     <Compile Include="Apex\NuGetUIProjectTestExtension.cs" />
     <Compile Include="Apex\NuGetBaseTestExtension.cs" />
+    <Compile Include="Utility\SigningUtility.cs" />
     <Compile Include="VisualStudioHostExtension.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Apex\NuGetConsoleTestExtensionVerifier.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="NuGetPackageSigningTests\RepositorySignedPackageTestCase.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Test.Apex-d15rel">
@@ -88,6 +96,6 @@
     <RuntimeIdentifier>x86</RuntimeIdentifier>
   </PropertyGroup>
   
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsPackageInstallerTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsPackageInstallerTestCase.cs
@@ -32,7 +32,7 @@ namespace NuGet.Tests.Apex
             nugetTestService.InstallPackage(project.UniqueName, "newtonsoft.json");
 
             // Assert
-            Utils.AssetPackageInPackagesConfig(VisualStudio, projExt, "newtonsoft.json", XunitLogger);
+            CommonUtility.AssetPackageInPackagesConfig(VisualStudio, projExt, "newtonsoft.json", XunitLogger);
         }
 
         [StaFact]
@@ -52,7 +52,7 @@ namespace NuGet.Tests.Apex
             nugetTestService.UninstallPackage(project.UniqueName, "newtonsoft.json");
 
             // Assert
-            Utils.AssetPackageNotInPackagesConfig(VisualStudio, projExt, "newtonsoft.json", XunitLogger);
+            CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, projExt, "newtonsoft.json", XunitLogger);
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -46,7 +46,7 @@ namespace NuGet.Tests.Apex
                 testContext.SolutionService.Build();
                 testContext.NuGetApexTestService.WaitForAutoRestore();
 
-                Utils.AssertPackageInAssetsFile(VisualStudio, testContext.Project, "TestProject2", "1.0.0", XunitLogger);
+                CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, "TestProject2", "1.0.0", XunitLogger);
             }
         }
 
@@ -55,7 +55,7 @@ namespace NuGet.Tests.Apex
 
         public static IEnumerable<object[]> GetNetCoreTemplates()
         {
-            for (var i = 0; i < Utils.GetIterations(); i++)
+            for (var i = 0; i < CommonUtility.GetIterations(); i++)
             {
                 //yield return new object[] { ProjectTemplate.NetCoreClassLib };
                 //yield return new object[] { ProjectTemplate.NetCoreConsoleApp };

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -29,14 +29,14 @@ namespace NuGet.Tests.Apex
             {
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion);
 
                 var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
 
-                Utils.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
-                Utils.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
+                CommonUtility.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
+                CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
             }
         }
 
@@ -51,7 +51,7 @@ namespace NuGet.Tests.Apex
             {
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion);
 
                 var nugetConsole = GetConsole(testContext.Project);
 
@@ -60,8 +60,8 @@ namespace NuGet.Tests.Apex
                 // Build before the install check to ensure that everything is up to date.
                 testContext.Project.Build();
 
-                Utils.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
-                Utils.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
+                CommonUtility.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
+                CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
             }
         }
 
@@ -76,13 +76,13 @@ namespace NuGet.Tests.Apex
             {
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion);
 
                 var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
 
-                Utils.AssetPackageInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
+                CommonUtility.AssetPackageInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
             }
         }
 
@@ -97,7 +97,7 @@ namespace NuGet.Tests.Apex
             {
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion);
 
                 var nugetConsole = GetConsole(testContext.Project);
 
@@ -108,8 +108,8 @@ namespace NuGet.Tests.Apex
                 nugetConsole.UninstallPackageFromPMC(packageName);
                 testContext.Project.Build();
 
-                Utils.AssertPackageReferenceDoesNotExist(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
-                Utils.AssertPackageNotInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
+                CommonUtility.AssertPackageReferenceDoesNotExist(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
+                CommonUtility.AssertPackageNotInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
             }
         }
 
@@ -124,14 +124,14 @@ namespace NuGet.Tests.Apex
             {
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion);
 
                 var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
                 nugetConsole.UninstallPackageFromPMC(packageName);
 
-                Utils.AssetPackageNotInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
+                CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
             }
         }
 
@@ -147,8 +147,8 @@ namespace NuGet.Tests.Apex
                 var packageName = "TestPackage";
                 var packageVersion1 = "1.0.0";
                 var packageVersion2 = "2.0.0";
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion1);
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion2);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion1);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion2);
 
                 var nugetConsole = GetConsole(testContext.Project);
 
@@ -159,8 +159,8 @@ namespace NuGet.Tests.Apex
                 nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2);
                 testContext.Project.Build();
 
-                Utils.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName, packageVersion2, XunitLogger);
-                Utils.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersion2, XunitLogger);
+                CommonUtility.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName, packageVersion2, XunitLogger);
+                CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersion2, XunitLogger);
             }
         }
 
@@ -176,15 +176,15 @@ namespace NuGet.Tests.Apex
                 var packageName = "TestPackage";
                 var packageVersion1 = "1.0.0";
                 var packageVersion2 = "2.0.0";
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion1);
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion2);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion1);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion2);
 
                 var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion1);
                 nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2);
 
-                Utils.AssetPackageInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion2, XunitLogger);
+                CommonUtility.AssetPackageInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion2, XunitLogger);
             }
         }
 
@@ -199,11 +199,11 @@ namespace NuGet.Tests.Apex
             {
                 var packageName1 = "TestPackage1";
                 var packageVersion1 = "1.0.0";
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName1, packageVersion1);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName1, packageVersion1);
 
                 var packageName2 = "TestPackage2";
                 var packageVersion2 = "1.2.3";
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName2, packageVersion2);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName2, packageVersion2);
 
                 var nugetConsole = GetConsole(testContext.Project);
 
@@ -214,11 +214,11 @@ namespace NuGet.Tests.Apex
                 nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2);
                 testContext.Project.Build();
 
-                Utils.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName1, packageVersion1, XunitLogger);
-                Utils.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName2, packageVersion2, XunitLogger);
+                CommonUtility.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName1, packageVersion1, XunitLogger);
+                CommonUtility.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName2, packageVersion2, XunitLogger);
 
-                Utils.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName1, packageVersion1, XunitLogger);
-                Utils.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName2, packageVersion2, XunitLogger);
+                CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName1, packageVersion1, XunitLogger);
+                CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName2, packageVersion2, XunitLogger);
             }
         }
 
@@ -233,19 +233,19 @@ namespace NuGet.Tests.Apex
             {
                 var packageName1 = "TestPackage1";
                 var packageVersion1 = "1.0.0";
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName1, packageVersion1);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName1, packageVersion1);
 
                 var packageName2 = "TestPackage2";
                 var packageVersion2 = "1.2.3";
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName2, packageVersion2);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName2, packageVersion2);
 
                 var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1);
                 nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2);
 
-                Utils.AssetPackageInPackagesConfig(VisualStudio, testContext.Project, packageName1, packageVersion1, XunitLogger);
-                Utils.AssetPackageInPackagesConfig(VisualStudio, testContext.Project, packageName2, packageVersion2, XunitLogger);
+                CommonUtility.AssetPackageInPackagesConfig(VisualStudio, testContext.Project, packageName1, packageVersion1, XunitLogger);
+                CommonUtility.AssetPackageInPackagesConfig(VisualStudio, testContext.Project, packageName2, packageVersion2, XunitLogger);
             }
         }
 
@@ -263,8 +263,8 @@ namespace NuGet.Tests.Apex
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
             {
 
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName1, packageVersion1);
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName2, packageVersion2);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName1, packageVersion1);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName2, packageVersion2);
 
                 var nugetConsole = GetConsole(testContext.Project);
 
@@ -280,11 +280,11 @@ namespace NuGet.Tests.Apex
                 nugetConsole.UninstallPackageFromPMC(packageName2);
                 testContext.Project.Build();
 
-                Utils.AssertPackageReferenceDoesNotExist(VisualStudio, testContext.Project, packageName1, packageVersion1, XunitLogger);
-                Utils.AssertPackageReferenceDoesNotExist(VisualStudio, testContext.Project, packageName2, packageVersion2, XunitLogger);
+                CommonUtility.AssertPackageReferenceDoesNotExist(VisualStudio, testContext.Project, packageName1, packageVersion1, XunitLogger);
+                CommonUtility.AssertPackageReferenceDoesNotExist(VisualStudio, testContext.Project, packageName2, packageVersion2, XunitLogger);
 
-                Utils.AssertPackageNotInAssetsFile(VisualStudio, testContext.Project, packageName1, packageVersion1, XunitLogger);
-                Utils.AssertPackageNotInAssetsFile(VisualStudio, testContext.Project, packageName2, packageVersion2, XunitLogger);
+                CommonUtility.AssertPackageNotInAssetsFile(VisualStudio, testContext.Project, packageName1, packageVersion1, XunitLogger);
+                CommonUtility.AssertPackageNotInAssetsFile(VisualStudio, testContext.Project, packageName2, packageVersion2, XunitLogger);
             }
         }
 
@@ -301,8 +301,8 @@ namespace NuGet.Tests.Apex
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
             {
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName1, packageVersion1);
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName2, packageVersion2);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName1, packageVersion1);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName2, packageVersion2);
 
                 var nugetConsole = GetConsole(testContext.Project);
 
@@ -322,8 +322,8 @@ namespace NuGet.Tests.Apex
                 testContext.Project.Build();
                 testContext.NuGetApexTestService.WaitForAutoRestore();
 
-                Utils.AssetPackageNotInPackagesConfig(VisualStudio, testContext.Project, packageName1, packageVersion1, XunitLogger);
-                Utils.AssetPackageNotInPackagesConfig(VisualStudio, testContext.Project, packageName2, packageVersion2, XunitLogger);
+                CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, testContext.Project, packageName1, packageVersion1, XunitLogger);
+                CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, testContext.Project, packageName2, packageVersion2, XunitLogger);
             }
         }
 
@@ -339,8 +339,8 @@ namespace NuGet.Tests.Apex
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
             {
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion1);
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion2);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion1);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion2);
 
                 var nugetConsole = GetConsole(testContext.Project);
 
@@ -351,8 +351,8 @@ namespace NuGet.Tests.Apex
                 nugetConsole.UpdatePackageFromPMC(packageName, packageVersion1);
                 testContext.Project.Build();
 
-                Utils.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName, packageVersion1, XunitLogger);
-                Utils.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersion1, XunitLogger);
+                CommonUtility.AssertPackageReferenceExists(VisualStudio, testContext.Project, packageName, packageVersion1, XunitLogger);
+                CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersion1, XunitLogger);
             }
         }
 
@@ -368,15 +368,15 @@ namespace NuGet.Tests.Apex
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
             {
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion1);
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion2);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion1);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion2);
 
                 var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion2);
                 nugetConsole.UpdatePackageFromPMC(packageName, packageVersion1);
 
-                Utils.AssetPackageInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion1, XunitLogger);
+                CommonUtility.AssetPackageInPackagesConfig(VisualStudio, testContext.Project, packageName, packageVersion1, XunitLogger);
             }
         }
 
@@ -407,7 +407,7 @@ namespace NuGet.Tests.Apex
 
                 var packageName = "newtonsoft.json";
                 var packageVersion = "9.0.1";
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion);
 
                 nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
                 testContext.Project.Build();
@@ -416,10 +416,10 @@ namespace NuGet.Tests.Apex
                 projectX.Build();
                 testContext.SolutionService.Build();
 
-                Utils.AssertPackageInAssetsFile(VisualStudio, project3, packageName, packageVersion, XunitLogger);
-                Utils.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
-                Utils.AssertPackageInAssetsFile(VisualStudio, project2, packageName, packageVersion, XunitLogger);
-                Utils.AssertPackageNotInAssetsFile(VisualStudio, projectX, packageName, packageVersion, XunitLogger);
+                CommonUtility.AssertPackageInAssetsFile(VisualStudio, project3, packageName, packageVersion, XunitLogger);
+                CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersion, XunitLogger);
+                CommonUtility.AssertPackageInAssetsFile(VisualStudio, project2, packageName, packageVersion, XunitLogger);
+                CommonUtility.AssertPackageNotInAssetsFile(VisualStudio, projectX, packageName, packageVersion, XunitLogger);
             }
         }
 
@@ -441,8 +441,8 @@ namespace NuGet.Tests.Apex
                 var solutionService = VisualStudio.Get<SolutionService>();
                 testContext.Project.Build();
 
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion1);
-                await Utils.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion2);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion1);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion2);
 
                 var nugetTestService = GetNuGetTestService();
                 var nugetConsole = GetConsole(testContext.Project);
@@ -478,7 +478,7 @@ namespace NuGet.Tests.Apex
         // Commenting out any NetCoreConsoleApp template and swapping it for NetStandardClassLib as both are package ref.
         public static IEnumerable<object[]> GetNetCoreTemplates()
         {
-            for (var i = 0; i < Utils.GetIterations(); i++)
+            for (var i = 0; i < CommonUtility.GetIterations(); i++)
             {
                 //yield return new object[] { ProjectTemplate.NetCoreConsoleApp };
                 yield return new object[] { ProjectTemplate.NetStandardClassLib };
@@ -487,7 +487,7 @@ namespace NuGet.Tests.Apex
 
         public static IEnumerable<object[]> GetPackageReferenceTemplates()
         {
-            for (var i = 0; i < Utils.GetIterations(); i++)
+            for (var i = 0; i < CommonUtility.GetIterations(); i++)
             {
                 //yield return new object[] { ProjectTemplate.NetCoreConsoleApp };
                 yield return new object[] { ProjectTemplate.NetStandardClassLib };
@@ -496,7 +496,7 @@ namespace NuGet.Tests.Apex
 
         public static IEnumerable<object[]> GetPackagesConfigTemplates()
         {
-            for (var i = 0; i < Utils.GetIterations(); i++)
+            for (var i = 0; i < CommonUtility.GetIterations(); i++)
             {
                 yield return new object[] { ProjectTemplate.ClassLibrary };
             }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -56,7 +56,7 @@ namespace NuGet.Tests.Apex
             uiwindow.InstallPackageFromUI("newtonsoft.json", "9.0.1");
 
             // Assert
-            Utils.AssetPackageInPackagesConfig(VisualStudio, project, "newtonsoft.json", "9.0.1", XunitLogger);
+            CommonUtility.AssetPackageInPackagesConfig(VisualStudio, project, "newtonsoft.json", "9.0.1", XunitLogger);
         }
 
         [StaFact]
@@ -84,8 +84,8 @@ namespace NuGet.Tests.Apex
             uiwindow2.InstallPackageFromUI("newtonsoft.json", "9.0.1");
 
             // Assert
-            Utils.AssetPackageInPackagesConfig(VisualStudio, project, "newtonsoft.json", "9.0.1", XunitLogger);
-            Utils.AssetPackageInPackagesConfig(VisualStudio, nuProject, "newtonsoft.json", "9.0.1", XunitLogger);
+            CommonUtility.AssetPackageInPackagesConfig(VisualStudio, project, "newtonsoft.json", "9.0.1", XunitLogger);
+            CommonUtility.AssetPackageInPackagesConfig(VisualStudio, nuProject, "newtonsoft.json", "9.0.1", XunitLogger);
         }
 
         [StaFact]
@@ -108,7 +108,7 @@ namespace NuGet.Tests.Apex
             uiwindow.UninstallPackageFromUI("newtonsoft.json");
 
             // Assert
-            Utils.AssetPackageNotInPackagesConfig(VisualStudio, project, "newtonsoft.json", XunitLogger);
+            CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, project, "newtonsoft.json", XunitLogger);
         }
 
         [StaFact]
@@ -134,7 +134,7 @@ namespace NuGet.Tests.Apex
             uiwindow.UpdatePackageFromUI("newtonsoft.json", "10.0.3");
 
             // Assert
-            Utils.AssetPackageInPackagesConfig(VisualStudio, project, "newtonsoft.json", "10.0.3", XunitLogger);
+            CommonUtility.AssetPackageInPackagesConfig(VisualStudio, project, "newtonsoft.json", "10.0.3", XunitLogger);
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/RepositorySignedPackageTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/RepositorySignedPackageTestCase.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -14,11 +15,11 @@ using Xunit.Abstractions;
 
 namespace NuGet.Tests.Apex
 {
-    public class AuthorSignedPackageTestCase : SharedVisualStudioHostTestClass, IClassFixture<SignedPackagesTestsApexFixture>
+    public class RepositorySignedPackageTestCase : SharedVisualStudioHostTestClass, IClassFixture<SignedPackagesTestsApexFixture>
     {
         private SignedPackagesTestsApexFixture _fixture;
 
-        public AuthorSignedPackageTestCase(SignedPackagesTestsApexFixture apexSigningFixture, ITestOutputHelper output)
+        public RepositorySignedPackageTestCase(SignedPackagesTestsApexFixture apexSigningFixture, ITestOutputHelper output)
             : base(apexSigningFixture, output)
         {
             _fixture = apexSigningFixture;
@@ -31,7 +32,7 @@ namespace NuGet.Tests.Apex
             // Arrange
             EnsureVisualStudioHost();
 
-            var signedPackage = _fixture.AuthorSignedTestPackage;
+            var signedPackage = _fixture.RepositorySignedTestPackage;
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
             {
@@ -55,7 +56,7 @@ namespace NuGet.Tests.Apex
             // Arrange
             EnsureVisualStudioHost();
 
-            var signedPackage = _fixture.AuthorSignedTestPackage;
+            var signedPackage = _fixture.RepositorySignedTestPackage;
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
             {
@@ -76,7 +77,7 @@ namespace NuGet.Tests.Apex
             // Arrange
             EnsureVisualStudioHost();
 
-            var signedPackage = _fixture.AuthorSignedTestPackage;
+            var signedPackage = _fixture.RepositorySignedTestPackage;
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
             {
@@ -103,7 +104,7 @@ namespace NuGet.Tests.Apex
             // Arrange
             EnsureVisualStudioHost();
 
-            var signedPackage = _fixture.AuthorSignedTestPackage;
+            var signedPackage = _fixture.RepositorySignedTestPackage;
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
             {
@@ -126,7 +127,7 @@ namespace NuGet.Tests.Apex
             EnsureVisualStudioHost();
 
             var packageVersion09 = "0.9.0";
-            var signedPackage = _fixture.AuthorSignedTestPackage;
+            var signedPackage = _fixture.RepositorySignedTestPackage;
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
             {
@@ -155,7 +156,7 @@ namespace NuGet.Tests.Apex
             EnsureVisualStudioHost();
 
             var packageVersion09 = "0.9.0";
-            var signedPackage = _fixture.AuthorSignedTestPackage;
+            var signedPackage = _fixture.RepositorySignedTestPackage;
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
             {
@@ -173,69 +174,6 @@ namespace NuGet.Tests.Apex
 
         [CIOnlyNuGetWpfTheory]
         [MemberData(nameof(GetPackageReferenceTemplates))]
-        public async Task DowngradeSignedToUnsignedVersionFromPMCForPR_SucceedAsync(ProjectTemplate projectTemplate)
-        {
-            // Arrange
-            EnsureVisualStudioHost();
-
-            // This test is not considered an ideal behavior of the product but states the current behavior.
-            // A package that is already installed as signed should be specailly treated and a user should not be
-            // able to downgrade to an unsigned version. This test needs to be updated once this behavior gets
-            // corrected in the product.
-
-            var packageVersion09 = "0.9.0";
-            var signedPackage = _fixture.AuthorSignedTestPackage;
-
-            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
-            {
-                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, signedPackage.Id, packageVersion09);
-                await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, signedPackage);
-
-                var nugetConsole = GetConsole(testContext.Project);
-
-                nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version);
-                testContext.Project.Build();
-                testContext.NuGetApexTestService.WaitForAutoRestore();
-
-                nugetConsole.UpdatePackageFromPMC(signedPackage.Id, packageVersion09);
-                testContext.Project.Build();
-                testContext.NuGetApexTestService.WaitForAutoRestore();
-
-                CommonUtility.AssertPackageReferenceExists(VisualStudio, testContext.Project, signedPackage.Id, packageVersion09, XunitLogger);
-            }
-        }
-
-        [CIOnlyNuGetWpfTheory]
-        [MemberData(nameof(GetPackagesConfigTemplates))]
-        public async Task DowngradeSignedToUnsignedVersionFromPMCForPC_SucceedAsync(ProjectTemplate projectTemplate)
-        {
-            // Arrange
-            EnsureVisualStudioHost();
-
-            // This test is not considered an ideal behavior of the product but states the current behavior.
-            // A package that is already installed as signed should be specailly treated and a user should not be
-            // able to downgrade to an unsigned version. This test needs to be updated once this behavior gets
-            // corrected in the product.
-
-            var packageVersion09 = "0.9.0";
-            var signedPackage = _fixture.AuthorSignedTestPackage;
-
-            using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
-            {
-                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, signedPackage.Id, packageVersion09);
-                await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, signedPackage);
-
-                var nugetConsole = GetConsole(testContext.Project);
-
-                nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version);
-                nugetConsole.UpdatePackageFromPMC(signedPackage.Id, packageVersion09);
-
-                CommonUtility.AssetPackageInPackagesConfig(VisualStudio, testContext.Project, signedPackage.Id, packageVersion09, XunitLogger);
-            }
-        }
-
-        [CIOnlyNuGetWpfTheory]
-        [MemberData(nameof(GetPackageReferenceTemplates))]
         public async Task WithExpiredCertificate_InstallFromPMCForPR_WarnAsync(ProjectTemplate projectTemplate)
         {
             // Arrange
@@ -248,7 +186,7 @@ namespace NuGet.Tests.Apex
                 var package = CommonUtility.CreatePackage("ExpiredTestPackage", "1.0.0");
 
                 XunitLogger.LogInformation("Signing package");
-                var expiredTestPackage = CommonUtility.AuthorSignPackage(package, trustedExpiringTestCert.Source.Cert);
+                var expiredTestPackage = CommonUtility.RepositorySignPackage(package, trustedExpiringTestCert.Source.Cert, new Uri("https://v3serviceIndexUrl.test/api/index.json"));
                 await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, expiredTestPackage);
 
                 XunitLogger.LogInformation("Waiting for package to expire");
@@ -280,7 +218,7 @@ namespace NuGet.Tests.Apex
                 var package = CommonUtility.CreatePackage("ExpiredTestPackage", "1.0.0");
 
                 XunitLogger.LogInformation("Signing package");
-                var expiredTestPackage = CommonUtility.AuthorSignPackage(package, trustedExpiringTestCert.Source.Cert);
+                var expiredTestPackage = CommonUtility.RepositorySignPackage(package, trustedExpiringTestCert.Source.Cert, new Uri("https://v3serviceIndexUrl.test/api/index.json"));
                 await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, expiredTestPackage);
 
                 XunitLogger.LogInformation("Waiting for package to expire");
@@ -303,7 +241,7 @@ namespace NuGet.Tests.Apex
             // Arrange
             EnsureVisualStudioHost();
 
-            var signedPackage = _fixture.AuthorSignedTestPackage;
+            var signedPackage = _fixture.RepositorySignedTestPackage;
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
             {
@@ -328,7 +266,7 @@ namespace NuGet.Tests.Apex
             // Arrange
             EnsureVisualStudioHost();
 
-            var signedPackage = _fixture.AuthorSignedTestPackage;
+            var signedPackage = _fixture.RepositorySignedTestPackage;
 
             using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, XunitLogger))
             {

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/SigningUtility.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/SigningUtility.cs
@@ -1,0 +1,29 @@
+// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using Xunit;
+
+namespace NuGet.Tests.Apex
+{
+    public class SigningUtility
+    {
+        internal static bool IsCertificateExpired(X509Certificate2 certificate)
+        {
+            return DateTime.Now > certificate.NotAfter;
+        }
+
+        internal static void WaitForCertificateToExpire(X509Certificate2 certificate)
+        {
+            while (DateTimeOffset.Now < certificate.NotAfter)
+            {
+                Thread.Sleep(100);
+            }
+
+            Assert.True(SigningUtility.IsCertificateExpired(certificate));
+        }
+
+    }
+}

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/VisualStudioHostExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/VisualStudioHostExtension.cs
@@ -27,7 +27,7 @@ namespace NuGet.Tests.Apex
         {
             var errors = new List<string>();
 
-            Utils.UIInvoke(() =>
+            CommonUtility.UIInvoke(() =>
             {
                 errors.AddRange(host.ObjectModel.Shell.ToolWindows.ErrorList.Messages.Select(e => e.Description));
             });
@@ -65,7 +65,7 @@ namespace NuGet.Tests.Apex
             try
             {
 
-                Utils.UIInvoke(() =>
+                CommonUtility.UIInvoke(() =>
                 {
                     var outputPane = host.ObjectModel.Shell.ToolWindows.OutputWindow.GetOutputPane(_nugetOutputWindowGuid);
                     lines.AddRange(outputPane.Text.Split('\n').Select(e => e.Trim()).Where(e => !string.IsNullOrEmpty(e)));
@@ -82,7 +82,7 @@ namespace NuGet.Tests.Apex
 
         public static void SelectProjectInSolutionExplorer(this VisualStudioHost host, string project)
         {
-            Utils.UIInvoke(() =>
+            CommonUtility.UIInvoke(() =>
             {
                 var item = host.ObjectModel.Shell.ToolWindows.SolutionExplorer.FindItemRecursive(project);
                 item.Select();
@@ -93,7 +93,7 @@ namespace NuGet.Tests.Apex
         {
             try
             {
-                Utils.UIInvoke(() =>
+                CommonUtility.UIInvoke(() =>
                 {
                     var outputPane = host.ObjectModel.Shell.ToolWindows.OutputWindow.GetOutputPane(_nugetOutputWindowGuid);
                     outputPane.Clear();
@@ -109,7 +109,7 @@ namespace NuGet.Tests.Apex
         {
             try
             {
-                Utils.UIInvoke(() => host.ObjectModel.Shell.ToolWindows.ErrorList.HideAllItems());
+                CommonUtility.UIInvoke(() => host.ObjectModel.Shell.ToolWindows.ErrorList.HideAllItems());
             }
             catch (ArgumentException)
             {

--- a/test/TestUtilities/Test.Utility/Signing/TrustedTestCert.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TrustedTestCert.cs
@@ -38,6 +38,8 @@ namespace Test.Utility.Signing
 
         public StoreLocation StoreLocation { get; }
 
+        private bool _isDisposed;
+
         public TrustedTestCert(T source,
             Func<T, X509Certificate2> getCert,
             StoreName storeName = StoreName.TrustedPeople,
@@ -93,12 +95,17 @@ namespace Test.Utility.Signing
 
         public void Dispose()
         {
-            using (_store)
+            if (!_isDisposed)
             {
-                _store.Remove(TrustedCert);
-            }
+                using (_store)
+                {
+                    _store.Remove(TrustedCert);
+                }
 
-            DisposeCrl();
+                DisposeCrl();
+
+                _isDisposed = true;
+            }
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageContext.cs
@@ -54,7 +54,8 @@ namespace NuGet.Test.Utility
 
         public bool UseDefaultRuntimeAssemblies { get; set; } = true;
 
-        public ITimestampProvider TimestampProvider { get; set; }
+        public ITimestampProvider PrimaryTimestampProvider { get; set; }
+        public ITimestampProvider CounterTimestampProvider { get; set; }
         public bool IsPrimarySigned { get; set; }
         public bool IsRepositoryCounterSigned { get; set; }
         public X509Certificate2 PrimarySignatureCertificate { get; set; }

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
@@ -284,7 +284,7 @@ namespace NuGet.Test.Utility
 
         private static async Task AddSignatureToPackageAsync(SimpleTestPackageContext packageContext, ISignedPackage package, SignPackageRequest request, ILogger logger)
         {
-            var testSignatureProvider = new X509SignatureProvider(packageContext.TimestampProvider);
+            var testSignatureProvider = new X509SignatureProvider(packageContext.PrimaryTimestampProvider);
 
             var zipArchiveHash = await package.GetArchiveHashAsync(request.SignatureHashAlgorithm, CancellationToken.None);
             var base64ZipArchiveHash = Convert.ToBase64String(zipArchiveHash);
@@ -304,7 +304,7 @@ namespace NuGet.Test.Utility
 
             if (primarySignature != null)
             {
-                var testSignatureProvider = new X509SignatureProvider(packageContext.TimestampProvider);
+                var testSignatureProvider = new X509SignatureProvider(packageContext.CounterTimestampProvider);
 
                 var signature = await testSignatureProvider.CreateRepositoryCountersignatureAsync(request, primarySignature, logger, CancellationToken.None);
 


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/6808

Adds test support for end to end scenarios in installing packages with repository signatures and repository countersignatures. This tests are based in Apex infrastructure and are subject to the current state of the test infrastructure. This tests may fail because of known apex reasons, but should not add any further flakiness.