### PR TITLE
[WIP]Fixing the string formatting on Package metadata published date

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -165,7 +165,7 @@
       <TextBox
         Style="{DynamicResource SelectableTextBlockStyle}" 
         Visibility="{Binding Path=Published,Converter={StaticResource NullToVisibilityConverter}}"
-        Text="{Binding Path=Published,StringFormat={}{0:D} ({0:d})}"
+        Text="{Binding Path=Published,StringFormat={}{0:dddd}\, {0:MMMM} {0:dd}\, {0:yyyy} ({0:d})}"
         Margin="8,8,0,0"
         TextWrapping="Wrap"
         Grid.Row="5"


### PR DESCRIPTION
## Bug
Fixes: [57506](https://devdiv.visualstudio.com/DevDiv/NuGet/_workitems/edit/457506)
Regression: No  

## Fix
Details: Fixes the string formatting over the published date in the package metadata page. This makes each part of the date clear and fixes the issue where the say would not be visible in JP.

### Screenshots - 
#### English -
![english](https://user-images.githubusercontent.com/10507120/39491954-d0d0cf6a-4d42-11e8-99a4-d1c7e36c2ddd.PNG)
#### Spanish-
![spanish](https://user-images.githubusercontent.com/10507120/39491953-d0b8c6cc-4d42-11e8-81da-536ec2d39da3.PNG)
#### French-
![french](https://user-images.githubusercontent.com/10507120/39491955-d0e65d62-4d42-11e8-8600-46c00c20e7fe.PNG)
#### Japanese-
![japanese](https://user-images.githubusercontent.com/10507120/39491952-d0a4368a-4d42-11e8-8578-50e42458f51e.PNG)
#### Japanese translation-
![japanese translation](https://user-images.githubusercontent.com/10507120/39491951-d08c0948-4d42-11e8-8ab9-e29e3a9c7e5b.PNG)


## Testing/Validation
Tests Added: No  
Reason for not adding tests:  UI text changes.
Validation done:  Manual validation in ENG, FR, JP and ESP.
