### PR TITLE
Make sure the version list always has the correct latest version

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/DisplayVersion.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/DisplayVersion.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using NuGet.Versioning;
 
 namespace NuGet.PackageManagement.UI
@@ -10,7 +11,7 @@ namespace NuGet.PackageManagement.UI
     /// </summary>
     public class DisplayVersion
     {
-        private readonly string _additionalInfo;
+        public readonly string AdditionalInfo;
 
         private readonly string _toString;
 
@@ -40,7 +41,7 @@ namespace NuGet.PackageManagement.UI
             }
 
             Range = range;
-            _additionalInfo = additionalInfo;
+            AdditionalInfo = additionalInfo;
 
             IsValidVersion = isValidVersion;
 
@@ -53,16 +54,16 @@ namespace NuGet.PackageManagement.UI
             {
                 var formattedVersionString = Version.ToString(versionFormat, VersionFormatter.Instance);
 
-                _toString = string.IsNullOrEmpty(_additionalInfo) ?
+                _toString = string.IsNullOrEmpty(AdditionalInfo) ?
                     formattedVersionString :
-                    _additionalInfo + " " + formattedVersionString;
+                    AdditionalInfo + " " + formattedVersionString;
             }
             else
             {
                 // Display the range, use the original value for floating ranges
-                _toString = string.IsNullOrEmpty(_additionalInfo) ?
+                _toString = string.IsNullOrEmpty(AdditionalInfo) ?
                     Range.OriginalString :
-                    _additionalInfo + " " + Range.OriginalString;
+                    AdditionalInfo + " " + Range.OriginalString;
             }
         }
 
@@ -84,7 +85,7 @@ namespace NuGet.PackageManagement.UI
         public override bool Equals(object obj)
         {
             var other = obj as DisplayVersion;
-            return other != null && other.Version == Version;
+            return other != null && other.Version == Version && string.Equals(other.AdditionalInfo, AdditionalInfo, StringComparison.Ordinal);
         }
 
         public override int GetHashCode()

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -141,7 +141,7 @@ namespace NuGet.PackageManagement.UI
             }
 
             // Add Current package version to package versions list.
-            _allPackageVersions = new List<NuGetVersion>() { searchResultPackage.Version };
+            _allPackageVersions = new List<NuGetVersion>() { searchResultPackage.LatestVersion };
             CreateVersions();
             OnCurrentPackageChanged();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -141,7 +141,7 @@ namespace NuGet.PackageManagement.UI
             }
 
             // Add Current package version to package versions list.
-            _allPackageVersions = new List<NuGetVersion>() { searchResultPackage.LatestVersion };
+            _allPackageVersions = new List<NuGetVersion>() { searchResultPackage.Version };
             CreateVersions();
             OnCurrentPackageChanged();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -146,10 +146,10 @@ namespace NuGet.PackageManagement.UI
         protected override void CreateVersions()
         {
             _versions = new List<DisplayVersion>();
-            var allVersions = _allPackageVersions?.OrderByDescending(v => v);
+            var allVersions = _allPackageVersions?.Where(v => v != null).OrderByDescending(v => v);
 
             // allVersions is null if server doesn't return any versions.
-            if (allVersions == null)
+            if (allVersions == null || !allVersions.Any())
             {
                 return;
             }


### PR DESCRIPTION
## Bug
Fixes: [Internal 491403](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/491403)

## Fix
Details: The versions dropdown was being filled with the latest installed version and that was taken as the latest version because of the way latest version is calculated. This PR fixes this by constructing the default list with the latest version (which is the one we want to show selected by default) instead of the current version.

**Before:**
![old_issue](https://user-images.githubusercontent.com/2132567/39789062-68ec89ac-52e2-11e8-8a58-78ba67b911e7.PNG)

**After:**
![fixed](https://user-images.githubusercontent.com/2132567/39789065-6b3901ae-52e2-11e8-8148-6e6a6f8bce23.PNG)
