### PR TITLE
Mimic Powershell error colors when erroring out in console

### DIFF
--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -650,7 +650,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
         private void WriteErrorLine(string message)
         {
-            ActiveConsole?.Write(message + Environment.NewLine, Colors.DarkRed, null);
+            ActiveConsole?.Write(message + Environment.NewLine, Colors.White, Colors.DarkRed);
         }
 
         private void WriteLine(string message = "")


### PR DESCRIPTION
## Bug
Fixes: Internal [489860](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/489860)

## Fix
Details: When the Package Manager Console had an error it was displayed in dark red. This didn't have enough contrast in VS dark theme and the text was not easy to see. This PR fixes this by mimicking the color scheme of the errors in Powershell. 

**Before:**
![old_dark](https://user-images.githubusercontent.com/2132567/39773384-ccb80fd2-52ac-11e8-9844-c5e9cc6bbc17.PNG)

**After:**
![fixed_dark](https://user-images.githubusercontent.com/2132567/39773386-ce66c288-52ac-11e8-9d08-f26107236543.PNG)

