### PR TITLE
Fixing string comparison in ProjectRestoreMetadata.Equals

### DIFF
--- a/NuGet.sln
+++ b/NuGet.sln
@@ -218,6 +218,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.MSSigning.Extensions"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.StaFact", "test\TestExtensions\NuGet.StaFact\NuGet.StaFact.csproj", "{5704AFAE-94ED-4AC9-979F-28A6DF8DF4DF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Shared.Tests", "test\NuGet.Core.Tests\NuGet.Shared.Tests\NuGet.Shared.Tests.csproj", "{21522CF8-12F2-4A30-94D5-6C794D4B043F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -520,6 +522,10 @@ Global
 		{5704AFAE-94ED-4AC9-979F-28A6DF8DF4DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5704AFAE-94ED-4AC9-979F-28A6DF8DF4DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5704AFAE-94ED-4AC9-979F-28A6DF8DF4DF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{21522CF8-12F2-4A30-94D5-6C794D4B043F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{21522CF8-12F2-4A30-94D5-6C794D4B043F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{21522CF8-12F2-4A30-94D5-6C794D4B043F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{21522CF8-12F2-4A30-94D5-6C794D4B043F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -609,6 +615,7 @@ Global
 		{6666CC37-75E0-451E-A24A-C51AF71B0C8E} = {BB63CACA-866F-454F-BA4C-78B788D032BB}
 		{32D8179F-2E22-441C-9DEE-6EB4AB8A5800} = {08F523EC-3C2A-4A00-A54C-2E54C5AC856B}
 		{5704AFAE-94ED-4AC9-979F-28A6DF8DF4DF} = {23CEFC88-9365-4464-A517-700224ECA033}
+		{21522CF8-12F2-4A30-94D5-6C794D4B043F} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3747A66A-00D1-41B8-A9C5-ED0D7BEA9D25}

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -160,7 +160,7 @@ namespace NuGet.ProjectModel
                    PathUtility.GetStringComparerBasedOnOS().Equals(OutputPath, other.OutputPath) &&
                    PathUtility.GetStringComparerBasedOnOS().Equals(ProjectName, other.ProjectName) &&
                    PathUtility.GetStringComparerBasedOnOS().Equals(ProjectUniqueName, other.ProjectUniqueName) &&
-                   Sources.OrderedEquals(other.Sources.Distinct(), source => source.Source, PathUtility.GetStringComparerBasedOnOS()) &&
+                   Sources.OrderedEquals(other.Sources.Distinct(), source => source.Source, StringComparer.OrdinalIgnoreCase) &&
                    PathUtility.GetStringComparerBasedOnOS().Equals(PackagesPath, other.PackagesPath) &&
                    ConfigFilePaths.OrderedEquals(other.ConfigFilePaths, filePath => filePath, PathUtility.GetStringComparerBasedOnOS(), PathUtility.GetStringComparerBasedOnOS()) &&
                    FallbackFolders.OrderedEquals(other.FallbackFolders, fallbackFolder => fallbackFolder, PathUtility.GetStringComparerBasedOnOS(), PathUtility.GetStringComparerBasedOnOS()) &&

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
-using NuGet.Protocol.Core.Types;
 using NuGet.Shared;
 
 namespace NuGet.ProjectModel
@@ -163,10 +162,10 @@ namespace NuGet.ProjectModel
                    PathUtility.GetStringComparerBasedOnOS().Equals(ProjectUniqueName, other.ProjectUniqueName) &&
                    Sources.OrderedEquals(other.Sources.Distinct(), source => source.Source, PathUtility.GetStringComparerBasedOnOS()) &&
                    PathUtility.GetStringComparerBasedOnOS().Equals(PackagesPath, other.PackagesPath) &&
-                   ConfigFilePaths.OrderedEquals(other.ConfigFilePaths, filePath => filePath, PathUtility.GetStringComparerBasedOnOS()) &&
-                   FallbackFolders.OrderedEquals(other.FallbackFolders, fallbackFolder => fallbackFolder, PathUtility.GetStringComparerBasedOnOS()) &&
+                   ConfigFilePaths.OrderedEquals(other.ConfigFilePaths, filePath => filePath, PathUtility.GetStringComparerBasedOnOS(), PathUtility.GetStringComparerBasedOnOS()) &&
+                   FallbackFolders.OrderedEquals(other.FallbackFolders, fallbackFolder => fallbackFolder, PathUtility.GetStringComparerBasedOnOS(), PathUtility.GetStringComparerBasedOnOS()) &&
                    EqualityUtility.SequenceEqualWithNullCheck(TargetFrameworks, other.TargetFrameworks) &&
-                   OriginalTargetFrameworks.OrderedEquals(other.OriginalTargetFrameworks, fw => fw, StringComparer.OrdinalIgnoreCase) &&
+                   OriginalTargetFrameworks.OrderedEquals(other.OriginalTargetFrameworks, fw => fw, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase) &&
                    CrossTargeting == other.CrossTargeting &&
                    LegacyPackagesDirectory == other.LegacyPackagesDirectory &&
                    ValidateRuntimeAssets == other.ValidateRuntimeAssets &&
@@ -177,27 +176,28 @@ namespace NuGet.ProjectModel
 
         public ProjectRestoreMetadata Clone()
         {
-            var clonedObject = new ProjectRestoreMetadata();
-            clonedObject.ProjectStyle = ProjectStyle;
-            clonedObject.ProjectPath = ProjectPath;
-            clonedObject.ProjectJsonPath = ProjectJsonPath;
-            clonedObject.OutputPath = OutputPath;
-            clonedObject.ProjectName = ProjectName;
-            clonedObject.ProjectUniqueName = ProjectUniqueName;
-            clonedObject.PackagesPath = PackagesPath;
-            clonedObject.CacheFilePath = CacheFilePath;
-            clonedObject.CrossTargeting = CrossTargeting;
-            clonedObject.LegacyPackagesDirectory = LegacyPackagesDirectory;
-            clonedObject.SkipContentFileWrite = SkipContentFileWrite;
-            clonedObject.ValidateRuntimeAssets = ValidateRuntimeAssets;
-            clonedObject.FallbackFolders = FallbackFolders != null ? new List<string>(FallbackFolders) : null;
-            clonedObject.ConfigFilePaths = ConfigFilePaths != null ? new List<string>(ConfigFilePaths) : null;
-            clonedObject.OriginalTargetFrameworks = OriginalTargetFrameworks != null ? new List<string>(OriginalTargetFrameworks) : null;
-            clonedObject.Sources = Sources?.Select(c => c.Clone()).ToList();
-            clonedObject.TargetFrameworks = TargetFrameworks?.Select( c => c.Clone()).ToList();
-            clonedObject.Files = Files?.Select(c => c.Clone()).ToList();
-            clonedObject.ProjectWideWarningProperties = ProjectWideWarningProperties?.Clone();
-            return clonedObject;
+            return new ProjectRestoreMetadata
+            {
+                ProjectStyle = ProjectStyle,
+                ProjectPath = ProjectPath,
+                ProjectJsonPath = ProjectJsonPath,
+                OutputPath = OutputPath,
+                ProjectName = ProjectName,
+                ProjectUniqueName = ProjectUniqueName,
+                PackagesPath = PackagesPath,
+                CacheFilePath = CacheFilePath,
+                CrossTargeting = CrossTargeting,
+                LegacyPackagesDirectory = LegacyPackagesDirectory,
+                SkipContentFileWrite = SkipContentFileWrite,
+                ValidateRuntimeAssets = ValidateRuntimeAssets,
+                FallbackFolders = FallbackFolders != null ? new List<string>(FallbackFolders) : null,
+                ConfigFilePaths = ConfigFilePaths != null ? new List<string>(ConfigFilePaths) : null,
+                OriginalTargetFrameworks = OriginalTargetFrameworks != null ? new List<string>(OriginalTargetFrameworks) : null,
+                Sources = Sources?.Select(c => c.Clone()).ToList(),
+                TargetFrameworks = TargetFrameworks?.Select(c => c.Clone()).ToList(),
+                Files = Files?.Select(c => c.Clone()).ToList(),
+                ProjectWideWarningProperties = ProjectWideWarningProperties?.Clone()
+            };
+        }
     }
-}
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using FluentAssertions;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -35,7 +34,7 @@ namespace NuGet.ProjectModel.Test
             metadata.Equals(null).Should().BeFalse();
         }
 
-        [PlatformFact(Platform.Windows, Platform.Darwin, Platform.Linux)]
+        [Fact]
         public void Equals_WithSameCaseInPaths_ReturnsTrue()
         {
             // Arrange
@@ -75,14 +74,14 @@ namespace NuGet.ProjectModel.Test
             metadata1.Equals(metadata2).Should().BeTrue();
         }
 
-        [PlatformFact(Platform.Windows, Platform.Darwin)]
+        [PlatformFact(Platform.Linux)]
         public void Equals_WithDifferentCaseInPathsOnLinux_ReturnsFalse()
         {
             // Arrange
             var metadata1 = CreateProjectRestoreMetadata();
             var metadata2 = metadata1.Clone();
 
-            metadata2.ProjectPath = "projecpPath";
+            metadata2.ProjectPath = "projectPath";
             metadata2.ProjectJsonPath = "projectJsonPath";
             metadata2.OutputPath = "outputPath";
             metadata2.ProjectName = "projectName";

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
@@ -1,0 +1,146 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using FluentAssertions;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public class ProjectRestoreMetadataTests
+    {
+        [Fact]
+        public void Equals_WithSameObject_ReturnsTrue()
+        {
+            // Arrange
+            var metadata = CreateProjectRestoreMetadata();
+
+            // Act & Assert
+            metadata.Equals(metadata).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Equals_WithNullObject_ReturnsFalse()
+        {
+            // Arrange
+            var metadata = CreateProjectRestoreMetadata();
+
+            // Act & Assert
+            metadata.Equals(null).Should().BeFalse();
+        }
+
+        [PlatformFact(Platform.Windows, Platform.Darwin, Platform.Linux)]
+        public void Equals_WithSameCaseInPaths_ReturnsTrue()
+        {
+            // Arrange
+            var metadata1 = CreateProjectRestoreMetadata();
+            var metadata2 = metadata1.Clone();
+
+            metadata2.ProjectPath = "ProjectPath";
+            metadata2.ProjectJsonPath = "ProjectJsonPath";
+            metadata2.OutputPath = "OutputPath";
+            metadata2.ProjectName = "ProjectName";
+            metadata2.ProjectUniqueName = "ProjectUniqueName";
+            metadata2.PackagesPath = "PackagesPath";
+            metadata2.ConfigFilePaths = new List<string>() { "config1" };
+            metadata2.FallbackFolders = new List<string>() { "fallback1" };
+
+            // Act & Assert
+            metadata1.Equals(metadata2).Should().BeTrue();
+        }
+
+        [PlatformFact(Platform.Windows, Platform.Darwin)]
+        public void Equals_WithDifferentCaseInPathsOnWindowsAndMac_ReturnsTrue()
+        {
+            // Arrange
+            var metadata1 = CreateProjectRestoreMetadata();
+            var metadata2 = metadata1.Clone();
+
+            metadata2.ProjectPath = "projectPath";
+            metadata2.ProjectJsonPath = "projectJsonPath";
+            metadata2.OutputPath = "outputPath";
+            metadata2.ProjectName = "projectName";
+            metadata2.ProjectUniqueName = "projectUniqueName";
+            metadata2.PackagesPath = "packagesPath";
+            metadata2.ConfigFilePaths = new List<string>() { "Config1" };
+            metadata2.FallbackFolders = new List<string>() { "Fallback1" };
+
+            // Act & Assert
+            metadata1.Equals(metadata2).Should().BeTrue();
+        }
+
+        [PlatformFact(Platform.Windows, Platform.Darwin)]
+        public void Equals_WithDifferentCaseInPathsOnLinux_ReturnsFalse()
+        {
+            // Arrange
+            var metadata1 = CreateProjectRestoreMetadata();
+            var metadata2 = metadata1.Clone();
+
+            metadata2.ProjectPath = "projecpPath";
+            metadata2.ProjectJsonPath = "projectJsonPath";
+            metadata2.OutputPath = "outputPath";
+            metadata2.ProjectName = "projectName";
+            metadata2.ProjectUniqueName = "projectUniqueName";
+            metadata2.PackagesPath = "packagesPath";
+            metadata2.ConfigFilePaths = new List<string>() { "Config1" };
+            metadata2.FallbackFolders = new List<string>() { "Fallback1" };
+
+            // Act & Assert
+            metadata1.Equals(metadata2).Should().BeFalse();
+        }
+
+        private ProjectRestoreMetadata CreateProjectRestoreMetadata()
+        {
+            var projectReference = new ProjectRestoreReference
+            {
+                ProjectPath = "Path",
+                ProjectUniqueName = "ProjectUniqueName",
+                IncludeAssets = LibraryIncludeFlags.All,
+                ExcludeAssets = LibraryIncludeFlags.Analyzers,
+                PrivateAssets = LibraryIncludeFlags.Build
+            };
+
+            var nugetFramework = NuGetFramework.Parse("net461");
+            var originalPRMFI = new ProjectRestoreMetadataFrameworkInfo(nugetFramework)
+            {
+                ProjectReferences = new List<ProjectRestoreReference>() { projectReference }
+            };
+
+            var targetframeworks = new List<ProjectRestoreMetadataFrameworkInfo>() { originalPRMFI };
+            var allWarningsAsErrors = true;
+            var noWarn = new HashSet<NuGetLogCode>() { NuGetLogCode.NU1000, NuGetLogCode.NU1500 };
+            var warningsAsErrors = new HashSet<NuGetLogCode>() { NuGetLogCode.NU1001, NuGetLogCode.NU1501 };
+            var warningProperties = new WarningProperties(allWarningsAsErrors: allWarningsAsErrors, warningsAsErrors: warningsAsErrors, noWarn: noWarn);
+            var originalProjectRestoreMetadata = new ProjectRestoreMetadata
+            {
+                ProjectStyle = ProjectStyle.PackageReference,
+                ProjectPath = "ProjectPath",
+                ProjectJsonPath = "ProjectJsonPath",
+                OutputPath = "OutputPath",
+                ProjectName = "ProjectName",
+                ProjectUniqueName = "ProjectUniqueName",
+                PackagesPath = "PackagesPath",
+                CacheFilePath = "CacheFilePath",
+                CrossTargeting = true,
+                LegacyPackagesDirectory = true,
+                ValidateRuntimeAssets = true,
+                SkipContentFileWrite = true,
+                TargetFrameworks = targetframeworks,
+                Sources = new List<PackageSource>() { new PackageSource("http://api.nuget.org/v3/index.json") },
+                FallbackFolders = new List<string>() { "fallback1" },
+                ConfigFilePaths = new List<string>() { "config1" },
+                OriginalTargetFrameworks = new List<string>() { "net45" },
+                Files = new List<ProjectRestoreMetadataFile>() { new ProjectRestoreMetadataFile("packagePath", "absolutePath") },
+                ProjectWideWarningProperties = warningProperties
+            };
+
+            return originalProjectRestoreMetadata;
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Shared.Tests/EqualityUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Shared.Tests/EqualityUtilityTests.cs
@@ -1,0 +1,262 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace NuGet.Shared.Tests
+{
+    public class EqualityUtilityTests
+    {
+        [Fact]
+        public void OrderedEquals_CompareWithNullList_ReturnsFalse()
+        {
+            // Arrange
+            var list = new List<string>();
+
+            // Act & Assert
+            list.OrderedEquals(null, s => s, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeFalse();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareFromANullList_ReturnsFalse()
+        {
+            // Arrange
+            List<string> list = null;
+
+            // Act & Assert
+            list.OrderedEquals(new List<string>(), s => s, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeFalse();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareTwoNullLists_ReturnsTrue()
+        {
+            // Arrange
+            List<string> list = null;
+
+            // Act & Assert
+            list.OrderedEquals(null, s => s, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeTrue();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareSameLists_ReturnsTrue()
+        {
+            // Arrange
+            var list = new List<string>();
+
+            // Act & Assert
+            list.OrderedEquals(list, s => s, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeTrue();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareEmptyLists_ReturnsTrue()
+        {
+            // Arrange
+            var list1 = new List<string>();
+            var list2 = new List<string>();
+
+            // Act & Assert
+            list1.OrderedEquals(list2, s => s, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase).Should().BeTrue();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareListsWithDifferentLengths_ReturnsFalse()
+        {
+            // Arrange
+            var list1 = new List<string> { "unit.test" };
+            var list2 = new List<string> { "unit.test", "unit.test" };
+
+            // Act & Assert
+            list1.OrderedEquals(list2, s => s, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase).Should().BeFalse();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareListsWithDifferentCaseWithOrdinalIgnoreCase_ReturnsTrue()
+        {
+            // Arrange
+            var list1 = new List<string> { "unit.test"};
+            var list2 = new List<string> { "unit.test" };
+
+            // Act & Assert
+            list1.OrderedEquals(list2, s => s, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase).Should().BeTrue();
+        }
+
+        [Fact]
+        public void OrderedEquals_CompareListsWithDifferentCaseWithOrdinal_ReturnsFalse()
+        {
+            // Arrange
+            var list1 = new List<string> { "unit.test" };
+            var list2 = new List<string> { "Unit.test" };
+
+            // Act & Assert
+            list1.OrderedEquals(list2, s => s, StringComparer.Ordinal, StringComparer.Ordinal).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareWithNullList_ReturnsFalse()
+        {
+            // Arrange
+            var list = new List<string>();
+
+            // Act & Assert
+            list.SequenceEqualWithNullCheck(null).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareFromANullList_ReturnsFalse()
+        {
+            // Arrange
+            List<string> list = null;
+
+            // Act & Assert
+            list.SequenceEqualWithNullCheck(new List<string>()).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SequenceEqualWithNullCheck_CompareTwoNullLists_ReturnsTrue()
+        {
+            // Arrange
+            List<string> list = null;
+
+            // Act & Assert
+            list.SequenceEqualWithNullCheck(null).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SetEqualsWithNullCheck_CompareWithNullSet_ReturnsFalse()
+        {
+            // Arrange
+            var set = new HashSet<string>();
+
+            // Act & Assert
+            set.SequenceEqualWithNullCheck(null).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SetEqualsWithNullCheck_CompareFromANullSet_ReturnsFalse()
+        {
+            // Arrange
+            HashSet<string> set = null;
+
+            // Act & Assert
+            set.SequenceEqualWithNullCheck(new HashSet<string>()).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SetEqualsWithNullCheck_CompareTwoNullSets_ReturnsTrue()
+        {
+            // Arrange
+            HashSet<string> set = null;
+
+            // Act & Assert
+            set.SequenceEqualWithNullCheck(null).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SetEqualsWithNullCheck_CompareTwoSetsWithDifferentLengths_ReturnsFalse()
+        {
+            // Arrange
+            var set1 = new HashSet<string>() { "unit.test", "unit" };
+            var set2 = new HashSet<string>() { "unit.test" };
+
+            // Act & Assert
+            set1.SequenceEqualWithNullCheck(set2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SetEqualsWithNullCheck_CompareSameSets_ReturnsTrue()
+        {
+            // Arrange
+            var set = new HashSet<string>();
+
+            // Act & Assert
+            set.SequenceEqualWithNullCheck(set).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SetEqualsWithNullCheck_CompareEmptySets_ReturnsTrue()
+        {
+            // Arrange
+            var set1 = new HashSet<string>();
+            var set2 = new HashSet<string>();
+
+            // Act & Assert
+            set1.SequenceEqualWithNullCheck(set2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SetEqualsWithNullCheck_CompareEquivalentSets_ReturnsTrue()
+        {
+            // Arrange
+            var set1 = new HashSet<string>() { "unit.test" };
+            var set2 = new HashSet<string>() { "unit.test" };
+
+            // Act & Assert
+            set1.SequenceEqualWithNullCheck(set2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void DictionaryEquals_CompareWithNullDict_ReturnsFalse()
+        {
+            // Arrange
+            var dict = new Dictionary<int, string>();
+
+            // Act & Assert
+            EqualityUtility.DictionaryEquals(dict, null).Should().BeFalse();
+        }
+        [Fact]
+        public void DictionaryEquals_CompareTwoNullDicts_ReturnsTrue()
+        {
+            // Arrange
+            Dictionary<int, string> dict = null;
+
+            // Act & Assert
+            dict.SequenceEqualWithNullCheck(null).Should().BeTrue();
+        }
+
+        [Fact]
+        public void DictionaryEquals_CompareTwoDictsWithDifferentLengths_ReturnsFalse()
+        {
+            // Arrange
+            var dict1 = new Dictionary<int, string>() { { 1, "unit.test" }, { 2, "unit" } };
+            var dict2 = new Dictionary<int, string>() { { 1, "unit.test" } };
+
+            // Act & Assert
+            EqualityUtility.DictionaryEquals(dict1, dict2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void DictionaryEquals_CompareSameDicts_ReturnsTrue()
+        {
+            // Arrange
+            var dict = new Dictionary<int, string>();
+
+            // Act & Assert
+            EqualityUtility.DictionaryEquals(dict, dict).Should().BeTrue();
+        }
+
+        [Fact]
+        public void DictionaryEquals_CompareEmptyDicts_ReturnsTrue()
+        {
+            // Arrange
+            var dict1 = new Dictionary<int, string>();
+            var dict2 = new Dictionary<int, string>();
+
+            // Act & Assert
+            EqualityUtility.DictionaryEquals(dict1, dict2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void DictionaryEquals_CompareEquivalentDicts_ReturnsTrue()
+        {
+            // Arrange
+            var dict1 = new Dictionary<int, string>() { { 1, "unit.test" } };
+            var dict2 = new Dictionary<int, string>() { { 1, "unit.test" } };
+
+            // Act & Assert
+            EqualityUtility.DictionaryEquals(dict1, dict2).Should().BeTrue();
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Shared.Tests/NuGet.Shared.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Shared.Tests/NuGet.Shared.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IsXPlat)' == 'true' ">netcoreapp1.0</TargetFrameworks>
+    <TestProject>true</TestProject>
+    <UseParallelXunit>true</UseParallelXunit>
+  </PropertyGroup>
+
+  <!-- Include shared files for netcore projects -->
+  <ItemGroup>
+    <Compile Include="$(SharedDirectory)\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
+  </ItemGroup>
+
+  <Import Project="$(BuildCommonDirectory)common.targets" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>


### PR DESCRIPTION
As part of a [commit](https://github.com/NuGet/NuGet.Client/commit/c318e14bac14895497080990baacbb777a33bf8b) recently we changed the assets file comparison to use OS based comparer. It seems we forgot to pass the comparer  to `EqualityUtility.OrderedEquals` for sequence comparison. This would make it default to `StringComparer.Ordinal`.

This PR fixes that and adds tests for equality comparison and `EqualityUtility`.