### PR TITLE
Improving error messages for unsupported algorithms in Timestamp Provider

### DIFF
--- a/src/NuGet.Core/NuGet.Common/CryptoHashUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/CryptoHashUtility.cs
@@ -15,6 +15,9 @@ namespace NuGet.Common
         private const string SHA256_OID = "2.16.840.1.101.3.4.2.1";
         private const string SHA384_OID = "2.16.840.1.101.3.4.2.2";
         private const string SHA512_OID = "2.16.840.1.101.3.4.2.3";
+        private const string SHA256_RSA_OID = "1.2.840.113549.1.1.11";
+        private const string SHA384_RSA_OID = "1.2.840.113549.1.1.12";
+        private const string SHA512_RSA_OID = "1.2.840.113549.1.1.13";
 
         /// <summary>
         /// Compute the hash as a base64 encoded string.
@@ -196,7 +199,7 @@ namespace NuGet.Common
 #endif
 
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithmName, hashAlgorithmName),
+                string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithm, hashAlgorithmName),
                 nameof(hashAlgorithmName));
         }
 
@@ -263,7 +266,7 @@ namespace NuGet.Common
                     return System.Security.Cryptography.HashAlgorithmName.SHA512;
                 default:
                     throw new ArgumentException(
-                        string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithmName, hashAlgorithmName),
+                        string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithm, hashAlgorithmName),
                         nameof(hashAlgorithmName));
             }
         }
@@ -284,7 +287,7 @@ namespace NuGet.Common
                     return SHA512_OID;
                 default:
                     throw new ArgumentException(
-                        string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithmName, hashAlgorithmName),
+                        string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithm, hashAlgorithmName),
                         nameof(hashAlgorithmName));
             }
         }
@@ -317,7 +320,61 @@ namespace NuGet.Common
                     return HashAlgorithmName.SHA512;
                 default:
                     throw new ArgumentException(
-                        string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithmName, oid),
+                        string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithm, oid),
+                        nameof(oid));
+            }
+        }
+
+        /// <summary>
+        /// Extension method to convert NuGet.Common.SignatureAlgorithmName to an Oid string
+        /// </summary>
+        /// <returns>Oid string equivalent of the NuGet.Common.SignatureAlgorithmName</returns>
+        public static string ConvertToOidString(this SignatureAlgorithmName signatureAlgorithmName)
+        {
+            switch (signatureAlgorithmName)
+            {
+                case SignatureAlgorithmName.SHA256RSA:
+                    return SHA256_RSA_OID;
+                case SignatureAlgorithmName.SHA384RSA:
+                    return SHA384_RSA_OID;
+                case SignatureAlgorithmName.SHA512RSA:
+                    return SHA512_RSA_OID;
+                default:
+                    throw new ArgumentException(
+                        string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedSignatureAlgorithm, signatureAlgorithmName),
+                        nameof(signatureAlgorithmName));
+            }
+        }
+
+        /// <summary>
+        /// Extension method to convert NuGet.Common.SignatureAlgorithmName to an Oid.
+        /// </summary>
+        /// <returns>Oid equivalent of the NuGet.Common.SignatureAlgorithmName</returns>
+        public static Oid ConvertToOid(this SignatureAlgorithmName signatureAlgorithmName)
+        {
+            var oidString = signatureAlgorithmName.ConvertToOidString();
+
+            return new Oid(oidString);
+        }
+
+        /// <summary>
+        /// Helper method to convert an Oid string to NuGet.Common.SignatureAlgorithmName
+        /// </summary>
+        /// <param name="oid">An Oid string.</param>
+        /// <returns>NuGet.Common.SignatureAlgorithmName equivalent of the Oid string</returns>
+        public static SignatureAlgorithmName OidToSignatureAlgorithmName(string oid)
+        {
+            switch (oid)
+            {
+                case SHA256_RSA_OID:
+                    return SignatureAlgorithmName.SHA256RSA;
+                case SHA384_RSA_OID:
+                    return SignatureAlgorithmName.SHA384RSA;
+                case SHA512_RSA_OID:
+                    return SignatureAlgorithmName.SHA512RSA;
+                default:
+                    throw new ArgumentException(
+                        string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedSignatureAlgorithm, oid),
                         nameof(oid));
             }
         }

--- a/src/NuGet.Core/NuGet.Common/CryptoHashUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/CryptoHashUtility.cs
@@ -199,7 +199,7 @@ namespace NuGet.Common
 #endif
 
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithm, hashAlgorithmName),
+                string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithmName, hashAlgorithmName),
                 nameof(hashAlgorithmName));
         }
 
@@ -266,7 +266,7 @@ namespace NuGet.Common
                     return System.Security.Cryptography.HashAlgorithmName.SHA512;
                 default:
                     throw new ArgumentException(
-                        string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithm, hashAlgorithmName),
+                        string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithmName, hashAlgorithmName),
                         nameof(hashAlgorithmName));
             }
         }
@@ -287,7 +287,7 @@ namespace NuGet.Common
                     return SHA512_OID;
                 default:
                     throw new ArgumentException(
-                        string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithm, hashAlgorithmName),
+                        string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithmName, hashAlgorithmName),
                         nameof(hashAlgorithmName));
             }
         }
@@ -320,7 +320,7 @@ namespace NuGet.Common
                     return HashAlgorithmName.SHA512;
                 default:
                     throw new ArgumentException(
-                        string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithm, oid),
+                        string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithmName, oid),
                         nameof(oid));
             }
         }
@@ -341,41 +341,8 @@ namespace NuGet.Common
                     return SHA512_RSA_OID;
                 default:
                     throw new ArgumentException(
-                        string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedSignatureAlgorithm, signatureAlgorithmName),
+                        string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedSignatureAlgorithmName, signatureAlgorithmName),
                         nameof(signatureAlgorithmName));
