### PR TITLE
Fixing signature exception logging in VS NugetUI

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -11171,6 +11171,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Signed package validation failed with multiple errors:{0}.
+        /// </summary>
+        public static string SignatureVerificationMultipleErrors {
+            get {
+                return ResourceManager.GetString("SignatureVerificationMultipleErrors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Nothing to do. None of the projects in this solution specify any packages for NuGet to restore..
         /// </summary>
         public static string SolutionRestoreCommandNoPackagesConfigOrProjectJson {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6158,4 +6158,8 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="ConsolePasswordProvider_PromptForPassword" xml:space="preserve">
     <value>Password: </value>
   </data>
+  <data name="SignatureVerificationMultipleErrors" xml:space="preserve">
+    <value>Signed package validation failed with multiple errors:{0}</value>
+    <comment>0 - new line separated list of errors</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -319,10 +319,7 @@ namespace NuGet.PackageManagement.UI
 
             if (signException != null)
             {
-                foreach (var result in signException.Results)
-                {
-                    ProcessSignatureIssues(result, signException.PackageIdentity);
-                }
+                ProcessSignatureIssues(signException);
             }
             else
             {
@@ -365,15 +362,21 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private void ProcessSignatureIssues(PackageVerificationResult result, PackageIdentity packageIdentity)
+        private void ProcessSignatureIssues(SignatureException ex)
         {
-            var errorList = result.GetErrorIssues().ToList();
-            var warningList = result.GetWarningIssues().ToList();
+            UILogger.ReportError(ex.AsLogMessage().FormatWithCode());
+            ProjectContext.Log(MessageLevel.Error, ex.AsLogMessage().FormatWithCode());
 
-            errorList.ForEach(p => UILogger.ReportError(p.Message));
+            foreach (var result in ex.Results)
+            {
+                var errorList = result.GetErrorIssues().ToList();
+                var warningList = result.GetWarningIssues().ToList();
 
-            errorList.ForEach(p => ProjectContext.Log(MessageLevel.Error, p.FormatWithCode()));
-            warningList.ForEach(p => ProjectContext.Log(MessageLevel.Warning,p.FormatWithCode()));
+                errorList.ForEach(p => UILogger.ReportError(p.FormatWithCode()));
+
+                errorList.ForEach(p => ProjectContext.Log(MessageLevel.Error, p.FormatWithCode()));
+                warningList.ForEach(p => ProjectContext.Log(MessageLevel.Warning, p.FormatWithCode()));
+            }            
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -319,7 +319,10 @@ namespace NuGet.PackageManagement.UI
 
             if (signException != null)
             {
-                ProcessSignatureIssues(signException);
+                foreach (var result in signException.Results)
+                {
+                    ProcessSignatureIssues(result, signException.PackageIdentity);
+                }
             }
             else
             {
@@ -362,21 +365,15 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private void ProcessSignatureIssues(SignatureException ex)
+        private void ProcessSignatureIssues(PackageVerificationResult result, PackageIdentity packageIdentity)
         {
-            UILogger.ReportError(ex.AsLogMessage().FormatWithCode());
-            ProjectContext.Log(MessageLevel.Error, ex.AsLogMessage().FormatWithCode());
+            var errorList = result.GetErrorIssues().ToList();
+            var warningList = result.GetWarningIssues().ToList();
 
-            foreach (var result in ex.Results)
-            {
-                var errorList = result.GetErrorIssues().ToList();
-                var warningList = result.GetWarningIssues().ToList();
+            errorList.ForEach(p => UILogger.ReportError(p.Message));
 
-                errorList.ForEach(p => UILogger.ReportError(p.FormatWithCode()));
-
-                errorList.ForEach(p => ProjectContext.Log(MessageLevel.Error, p.FormatWithCode()));
-                warningList.ForEach(p => ProjectContext.Log(MessageLevel.Warning, p.FormatWithCode()));
-            }            
+            errorList.ForEach(p => ProjectContext.Log(MessageLevel.Error, p.FormatWithCode()));
+            warningList.ForEach(p => ProjectContext.Log(MessageLevel.Warning,p.FormatWithCode()));
         }
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2340,35 +2340,6 @@ namespace NuGet.PackageManagement
                     // Open readme file
                     await OpenReadmeFile(nuGetProject, nuGetProjectContext, token);
                 }
-                catch (SignatureException ex)
-                {
-                    var errors = ex.Results.SelectMany(r => r.GetErrorIssues());
-                    var warnings = ex.Results.SelectMany(r => r.GetWarningIssues());
-                    SignatureException unwrappedException = null;
-
-                    if (errors.Count() == 1)
-                    {
-                        // In case of one error, throw it as the exception
-                        var error = errors.First();
-                        unwrappedException = new SignatureException(error.Code, error.Message, ex.PackageIdentity);
-                    }
-                    else
-                    {
-                        // In case of multiple errors, wrap them in a general NU3000 error
-                        var errorMessage = string.Format(CultureInfo.CurrentCulture,
-                            Strings.SignatureVerificationMultiple,
-                            $"{Environment.NewLine}{string.Join(Environment.NewLine, errors.Select(e => e.FormatWithCode()))}");
-
-                        unwrappedException = new SignatureException(NuGetLogCode.NU3000, errorMessage, ex.PackageIdentity);
-                    }
-
-                    foreach (var warning in warnings)
-                    {
-                        nuGetProjectContext.Log(MessageLevel.Warning, warning.FormatWithCode());
-                    }
-
-                    exceptionInfo = ExceptionDispatchInfo.Capture(unwrappedException);
-                }
                 catch (Exception ex)
                 {
                     exceptionInfo = ExceptionDispatchInfo.Capture(ex);

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -898,15 +898,6 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Signed package validation failed with multiple errors:{0}.
-        /// </summary>
-        internal static string SignatureVerificationMultiple {
-            get {
-                return ResourceManager.GetString("SignatureVerificationMultiple", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Solution directory &apos;{0}&apos; must be a rooted path..
         /// </summary>
         internal static string SolutionDirectoryMustBeRooted {

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -487,8 +487,4 @@
   <data name="XdtError" xml:space="preserve">
     <value>An error occurred while applying transformation to '{0}' in project '{1}'</value>
   </data>
-  <data name="SignatureVerificationMultiple" xml:space="preserve">
-    <value>Signed package validation failed with multiple errors:{0}</value>
-    <comment>0 - new line separated list of errors</comment>
-  </data>
 </root>


### PR DESCRIPTION
## Bug
Fixes: Issue reported by vendors during signing pass.

## Fix
Details: As part of https://github.com/NuGet/NuGet.Client/commit/e95a67ded682c5727ec3a2ff138cf748251006ce we fixed error loggin for install command. but that regressed the VS experience. This PR fixes that by improving our logging to first log top level error before logging logs from verification result.

## Testing/Validation
Tests Added: No
Reason for not adding tests:  Current tests cover this scenario which were failing, but passing now.
Validation done:  Manual
