### PR TITLE
Add unit and functional tests to mmsign and reposign commands

### DIFF
--- a/NuGet.sln
+++ b/NuGet.sln
@@ -218,7 +218,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.MSSigning.Extensions"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.StaFact", "test\TestExtensions\NuGet.StaFact\NuGet.StaFact.csproj", "{5704AFAE-94ED-4AC9-979F-28A6DF8DF4DF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Shared.Tests", "test\NuGet.Core.Tests\NuGet.Shared.Tests\NuGet.Shared.Tests.csproj", "{21522CF8-12F2-4A30-94D5-6C794D4B043F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Shared.Tests", "test\NuGet.Core.Tests\NuGet.Shared.Tests\NuGet.Shared.Tests.csproj", "{21522CF8-12F2-4A30-94D5-6C794D4B043F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.MSSigning.Extensions.FuncTest", "test\NuGet.Clients.FuncTests\NuGet.MSSigning.Extensions.FuncTest\NuGet.MSSigning.Extensions.FuncTest.csproj", "{BA7F681E-FDC7-42B6-8BF1-74DA6421BA1A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.MSSigning.Extensions.Test", "test\NuGet.Clients.Tests\NuGet.MSSigning.Extensions.Test\NuGet.MSSigning.Extensions.Test.csproj", "{2A604A43-C72A-4A03-B68B-66AF4B6F430E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Build.NuGetSdkResolver", "src\NuGet.Core\Microsoft.Build.NuGetSdkResolver\Microsoft.Build.NuGetSdkResolver.csproj", "{299B3E44-5372-4D6B-A4E9-3DBEA4705701}"
 EndProject
@@ -538,6 +542,14 @@ Global
 		{ADCF5BF7-5A77-4F0E-AE76-96C611A079D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ADCF5BF7-5A77-4F0E-AE76-96C611A079D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ADCF5BF7-5A77-4F0E-AE76-96C611A079D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BA7F681E-FDC7-42B6-8BF1-74DA6421BA1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA7F681E-FDC7-42B6-8BF1-74DA6421BA1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA7F681E-FDC7-42B6-8BF1-74DA6421BA1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA7F681E-FDC7-42B6-8BF1-74DA6421BA1A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A604A43-C72A-4A03-B68B-66AF4B6F430E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A604A43-C72A-4A03-B68B-66AF4B6F430E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A604A43-C72A-4A03-B68B-66AF4B6F430E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A604A43-C72A-4A03-B68B-66AF4B6F430E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -630,6 +642,8 @@ Global
 		{21522CF8-12F2-4A30-94D5-6C794D4B043F} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 		{299B3E44-5372-4D6B-A4E9-3DBEA4705701} = {506AF844-92E0-4404-BBFC-0AB073890A72}
 		{ADCF5BF7-5A77-4F0E-AE76-96C611A079D8} = {7323F93B-D141-4001-BB9E-7AF14031143E}
+		{BA7F681E-FDC7-42B6-8BF1-74DA6421BA1A} = {00CE0FBE-DA5A-4AD8-B0D6-04ECE6B04F0D}
+		{2A604A43-C72A-4A03-B68B-66AF4B6F430E} = {01BC4531-1E25-48D7-A8FD-A47D6FEC47FB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3747A66A-00D1-41B8-A9C5-ED0D7BEA9D25}

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignAbstract.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignAbstract.cs
@@ -59,10 +59,12 @@ namespace NuGet.MSSigning.Extensions
                 return rsakey.Key;
             }
 
+            CngKey cngkey = null;
+
             try
             {
                 var provider = new CngProvider(CSPName);
-                var cngkey = CngKey.Open(KeyContainer, provider, CngKeyOpenOptions.MachineKey);
+                cngkey = CngKey.Open(KeyContainer, provider, CngKeyOpenOptions.MachineKey);
 
                 if (cngkey == null)
                 {
@@ -71,6 +73,7 @@ namespace NuGet.MSSigning.Extensions
             
                 if (cngkey.AlgorithmGroup != CngAlgorithmGroup.Rsa)
                 {
+                    cngkey.Dispose();
                     throw new InvalidOperationException(NuGetMSSignCommand.MSSignCommandInvalidCngKeyException);
                 }
 
@@ -78,6 +81,7 @@ namespace NuGet.MSSigning.Extensions
             }
             catch (CryptographicException)
             {
+                cngkey?.Dispose();
                 throw new InvalidOperationException(NuGetMSSignCommand.MSSignCommandNoCngKeyException);
             }
         }

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignAbstract.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignAbstract.cs
@@ -59,20 +59,27 @@ namespace NuGet.MSSigning.Extensions
                 return rsakey.Key;
             }
 
-            var provider = new CngProvider(CSPName);
-            var cngkey = CngKey.Open(KeyContainer, provider, CngKeyOpenOptions.MachineKey);
+            try
+            {
+                var provider = new CngProvider(CSPName);
+                var cngkey = CngKey.Open(KeyContainer, provider, CngKeyOpenOptions.MachineKey);
 
-            if (cngkey == null)
+                if (cngkey == null)
+                {
+                    throw new InvalidOperationException(NuGetMSSignCommand.MSSignCommandNoCngKeyException);
+                }
+            
+                if (cngkey.AlgorithmGroup != CngAlgorithmGroup.Rsa)
+                {
+                    throw new InvalidOperationException(NuGetMSSignCommand.MSSignCommandInvalidCngKeyException);
+                }
+
+                return cngkey;
+            }
+            catch (CryptographicException)
             {
                 throw new InvalidOperationException(NuGetMSSignCommand.MSSignCommandNoCngKeyException);
             }
-
-            if (cngkey.AlgorithmGroup != CngAlgorithmGroup.Rsa)
-            {
-                throw new InvalidOperationException(NuGetMSSignCommand.MSSignCommandInvalidCngKeyException);
-            }
-
-            return cngkey;
         }
 
         protected X509Certificate2 GetCertificate(X509Certificate2Collection certCollection)

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignCommand.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignCommand.cs
@@ -36,7 +36,7 @@ namespace NuGet.MSSigning.Extensions
             }
         }
 
-        private AuthorSignPackageRequest GetAuthorSignRequest()
+        public AuthorSignPackageRequest GetAuthorSignRequest()
         {
             ValidatePackagePath();
             WarnIfNoTimestamper(Console);
@@ -46,6 +46,7 @@ namespace NuGet.MSSigning.Extensions
             var signingSpec = SigningSpecifications.V1;
             var signatureHashAlgorithm = ValidateAndParseHashAlgorithm(HashAlgorithm, nameof(HashAlgorithm), signingSpec);
             var timestampHashAlgorithm = ValidateAndParseHashAlgorithm(TimestampHashAlgorithm, nameof(TimestampHashAlgorithm), signingSpec);
+
             var certCollection = GetCertificateCollection();
             var certificate = GetCertificate(certCollection);
             var privateKey = GetPrivateKey(certificate);

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.resx
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.resx
@@ -194,7 +194,7 @@ nuget mssign MyPackage.nupkg -Timestamper https://foo.bar -CertificateFile foo.p
   <data name="RepoSignCommandUsageExamples" xml:space="preserve">
     <value>nuget reposign MyPackage.nupkg -Timestamper http://timestamper.test -CertificateFile certificates.p7b -CSPName "Cryptographic Service Provider" -KeyContainer 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -CertificateFingerprint 8599ADD1C62EE42E315EA887FF60908B7A7C6E9B -V3ServiceIndexUrl https://v3.index.test
 
-nuget reposign MyPackage.nupkg -Timestamper http://timestamper.test -CertificateFile certificates.p7b -CSPName "Cryptographic Service Provider" -KeyContainer 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -CertificateFingerprint 8599ADD1C62EE42E315EA887FF60908B7A7C6E9B -OutputDirectory .\..\Signed -PackageOwners owner1;owner2 -V3ServiceIndexUrl https://v3.index.test</value>
+nuget reposign MyPackage.nupkg -Timestamper http://timestamper.test -CertificateFile certificates.p7b -CSPName "Cryptographic Service Provider" -KeyContainer 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -CertificateFingerprint 8599ADD1C62EE42E315EA887FF60908B7A7C6E9B -OutputDirectory .\..\Signed -PackageOwners "owner1;owner2" -V3ServiceIndexUrl https://v3.index.test</value>
   </data>
   <data name="RepoSignCommandUsageSummary" xml:space="preserve">
     <value>&lt;package_path&gt; -Timestamper &lt;timestamp_server_url&gt; -CertificateFile &lt;p7b_file_path&gt; -CSPName &lt;cryptographic_service_provider_name&gt; -KeyContainer &lt;key_container_guid&gt; -CertificateFingerprint &lt;certificate_fingerprint&gt; -PackageOwners &lt;package_owners&gt; -V3ServiceIndexUrl &lt;v3_service_index_url&gt;</value>

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/RepoSignCommand.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/RepoSignCommand.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.CommandLine;
 using NuGet.Commands;
-using NuGet.Common;
 using NuGet.Packaging.Signing;
 
 namespace NuGet.MSSigning.Extensions
@@ -23,13 +22,16 @@ namespace NuGet.MSSigning.Extensions
        UsageDescriptionResourceName = "RepoSignCommandUsageDescription")]
     public class RepoSignCommand : MSSignAbstract
     {
-        private readonly List<string> _packageOwners = new List<string>();
-
         [Option(typeof(NuGetMSSignCommand), "RepoSignCommandPackageOwnersDescription")]
-        public IList<string> PackageOwners => _packageOwners;
+        public IList<string> PackageOwners { get; set; }
 
         [Option(typeof(NuGetMSSignCommand), "RepoSignCommandV3ServiceIndexUrlDescription")]
         public string V3ServiceIndexUrl { get; set; }
+
+        public RepoSignCommand() : base()
+        {
+            PackageOwners = new List<string>();
+        }
 
         public override async Task ExecuteCommandAsync()
         {
@@ -47,7 +49,7 @@ namespace NuGet.MSSigning.Extensions
             }
         }
 
