### PR TITLE
Add XPlat build properties to NuGet.Credentials.

### DIFF
--- a/src/NuGet.Clients/NuGet.Credentials/NuGet.Credentials.csproj
+++ b/src/NuGet.Clients/NuGet.Credentials/NuGet.Credentials.csproj
@@ -4,10 +4,12 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">netstandard1.6</TargetFrameworks>
     <Shipping>true</Shipping>
     <PackProject>true</PackProject>
     <IncludeInVsix>true</IncludeInVsix>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <XPLATProject>true</XPLATProject>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Bug
Since the last source-build release, NuGet.Command has a new dependency on NuGet.Credentials (introduced in [e3a1c04fe2](https://github.com/NuGet/NuGet.Client/commit/e3a1c04fe24ca173abc5848e982f171b434606a4#diff-aa45b664821154d7562b7b6575d05bc6R27)).  This means that NuGet.Credentials must now also build under source-build.

## Fix
- Add check for `IsBuildOnlyXPLATProjects` to build only the XPlat version of NuGet.Credentials.
- Mark NuGet.Credentials as XPlat.

## Testing/Validation
Tests Added: No
Reason for not adding tests: Build process-only change that is tested by inclusion in source-build.
Validation done:  Built NuGet in source-build to ensure this change fixes the issue.
