### PR TITLE
Respect the user's package format selection when creating new projects

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
@@ -64,7 +64,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public async Task<NuGetProject> TryCreateNuGetProjectAsync(
             IVsProjectAdapter vsProjectAdapter,
-            ProjectProviderContext _,
+            ProjectProviderContext context,
             bool forceProjectType)
         {
             Assumes.Present(vsProjectAdapter);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/NuGetProjectUpgradeUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/NuGetProjectUpgradeUtility.cs
@@ -34,7 +34,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 VsProjectTypes.WebSiteProjectTypeGuid
             };
 
-        public static async Task<bool> IsNuGetProjectUpgradeableAsync(NuGetProject nuGetProject, Project envDTEProject = null)
+        public static async Task<bool> IsNuGetProjectUpgradeableAsync(NuGetProject nuGetProject, Project envDTEProject = null, bool needsAPackagesConfig = true)
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
@@ -43,22 +43,16 @@ namespace NuGet.PackageManagement.VisualStudio
                 return false;
             }
 
+            nuGetProject = nuGetProject ?? await GetNuGetProject(envDTEProject);
+
             if (nuGetProject == null)
             {
-                var solutionManager = ServiceLocator.GetInstance<IVsSolutionManager>();
-
-                var projectSafeName = await EnvDTEProjectInfoUtility.GetCustomUniqueNameAsync(envDTEProject);
-                nuGetProject = await solutionManager.GetNuGetProjectAsync(projectSafeName);
-
-                if (nuGetProject == null)
-                {
-                    return false;
-                }
+                return false;
             }
 
             // check if current project is packages.config based or not
             var msBuildNuGetProject = nuGetProject as MSBuildNuGetProject;
-            if (msBuildNuGetProject == null || !msBuildNuGetProject.PackagesConfigNuGetProject.PackagesConfigExists())
+            if (msBuildNuGetProject == null || (!msBuildNuGetProject.PackagesConfigNuGetProject.PackagesConfigExists() && needsAPackagesConfig))
             {
                 return false;
             }
@@ -85,7 +79,22 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 return false;
             }
-            var projectGuids = VsHierarchyUtility.GetProjectTypeGuids(envDTEProject);
+
+            return IsProjectPackageReferenceCompatible(envDTEProject);
+        }
+
+        private static async Task<NuGetProject> GetNuGetProject(Project envDTEProject)
+        {
+            var solutionManager = ServiceLocator.GetInstance<IVsSolutionManager>();
+
+            var projectSafeName = await EnvDTEProjectInfoUtility.GetCustomUniqueNameAsync(envDTEProject);
+            var nuGetProject = await solutionManager.GetNuGetProjectAsync(projectSafeName);
+            return nuGetProject;
+        }
+
+        private static bool IsProjectPackageReferenceCompatible(Project project)
+        {
+            var projectGuids = VsHierarchyUtility.GetProjectTypeGuids(project);
 
             if (projectGuids.Any(t => UnupgradeableProjectTypes.Contains(t)))
             {
@@ -93,7 +102,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             // Project is supported language, and not an unsupported type
-            return UpgradeableProjectTypes.Contains(envDTEProject.Kind) &&
+            return UpgradeableProjectTypes.Contains(project.Kind) &&
                    projectGuids.All(projectTypeGuid => !SupportedProjectTypes.IsUnsupported(projectTypeGuid));
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/PreinstalledPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/PreinstalledPackageInstaller.cs
@@ -149,6 +149,7 @@ namespace NuGet.VisualStudio
         /// their installation.
         /// </param>
         /// <param name="repositorySettings">The repository settings for the packages being installed.</param>
+        /// <param name="preferPackageReferenceFormat">Install packages to the project as PackageReference if the project type supports it</param>
         /// <param name="warningHandler">
         /// An action that accepts a warning message and presents it to the user, allowing
         /// execution to continue.
@@ -173,9 +174,8 @@ namespace NuGet.VisualStudio
 
             // find the project
             var defaultProjectContext = new VSAPIProjectContext();
-
             var nuGetProject = await _solutionManager.GetOrCreateProjectAsync(project, defaultProjectContext);
-            if (preferPackageReferenceFormat && await NuGetProjectUpgradeUtility.IsNuGetProjectUpgradeableAsync(nuGetProject, project, false))
+            if (preferPackageReferenceFormat && await NuGetProjectUpgradeUtility.IsNuGetProjectUpgradeableAsync(nuGetProject, project, needsAPackagesConfig: false))
             {
                 nuGetProject = await _solutionManager.UpgradeProjectToPackageReferenceAsync(nuGetProject);
             }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VsTemplateWizard.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VsTemplateWizard.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -266,9 +266,12 @@ namespace NuGet.VisualStudio
             {
                 if (configuration.Packages.Any())
                 {
+                    var packageManagementFormat = new PackageManagementFormat(_settings);
+                    
                     await _preinstalledPackageInstaller.PerformPackageInstallAsync(_installer,
                         project,
                         configuration,
+                        packageManagementFormat.SelectedPackageManagementFormat == 1,
                         ShowWarningMessage,
                         ShowErrorMessage);
                 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VsTemplateWizard.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VsTemplateWizard.cs
@@ -267,11 +267,12 @@ namespace NuGet.VisualStudio
                 if (configuration.Packages.Any())
                 {
                     var packageManagementFormat = new PackageManagementFormat(_settings);
-                    
+                    // 1 means PackageReference
+                    var preferPackageReference = packageManagementFormat.SelectedPackageManagementFormat == 1;
                     await _preinstalledPackageInstaller.PerformPackageInstallAsync(_installer,
                         project,
                         configuration,
-                        packageManagementFormat.SelectedPackageManagementFormat == 1,
+                        preferPackageReference,
                         ShowWarningMessage,
                         ShowErrorMessage);
                 }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6736
Regression: No  
If Regression then when did it last work:   Never worked, missed in PR
If Regression then how are we preventing it in future:   

## Fix
Details: 
Respect the customer's selected default package management format during template creation if the given project template supports Package Reference

## Testing/Validation
Tests Added: Not yet.
Reason for not adding tests: Will add tests in this PR soon. Just wanted to get eyes on the logic.  
Validation done:  Manual, will add automated tests. 
