### PR TITLE
fix signing and loc of pack nupkg

### DIFF
--- a/build/common.targets
+++ b/build/common.targets
@@ -24,13 +24,13 @@
   <ImportGroup Condition=" '$(SkipSigning)' != 'true' ">
     <Import Project="sign.targets" />
   </ImportGroup>
+  
   <PropertyGroup Condition="'$(Shipping)' == 'true'">
     <SignTargetsForRealSigning>GetBuildOutputWithSigningMetadata</SignTargetsForRealSigning>
     <SymbolTargetsToGetPdbs>GetDebugSymbolsProjectOutput</SymbolTargetsToGetPdbs>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Shipping)' == 'true'">
     <LocTargets>GetBuildOutputWithLocMetadata</LocTargets>
   </PropertyGroup>
+
   <!-- Write out .XML files for projects that will be packed. -->
   <PropertyGroup Condition=" '$(PackProject)' == 'true' ">
     <GenerateDocumentationFile Condition=" '$(GenerateDocumentationFile)' == '' ">true</GenerateDocumentationFile>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -100,11 +100,6 @@
     <Exec Command="$(IlmergeCommand)" ContinueOnError="false" />
   </Target>
   
-  <PropertyGroup>
-    <SignTargetsForRealSigning Condition="'$(IsSymbolsBuild)' != 'true'">GetIlmergeBuildOutput</SignTargetsForRealSigning>
-    <SymbolTargetsToGetPdbs>GetIlmergeSymbolOutput;GetFinalBuildOutput</SymbolTargetsToGetPdbs>
-  </PropertyGroup>
-  
   <!--These targets help get all the DLLs that are packed in the nuspec to be sent for signing.-->
   <Target Name="GetIlmergeBuildOutput" DependsOnTargets="ILMergeNuGetPackResourcesPerCulture;_GetDllsInOutputDirectory" Returns="@(DllsToSign)">
     <ItemGroup>
@@ -143,4 +138,10 @@
 
   <Import Project="$(BuildCommonDirectory)common.targets"/>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <SignTargetsForRealSigning Condition="'$(IsSymbolsBuild)' != 'true'">GetIlmergeBuildOutput</SignTargetsForRealSigning>
+    <SymbolTargetsToGetPdbs>GetIlmergeSymbolOutput;GetFinalBuildOutput</SymbolTargetsToGetPdbs>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
This was broken as a result of : https://github.com/NuGet/NuGet.Client/pull/2157

Since the targets were imported after the properties were overridden, it caused the overridden properties to be discarded.