### PR TITLE
Adding development dependency support for PackageReference

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -146,7 +146,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 LibraryRange = new LibraryRange(
                     name: packageId,
                     versionRange: range,
-                    typeConstraint: LibraryDependencyTarget.Package)
+                    typeConstraint: LibraryDependencyTarget.Package),
+                SuppressParent = __.SuppressParent,
+                IncludeType = __.IncludeType
             };
 
             await ProjectServices.References.AddOrUpdatePackageReferenceAsync(dependency, token);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft;
 using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.References;
 using NuGet.Commands;
 using NuGet.Common;
@@ -275,11 +276,26 @@ namespace NuGet.PackageManagement.VisualStudio
                         originalFramework = framework.GetShortFolderName();
                     }
 
-                    await conditionalService.AddAsync(
+                    var reference = await conditionalService.AddAsync(
                         packageId,
                         formattedRange,
                         TargetFrameworkCondition,
                         originalFramework);
+
+                    // SuppressParent could be set to All if developmentDependency flag is true in package nuspec file.
+                    if (installationContext.SuppressParent != LibraryIncludeFlagUtils.DefaultSuppressParent &&
+                        installationContext.IncludeType != LibraryIncludeFlags.All)
+                    {
+                        await SetPackagePropertyValueAsync(
+                            reference.Metadata,
+                            ProjectItemProperties.PrivateAssets,
+                            MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(installationContext.SuppressParent)));
+
+                        await SetPackagePropertyValueAsync(
+                            reference.Metadata,
+                            ProjectItemProperties.IncludeAssets,
+                            MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(installationContext.IncludeType)));
+                    }
                 }
             }
             else
@@ -298,9 +314,30 @@ namespace NuGet.PackageManagement.VisualStudio
                     var existingReference = result.Reference;
                     await existingReference.Metadata.SetPropertyValueAsync("Version", formattedRange);
                 }
+
+                if (installationContext.SuppressParent != LibraryIncludeFlagUtils.DefaultSuppressParent &&
+                    installationContext.IncludeType != LibraryIncludeFlags.All)
+                {
+                    await SetPackagePropertyValueAsync(
+                        result.Reference.Metadata,
+                        ProjectItemProperties.PrivateAssets,
+                        MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(installationContext.SuppressParent)));
+
+                    await SetPackagePropertyValueAsync(
+                        result.Reference.Metadata,
+                        ProjectItemProperties.IncludeAssets,
+                        MSBuildStringUtility.Convert(LibraryIncludeFlagUtils.GetFlagString(installationContext.IncludeType)));
+                }
             }
 
             return true;
+        }
+
+        private async Task SetPackagePropertyValueAsync(IProjectProperties metadata, string propertyName, string propertyValue)
+        {
+            await metadata.SetPropertyValueAsync(
+                propertyName,
+                propertyValue);
         }
 
         public override async Task<bool> UninstallPackageAsync(PackageIdentity packageIdentity, INuGetProjectContext nuGetProjectContext, CancellationToken token)

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/Common/MSBuildUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/Common/MSBuildUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Globalization;
 using System.Threading.Tasks;
+using NuGet.LibraryModel;
 
 namespace NuGet.CommandLine.XPlat
 {
@@ -16,9 +17,16 @@ namespace NuGet.CommandLine.XPlat
                 packageReferenceArgs.PackageDependency.Id,
                 packageReferenceArgs.ProjectPath));
 
+            var libraryDependency = new LibraryDependency
+            {
+                LibraryRange = new LibraryRange(
+                    name: packageReferenceArgs.PackageDependency.Id,
+                    versionRange: packageReferenceArgs.PackageDependency.VersionRange,
+                    typeConstraint: LibraryDependencyTarget.Package)
+            };
+
             // Remove reference from the project
-            var result = msBuild.RemovePackageReference(packageReferenceArgs.ProjectPath,
-                packageReferenceArgs.PackageDependency);
+            var result = msBuild.RemovePackageReference(packageReferenceArgs.ProjectPath, libraryDependency);
 
             return Task.FromResult(result);
         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -545,5 +545,6 @@ namespace NuGet.Commands
 
             return packageVersions;
         }
+
     }
 }

--- a/src/NuGet.Core/NuGet.Common/MsBuildStringUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/MsBuildStringUtility.cs
@@ -99,5 +99,18 @@ namespace NuGet.Common
                 }
             }
         }
