### PR TITLE
Improve error message in VS Setting UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.cs
@@ -59,14 +59,21 @@ namespace NuGet.Options
                     showPackageManagementChooser.Checked = packageManagement.Enabled;
 #endif
                 }
-                catch (InvalidOperationException)
+                // Thrown during creating or saving NuGet.Config.
+                catch (NuGetConfigurationException ex)
                 {
-                    MessageHelper.ShowErrorMessage(Resources.ShowError_ConfigInvalidOperation, Resources.ErrorDialogBoxTitle);
-                } 
+                    MessageHelper.ShowErrorMessage(ex.Message, Resources.ErrorDialogBoxTitle);
+                }
+                // Thrown if no nuget.config found.
+                catch (InvalidOperationException ex)
+                {
+                    MessageHelper.ShowErrorMessage(ex.Message, Resources.ErrorDialogBoxTitle);
+                }
                 catch (UnauthorizedAccessException)
                 {
                     MessageHelper.ShowErrorMessage(Resources.ShowError_ConfigUnauthorizedAccess, Resources.ErrorDialogBoxTitle);
                 }
+                // Unknown exception.
                 catch (Exception ex)
                 {
                     MessageHelper.ShowErrorMessage(Resources.ShowError_SettingActivatedFailed, Resources.ErrorDialogBoxTitle);
@@ -95,9 +102,16 @@ namespace NuGet.Options
                 packageManagement.ApplyChanges();
 #endif
             }
-            catch (InvalidOperationException)
+            // Thrown during creating or saving NuGet.Config.
+            catch (NuGetConfigurationException ex)
             {
-                MessageHelper.ShowErrorMessage(Resources.ShowError_ConfigInvalidOperation, Resources.ErrorDialogBoxTitle);
+                MessageHelper.ShowErrorMessage(ex.Message, Resources.ErrorDialogBoxTitle);
+                return false;
+            }
+            // Thrown if no nuget.config found.
+            catch (InvalidOperationException ex)
+            {
+                MessageHelper.ShowErrorMessage(ex.Message, Resources.ErrorDialogBoxTitle);
                 return false;
             }
             catch (UnauthorizedAccessException)
@@ -105,6 +119,7 @@ namespace NuGet.Options
                 MessageHelper.ShowErrorMessage(Resources.ShowError_ConfigUnauthorizedAccess, Resources.ErrorDialogBoxTitle);
                 return false;
             }
+            // Unknown exception.
             catch (Exception ex)
             {
                 MessageHelper.ShowErrorMessage(Resources.ShowError_ApplySettingFailed, Resources.ErrorDialogBoxTitle);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.PackageManagement.UI;
 using NuGet.Protocol.Core.Types;
 using NuGet.VisualStudio;
@@ -182,14 +183,21 @@ namespace NuGet.Options
 
                 OnSelectedPackageSourceChanged(null, EventArgs.Empty);
             }
-            catch (InvalidOperationException)
+            // Thrown during creating or saving NuGet.Config.
+            catch (NuGetConfigurationException ex)
             {
-                MessageHelper.ShowErrorMessage(Resources.ShowError_ConfigInvalidOperation, Resources.ErrorDialogBoxTitle);
+                MessageHelper.ShowErrorMessage(ex.Message, Resources.ErrorDialogBoxTitle);
+            }
+            // Thrown if no nuget.config found.
+            catch (InvalidOperationException ex)
+            {
+                MessageHelper.ShowErrorMessage(ex.Message, Resources.ErrorDialogBoxTitle);
             }
             catch (UnauthorizedAccessException)
             {
                 MessageHelper.ShowErrorMessage(Resources.ShowError_ConfigUnauthorizedAccess, Resources.ErrorDialogBoxTitle);
             }
+            // Unknown exception.
             catch (Exception ex)
             {
                 MessageHelper.ShowErrorMessage(Resources.ShowError_SettingActivatedFailed, Resources.ErrorDialogBoxTitle);
@@ -245,14 +253,16 @@ namespace NuGet.Options
                     _packageSourceProvider.SavePackageSources(packageSources);
                 }
             }
