### PR TITLE
Fix NU1103 message in the floating case with no lower and upper bounds

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
@@ -230,26 +230,12 @@ namespace NuGet.Commands
             NuGetVersion bestMatch = null;
             if (range != null)
             {
-                // There's a caveat with the way we display this for floating versions, as the nearest version is not necesarilly the best selectable version.
-                // We might need to amend the message for floating version
-                // clarify what nearest means for floating versions really....probably easiest to just get the highest one.
-                if (range.HasUpperBound)
-                {
-                    ideal = range.MaxVersion;
-                }
-
-                if (range.HasLowerBound)
-                {
-                    ideal = range.MinVersion;
-                    // Take the lowest version higher than the pivot if one exists.
-                    bestMatch = versions.Where(e => e >= ideal).FirstOrDefault();
-                }
-
                 if (range.IsFloating)
                 {
                     if (range.HasUpperBound)
                     {
-                        // Take the highest version higher than the pivot if one exists.
+                        ideal = range.MaxVersion;
+                        // Take the highest version that falls into the range
                         bestMatch = versions.Where(e => e <= ideal).LastOrDefault();
                     }
                     else
@@ -258,12 +244,22 @@ namespace NuGet.Commands
                         bestMatch = versions.Last();
                     }
                 }
-            }
+                else
+                {
+                    if (range.HasLowerBound)
+                    {
+                        ideal = range.MinVersion;
+                    }
 
-            if (bestMatch == null)
-            {
-                // Take the highest possible version.
-                bestMatch = versions.Last();
+                    // Take the lowest version higher than the pivot if one exists.
+                    bestMatch = versions.Where(e => e >= ideal).FirstOrDefault();
+
+                    if (bestMatch == null)
+                    {
+                        // Take the highest possible version.
+                        bestMatch = versions.Last();
+                    }
+                }
             }
 
             return bestMatch;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
