### PR TITLE
Fixed some part of ui delay of VSSoluitonManager EnsureInitializeAsync

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 extern alias CoreV2;
 
@@ -173,7 +173,7 @@ namespace NuGet.CommandLine
 
             CoreV2.NuGet.HttpClient.DefaultCredentialProvider = new CredentialServiceAdapter(CredentialService);
 
-            HttpHandlerResourceV3.CredentialService = CredentialService;
+            HttpHandlerResourceV3.CredentialService = new Lazy<Configuration.ICredentialService>(() => CredentialService);
 
             HttpHandlerResourceV3.CredentialsSuccessfullyUsed = (uri, credentials) =>
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -160,7 +160,15 @@ namespace NuGet.PackageManagement.VisualStudio
             UserAgent.SetUserAgentString(
                     new UserAgentStringBuilder(VSNuGetClientName).WithVisualStudioSKU(dte.GetFullVsVersionString()));
 
-            HttpHandlerResourceV3.CredentialService = _credentialServiceProvider.GetCredentialService();
+            HttpHandlerResourceV3.CredentialService = new Lazy<ICredentialService>(() =>
+            {
+                return NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+                {
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    return _credentialServiceProvider.GetCredentialService();
+                });
+            });
+
             TelemetryActivity.NuGetTelemetryService = new NuGetVSTelemetryService();
 
             _vsMonitorSelection = _serviceProvider.GetService<SVsShellMonitorSelection, IVsMonitorSelection>();

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -37,7 +37,7 @@ namespace NuGet.Protocol
 
         public override HttpMessageHandler MessageHandler => _messageHandler;
 
-        public static ICredentialService CredentialService { get; set; }
+        public static Lazy<ICredentialService> CredentialService { get; set; }
 
         /// <summary>
         /// Gets or sets a delegate that is to be invoked when authenticated feed credentials are successfully

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -52,7 +52,7 @@ namespace NuGet.Protocol
 
             if (proxy != null)
             {
-                messageHandler = new ProxyAuthenticationHandler(clientHandler, HttpHandlerResourceV3.CredentialService, ProxyCache.Instance);
+                messageHandler = new ProxyAuthenticationHandler(clientHandler, HttpHandlerResourceV3.CredentialService?.Value, ProxyCache.Instance);
             }
 
 #if !IS_CORECLR
