### PR TITLE
Add new plugin discovery capabilities

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
@@ -178,7 +178,8 @@ namespace NuGet.Protocol.Plugins
         {
             if (string.IsNullOrEmpty(_rawPluginPaths))
             {
-                return Enumerable.Empty<string>();
+                var directories = new List<string> { PluginDiscoveryUtility.GetNuGetHomePluginsPath(), PluginDiscoveryUtility.GetInternalPlugins() };
+                return PluginDiscoveryUtility.GetConventionBasedPlugins(directories);
             }
 
             return _rawPluginPaths.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.Common;
+
+namespace NuGet.Protocol.Plugins
+{
+    public static class PluginDiscoveryUtility
+    {
+        public static string InternalPluginDiscoveryRoot { get; set; }
+
+        public static string GetInternalPlugins()
+        {
+            var rootDirectory = InternalPluginDiscoveryRoot ?? System.Reflection.Assembly.GetEntryAssembly()?.Location;;
+
+            return rootDirectory ?? Path.GetDirectoryName(rootDirectory);
+        }
+
+        public static string GetNuGetHomePluginsPath()
+        {
+            var nuGetHome = NuGetEnvironment.GetFolderPath(NuGetFolderPath.NuGetHome);
+
+            return Path.Combine(nuGetHome,
+                "plugins",
+#if IS_DESKTOP
+                "netfx"
+#else
+                "netcore"
+#endif
+                );
+        }
+
+        public static IEnumerable<string> GetConventionBasedPlugins(IEnumerable<string> directories)
+        {
+            var paths = new List<string>();
+            var existingDirectories = directories.Where(Directory.Exists);
+            foreach (var directory in existingDirectories)
+            {
+                var pluginDirectories = Directory.GetDirectories(directory);
+
+                foreach (var pluginDirectory in pluginDirectories)
+                {
+#if IS_DESKTOP
+                    var expectedPluginName = Path.Combine(pluginDirectory, Path.GetFileName(pluginDirectory) + ".exe");
+#else
+                    var expectedPluginName = Path.Combine(pluginDirectory, Path.GetFileName(pluginDirectory) + ".dll");
+#endif
+
+                    var filesInDirectory = Directory.EnumerateFiles(pluginDirectory);
+                    if (filesInDirectory.Contains(expectedPluginName, PathUtility.GetStringComparerBasedOnOS()))
+                    {
+                        paths.Add(expectedPluginName);
+                    }
+                }
+            }
+
+            return paths;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
@@ -45,9 +45,7 @@ namespace NuGet.Protocol.Plugins
 #else
                     var expectedPluginName = Path.Combine(pluginDirectory, Path.GetFileName(pluginDirectory) + ".dll");
 #endif
-
-                    var filesInDirectory = Directory.EnumerateFiles(pluginDirectory);
-                    if (filesInDirectory.Contains(expectedPluginName, PathUtility.GetStringComparerBasedOnOS()))
+                    if (File.Exists(expectedPluginName))
                     {
                         paths.Add(expectedPluginName);
                     }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ExtensionsTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -21,7 +21,7 @@ namespace NuGet.CommandLine.Test
                     "hello",
                     true);
 
-                Assert.Equal("Hello!" + Environment.NewLine, result.Item2);
+                Assert.Equal("Hello!" + Environment.NewLine, Util.TrimMSBuildDiscoveryAutoDetectionMessage(result.Item2));
             }
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetConfigCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetConfigCommandTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -179,7 +179,7 @@ namespace NuGet.CommandLine.Test
                 var expectedValue = Path.Combine(Path.GetDirectoryName(configFile), "Value1")
                     + Environment.NewLine;
 
-                Assert.Equal(expectedValue, output);
+                Assert.Equal(expectedValue, Util.TrimMSBuildDiscoveryAutoDetectionMessage(output));
             }
         }
 
