### PR TITLE
Adding more data points in restore command

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
@@ -24,7 +24,7 @@ namespace NuGet.VisualStudio
             double duration) : base(RestoreActionEventName, operationId, projectIds, startTime, status, packageCount, endTime, duration)
         {
             base[nameof(OperationSource)] = source;
-            base[(nameof(NoOpProjectsCount))] = noOpProjectsCount;
+            base[nameof(NoOpProjectsCount)] = noOpProjectsCount;
         }
 
         public const string RestoreActionEventName = "RestoreInformation";

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,8 +23,10 @@ namespace NuGet.Commands
     internal class ProjectRestoreCommand
     {
         private readonly RestoreCollectorLogger _logger;
-
         private readonly ProjectRestoreRequest _request;
+
+        private const string WalkFrameworkDependencyDuration = "WalkFrameworkDependencyDuration";
+        private const string WalkRuntimeDependencyDuration = "WalkRuntimeDependencyDuration";
 
         public Guid ParentId { get; }
 
@@ -43,13 +44,16 @@ namespace NuGet.Commands
             RemoteDependencyWalker remoteWalker,
             RemoteWalkContext context,
             bool forceRuntimeGraphCreation,
-            CancellationToken token)
+            CancellationToken token,
+            TelemetryActivity telemetryActivity)
         {
             var allRuntimes = RuntimeGraph.Empty;
             var frameworkTasks = new List<Task<RestoreTargetGraph>>();
             var graphs = new List<RestoreTargetGraph>();
             var runtimesByFramework = frameworkRuntimePairs.ToLookup(p => p.Framework, p => p.RuntimeIdentifier);
             var success = true;
+
+            telemetryActivity.StartIntervalMeasure();
 
             foreach (var pair in runtimesByFramework)
             {
@@ -66,6 +70,8 @@ namespace NuGet.Commands
 
             graphs.AddRange(frameworkGraphs);
 
+            telemetryActivity.EndIntervalMeasure(WalkFrameworkDependencyDuration); // TODO cleanup
+
             success &= await InstallPackagesAsync(graphs,
                 userPackageFolder,
                 token);
@@ -79,6 +85,8 @@ namespace NuGet.Commands
             // Resolve runtime dependencies
             if (hasNonEmptyRIDs || forceRuntimeGraphCreation)
             {
+                telemetryActivity.StartIntervalMeasure();
+
                 var localRepositories = new List<NuGetv3LocalRepository>();
                 localRepositories.Add(userPackageFolder);
                 localRepositories.AddRange(fallbackPackageFolders);
@@ -110,6 +118,8 @@ namespace NuGet.Commands
                 }
 
                 graphs.AddRange(runtimeGraphs);
+
+                telemetryActivity.EndIntervalMeasure(WalkRuntimeDependencyDuration);
 
                 // Install runtime-specific packages
                 success &= await InstallPackagesAsync(runtimeGraphs,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
@@ -70,7 +70,7 @@ namespace NuGet.Commands
 
             graphs.AddRange(frameworkGraphs);
 
-            telemetryActivity.EndIntervalMeasure(WalkFrameworkDependencyDuration); // TODO cleanup
+            telemetryActivity.EndIntervalMeasure(WalkFrameworkDependencyDuration);
 
             success &= await InstallPackagesAsync(graphs,
                 userPackageFolder,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -45,10 +45,10 @@ namespace NuGet.Commands
         private const string RestoreSuccess = "RestoreSuccess";
 
         // names for child events for ProjectRestoreInformation
-        private const string RestoreGenerateGraph = "RestoreGenerateGraph";
-        private const string RestoreGenerateAssetsFile = "RestoreGenerateAssetsFile";
-        private const string RestoreValidateGraphs = "RestoreValidateGraphs";
-        private const string RestoreCreateResult = "RestoreCreateResult";
+        private const string GenerateRestoreGraph = "GenerateRestoreGraph";
+        private const string GenerateAssetsFile = "GenerateAssetsFile";
+        private const string ValidateRestoreGraphs = "ValidateRestoreGraphs";
+        private const string CreateRestoreResult = "CreateRestoreResult";
         private const string RestoreNoOpInformation = "RestoreNoOpInformation";
 
         // names for intervals in RestoreNoOpInformation
@@ -58,8 +58,8 @@ namespace NuGet.Commands
         private const string ReplayLogsDuration = "ReplayLogsDuration";
 
         //names for child events for GenerateRestoreGraph
-        private const string RestoreAttempt = "RestoreAttempt";
-        private const string RestoreRuntimeCompatCheck = "RestoreRuntimeCompatCheck";
+        private const string CreateRestoreTargetGraph = "CreateRestoreTargetGraph";
+        private const string RestoreAdditionalCompatCheck = "RestoreAdditionalCompatCheck";
 
         public RestoreCommand(RestoreRequest request)
         {
@@ -152,7 +152,7 @@ namespace NuGet.Commands
                 }
 
                 IEnumerable<RestoreTargetGraph> graphs = null;
-                using (var restoreGraphTelemetry = TelemetryActivity.CreateTelemetryActivityWithNewOperationIdAndEvent(parentId: _operationId, eventName: RestoreGenerateGraph))
+                using (var restoreGraphTelemetry = TelemetryActivity.CreateTelemetryActivityWithNewOperationIdAndEvent(parentId: _operationId, eventName: GenerateRestoreGraph))
                 {
                     // Restore
                     graphs = await ExecuteRestoreAsync(
@@ -164,7 +164,7 @@ namespace NuGet.Commands
                 }
 
                 LockFile assetsFile = null;
-                using (TelemetryActivity.CreateTelemetryActivityWithNewOperationIdAndEvent(parentId: _operationId, eventName: RestoreGenerateAssetsFile))
+                using (TelemetryActivity.CreateTelemetryActivityWithNewOperationIdAndEvent(parentId: _operationId, eventName: GenerateAssetsFile))
                 {
                     // Create assets file
                     assetsFile = BuildAssetsFile(
@@ -176,7 +176,7 @@ namespace NuGet.Commands
                 }
 
                 IList<CompatibilityCheckResult> checkResults = null;
-                using (TelemetryActivity.CreateTelemetryActivityWithNewOperationIdAndEvent(parentId: _operationId, eventName: RestoreValidateGraphs))
+                using (TelemetryActivity.CreateTelemetryActivityWithNewOperationIdAndEvent(parentId: _operationId, eventName: ValidateRestoreGraphs))
                 {
                     _success &= await ValidateRestoreGraphsAsync(graphs, _logger);
 
@@ -201,7 +201,7 @@ namespace NuGet.Commands
                 var msbuildOutputFiles = Enumerable.Empty<MSBuildOutputFile>();
                 string assetsFilePath = null;
                 string cacheFilePath = null;
-                using (TelemetryActivity.CreateTelemetryActivityWithNewOperationIdAndEvent(parentId: _operationId, eventName: RestoreCreateResult))
+                using (TelemetryActivity.CreateTelemetryActivityWithNewOperationIdAndEvent(parentId: _operationId, eventName: CreateRestoreResult))
                 {
                     // Determine the lock file output path
                     assetsFilePath = GetAssetsFilePath(assetsFile);
@@ -682,7 +682,7 @@ namespace NuGet.Commands
             var projectRestoreCommand = new ProjectRestoreCommand(projectRestoreRequest);
 
             Tuple<bool, List<RestoreTargetGraph>, RuntimeGraph> result = null;
-            using (var tryRestoreTelemetry = TelemetryActivity.CreateTelemetryActivityWithNewOperationIdAndEvent(telemetryActivity.OperationId, RestoreAttempt))
+            using (var tryRestoreTelemetry = TelemetryActivity.CreateTelemetryActivityWithNewOperationIdAndEvent(telemetryActivity.OperationId, CreateRestoreTargetGraph))
             {
                 result = await projectRestoreCommand.TryRestoreAsync(
                     projectRange,
@@ -731,7 +731,7 @@ namespace NuGet.Commands
             if (_success && _request.CompatibilityProfiles.Any())
             {
                 Tuple<bool, List<RestoreTargetGraph>, RuntimeGraph> compatibilityResult = null;
-                using (var runtimeTryRestoreTelemetry = TelemetryActivity.CreateTelemetryActivityWithNewOperationIdAndEvent(telemetryActivity.OperationId, RestoreRuntimeCompatCheck))
+                using (var runtimeTryRestoreTelemetry = TelemetryActivity.CreateTelemetryActivityWithNewOperationIdAndEvent(telemetryActivity.OperationId, RestoreAdditionalCompatCheck))
                 {
                     compatibilityResult = await projectRestoreCommand.TryRestoreAsync(
                     projectRange,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -53,8 +53,8 @@ namespace NuGet.Commands
 
         // names for intervals in RestoreNoOpInformation
         private const string CacheFileEvaluateDuration = "CacheFileEvaluateDuration";
-        private const string AssetsVerificationDuration = "AssetVerificationDuration";
-        private const string AssetsVerificationResult = "AssetVerificationResult";
+        private const string MsbuildAssetsVerificationDuration = "MsbuildAssetsVerificationDuration";
+        private const string MsbuildAssetsVerificationResult = "MsbuildAssetsVerificationResult";
         private const string ReplayLogsDuration = "ReplayLogsDuration";
 
         //names for child events for GenerateRestoreGraph
@@ -123,8 +123,8 @@ namespace NuGet.Commands
 
                             var noOpSuccess = NoOpRestoreUtilities.VerifyAssetsAndMSBuildFilesAndPackagesArePresent(_request);
 
-                            noOpTelemetry.EndIntervalMeasure(AssetsVerificationDuration);
-                            noOpTelemetry.TelemetryEvent[AssetsVerificationResult] = noOpSuccess;
+                            noOpTelemetry.EndIntervalMeasure(MsbuildAssetsVerificationDuration);
+                            noOpTelemetry.TelemetryEvent[MsbuildAssetsVerificationResult] = noOpSuccess;
 
                             if (noOpSuccess)
                             {

--- a/src/NuGet.Core/NuGet.Common/Telemetry/TelemetryActivity.cs
+++ b/src/NuGet.Core/NuGet.Common/Telemetry/TelemetryActivity.cs
@@ -89,6 +89,20 @@ namespace NuGet.Common
             NuGetTelemetryService?.EmitTelemetryEvent(TelemetryEvent);
         }
 
+        /// <summary>
+        /// Creates a TelemetryActivity.
+        /// </summary>
+        /// <param name="parentId">OperationId of the parent event.</param>
+        /// <param name="eventName">Name of the event.</param>
+        /// <returns>TelemetryActivity with a given parentId and new operationId and a TelemetryEvent with eventName</returns>
+        public static TelemetryActivity CreateTelemetryActivityWithNewOperationIdAndEvent(Guid parentId, string eventName)
+        {
+            return new TelemetryActivity(parentId, Guid.NewGuid(), null)
+            {
+                TelemetryEvent = new TelemetryEvent(eventName)
+            };
+        }
+
         public static TelemetryActivity CreateTelemetryActivityWithNewOperationId(Guid parentId)
         {
             return new TelemetryActivity(parentId, Guid.NewGuid(), null);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -6066,12 +6066,12 @@ namespace NuGet.Test
                 // Assert
                 Assert.Equal(15, telemetryEvents.Count);
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreGenerateGraph").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreGenerateAssetsFile").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreValidateGraphs").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreCreateResult").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateRestoreGraph").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateAssetsFile").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ValidateRestoreGraphs").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "CreateRestoreResult").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreNoOpInformation").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreAttempt").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "CreateRestoreTargetGraph").Count());
                 Assert.Equal(1, telemetryEvents.Where(p => p.Name == "NugetActionSteps").Count());
 
                 var projectId = string.Empty;
@@ -6270,12 +6270,12 @@ namespace NuGet.Test
                 Assert.Equal(16, telemetryEvents.Count);
 
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreGenerateGraph").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreGenerateAssetsFile").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreValidateGraphs").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreCreateResult").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateRestoreGraph").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateAssetsFile").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ValidateRestoreGraphs").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "CreateRestoreResult").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreNoOpInformation").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreAttempt").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "CreateRestoreTargetGraph").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "NugetActionSteps").Count());
 
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -25,7 +25,6 @@ using NuGet.Resolver;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using NuGet.VisualStudio;
-using NuGet.VisualStudio.Telemetry;
 using Test.Utility;
 using Xunit;
 
@@ -6065,11 +6064,18 @@ namespace NuGet.Test
                     CancellationToken.None);
 
                 // Assert
-                Assert.Equal(3, telemetryEvents.Count);
+                Assert.Equal(15, telemetryEvents.Count);
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ExecuteRestoreAsyncInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "BuildAssetsFileInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ValidateRestoreGraphsAsyncInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "VerifyCompatibilityAsyncInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "CreateRestoreResultInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "NoOpInformation").Count());
+                Assert.Equal(1, telemetryEvents.Where(p => p.Name == "NugetActionSteps").Count());
 
                 var projectId = string.Empty;
-                buildIntegratedProject.TryGetMetadata<string>(NuGetProjectMetadataKeys.ProjectId, out projectId);
+                buildIntegratedProject.TryGetMetadata(NuGetProjectMetadataKeys.ProjectId, out projectId);
                 Assert.True(telemetryEvents.Where(p => p.Name == "NugetActionSteps").
                     Any(p => (string)p["StepName"] == string.Format(TelemetryConstants.PreviewBuildIntegratedStepName, projectId)));
             }
@@ -6259,12 +6265,20 @@ namespace NuGet.Test
 
                 // Assert
                 var projectId = string.Empty;
-                buildIntegratedProject.TryGetMetadata<string>(NuGetProjectMetadataKeys.ProjectId, out projectId);
+                buildIntegratedProject.TryGetMetadata(NuGetProjectMetadataKeys.ProjectId, out projectId);
 
-                Assert.Equal(4, telemetryEvents.Count);
+                Assert.Equal(16, telemetryEvents.Count);
 
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "NugetActionSteps").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ExecuteRestoreAsyncInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "BuildAssetsFileInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ValidateRestoreGraphsAsyncInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "VerifyCompatibilityAsyncInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "CreateRestoreResultInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "NoOpInformation").Count());
+
+
                 Assert.True(telemetryEvents.Where(p => p.Name == "NugetActionSteps").
                     Any(p => (string)p["StepName"] == string.Format(TelemetryConstants.PreviewBuildIntegratedStepName, projectId)));
                 Assert.True(telemetryEvents.Where(p => p.Name == "NugetActionSteps").

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -6066,12 +6066,12 @@ namespace NuGet.Test
                 // Assert
                 Assert.Equal(15, telemetryEvents.Count);
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ExecuteRestoreAsyncInformation").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "BuildAssetsFileInformation").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ValidateRestoreGraphsAsyncInformation").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "VerifyCompatibilityAsyncInformation").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "CreateRestoreResultInformation").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "NoOpInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreGenerateGraph").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreGenerateAssetsFile").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreValidateGraphs").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreCreateResult").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreNoOpInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreAttempt").Count());
                 Assert.Equal(1, telemetryEvents.Where(p => p.Name == "NugetActionSteps").Count());
 
                 var projectId = string.Empty;