-        private RepositorySignPackageRequest GetRepositorySignRequest()
+        public RepositorySignPackageRequest GetRepositorySignRequest()
         {
             ValidatePackagePath();
             WarnIfNoTimestamper(Console);
@@ -58,10 +60,11 @@ namespace NuGet.MSSigning.Extensions
             var signingSpec = SigningSpecifications.V1;
             var signatureHashAlgorithm = ValidateAndParseHashAlgorithm(HashAlgorithm, nameof(HashAlgorithm), signingSpec);
             var timestampHashAlgorithm = ValidateAndParseHashAlgorithm(TimestampHashAlgorithm, nameof(TimestampHashAlgorithm), signingSpec);
+            var v3ServiceIndexUri = ValidateAndParseV3ServiceIndexUrl();
+
             var certCollection = GetCertificateCollection();
             var certificate = GetCertificate(certCollection);
             var privateKey = GetPrivateKey(certificate);
-            var v3ServiceIndexUri = ValidateAndParseV3ServiceIndexUrl();
 
             var request = new RepositorySignPackageRequest(
                 certificate,

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/VerifyCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/VerifyCommandTests.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NuGet.Common;
-using NuGet.Packaging.Signing;
 using NuGet.Test.Utility;
 using Test.Utility.Signing;
 using Xunit;

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/MSSignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/MSSignCommandTests.cs
@@ -1,0 +1,285 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NuGet.CommandLine;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using NuGet.Test.Utility;
+using Test.Utility.Signing;
+using Xunit;
+
+namespace NuGet.MSSigning.Extensions.FuncTest.Commands
+{
+    /// <summary>
+    /// Tests Sign command
+    /// These tests require admin privilege as the certs need to be added to the root store location
+    /// </summary>
+    [Collection(MSSignCommandTestCollection.Name)]
+    public class MSSignCommandTests
+    {
+        private readonly string _noTimestamperWarningCode = NuGetLogCode.NU3002.ToString();
+
+        private TrustedTestCert<TestCertificate> _trustedTestCertWithPrivateKey;
+        private TrustedTestCert<TestCertificate> _trustedTestCertWithoutPrivateKey;
+
+        private MSSignCommandTestFixture _testFixture;
+        private string _nugetExePath;
+
+        public MSSignCommandTests(MSSignCommandTestFixture fixture)
+        {
+            _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+            _trustedTestCertWithPrivateKey = _testFixture.TrustedTestCertificateWithPrivateKey;
+            _trustedTestCertWithoutPrivateKey = _testFixture.TrustedTestCertificateWithoutPrivateKey;
+            _nugetExePath = _testFixture.NuGetExePath;
+        }
+
+        [CIOnlyFact]
+        public void GetAuthorSignRequest_InvalidCertificateFile()
+        {
+            var mockConsole = new Mock<IConsole>();
+            var timestampUri = "http://timestamp.test/url";
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
+            {
+                var signCommand = new MSSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestampUri,
+                    CertificateFile = @"\\wrong\cert\path.pfx",
+                    CSPName = test.CertificateCSPName,
+                    KeyContainer = test.CertificateKeyContainer,
+                    CertificateFingerprint = test.Cert.Thumbprint,
+                };
+                signCommand.Arguments.Add(@"\\path\to\package.nupkg");
+
+                // Act & Assert
+                var ex = Assert.Throws<CryptographicException>(() => signCommand.GetAuthorSignRequest());
+                Assert.Contains("The network path was not found.", ex.Message);
+            }
+        }
+
+        [CIOnlyFact]
+        public void GetAuthorSignRequest_InvalidCSPName()
+        {
+            var mockConsole = new Mock<IConsole>();
+            var timestampUri = "http://timestamp.test/url";
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithoutPrivateKey.TrustedCert, exportPfx: false))
+            {
+                var signCommand = new MSSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestampUri,
+                    CertificateFile = test.CertificatePath,
+                    CSPName = "random nonexistant csp name",
+                    KeyContainer = test.CertificateKeyContainer,
+                    CertificateFingerprint = test.Cert.Thumbprint,
+                };
+                signCommand.Arguments.Add(@"\\path\to\package.nupkg");
+
+                // Act & Assert
+                var ex = Assert.Throws<InvalidOperationException>(() => signCommand.GetAuthorSignRequest());
+                Assert.Equal("Can't find cng key.", ex.Message);
+            }
+        }
+
+        [CIOnlyFact]
+        public void GetAuthorSignRequest_InvalidKeyContainer()
+        {
+            var mockConsole = new Mock<IConsole>();
+            var timestampUri = "http://timestamp.test/url";
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithoutPrivateKey.TrustedCert, exportPfx: false))
+            {
+                var signCommand = new MSSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestampUri,
+                    CertificateFile = test.CertificatePath,
+                    CSPName = test.CertificateCSPName,
+                    KeyContainer = "invalid-key-container",
+                    CertificateFingerprint = test.Cert.Thumbprint,
+                };
+                signCommand.Arguments.Add(@"\\path\to\package.nupkg");
+
+                // Act & Assert
+                var ex = Assert.Throws<InvalidOperationException>(() => signCommand.GetAuthorSignRequest());
+                Assert.Equal("Can't find cng key.", ex.Message);
+            }
+        }
+
+        [CIOnlyFact]
+        public void GetAuthorSignRequest_InvalidFingerprint()
+        {
+            var mockConsole = new Mock<IConsole>();
+            var timestampUri = "http://timestamp.test/url";
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
+            {
+                var signCommand = new MSSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestampUri,
+                    CertificateFile = test.CertificatePath,
+                    CSPName = test.CertificateCSPName,
+                    KeyContainer = test.CertificateKeyContainer,
+                    CertificateFingerprint = "invalid-fingerprint",
+                };
+                signCommand.Arguments.Add(@"\\path\to\package.nupkg");
+
+                // Act & Assert
+                var ex = Assert.Throws<InvalidOperationException>(() => signCommand.GetAuthorSignRequest());
+                Assert.Equal("Can't find specified certificate.", ex.Message);
+            }
+        }
+
+        [CIOnlyFact]
+        public void GetAuthorSignRequest_Success()
+        {
+            var mockConsole = new Mock<IConsole>();
+            var timestampUri = "http://timestamp.test/url";
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
+            {
+                var signCommand = new MSSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestampUri,
+                    CertificateFile = test.CertificatePath,
+                    CSPName = test.CertificateCSPName,
+                    KeyContainer = test.CertificateKeyContainer,
+                    CertificateFingerprint = test.Cert.Thumbprint,
+                };
+                signCommand.Arguments.Add(@"\\path\to\package.nupkg");
+
+                // Act
+                var signRequest = signCommand.GetAuthorSignRequest();
+
+                // Assert
+                Assert.Equal(SignatureType.Author, signRequest.SignatureType);
+                Assert.NotNull(signRequest.Certificate);
+                Assert.Equal(signRequest.Certificate.Thumbprint, test.Cert.Thumbprint, StringComparer.Ordinal);
+                Assert.NotNull(signRequest.PrivateKey);
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task MSSignCommand_PrimarySignPackage_WithNoTimestampAsync()
+        {
+            var package = new SimpleTestPackageContext();
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
+            {
+                var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
+                var command = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint}";
+
+                var result = CommandRunner.Run(
+                    _nugetExePath,
+                    test.Directory,
+                    command,
+                    waitForExit: true);
+
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task MSSignCommand_PrimarySignPackage_WithTimestampAsync()
+        {
+            var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
+            var package = new SimpleTestPackageContext();
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
+            {
+                var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
+                var command = $"mssign {unsignedPackageFile} -Timestamper {timestampService.Url} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint}";
+
+                var result = CommandRunner.Run(
+                    _nugetExePath,
+                    test.Directory,
+                    command,
+                    waitForExit: true);
+
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().NotContain(_noTimestamperWarningCode);
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task MSSignCommand_ResignPackageWithoutOverwriteFailsAsync()
+        {
+            var package = new SimpleTestPackageContext();
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
+            {
+                var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
+                var command = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint}";
+
+                var result = CommandRunner.Run(
+                    _nugetExePath,
+                    test.Directory,
+                    command,
+                    waitForExit: true);
+
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+
+                result = CommandRunner.Run(
+                    _nugetExePath,
+                    test.Directory,
+                    command,
+                    waitForExit: true);
+
+                result.Success.Should().BeFalse();
+                result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+                result.Errors.Should().Contain("NU3001: The package already contains a signature. Please remove the existing signature before adding a new signature.");
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task MSSignCommand_ResignPackageWithOverwriteSuccessAsync()
+        {
+            var package = new SimpleTestPackageContext();
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
+            {
+                var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
+                var command = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint}";
+                var commandWithOverwrite = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint} -Overwrite";
+
+                var result = CommandRunner.Run(
+                    _nugetExePath,
+                    test.Directory,
+                    command,
+                    waitForExit: true);
+
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+
+                result = CommandRunner.Run(
+                    _nugetExePath,
+                    test.Directory,
+                    commandWithOverwrite,
+                    waitForExit: true);
+
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/MSSignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/MSSignCommandTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -45,22 +46,23 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             var timestampUri = "http://timestamp.test/url";
 
             // Arrange
+            using (var dir = TestDirectory.Create())
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
             {
                 var signCommand = new MSSignCommand
                 {
                     Console = mockConsole.Object,
                     Timestamper = timestampUri,
-                    CertificateFile = @"\\wrong\cert\path.pfx",
+                    CertificateFile = Path.Combine(dir, "non-existant-cert.pfx"),
                     CSPName = test.CertificateCSPName,
                     KeyContainer = test.CertificateKeyContainer,
                     CertificateFingerprint = test.Cert.Thumbprint,
                 };
-                signCommand.Arguments.Add(@"\\path\to\package.nupkg");
+                signCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
 
                 // Act & Assert
                 var ex = Assert.Throws<CryptographicException>(() => signCommand.GetAuthorSignRequest());
-                Assert.Contains("The network path was not found.", ex.Message);
+                Assert.Contains("The system cannot find the file specified.", ex.Message);
             }
         }
 
@@ -71,6 +73,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             var timestampUri = "http://timestamp.test/url";
 
             // Arrange
+            using (var dir = TestDirectory.Create())
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithoutPrivateKey.TrustedCert, exportPfx: false))
             {
                 var signCommand = new MSSignCommand
@@ -82,7 +85,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     KeyContainer = test.CertificateKeyContainer,
                     CertificateFingerprint = test.Cert.Thumbprint,
                 };
-                signCommand.Arguments.Add(@"\\path\to\package.nupkg");
+                signCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
 
                 // Act & Assert
                 var ex = Assert.Throws<InvalidOperationException>(() => signCommand.GetAuthorSignRequest());
@@ -97,6 +100,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             var timestampUri = "http://timestamp.test/url";
 
             // Arrange
+            using (var dir = TestDirectory.Create())
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithoutPrivateKey.TrustedCert, exportPfx: false))
             {
                 var signCommand = new MSSignCommand
@@ -108,7 +112,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     KeyContainer = "invalid-key-container",
                     CertificateFingerprint = test.Cert.Thumbprint,
                 };
-                signCommand.Arguments.Add(@"\\path\to\package.nupkg");
+                signCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
 
                 // Act & Assert
                 var ex = Assert.Throws<InvalidOperationException>(() => signCommand.GetAuthorSignRequest());
@@ -123,6 +127,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             var timestampUri = "http://timestamp.test/url";
 
             // Arrange
+            using (var dir = TestDirectory.Create())
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
             {
                 var signCommand = new MSSignCommand
@@ -134,7 +139,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     KeyContainer = test.CertificateKeyContainer,
                     CertificateFingerprint = "invalid-fingerprint",
                 };
-                signCommand.Arguments.Add(@"\\path\to\package.nupkg");
+                signCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
 
                 // Act & Assert
                 var ex = Assert.Throws<InvalidOperationException>(() => signCommand.GetAuthorSignRequest());
@@ -149,6 +154,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             var timestampUri = "http://timestamp.test/url";
 
             // Arrange
+            using (var dir = TestDirectory.Create())
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
             {
                 var signCommand = new MSSignCommand
@@ -160,7 +166,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     KeyContainer = test.CertificateKeyContainer,
                     CertificateFingerprint = test.Cert.Thumbprint,
                 };
