### PR TITLE
update to the right version of cli for tests

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -213,7 +213,7 @@ Function Install-DotnetCLI {
 
         Invoke-WebRequest $cli.DotNetInstallUrl -OutFile $DotNetInstall
 
-        & $DotNetInstall -Channel Master -i $cli.Root -Version 2.2.0-preview1-007853
+        & $DotNetInstall -Channel release/2.1.3xx -i $cli.Root
     }
 
     if (-not (Test-Path $cli.DotNetExe)) {

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -213,7 +213,7 @@ Function Install-DotnetCLI {
 
         Invoke-WebRequest $cli.DotNetInstallUrl -OutFile $DotNetInstall
 
-        & $DotNetInstall -Channel release/2.1.3xx -i $cli.Root
+        & $DotNetInstall -Channel release/2.1.4xx -i $cli.Root
     }
 
     if (-not (Test-Path $cli.DotNetExe)) {

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -56,7 +56,7 @@ Function InitializeAllTestsToPending {
     )
 
     Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Unit Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
-    if($env:RunFunctionalTestsOnWindows -ne "true")
+    if($env:RunFunctionalTestsOnWindows -eq "true")
     {
         Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
     } 
@@ -64,7 +64,7 @@ Function InitializeAllTestsToPending {
     {
         Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional Tests On Windows" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
     }
-    if($env:RunTestsOnMac -ne "true")
+    if($env:RunTestsOnMac -eq "true")
     {
         Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests On Mac" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
     } 
@@ -72,7 +72,7 @@ Function InitializeAllTestsToPending {
     {
         Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests On Mac" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
     }
-    if($env:RunTestsOnLinux -ne "true")
+    if($env:RunTestsOnLinux -eq "true")
     {
         Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests On Linux" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
     } 
@@ -80,7 +80,7 @@ Function InitializeAllTestsToPending {
     {
         Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Tests On Linux" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
     }
-    if($env:RunEndToEndTests -ne "true")
+    if($env:RunEndToEndTests -eq "true")
     {
         Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "EndToEnd Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
     } 
@@ -88,7 +88,7 @@ Function InitializeAllTestsToPending {
     {
         Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "EndToEnd Tests On Windows" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
     }
-    if($env:RunApexTests -ne "true")
+    if($env:RunApexTests -eq "true")
     {
         Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Apex Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
     } 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -34,6 +34,7 @@ namespace Dotnet.Integration.Test
             _processEnvVars.Add("MSBuildSDKsPath", MsBuildSdksPath);
             _processEnvVars.Add("UseSharedCompilation", "false");
             _processEnvVars.Add("DOTNET_MULTILEVEL_LOOKUP", "0");
+            _processEnvVars.Add("MSBUILDDISABLENODEREUSE ", "true");
             // We do this here so that dotnet new will extract all the packages on the first run on the machine.
             InitDotnetNewToExtractPackages();
         }
@@ -148,10 +149,6 @@ namespace Dotnet.Integration.Test
         /// </summary>
         internal CommandRunnerResult RunDotnet(string workingDirectory, string args)
         {
-            var envVar = new Dictionary<string, string>
-            {
-                { "MSBuildSDKsPath", MsBuildSdksPath }
-            };
 
             var result = CommandRunner.Run(TestDotnetCli,
                 workingDirectory,
@@ -329,6 +326,7 @@ namespace Dotnet.Integration.Test
 
         public void Dispose()
         {
+            RunDotnet(Path.GetDirectoryName(TestDotnetCli), "buildserver shutdown");
             KillDotnetExe(TestDotnetCli);
             DeleteDirectory(Path.GetDirectoryName(TestDotnetCli));
         }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -145,18 +145,8 @@ namespace Dotnet.Integration.Test
                 {
                     var xml = XDocument.Load(stream);
                     ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "netcoreapp1.0;net45");
-                    ProjectFileUtils.AddProperty(xml, "RuntimeIdentifier", "win7-x64");
 
                     var attributes = new Dictionary<string, string>();
-
-                    attributes["Version"] = "1.0.1";
-                    ProjectFileUtils.AddItem(
-                        xml,
-                        "PackageReference",
-                        "Microsoft.NETCore.App",
-                        "netcoreapp1.0",
-                        new Dictionary<string, string>(),
-                        attributes);
 
                     attributes["Version"] = "9.0.1";
                     ProjectFileUtils.AddItem(
@@ -200,7 +190,7 @@ namespace Dotnet.Integration.Test
                     Assert.Equal(1,
                         packagesA.Count);
                     Assert.Equal("Microsoft.NETCore.App", packagesA[0].Id);
-                    Assert.Equal(new VersionRange(new NuGetVersion("1.0.1")), packagesA[0].VersionRange);
+                    Assert.Equal(new VersionRange(new NuGetVersion("1.0.5")), packagesA[0].VersionRange);
                     Assert.Equal(new List<string> {"Analyzers", "Build"}, packagesA[0].Exclude);
                     Assert.Empty(packagesA[0].Include);
 
@@ -2431,20 +2421,25 @@ namespace ClassLibrary
 
                     ProjectFileUtils.AddProperty(xml, "RepositoryType", "git");
 
-                    // mock implementation of InitializeSourceControlInformation common targets:
-                    xml.Root.Add(
-                        new XElement(ns + "Target",
-                            new XAttribute("Name", "InitializeSourceControlInformation"),
-                            new XElement(ns + "PropertyGroup",
-                                new XElement("SourceRevisionId", "e1c65e4524cd70ee6e22abe33e6cb6ec73938cb1"),
-                                new XElement("PrivateRepositoryUrl", "https://github.com/NuGet/NuGet.Client.git"))));
-
                     xml.Root.Add(
                         new XElement(ns + "PropertyGroup",
                             new XElement("SourceControlInformationFeatureSupported", "true")));
 
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
+
+                // mock implementation of InitializeSourceControlInformation common targets:
+                var mockXml = @"<Project>
+<Target Name=""InitializeSourceControlInformation"">
+    <PropertyGroup>
+      <SourceRevisionId>e1c65e4524cd70ee6e22abe33e6cb6ec73938cb1</SourceRevisionId>
+      <PrivateRepositoryUrl>https://github.com/NuGet/NuGet.Client.git</PrivateRepositoryUrl>
+    </PropertyGroup>
+</Target>
+</Project>";
+
+                File.WriteAllText(Path.Combine(workingDirectory, "Directory.build.targets"), mockXml);
+
 
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
                 msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory}");
@@ -2488,20 +2483,24 @@ namespace ClassLibrary
                     ProjectFileUtils.AddProperty(xml, "RepositoryType", "git");
                     ProjectFileUtils.AddProperty(xml, "PublishRepositoryUrl", "true");
 
-                    // mock implementation of InitializeSourceControlInformation common targets:
-                    xml.Root.Add(
-                        new XElement(ns + "Target",
-                            new XAttribute("Name", "InitializeSourceControlInformation"),
-                            new XElement(ns + "PropertyGroup",
-                                new XElement("SourceRevisionId", "e1c65e4524cd70ee6e22abe33e6cb6ec73938cb1"),
-                                new XElement("PrivateRepositoryUrl", "https://github.com/NuGet/NuGet.Client.git"))));
-
                     xml.Root.Add(
                         new XElement(ns + "PropertyGroup",
                             new XElement("SourceControlInformationFeatureSupported", "true")));
 
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
+
+                // mock implementation of InitializeSourceControlInformation common targets:
+                var mockXml = @"<Project>
+<Target Name=""InitializeSourceControlInformation"">
+    <PropertyGroup>
+      <SourceRevisionId>e1c65e4524cd70ee6e22abe33e6cb6ec73938cb1</SourceRevisionId>
+      <PrivateRepositoryUrl>https://github.com/NuGet/NuGet.Client.git</PrivateRepositoryUrl>
+    </PropertyGroup>
+</Target>
+</Project>";
+
+                File.WriteAllText(Path.Combine(workingDirectory, "Directory.build.targets"), mockXml);
 
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
                 msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory}");


### PR DESCRIPTION
we have been using the wrong version of cli (from the master branch and fixed version). This pr changes so that dev (currently targeting 15.8) will use release/2.1.4xx which will ship with 15.8 in-box.