### PR TITLE
Avoid sending InstalledPackagesCount as part of ProjectInformation telemetry to fix part of UIDelay

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NuGetProjectType.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NuGetProjectType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace NuGet.PackageManagement.Telemetry
@@ -42,5 +42,11 @@ namespace NuGet.PackageManagement.Telemetry
         /// It will be used for legacy project system with package references.
         /// </summary>
         LegacyProjectSystemWithPackageRefs = 6,
+
+        /// <summary>
+        /// Used when no NuGet package has been installed into the project yet but it still a supported and known project type.
+        /// and we by default create a <see cref="MSBuildNuGetProject"/>
+        /// </summary>
+        UnconfiguredNuGetType = 7,
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/ProjectTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/ProjectTelemetryEvent.cs
@@ -12,11 +12,9 @@ namespace NuGet.PackageManagement.Telemetry
             string nuGetVersion,
             string projectId,
             NuGetProjectType nuGetProjectType,
-            int installedPackageCount,
             bool isPRUpgradable) :
             base(ProjectInformationEventName, new Dictionary<string, object>
                 {
-                    { nameof(InstalledPackageCount), installedPackageCount },
                     { nameof(NuGetProjectType), nuGetProjectType },
                     { nameof(NuGetVersion), nuGetVersion },
                     { nameof(ProjectId), projectId.ToString() },
@@ -42,11 +40,6 @@ namespace NuGet.PackageManagement.Telemetry
         /// The type of NuGet project this project is.
         /// </summary>
         public NuGetProjectType NuGetProjectType => (NuGetProjectType)base[nameof(NuGetProjectType)];
-
-        /// <summary>
-        /// The number of NuGet packages installed to this project.
-        /// </summary>
-        public int InstalledPackageCount => (int)base[nameof(InstalledPackageCount)];
 
         /// <summary>
         /// True, if project can be upgraded to PackageReference.

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -113,6 +113,11 @@ namespace NuGet.ProjectManagement
         public override Task<IEnumerable<PackageReference>> GetInstalledPackagesAsync(CancellationToken token)
         {
             return PackagesConfigNuGetProject.GetInstalledPackagesAsync(token);
+        }
+
+        public bool DoesPackagesConfigExists()
+        {
+            return PackagesConfigNuGetProject.PackagesConfigExists();
         }
 
         public void AddBindingRedirects()

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
@@ -20,6 +20,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         [InlineData(NuGetProjectType.XProjProjectJson)]
         [InlineData(NuGetProjectType.CPSBasedPackageRefs)]
         [InlineData(NuGetProjectType.LegacyProjectSystemWithPackageRefs)]
+        [InlineData(NuGetProjectType.UnconfiguredNuGetType)]
         public void NuGetTelemetryService_EmitProjectInformation(NuGetProjectType projectType)
         {
             // Arrange
@@ -33,7 +34,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 "3.5.0-beta2",
                 "15e9591f-9391-4ddf-a246-ca9e0351277d",
                 projectType,
-                3,
                 true);
             var target = new NuGetVSTelemetryService(telemetrySession.Object);
 
@@ -44,7 +44,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             telemetrySession.Verify(x => x.PostEvent(It.IsAny<TelemetryEvent>()), Times.Once);
             Assert.NotNull(lastTelemetryEvent);
             Assert.Equal("ProjectInformation", lastTelemetryEvent.Name);
-            Assert.Equal(5, lastTelemetryEvent.Count);
+            Assert.Equal(4, lastTelemetryEvent.Count);
 
             var nuGetVersion = lastTelemetryEvent["NuGetVersion"];
             Assert.NotNull(nuGetVersion);
@@ -60,11 +60,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.NotNull(actualProjectType);
             Assert.IsType<NuGetProjectType>(actualProjectType);
             Assert.Equal(projectInformation.NuGetProjectType, actualProjectType);
-
-            var installedPackageCount = lastTelemetryEvent["InstalledPackageCount"];
-            Assert.NotNull(installedPackageCount);
-            Assert.IsType<int>(installedPackageCount);
-            Assert.Equal(projectInformation.InstalledPackageCount, installedPackageCount);
 
             var isPRUpgradable = lastTelemetryEvent["IsPRUpgradable"];
             Assert.NotNull(isPRUpgradable);


### PR DESCRIPTION
This is the second part on top of https://github.com/NuGet/NuGet.Client/pull/2170 to further improve ~15% of the total UIDelay of VSSolutionManager EnsureInitializeAsync. This PR avoid sending InstalledPackagesCount as part of ProjectInformation telemetry which is anyways not consistent across project types. And also, differentiate between projects with actual packages.config vs default projects which are just treated as packages.config. The later will now be categories under `UnconfiguredNuGetType`.

Also, created a tracking issue# https://github.com/NuGet/Home/issues/6847 to follow up on updating restore telemetry event to differentiate between direct and transitive dependencies count.

\|\| \|   \| \|              \|\|  +nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.Telemetry.VSTelemetryServiceUtility.GetProjectTelemetryEventAsync | 12 | 2,135
-- | -- | --
\|\| \|   \| \|              \|\|  \| mscorlib.dll!System.Runtime.CompilerServices.AsyncTaskMethodBuilder`[System.__Canon].Start | 12 | 2,135
\|\| \|   \| \|              \|\|  \|  nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.Telemetry.VSTelemetryServiceUtility+<GetProjectTelemetryEventAsync>d__.MoveNext | 12 | 2,135
\|\| \|   \| \|              \|\|  \|  +nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.VisualStudio.NetCorePackageReferenceProject.GetInstalledPackagesAsync | 6 | 2,557
\|\| \|   \| \|              \|\|  \|  +nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.VisualStudio.LegacyPackageReferenceProject.GetInstalledPackagesAsync | 4 | 1,325
\|\| \|   \| \|              \|\|  \|  +nuget.packagemanagement.dll!NuGet.ProjectManagement.PackagesConfigNuGetProject.GetInstalledPackagesAsync | 2 | 2,490


Fixes  590844 [PerfWatson] UIDelay: nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.VisualStudio.VSSolutionManager+d__.MoveNext 