-                signCommand.Arguments.Add(@"\\path\to\package.nupkg");
+                signCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
 
                 // Act
                 var signRequest = signCommand.GetAuthorSignRequest();

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/ReposignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/ReposignCommandTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -46,23 +47,24 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             var timestampUri = "http://timestamp.test/url";
 
             // Arrange
+            using (var dir = TestDirectory.Create())
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
             {
                 var reposignCommand = new RepoSignCommand
                 {
                     Console = mockConsole.Object,
                     Timestamper = timestampUri,
-                    CertificateFile = @"\\wrong\cert\path.pfx",
+                    CertificateFile = Path.Combine(dir, "non-existant-cert.pfx"),
                     CSPName = test.CertificateCSPName,
                     KeyContainer = test.CertificateKeyContainer,
                     CertificateFingerprint = test.Cert.Thumbprint,
                     V3ServiceIndexUrl = v3serviceIndex,
                 };
-                reposignCommand.Arguments.Add(@"\\path\to\package.nupkg");
+                reposignCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
 
                 // Act & Assert
                 var ex = Assert.Throws<CryptographicException>(() => reposignCommand.GetRepositorySignRequest());
-                Assert.Contains("The network path was not found.", ex.Message);
+                Assert.Contains("The system cannot find the file specified.", ex.Message);
             }
         }
 
@@ -74,6 +76,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             var timestampUri = "http://timestamp.test/url";
 
             // Arrange
+            using (var dir = TestDirectory.Create())
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithoutPrivateKey.TrustedCert, exportPfx: false))
             {
                 var reposignCommand = new RepoSignCommand
@@ -86,7 +89,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     CertificateFingerprint = test.Cert.Thumbprint,
                     V3ServiceIndexUrl = v3serviceIndex,
                 };
-                reposignCommand.Arguments.Add(@"\\path\to\package.nupkg");
+                reposignCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
 
                 // Act & Assert
                 var ex = Assert.Throws<InvalidOperationException>(() => reposignCommand.GetRepositorySignRequest());
@@ -102,6 +105,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             var timestampUri = "http://timestamp.test/url";
 
             // Arrange
+            using (var dir = TestDirectory.Create())
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithoutPrivateKey.TrustedCert, exportPfx: false))
             {
                 var reposignCommand = new RepoSignCommand
@@ -114,7 +118,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     CertificateFingerprint = test.Cert.Thumbprint,
                     V3ServiceIndexUrl = v3serviceIndex,
                 };
-                reposignCommand.Arguments.Add(@"\\path\to\package.nupkg");
+                reposignCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
 
                 // Act & Assert
                 var ex = Assert.Throws<InvalidOperationException>(() => reposignCommand.GetRepositorySignRequest());
@@ -130,6 +134,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             var timestampUri = "http://timestamp.test/url";
 
             // Arrange
+            using (var dir = TestDirectory.Create())
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
             {
                 var reposignCommand = new RepoSignCommand
@@ -142,7 +147,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     CertificateFingerprint = "invalid-fingerprint",
                     V3ServiceIndexUrl = v3serviceIndex,
                 };
-                reposignCommand.Arguments.Add(@"\\path\to\package.nupkg");
+                reposignCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
 
                 // Act & Assert
                 var ex = Assert.Throws<InvalidOperationException>(() => reposignCommand.GetRepositorySignRequest());
@@ -158,6 +163,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             var timestampUri = "http://timestamp.test/url";
 
             // Arrange
+            using (var dir = TestDirectory.Create())
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
             {
                 var reposignCommand = new RepoSignCommand
@@ -170,7 +176,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     CertificateFingerprint = test.Cert.Thumbprint,
                     V3ServiceIndexUrl = v3serviceIndex,
                 };