+
+        /// <summary>
+        /// Convert the provided string to MSBuild style.
+        /// </summary>
+        public static string Convert(string value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            return value.Replace(',', ';');
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
@@ -163,5 +163,6 @@ namespace NuGet.DependencyResolver
         {
             throw new NotImplementedException();
         }
+
     }
 }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteResolveResult.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteResolveResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegratedInstallationContext.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegratedInstallationContext.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using NuGet.Frameworks;
+using NuGet.LibraryModel;
 using NuGet.ProjectManagement.Projects;
 
 namespace NuGet.ProjectManagement
@@ -39,5 +40,15 @@ namespace NuGet.ProjectManagement
         /// framework evaluation depends on the target framework string matching exactly.
         /// </summary>
         public IDictionary<NuGetFramework, string> OriginalFrameworks { get; }
+
+        /// <summary>
+        /// Define transitive behavior for each package dependency for the current project.
+        /// </summary>
+        public LibraryIncludeFlags SuppressParent { get; set; } = LibraryIncludeFlagUtils.DefaultSuppressParent;
+
+        /// <summary>
+        /// Define what all sections of the current package to include in this project.
+        /// </summary>
+        public LibraryIncludeFlags IncludeType { get; set; } = LibraryIncludeFlags.All;
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/IProjectSystemReferencesService.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/IProjectSystemReferencesService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -636,12 +636,17 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     projectServices,
                     _threadingService);
 
+                var buildIntegratedInstallationContext = new BuildIntegratedInstallationContext(
+                    Enumerable.Empty<NuGetFramework>(),
+                    Enumerable.Empty<NuGetFramework>(),
+                    new Dictionary<NuGetFramework, string>());
+
                 // Act
                 var result = await testProject.InstallPackageAsync(
                     "packageA",
                     VersionRange.Parse("1.*"),
                     null,
-                    null,
+                    buildIntegratedInstallationContext,
                     CancellationToken.None);
 
                 // Assert

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -2588,5 +2588,65 @@ namespace ClassLibrary
                 }
             }
         }
+
+        [PlatformFact(Platform.Windows)]
+        public void PackCommand_ManualAddPackage_DevelopmentDependency()
+        {
+            // Arrange
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName);
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", "net45");
+
+                    var attributes = new Dictionary<string, string>();
+
+                    attributes["Version"] = "1.0.2";
+                    ProjectFileUtils.AddItem(
+                        xml,
+                        "PackageReference",
+                        "StyleCop.Analyzers",
+                        "net45",
+                        new Dictionary<string, string>(),
+                        attributes);
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+
+                // Act
+                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory}");
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                // Assert
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var nuspecReader = nupkgReader.NuspecReader;
+
+                    var dependencyGroups = nuspecReader
+                        .GetDependencyGroups()
+                        .OrderBy(x => x.TargetFramework,
+                            new NuGetFrameworkSorter())
+                        .ToList();
+
+                    Assert.Equal(1,
+                        dependencyGroups.Count);
+
+                    Assert.Equal(FrameworkConstants.CommonFrameworks.Net45, dependencyGroups[0].TargetFramework);
+                    Assert.Equal(1, dependencyGroups[0].Packages.Count());
+                }
+            }
+        }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -940,5 +940,38 @@ namespace NuGet.XPlat.FuncTest
                 Assert.True(XPlatTestUtils.ValidateReference(projectXmlRoot, packages[0].Id, noVersion ? latestVersion : userInputVersionNew));
             }
         }
+
+        [Fact]
+        public async void AddPkg_DevelopmentDependency()
+        {
+            // Arrange
+
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+                var packageX = XPlatTestUtils.CreatePackage(developmentDependency: true);
+
+                // Generate Package
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Since user is not inputing a version, it is converted to a "*"
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, "*", projectA, noVersion: true);
+                var commandRunner = new AddPackageReferenceCommandRunner();
+
+                // Act
+                var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
+                    .Result;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+
+                // Assert
+                Assert.Equal(0, result);
+
+                // Since user did not specify a version, the package reference will contain the resolved version
+                Assert.True(XPlatTestUtils.ValidateReference(projectXmlRoot, packageX.Id, "1.0.0", developmentDependency: true));
+            }
+        }
     }
 }

--- a/test/TestUtilities/Test.Utility/DebuggerUtils.cs
+++ b/test/TestUtilities/Test.Utility/DebuggerUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;


### PR DESCRIPTION
This is the updated version of https://github.com/NuGet/NuGet.Client/pull/1930 to support `developmentDependency` for `PackageReference`. Only change from last PR is to use `Exclude=Compile` instead of `Exclude=Runtime` which has also been tested with ASP.NET/ EF team.

Fixes https://github.com/NuGet/Home/issues/4125