### PR TITLE
Enforce repository signature info contentUrl to be HTTPS

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
@@ -30,12 +30,10 @@ namespace NuGet.Protocol
             AllRepositorySigned = allRepositorySigned;
             RepositoryCertificateInfos = data.OfType<JObject>().Select(p => p.FromJToken<RepositoryCertificateInfo>());
 
-            if (Uri.TryCreate(source.PackageSource.Source, UriKind.Absolute, out var v3ServiceIndexUrl))
+            var validUri = Uri.TryCreate(source.PackageSource.Source, UriKind.Absolute, out var v3ServiceIndexUrl);
+            if (!validUri || !string.Equals(v3ServiceIndexUrl.Scheme, "https", StringComparison.OrdinalIgnoreCase))
             {
-                if (!string.Equals(v3ServiceIndexUrl.Scheme, "https", StringComparison.OrdinalIgnoreCase))
-                {
-                    throw new FatalProtocolException(Strings.RepositoryContentUrlMustBeHttps);
-                }
+                throw new FatalProtocolException(Strings.RepositoryContentUrlMustBeHttps);
             }
 
             Source = source.PackageSource.Source;

--- a/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -28,6 +29,15 @@ namespace NuGet.Protocol
 
             AllRepositorySigned = allRepositorySigned;
             RepositoryCertificateInfos = data.OfType<JObject>().Select(p => p.FromJToken<RepositoryCertificateInfo>());
