### PR TITLE
Changed the order of multiple JTFs to allow task to be added in JTF collection

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetLockService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetLockService.cs
@@ -44,42 +44,47 @@ namespace NuGet.PackageManagement.VisualStudio
         /// </summary>
         public async Task<T> ExecuteNuGetOperationAsync<T>(Func<Task<T>> action, CancellationToken token)
         {
-            return await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            if (_lockCount.Value == 0)
             {
-                if (_lockCount.Value == 0)
+                return await _joinableTaskFactory.RunAsync(async delegate
                 {
-                    return await _joinableTaskFactory.RunAsync(async delegate
+                    using (_joinableTaskCollection.Join())
                     {
-                        using (_joinableTaskCollection.Join())
-                        {
-                            await _semaphore.WaitAsync(token);
-                        }
+                        await _semaphore.WaitAsync(token);
+                    }
 
-                        // Once this thread acquired the lock then increment lockCount
-                        _lockCount.Value++;
+                    // Once this thread acquired the lock then increment lockCount
+                    _lockCount.Value++;
 
-                        try
+                    try
+                    {
+                        // Run it as part of CPS JTF so that it can be joined in Shell JTF collection
+                        // and allows other tasks to proceed instead of deadlocking them.
+                        return await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                         {
                             return await action();
-                        }
-                        finally
+                        });
+                    }
+                    finally
+                    {
+                        try
                         {
-                            try
-                            {
-                                _semaphore.Release();
-                            }
-                            catch (ObjectDisposedException) { }
-
-                            _lockCount.Value--;
+                            _semaphore.Release();
                         }
-                    });
+                        catch (ObjectDisposedException) { }
+
+                        _lockCount.Value--;
+                    }
+                });
                 
-                }
-                else
+            }
+            else
+            {
+                return await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
                     return await action();
-                }
-            });
+                });
+            }
         }
 
         public Task ExecuteNuGetOperationAsync(Func<Task> action, CancellationToken token)


### PR DESCRIPTION
This PR is to fix multiple customer reports of VS UI hang on NuGet update operation for SDK based projects. Previous order of execution was `CPS JTF -> Shell JTF -> JTF collection` so with that order, Shell JTF was not able to add CPS task in that collection which is why it didn't allow other tasks to proceed. After going through the dump and JTF code, we realized that this order should be reverse in order to Shell JTF to allow adding this CPS JTF task. So current order of execution will be `Shell JTF -> CPS JTF -> JTF collection`

Fixes [Feedback] NuGet updates causes VS (15.7 preview 4.0) to freeze on .NET SDK projects [603199](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/603199?src=alerts&src-action=cta)