-                reposignCommand.Arguments.Add(@"\\path\to\package.nupkg");
+                reposignCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
 
                 // Act
                 var signRequest = reposignCommand.GetRepositorySignRequest();

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/ReposignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/ReposignCommandTests.cs
@@ -1,0 +1,371 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NuGet.CommandLine;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using NuGet.Test.Utility;
+using Test.Utility.Signing;
+using Xunit;
+
+namespace NuGet.MSSigning.Extensions.FuncTest.Commands
+{
+    /// <summary>
+    /// Tests Sign command
+    /// These tests require admin privilege as the certs need to be added to the root store location
+    /// </summary>
+    [Collection(MSSignCommandTestCollection.Name)]
+    public class ReposignCommandTests
+    {
+        private readonly string _noTimestamperWarningCode = NuGetLogCode.NU3002.ToString();
+
+        private TrustedTestCert<TestCertificate> _trustedTestCertWithPrivateKey;
+        private TrustedTestCert<TestCertificate> _trustedTestCertWithoutPrivateKey;
+
+        private MSSignCommandTestFixture _testFixture;
+        private string _nugetExePath;
+
+        public ReposignCommandTests(MSSignCommandTestFixture fixture)
+        {
+            _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+            _trustedTestCertWithPrivateKey = _testFixture.TrustedTestCertificateWithPrivateKey;
+            _trustedTestCertWithoutPrivateKey = _testFixture.TrustedTestCertificateWithoutPrivateKey;
+            _nugetExePath = _testFixture.NuGetExePath;
+        }
+
+        [CIOnlyFact]
+        public void GetRepositorySignRequest_InvalidCertificateFile()
+        {
+            var mockConsole = new Mock<IConsole>();
+            var v3serviceIndex = "https://v3serviceindex.test/api/index.json";
+            var timestampUri = "http://timestamp.test/url";
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
+            {
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestampUri,
+                    CertificateFile = @"\\wrong\cert\path.pfx",
+                    CSPName = test.CertificateCSPName,
+                    KeyContainer = test.CertificateKeyContainer,
+                    CertificateFingerprint = test.Cert.Thumbprint,
+                    V3ServiceIndexUrl = v3serviceIndex,
+                };
+                reposignCommand.Arguments.Add(@"\\path\to\package.nupkg");
+
+                // Act & Assert
+                var ex = Assert.Throws<CryptographicException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.Contains("The network path was not found.", ex.Message);
+            }
+        }
+
+        [CIOnlyFact]
+        public void GetRepositorySignRequest_InvalidCSPName()
+        {
+            var mockConsole = new Mock<IConsole>();
+            var v3serviceIndex = "https://v3serviceindex.test/api/index.json";
+            var timestampUri = "http://timestamp.test/url";
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithoutPrivateKey.TrustedCert, exportPfx: false))
+            {
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestampUri,
+                    CertificateFile = test.CertificatePath,
+                    CSPName = "random nonexistant csp name",
+                    KeyContainer = test.CertificateKeyContainer,
+                    CertificateFingerprint = test.Cert.Thumbprint,
+                    V3ServiceIndexUrl = v3serviceIndex,
+                };
+                reposignCommand.Arguments.Add(@"\\path\to\package.nupkg");
+
+                // Act & Assert
+                var ex = Assert.Throws<InvalidOperationException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.Equal("Can't find cng key.", ex.Message);
+            }
+        }
+
+        [CIOnlyFact]
+        public void GetRepositorySignRequest_InvalidKeyContainer()
+        {
+            var mockConsole = new Mock<IConsole>();
+            var v3serviceIndex = "https://v3serviceindex.test/api/index.json";
+            var timestampUri = "http://timestamp.test/url";
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithoutPrivateKey.TrustedCert, exportPfx: false))
+            {
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestampUri,
+                    CertificateFile = test.CertificatePath,
+                    CSPName = test.CertificateCSPName,
+                    KeyContainer = "invalid-key-container",
+                    CertificateFingerprint = test.Cert.Thumbprint,
+                    V3ServiceIndexUrl = v3serviceIndex,
+                };
+                reposignCommand.Arguments.Add(@"\\path\to\package.nupkg");
+
+                // Act & Assert
+                var ex = Assert.Throws<InvalidOperationException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.Equal("Can't find cng key.", ex.Message);
+            }
+        }
+
+        [CIOnlyFact]
+        public void GetRepositorySignRequest_InvalidFingerprint()
+        {
+            var mockConsole = new Mock<IConsole>();
+            var v3serviceIndex = "https://v3serviceindex.test/api/index.json";
+            var timestampUri = "http://timestamp.test/url";
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
+            {
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestampUri,
+                    CertificateFile = test.CertificatePath,
+                    CSPName = test.CertificateCSPName,
+                    KeyContainer = test.CertificateKeyContainer,
+                    CertificateFingerprint = "invalid-fingerprint",
+                    V3ServiceIndexUrl = v3serviceIndex,
+                };
+                reposignCommand.Arguments.Add(@"\\path\to\package.nupkg");
+
+                // Act & Assert
+                var ex = Assert.Throws<InvalidOperationException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.Equal("Can't find specified certificate.", ex.Message);
+            }
+        }
+
+        [CIOnlyFact]
+        public void GetRepositorySignRequest_Success()
+        {
+            var mockConsole = new Mock<IConsole>();
+            var v3serviceIndex = "https://v3serviceindex.test/api/index.json";
+            var timestampUri = "http://timestamp.test/url";
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
+            {
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestampUri,
+                    CertificateFile = test.CertificatePath,
+                    CSPName = test.CertificateCSPName,
+                    KeyContainer = test.CertificateKeyContainer,
+                    CertificateFingerprint = test.Cert.Thumbprint,
+                    V3ServiceIndexUrl = v3serviceIndex,
+                };
+                reposignCommand.Arguments.Add(@"\\path\to\package.nupkg");
+
+                // Act
+                var signRequest = reposignCommand.GetRepositorySignRequest();
+
+                // Assert
+                Assert.Equal(v3serviceIndex, signRequest.V3ServiceIndexUrl.AbsoluteUri, StringComparer.Ordinal);
+                Assert.Equal(SignatureType.Repository, signRequest.SignatureType);
+                Assert.NotNull(signRequest.Certificate);
+                Assert.Equal(signRequest.Certificate.Thumbprint, test.Cert.Thumbprint, StringComparer.Ordinal);
+                Assert.NotNull(signRequest.PrivateKey);
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task ReposignCommand_PrimarySignPackage_WithNoTimestampAsync()
+        {
+            var package = new SimpleTestPackageContext();
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
+            {
+                var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
+                var command = $"reposign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
+
+                var result = CommandRunner.Run(
+                    _nugetExePath,
+                    test.Directory,
+                    command,
+                    waitForExit: true);
+
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task ReposignCommand_PrimarySignPackage_WithTimestampAsync()
+        {
+            var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
+            var package = new SimpleTestPackageContext();
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
+            {
+                var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
+                var command = $"reposign {unsignedPackageFile} -Timestamper {timestampService.Url} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
+
+                var result = CommandRunner.Run(
+                    _nugetExePath,
+                    test.Directory,
+                    command,
+                    waitForExit: true);
+
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().NotContain(_noTimestamperWarningCode);
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task ReposignCommand_Countersign_RepositorySignedPackage_FailAsync()
+        {
+            var package = new SimpleTestPackageContext();
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
+            {
+                var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
+                var command = $"reposign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
+
+                var result = CommandRunner.Run(
+                    _nugetExePath,
+                    test.Directory,
+                    command,
+                    waitForExit: true);
+
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+
+                result = CommandRunner.Run(
+                    _nugetExePath,
+                    test.Directory,
+                    command,
+                    waitForExit: true);
+
+                result.Success.Should().BeFalse();
+                result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+                result.Errors.Should().Contain("NU3033: A repository primary signature must not have a repository countersignature.");
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task ReposignCommand_Countersign_AuthorSignedPackage_WithNoTimestampAsync()
+        {
+            var package = new SimpleTestPackageContext();
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
+            {
+                var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
+                var authorSignCommand = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint}";
+                var repoSignCommand = $"reposign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
+
+                var result = CommandRunner.Run(
+                    _nugetExePath,
+                    test.Directory,
+                    authorSignCommand,
+                    waitForExit: true);
+
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+
+                result = CommandRunner.Run(
+                    _nugetExePath,
+                    test.Directory,
+                    repoSignCommand,
+                    waitForExit: true);
+
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task ReposignCommand_Countersign_AuthorSignedPackage_WithTimestampAsync()
+        {
+            var package = new SimpleTestPackageContext();
+            var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
+            {
+                var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
+                var authorSignCommand = $"mssign {unsignedPackageFile} -Timestamper {timestampService.Url} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint}";
+                var repoSignCommand = $"reposign {unsignedPackageFile} -Timestamper {timestampService.Url} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
+
+                var result = CommandRunner.Run(
+                    _nugetExePath,
+                    test.Directory,
+                    authorSignCommand,
+                    waitForExit: true);
+
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().NotContain(_noTimestamperWarningCode);
+
+                result = CommandRunner.Run(
+                    _nugetExePath,
+                    test.Directory,
+                    repoSignCommand,
+                    waitForExit: true);
+
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().NotContain(_noTimestamperWarningCode);
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task ReposignCommand_Countersign_RepositoryCountersignedPackage_FailAsync()
+        {
+            var package = new SimpleTestPackageContext();
+
+            // Arrange
+            using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
+            {
+                var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
+                var authorSignCommand = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint}";
+                var repoSignCommand = $"reposign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
+
+                var result = CommandRunner.Run(
+                    _nugetExePath,
+                    test.Directory,
+                    authorSignCommand,
+                    waitForExit: true);
+
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+
+                result = CommandRunner.Run(
+                    _nugetExePath,
+                    test.Directory,
+                    repoSignCommand,
+                    waitForExit: true);
+
+                result.Success.Should().BeTrue();
+                result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+
+                result = CommandRunner.Run(
+                    _nugetExePath,
+                    test.Directory,
+                    repoSignCommand,
+                    waitForExit: true);
+
+                result.Success.Should().BeFalse();
+                result.AllOutput.Should().Contain(_noTimestamperWarningCode);
+                result.Errors.Should().Contain("NU3032: The package already contains a repository countersignature. Please remove the existing signature before adding a new repository countersignature.");
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/CommonAssemblyInfo.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/CommonAssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Resources;
+using System.Runtime.InteropServices;

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/MSSignCommandTestCollection.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/MSSignCommandTestCollection.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGet.MSSigning.Extensions.FuncTest.Commands
+{
+    [CollectionDefinition(Name)]
+    public class MSSignCommandTestCollection : ICollectionFixture<MSSignCommandTestFixture>
+    {
+        public const string Name = "MSSign Command Test Collection";
+
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+}

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/MSSignCommandTestContext.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/MSSignCommandTestContext.cs
@@ -1,0 +1,68 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using NuGet.Test.Utility;
+
+namespace NuGet.MSSigning.Extensions.FuncTest
+{
+    internal sealed class MSSignCommandTestContext : IDisposable
+    {
+        private bool _isDisposed;
+        private readonly string _defaultProviderName = "Microsoft Enhanced RSA and AES Cryptographic Provider";
+
+        internal TestDirectory Directory { get; }
+        internal X509Certificate2 Cert { get; }
+        internal string CertificatePath { get; }
+        internal string CertificateCSPName { get; private set; }
+        internal string CertificateKeyContainer { get; private set; }
+
+        internal MSSignCommandTestContext(X509Certificate2 certificate, bool exportPfx = true)
+        {
+            Directory = TestDirectory.Create();
+            Cert = new X509Certificate2(certificate);
+            CertificatePath = $"{Path.Combine(Directory, Guid.NewGuid().ToString())}.pfx";
+
+            var certData = Cert.Export(exportPfx ? X509ContentType.Pfx : X509ContentType.Cert);
+            File.WriteAllBytes(CertificatePath, certData);
+
+            GetKeyContainerInformation(Cert);
+        }
+
+        public void Dispose()
+        {
+            if (!_isDisposed)
+            {
+                Directory.Dispose();
+                Cert.Dispose();
+
+                GC.SuppressFinalize(this);
+
+                _isDisposed = true;
+            }
+        }
+
+        private void GetKeyContainerInformation(X509Certificate2 certificate)
+        {
+            if (certificate == null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            var key = certificate.PrivateKey as ICspAsymmetricAlgorithm;
+            if (key != null)
+            {
+                var keyContainer = key.CspKeyContainerInfo;
+
+                CertificateCSPName = keyContainer.ProviderName;
+                CertificateKeyContainer = keyContainer.KeyContainerName;
+            }
+
+            CertificateCSPName = CertificateCSPName ?? _defaultProviderName;
+            CertificateKeyContainer = CertificateKeyContainer ?? new Guid().ToString();
+        }
+    }
+}

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/MSSignCommandTestFixture.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/MSSignCommandTestFixture.cs
@@ -1,0 +1,144 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using NuGet.CommandLine.Test;
+using Test.Utility.Signing;
+
+namespace NuGet.MSSigning.Extensions.FuncTest.Commands
+{
+    /// <summary>
+    /// Used to bootstrap functional tests for signing.
+    /// </summary>
+    public class MSSignCommandTestFixture : IDisposable
+    {
+        private TrustedTestCert<TestCertificate> _trustedTestCertWithPrivateKey;
+        private TrustedTestCert<TestCertificate> _trustedTestCertWithoutPrivateKey;
+        private TrustedTestCert<X509Certificate2> _trustedTimestampRoot;
+
+        private string _nugetExePath;
+        private Lazy<Task<SigningTestServer>> _testServer;
+        private Lazy<Task<CertificateAuthority>> _defaultTrustedCertificateAuthority;
+        private Lazy<Task<TimestampService>> _defaultTrustedTimestampService;
+        private readonly DisposableList<IDisposable> _responders;
+
+
+        public MSSignCommandTestFixture()
+        {
+            _testServer = new Lazy<Task<SigningTestServer>>(SigningTestServer.CreateAsync);
+            _defaultTrustedCertificateAuthority = new Lazy<Task<CertificateAuthority>>(CreateDefaultTrustedCertificateAuthorityAsync);
+            _defaultTrustedTimestampService = new Lazy<Task<TimestampService>>(CreateDefaultTrustedTimestampServiceAsync);
+            _responders = new DisposableList<IDisposable>();
+        }
+
+        public TrustedTestCert<TestCertificate> TrustedTestCertificateWithPrivateKey
+        {
+            get
+            {
+                if (_trustedTestCertWithPrivateKey == null)
+                {
+                    var actionGenerator = SigningTestUtility.CertificateModificationGeneratorForCodeSigningEkuCert;
+
+                    // Code Sign EKU needs trust to a root authority
+                    // Add the cert to Root CA list in LocalMachine as it does not prompt a dialog
+                    // This makes all the associated tests to require admin privilege
+                    _trustedTestCertWithPrivateKey = TestCertificate.Generate(actionGenerator).WithPrivateKeyAndTrust(StoreName.Root, StoreLocation.LocalMachine);
+                }
+
+                return _trustedTestCertWithPrivateKey;
+            }
+        }
+
+        public TrustedTestCert<TestCertificate> TrustedTestCertificateWithoutPrivateKey
+        {
+            get
+            {
+                if (_trustedTestCertWithoutPrivateKey == null)
+                {
+                    var actionGenerator = SigningTestUtility.CertificateModificationGeneratorForCodeSigningEkuCert;
+
+                    // Code Sign EKU needs trust to a root authority
+                    // Add the cert to Root CA list in LocalMachine as it does not prompt a dialog
+                    // This makes all the associated tests to require admin privilege
+                    _trustedTestCertWithoutPrivateKey = TestCertificate.Generate(actionGenerator).WithTrust(StoreName.Root, StoreLocation.LocalMachine);
+                }
+
+                return _trustedTestCertWithoutPrivateKey;
+            }
+        }
+
+        public string NuGetExePath
+        {
+            get
+            {
+                if (_nugetExePath == null)
+                {
+                    _nugetExePath = Util.GetNuGetExePath();
+                }
+
+                return _nugetExePath;
+            }
+        }
+
+        public async Task<CertificateAuthority> GetDefaultTrustedCertificateAuthorityAsync()
+        {
+            return await _defaultTrustedCertificateAuthority.Value;
+        }
+
+        public async Task<TimestampService> GetDefaultTrustedTimestampServiceAsync()
+        {
+            return await _defaultTrustedTimestampService.Value;
+        }
+
+        private async Task<CertificateAuthority> CreateDefaultTrustedCertificateAuthorityAsync()
+        {
+            var testServer = await _testServer.Value;
+            var rootCa = CertificateAuthority.Create(testServer.Url);
+            var intermediateCa = rootCa.CreateIntermediateCertificateAuthority();
+            var rootCertificate = new X509Certificate2(rootCa.Certificate.GetEncoded());
+
+            _trustedTimestampRoot = TrustedTestCert.Create(
+                rootCertificate,
+                StoreName.Root,
+                StoreLocation.LocalMachine);
+
+            var ca = intermediateCa;
+
+            while (ca != null)
+            {
+                _responders.Add(testServer.RegisterResponder(ca));
+                _responders.Add(testServer.RegisterResponder(ca.OcspResponder));
+
+                ca = ca.Parent;
+            }
+
+            return intermediateCa;
+        }
+
+        private async Task<TimestampService> CreateDefaultTrustedTimestampServiceAsync()
+        {
+            var testServer = await _testServer.Value;
+            var ca = await _defaultTrustedCertificateAuthority.Value;
+            var timestampService = TimestampService.Create(ca);
+
+            _responders.Add(testServer.RegisterResponder(timestampService));
+
+            return timestampService;
+        }
+
+        public void Dispose()
+        {
+            _trustedTestCertWithPrivateKey?.Dispose();
+            _trustedTestCertWithoutPrivateKey?.Dispose();
+            _trustedTimestampRoot?.Dispose();
+            _responders.Dispose();
+
+            if (_testServer.IsValueCreated)
+            {
+                _testServer.Value.Result.Dispose();
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/NuGet.MSSigning.Extensions.FuncTest.csproj
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/NuGet.MSSigning.Extensions.FuncTest.csproj
@@ -1,0 +1,22 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IsXPlat)' == 'true' "></TargetFrameworks>
+    <TestProject>true</TestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.MSSigning.Extensions\NuGet.MSSigning.Extensions.csproj" />
+    <ProjectReference Include="..\..\NuGet.Clients.Tests\NuGet.CommandLine.Test\NuGet.CommandLine.Test.csproj" />
+    <ProjectReference Include="..\..\TestUtilities\Test.Utility\Test.Utility.csproj" />
+
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+  <Import Project="$(BuildCommonDirectory)common.targets" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/xunit.runner.json
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "maxParallelThreads": 1,
+  "parallelizeTestCollections": false
+}

--- a/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGet.MSSigning.Extensions.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGet.MSSigning.Extensions.Test.csproj
@@ -1,0 +1,37 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IsXPlat)' == 'true' "></TargetFrameworks>
+    <TestProject>true</TestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
+    <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.MSSigning.Extensions\NuGet.MSSigning.Extensions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="compiler\resources\*" />
+    <EmbeddedResource Include="compiler\resources\*" />
+  </ItemGroup>
+
+  <Import Project="$(BuildCommonDirectory)common.targets" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>

--- a/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetMSSignCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetMSSignCommandTest.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Security.Cryptography;
 using Moq;
 using NuGet.CommandLine;
+using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.MSSigning.Extensions.Test
@@ -17,133 +19,149 @@ namespace NuGet.MSSigning.Extensions.Test
         public void MSSignCommandArgParsing_NoPackagePath()
         {
             // Arrange
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
 
-            var mockConsole = new Mock<IConsole>();
-            var signCommand = new MSSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CSPName = cspName,
-                KeyContainer = keyContainer,
-                CertificateFingerprint = certificateFingerprint,
-            };
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
-            Assert.Equal(_noPackageException, ex.Message);
+                var mockConsole = new Mock<IConsole>();
+                var signCommand = new MSSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CSPName = cspName,
+                    KeyContainer = keyContainer,
+                    CertificateFingerprint = certificateFingerprint,
+                };
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
+                Assert.Equal(_noPackageException, ex.Message);
+            }
         }
 
         [Fact]
         public void MSSignCommandArgParsing_NoCertificateFile()
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
-
-            var mockConsole = new Mock<IConsole>();
-            var signCommand = new MSSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CSPName = cspName,
-                KeyContainer = keyContainer,
-                CertificateFingerprint = certificateFingerprint,
-            };
-            signCommand.Arguments.Add(packagePath);
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
-            Assert.Equal(string.Format(_noCertificateException, nameof(signCommand.CertificateFile)), ex.Message);
+                var mockConsole = new Mock<IConsole>();
+                var signCommand = new MSSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CSPName = cspName,
+                    KeyContainer = keyContainer,
+                    CertificateFingerprint = certificateFingerprint,
+                };
+                signCommand.Arguments.Add(packagePath);
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
+                Assert.Equal(string.Format(_noCertificateException, nameof(signCommand.CertificateFile)), ex.Message);
+            }
         }
 
         [Fact]
         public void MSSignCommandArgParsing_NoCSPName()
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-
-            var mockConsole = new Mock<IConsole>();
-            var signCommand = new MSSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                KeyContainer = keyContainer,
-                CertificateFingerprint = certificateFingerprint,
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
 
-            signCommand.Arguments.Add(packagePath);
+                var mockConsole = new Mock<IConsole>();
+                var signCommand = new MSSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    KeyContainer = keyContainer,
+                    CertificateFingerprint = certificateFingerprint,
+                };
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
-            Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.CSPName)), ex.Message);
+                signCommand.Arguments.Add(packagePath);
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
+                Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.CSPName)), ex.Message);
+            }
         }
 
         [Fact]
         public void MSSignCommandArgParsing_NoKeyContainer()
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var cspName = "cert provider";
-
-            var mockConsole = new Mock<IConsole>();
-            var signCommand = new MSSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CSPName = cspName,
-                CertificateFingerprint = certificateFingerprint,
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var cspName = "cert provider";
 