-            catch (Configuration.NuGetConfigurationException e)
+            // Thrown during creating or saving NuGet.Config.
+            catch (NuGetConfigurationException ex)
             {
-                MessageHelper.ShowErrorMessage(ExceptionUtilities.DisplayMessage(e), Resources.ErrorDialogBoxTitle);
+                MessageHelper.ShowErrorMessage(ex.Message, Resources.ErrorDialogBoxTitle);
                 return false;
             }
-            catch (InvalidOperationException)
+            // Thrown if no nuget.config found.
+            catch (InvalidOperationException ex)
             {
-                MessageHelper.ShowErrorMessage(Resources.ShowError_ConfigInvalidOperation, Resources.ErrorDialogBoxTitle);
+                MessageHelper.ShowErrorMessage(ex.Message, Resources.ErrorDialogBoxTitle);
                 return false;
             }
             catch (UnauthorizedAccessException)
@@ -260,6 +270,7 @@ namespace NuGet.Options
                 MessageHelper.ShowErrorMessage(Resources.ShowError_ConfigUnauthorizedAccess, Resources.ErrorDialogBoxTitle);
                 return false;
             }
+            // Unknown exception.
             catch (Exception ex)
             {
                 MessageHelper.ShowErrorMessage(Resources.ShowError_ApplySettingFailed, Resources.ErrorDialogBoxTitle);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1188,20 +1188,11 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Applying setting failed..
+        ///   Looks up a localized string similar to Failed to apply NuGet Package Manager settings. Please report a problem using Help &gt; Send Feedback &gt; Report a Problem..
         /// </summary>
         public static string ShowError_ApplySettingFailed {
             get {
                 return ResourceManager.GetString("ShowError_ApplySettingFailed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to NuGet.Config is malformed, Please check NuGet.Config.
-        /// </summary>
-        public static string ShowError_ConfigInvalidOperation {
-            get {
-                return ResourceManager.GetString("ShowError_ConfigInvalidOperation", resourceCulture);
             }
         }
         
@@ -1215,7 +1206,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to NuGet setting initialization failed..
+        ///   Looks up a localized string similar to Failed to initialize NuGet Package Manager Settings. Please report a problem using Help &gt; Send Feedback &gt; Report a Problem..
         /// </summary>
         public static string ShowError_SettingActivatedFailed {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -615,9 +615,6 @@ Packages installed into Website projects will not be restored during build. Cons
   <data name="ErrorDialogBoxTitle" xml:space="preserve">
     <value>Operation failed</value>
   </data>
-  <data name="ShowError_ConfigInvalidOperation" xml:space="preserve">
-    <value>NuGet.Config is malformed, Please check NuGet.Config</value>
-  </data>
   <data name="ShowError_ConfigUnauthorizedAccess" xml:space="preserve">
     <value>Can not access NuGet.Config, Please check NuGet.Config</value>
   </data>
@@ -685,7 +682,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <value>Refresh</value>
   </data>
   <data name="ShowError_ApplySettingFailed" xml:space="preserve">
-    <value>Applying setting failed.</value>
+    <value>Failed to apply NuGet Package Manager settings. Please report a problem using Help &gt; Send Feedback &gt; Report a Problem.</value>
   </data>
   <data name="NuGetUpgrade_Progress_Installing" xml:space="preserve">
     <value>Installing required packages</value>
@@ -800,6 +797,6 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <value>Don't show again</value>
   </data>
   <data name="ShowError_SettingActivatedFailed" xml:space="preserve">
-    <value>NuGet setting initialization failed.</value>
+    <value>Failed to initialize NuGet Package Manager Settings. Please report a problem using Help &gt; Send Feedback &gt; Report a Problem.</value>
   </data>
 </root>


### PR DESCRIPTION
Improvement:
1. use NuGetConfigurationException which contains nuget.config path.
2. ask user  to report issue through VSFeedback if unknown issue happens.
3. remove the ConfigInvalid message, because InvalidOperationException is thrown when can't find nuget.config.