### PR TITLE
Change key binding for search focus

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml
@@ -35,7 +35,7 @@
   <UserControl.InputBindings>
     <KeyBinding
       Command="{x:Static nuget:Commands.FocusOnSearchBox}"
-      Gesture="CTRL+E" />
+      Gesture="CTRL+L" />
   </UserControl.InputBindings>
   <DockPanel
     x:Name="_root"


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/5943

## Fix
Details: CTRL+E has been taken as a multi-key binding for VS, therefore we need to update the key binding of our search bar to something else that is not taken and not multi-binding.