### PR TITLE
Fix caching when RestoreSources are set as a property

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -12,6 +12,7 @@ using NuGet.Packaging;
 using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
+using NuGet.Shared;
 
 namespace NuGet.Commands
 {
@@ -122,8 +123,13 @@ namespace NuGet.Commands
             {
                 throw new ArgumentNullException(nameof(settings));
             }
+            var values = settings.Priority.Select(e => e.Root).AsList();
+            if(dgSpecSources != null)
+            {
+                values.AddRange(dgSpecSources.Select(e => e.Source));
+            }
 
-            var cacheKey = string.Join("|", settings.Priority.Select(e => e.Root));
+            var cacheKey = string.Join("|", values);
 
             return _sourcesCache.GetOrAdd(cacheKey, (root) => GetEffectiveSourcesCore(settings, dgSpecSources));
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -5506,9 +5506,9 @@ namespace NuGet.CommandLine.Test
                 Directory.GetDirectories(pathContext.UserPackagesFolder).Should().BeEmpty();
             }
         }
-
+        // The scenario here is 2 different projects are setting RestoreSources, and the caching of the sources takes this into consideration
         [Fact]
-        public async Task RestoreNetCore_VerifySourcesResolvedAgainstProjectPropertyAsync()
+        public async Task RestoreNetCore_VerifySourcesResolvedCorrectlyForMultipleProjectsAsync()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -5573,9 +5573,8 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        // The scenario here is 2 different projects are setting RestoreSources, and the caching of the sources takes this into consideration
         [Fact]
-        public async Task RestoreNetCore_VerifySourcesResolvedCorrectlyForMultipleProjects()
+        public async Task RestoreNetCore_VerifySourcesResolvedAgainstProjectPropertyAsync()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6776
Regression: No
If Regression then when did it last work:
If Regression then how are we preventing it in future:   Tests

## Fix
Details:
When we cache the sources we need to consider the values set in the RestoreSources property. 

## Testing/Validation
Tests Added: Yes
Reason for not adding tests:  
Validation done:  
