### PR TITLE
Fixing localization path for NuGet.Credentials

### DIFF
--- a/src/NuGet.Clients/NuGet.Credentials/NuGet.Credentials.csproj
+++ b/src/NuGet.Clients/NuGet.Credentials/NuGet.Credentials.csproj
@@ -1,13 +1,19 @@
-﻿<Project>
+<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
+    <TargetFramework />
     <Shipping>true</Shipping>
     <PackProject>true</PackProject>
     <IncludeInVsix>true</IncludeInVsix>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
+    <TargetFrameworks />
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,6 +44,6 @@
     </Compile>
   </ItemGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>


### PR DESCRIPTION
Recent builds have NuGet.Credential's localized resources in tfm folders - 

![image](https://user-images.githubusercontent.com/10507120/39160534-a5df6ca8-4720-11e8-9f26-4b9d0c45f111.png)