@@ -246,7 +246,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.Equal(0, result.Item1);
-                Assert.Equal(expectedValue, output);
+                Assert.Equal(expectedValue, Util.TrimMSBuildDiscoveryAutoDetectionMessage(output));
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
@@ -94,7 +94,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.Equal(0, result.Item1);
-                var output = result.Item2;
+                var output = Util.TrimMSBuildDiscoveryAutoDetectionMessage(result.Item2);
                 Assert.Equal($"testPackage1 1.1.0{Environment.NewLine}testPackage2 2.0.0{Environment.NewLine}", output);
             }
         }
@@ -123,11 +123,11 @@ namespace NuGet.CommandLine.Test
                 var output = r.Item2;
                 string[] lines = output.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
 
-                Assert.Equal(5, lines.Length);
-                Assert.Equal("testPackage1", lines[1]);
-                Assert.Equal(" 1.1.0", lines[2]);
-                Assert.Equal(" desc of testPackage1 1.1.0", lines[3]);
-                Assert.Equal(" License url: http://kaka", lines[4]);
+                Assert.Equal(6, lines.Length);
+                Assert.Equal("testPackage1", lines[2]);
+                Assert.Equal(" 1.1.0", lines[3]);
+                Assert.Equal(" desc of testPackage1 1.1.0", lines[4]);
+                Assert.Equal(" License url: http://kaka", lines[5]);
             }
         }
 
@@ -171,7 +171,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.Equal(0, result.Item1);
-                var output = result.Item2;
+                var output = Util.TrimMSBuildDiscoveryAutoDetectionMessage(result.Item2);
                 Assert.Equal($"testPackage1 1.1.0{Environment.NewLine}testPackage2 2.0.0{Environment.NewLine}", output);
             }
         }
@@ -224,7 +224,7 @@ namespace NuGet.CommandLine.Test
                     // verify that only package id & version is displayed
                     var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, result.Item2);