@@ -6270,13 +6270,13 @@ namespace NuGet.Test
                 Assert.Equal(16, telemetryEvents.Count);
 
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreGenerateGraph").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreGenerateAssetsFile").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreValidateGraphs").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreCreateResult").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreNoOpInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreAttempt").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "NugetActionSteps").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ExecuteRestoreAsyncInformation").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "BuildAssetsFileInformation").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ValidateRestoreGraphsAsyncInformation").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "VerifyCompatibilityAsyncInformation").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "CreateRestoreResultInformation").Count());
-                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "NoOpInformation").Count());
 
 
                 Assert.True(telemetryEvents.Where(p => p.Name == "NugetActionSteps").


### PR DESCRIPTION
## Bug
Fixes https://github.com/NuGet/Home/issues/6814 

## Fix
Details: Adds more data points in restore command. Data points added - 
1. NoOp total duration
2. NoOp cache file evaluation duration
3. NoOp verify assets duration
4. NoOp result
5. NoOp logging duration
6. ExecuteRestoreAsync duration
7. BuildAssetsFile duration
8. ValidateRestoreGraphsAsync duration
9. VerifyCompatibilityAsync duration
10. Generation of restore result duration

task for test coverage for all our VS data points - https://github.com/NuGet/Home/issues/6843