@@ -230,27 +230,18 @@ namespace NuGet.Commands
             NuGetVersion bestMatch = null;
             if (range != null)
             {
-                if (range.IsFloating)
+                if (range.HasUpperBound)
                 {
-                    if (range.HasUpperBound)
-                    {
-                        ideal = range.MaxVersion;
-                        // Take the highest version that falls into the range
-                        bestMatch = versions.Where(e => e >= ideal).FirstOrDefault();
-                    }
+                    ideal = range.MaxVersion;
                 }
-                else
+
+                if (range.HasLowerBound)
                 {
-                    if (range.HasUpperBound)
-                    {
-                        ideal = range.MaxVersion;
-                    }
+                    ideal = range.MinVersion;
+                }
 
-                    if (range.HasLowerBound)
-                    {
-                        ideal = range.MinVersion;
-                    }
-
+                if (!range.IsFloating || range.HasLowerBound || range.HasUpperBound)
+                {
                     // Take the lowest version higher than the pivot if one exists.
                     bestMatch = versions.Where(e => e >= ideal).FirstOrDefault();
                 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -227,9 +227,12 @@ namespace NuGet.Commands
 
             // Find a pivot point
             var ideal = new NuGetVersion(0, 0, 0);
-
+            NuGetVersion bestMatch = null;
             if (range != null)
             {
+                // There's a caveat with the way we display this for floating versions, as the nearest version is not necesarilly the best selectable version.
+                // We might need to amend the message for floating version
+                // clarify what nearest means for floating versions really....probably easiest to just get the highest one.
                 if (range.HasUpperBound)
                 {
                     ideal = range.MaxVersion;
@@ -238,11 +241,24 @@ namespace NuGet.Commands
                 if (range.HasLowerBound)
                 {
                     ideal = range.MinVersion;
+                    // Take the lowest version higher than the pivot if one exists.
+                    bestMatch = versions.Where(e => e >= ideal).FirstOrDefault();
+                }
+
+                if (range.IsFloating)
+                {
+                    if (range.HasUpperBound)
+                    {
+                        // Take the highest version higher than the pivot if one exists.
+                        bestMatch = versions.Where(e => e <= ideal).LastOrDefault();
+                    }
+                    else
+                    {
+                        // If it's floating without an upper bound
+                        bestMatch = versions.Last();
+                    }
                 }
             }
-
-            // Take the lowest version higher than the pivot if one exists.
-            var bestMatch = versions.Where(e => e >= ideal).FirstOrDefault();
 
             if (bestMatch == null)
             {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
@@ -236,16 +236,16 @@ namespace NuGet.Commands
                     {
                         ideal = range.MaxVersion;
                         // Take the highest version that falls into the range
-                        bestMatch = versions.Where(e => e <= ideal).LastOrDefault();
-                    }
-                    else
-                    {
-                        // If it's floating without an upper bound
-                        bestMatch = versions.Last();
+                        bestMatch = versions.Where(e => e >= ideal).FirstOrDefault();
                     }
                 }
                 else
                 {
+                    if (range.HasUpperBound)
+                    {
+                        ideal = range.MaxVersion;
+                    }
+
                     if (range.HasLowerBound)
                     {
                         ideal = range.MinVersion;
@@ -253,12 +253,12 @@ namespace NuGet.Commands
 
                     // Take the lowest version higher than the pivot if one exists.
                     bestMatch = versions.Where(e => e >= ideal).FirstOrDefault();
+                }
 
-                    if (bestMatch == null)
-                    {
-                        // Take the highest possible version.
-                        bestMatch = versions.Last();
-                    }
+                if (bestMatch == null)
+                {
+                    // Take the highest possible version.
+                    bestMatch = versions.Last();
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
@@ -239,18 +239,18 @@ namespace NuGet.Commands
                 {
                     ideal = range.MinVersion;
                 }
+            }
 
-                if (!range.IsFloating || range.HasLowerBound || range.HasUpperBound)
-                {
-                    // Take the lowest version higher than the pivot if one exists.
-                    bestMatch = versions.Where(e => e >= ideal).FirstOrDefault();
-                }
+            if (!range.IsFloating || range.HasLowerBound || range.HasUpperBound)
+            {
+                // Take the lowest version higher than the pivot if one exists.
+                bestMatch = versions.Where(e => e >= ideal).FirstOrDefault();
+            }
 
-                if (bestMatch == null)
-                {
-                    // Take the highest possible version.
-                    bestMatch = versions.Last();
-                }
+            if (bestMatch == null)
+            {
+                // Take the highest possible version.
+                bestMatch = versions.Last();
             }
 
             return bestMatch;

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/UnresolvedMessagesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/UnresolvedMessagesTests.cs
@@ -278,6 +278,17 @@ namespace NuGet.Commands.Test
             UnresolvedMessages.GetBestMatch(versions, range).ShouldBeEquivalentTo(NuGetVersion.Parse(expected));
         }
 
+        [Theory]
+        [InlineData("1.*", "1.1.0", "0.1.0,1.0.0,1.0.1,1.1.0")]
+        [InlineData("[1.*,2.0.0-0)", "1.1.0", "0.1.0,1.0.0,1.0.1,1.1.0")]
+        public void GivenVersionRangeVerifyBestMatch(string versionRange, string expectedVersion, string versionStrings)
+        {
+            var range = VersionRange.Parse(versionRange);
+            var versions = new SortedSet<NuGetVersion>(versionStrings.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(NuGetVersion.Parse));
+
+            UnresolvedMessages.GetBestMatch(versions, range).ShouldBeEquivalentTo(NuGetVersion.Parse(expectedVersion));
+        }
+
         [Fact]
         public void GivenNoVersionsVerifyBestMatch()
         {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/UnresolvedMessagesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/UnresolvedMessagesTests.cs
@@ -278,18 +278,22 @@ namespace NuGet.Commands.Test
             UnresolvedMessages.GetBestMatch(versions, range).ShouldBeEquivalentTo(NuGetVersion.Parse(expected));
         }
 
-        // ACtually these make no sense. There should be no values in the range specified
+        // Actually these make no sense. There should be no values in the range specified
         [Theory]
-        [InlineData("[1.*,2.0.0]", "2.0.0", "0.1.0,1.0.0,1.0.1,1.1.0,2.0.0")] // has LowerBound, has UpperBound, floating - inclusivity doesn't matter for this command as it's not selecting assets.
-        [InlineData("(1.0.1,2.0.0]", "1.0.1", "0.1.0,1.0.0,1.0.1,1.1.0,2.0.0")] // has LowerBound, has UpperBound, not floating
-        [InlineData("(,2.0.0]", "0.1.0", "0.1.0,1.0.0,1.0.1,1.1.0,2.0.0")] // no LowerBound, has UpperBound, not floating, TODO NK - is lowest ok? Make sense in production code? => no LowerBound, has UpperBound, floating is not a valid scenario
-        [InlineData("[1.*,)", "2.0.0", "0.1.0,1.0.0,1.0.1,1.1.0,2.0.0")] // lower bound, no upper bound, floating
-        [InlineData("[1.0.0,)", "1.0.0", "0.1.0,1.0.0,1.0.1,1.1.0,2.0.0")] // lower bound, no upper bound, no floating
-        [InlineData("1.*", "1.1.0", "0.1.0,1.0.0,1.0.1,1.1.0")]
+        // TODO NK - this is broken...it'll look for the first version under the range
+        [InlineData("[1.*,2.0.0]", "3.0.0", "0.1.0,0.3.0,0.9.9,3.0.0")] // has LowerBound, has UpperBound, floating - inclusivity doesn't matter for this command as it's not selecting assets.
+        // Lowest version higher than the pivot makes sense here
+        [InlineData("(1.0.1,2.0.0]", "3.0.0", "0.1.0,0.3.0,0.9.9,3.0.0")] // has LowerBound, has UpperBound, not floating
+        // Here we go at to the next higher available version
+        [InlineData("(,2.0.0]", "2.0.1", "2.0.1,2.5.0,3.0.0")] // no LowerBound, has UpperBound, not floating, TODO NK - is lowest ok? Make sense in production code? => no LowerBound, has UpperBound, floating is not a valid scenario
+         // if it has a lower bound, it's always the one under
+        [InlineData("[1.*,)", "0.9", "0.0.1, 0.0.5, 0.1,0.9")] // lower bound, no upper bound, floating
+        [InlineData("[1.0.0,)", "0.9", "0.0.1, 0.0.5, 0.1,0.9")] // lower bound, no upper bound, no floating
         public void GivenVersionRangeVerifyBestMatch(string versionRange, string expectedVersion, string versionStrings)
         {
             var range = VersionRange.Parse(versionRange);
             var versions = new SortedSet<NuGetVersion>(versionStrings.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(NuGetVersion.Parse));
+            Assert.Null(range.FindBestMatch(versions));
             UnresolvedMessages.GetBestMatch(versions, range).ShouldBeEquivalentTo(NuGetVersion.Parse(expectedVersion));
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/UnresolvedMessagesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/UnresolvedMessagesTests.cs
@@ -278,17 +278,14 @@ namespace NuGet.Commands.Test
             UnresolvedMessages.GetBestMatch(versions, range).ShouldBeEquivalentTo(NuGetVersion.Parse(expected));
         }
 
-        // Actually these make no sense. There should be no values in the range specified
         [Theory]
-        // TODO NK - this is broken...it'll look for the first version under the range
+        // Any time there is a upper bound, we go to the first version above the upper bound
         [InlineData("[1.*,2.0.0]", "3.0.0", "0.1.0,0.3.0,0.9.9,3.0.0")] // has LowerBound, has UpperBound, floating - inclusivity doesn't matter for this command as it's not selecting assets.
-        // Lowest version higher than the pivot makes sense here
         [InlineData("(1.0.1,2.0.0]", "3.0.0", "0.1.0,0.3.0,0.9.9,3.0.0")] // has LowerBound, has UpperBound, not floating
-        // Here we go at to the next higher available version
-        [InlineData("(,2.0.0]", "2.0.1", "2.0.1,2.5.0,3.0.0")] // no LowerBound, has UpperBound, not floating, TODO NK - is lowest ok? Make sense in production code? => no LowerBound, has UpperBound, floating is not a valid scenario
+        [InlineData("(,2.0.0]", "2.0.1", "2.0.1,2.5.0,3.0.0")] // no LowerBound, has UpperBound, not floating => no LowerBound, has UpperBound, floating is not a valid scenario
          // if it has a lower bound, it's always the one under
-        [InlineData("[1.*,)", "0.9", "0.0.1, 0.0.5, 0.1,0.9")] // lower bound, no upper bound, floating
-        [InlineData("[1.0.0,)", "0.9", "0.0.1, 0.0.5, 0.1,0.9")] // lower bound, no upper bound, no floating
+        [InlineData("[1.*,)", "0.9", "0.0.1,0.0.5,0.1,0.9")] // lower bound, no upper bound, floating
+        [InlineData("[1.0.0,)", "0.9", "0.0.1,0.0.5,0.1,0.9")] // lower bound, no upper bound, no floating
         public void GivenVersionRangeVerifyBestMatch(string versionRange, string expectedVersion, string versionStrings)
         {
             var range = VersionRange.Parse(versionRange);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/UnresolvedMessagesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/UnresolvedMessagesTests.cs
@@ -284,8 +284,9 @@ namespace NuGet.Commands.Test
         [InlineData("(1.0.1,2.0.0]", "3.0.0", "0.1.0,0.3.0,0.9.9,3.0.0")] // has LowerBound, has UpperBound, not floating
         [InlineData("(,2.0.0]", "2.0.1", "2.0.1,2.5.0,3.0.0")] // no LowerBound, has UpperBound, not floating => no LowerBound, has UpperBound, floating is not a valid scenario
          // if it has a lower bound, it's always the one under
-        [InlineData("[1.*,)", "0.9", "0.0.1,0.0.5,0.1,0.9")] // lower bound, no upper bound, floating
         [InlineData("[1.0.0,)", "0.9", "0.0.1,0.0.5,0.1,0.9")] // lower bound, no upper bound, no floating
+        [InlineData("[1.*,)", "0.9", "0.0.1,0.0.5,0.1,0.9")] // lower bound, no upper bound, floating
+        [InlineData("*", "2.1.0-preview1-final", "0.0.1-alpha,2.1.0-preview1-final")] // lower bound, no upper bound, floating
         public void GivenVersionRangeVerifyBestMatch(string versionRange, string expectedVersion, string versionStrings)
         {
             var range = VersionRange.Parse(versionRange);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/UnresolvedMessagesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/UnresolvedMessagesTests.cs
@@ -278,14 +278,18 @@ namespace NuGet.Commands.Test
             UnresolvedMessages.GetBestMatch(versions, range).ShouldBeEquivalentTo(NuGetVersion.Parse(expected));
         }
 
+        // ACtually these make no sense. There should be no values in the range specified
         [Theory]
+        [InlineData("[1.*,2.0.0]", "2.0.0", "0.1.0,1.0.0,1.0.1,1.1.0,2.0.0")] // has LowerBound, has UpperBound, floating - inclusivity doesn't matter for this command as it's not selecting assets.
+        [InlineData("(1.0.1,2.0.0]", "1.0.1", "0.1.0,1.0.0,1.0.1,1.1.0,2.0.0")] // has LowerBound, has UpperBound, not floating
+        [InlineData("(,2.0.0]", "0.1.0", "0.1.0,1.0.0,1.0.1,1.1.0,2.0.0")] // no LowerBound, has UpperBound, not floating, TODO NK - is lowest ok? Make sense in production code? => no LowerBound, has UpperBound, floating is not a valid scenario
+        [InlineData("[1.*,)", "2.0.0", "0.1.0,1.0.0,1.0.1,1.1.0,2.0.0")] // lower bound, no upper bound, floating
+        [InlineData("[1.0.0,)", "1.0.0", "0.1.0,1.0.0,1.0.1,1.1.0,2.0.0")] // lower bound, no upper bound, no floating
         [InlineData("1.*", "1.1.0", "0.1.0,1.0.0,1.0.1,1.1.0")]
-        [InlineData("[1.*,2.0.0-0)", "1.1.0", "0.1.0,1.0.0,1.0.1,1.1.0")]
         public void GivenVersionRangeVerifyBestMatch(string versionRange, string expectedVersion, string versionStrings)
         {
             var range = VersionRange.Parse(versionRange);
             var versions = new SortedSet<NuGetVersion>(versionStrings.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(NuGetVersion.Parse));
-
             UnresolvedMessages.GetBestMatch(versions, range).ShouldBeEquivalentTo(NuGetVersion.Parse(expectedVersion));
         }
 


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6658
Regression: No  
If Regression then when did it last work:   Never
If Regression then how are we preventing it in future:   Adding tests

## Fix
Details: 

As the issue says, if you have a floating version without an upper bound, then we will pick the lowest version below the pivot instead of the highest. 
The only time a floating version would not be able to resolve anything is when it's only prerelease versions available, or all the values are under the lower bound. 

The lower bound case was covered, the * case wasn't. 

Here's a table of the behavior.

| Requested        | Closest unresolved           | Available  |
| ------------- |:-------------:| -----:|
| [1.*,2.0.0] | 3.0.0 | 0.1.0,0.3.0,0.9.9,3.0.0 |
| (1.0.1,2.0.0] | 3.0.0 | 0.1.0,0.3.0,0.9.9,3.0.0 |
| (,2.0.0] | 2.0.1 | 2.0.1,2.5.0,3.0.0 |
| [1.*,) | 0.9 | 0.0.1,0.0.5,0.1,0.9 |
| [1.0.0,) | 0.9 | 0.0.1,0.0.5,0.1,0.9 |
| * | 2.1.0-preview1-final | 0.0.1-alpha,2.1.0-preview1-final |


## Testing/Validation
Tests Added: Yes  
Reason for not adding tests:  
Validation done: Tests

//cc @wli3 @natemcmaster 