### PR TITLE
Add the ability to start a netcore based plugin

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
@@ -144,16 +144,29 @@ namespace NuGet.Protocol.Plugins
             ConnectionOptions options,
             CancellationToken sessionCancellationToken)
         {
+            var args = string.Join(" ", arguments);
+#if IS_DESKTOP
             var startInfo = new ProcessStartInfo(filePath)
             {
-                Arguments = string.Join(" ", arguments),
+                Arguments = args,
                 UseShellExecute = false,
                 RedirectStandardError = false,
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
                 StandardOutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)
             };
-
+#else
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH"),
+                Arguments = $"\"{filePath}\" " + args,
+                UseShellExecute = false,
+                RedirectStandardError = false,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                StandardOutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)
+            };
+#endif
             var process = Process.Start(startInfo);
             var sender = new Sender(process.StandardInput);
             var receiver = new StandardOutputReceiver(new PluginProcess(process));

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/PluginTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/PluginTests.cs
@@ -38,7 +38,7 @@ namespace NuGet.Protocol.FuncTest
         {
             logger.WriteLine($"Plugin file path:  {_pluginFile.FullName}");
         }
-
+#if !IS_CORECLR
         [PlatformFact(Platform.Windows)]
         public async Task GetOrCreateAsync_SuccessfullyHandshakes()
         {
@@ -178,7 +178,7 @@ namespace NuGet.Protocol.FuncTest
                     consoleOutput);
             }
         }
-
+#endif
         private static int GetCurrentProcessId()
         {
             using (var process = Process.GetCurrentProcess())


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6706
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 

Add the ability to start plugins cross-plat. 

There is really no good way to automate testing this, since a plugin need to be authenticode signed to be started.

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  
Validation done:  
I've done quite a bit of manual validation with the following plugin https://github.com/nkolev92/NuGet.Tools/tree/master/NuGet.CredentialProvider.  
