### PR TITLE
Allowing https in timestamper url in Rfc3161TimestampRequest

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampRequest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampRequest.cs
@@ -186,8 +186,8 @@ namespace NuGet.Packaging.Signing
                 throw new ArgumentNullException(nameof(timestampUri));
             if (!timestampUri.IsAbsoluteUri)
                 throw new ArgumentException("Absolute URI required", nameof(timestampUri));
-            if (timestampUri.Scheme != Uri.UriSchemeHttp)
-                throw new ArgumentException("HTTP required", nameof(timestampUri));
+            if (timestampUri.Scheme != Uri.UriSchemeHttp && timestampUri.Scheme != Uri.UriSchemeHttps)
+                throw new ArgumentException("HTTP/HTTPS required", nameof(timestampUri));
 
             IntPtr requestedPolicyPtr = IntPtr.Zero;
             IntPtr pTsContext = IntPtr.Zero;


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6871
Regression: No  

## Fix
Details: We allow timestamper url to be https in the [Rfc3161TimestampProvider](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs#L35), but we did not allow it in the `Rfc3161TimestampRequest`. This PR fixes this.