### PR TITLE
allow empty nuspec property values

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -739,12 +739,19 @@ namespace NuGet.Build.Tasks.Pack
             var dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (var item in properties)
             {
-                int index = item.IndexOf("=");
+                var index = item.IndexOf("=");
                 // Make sure '=' is not the first or the last character of the string
                 if (index > 0 && index < item.Length - 1)
                 {
                     var key = item.Substring(0, index);
                     var value = item.Substring(index + 1);
+                    dictionary[key] = value;
+                }
+                // if value is empty string, set it to string.Empty instead of erroring out
+                else if (index == item.Length - 1)
+                {
+                    var key = item.Substring(0, index);
+                    var value = string.Empty;
                     dictionary[key] = value;
                 }
                 else

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -713,20 +713,24 @@ namespace Dotnet.Integration.Test
         }
 
         [PlatformTheory(Platform.Windows)]
-        // Command line : /p:NuspecProperties=\"id=MyPackage;version=1.2.3;description="hello world"\"
-        [InlineData("/p:NuspecProperties=\\\"id=MyPackage;version=1.2.3;description=\"hello world\"\\\"", "MyPackage",
-            "1.2.3", "hello world")]
-        // Command line : /p:NuspecProperties=\"id=MyPackage;version=1.2.3;description="hello = world"\"
-        [InlineData("/p:NuspecProperties=\\\"id=MyPackage;version=1.2.3;description=\"hello = world\"\\\"", "MyPackage",
-            "1.2.3", "hello = world")]
-        // Command line : /p:NuspecProperties=\"id=MyPackage;version=1.2.3;description="hello = world with a %3B"\"
-        [InlineData("/p:NuspecProperties=\\\"id=MyPackage;version=1.2.3;description=\"hello = world with a %3B\"\\\"",
-            "MyPackage", "1.2.3", "hello = world with a ;")]
+        // Command line : /p:NuspecProperties=\"id=MyPackage;version=1.2.3;tags=tag1;description="hello world"\"
+        [InlineData("/p:NuspecProperties=\\\"id=MyPackage;version=1.2.3;tags=tag1;description=\"hello world\"\\\"", "MyPackage",
+            "1.2.3", "hello world", "tag1")]
+        // Command line : /p:NuspecProperties=\"id=MyPackage;version=1.2.3;tasg=tag1,tag2;description=""\"
+        [InlineData("/p:NuspecProperties=\\\"id=MyPackage;version=1.2.3;tags=tag1,tag2;description=\"hello world\"\\\"", "MyPackage",
+            "1.2.3", "hello world", "tag1,tag2")]
+        // Command line : /p:NuspecProperties=\"id=MyPackage;version=1.2.3;tags=;description="hello = world"\"
+        [InlineData("/p:NuspecProperties=\\\"id=MyPackage;version=1.2.3;tags=;description=\"hello = world\"\\\"", "MyPackage",
+            "1.2.3", "hello = world","")]
+        // Command line : /p:NuspecProperties=\"id=MyPackage;version=1.2.3;tags="";description="hello = world with a %3B"\"
+        [InlineData("/p:NuspecProperties=\\\"id=MyPackage;version=1.2.3;tags=\"\";description=\"hello = world with a %3B\"\\\"",
+            "MyPackage", "1.2.3", "hello = world with a ;","")]
         public void PackCommand_PackProject_PacksFromNuspecWithTokenSubstitution(
             string nuspecProperties,
             string expectedId,
             string expectedVersion,
-            string expectedDescription
+            string expectedDescription,
+            string expectedTags
             )
         {
             var nuspecFileContent = @"<?xml version=""1.0""?>
@@ -736,6 +740,7 @@ namespace Dotnet.Integration.Test
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>NuGet</owners>
+    <tags>$tags$</tags>
     <description>$description$</description>
   </metadata>
   <files>
@@ -768,6 +773,7 @@ namespace Dotnet.Integration.Test
                     Assert.Equal("Microsoft", nuspecReader.GetAuthors());
                     Assert.Equal("NuGet", nuspecReader.GetOwners());
                     Assert.Equal(expectedDescription, nuspecReader.GetDescription());
+                    Assert.Equal(expectedTags, nuspecReader.GetTags());
                     Assert.False(nuspecReader.GetRequireLicenseAcceptance());
 
                     // Validate the assets.


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/6722

This allows passing empty tokens to nuspec when being packed via a csproj using dotnet.exe or msbuild /t:pack

CC: @natemcmaster 