### PR TITLE
Improve error experience on invalid nupkg file

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -119,10 +120,10 @@ namespace NuGet.Packaging
                 ZipReadStream = stream;
                 _zipArchive = new ZipArchive(stream, ZipArchiveMode.Read);
             }
-            catch
+            catch (Exception ex)
             {
                 stream?.Dispose();
-                throw;
+                throw new InvalidDataException(string.Format(CultureInfo.CurrentCulture, Strings.InvalidPackageNupkg, filePath), ex);
             }
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -512,7 +512,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} cannot be read. File is not a valid nupkg..
+        ///   Looks up a localized string similar to The file is not a valid nupkg. File path: {0}.
         /// </summary>
         internal static string InvalidPackageNupkg {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -512,6 +512,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} cannot be read. File is not a valid nupkg..
+        /// </summary>
+        internal static string InvalidPackageNupkg {
+            get {
+                return ResourceManager.GetString("InvalidPackageNupkg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package {0} signature is invalid..
         /// </summary>
         internal static string InvalidPackageSignature {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -667,7 +667,7 @@ Valid from:</comment>
     <value>The timestamp's generalized time is outside the timestamping certificate's validity period.</value>
   </data>
   <data name="InvalidPackageNupkg" xml:space="preserve">
-    <value>{0} cannot be read. File is not a valid nupkg.</value>
+    <value>The file is not a valid nupkg. File path: {0}</value>
     <comment>0 - Nupkg file path</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -666,4 +666,8 @@ Valid from:</comment>
   <data name="SignError_TimestampGeneralizedTimeInvalid" xml:space="preserve">
     <value>The timestamp's generalized time is outside the timestamping certificate's validity period.</value>
   </data>
+  <data name="InvalidPackageNupkg" xml:space="preserve">
+    <value>{0} cannot be read. File is not a valid nupkg.</value>
+    <comment>0 - Nupkg file path</comment>
+  </data>
 </root>


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/6721

This PR improves the error experience when trying to open a nupkg file that is invalid. We used to rethrow `ZipArchive` exceptions when creating a `PackageArchiveReader`. This PR makes a custom exception with a nicer message for the user.

When trying to restore a package with corrupted dependencies we used to show this error:
![issue](https://user-images.githubusercontent.com/10507120/37743963-f39f2b38-2d29-11e8-94c4-3382282764d1.png)

The new error is:
![newerrorrestore](https://user-images.githubusercontent.com/2132567/39386288-cafcddf8-4a28-11e8-8054-4980f6d1cb4a.PNG)