-            }
-        }
-
-        /// <summary>
-        /// Extension method to convert NuGet.Common.SignatureAlgorithmName to an Oid.
-        /// </summary>
-        /// <returns>Oid equivalent of the NuGet.Common.SignatureAlgorithmName</returns>
-        public static Oid ConvertToOid(this SignatureAlgorithmName signatureAlgorithmName)
-        {
-            var oidString = signatureAlgorithmName.ConvertToOidString();
-
-            return new Oid(oidString);
-        }
-
-        /// <summary>
-        /// Helper method to convert an Oid string to NuGet.Common.SignatureAlgorithmName
-        /// </summary>
-        /// <param name="oid">An Oid string.</param>
-        /// <returns>NuGet.Common.SignatureAlgorithmName equivalent of the Oid string</returns>
-        public static SignatureAlgorithmName OidToSignatureAlgorithmName(string oid)
-        {
-            switch (oid)
-            {
-                case SHA256_RSA_OID:
-                    return SignatureAlgorithmName.SHA256RSA;
-                case SHA384_RSA_OID:
-                    return SignatureAlgorithmName.SHA384RSA;
-                case SHA512_RSA_OID:
-                    return SignatureAlgorithmName.SHA512RSA;
-                default:
-                    throw new ArgumentException(
-                        string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedSignatureAlgorithm, oid),
-                        nameof(oid));
             }
         }
 

--- a/src/NuGet.Core/NuGet.Common/SignatureAlgorithmName.cs
+++ b/src/NuGet.Core/NuGet.Common/SignatureAlgorithmName.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Common
+{
+    public enum SignatureAlgorithmName
+    {
+        Unknown = 0,
+        SHA256RSA = 1,
+        SHA384RSA = 2,
+        SHA512RSA = 3,
+    }
+}

