### PR TITLE
 fix null reference exception when no nuspec file is specified

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -274,7 +274,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
   </Target>
   
-  <Target Name="_GetProjectReferenceVersions" DependsOnTargets="_CalculateInputsOutputsForPack;$(GetPackageVersionDependsOn)">
+  <Target Name="_GetProjectReferenceVersions" 
+          Condition="'$(NuspecFile)' == ''"
+          DependsOnTargets="_CalculateInputsOutputsForPack;$(GetPackageVersionDependsOn)">
     <ConvertToAbsolutePath Paths="$(RestoreOutputPath)">
       <Output TaskParameter="AbsolutePaths" PropertyName="RestoreOutputAbsolutePath" />
     </ConvertToAbsolutePath>

--- a/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
@@ -69,7 +69,8 @@ namespace NuGet.Commands
                 MachineWideSettings = packArgs.MachineWideSettings,
                 Build = false,
                 PackTargetArgs = packArgs.PackTargetArgs,
-                Files = new HashSet<ManifestFile>()
+                Files = new HashSet<ManifestFile>(),
+                ProjectProperties = new Dictionary<string, string>()
             };
         }
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4649
Fixes: https://github.com/NuGet/Home/issues/6866

If NuspecProperties was specified in csproj without specifying the NuspecFile property, the PackTask would throw a null ref exception. This change fixes it.

This also fixes the fact that you don't need to pass ```IncludeBuildOutput=false``` when packing via a nuspec and ```--no-build``` . 

Turns out , restore is needed by another component. See comment :https://github.com/NuGet/Home/issues/6866#issuecomment-384485270