### PR TITLE
Updating localization validator to v2.0.0

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -20,7 +20,7 @@
   <package id="VSLangProj150" version="1.0.0" targetFramework="net46" />
   <package id="xunit.runner.console" version="2.3.1" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" />
-  <package id="NuGetValidator" version="1.3.7" targetFramework="net461" />
+  <package id="NuGetValidator" version="2.0.0" targetFramework="net461" />
   <package id="XunitXml.TestLogger" version="2.0.0" />
   <package id="Microsoft.DotNet.Build.Tasks.Feed" version="2.1.0-prerelease-02419-02" />   <!-- For the .NET Core orchestrated build.-->
 </packages>

--- a/scripts/cibuild/BuildValidator.ps1
+++ b/scripts/cibuild/BuildValidator.ps1
@@ -27,7 +27,7 @@ if ($BuildRTM -eq 'false')
 {   
 
     $NuGetClientRoot = $env:BUILD_REPOSITORY_LOCALPATH
-    $NuGetValidator = [System.IO.Path]::Combine($NuGetClientRoot, 'packages', 'NuGetValidator.1.3.7', 'tools', 'NuGetValidator.exe')
+    $NuGetValidator = [System.IO.Path]::Combine($NuGetClientRoot, 'packages', 'NuGetValidator.2.0.0', 'tools', 'NuGetValidator.exe')
     $VsixLogOutputDir = [System.IO.Path]::Combine($BuildOutputTargetPath, 'LocalizationValidation', 'vsix' )
     $LocalizationRepository = [System.IO.Path]::Combine($NuGetClientRoot, 'submodules', 'NuGet.Build.Localization', 'localize', 'comments', '15')
     
@@ -51,6 +51,6 @@ if ($BuildRTM -eq 'false')
         & $NuGetValidator localization --artifacts-path $ArtifactsLocation --output-path $ArtifactsLogOutputDir --comments-path $LocalizationRepository
     }
 
-    # We want to exit the process with success even if there are errors.
-    exit 0
+    # return the exit code from the validator
+    exit $LASTEXITCODE
 }


### PR DESCRIPTION
## Fix
Details: Updating the loc validation tool. The tool has been [updated](https://github.com/NuGet/Entropy/pull/9) in  2 aspects - 

1. Add additional validation step to assert that NuGet dlls in the vsix have all the necessary localized resource dlls in known paths. This will prevent future cases of issue fixed by https://github.com/NuGet/NuGet.Client/commit/1d3aa71b4a437456feb87fb7282c32edb9d882f5
2. Write output files in json format to make them machine parseable


## Testing/Validation
Validation done:  Running validation tool in a separate private branch's [build](https://devdiv.visualstudio.com/DevDiv/NuGet/_build/index?buildId=1628975)