-            signCommand.Arguments.Add(packagePath);
+                var mockConsole = new Mock<IConsole>();
+                var signCommand = new MSSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CSPName = cspName,
+                    CertificateFingerprint = certificateFingerprint,
+                };
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
-            Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.KeyContainer)), ex.Message);
+                signCommand.Arguments.Add(packagePath);
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
+                Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.KeyContainer)), ex.Message);
+            }
         }
 
         [Fact]
         public void MSSignCommandArgParsing_NoCertificateFingerprint()
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
-
-            var mockConsole = new Mock<IConsole>();
-            var signCommand = new MSSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CSPName = cspName,
-                KeyContainer = keyContainer,
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
 
-            signCommand.Arguments.Add(packagePath);
+                var mockConsole = new Mock<IConsole>();
+                var signCommand = new MSSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CSPName = cspName,
+                    KeyContainer = keyContainer,
+                };
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
-            Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.CertificateFingerprint)), ex.Message);
+                signCommand.Arguments.Add(packagePath);
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
+                Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.CertificateFingerprint)), ex.Message);
+            }
         }
 
         [Theory]
@@ -156,63 +174,69 @@ namespace NuGet.MSSigning.Extensions.Test
         [InlineData("SHA512")]
         public void MSSignCommandArgParsing_ValidHashAlgorithm(string hashAlgorithm)
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
-            var parsable = Enum.TryParse(hashAlgorithm, ignoreCase: true, result: out Common.HashAlgorithmName parsedHashAlgorithm);
-            var mockConsole = new Mock<IConsole>();
-            var signCommand = new MSSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CertificateFingerprint = certificateFingerprint,
-                KeyContainer = keyContainer,
-                CSPName = cspName,
-                HashAlgorithm = hashAlgorithm
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
+                var parsable = Enum.TryParse(hashAlgorithm, ignoreCase: true, result: out Common.HashAlgorithmName parsedHashAlgorithm);
+                var mockConsole = new Mock<IConsole>();
+                var signCommand = new MSSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CertificateFingerprint = certificateFingerprint,
+                    KeyContainer = keyContainer,
+                    CSPName = cspName,
+                    HashAlgorithm = hashAlgorithm
+                };
 
-            signCommand.Arguments.Add(packagePath);
+                signCommand.Arguments.Add(packagePath);
 
-            // Act & Assert
-            Assert.True(parsable);
-            var ex = Assert.Throws<CryptographicException>(() => signCommand.GetAuthorSignRequest());
-            Assert.NotEqual(string.Format(_invalidArgException, nameof(signCommand.HashAlgorithm)), ex.Message);
+                // Act & Assert
+                Assert.True(parsable);
+                var ex = Assert.Throws<CryptographicException>(() => signCommand.GetAuthorSignRequest());
+                Assert.NotEqual(string.Format(_invalidArgException, nameof(signCommand.HashAlgorithm)), ex.Message);
+            }
         }
 
         [Fact]
         public void MSSignCommandArgParsing_InvalidHashAlgorithm()
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
-            var hashAlgorithm = "MD5";
-            var mockConsole = new Mock<IConsole>();
-
-            var signCommand = new MSSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CertificateFingerprint = certificateFingerprint,
-                KeyContainer = keyContainer,
-                CSPName = cspName,
-                HashAlgorithm = hashAlgorithm
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
+                var hashAlgorithm = "MD5";
+                var mockConsole = new Mock<IConsole>();
 
-            signCommand.Arguments.Add(packagePath);
+                var signCommand = new MSSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CertificateFingerprint = certificateFingerprint,
+                    KeyContainer = keyContainer,
+                    CSPName = cspName,
+                    HashAlgorithm = hashAlgorithm
+                };
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
-            Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.HashAlgorithm)), ex.Message);
+                signCommand.Arguments.Add(packagePath);
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
+                Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.HashAlgorithm)), ex.Message);
+            }
         }
 
         [Theory]
@@ -225,63 +249,69 @@ namespace NuGet.MSSigning.Extensions.Test
         [InlineData("SHA512")]
         public void MSSignCommandArgParsing_ValidTimestampHashAlgorithm(string timestampHashAlgorithm)
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
-            var parsable = Enum.TryParse(timestampHashAlgorithm, ignoreCase: true, result: out Common.HashAlgorithmName parsedHashAlgorithm);
-            var mockConsole = new Mock<IConsole>();
-            var signCommand = new MSSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CertificateFingerprint = certificateFingerprint,
-                KeyContainer = keyContainer,
-                CSPName = cspName,
-                TimestampHashAlgorithm = timestampHashAlgorithm
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
+                var parsable = Enum.TryParse(timestampHashAlgorithm, ignoreCase: true, result: out Common.HashAlgorithmName parsedHashAlgorithm);
+                var mockConsole = new Mock<IConsole>();
+                var signCommand = new MSSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CertificateFingerprint = certificateFingerprint,
+                    KeyContainer = keyContainer,
+                    CSPName = cspName,
+                    TimestampHashAlgorithm = timestampHashAlgorithm
+                };
 
-            signCommand.Arguments.Add(packagePath);
+                signCommand.Arguments.Add(packagePath);
 
-            // Act & Assert
-            Assert.True(parsable);
-            var ex = Assert.Throws<CryptographicException>(() => signCommand.GetAuthorSignRequest());
-            Assert.NotEqual(string.Format(_invalidArgException, nameof(signCommand.TimestampHashAlgorithm)), ex.Message);
+                // Act & Assert
+                Assert.True(parsable);
+                var ex = Assert.Throws<CryptographicException>(() => signCommand.GetAuthorSignRequest());
+                Assert.NotEqual(string.Format(_invalidArgException, nameof(signCommand.TimestampHashAlgorithm)), ex.Message);
+            }
         }
 
         [Fact]
         public void MSSignCommandArgParsing_InvalidTimestampHashAlgorithm()
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
-            var timestampHashAlgorithm = "MD5";
-            var mockConsole = new Mock<IConsole>();
-
-            var signCommand = new MSSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CertificateFingerprint = certificateFingerprint,
-                KeyContainer = keyContainer,
-                CSPName = cspName,
-                TimestampHashAlgorithm = timestampHashAlgorithm
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
+                var timestampHashAlgorithm = "MD5";
+                var mockConsole = new Mock<IConsole>();
 
