### PR TITLE
Fixing signature exception logging in VS

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
@@ -196,7 +196,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
                 var logMessages = ex.Results.SelectMany(p => p.Issues).Select(p => p.ToLogMessage()).ToList();
 
-                logMessages.ForEach(p => Log(LogUtility.LogLevelToMessageLevel(p.Level), p.Message));
+                logMessages.ForEach(p => Log(LogUtility.LogLevelToMessageLevel(p.Level), p.FormatWithCode()));
             }
             catch (Exception ex)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
@@ -131,9 +131,14 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                 // set nuget operation status to failed when an exception is thrown
                 _status = NuGetOperationStatus.Failed;
 
+                if (!string.IsNullOrEmpty(ex.Message))
+                {
+                    Log(LogUtility.LogLevelToMessageLevel(LogLevel.Error), ex.AsLogMessage().FormatWithCode());
+                }
+
                 var logMessages = ex.Results.SelectMany(p => p.Issues).Select(p => p.ToLogMessage()).ToList();
 
-                logMessages.ForEach(p => Log(LogUtility.LogLevelToMessageLevel(p.Level), p.Message));
+                logMessages.ForEach(p => Log(LogUtility.LogLevelToMessageLevel(p.Level), p.FormatWithCode()));
             }
             catch (Exception ex)
             {
@@ -183,6 +188,11 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             {
                 // set nuget operation status to failed when an exception is thrown
                 _status = NuGetOperationStatus.Failed;
+
+                if (!string.IsNullOrEmpty(ex.Message))
+                {
+                    Log(LogUtility.LogLevelToMessageLevel(LogLevel.Error), ex.AsLogMessage().FormatWithCode());
+                }
 
                 var logMessages = ex.Results.SelectMany(p => p.Issues).Select(p => p.ToLogMessage()).ToList();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
@@ -216,7 +216,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
                 var logMessages = ex.Results.SelectMany(p => p.Issues).Select(p => p.ToLogMessage()).ToList();
 
-                logMessages.ForEach(p => Log(LogUtility.LogLevelToMessageLevel(p.Level), p.Message));
+                logMessages.ForEach(p => Log(LogUtility.LogLevelToMessageLevel(p.Level), p.FormatWithCode()));
             }
             catch (Exception ex)
             {
@@ -263,7 +263,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
                 var logMessages = ex.Results.SelectMany(p => p.Issues).Select(p => p.ToLogMessage()).ToList();
 
-                logMessages.ForEach(p => Log(LogUtility.LogLevelToMessageLevel(p.Level), p.Message));
+                logMessages.ForEach(p => Log(LogUtility.LogLevelToMessageLevel(p.Level), p.FormatWithCode()));
             }
             catch (Exception ex)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
@@ -209,6 +209,11 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                 // set nuget operation status to failed when an exception is thrown
                 _status = NuGetOperationStatus.Failed;
 
+                if (!string.IsNullOrEmpty(ex.Message))
+                {
+                    Log(LogUtility.LogLevelToMessageLevel(LogLevel.Error), ex.AsLogMessage().FormatWithCode());
+                }
+
                 var logMessages = ex.Results.SelectMany(p => p.Issues).Select(p => p.ToLogMessage()).ToList();
 
                 logMessages.ForEach(p => Log(LogUtility.LogLevelToMessageLevel(p.Level), p.Message));
@@ -250,6 +255,11 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             {
                 // set nuget operation status to failed when an exception is thrown
                 _status = NuGetOperationStatus.Failed;
+
+                if (!string.IsNullOrEmpty(ex.Message))
+                {
+                    Log(LogUtility.LogLevelToMessageLevel(LogLevel.Error), ex.AsLogMessage().FormatWithCode());
+                }
 
                 var logMessages = ex.Results.SelectMany(p => p.Issues).Select(p => p.ToLogMessage()).ToList();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -319,10 +319,7 @@ namespace NuGet.PackageManagement.UI
 
             if (signException != null)
             {
-                foreach (var result in signException.Results)
-                {
-                    ProcessSignatureIssues(result, signException.PackageIdentity);
-                }
+                ProcessSignatureIssues(signException);
             }
             else
             {
@@ -365,15 +362,21 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private void ProcessSignatureIssues(PackageVerificationResult result, PackageIdentity packageIdentity)
+        private void ProcessSignatureIssues(SignatureException ex)
         {
-            var errorList = result.GetErrorIssues().ToList();
-            var warningList = result.GetWarningIssues().ToList();
+            UILogger.ReportError(ex.AsLogMessage().FormatWithCode());
+            ProjectContext.Log(MessageLevel.Error, ex.AsLogMessage().FormatWithCode());
 
-            errorList.ForEach(p => UILogger.ReportError(p.Message));
+            foreach (var result in ex.Results)
+            {
+                var errorList = result.GetErrorIssues().ToList();
+                var warningList = result.GetWarningIssues().ToList();
 
-            errorList.ForEach(p => ProjectContext.Log(MessageLevel.Error, p.FormatWithCode()));
-            warningList.ForEach(p => ProjectContext.Log(MessageLevel.Warning,p.FormatWithCode()));
+                errorList.ForEach(p => UILogger.ReportError(p.FormatWithCode()));
+
+                errorList.ForEach(p => ProjectContext.Log(MessageLevel.Error, p.FormatWithCode()));
+                warningList.ForEach(p => ProjectContext.Log(MessageLevel.Warning, p.FormatWithCode()));
+            }            
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -364,8 +364,11 @@ namespace NuGet.PackageManagement.UI
 
         private void ProcessSignatureIssues(SignatureException ex)
         {
-            UILogger.ReportError(ex.AsLogMessage().FormatWithCode());
-            ProjectContext.Log(MessageLevel.Error, ex.AsLogMessage().FormatWithCode());
+            if (!string.IsNullOrEmpty(ex.Message))
+            {
+                UILogger.ReportError(ex.AsLogMessage().FormatWithCode());
+                ProjectContext.Log(MessageLevel.Error, ex.AsLogMessage().FormatWithCode());
+            }
 
             foreach (var result in ex.Results)
             {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -393,6 +393,11 @@ namespace NuGet.SolutionRestoreManager
 
                 var ex = args.Exception as SignatureException;
 
+                if (!string.IsNullOrEmpty(ex.Message))
+                {
+                    _logger.Log(ex.AsLogMessage());
+                }
+
                 ex.Results.SelectMany(p => p.Issues).ToList().ForEach(p => _logger.Log(p.ToLogMessage()));
 
                 return;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
@@ -305,6 +305,11 @@ namespace NuGet.Commands
                 }
                 catch (SignatureException e)
                 {
+                    if (!string.IsNullOrEmpty(e.Message))
+                    {
+                        await _logger.LogAsync(e.AsLogMessage());
+                    }
+
                     await _logger.LogMessagesAsync(e.Results.SelectMany(p => p.Issues).Select(p => p.ToLogMessage()));
                     return false;
                 }


### PR DESCRIPTION
## Bug
Fixes: Issue reported by vendors during signing pass.

## Fix
Details: As part of https://github.com/NuGet/NuGet.Client/commit/e95a67ded682c5727ec3a2ff138cf748251006ce we fixed error loggin for install command. but that regressed the VS experience. This PR fixes that by improving our logging to first log top level error before logging verification result.

## Testing/Validation
Tests Added: No
Reason for not adding tests:  Current tests cover this scenario which were failing, but passing now.
Validation done:  Manual
