### PR TITLE
verify signing of libraries and nupkgs

### DIFF
--- a/build/common.targets
+++ b/build/common.targets
@@ -159,11 +159,14 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="GetBuildOutputWithSigningMetadata" DependsOnTargets="BuiltProjectOutputGroup" Returns="@(DllsToSignWithMetadata)">
+  <Target Name="GetBuildOutputWithSigningMetadata" DependsOnTargets="BuiltProjectOutputGroup;DocumentationProjectOutputGroup" Returns="@(DllsToSignWithMetadata)">
     <ItemGroup>
-      <DllsToSignWithMetadata Include="@(BuiltProjectOutputGroupOutput->'%(FinalOutputPath)')" Condition="'%(Extension)' != '.json'" KeepDuplicates="false">
+      <DllsToSignWithMetadata Include="@(BuiltProjectOutputGroupOutput->'%(FinalOutputPath)')" Condition="'%(Extension)' == '.dll' OR '%(Extension)' == '.exe'" KeepDuplicates="false">
         <StrongName>$(StrongNameCert)</StrongName>
         <Authenticode>Microsoft</Authenticode>
+      </DllsToSignWithMetadata>
+      <DllsToSignWithMetadata Include="@(DocumentationProjectOutputGroupOutput->'%(FinalOutputPath)')" KeepDuplicates="false">
+        <Authenticode>XML94</Authenticode>
       </DllsToSignWithMetadata>
     </ItemGroup>
   </Target>

--- a/build/sign.proj
+++ b/build/sign.proj
@@ -45,7 +45,7 @@
   <Target Name="GetOutputVsix">
     <ItemGroup>
       <FilesToSign Include="$(VsixPublishDestination)**\*.vsix">
-        <Authenticode>100040160</Authenticode>
+        <Authenticode>VsixSHA2</Authenticode>
       </FilesToSign>
     </ItemGroup>
   </Target>

--- a/build/sign.proj
+++ b/build/sign.proj
@@ -45,7 +45,7 @@
   <Target Name="GetOutputVsix">
     <ItemGroup>
       <FilesToSign Include="$(VsixPublishDestination)**\*.vsix">
-        <Authenticode>VsixSHA2</Authenticode>
+        <Authenticode>100040160</Authenticode>
       </FilesToSign>
     </ItemGroup>
   </Target>

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -212,6 +212,10 @@ phases:
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/t:AfterBuild /p:SignPackages=true"
 
+  - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
+    inputs:
+      TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
+
   - task: CopyFiles@2
     displayName: "Copy Nupkgs"
     inputs:

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -65,6 +65,11 @@ phases:
         Write-Host "##vso[build.updatebuildnumber]$env:BuildNumber"
         gci env:* | sort-object name
 
+  - task: NuGetToolInstaller@0
+    displayName: "Use NuGet 4.6.2"
+    inputs:
+      versionSpec: "4.6.2"
+
   - task: PowerShell@1
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
@@ -212,8 +217,14 @@ phases:
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/t:AfterBuild /p:SignPackages=true"
 
+  - task: NuGetCommand@2
+    displayName: "Verify Nupkg Signatures"
+    inputs:
+      command: "custom"
+      arguments: "verify -Signatures $(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)\\*.nupkg"
+
   - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
-    displayName: Verify Signatures and StrongName
+    displayName: Verify Assembly Signatures and StrongName
     inputs:
       TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
 

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -215,6 +215,7 @@ phases:
   - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
     inputs:
       TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
+      WhiteListPathForCerts: '*.xml'
 
   - task: CopyFiles@2
     displayName: "Copy Nupkgs"

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -213,6 +213,7 @@ phases:
       msbuildArguments: "/t:AfterBuild /p:SignPackages=true"
 
   - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
+    displayName: Verify Signatures and StrongName
     inputs:
       TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
 

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -215,7 +215,6 @@ phases:
   - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
     inputs:
       TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
-      WhiteListPathForCerts: '*.xml'
 
   - task: CopyFiles@2
     displayName: "Copy Nupkgs"

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
@@ -157,7 +157,7 @@
   <Target Name="GetScriptsForSigning" Returns="@(ScriptsToSign)">
     <ItemGroup>
       <ScriptsToSign Include="$(MSBuildProjectDirectory)\Scripts\*.ps*">
-        <Authenticode>Microsoft402</Authenticode>
+        <Authenticode>402</Authenticode>
       </ScriptsToSign>
     </ItemGroup>
   </Target>

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
@@ -157,7 +157,7 @@
   <Target Name="GetScriptsForSigning" Returns="@(ScriptsToSign)">
     <ItemGroup>
       <ScriptsToSign Include="$(MSBuildProjectDirectory)\Scripts\*.ps*">
-        <Authenticode>402</Authenticode>
+        <Authenticode>Microsoft402</Authenticode>
       </ScriptsToSign>
     </ItemGroup>
   </Target>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -113,6 +113,9 @@
         <StrongName>MsSharedLib72</StrongName>
         <Authenticode>Microsoft</Authenticode>
       </DllsInOutputDir>
+      <DllsInOutputDir Include="$(OutputPath)ilmerge\*.xml" KeepDuplicates="false">
+        <Authenticode>XML94</Authenticode>
+      </DllsInOutputDir>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/6883 
This PR does the following:

1) Start signing the xml files shipped in a nupkg with XML94 certificate
2) Verify all DLLs , XMLs and EXEs within a nupkg are signed properly
3) Verify all nuget packages are signed properly