-            signCommand.Arguments.Add(packagePath);
+                var signCommand = new MSSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CertificateFingerprint = certificateFingerprint,
+                    KeyContainer = keyContainer,
+                    CSPName = cspName,
+                    TimestampHashAlgorithm = timestampHashAlgorithm
+                };
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
-            Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.TimestampHashAlgorithm)), ex.Message);
+                signCommand.Arguments.Add(packagePath);
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
+                Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.TimestampHashAlgorithm)), ex.Message);
+            }
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetMSSignCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetMSSignCommandTest.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using Moq;
+using NuGet.CommandLine;
+using Xunit;
+
+namespace NuGet.MSSigning.Extensions.Test
+{
+    public class NuGetMSSignCommandTest
+    {
+        private const string _noPackageException = "No package was provided. For a list of accepted ways to provide a package, please visit https://docs.nuget.org/docs/reference/command-line-reference";
+        private const string _invalidArgException = "Invalid value provided for '{0}'. For a list of accepted values, please visit https://docs.nuget.org/docs/reference/command-line-reference";
+        private const string _noCertificateException = "No {0} provided or provided file is not a p7b file.";
+
+        [Fact]
+        public void MSSignCommandArgParsing_NoPackagePath()
+        {
+            // Arrange
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+
+            var mockConsole = new Mock<IConsole>();
+            var signCommand = new MSSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CSPName = cspName,
+                KeyContainer = keyContainer,
+                CertificateFingerprint = certificateFingerprint,
+            };
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
+            Assert.Equal(_noPackageException, ex.Message);
+        }
+
+        [Fact]
+        public void MSSignCommandArgParsing_NoCertificateFile()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+
+            var mockConsole = new Mock<IConsole>();
+            var signCommand = new MSSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CSPName = cspName,
+                KeyContainer = keyContainer,
+                CertificateFingerprint = certificateFingerprint,
+            };
+            signCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
+            Assert.Equal(string.Format(_noCertificateException, nameof(signCommand.CertificateFile)), ex.Message);
+        }
+
+        [Fact]
+        public void MSSignCommandArgParsing_NoCSPName()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+
+            var mockConsole = new Mock<IConsole>();
+            var signCommand = new MSSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                KeyContainer = keyContainer,
+                CertificateFingerprint = certificateFingerprint,
+            };
+
+            signCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
+            Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.CSPName)), ex.Message);
+        }
+
+        [Fact]
+        public void MSSignCommandArgParsing_NoKeyContainer()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var cspName = "cert provider";
+
+            var mockConsole = new Mock<IConsole>();
+            var signCommand = new MSSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CSPName = cspName,
+                CertificateFingerprint = certificateFingerprint,
+            };
+
+            signCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
+            Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.KeyContainer)), ex.Message);
+        }
+
+        [Fact]
+        public void MSSignCommandArgParsing_NoCertificateFingerprint()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+
+            var mockConsole = new Mock<IConsole>();
+            var signCommand = new MSSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CSPName = cspName,
+                KeyContainer = keyContainer,
+            };
+
+            signCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
+            Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.CertificateFingerprint)), ex.Message);
+        }
+
+        [Theory]
+        [InlineData("sha256")]
+        [InlineData("sha384")]
+        [InlineData("sha512")]
+        [InlineData("ShA256")]
+        [InlineData("SHA256")]
+        [InlineData("SHA384")]
+        [InlineData("SHA512")]
+        public void MSSignCommandArgParsing_ValidHashAlgorithm(string hashAlgorithm)
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+            var parsable = Enum.TryParse(hashAlgorithm, ignoreCase: true, result: out Common.HashAlgorithmName parsedHashAlgorithm);
+            var mockConsole = new Mock<IConsole>();
+            var signCommand = new MSSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CertificateFingerprint = certificateFingerprint,
+                KeyContainer = keyContainer,
+                CSPName = cspName,
+                HashAlgorithm = hashAlgorithm
+            };
+
+            signCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            Assert.True(parsable);
+            var ex = Assert.Throws<CryptographicException>(() => signCommand.GetAuthorSignRequest());
+            Assert.NotEqual(string.Format(_invalidArgException, nameof(signCommand.HashAlgorithm)), ex.Message);
+        }
+
+        [Fact]
+        public void MSSignCommandArgParsing_InvalidHashAlgorithm()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+            var hashAlgorithm = "MD5";
+            var mockConsole = new Mock<IConsole>();
+
+            var signCommand = new MSSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CertificateFingerprint = certificateFingerprint,
+                KeyContainer = keyContainer,
+                CSPName = cspName,
+                HashAlgorithm = hashAlgorithm
+            };
+
+            signCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
+            Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.HashAlgorithm)), ex.Message);
+        }
+
+        [Theory]
+        [InlineData("sha256")]
+        [InlineData("sha384")]
+        [InlineData("sha512")]
+        [InlineData("ShA256")]
+        [InlineData("SHA256")]
+        [InlineData("SHA384")]
+        [InlineData("SHA512")]
+        public void MSSignCommandArgParsing_ValidTimestampHashAlgorithm(string timestampHashAlgorithm)
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+            var parsable = Enum.TryParse(timestampHashAlgorithm, ignoreCase: true, result: out Common.HashAlgorithmName parsedHashAlgorithm);
+            var mockConsole = new Mock<IConsole>();
+            var signCommand = new MSSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CertificateFingerprint = certificateFingerprint,
+                KeyContainer = keyContainer,
+                CSPName = cspName,
+                TimestampHashAlgorithm = timestampHashAlgorithm
+            };
+
+            signCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            Assert.True(parsable);
+            var ex = Assert.Throws<CryptographicException>(() => signCommand.GetAuthorSignRequest());
+            Assert.NotEqual(string.Format(_invalidArgException, nameof(signCommand.TimestampHashAlgorithm)), ex.Message);
+        }
+
+        [Fact]
+        public void MSSignCommandArgParsing_InvalidTimestampHashAlgorithm()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+            var timestampHashAlgorithm = "MD5";
+            var mockConsole = new Mock<IConsole>();
+
+            var signCommand = new MSSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CertificateFingerprint = certificateFingerprint,
+                KeyContainer = keyContainer,
+                CSPName = cspName,
+                TimestampHashAlgorithm = timestampHashAlgorithm
+            };
+
+            signCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => signCommand.GetAuthorSignRequest());
+            Assert.Equal(string.Format(_invalidArgException, nameof(signCommand.TimestampHashAlgorithm)), ex.Message);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetReposignCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetReposignCommandTest.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Security.Cryptography;
 using Moq;
 using NuGet.MSSigning.Extensions;
+using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.CommandLine.MSSigning.Extensions.Test
@@ -19,268 +21,295 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
         [Fact]
         public void ReposignCommandArgParsing_NoPackagePath()
         {
-            // Arrange
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
-            var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
-
-            var mockConsole = new Mock<IConsole>();
-            var reposignCommand = new RepoSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CSPName = cspName,
-                KeyContainer = keyContainer,
-                CertificateFingerprint = certificateFingerprint,
-                V3ServiceIndexUrl = v3serviceIndexUrl,
-            };
+                // Arrange
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
+                var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-            Assert.Equal(_noPackageException, ex.Message);
+                var mockConsole = new Mock<IConsole>();
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CSPName = cspName,
+                    KeyContainer = keyContainer,
+                    CertificateFingerprint = certificateFingerprint,
+                    V3ServiceIndexUrl = v3serviceIndexUrl,
+                };
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.Equal(_noPackageException, ex.Message);
+            }
         }
 
         [Fact]
         public void ReposignCommandArgParsing_NoCertificateFile()
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
-            var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
-
-            var mockConsole = new Mock<IConsole>();
-            var reposignCommand = new RepoSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CSPName = cspName,
-                KeyContainer = keyContainer,
-                CertificateFingerprint = certificateFingerprint,
-                V3ServiceIndexUrl = v3serviceIndexUrl,
-            };
-            reposignCommand.Arguments.Add(packagePath);
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
+                var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-            Assert.Equal(string.Format(_noCertificateException, nameof(reposignCommand.CertificateFile)), ex.Message);
+                var mockConsole = new Mock<IConsole>();
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CSPName = cspName,
+                    KeyContainer = keyContainer,
+                    CertificateFingerprint = certificateFingerprint,
+                    V3ServiceIndexUrl = v3serviceIndexUrl,
+                };
+                reposignCommand.Arguments.Add(packagePath);
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.Equal(string.Format(_noCertificateException, nameof(reposignCommand.CertificateFile)), ex.Message);
+            }
         }
 
         [Fact]
         public void ReposignCommandArgParsing_NoCSPName()
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-            var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
-
-            var mockConsole = new Mock<IConsole>();
-            var reposignCommand = new RepoSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                KeyContainer = keyContainer,
-                CertificateFingerprint = certificateFingerprint,
-                V3ServiceIndexUrl = v3serviceIndexUrl,
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
+                var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
 
-            reposignCommand.Arguments.Add(packagePath);
+                var mockConsole = new Mock<IConsole>();
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    KeyContainer = keyContainer,
+                    CertificateFingerprint = certificateFingerprint,
+                    V3ServiceIndexUrl = v3serviceIndexUrl,
+                };
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.CSPName)), ex.Message);
+                reposignCommand.Arguments.Add(packagePath);
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.CSPName)), ex.Message);
+            }
         }
 
         [Fact]
         public void ReposignCommandArgParsing_NoKeyContainer()
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var cspName = "cert provider";
-            var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
-
-            var mockConsole = new Mock<IConsole>();
-            var reposignCommand = new RepoSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CSPName = cspName,
-                CertificateFingerprint = certificateFingerprint,
-                V3ServiceIndexUrl = v3serviceIndexUrl,
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var cspName = "cert provider";
+                var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
 
-            reposignCommand.Arguments.Add(packagePath);
+                var mockConsole = new Mock<IConsole>();
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CSPName = cspName,
+                    CertificateFingerprint = certificateFingerprint,
+                    V3ServiceIndexUrl = v3serviceIndexUrl,
+                };
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.KeyContainer)), ex.Message);
+                reposignCommand.Arguments.Add(packagePath);
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.KeyContainer)), ex.Message);
+            }
         }
 
         [Fact]
         public void ReposignCommandArgParsing_NoCertificateFingerprint()
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
-            var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
-
-            var mockConsole = new Mock<IConsole>();
-            var reposignCommand = new RepoSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CSPName = cspName,
-                KeyContainer = keyContainer,
-                V3ServiceIndexUrl = v3serviceIndexUrl,
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
+                var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
 
-            reposignCommand.Arguments.Add(packagePath);
+                var mockConsole = new Mock<IConsole>();
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CSPName = cspName,
+                    KeyContainer = keyContainer,
+                    V3ServiceIndexUrl = v3serviceIndexUrl,
+                };
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.CertificateFingerprint)), ex.Message);
+                reposignCommand.Arguments.Add(packagePath);
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.CertificateFingerprint)), ex.Message);
+            }
         }
 
         [Fact]
         public void ReposignCommandArgParsing_NoV3ServiceIndex()
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
-
-            var mockConsole = new Mock<IConsole>();
-            var reposignCommand = new RepoSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CSPName = cspName,
-                KeyContainer = keyContainer,
-                CertificateFingerprint = certificateFingerprint,
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
 
-            reposignCommand.Arguments.Add(packagePath);
+                var mockConsole = new Mock<IConsole>();
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CSPName = cspName,
+                    KeyContainer = keyContainer,
+                    CertificateFingerprint = certificateFingerprint,
+                };
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.V3ServiceIndexUrl)), ex.Message);
+                reposignCommand.Arguments.Add(packagePath);
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.V3ServiceIndexUrl)), ex.Message);
+            }
         }
 
         [Fact]
         public void ReposignCommandArgParsing_InvalidV3ServiceIndex_NotValidURI()
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
-            var serviceIndex = "not-valid-uri";
-
-            var mockConsole = new Mock<IConsole>();
-            var reposignCommand = new RepoSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CSPName = cspName,
-                KeyContainer = keyContainer,
-                CertificateFingerprint = certificateFingerprint,
-                V3ServiceIndexUrl = serviceIndex,
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
+                var serviceIndex = "not-valid-uri";
 