+                    Assert.Equal(expectedOutput, Util.TrimMSBuildDiscoveryAutoDetectionMessage(result.Item2));
 
                     Assert.Contains("$filter=IsLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -283,7 +283,7 @@ namespace NuGet.CommandLine.Test
                     // verify that only testPackage2 is listed since the package testPackage1
                     // is not listed.
                     var expectedOutput = "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, r1.Item2);
+                    Assert.Equal(expectedOutput, Util.TrimMSBuildDiscoveryAutoDetectionMessage(r1.Item2));
 
                     Assert.Contains("$filter=IsLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -346,7 +346,7 @@ namespace NuGet.CommandLine.Test
                     var expectedOutput =
                         "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, r1.Item2);
+                    Assert.Equal(expectedOutput, Util.TrimMSBuildDiscoveryAutoDetectionMessage(r1.Item2));
 
                     Assert.Contains("$filter=IsLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -460,7 +460,7 @@ namespace NuGet.CommandLine.Test
                     // verify that the output is detailed
                     var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, r1.Item2);
+                    Assert.Equal(expectedOutput, Util.TrimMSBuildDiscoveryAutoDetectionMessage(r1.Item2));
 
                     Assert.DoesNotContain("$filter", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -518,7 +518,7 @@ namespace NuGet.CommandLine.Test
                     // verify that the output is detailed
                     var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, r1.Item2);
+                    Assert.Equal(expectedOutput, Util.TrimMSBuildDiscoveryAutoDetectionMessage(r1.Item2));
 
                     Assert.Contains("$filter=IsAbsoluteLatestVersion", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -576,7 +576,7 @@ namespace NuGet.CommandLine.Test
                     // verify that the output is detailed
                     var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                         "testPackage2 2.1.0" + Environment.NewLine;
-                    Assert.Equal(expectedOutput, r1.Item2);
+                    Assert.Equal(expectedOutput, Util.TrimMSBuildDiscoveryAutoDetectionMessage(r1.Item2));
 
                     Assert.DoesNotContain("$filter", searchRequest);
                     Assert.Contains("searchTerm='test", searchRequest);
@@ -675,7 +675,7 @@ namespace NuGet.CommandLine.Test
                         // verify that only package id & version is displayed
                         var expectedOutput = "testPackage1 1.1.0" + Environment.NewLine +
                             "testPackage2 2.1.0" + Environment.NewLine;
-                        Assert.Equal(expectedOutput, result.Item2);
+                        Assert.Equal(expectedOutput, Util.TrimMSBuildDiscoveryAutoDetectionMessage(result.Item2));
 
                         Assert.Contains("$filter=IsLatestVersion", searchRequest);
                         Assert.Contains("searchTerm='test", searchRequest);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -1163,5 +1163,14 @@ EndProject");
             // Simply test the extension as that is all we care about
             return string.Equals(Path.GetExtension(configFileName), ".json", StringComparison.OrdinalIgnoreCase);
         }
+
+        public static string TrimMSBuildDiscoveryAutoDetectionMessage(string message)
+        {
+            if (message != null && message.StartsWith("MSBuild auto-detection"))
+            {
+                return message.Substring(message.IndexOf("\n") + 1);
+            }
+            return message;
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
@@ -1,0 +1,95 @@
+using System.IO;
+using NuGet.Test.Utility;
+using Xunit;
+using System.Linq;
+using System;
+using NuGet.Common;
+using System.Diagnostics;
+
+namespace NuGet.Protocol.Plugins.Tests
+{
+    public class PluginDiscoveryUtilityTest
+    {
+
+#if IS_DESKTOP
+        private static string PluginExtension = ".exe";
+#else
+        private static string PluginExtension = ".dll";
+#endif
+
+        [Theory]
+        [InlineData("VSTSCredProv", "VSTSCredProv", true, true)]
+        [InlineData("VSTSCredProv", "vstscredprov", true, false)]
+        [InlineData("vstscredprov", "VSTSCredProv", true, false)]
+        [InlineData("VSTSCredProv", "MyGetProv", false, false)]
+        public void PluginDiscoveryUtilitySimpleTest(string pluginFolderName, string pluginFileName, bool success, bool matchesCase)
+        {
+            using (var test = TestDirectory.Create())
+            {
+                // Determine what the expected result is based on the case sensitivity of the system.
+                var expectedSuccess = (matchesCase || Common.PathUtility.IsFileSystemCaseInsensitive) && success;
+
+                // Setup
+                var pluginDirectoryPath = Path.Combine(test, pluginFolderName);
+                var fullPluginFilePath = Path.Combine(pluginDirectoryPath, pluginFileName + PluginExtension);
+
+                // Create plugin Directory and name
+                Directory.CreateDirectory(pluginDirectoryPath);
+                File.Create(fullPluginFilePath);
+
+                // Act
+                var results = PluginDiscoveryUtility.GetConventionBasedPlugins(new string[] { test.Path });
+                //Assert
+                Assert.Equal(expectedSuccess ? 1 : 0, results.Count());
+                if (expectedSuccess)
+                {
+                    Assert.Equal(fullPluginFilePath, results.Single(), PathUtility.GetStringComparerBasedOnOS());
+                }
+            }
+        }
+
+        [PlatformTheory(Platform.Linux)]
+        [InlineData("VSTSCredProv", "VSTSCredProv", "vstscredprov", true)] // first matching
+        [InlineData("VSTSCredProv", "vstscredProv", "vstscredprov", false)] // none matching
+        [InlineData("VSTSCredProv", "vstscredProv", "VSTSCredProv", true)] // second matching
+        public void PluginDiscoveryUtilityPluginsWithDifferentCasing(string pluginFolderName, string pluginFileName, string secondPluginName, bool success)
+        {
+            using (var test = TestDirectory.Create())
+            {
+                // Setup
+                var pluginDirectoryPath = Path.Combine(test, pluginFolderName);
+                var fullPluginFilePath = Path.Combine(pluginDirectoryPath, pluginFileName + PluginExtension);
+                var secondFullPluginFilePath = Path.Combine(pluginDirectoryPath, secondPluginName + PluginExtension);
+                var expectedPluginPath = Path.Combine(pluginDirectoryPath, pluginFolderName + PluginExtension);
+
+                // Create plugin Directory and name
+                Directory.CreateDirectory(pluginDirectoryPath);
+                File.Create(fullPluginFilePath);
+                File.Create(secondFullPluginFilePath);
+                // Act
+                var results = PluginDiscoveryUtility.GetConventionBasedPlugins(new string[] { test.Path });
+
+                //Assert
+                Assert.Equal(success ? 1 : 0, results.Count());
+                if (success)
+                {
+                    Assert.Equal(expectedPluginPath, results.Single());
+                }
+            }
+        }
+
+        [Fact]
+        public void PluginDiscoveryUtilityGetsNuGetHomePluginPath()
+        {
+            var result = PluginDiscoveryUtility.GetNuGetHomePluginsPath();
+
+            Assert.Contains(Path.Combine(".nuget", "plugins",
+#if IS_DESKTOP
+                "netfx"
+#else
+                "netcore"
+#endif
+                ), result);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
@@ -19,8 +19,6 @@ namespace NuGet.Protocol.Plugins.Tests
 
         [Theory]
         [InlineData("VSTSCredProv", "VSTSCredProv", true)]
-        [InlineData("VSTSCredProv", "vstscredprov", true)]
-        [InlineData("vstscredprov", "VSTSCredProv", true )]
         [InlineData("VSTSCredProv", "MyGetProv", false)]
         public void PluginDiscoveryUtilitySimpleTest(string pluginFolderName, string pluginFileName, bool success)
         {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
@@ -18,17 +18,14 @@ namespace NuGet.Protocol.Plugins.Tests
 #endif
 
         [Theory]
-        [InlineData("VSTSCredProv", "VSTSCredProv", true, true)]
-        [InlineData("VSTSCredProv", "vstscredprov", true, false)]
-        [InlineData("vstscredprov", "VSTSCredProv", true, false)]
-        [InlineData("VSTSCredProv", "MyGetProv", false, false)]
-        public void PluginDiscoveryUtilitySimpleTest(string pluginFolderName, string pluginFileName, bool success, bool matchesCase)
+        [InlineData("VSTSCredProv", "VSTSCredProv", true)]
+        [InlineData("VSTSCredProv", "vstscredprov", true)]
+        [InlineData("vstscredprov", "VSTSCredProv", true )]
+        [InlineData("VSTSCredProv", "MyGetProv", false)]
+        public void PluginDiscoveryUtilitySimpleTest(string pluginFolderName, string pluginFileName, bool success)
         {
             using (var test = TestDirectory.Create())
             {
-                // Determine what the expected result is based on the case sensitivity of the system.
-                var expectedSuccess = (matchesCase || Common.PathUtility.IsFileSystemCaseInsensitive) && success;
-
                 // Setup
                 var pluginDirectoryPath = Path.Combine(test, pluginFolderName);
                 var fullPluginFilePath = Path.Combine(pluginDirectoryPath, pluginFileName + PluginExtension);
@@ -39,41 +36,11 @@ namespace NuGet.Protocol.Plugins.Tests
 
                 // Act
                 var results = PluginDiscoveryUtility.GetConventionBasedPlugins(new string[] { test.Path });
-                //Assert
-                Assert.Equal(expectedSuccess ? 1 : 0, results.Count());
-                if (expectedSuccess)
-                {
-                    Assert.Equal(fullPluginFilePath, results.Single(), PathUtility.GetStringComparerBasedOnOS());
-                }
-            }
-        }
-
-        [PlatformTheory(Platform.Linux)]
-        [InlineData("VSTSCredProv", "VSTSCredProv", "vstscredprov", true)] // first matching
-        [InlineData("VSTSCredProv", "vstscredProv", "vstscredprov", false)] // none matching
-        [InlineData("VSTSCredProv", "vstscredProv", "VSTSCredProv", true)] // second matching
-        public void PluginDiscoveryUtilityPluginsWithDifferentCasing(string pluginFolderName, string pluginFileName, string secondPluginName, bool success)
-        {
-            using (var test = TestDirectory.Create())
-            {
-                // Setup
-                var pluginDirectoryPath = Path.Combine(test, pluginFolderName);
-                var fullPluginFilePath = Path.Combine(pluginDirectoryPath, pluginFileName + PluginExtension);
-                var secondFullPluginFilePath = Path.Combine(pluginDirectoryPath, secondPluginName + PluginExtension);
-                var expectedPluginPath = Path.Combine(pluginDirectoryPath, pluginFolderName + PluginExtension);
-
-                // Create plugin Directory and name
-                Directory.CreateDirectory(pluginDirectoryPath);
-                File.Create(fullPluginFilePath);
-                File.Create(secondFullPluginFilePath);
-                // Act
-                var results = PluginDiscoveryUtility.GetConventionBasedPlugins(new string[] { test.Path });
-
                 //Assert
                 Assert.Equal(success ? 1 : 0, results.Count());
                 if (success)
                 {
-                    Assert.Equal(expectedPluginPath, results.Single());
+                    Assert.Equal(fullPluginFilePath, results.Single(), StringComparer.OrdinalIgnoreCase);
                 }
             }
         }


### PR DESCRIPTION
## Bug
Half of the work for: https://github.com/NuGet/Home/issues/6704
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 

*Note* that this *targets* the *feature* branch. 

As per the spec  here: 
https://github.com/NuGet/Home/wiki/NuGet-cross-plat-authentication-plugin#plugin-installation-and-discovery

Copying the relevant information for simplicity below:

The plugins will be discovered as follows:

1. An environment variable NUGET_PLUGIN_PATHS, priority reserved of the plugins reserved. If the NUGET_PLUGIN_PATHS environment variable is set, it overrides the convention based plugin discovery.

    The environment variable should contain a full path to the executable, exe in the .NET Framework case and dll in the .NET Core case. It's at the user's discretion to make sure that the plugins are executable under that runtime.
2. User-location - The NuGet Home location - %UserProfile%/.nuget/plugins/

    .NET Core based plugins should be installed in:
    > %UserProfile%/.nuget/plugins/netcore

    .NET Framework based plugins should be installed in:
    > %UserProfile%/.nuget/plugins/netfx

    Each plugin will be installed in it's own folder.

    The plugin entry point will be the name of the installed folder, with the .dll extensions for .NET Core, and .exe extension for .NET Framework.

    Example:

    ```
    .nuget
        plugins
            netfx
                myFeedCredentialProvider
                    myFeedCredentialProvider.exe
                    nuget.protocol.dll
            netcore
                myFeedCredentialProvider
                    myFeedCredentialProvider.dll
                    nuget.protocol.dll
    ``` 

    There's a gap in this approach.

3. Predetermined location in Visual Studio and dotnet (relative to MsBuild.exe)

    The fixed location would be a folder such as, nugetplugins and will follow the same directory rules as listed under 2.

All plugins should be self-contained, and install all their dependencies in their respective folders.

Issues with the discovery of the user-location plugins

Different versions of nuget.exe/dotnet.exe could be using the same plugins.
The obvious issue arises when an older client tries to execute a newer plugin.
If a dotnet.exe under the 2.x runtime, tries to launch a 3.x plugin.
A potential approach would involve adding the target framework under which the plugin has been built.
As this a corner-case scenario that's easily resolvable, the current approach is that we go with the cleaner approach of not including any compatibility checks.


An additional sideeffect of discovering msbuild for every nuget operation is an extra message about the MSBuild discovery whenever nuget.exe is launched. 

The leftover work is actually coding in the built in path for both dotnet.exe and VS/MSBuild shipping vehicles. 
We could consider lowering the verbosity of this message. 

## Testing/Validation
Tests Added: Yes  
Reason for not adding tests:  
Validation done:  
