### PR TITLE
locking cli to version where func tests work

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -213,7 +213,7 @@ Function Install-DotnetCLI {
 
         Invoke-WebRequest $cli.DotNetInstallUrl -OutFile $DotNetInstall
 
-        & $DotNetInstall -Channel release/2.1.4xx -i $cli.Root
+        & $DotNetInstall -Channel release/2.1.4xx -Version 2.1.400-preview-008644 -i $cli.Root
     }
 
     if (-not (Test-Path $cli.DotNetExe)) {

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -213,7 +213,7 @@ Function Install-DotnetCLI {
 
         Invoke-WebRequest $cli.DotNetInstallUrl -OutFile $DotNetInstall
 
-        & $DotNetInstall -Channel release/2.1.4xx -Version 2.1.400-preview-008644 -i $cli.Root
+        & $DotNetInstall -Channel release/2.1.4xx -i $cli.Root
     }
 
     if (-not (Test-Path $cli.DotNetExe)) {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -326,7 +326,7 @@ namespace Dotnet.Integration.Test
 
         public void Dispose()
         {
-            RunDotnet(Path.GetDirectoryName(TestDotnetCli), "buildserver shutdown");
+            RunDotnet(Path.GetDirectoryName(TestDotnetCli), "build-server shutdown");
             KillDotnetExe(TestDotnetCli);
             DeleteDirectory(Path.GetDirectoryName(TestDotnetCli));
         }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -155,7 +155,7 @@ namespace Dotnet.Integration.Test
                 args,
                 waitForExit: true,
                 environmentVariables: _processEnvVars);
-
+            Assert.True(result.Item1 == 0, $"dotnet.exe {args} command failed with following log information :\n {result.AllOutput}");                
             return result;
         }
 


### PR DESCRIPTION
locking CLI version to 2.1.400-preview-008644 because any versions after this cause our functional tests to fail with "Access to the path hostfxr.dll is denied" . I have an email thread with CLI about this, and once they figure out the root cause, we will switch back to using the latest CLI build from the release/2.1.4xx branch.


UPDATE: 

Turns out the root cause was that the 
“dotnet.exe buildserver shutdown” command changed after the 2.1.400-preview-008644. In later builds, it changed to “dotnet.exe build-server shutdown”


CC: @livarcocc @rrelyea 