### PR TITLE
Make sure there's a logger present for each Credentials Request call

### DIFF
--- a/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
@@ -91,7 +91,7 @@ namespace NuGet.Credentials
 
             if (_isAnAuthenticationPlugin)
             {
-                AddOrUpdateLogger(plugin.Plugin, _logger);
+                AddOrUpdateLogger(plugin.Plugin);
                 var request = new GetAuthenticationCredentialsRequest(uri, isRetry, nonInteractive);
 
                 var credentialResponse = await plugin.Plugin.Connection.SendRequestAndReceiveResponseAsync<GetAuthenticationCredentialsRequest, GetAuthenticationCredentialsResponse>(
@@ -108,14 +108,14 @@ namespace NuGet.Credentials
             return taskResponse;
         }
 
-        private void AddOrUpdateLogger(IPlugin plugin, ILogger logger)
+        private void AddOrUpdateLogger(IPlugin plugin)
         {
             plugin.Connection.MessageDispatcher.RequestHandlers.AddOrUpdate(
                 MessageMethod.Log,
-                () => new LogRequestHandler(logger),
+                () => new LogRequestHandler(_logger),
                 existingHandler =>
                 {
-                    ((LogRequestHandler)existingHandler).SetLogger(logger);
+                    ((LogRequestHandler)existingHandler).SetLogger(_logger);
 
                     return existingHandler;
                 });

--- a/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
@@ -6,8 +6,8 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Configuration;
-using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Plugins;
 
 namespace NuGet.Credentials
@@ -42,7 +42,7 @@ namespace NuGet.Credentials
         /// <exception cref="ArgumentNullException">if <paramref name="logger"/> is null</exception>
         /// <exception cref="ArgumentNullException">if <paramref name="pluginManager"/> is null</exception>
         /// <exception cref="ArgumentException">if plugin file is not valid</exception>
-        public SecurePluginCredentialProvider(IPluginManager pluginManager, PluginDiscoveryResult pluginDiscoveryResult, Common.ILogger logger)
+        public SecurePluginCredentialProvider(IPluginManager pluginManager, PluginDiscoveryResult pluginDiscoveryResult, ILogger logger)
         {
             if (pluginDiscoveryResult == null)
             {
@@ -91,6 +91,7 @@ namespace NuGet.Credentials
 
             if (_isAnAuthenticationPlugin)
             {
+                AddOrUpdateLogger(plugin.Plugin, _logger);
                 var request = new GetAuthenticationCredentialsRequest(uri, isRetry, nonInteractive);
 
                 var credentialResponse = await plugin.Plugin.Connection.SendRequestAndReceiveResponseAsync<GetAuthenticationCredentialsRequest, GetAuthenticationCredentialsResponse>(
@@ -105,6 +106,19 @@ namespace NuGet.Credentials
             }
 
             return taskResponse;
+        }
+
+        private void AddOrUpdateLogger(IPlugin plugin, ILogger logger)
+        {
+            plugin.Connection.MessageDispatcher.RequestHandlers.AddOrUpdate(
+                MessageMethod.Log,
+                () => new LogRequestHandler(logger),
+                existingHandler =>
+                {
+                    ((LogRequestHandler)existingHandler).SetLogger(logger);
+
+                    return existingHandler;
+                });
         }
 
         /// <summary>


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6762
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: The fix here is rather simple but the impact is considerable. 
We don't have a logger available every time a plugin is created. 
We also have different types of loggers etc. 
It's near impossible to solve the logging problem on a generic level, so I'll just address this use case here. 

Basically, simply by making sure that a plugin has a logger each time before it calls GetRequestCredentials. 
That way the plugin is allowed to log between the time it receives the request and it sends the response. 
This is how device flow auth will work for dotnet.exe

I will work on adding this extra behavior in the spec. 

## Testing/Validation
Tests Added: No  
Reason for not adding tests: Difficult to add automated tests for this. Tested extensively manually, by simulating a device flow auth with the test plugin:
https://github.com/nkolev92/NuGet.Tools/commit/0b9cbdb216ce53dcf4d2073f58e18ace64288618  
Validation done:  ^^

//cc @jeffkl