+
+            if (Uri.TryCreate(source.PackageSource.Source, UriKind.Absolute, out var v3ServiceIndexUrl))
+            {
+                if (!string.Equals(v3ServiceIndexUrl.Scheme, "https", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new FatalProtocolException(Strings.RepositoryContentUrlMustBeHttps);
+                }
+            }
+
             Source = source.PackageSource.Source;
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -953,7 +953,7 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Repository content URL for repository sigantures must be HTTPS..
+        ///   Looks up a localized string similar to Repository content URL for repository signatures must be HTTPS..
         /// </summary>
         internal static string RepositoryContentUrlMustBeHttps {
             get {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -953,6 +953,15 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Repository content URL for repository sigantures must be HTTPS..
+        /// </summary>
+        internal static string RepositoryContentUrlMustBeHttps {
+            get {
+                return ResourceManager.GetString("RepositoryContentUrlMustBeHttps", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The &apos;{0}&apos; installation feature was required by a package but is not supported on the current host..
         /// </summary>
         internal static string RequiredFeatureUnsupportedException_DefaultMessageWithFeature {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -487,4 +487,7 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
     <comment>{0} is the information name that needs to be parsed. 
 {1} is the repository signature information endpoint.</comment>
   </data>
+  <data name="RepositoryContentUrlMustBeHttps" xml:space="preserve">
+    <value>Repository content URL for repository sigantures must be HTTPS.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -488,6 +488,6 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
 {1} is the repository signature information endpoint.</comment>
   </data>
   <data name="RepositoryContentUrlMustBeHttps" xml:space="preserve">
-    <value>Repository content URL for repository sigantures must be HTTPS.</value>
+    <value>Repository content URL for repository signatures must be HTTPS.</value>
   </data>
 </root>

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/NuGet.Packaging.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/NuGet.Packaging.FuncTest.csproj
@@ -35,6 +35,6 @@
     <ProjectReference Include="..\..\TestUtilities\Test.Utility\Test.Utility.csproj" />
   </ItemGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/RepositorySignatureResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/RepositorySignatureResourceTests.cs
@@ -29,7 +29,7 @@ namespace NuGet.Protocol.Tests
         public async Task RepositorySignatureResource_BasicAsync()
         {
             // Arrange
-            var source = $"https://unit.test-{Guid.NewGuid()}/v3-with-flat-container/index.json";
+            var source = $"https://{Guid.NewGuid()}.unit.test/v3-with-flat-container/index.json";
             var responses = new Dictionary<string, string>
             {
                 { source, JsonData.RepoSignIndexJsonData },
@@ -54,7 +54,7 @@ namespace NuGet.Protocol.Tests
         public async Task RepositorySignatureResource_WithoutReposignEndpointAsync()
         {
             // Arrange
-            var source = $"https://unit.test-{Guid.NewGuid()}/v3-with-flat-container/index.json";
+            var source = $"https://{Guid.NewGuid()}.unit.test/v3-with-flat-container/index.json";
             var responses = new Dictionary<string, string>
             {
                 { source, JsonData.IndexWithFlatContainer }
@@ -73,7 +73,7 @@ namespace NuGet.Protocol.Tests
         public void RepositorySignatureResource_NoAllRepositorySigned()
         {
             // Arrange
-            var source = $"https://unit.test-{Guid.NewGuid()}/v3-with-flat-container/index.json";
+            var source = $"https://{Guid.NewGuid()}.unit.test/v3-with-flat-container/index.json";
             var responses = new Dictionary<string, string>();
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
             var jobject = JObject.Parse(JsonData.RepoSignDataNoAllRepositorySigned);
@@ -87,7 +87,7 @@ namespace NuGet.Protocol.Tests
         public void RepositorySignatureResource_NoCertInfo()
         {
             // Arrange
-            var source = $"https://unit.test-{Guid.NewGuid()}/v3-with-flat-container/index.json";
+            var source = $"https://{Guid.NewGuid()}.unit.test/v3-with-flat-container/index.json";
             var responses = new Dictionary<string, string>();
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
             var jobject = JObject.Parse(JsonData.RepoSignDataNoCertInfo);
@@ -97,23 +97,27 @@ namespace NuGet.Protocol.Tests
         }
 
         [Fact]
-        public void RepositorySignatureResource_WithNonHttpsSource()
+        public async Task RepositorySignatureResource_WithNonHttpsSourceAsync()
         {
             // Arrange
-            var source = $"http://unit.test-{Guid.NewGuid()}/v3-with-flat-container/index.json";
-            var responses = new Dictionary<string, string>();
+            var source = $"http://{Guid.NewGuid()}.unit.test/v3-with-flat-container/index.json";
+            var responses = new Dictionary<string, string>
+            {
+                { source, JsonData.RepoSignIndexJsonData },
+                { "https://api.nuget.org/v3-index/repository-signatures/index.json", JsonData.RepoSignData }
+            };
+
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-            var jobject = JObject.Parse(JsonData.RepoSignDataNoCertInfo);
 
             // Act & Assert
-            Assert.Throws<FatalProtocolException>(() => new RepositorySignatureResource(jobject, repo));
+            await Assert.ThrowsAsync<FatalProtocolException>(async () => await repo.GetResourceAsync<RepositorySignatureResource>());
         }
 
         [Fact]
         public async Task RepositorySignatureResource_RepositorySignatureInfoAsync()
         {
             // Arrange
-            var source = $"https://unit.test-{Guid.NewGuid()}/v3-with-flat-container/index.json";
+            var source = $"https://{Guid.NewGuid()}.unit.test/v3-with-flat-container/index.json";
             var responses = new Dictionary<string, string>
             {
                 { source, JsonData.RepoSignIndexJsonData },
@@ -142,9 +146,9 @@ namespace NuGet.Protocol.Tests
         public async Task RepositorySignatureResource_RepositorySignatureInfoConcurrencyAsync()
         {
             // Arrange
-            var source1 = $"https://unit.test-{Guid.NewGuid()}-1/v3-with-flat-container/index.json";
-            var source2 = $"https://unit.test-{Guid.NewGuid()}-2/v3-with-flat-container/index.json";
-            var source3 = $"https://unit.test-{Guid.NewGuid()}-3/v3-with-flat-container/index.json";
+            var source1 = $"https://1.{Guid.NewGuid()}.unit.test/v3-with-flat-container/index.json";
+            var source2 = $"https://2.{Guid.NewGuid()}.unit.test/v3-with-flat-container/index.json";
+            var source3 = $"https://3.{Guid.NewGuid()}.unit.test/v3-with-flat-container/index.json";
 
             var sources = new List<string>() { source1, source2, source3 };
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/RepositorySignatureResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/RepositorySignatureResourceTests.cs
@@ -26,13 +26,15 @@ namespace NuGet.Protocol.Tests
         private const string _notBefore = "2018-02-26T00:00:00.0000000Z";
 
         [Fact]
-        public async Task RepositorySignatureResource_Basic()
+        public async Task RepositorySignatureResource_BasicAsync()
         {
             // Arrange
-            var source = $"http://unit.test/{Guid.NewGuid()}/v3-with-flat-container/index.json";
-            var responses = new Dictionary<string, string>();
-            responses.Add(source, JsonData.RepoSignIndexJsonData);
-            responses.Add("https://api.nuget.org/v3-index/repository-signatures/index.json", JsonData.RepoSignData);
+            var source = $"https://unit.test-{Guid.NewGuid()}/v3-with-flat-container/index.json";
+            var responses = new Dictionary<string, string>
+            {
+                { source, JsonData.RepoSignIndexJsonData },
+                { "https://api.nuget.org/v3-index/repository-signatures/index.json", JsonData.RepoSignData }
+            };
 
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
 
@@ -49,12 +51,14 @@ namespace NuGet.Protocol.Tests
         }
 
         [Fact]
-        public async Task RepositorySignatureResource_WithoutReposignEndpoint()
+        public async Task RepositorySignatureResource_WithoutReposignEndpointAsync()
         {
             // Arrange
-            var source = $"http://unit.test{Guid.NewGuid()}/v3-with-flat-container/index.json";
-            var responses = new Dictionary<string, string>();
-            responses.Add(source, JsonData.IndexWithFlatContainer);
+            var source = $"https://unit.test-{Guid.NewGuid()}/v3-with-flat-container/index.json";
+            var responses = new Dictionary<string, string>
+            {
+                { source, JsonData.IndexWithFlatContainer }
+            };
 
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
 
@@ -69,7 +73,7 @@ namespace NuGet.Protocol.Tests
         public void RepositorySignatureResource_NoAllRepositorySigned()
         {
             // Arrange
-            var source = "http://unit.test1/v3-with-flat-container/index.json";
+            var source = $"https://unit.test-{Guid.NewGuid()}/v3-with-flat-container/index.json";
             var responses = new Dictionary<string, string>();
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
             var jobject = JObject.Parse(JsonData.RepoSignDataNoAllRepositorySigned);
@@ -83,7 +87,7 @@ namespace NuGet.Protocol.Tests
         public void RepositorySignatureResource_NoCertInfo()
         {
             // Arrange
-            var source = "http://unit.test1/v3-with-flat-container/index.json";
+            var source = $"https://unit.test-{Guid.NewGuid()}/v3-with-flat-container/index.json";
             var responses = new Dictionary<string, string>();
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
             var jobject = JObject.Parse(JsonData.RepoSignDataNoCertInfo);
@@ -93,13 +97,28 @@ namespace NuGet.Protocol.Tests
         }
 
         [Fact]
-        public async Task RepositorySignatureResource_RepositorySignatureInfo()
+        public void RepositorySignatureResource_WithNonHttpsSource()
         {
             // Arrange
-            var source = $"http://unit.test/{Guid.NewGuid()}/v3-with-flat-container/index.json";
+            var source = $"http://unit.test-{Guid.NewGuid()}/v3-with-flat-container/index.json";
             var responses = new Dictionary<string, string>();
-            responses.Add(source, JsonData.RepoSignIndexJsonData);
-            responses.Add("https://api.nuget.org/v3-index/repository-signatures/index.json", JsonData.RepoSignData);
+            var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
+            var jobject = JObject.Parse(JsonData.RepoSignDataNoCertInfo);
+
+            // Act & Assert
+            Assert.Throws<FatalProtocolException>(() => new RepositorySignatureResource(jobject, repo));
+        }
+
+        [Fact]
+        public async Task RepositorySignatureResource_RepositorySignatureInfoAsync()
+        {
+            // Arrange
+            var source = $"https://unit.test-{Guid.NewGuid()}/v3-with-flat-container/index.json";
+            var responses = new Dictionary<string, string>
+            {
+                { source, JsonData.RepoSignIndexJsonData },
+                { "https://api.nuget.org/v3-index/repository-signatures/index.json", JsonData.RepoSignData }
+            };
 
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
 
@@ -120,21 +139,23 @@ namespace NuGet.Protocol.Tests
         }
 
         [Fact]
-        public async Task RepositorySignatureResource_RepositorySignatureInfoConcurrency()
+        public async Task RepositorySignatureResource_RepositorySignatureInfoConcurrencyAsync()
         {
             // Arrange
-            var source1 = $"http://unit.test/{Guid.NewGuid()}1/v3-with-flat-container/index.json";
-            var source2 = $"http://unit.test/{Guid.NewGuid()}2/v3-with-flat-container/index.json";
-            var source3 = $"http://unit.test/{Guid.NewGuid()}3/v3-with-flat-container/index.json";
+            var source1 = $"https://unit.test-{Guid.NewGuid()}-1/v3-with-flat-container/index.json";
+            var source2 = $"https://unit.test-{Guid.NewGuid()}-2/v3-with-flat-container/index.json";
+            var source3 = $"https://unit.test-{Guid.NewGuid()}-3/v3-with-flat-container/index.json";
 
             var sources = new List<string>() { source1, source2, source3 };
 
-            var responses = new Dictionary<string, string>();
-            responses.Add(source1, JsonData.RepoSignIndexJsonData);
-            responses.Add(source2, JsonData.RepoSignIndexJsonData);
-            responses.Add(source3, JsonData.RepoSignIndexJsonData);
+            var responses = new Dictionary<string, string>
+            {
+                { source1, JsonData.RepoSignIndexJsonData },
+                { source2, JsonData.RepoSignIndexJsonData },
+                { source3, JsonData.RepoSignIndexJsonData },
 
-            responses.Add("https://api.nuget.org/v3-index/repository-signatures/index.json", JsonData.RepoSignData);
+                { "https://api.nuget.org/v3-index/repository-signatures/index.json", JsonData.RepoSignData }
+            };
 
             var repos = sources.Select(p => StaticHttpHandler.CreateSource(p, Repository.Provider.GetCoreV3(), responses));
 


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/6777

The `contentUrl` for a source was not enforced to be HTTPS in the `RepositorySignatureResource`. This PR makes sure the source is HTTPS and adds a test for it.