### PR TITLE
Better error handling of UnAuthorizedAccessException for System Temp location

### DIFF
--- a/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
+++ b/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
@@ -29,16 +29,17 @@ namespace NuGet.Common
             // limit the number of unauthorized, this should be around 30 seconds.
             var unauthorizedAttemptsLeft = NumberOfRetries;
 
-            var lockPath = FileLockPath(filePath);
-
             while (true)
             {
                 FileStream fs = null;
+                var lockPath = string.Empty;
 
                 try
                 {
                     try
                     {
+                        lockPath = FileLockPath(filePath);
+
                         fs = AcquireFileStream(lockPath);
                     }
                     catch (DirectoryNotFoundException)
@@ -51,6 +52,11 @@ namespace NuGet.Common
 
                         if (unauthorizedAttemptsLeft < 1)
                         {
+                            if (string.IsNullOrEmpty(lockPath))
+                            {
+                                lockPath = BasePath;
+                            }
+
                             var message = string.Format(
                                 CultureInfo.CurrentCulture,
                                 Strings.UnauthorizedLockFail,
@@ -100,15 +106,16 @@ namespace NuGet.Common
             // limit the number of unauthorized, this should be around 30 seconds.
             var unauthorizedAttemptsLeft = NumberOfRetries;
 
-            var lockPath = FileLockPath(filePath);
-
             while (true)
             {
                 FileStream fs = null;
+                var lockPath = string.Empty;
                 try
                 {
                     try
                     {
+                        lockPath = FileLockPath(filePath);
+
                         fs = AcquireFileStream(lockPath);
                     }
                     catch (DirectoryNotFoundException)
@@ -119,6 +126,11 @@ namespace NuGet.Common
                     {
                         if (unauthorizedAttemptsLeft < 1)
                         {
+                            if (string.IsNullOrEmpty(lockPath))
+                            {
+                                lockPath = BasePath;
+                            }
+
                             var message = string.Format(
                                 CultureInfo.CurrentCulture,
                                 Strings.UnauthorizedLockFail,


### PR DESCRIPTION
Sometimes `Path.GetTempDir()` is returning `C:\Windows\Temp` and when NuGet tries to access it and create a folder in there, it throws `UnauthorizedAccessException` and crash VS. This `C:\Windows\Temp` is a system variable TEMP whereas user variable TEMP will be `%userprofile%\AppData\Local\temp` (which is what NuGet would have expected in this case).

So this PR takes care of this unauthorized exception and show better error message instead of crashing the VS.

Fixes [Watson] clr20r3: CLR_EXCEPTION_System.UnauthorizedAccessException_80070005_NuGet.Common.dll!NuGet.Common.DirectoryUtility.CreateSharedDirectory [600743](https://devdiv.visualstudio.com/DevDiv/NuGet/_workitems/edit/600743)

@rrelyea 