-            reposignCommand.Arguments.Add(packagePath);
+                var mockConsole = new Mock<IConsole>();
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CSPName = cspName,
+                    KeyContainer = keyContainer,
+                    CertificateFingerprint = certificateFingerprint,
+                    V3ServiceIndexUrl = serviceIndex,
+                };
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.V3ServiceIndexUrl)), ex.Message);
+                reposignCommand.Arguments.Add(packagePath);
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.V3ServiceIndexUrl)), ex.Message);
+            }
         }
 
         [Fact]
         public void ReposignCommandArgParsing_InvalidV3ServiceIndex_NotHTTPS()
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
-            var serviceIndex = "http://validv3NonhttpsUri.test/api/index.json";
-
-            var mockConsole = new Mock<IConsole>();
-            var reposignCommand = new RepoSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CSPName = cspName,
-                KeyContainer = keyContainer,
-                CertificateFingerprint = certificateFingerprint,
-                V3ServiceIndexUrl = serviceIndex,
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
+                var serviceIndex = "http://validv3NonhttpsUri.test/api/index.json";
 
-            reposignCommand.Arguments.Add(packagePath);
+                var mockConsole = new Mock<IConsole>();
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CSPName = cspName,
+                    KeyContainer = keyContainer,
+                    CertificateFingerprint = certificateFingerprint,
+                    V3ServiceIndexUrl = serviceIndex,
+                };
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.V3ServiceIndexUrl)), ex.Message);
+                reposignCommand.Arguments.Add(packagePath);
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.V3ServiceIndexUrl)), ex.Message);
+            }
         }
 
         [Fact]
         public void ReposignCommandArgParsing_InvalidPackageOwners()
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
-            var serviceIndex = "https://v3serviceindex.test/api/index.json";
-            var packageOwners = new List<string>() { "owner", "", "anotherOwner", null };
-
-            var mockConsole = new Mock<IConsole>();
-            var reposignCommand = new RepoSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CSPName = cspName,
-                KeyContainer = keyContainer,
-                CertificateFingerprint = certificateFingerprint,
-                V3ServiceIndexUrl = serviceIndex,
-                PackageOwners = packageOwners,
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
+                var serviceIndex = "https://v3serviceindex.test/api/index.json";
+                var packageOwners = new List<string>() { "owner", "", "anotherOwner", null };
 
-            reposignCommand.Arguments.Add(packagePath);
+                var mockConsole = new Mock<IConsole>();
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CSPName = cspName,
+                    KeyContainer = keyContainer,
+                    CertificateFingerprint = certificateFingerprint,
+                    V3ServiceIndexUrl = serviceIndex,
+                    PackageOwners = packageOwners,
+                };
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.PackageOwners)), ex.Message);
+                reposignCommand.Arguments.Add(packagePath);
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.PackageOwners)), ex.Message);
+            }
         }
 
         [Theory]
@@ -293,67 +322,73 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
         [InlineData("SHA512")]
         public void ReposignCommandArgParsing_ValidHashAlgorithm(string hashAlgorithm)
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
-            var serviceIndex = "https://v3serviceindex.test/api/index.json";
-            var parsable = Enum.TryParse(hashAlgorithm, ignoreCase: true, result: out Common.HashAlgorithmName parsedHashAlgorithm);
-            var mockConsole = new Mock<IConsole>();
-            var reposignCommand = new RepoSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CertificateFingerprint = certificateFingerprint,
-                KeyContainer = keyContainer,
-                CSPName = cspName,
-                V3ServiceIndexUrl = serviceIndex,
-                HashAlgorithm = hashAlgorithm
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
+                var serviceIndex = "https://v3serviceindex.test/api/index.json";
+                var parsable = Enum.TryParse(hashAlgorithm, ignoreCase: true, result: out Common.HashAlgorithmName parsedHashAlgorithm);
+                var mockConsole = new Mock<IConsole>();
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CertificateFingerprint = certificateFingerprint,
+                    KeyContainer = keyContainer,
+                    CSPName = cspName,
+                    V3ServiceIndexUrl = serviceIndex,
+                    HashAlgorithm = hashAlgorithm
+                };
 
-            reposignCommand.Arguments.Add(packagePath);
+                reposignCommand.Arguments.Add(packagePath);
 
-            // Act & Assert
-            Assert.True(parsable);
-            var ex = Assert.Throws<CryptographicException>(() => reposignCommand.GetRepositorySignRequest());
-            Assert.NotEqual(string.Format(_invalidArgException, nameof(reposignCommand.HashAlgorithm)), ex.Message);
+                // Act & Assert
+                Assert.True(parsable);
+                var ex = Assert.Throws<CryptographicException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.NotEqual(string.Format(_invalidArgException, nameof(reposignCommand.HashAlgorithm)), ex.Message);
+            }
         }
 
         [Fact]
         public void ReposignCommandArgParsing_InvalidHashAlgorithm()
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
-            var serviceIndex = "https://v3serviceindex.test/api/index.json";
-            var hashAlgorithm = "MD5";
-            var mockConsole = new Mock<IConsole>();
-
-            var reposignCommand = new RepoSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CertificateFingerprint = certificateFingerprint,
-                KeyContainer = keyContainer,
-                CSPName = cspName,
-                V3ServiceIndexUrl = serviceIndex,
-                HashAlgorithm = hashAlgorithm
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
+                var serviceIndex = "https://v3serviceindex.test/api/index.json";
+                var hashAlgorithm = "MD5";
+                var mockConsole = new Mock<IConsole>();
 
-            reposignCommand.Arguments.Add(packagePath);
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CertificateFingerprint = certificateFingerprint,
+                    KeyContainer = keyContainer,
+                    CSPName = cspName,
+                    V3ServiceIndexUrl = serviceIndex,
+                    HashAlgorithm = hashAlgorithm
+                };
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.HashAlgorithm)), ex.Message);
+                reposignCommand.Arguments.Add(packagePath);
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.HashAlgorithm)), ex.Message);
+            }
         }
 
         [Theory]
@@ -366,67 +401,73 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
         [InlineData("SHA512")]
         public void ReposignCommandArgParsing_ValidTimestampHashAlgorithm(string timestampHashAlgorithm)
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
-            var serviceIndex = "https://v3serviceindex.test/api/index.json";
-            var parsable = Enum.TryParse(timestampHashAlgorithm, ignoreCase: true, result: out Common.HashAlgorithmName parsedHashAlgorithm);
-            var mockConsole = new Mock<IConsole>();
-            var reposignCommand = new RepoSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CertificateFingerprint = certificateFingerprint,
-                KeyContainer = keyContainer,
-                CSPName = cspName,
-                V3ServiceIndexUrl = serviceIndex,
-                TimestampHashAlgorithm = timestampHashAlgorithm
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
+                var serviceIndex = "https://v3serviceindex.test/api/index.json";
+                var parsable = Enum.TryParse(timestampHashAlgorithm, ignoreCase: true, result: out Common.HashAlgorithmName parsedHashAlgorithm);
+                var mockConsole = new Mock<IConsole>();
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CertificateFingerprint = certificateFingerprint,
+                    KeyContainer = keyContainer,
+                    CSPName = cspName,
+                    V3ServiceIndexUrl = serviceIndex,
+                    TimestampHashAlgorithm = timestampHashAlgorithm
+                };
 
-            reposignCommand.Arguments.Add(packagePath);
+                reposignCommand.Arguments.Add(packagePath);
 