@@ -68,7 +68,7 @@ namespace NuGet.Protocol
             {
                 var innerHandler = messageHandler;
 
-                messageHandler = new HttpSourceAuthenticationHandler(packageSource, clientHandler, HttpHandlerResourceV3.CredentialService)
+                messageHandler = new HttpSourceAuthenticationHandler(packageSource, clientHandler, HttpHandlerResourceV3.CredentialService?.Value)
                 {
                     InnerHandler = innerHandler
                 };

--- a/src/NuGet.Core/NuGet.Protocol/Providers/DownloadResourcePluginProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/DownloadResourcePluginProvider.cs
@@ -84,7 +84,7 @@ namespace NuGet.Protocol
                 () => new GetCredentialsRequestHandler(
                     plugin,
                     httpHandlerResource.ClientHandler?.Proxy,
-                    HttpHandlerResourceV3.CredentialService),
+                    HttpHandlerResourceV3.CredentialService?.Value),
                 existingHandler =>
                     {
                         var handler = (GetCredentialsRequestHandler)existingHandler;

--- a/src/NuGet.Core/NuGet.Protocol/Providers/PluginResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/PluginResourceProvider.cs
@@ -117,7 +117,7 @@ namespace NuGet.Protocol.Core.Types
                         resource = new PluginResource(
                             pluginCreationResults,
                             source.PackageSource,
-                            HttpHandlerResourceV3.CredentialService);
+                            HttpHandlerResourceV3.CredentialService?.Value);
                     }
                 }
             }

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/PluginFindPackageByIdResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/PluginFindPackageByIdResourceProvider.cs
@@ -84,7 +84,7 @@ namespace NuGet.Protocol
                 () => new GetCredentialsRequestHandler(
                     plugin,
                     httpHandlerResource.ClientHandler?.Proxy,
-                    HttpHandlerResourceV3.CredentialService),
+                    HttpHandlerResourceV3.CredentialService?.Value),
                 existingHandler =>
                     {
                         var handler = (GetCredentialsRequestHandler)existingHandler;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/DownloadResourcePluginProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/DownloadResourcePluginProviderTests.cs
@@ -27,7 +27,7 @@ namespace NuGet.Protocol.Plugins.Tests
         {
             _provider = new DownloadResourcePluginProvider();
 
-            HttpHandlerResourceV3.CredentialService = Mock.Of<ICredentialService>();
+            HttpHandlerResourceV3.CredentialService = new Lazy<ICredentialService>(() => Mock.Of<ICredentialService>());
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginFindPackageByIdResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginFindPackageByIdResourceProviderTests.cs
@@ -21,7 +21,7 @@ namespace NuGet.Protocol.Plugins.Tests
         {
             _provider = new PluginFindPackageByIdResourceProvider();
 
-            HttpHandlerResourceV3.CredentialService = Mock.Of<ICredentialService>();
+            HttpHandlerResourceV3.CredentialService = new Lazy<ICredentialService>(() => Mock.Of<ICredentialService>());
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginFindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginFindPackageByIdResourceTests.cs
@@ -33,7 +33,7 @@ namespace NuGet.Protocol.Plugins.Tests
             _plugin = new Mock<IPlugin>();
             _utilities = new Mock<IPluginMulticlientUtilities>();
 
-            HttpHandlerResourceV3.CredentialService = Mock.Of<ICredentialService>();
+            HttpHandlerResourceV3.CredentialService = new Lazy<ICredentialService>(() => Mock.Of<ICredentialService>());
         }
 
         [Fact]


### PR DESCRIPTION
This PR delay initializing CredentialService as part of VSSolutionManager initialization which is the first thing to be initialized as part of NuGet, which help us resolve ~30% of ui delay of this current issue. With this PR, CredentialService will be initialized when it's really needed and as part of Background work (while initializing V3 resources).

Fixes [590844](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/590844) [PerfWatson] UIDelay: nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.VisualStudio.VSSolutionManager+<EnsureInitializeAsync>d__.MoveNext

Stack trace of ui delay:

+nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.VisualStudio.VSSolutionManager.InitializeAsync | 28 | 2,754
-- | -- | --
+mscorlib.dll!System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start | 26 | 2,820
\|+nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.VisualStudio.VSSolutionManager+<InitializeAsync>d__.MoveNext | 25 | 2,761
\|\|+nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.VisualStudio.DefaultVSCredentialServiceProvider.GetCredentialService | 23 | 2,789
\|\|\| nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.VisualStudio.DefaultVSCredentialServiceProvider.TryAddCredentialProviders | 23 | 2,789
\|\|\|  nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.VisualStudio.DefaultVSCredentialServiceProvider.<GetCredentialService>b___ | 23 | 2,789
\|\|\|   nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.VisualStudio.VsCredentialProviderImporter.GetProviders | 23 | 2,789
\|\|\|    nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.VisualStudio.VsCredentialProviderImporter.TryImportCredentialProviders | 23 | 2,789
\|\|\|     mscorlib.dll!System.Lazy`[System.__Canon].get_Value | 23 | 2,789
\|\|\|      mscorlib.dll!System.Lazy`[System.__Canon].LazyInitValue | 23 | 2,789
\|\|\|       system.componentmodel.composition.dll!System.ComponentModel.Composition.ExportServices+<>c__DisplayClass_0`[System.__Canon].<CreateStronglyTypedLazyOfT>b__ | 23 | 2,789
\|\|\|       +system.componentmodel.composition.dll!System.ComponentModel.Composition.ExportServices.GetCastedExportedValue[System.__Canon] | 20 | 2,737
\|\|\|       +system.componentmodel.composition.dll!System.ComponentModel.Composition.ExportServices.GetCastedExportedValue | 3 | 3,140