Failure Stack-trace:
```
3ce82778 <0> Microsoft.VisualStudio.ProjectSystem.VS.Implementation.Package.Components.SourceControlIntegration+<TryCheckoutForEditAsync>d__19
.3ce82a4c <0> Microsoft.VisualStudio.ProjectSystem.VS.Implementation.Package.Components.SourceControlIntegration+<VerifyThrowCheckoutForEditAsync>d__20
..3ce82b14 <0> Microsoft.VisualStudio.ProjectSystem.VS.Implementation.Package.Components.SourceControlIntegration+<CanChangeProjectFilesAsync>d__18
...3ce82bd8 <0> Microsoft.VisualStudio.ProjectSystem.ProjectLockService+<CheckoutFromSourceControlAsync>d__84
....3cdca548 <5> Microsoft.VisualStudio.ProjectSystem.Properties.ProjectPropertyWriter+<SetItemPropertyAsync>d__2
.....3cdca714 <2> Microsoft.VisualStudio.ProjectSystem.Properties.ItemProperties+<SetPropertyValueAsync>d__20
......3cdca7f0 <2> Microsoft.VisualStudio.ProjectSystem.Properties.ItemPropertiesWithCatalog+<SetPropertyValueAsync>d__4
.......3cdc78e4 <2> Microsoft.VisualStudio.ProjectSystem.Properties.ProjectPropertiesBase+<Microsoft-VisualStudio-ProjectSystem-Properties-IProjectProperties-SetPropertyValueAsync>d__27
........3cd1f734 <3> NuGet.PackageManagement.VisualStudio.NetCorePackageReferenceProject+<InstallPackageAsync>d__22
.........3cd1f828 <1> NuGet.PackageManagement.NuGetPackageManager+<ExecuteBuildIntegratedProjectActionsAsync>d__76
..........3cd1f92c <0> NuGet.PackageManagement.NuGetPackageManager+<ExecuteNuGetProjectActionsAsync>d__74
...........3cd1fa7c <0> NuGet.PackageManagement.NuGetPackageManager+<ExecuteNuGetProjectActionsAsync>d__73
............3cb81264 <2> NuGet.PackageManagement.NuGetPackageManager+<ExecuteNuGetProjectActionsAsync>d__72
.............3cb81348 <0> NuGet.PackageManagement.UI.UIActionEngine+<>c__DisplayClass5_0+<<PerformUpdateAsync>b__1>d
..............4010f2cc <3> NuGet.PackageManagement.UI.UIActionEngine+<>c__DisplayClass7_0+<<PerformActionImplAsync>b__0>d
...............4010f384 <0> NuGet.PackageManagement.VisualStudio.NuGetLockService+<>c__DisplayClass10_0+<<ExecuteNuGetOperationAsync>b__0>d
................4010f42c <1> NuGet.PackageManagement.VisualStudio.NuGetLockService+<>c__DisplayClass9_0`1+<<ExecuteNuGetOperationAsync>b__1>d[[System.Boolean, mscorlib]]
.................4010f6a8 <0> Microsoft.VisualStudio.Threading.JoinableTask+<JoinAsync>d__78
..................4010f798 <0> Microsoft.VisualStudio.Threading.JoinableTask`1+<JoinAsync>d__3[[System.Boolean, mscorlib]]
...................4010f850 <0> NuGet.PackageManagement.VisualStudio.NuGetLockService+<>c__DisplayClass9_0`1+<<ExecuteNuGetOperationAsync>b__0>d[[System.Boolean, mscorlib]]
....................4010fabc <0> Microsoft.VisualStudio.Threading.JoinableTask+<JoinAsync>d__78
.....................4010fbac <0> Microsoft.VisualStudio.Threading.JoinableTask`1+<JoinAsync>d__3[[System.Boolean, mscorlib]]
......................4010fc64 <0> NuGet.PackageManagement.VisualStudio.NuGetLockService+<ExecuteNuGetOperationAsync>d__9`1[[System.Boolean, mscorlib]]
.......................4010fd24 <0> NuGet.PackageManagement.UI.UIActionEngine+<PerformActionImplAsync>d__7
........................4010fde0 <0> NuGet.PackageManagement.UI.UIActionEngine+<PerformUpdateAsync>d__5
.........................4010c7a0 <1> NuGet.PackageManagement.UI.PackageManagerControl+<>c__DisplayClass98_0+<<ExecuteAction>b__0>d

3cf2888c <0> NuGet.SolutionRestoreManager.RestoreOperationLogger+<<StartAsync>b__18_2>d
.3cf290d4 <0> Microsoft.VisualStudio.Threading.JoinableTask+<JoinAsync>d__78
..3cf291c4 <0> NuGet.SolutionRestoreManager.RestoreOperationLogger+<StartAsync>d__18
...3cf2927c <1> NuGet.SolutionRestoreManager.SolutionRestoreWorker+<>c__DisplayClass47_1+<<StartRestoreJobAsync>b__0>d
....3cf29340 <1> NuGet.PackageManagement.VisualStudio.NuGetLockService+<ExecuteNuGetOperationAsync>d__9`1[[System.Boolean, mscorlib]]
.....3cf293f4 <1> NuGet.SolutionRestoreManager.SolutionRestoreWorker+<StartRestoreJobAsync>d__47
......3cf297d8 <0> Microsoft.VisualStudio.Threading.JoinableTask+<JoinAsync>d__78
.......3cf29894 <0> Microsoft.VisualStudio.Threading.JoinableTask`1+<JoinAsync>d__3[[System.Boolean, mscorlib]]
........3cf2994c <0> NuGet.SolutionRestoreManager.SolutionRestoreWorker+<ProcessRestoreRequestAsync>d__45
.........3cf29a00 <5> NuGet.SolutionRestoreManager.SolutionRestoreWorker+<StartBackgroundJobRunnerAsync>d__44
..........3cf04274 <1> Microsoft.VisualStudio.Threading.AsyncLazy`1+<>c__DisplayClass13_1+<<GetValueAsync>b__0>d[[System.Boolean, mscorlib]]
...........3cf29b30 <0> Microsoft.VisualStudio.Threading.JoinableTask+<JoinAsync>d__78
............3cf29c20 <0> Microsoft.VisualStudio.Threading.JoinableTask`1+<JoinAsync>d__3[[System.Boolean, mscorlib]]
```

@lifengl @AArnott @rrelyea 