--- a/src/NuGet.Core/NuGet.Common/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Common/Strings.Designer.cs
@@ -143,7 +143,7 @@ namespace NuGet.Common {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hash algorithm &apos;{0}&apos; is unsupported..
+        ///   Looks up a localized string similar to Hash algorithm &apos;{0}&apos; is unsupported. Supported algorithms include: SHA512 and SHA256..
         /// </summary>
         internal static string UnsupportedHashAlgorithm {
             get {
@@ -152,11 +152,20 @@ namespace NuGet.Common {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hash algorithm &apos;{0}&apos; is unsupported..
+        /// </summary>
+        internal static string UnsupportedHashAlgorithmName {
+            get {
+                return ResourceManager.GetString("UnsupportedHashAlgorithmName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Signature algorithm &apos;{0}&apos; is unsupported..
         /// </summary>
-        internal static string UnsupportedSignatureAlgorithm {
+        internal static string UnsupportedSignatureAlgorithmName {
             get {
-                return ResourceManager.GetString("UnsupportedSignatureAlgorithm", resourceCulture);
+                return ResourceManager.GetString("UnsupportedSignatureAlgorithmName", resourceCulture);
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Common/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Common/Strings.Designer.cs
@@ -20,7 +20,7 @@ namespace NuGet.Common {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -143,7 +143,7 @@ namespace NuGet.Common {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hash algorithm &apos;{0}&apos; is unsupported. Supported algorithms include: SHA512 and SHA256..
+        ///   Looks up a localized string similar to Hash algorithm &apos;{0}&apos; is unsupported..
         /// </summary>
         internal static string UnsupportedHashAlgorithm {
             get {
@@ -152,11 +152,11 @@ namespace NuGet.Common {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The hash algorithm &apos;{0}&apos; is unsupported..
+        ///   Looks up a localized string similar to Signature algorithm &apos;{0}&apos; is unsupported..
         /// </summary>
-        internal static string UnsupportedHashAlgorithmName {
+        internal static string UnsupportedSignatureAlgorithm {
             get {
-                return ResourceManager.GetString("UnsupportedHashAlgorithmName", resourceCulture);
+                return ResourceManager.GetString("UnsupportedSignatureAlgorithm", resourceCulture);
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Common/Strings.resx
+++ b/src/NuGet.Core/NuGet.Common/Strings.resx
@@ -146,10 +146,11 @@
     <comment>{0} and {1} are both file paths.</comment>
   </data>
   <data name="UnsupportedHashAlgorithm" xml:space="preserve">
-    <value>Hash algorithm '{0}' is unsupported. Supported algorithms include: SHA512 and SHA256.</value>
+    <value>Hash algorithm '{0}' is unsupported.</value>
+    <comment>0 - hash algorithm name/oid</comment>
   </data>
-  <data name="UnsupportedHashAlgorithmName" xml:space="preserve">
-    <value>The hash algorithm '{0}' is unsupported.</value>
-    <comment>{0} is an algorithm identifier</comment>
+  <data name="UnsupportedSignatureAlgorithm" xml:space="preserve">
+    <value>Signature algorithm '{0}' is unsupported.</value>
+    <comment>0 - Signature Algorithma name/oid</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Common/Strings.resx
+++ b/src/NuGet.Core/NuGet.Common/Strings.resx
@@ -146,11 +146,15 @@
     <comment>{0} and {1} are both file paths.</comment>
   </data>
   <data name="UnsupportedHashAlgorithm" xml:space="preserve">
-    <value>Hash algorithm '{0}' is unsupported.</value>
-    <comment>0 - hash algorithm name/oid</comment>
+    <value>Hash algorithm '{0}' is unsupported. Supported algorithms include: SHA512 and SHA256.</value>
+    <comment>{0} is an algorithm identifier</comment>
   </data>
-  <data name="UnsupportedSignatureAlgorithm" xml:space="preserve">
+  <data name="UnsupportedHashAlgorithmName" xml:space="preserve">
+    <value>Hash algorithm '{0}' is unsupported.</value>
+    <comment>{0} is an algorithm identifier</comment>
+  </data>
+  <data name="UnsupportedSignatureAlgorithmName" xml:space="preserve">
     <value>Signature algorithm '{0}' is unsupported.</value>
-    <comment>0 - Signature Algorithma name/oid</comment>
+    <comment>{0} is an algorithm identifier</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Specifications/SigningSpecifications.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Specifications/SigningSpecifications.cs
@@ -39,12 +39,12 @@ namespace NuGet.Packaging.Signing
         /// <summary>
         /// Returns the set of allowed signature algorithms.
         /// </summary>
-        public abstract SignatureAlgorithmName[] AllowedCertificateSignatureAlgorithms { get; }
+        public abstract SignatureAlgorithmName[] AllowedSignatureAlgorithms { get; }
 
         /// <summary>
         /// Returns the set of allowed signature algorithm Oids.
         /// </summary>
-        public abstract string[] AllowedCertificateSignatureAlgorithmOids { get; }
+        public abstract string[] AllowedSignatureAlgorithmOids { get; }
 
         /// <summary>
         /// Returns minumum length required for RSA public keys.

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Specifications/SigningSpecifications.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Specifications/SigningSpecifications.cs
@@ -37,6 +37,16 @@ namespace NuGet.Packaging.Signing
         public abstract string[] AllowedHashAlgorithmOids { get; }
 
         /// <summary>
+        /// Returns the set of allowed signature algorithms.
+        /// </summary>
+        public abstract SignatureAlgorithmName[] AllowedCertificateSignatureAlgorithms { get; }
+
+        /// <summary>
+        /// Returns the set of allowed signature algorithm Oids.
+        /// </summary>
+        public abstract string[] AllowedCertificateSignatureAlgorithmOids { get; }
+
+        /// <summary>
         /// Returns minumum length required for RSA public keys.
         /// </summary>
         public abstract int RSAPublicKeyMinLength { get; }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Specifications/SigningSpecificationsV1.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Specifications/SigningSpecificationsV1.cs
@@ -29,9 +29,9 @@ namespace NuGet.Packaging.Signing
         private static readonly string[] _allowedHashAlgorithmOids = _allowedHashAlgorithms.Select(hash => hash.ConvertToOidString()).ToArray();
 
         /// <summary>
-        /// Allowed certifiacte signature algorithms.
+        /// Allowed signature algorithms.
         /// </summary>
-        private static readonly SignatureAlgorithmName[] _allowedCertSignatureAlgorithms = new[]
+        private static readonly SignatureAlgorithmName[] _allowedSignatureAlgorithms = new[]
         {
             SignatureAlgorithmName.SHA256RSA,
             SignatureAlgorithmName.SHA384RSA,
@@ -39,9 +39,9 @@ namespace NuGet.Packaging.Signing
         };
 
         /// <summary>
-        /// Allowed certificate signature algorithm Oids.
+        /// Allowed signature algorithm Oids.
         /// </summary>
-        private static readonly string[] _allowedCertSignatureAlgorithmOids = _allowedCertSignatureAlgorithms.Select(algorithm => algorithm.ConvertToOidString()).ToArray();
+        private static readonly string[] _allowedSignatureAlgorithmOids = _allowedSignatureAlgorithms.Select(algorithm => algorithm.ConvertToOidString()).ToArray();
 
         /// <summary>
         /// Gets the signature format version.
@@ -54,9 +54,9 @@ namespace NuGet.Packaging.Signing
 
         public override string[] AllowedHashAlgorithmOids => _allowedHashAlgorithmOids;
 
-        public override SignatureAlgorithmName[] AllowedCertificateSignatureAlgorithms => _allowedCertSignatureAlgorithms;
+        public override SignatureAlgorithmName[] AllowedSignatureAlgorithms => _allowedSignatureAlgorithms;
 
-        public override string[] AllowedCertificateSignatureAlgorithmOids => _allowedCertSignatureAlgorithmOids;
+        public override string[] AllowedSignatureAlgorithmOids => _allowedSignatureAlgorithmOids;
 
         public override int RSAPublicKeyMinLength => _rsaPublicKeyMinLength;
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Specifications/SigningSpecificationsV1.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Specifications/SigningSpecificationsV1.cs
@@ -29,6 +29,21 @@ namespace NuGet.Packaging.Signing
         private static readonly string[] _allowedHashAlgorithmOids = _allowedHashAlgorithms.Select(hash => hash.ConvertToOidString()).ToArray();
 
         /// <summary>
+        /// Allowed certifiacte signature algorithms.
+        /// </summary>
+        private static readonly SignatureAlgorithmName[] _allowedCertSignatureAlgorithms = new[]
+        {
+            SignatureAlgorithmName.SHA256RSA,
+            SignatureAlgorithmName.SHA384RSA,
+            SignatureAlgorithmName.SHA512RSA
+        };
+
+        /// <summary>
+        /// Allowed certificate signature algorithm Oids.
+        /// </summary>
+        private static readonly string[] _allowedCertSignatureAlgorithmOids = _allowedCertSignatureAlgorithms.Select(algorithm => algorithm.ConvertToOidString()).ToArray();
+
+        /// <summary>
         /// Gets the signature format version.
         /// </summary>
         public override string Version => "1";
@@ -38,6 +53,10 @@ namespace NuGet.Packaging.Signing
         public override HashAlgorithmName[] AllowedHashAlgorithms => _allowedHashAlgorithms;
 
         public override string[] AllowedHashAlgorithmOids => _allowedHashAlgorithmOids;
+
+        public override SignatureAlgorithmName[] AllowedCertificateSignatureAlgorithms => _allowedCertSignatureAlgorithms;
+
+        public override string[] AllowedCertificateSignatureAlgorithmOids => _allowedCertSignatureAlgorithmOids;
 
         public override int RSAPublicKeyMinLength => _rsaPublicKeyMinLength;
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
@@ -163,10 +163,10 @@ namespace NuGet.Packaging.Signing
             {
                 var certificateSignatureAlgorithm = GetNameOrOidString(signerInfo.Certificate.SignatureAlgorithm);
 
-                var supportedSignatureAlgorithms = string.Join(", ", spec.AllowedCertificateSignatureAlgorithms);
+                var supportedSignatureAlgorithms = string.Join(", ", spec.AllowedSignatureAlgorithms);
 
                 var errorMessage = string.Format(CultureInfo.CurrentCulture,
-                    Strings.SignError_TimestampCertificateUnsupportedSignatureAlgorithm,
+                    Strings.TimestampCertificateUnsupportedSignatureAlgorithm,
                     certificateSignatureAlgorithm,
                     supportedSignatureAlgorithms);
 
@@ -185,7 +185,7 @@ namespace NuGet.Packaging.Signing
                 var supportedSignatureAlgorithms = string.Join(", ", spec.AllowedHashAlgorithms);
 
                 var errorMessage = string.Format(CultureInfo.CurrentCulture,
-                    Strings.SignError_TimestampResponseUnsupportedDigestAlgorithm,
+                    Strings.TimestampResponseUnsupportedDigestAlgorithm,
                     digestAlgorithm,
                     supportedSignatureAlgorithms);
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
@@ -144,7 +144,6 @@ namespace NuGet.Packaging.Signing
 
         private static void ValidateTimestampCms(SigningSpecifications spec, SignedCms timestampCms, Rfc3161TimestampToken timestampToken)
         {
-
             var signerInfo = timestampCms.SignerInfos[0];
             try
             {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
@@ -144,6 +144,7 @@ namespace NuGet.Packaging.Signing
 
         private static void ValidateTimestampCms(SigningSpecifications spec, SignedCms timestampCms, Rfc3161TimestampToken timestampToken)
         {
+
             var signerInfo = timestampCms.SignerInfos[0];
             try
             {
@@ -161,7 +162,17 @@ namespace NuGet.Packaging.Signing
 
             if (!CertificateUtility.IsSignatureAlgorithmSupported(signerInfo.Certificate))
             {
-                throw new TimestampException(NuGetLogCode.NU3022, Strings.SignError_TimestampUnsupportedSignatureAlgorithm);
+                var certificateSignatureAlgorithm = signerInfo.Certificate.SignatureAlgorithm.FriendlyName?.ToUpper() ??
+                    signerInfo.Certificate.SignatureAlgorithm.Value;
+
+                var supportedSignatureAlgorithms = string.Join(", ", spec.AllowedCertificateSignatureAlgorithms);
+
+                var errorMessage = string.Format(CultureInfo.CurrentCulture,
+                    Strings.SignError_TimestampCertificateUnsupportedSignatureAlgorithm,
+                    certificateSignatureAlgorithm,
+                    supportedSignatureAlgorithms);
+
+                throw new TimestampException(NuGetLogCode.NU3022, errorMessage);
             }
 
             if (!CertificateUtility.IsCertificatePublicKeyValid(signerInfo.Certificate))
@@ -171,7 +182,17 @@ namespace NuGet.Packaging.Signing
 
             if (!spec.AllowedHashAlgorithmOids.Contains(signerInfo.DigestAlgorithm.Value))
             {
-                throw new TimestampException(NuGetLogCode.NU3024, Strings.SignError_TimestampUnsupportedSignatureAlgorithm);
+                var digestAlgorithm = signerInfo.DigestAlgorithm.FriendlyName?.ToUpper() ??
+                    signerInfo.DigestAlgorithm.Value;
+
+                var supportedSignatureAlgorithms = string.Join(", ", spec.AllowedHashAlgorithms);
+
+                var errorMessage = string.Format(CultureInfo.CurrentCulture,
+                    Strings.SignError_TimestampResponseUnsupportedDigestAlgorithm,
+                    digestAlgorithm,
+                    supportedSignatureAlgorithms);
+
+                throw new TimestampException(NuGetLogCode.NU3024, errorMessage);
             }
 
             if (CertificateUtility.IsCertificateValidityPeriodInTheFuture(signerInfo.Certificate))
@@ -225,6 +246,7 @@ namespace NuGet.Packaging.Signing
 
             return nonce;
         }
+
 #else
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
@@ -26,7 +26,7 @@ namespace NuGet.Packaging.Signing
     {
         // Url to an RFC 3161 timestamp server
         private readonly Uri _timestamperUrl;
-        private const int _rfc3161RequestTimeoutSeconds = 20;
+        private const int _rfc3161RequestTimeoutSeconds = 10;
 
         public Rfc3161TimestampProvider(Uri timeStampServerUrl)
         {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
@@ -26,7 +26,7 @@ namespace NuGet.Packaging.Signing
     {
         // Url to an RFC 3161 timestamp server
         private readonly Uri _timestamperUrl;
-        private const int _rfc3161RequestTimeoutSeconds = 10;
+        private const int _rfc3161RequestTimeoutSeconds = 20;
 
         public Rfc3161TimestampProvider(Uri timeStampServerUrl)
         {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
@@ -161,8 +161,7 @@ namespace NuGet.Packaging.Signing
 
             if (!CertificateUtility.IsSignatureAlgorithmSupported(signerInfo.Certificate))
             {
-                var certificateSignatureAlgorithm = signerInfo.Certificate.SignatureAlgorithm.FriendlyName?.ToUpper() ??
-                    signerInfo.Certificate.SignatureAlgorithm.Value;
+                var certificateSignatureAlgorithm = GetNameOrOidString(signerInfo.Certificate.SignatureAlgorithm);
 
                 var supportedSignatureAlgorithms = string.Join(", ", spec.AllowedCertificateSignatureAlgorithms);
 
@@ -181,8 +180,7 @@ namespace NuGet.Packaging.Signing
 
             if (!spec.AllowedHashAlgorithmOids.Contains(signerInfo.DigestAlgorithm.Value))
             {
-                var digestAlgorithm = signerInfo.DigestAlgorithm.FriendlyName?.ToUpper() ??
-                    signerInfo.DigestAlgorithm.Value;
+                var digestAlgorithm = GetNameOrOidString(signerInfo.DigestAlgorithm);
 
                 var supportedSignatureAlgorithms = string.Join(", ", spec.AllowedHashAlgorithms);
 
@@ -216,7 +214,14 @@ namespace NuGet.Packaging.Signing
             {
                 throw new TimestampException(NuGetLogCode.NU3019, Strings.SignError_TimestampIntegrityCheckFailed);
             }
+        }
 
+        /// <summary>
+        /// Returns the FriendlyName of an Oid. If FriendlyName is null, then the Oid string is returned.
+        /// </summary>
+        private static string GetNameOrOidString(Oid oid)
+        {
+            return oid.FriendlyName?.ToUpper() ?? oid.Value;
         }
 
         private static byte[] GenerateNonce()

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -989,15 +989,6 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The timestamp certificate has an unsupported signature algorithm - &apos;{0}&apos;. The following algorithms are supported - &apos;{1}&apos;..
-        /// </summary>
-        internal static string SignError_TimestampCertificateUnsupportedSignatureAlgorithm {
-            get {
-                return ResourceManager.GetString("SignError_TimestampCertificateUnsupportedSignatureAlgorithm", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The timestamp&apos;s generalized time is outside the timestamping certificate&apos;s validity period..
         /// </summary>
         internal static string SignError_TimestampGeneralizedTimeInvalid {
@@ -1030,15 +1021,6 @@ namespace NuGet.Packaging {
         internal static string SignError_TimestampNotYetValid {
             get {
                 return ResourceManager.GetString("SignError_TimestampNotYetValid", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The timestamp response has an unsupported digest algorithm - &apos;{0}&apos;. The following algorithms are supported - &apos;{1}&apos;..
-        /// </summary>
-        internal static string SignError_TimestampResponseUnsupportedDigestAlgorithm {
-            get {
-                return ResourceManager.GetString("SignError_TimestampResponseUnsupportedDigestAlgorithm", resourceCulture);
             }
         }
         
@@ -1214,6 +1196,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The timestamp certificate has an unsupported signature algorithm ({0}). The following algorithms are supported: {1}..
+        /// </summary>
+        internal static string TimestampCertificateUnsupportedSignatureAlgorithm {
+            get {
+                return ResourceManager.GetString("TimestampCertificateUnsupportedSignatureAlgorithm", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The timestamper URL &apos;{0}&apos; has an invalid URI scheme. The supported schemes are &apos;{1}&apos; and &apos;{2}&apos;..
         /// </summary>
         internal static string TimestampFailureInvalidHttpScheme {
@@ -1237,6 +1228,15 @@ namespace NuGet.Packaging {
         internal static string TimestampResponseExceptionGeneral {
             get {
                 return ResourceManager.GetString("TimestampResponseExceptionGeneral", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The timestamp response has an unsupported digest algorithm ({0}). The following algorithms are supported: {1}..
+        /// </summary>
+        internal static string TimestampResponseUnsupportedDigestAlgorithm {
+            get {
+                return ResourceManager.GetString("TimestampResponseUnsupportedDigestAlgorithm", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -989,6 +989,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The timestamp certificate has an unsupported signature algorithm - &apos;{0}&apos;. The following algorithms are supported - &apos;{1}&apos;..
+        /// </summary>
+        internal static string SignError_TimestampCertificateUnsupportedSignatureAlgorithm {
+            get {
+                return ResourceManager.GetString("SignError_TimestampCertificateUnsupportedSignatureAlgorithm", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The timestamp&apos;s generalized time is outside the timestamping certificate&apos;s validity period..
         /// </summary>
         internal static string SignError_TimestampGeneralizedTimeInvalid {
@@ -1025,20 +1034,20 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The timestamp response has an unsupported digest algorithm - &apos;{0}&apos;. The following algorithms are supported - &apos;{1}&apos;..
+        /// </summary>
+        internal static string SignError_TimestampResponseUnsupportedDigestAlgorithm {
+            get {
+                return ResourceManager.GetString("SignError_TimestampResponseUnsupportedDigestAlgorithm", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The timestamp signature validation failed..
         /// </summary>
         internal static string SignError_TimestampSignatureValidationFailed {
             get {
                 return ResourceManager.GetString("SignError_TimestampSignatureValidationFailed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The timestamp certificate has an unsupported signature algorithm..
-        /// </summary>
-        internal static string SignError_TimestampUnsupportedSignatureAlgorithm {
-            get {
-                return ResourceManager.GetString("SignError_TimestampUnsupportedSignatureAlgorithm", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -650,8 +650,8 @@ Valid from:</comment>
   <data name="SignError_TimestampSignatureValidationFailed" xml:space="preserve">
     <value>The timestamp signature validation failed.</value>
   </data>
-  <data name="SignError_TimestampCertificateUnsupportedSignatureAlgorithm" xml:space="preserve">
-    <value>The timestamp certificate has an unsupported signature algorithm - '{0}'. The following algorithms are supported - '{1}'.</value>
+  <data name="TimestampCertificateUnsupportedSignatureAlgorithm" xml:space="preserve">
+    <value>The timestamp certificate has an unsupported signature algorithm ({0}). The following algorithms are supported: {1}.</value>
     <comment>0 - certificate signature algorithm name/oid
 1 - supported signature algorithm names</comment>
   </data>
@@ -672,8 +672,8 @@ Valid from:</comment>
   <data name="ArgumentCannotBeNullOrEmpty" xml:space="preserve">
     <value>The argument cannot be null or empty.</value>
   </data>
-  <data name="SignError_TimestampResponseUnsupportedDigestAlgorithm" xml:space="preserve">
-    <value>The timestamp response has an unsupported digest algorithm - '{0}'. The following algorithms are supported - '{1}'.</value>
+  <data name="TimestampResponseUnsupportedDigestAlgorithm" xml:space="preserve">
+    <value>The timestamp response has an unsupported digest algorithm ({0}). The following algorithms are supported: {1}.</value>
     <comment>0 - signature algorithm name/oid
 1 - supported signature algorithm names</comment>
   </data>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -385,9 +385,6 @@ Valid from:</comment>
   <data name="ErrorInvalidCertificateChainUnspecifiedReason" xml:space="preserve">
     <value>Certificate chain validation failed for an unspecified reason.</value>
   </data>
-  <data name="ArgumentCannotBeNullOrEmpty" xml:space="preserve">
-    <value>The argument cannot be null or empty.</value>
-  </data>
   <data name="VerifyError_CertificateHasUnsupportedSignatureAlgorithm" xml:space="preserve">
     <value>The {0}'s certificate has an unsupported signature algorithm.</value>
     <comment>0 - Signature friendly name</comment>
@@ -653,8 +650,10 @@ Valid from:</comment>
   <data name="SignError_TimestampSignatureValidationFailed" xml:space="preserve">
     <value>The timestamp signature validation failed.</value>
   </data>
-  <data name="SignError_TimestampUnsupportedSignatureAlgorithm" xml:space="preserve">
-    <value>The timestamp certificate has an unsupported signature algorithm.</value>
+  <data name="SignError_TimestampCertificateUnsupportedSignatureAlgorithm" xml:space="preserve">
+    <value>The timestamp certificate has an unsupported signature algorithm - '{0}'. The following algorithms are supported - '{1}'.</value>
+    <comment>0 - certificate signature algorithm name/oid
+1 - supported signature algorithm names</comment>
   </data>
   <data name="ErrorAuthorTargetCannotBeACountersignature" xml:space="preserve">
     <value>Cannot target author signatures that are countersignatures.</value>
@@ -669,5 +668,13 @@ Valid from:</comment>
   <data name="InvalidPackageNupkg" xml:space="preserve">
     <value>The file is not a valid nupkg. File path: {0}</value>
     <comment>0 - Nupkg file path</comment>
+  </data>
+  <data name="ArgumentCannotBeNullOrEmpty" xml:space="preserve">
+    <value>The argument cannot be null or empty.</value>
+  </data>
+  <data name="SignError_TimestampResponseUnsupportedDigestAlgorithm" xml:space="preserve">
+    <value>The timestamp response has an unsupported digest algorithm - '{0}'. The following algorithms are supported - '{1}'.</value>
+    <comment>0 - signature algorithm name/oid
+1 - supported signature algorithm names</comment>
   </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -705,7 +705,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                         waitForExit: true);
 
                     Assert.False(result.Success);
-                    Assert.Contains("The timestamp response has an unsupported digest algorithm - 'SHA1'. The following algorithms are supported - 'SHA256, SHA384, SHA512'.", result.AllOutput);
+                    Assert.Contains("The timestamp response has an unsupported digest algorithm (SHA1). The following algorithms are supported: SHA256, SHA384, SHA512.", result.AllOutput);
 
                     var resultingFile = File.ReadAllBytes(packageFile.FullName);
                     Assert.Equal(resultingFile, originalFile);

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/SignCommandTests.cs
@@ -705,7 +705,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                         waitForExit: true);
 
                     Assert.False(result.Success);
-                    Assert.Contains("The timestamp certificate has an unsupported signature algorithm.", result.AllOutput);
+                    Assert.Contains("The timestamp response has an unsupported digest algorithm - 'SHA1'. The following algorithms are supported - 'SHA256, SHA384, SHA512'.", result.AllOutput);
 
                     var resultingFile = File.ReadAllBytes(packageFile.FullName);
                     Assert.Equal(resultingFile, originalFile);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -353,13 +353,11 @@ namespace NuGet.Packaging.FuncTest
         [CIOnlyFact]
         public async Task GetTimestamp_WhenCertificateSignatureAlgorithmIsSha1_ThrowsAsync()
         {
-            Debugger.Launch();
-
             var testServer = await _testFixture.GetSigningTestServerAsync();
             var certificateAuthority = await _testFixture.GetDefaultTrustedCertificateAuthorityAsync();
             var timestampServiceOptions = new TimestampServiceOptions() { SignatureHashAlgorithm = new Oid(Oids.Sha1) };
-            var issueCertificateOptions = IssueCertificateOptions.CreateDefaultForRootCertificateAuthority();
-            issueCertificateOptions.SignatureAlgorithmName = "MD5WITHRSA";
+            var issueCertificateOptions = IssueCertificateOptions.CreateDefaultForTimestampService();
+            issueCertificateOptions.SignatureAlgorithmName = "SHA1WITHRSA";
 
             var timestampService = TimestampService.Create(certificateAuthority, timestampServiceOptions, issueCertificateOptions);
 
@@ -372,7 +370,7 @@ namespace NuGet.Packaging.FuncTest
                         () => timestampProvider.GetTimestamp(request, NullLogger.Instance, CancellationToken.None));
 
                     Assert.Equal(
-                        "The timestamp response has an unsupported digest algorithm - 'SHA1'. The following algorithms are supported - 'SHA256, SHA384, SHA512'.",
+                        "The timestamp certificate has an unsupported signature algorithm - 'SHA1RSA'. The following algorithms are supported - 'SHA256RSA, SHA384RSA, SHA512RSA'.",
                         exception.Message);
                 });
         }

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -345,7 +345,7 @@ namespace NuGet.Packaging.FuncTest
                         () => timestampProvider.GetTimestamp(request, NullLogger.Instance, CancellationToken.None));
 
                     Assert.Equal(
-                        "The timestamp response has an unsupported digest algorithm - 'SHA1'. The following algorithms are supported - 'SHA256, SHA384, SHA512'.",
+                        "The timestamp response has an unsupported digest algorithm (SHA1). The following algorithms are supported: SHA256, SHA384, SHA512.",
                         exception.Message);
                 });
         }
@@ -370,7 +370,7 @@ namespace NuGet.Packaging.FuncTest
                         () => timestampProvider.GetTimestamp(request, NullLogger.Instance, CancellationToken.None));
 
                     Assert.Equal(
-                        "The timestamp certificate has an unsupported signature algorithm - 'SHA1RSA'. The following algorithms are supported - 'SHA256RSA, SHA384RSA, SHA512RSA'.",
+                        "The timestamp certificate has an unsupported signature algorithm (SHA1RSA). The following algorithms are supported: SHA256RSA, SHA384RSA, SHA512RSA.",
                         exception.Message);
                 });
         }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/CryptoHashUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/CryptoHashUtilityTests.cs
@@ -42,7 +42,7 @@ namespace NuGet.Common.Test
                 () => HashAlgorithmName.Unknown.ConvertToSystemSecurityHashAlgorithmName());
 
             Assert.Equal("hashAlgorithmName", exception.ParamName);
-            Assert.StartsWith("The hash algorithm 'Unknown' is unsupported.", exception.Message);
+            Assert.StartsWith("Hash algorithm 'Unknown' is unsupported.", exception.Message);
         }
 
         [Theory]
@@ -63,7 +63,7 @@ namespace NuGet.Common.Test
                 () => HashAlgorithmName.Unknown.ConvertToOidString());
 
             Assert.Equal("hashAlgorithmName", exception.ParamName);
-            Assert.StartsWith("The hash algorithm 'Unknown' is unsupported.", exception.Message);
+            Assert.StartsWith("Hash algorithm 'Unknown' is unsupported.", exception.Message);
         }
 
         [Theory]
@@ -84,7 +84,7 @@ namespace NuGet.Common.Test
                 () => CryptoHashUtility.OidToHashAlgorithmName(Oids.Sha1));
 
             Assert.Equal("oid", exception.ParamName);
-            Assert.StartsWith($"The hash algorithm '{Oids.Sha1}' is unsupported.", exception.Message);
+            Assert.StartsWith($"Hash algorithm '{Oids.Sha1}' is unsupported.", exception.Message);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/CryptoHashUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/CryptoHashUtilityTests.cs
@@ -49,7 +49,7 @@ namespace NuGet.Common.Test
         [InlineData(HashAlgorithmName.SHA256, Oids.Sha256)]
         [InlineData(HashAlgorithmName.SHA384, Oids.Sha384)]
         [InlineData(HashAlgorithmName.SHA512, Oids.Sha512)]
-        public void ConvertToOidString_WithValidInput_Succeeds(HashAlgorithmName hashAlgorithmName, string expectedOid)
+        public void ConvertToOidString_HashAlgorithmName_WithValidInput_Succeeds(HashAlgorithmName hashAlgorithmName, string expectedOid)
         {
             var actualOid = hashAlgorithmName.ConvertToOidString();
 
@@ -57,13 +57,34 @@ namespace NuGet.Common.Test
         }
 
         [Fact]
-        public void ConvertToOidString_WithUnknown_Succeeds()
+        public void ConvertToOidString_HashAlgorithmName_WithUnknown_Throws()
         {
             var exception = Assert.Throws<ArgumentException>(
                 () => HashAlgorithmName.Unknown.ConvertToOidString());
 
             Assert.Equal("hashAlgorithmName", exception.ParamName);
             Assert.StartsWith("Hash algorithm 'Unknown' is unsupported.", exception.Message);
+        }
+
+        [Theory]
+        [InlineData(SignatureAlgorithmName.SHA256RSA, Oids.Sha256WithRSAEncryption)]
+        [InlineData(SignatureAlgorithmName.SHA384RSA, Oids.Sha384WithRSAEncryption)]
+        [InlineData(SignatureAlgorithmName.SHA512RSA, Oids.Sha512WithRSAEncryption)]
+        public void ConvertToOidString_SignatureAlgorithmName_WithValidInput_Succeeds(SignatureAlgorithmName signatureAlgorithmName, string expectedOid)
+        {
+            var actualOid = signatureAlgorithmName.ConvertToOidString();
+
+            Assert.Equal(expectedOid, actualOid);
+        }
+
+        [Fact]
+        public void ConvertToOidString_SignatureAlgorithmName_WithUnknown_Throws()
+        {
+            var exception = Assert.Throws<ArgumentException>(
+                () => SignatureAlgorithmName.Unknown.ConvertToOidString());
+
+            Assert.Equal("signatureAlgorithmName", exception.ParamName);
+            Assert.StartsWith("Signature algorithm 'Unknown' is unsupported.", exception.Message);
         }
 
         [Theory]

--- a/test/TestUtilities/Test.Utility/Signing/CertificateAuthority.cs
+++ b/test/TestUtilities/Test.Utility/Signing/CertificateAuthority.cs
@@ -202,9 +202,11 @@ namespace Test.Utility.Signing
                         extensionValue: new KeyUsage(KeyUsage.DigitalSignature | KeyUsage.KeyCertSign | KeyUsage.CrlSign));
                 };
 
+            var signatureFactory = new Asn1SignatureFactory(options.SignatureAlgorithmName, options.IssuerPrivateKey);
+
             var certificate = CreateCertificate(
                 options.KeyPair.Public,
-                options.IssuerPrivateKey,
+                signatureFactory,
                 BigInteger.One,
                 options.SubjectName,
                 options.SubjectName,
@@ -274,9 +276,11 @@ namespace Test.Utility.Signing
                 notAfter = Certificate.NotAfter;
             }
 
+            var signatureFactory = new Asn1SignatureFactory(options.SignatureAlgorithmName, options.IssuerPrivateKey ?? KeyPair.Private);
+
             var certificate = CreateCertificate(
                 options.KeyPair.Public,
-                options.IssuerPrivateKey ?? KeyPair.Private,
+                signatureFactory,
                 serialNumber,
                 issuerName,
                 options.SubjectName,
@@ -292,7 +296,7 @@ namespace Test.Utility.Signing
 
         private static X509Certificate CreateCertificate(
             AsymmetricKeyParameter certificatePublicKey,
-            AsymmetricKeyParameter signingPrivateKey,
+            Asn1SignatureFactory signatureFactory,
             BigInteger serialNumber,
             X509Name issuerName,
             X509Name subjectName,
@@ -310,8 +314,6 @@ namespace Test.Utility.Signing
             generator.SetPublicKey(certificatePublicKey);
 
             customizeCertificate(generator);
-
-            var signatureFactory = new Asn1SignatureFactory("SHA256WITHRSA", signingPrivateKey);
 
             return generator.Generate(signatureFactory);
         }

--- a/test/TestUtilities/Test.Utility/Signing/IssueCertificateOptions.cs
+++ b/test/TestUtilities/Test.Utility/Signing/IssueCertificateOptions.cs
@@ -28,12 +28,16 @@ namespace Test.Utility.Signing
         public AsymmetricKeyParameter IssuerPrivateKey { get; set; }
 
         public AsymmetricCipherKeyPair KeyPair { get; set; }
+
         public X509Name SubjectName { get; set; }
+
+        public string SignatureAlgorithmName { get; set; }
 
         public IssueCertificateOptions()
         {
             NotBefore = DateTimeOffset.UtcNow;
             NotAfter = NotBefore.AddHours(2);
+            SignatureAlgorithmName = "SHA256WITHRSA";
         }
 
         public static IssueCertificateOptions CreateDefaultForRootCertificateAuthority()
@@ -46,7 +50,8 @@ namespace Test.Utility.Signing
             {
                 KeyPair = keyPair,
                 IssuerPrivateKey = keyPair.Private,
-                SubjectName = subjectName
+                SubjectName = subjectName,
+                SignatureAlgorithmName = "SHA256WITHRSA"
             };
         }
 
@@ -59,7 +64,8 @@ namespace Test.Utility.Signing
             return new IssueCertificateOptions()
             {
                 KeyPair = keyPair,
-                SubjectName = subjectName
+                SubjectName = subjectName,
+                SignatureAlgorithmName = "SHA256WITHRSA"
             };
         }
 
@@ -72,7 +78,8 @@ namespace Test.Utility.Signing
             return new IssueCertificateOptions()
             {
                 KeyPair = keyPair,
-                SubjectName = subjectName
+                SubjectName = subjectName,
+                SignatureAlgorithmName = "SHA256WITHRSA"
             };
         }
     }

--- a/test/TestUtilities/Test.Utility/Signing/IssueCertificateOptions.cs
+++ b/test/TestUtilities/Test.Utility/Signing/IssueCertificateOptions.cs
@@ -50,8 +50,7 @@ namespace Test.Utility.Signing
             {
                 KeyPair = keyPair,
                 IssuerPrivateKey = keyPair.Private,
-                SubjectName = subjectName,
-                SignatureAlgorithmName = "SHA256WITHRSA"
+                SubjectName = subjectName
             };
         }
 
@@ -64,8 +63,7 @@ namespace Test.Utility.Signing
             return new IssueCertificateOptions()
             {
                 KeyPair = keyPair,
-                SubjectName = subjectName,
-                SignatureAlgorithmName = "SHA256WITHRSA"
+                SubjectName = subjectName
             };
         }
 
@@ -78,8 +76,7 @@ namespace Test.Utility.Signing
             return new IssueCertificateOptions()
             {
                 KeyPair = keyPair,
-                SubjectName = subjectName,
-                SignatureAlgorithmName = "SHA256WITHRSA"
+                SubjectName = subjectName
             };
         }
 

--- a/test/TestUtilities/Test.Utility/Signing/IssueCertificateOptions.cs
+++ b/test/TestUtilities/Test.Utility/Signing/IssueCertificateOptions.cs
@@ -82,5 +82,18 @@ namespace Test.Utility.Signing
                 SignatureAlgorithmName = "SHA256WITHRSA"
             };
         }
+
+        public static IssueCertificateOptions CreateDefaultForTimestampService()
+        {
+            var keyPair = CertificateUtilities.CreateKeyPair();
+            var id = Guid.NewGuid().ToString();
+            var subjectName = new X509Name($"C=US,ST=WA,L=Redmond,O=NuGet,CN=NuGet Test Timestamp Service ({id})");
+
+            return new IssueCertificateOptions()
+            {
+                KeyPair = keyPair,
+                SubjectName = subjectName
+            };
+        }
     }
 }

--- a/test/TestUtilities/Test.Utility/Signing/TimestampService.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TimestampService.cs
@@ -72,16 +72,7 @@ namespace Test.Utility.Signing
 
             if (issueCertificateOptions == null)
             {
-                var keyPair = CertificateUtilities.CreateKeyPair();
-                var id = Guid.NewGuid().ToString();
-                var subjectName = new X509Name($"C=US,ST=WA,L=Redmond,O=NuGet,CN=NuGet Test Timestamp Service ({id})");
-
-                issueCertificateOptions = new IssueCertificateOptions()
-                {
-                    KeyPair = keyPair,
-                    SubjectName = subjectName,
-                    CustomizeCertificate = customizeCertificate
-                };
+                issueCertificateOptions = IssueCertificateOptions.CreateDefaultForTimestampService();
             }
 
             void customizeCertificate(X509V3CertificateGenerator generator)
@@ -114,6 +105,11 @@ namespace Test.Utility.Signing
                     X509Extensions.ExtendedKeyUsage,
                     critical: true,
                     extensionValue: ExtendedKeyUsage.GetInstance(new DerSequence(KeyPurposeID.IdKPTimeStamping)));
+            }
+
+            if (issueCertificateOptions.CustomizeCertificate == null)
+            {
+                issueCertificateOptions.CustomizeCertificate = customizeCertificate;
             }
 
             if (serviceOptions.IssuedCertificateNotBefore.HasValue)


### PR DESCRIPTION
## Bug
Came up while discussing https://github.com/NuGet/Home/issues/6871
Regression: No

## Fix
Details: This PR improves the error messages for 2 scenarios in `Rfc3161TimestampProvider` - 

1. If the timestamping service certificate signature algorithm is not supported then the error message is improved from -
`The timestamp certificate has an unsupported signature algorithm.`
to - 
`The timestamp certificate has an unsupported signature algorithm - 'SHA1RSA'. The following algorithms are supported - 'SHA256RSA, SHA384RSA, SHA512RSA'.`

2. If the timestamping response digest algorithm is not supported then the error message is improved from -
`The timestamp certificate has an unsupported signature algorithm.`
to - 
`The timestamp response has an unsupported digest algorithm - 'SHA1'. The following algorithms are supported - 'SHA256, SHA384, SHA512'.`

## Testing/Validation
Tests Added: Yes