-            // Act & Assert
-            Assert.True(parsable);
-            var ex = Assert.Throws<CryptographicException>(() => reposignCommand.GetRepositorySignRequest());
-            Assert.NotEqual(string.Format(_invalidArgException, nameof(reposignCommand.TimestampHashAlgorithm)), ex.Message);
+                // Act & Assert
+                Assert.True(parsable);
+                var ex = Assert.Throws<CryptographicException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.NotEqual(string.Format(_invalidArgException, nameof(reposignCommand.TimestampHashAlgorithm)), ex.Message);
+            }
         }
 
         [Fact]
         public void ReposignCommandArgParsing_InvalidTimestampHashAlgorithm()
         {
-            // Arrange
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var certFile = @"\\path\certificate.p7b";
-            var certificateFingerprint = new Guid().ToString();
-            var keyContainer = new Guid().ToString();
-            var cspName = "cert provider";
-            var serviceIndex = "https://v3serviceindex.test/api/index.json";
-            var timestampHashAlgorithm = "MD5";
-            var mockConsole = new Mock<IConsole>();
-
-            var reposignCommand = new RepoSignCommand
+            using (var dir = TestDirectory.Create())
             {
-                Console = mockConsole.Object,
-                Timestamper = timestamper,
-                CertificateFile = certFile,
-                CertificateFingerprint = certificateFingerprint,
-                KeyContainer = keyContainer,
-                CSPName = cspName,
-                V3ServiceIndexUrl = serviceIndex,
-                TimestampHashAlgorithm = timestampHashAlgorithm
-            };
+                // Arrange
+                var packagePath = Path.Combine(dir, "package.nupkg");
+                var timestamper = "https://timestamper.test";
+                var certFile = Path.Combine(dir, "cert.p7b");
+                var certificateFingerprint = new Guid().ToString();
+                var keyContainer = new Guid().ToString();
+                var cspName = "cert provider";
+                var serviceIndex = "https://v3serviceindex.test/api/index.json";
+                var timestampHashAlgorithm = "MD5";
+                var mockConsole = new Mock<IConsole>();
 
-            reposignCommand.Arguments.Add(packagePath);
+                var reposignCommand = new RepoSignCommand
+                {
+                    Console = mockConsole.Object,
+                    Timestamper = timestamper,
+                    CertificateFile = certFile,
+                    CertificateFingerprint = certificateFingerprint,
+                    KeyContainer = keyContainer,
+                    CSPName = cspName,
+                    V3ServiceIndexUrl = serviceIndex,
+                    TimestampHashAlgorithm = timestampHashAlgorithm
+                };
 
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
-            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.TimestampHashAlgorithm)), ex.Message);
+                reposignCommand.Arguments.Add(packagePath);
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+                Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.TimestampHashAlgorithm)), ex.Message);
+            }
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetReposignCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetReposignCommandTest.cs
@@ -1,0 +1,432 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using Moq;
+using NuGet.MSSigning.Extensions;
+using Xunit;
+
+namespace NuGet.CommandLine.MSSigning.Extensions.Test
+{
+    public class NuGetReposignCommandTest
+    {
+        private const string _noPackageException = "No package was provided. For a list of accepted ways to provide a package, please visit https://docs.nuget.org/docs/reference/command-line-reference";
+        private const string _invalidArgException = "Invalid value provided for '{0}'. For a list of accepted values, please visit https://docs.nuget.org/docs/reference/command-line-reference";
+        private const string _noCertificateException = "No {0} provided or provided file is not a p7b file.";
+
+        [Fact]
+        public void ReposignCommandArgParsing_NoPackagePath()
+        {
+            // Arrange
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+            var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
+
+            var mockConsole = new Mock<IConsole>();
+            var reposignCommand = new RepoSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CSPName = cspName,
+                KeyContainer = keyContainer,
+                CertificateFingerprint = certificateFingerprint,
+                V3ServiceIndexUrl = v3serviceIndexUrl,
+            };
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+            Assert.Equal(_noPackageException, ex.Message);
+        }
+
+        [Fact]
+        public void ReposignCommandArgParsing_NoCertificateFile()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+            var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
+
+            var mockConsole = new Mock<IConsole>();
+            var reposignCommand = new RepoSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CSPName = cspName,
+                KeyContainer = keyContainer,
+                CertificateFingerprint = certificateFingerprint,
+                V3ServiceIndexUrl = v3serviceIndexUrl,
+            };
+            reposignCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+            Assert.Equal(string.Format(_noCertificateException, nameof(reposignCommand.CertificateFile)), ex.Message);
+        }
+
+        [Fact]
+        public void ReposignCommandArgParsing_NoCSPName()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+            var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
+
+            var mockConsole = new Mock<IConsole>();
+            var reposignCommand = new RepoSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                KeyContainer = keyContainer,
+                CertificateFingerprint = certificateFingerprint,
+                V3ServiceIndexUrl = v3serviceIndexUrl,
+            };
+
+            reposignCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.CSPName)), ex.Message);
+        }
+
+        [Fact]
+        public void ReposignCommandArgParsing_NoKeyContainer()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var cspName = "cert provider";
+            var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
+
+            var mockConsole = new Mock<IConsole>();
+            var reposignCommand = new RepoSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CSPName = cspName,
+                CertificateFingerprint = certificateFingerprint,
+                V3ServiceIndexUrl = v3serviceIndexUrl,
+            };
+
+            reposignCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.KeyContainer)), ex.Message);
+        }
+
+        [Fact]
+        public void ReposignCommandArgParsing_NoCertificateFingerprint()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+            var v3serviceIndexUrl = "https://v3serviceIndex.test/api/index.json";
+
+            var mockConsole = new Mock<IConsole>();
+            var reposignCommand = new RepoSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CSPName = cspName,
+                KeyContainer = keyContainer,
+                V3ServiceIndexUrl = v3serviceIndexUrl,
+            };
+
+            reposignCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.CertificateFingerprint)), ex.Message);
+        }
+
+        [Fact]
+        public void ReposignCommandArgParsing_NoV3ServiceIndex()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+
+            var mockConsole = new Mock<IConsole>();
+            var reposignCommand = new RepoSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CSPName = cspName,
+                KeyContainer = keyContainer,
+                CertificateFingerprint = certificateFingerprint,
+            };
+
+            reposignCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.V3ServiceIndexUrl)), ex.Message);
+        }
+
+        [Fact]
+        public void ReposignCommandArgParsing_InvalidV3ServiceIndex_NotValidURI()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+            var serviceIndex = "not-valid-uri";
+
+            var mockConsole = new Mock<IConsole>();
+            var reposignCommand = new RepoSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CSPName = cspName,
+                KeyContainer = keyContainer,
+                CertificateFingerprint = certificateFingerprint,
+                V3ServiceIndexUrl = serviceIndex,
+            };
+
+            reposignCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.V3ServiceIndexUrl)), ex.Message);
+        }
+
+        [Fact]
+        public void ReposignCommandArgParsing_InvalidV3ServiceIndex_NotHTTPS()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+            var serviceIndex = "http://validv3NonhttpsUri.test/api/index.json";
+
+            var mockConsole = new Mock<IConsole>();
+            var reposignCommand = new RepoSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CSPName = cspName,
+                KeyContainer = keyContainer,
+                CertificateFingerprint = certificateFingerprint,
+                V3ServiceIndexUrl = serviceIndex,
+            };
+
+            reposignCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.V3ServiceIndexUrl)), ex.Message);
+        }
+
+        [Fact]
+        public void ReposignCommandArgParsing_InvalidPackageOwners()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+            var serviceIndex = "https://v3serviceindex.test/api/index.json";
+            var packageOwners = new List<string>() { "owner", "", "anotherOwner", null };
+
+            var mockConsole = new Mock<IConsole>();
+            var reposignCommand = new RepoSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CSPName = cspName,
+                KeyContainer = keyContainer,
+                CertificateFingerprint = certificateFingerprint,
+                V3ServiceIndexUrl = serviceIndex,
+                PackageOwners = packageOwners,
+            };
+
+            reposignCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.PackageOwners)), ex.Message);
+        }
+
+        [Theory]
+        [InlineData("sha256")]
+        [InlineData("sha384")]
+        [InlineData("sha512")]
+        [InlineData("ShA256")]
+        [InlineData("SHA256")]
+        [InlineData("SHA384")]
+        [InlineData("SHA512")]
+        public void ReposignCommandArgParsing_ValidHashAlgorithm(string hashAlgorithm)
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+            var serviceIndex = "https://v3serviceindex.test/api/index.json";
+            var parsable = Enum.TryParse(hashAlgorithm, ignoreCase: true, result: out Common.HashAlgorithmName parsedHashAlgorithm);
+            var mockConsole = new Mock<IConsole>();
+            var reposignCommand = new RepoSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CertificateFingerprint = certificateFingerprint,
+                KeyContainer = keyContainer,
+                CSPName = cspName,
+                V3ServiceIndexUrl = serviceIndex,
+                HashAlgorithm = hashAlgorithm
+            };
+
+            reposignCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            Assert.True(parsable);
+            var ex = Assert.Throws<CryptographicException>(() => reposignCommand.GetRepositorySignRequest());
+            Assert.NotEqual(string.Format(_invalidArgException, nameof(reposignCommand.HashAlgorithm)), ex.Message);
+        }
+
+        [Fact]
+        public void ReposignCommandArgParsing_InvalidHashAlgorithm()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+            var serviceIndex = "https://v3serviceindex.test/api/index.json";
+            var hashAlgorithm = "MD5";
+            var mockConsole = new Mock<IConsole>();
+
+            var reposignCommand = new RepoSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CertificateFingerprint = certificateFingerprint,
+                KeyContainer = keyContainer,
+                CSPName = cspName,
+                V3ServiceIndexUrl = serviceIndex,
+                HashAlgorithm = hashAlgorithm
+            };
+
+            reposignCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.HashAlgorithm)), ex.Message);
+        }
+
+        [Theory]
+        [InlineData("sha256")]
+        [InlineData("sha384")]
+        [InlineData("sha512")]
+        [InlineData("ShA256")]
+        [InlineData("SHA256")]
+        [InlineData("SHA384")]
+        [InlineData("SHA512")]
+        public void ReposignCommandArgParsing_ValidTimestampHashAlgorithm(string timestampHashAlgorithm)
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+            var serviceIndex = "https://v3serviceindex.test/api/index.json";
+            var parsable = Enum.TryParse(timestampHashAlgorithm, ignoreCase: true, result: out Common.HashAlgorithmName parsedHashAlgorithm);
+            var mockConsole = new Mock<IConsole>();
+            var reposignCommand = new RepoSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CertificateFingerprint = certificateFingerprint,
+                KeyContainer = keyContainer,
+                CSPName = cspName,
+                V3ServiceIndexUrl = serviceIndex,
+                TimestampHashAlgorithm = timestampHashAlgorithm
+            };
+
+            reposignCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            Assert.True(parsable);
+            var ex = Assert.Throws<CryptographicException>(() => reposignCommand.GetRepositorySignRequest());
+            Assert.NotEqual(string.Format(_invalidArgException, nameof(reposignCommand.TimestampHashAlgorithm)), ex.Message);
+        }
+
+        [Fact]
+        public void ReposignCommandArgParsing_InvalidTimestampHashAlgorithm()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var timestamper = "https://timestamper.test";
+            var certFile = @"\\path\certificate.p7b";
+            var certificateFingerprint = new Guid().ToString();
+            var keyContainer = new Guid().ToString();
+            var cspName = "cert provider";
+            var serviceIndex = "https://v3serviceindex.test/api/index.json";
+            var timestampHashAlgorithm = "MD5";
+            var mockConsole = new Mock<IConsole>();
+
+            var reposignCommand = new RepoSignCommand
+            {
+                Console = mockConsole.Object,
+                Timestamper = timestamper,
+                CertificateFile = certFile,
+                CertificateFingerprint = certificateFingerprint,
+                KeyContainer = keyContainer,
+                CSPName = cspName,
+                V3ServiceIndexUrl = serviceIndex,
+                TimestampHashAlgorithm = timestampHashAlgorithm
+            };
+
+            reposignCommand.Arguments.Add(packagePath);
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => reposignCommand.GetRepositorySignRequest());
+            Assert.Equal(string.Format(_invalidArgException, nameof(reposignCommand.TimestampHashAlgorithm)), ex.Message);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/xunit.runner.json
+++ b/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/xunit.runner.json
@@ -1,0 +1,5 @@
+﻿{
+  "maxParallelThreads": 1,
+  "parallelizeTestCollections": false,
+  "longRunningTestSeconds": 1200
+}

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -492,8 +492,7 @@ namespace Test.Utility.Signing
         /// </summary>
         public static X509Certificate2 GetPublicCert(X509Certificate2 cert)
         {
-            var pass = new Guid().ToString();
-            return new X509Certificate2(cert.Export(X509ContentType.Cert), pass, X509KeyStorageFlags.Exportable);
+            return new X509Certificate2(cert.Export(X509ContentType.Cert));
         }
 
         /// <summary>
@@ -501,8 +500,8 @@ namespace Test.Utility.Signing
         /// </summary>
         public static X509Certificate2 GetPublicCertWithPrivateKey(X509Certificate2 cert)
         {
-            var pass = new Guid().ToString();
-            return new X509Certificate2(cert.Export(X509ContentType.Pfx, pass), pass, X509KeyStorageFlags.PersistKeySet|X509KeyStorageFlags.Exportable);
+            var password = new Guid().ToString();
+            return new X509Certificate2(cert.Export(X509ContentType.Pfx, password), password, X509KeyStorageFlags.PersistKeySet|X509KeyStorageFlags.Exportable);
         }
 
         public static TrustedTestCert<TestCertificate> GenerateTrustedTestCertificate()

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -210,7 +210,7 @@ namespace Test.Utility.Signing
             var keyUsage = KeyUsage.DigitalSignature;
             var issuerDN = chainCertificateRequest?.IssuerDN ?? subjectDN;
             certGen.SetIssuerDN(new X509Name(issuerDN));
-
+            
 #if IS_DESKTOP
             if (chainCertificateRequest != null)
             {
@@ -492,7 +492,8 @@ namespace Test.Utility.Signing
         /// </summary>
         public static X509Certificate2 GetPublicCert(X509Certificate2 cert)
         {
-            return new X509Certificate2(cert.Export(X509ContentType.Cert));
+            var pass = new Guid().ToString();
+            return new X509Certificate2(cert.Export(X509ContentType.Cert), pass, X509KeyStorageFlags.Exportable);
         }
 
         /// <summary>
@@ -501,7 +502,7 @@ namespace Test.Utility.Signing
         public static X509Certificate2 GetPublicCertWithPrivateKey(X509Certificate2 cert)
         {
             var pass = new Guid().ToString();
-            return new X509Certificate2(cert.Export(X509ContentType.Pfx, pass), pass, X509KeyStorageFlags.PersistKeySet);
+            return new X509Certificate2(cert.Export(X509ContentType.Pfx, pass), pass, X509KeyStorageFlags.PersistKeySet|X509KeyStorageFlags.Exportable);
         }
 
         public static TrustedTestCert<TestCertificate> GenerateTrustedTestCertificate()


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/6684

This PR adds unit and functional tests for NuGet `mssign` and `reposing` commands. Also includes some fixes for a better error experience and better testability in the `reposing` and `mssign`, as well as a typo in the `mssign` usage description.