### PR TITLE
Timestamp's should not fail because unknown revocation or certificate expiring

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
@@ -105,7 +105,8 @@ namespace NuGet.Packaging.Signing
             {
                 verificationFlags |= timestamp.Verify(this, settings, fingerprintAlgorithm, issues);
 
-                if (verificationFlags != SignatureVerificationStatusFlags.NoErrors)
+                if (verificationFlags != SignatureVerificationStatusFlags.NoErrors &&
+                    verificationFlags != SignatureVerificationStatusFlags.UnknownRevocation)
                 {
                     return false;
                 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Timestamp.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Timestamp.cs
@@ -158,8 +158,7 @@ namespace NuGet.Packaging.Signing
                     var chainBuildingHasIssues = false;
                     IEnumerable<string> messages;
 
-                    var timestampInvalidCertificateFlags = CertificateChainUtility.DefaultObservedStatusFlags |
-                        (X509ChainStatusFlags.NotTimeValid);
+                    var timestampInvalidCertificateFlags = CertificateChainUtility.DefaultObservedStatusFlags;
 
                     if (CertificateChainUtility.TryGetStatusMessage(chainStatusList, timestampInvalidCertificateFlags, out messages))
                     {


### PR DESCRIPTION
Timestamps should not be considered invalid if chain building failed only with unknown or offline revocation status and time expiring in chain building should be ignored because we do those checks manually.

In a refactoring done for 15.7 we mistakenly made the timestamp fail because of these two reasons. This PR reverts that behavior to the intended one.