### PR TITLE
Updated brushed to avoid loading unnecesary dll

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -20,8 +20,6 @@ namespace NuGet.PackageManagement.UI
         public static object BorderBrush { get; private set; } = SystemColors.InactiveBorderBrushKey;
 
         public static object ComboBoxBorderKey { get; private set; } = SystemColors.InactiveBorderBrushKey;
-
-        public static object ContentBrushKey { get; private set; } = SystemColors.WindowBrushKey;
 
         public static object ContentInactiveSelectedBrushKey { get; private set; } = SystemColors.ControlTextBrushKey;
 
@@ -185,6 +183,7 @@ namespace NuGet.PackageManagement.UI
             HeaderColorsSeparatorLineBrushKey = HeaderColors.SeparatorLineBrushKey;
 
             IndicatorFillBrushKey = ProgressBarColors.IndicatorFillBrushKey;
+
             ButtonTextStyleBrushKey = CommonControlsColors.ButtonTextBrushKey; 
             ButtonBorderBrushKey = CommonControlsColors.ButtonBorderBrushKey; 
             ButtonBackgroundStyleBrushKey = CommonControlsColors.ButtonBrushKey; 
@@ -215,31 +214,16 @@ namespace NuGet.PackageManagement.UI
             CheckBoxTextHoverBrushKey = CommonControlsColors.CheckBoxTextHoverBrushKey; 
             CheckBoxTextPressedBrushKey = CommonControlsColors.CheckBoxTextPressedBrushKey; 
             CheckBoxBorderHoverBrushKey = CommonControlsColors.CheckBoxBorderHoverBrushKey; 
-            CheckBoxBorderPressedBrushKey = CommonControlsColors.CheckBoxBorderPressedBrushKey; 
+            CheckBoxBorderPressedBrushKey = CommonControlsColors.CheckBoxBorderPressedBrushKey;
 
-            var colorResources = GetColorResources();
-            BackgroundBrushKey = colorResources["BackgroundBrushKey"];
-            ContentMouseOverBrushKey = colorResources["ContentMouseOverBrushKey"];
-            ContentMouseOverTextBrushKey = colorResources["ContentMouseOverTextBrushKey"];
-            ContentInactiveSelectedBrushKey = colorResources["ContentInactiveSelectedBrushKey"];
-            ContentInactiveSelectedTextBrushKey = colorResources["ContentInactiveSelectedTextBrushKey"];
-            ContentSelectedBrushKey = colorResources["ContentSelectedBrushKey"];
-            ContentSelectedTextBrushKey = colorResources["ContentSelectedTextBrushKey"];
-            ContentBrushKey = colorResources["ContentBrushKey"];
-        }
+            BackgroundBrushKey = EnvironmentColors.ToolWindowBackgroundBrushKey;
+            ContentMouseOverBrushKey = EnvironmentColors.ToolboxContentMouseOverBrushKey;
+            ContentMouseOverTextBrushKey = EnvironmentColors.ToolboxContentMouseOverTextBrushKey;
 
-        private static IDictionary<string, ThemeResourceKey> GetColorResources()
-        {
-            // use colors of VisualStudio UI.
-            var assembly = AppDomain.CurrentDomain.Load(
-                "Microsoft.VisualStudio.ExtensionsExplorer.UI");
-            var colorResources = assembly.GetType(
-                "Microsoft.VisualStudio.ExtensionsExplorer.UI.ColorResources");
-
-            var properties = colorResources.GetProperties(BindingFlags.Public | BindingFlags.Static);
-            return properties
-                .Where(p => p.PropertyType == typeof(ThemeResourceKey))
-                .ToDictionary(p => p.Name, p => (ThemeResourceKey)p.GetValue(null));
+            ContentInactiveSelectedBrushKey = TreeViewColors.SelectedItemInactiveBrushKey;
+            ContentInactiveSelectedTextBrushKey = TreeViewColors.SelectedItemInactiveTextBrushKey;
+            ContentSelectedBrushKey = TreeViewColors.SelectedItemActiveBrushKey;
+            ContentSelectedTextBrushKey = TreeViewColors.SelectedItemActiveTextBrushKey;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DeprecatedFrameworkWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DeprecatedFrameworkWindow.xaml
@@ -1,4 +1,4 @@
-﻿<nuget:VsDialogWindow
+<nuget:VsDialogWindow
   x:Class="NuGet.PackageManagement.UI.DeprecatedFrameworkWindow"
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -50,7 +50,6 @@
       BorderThickness="1">
       <ScrollViewer
         HorizontalScrollBarVisibility="Auto"
-        Background="{DynamicResource {x:Static nuget:Brushes.ContentBrushKey}}"
         IsTabStop="True">
         <ItemsControl
           ItemsSource="{Binding Path=Projects}"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
@@ -1,4 +1,4 @@
-﻿<nuget:VsDialogWindow
+<nuget:VsDialogWindow
   x:Class="NuGet.PackageManagement.UI.LicenseAcceptanceWindow"
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -94,7 +94,6 @@
             BorderBrush="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}">
             <ScrollViewer
               Padding="3"
-              Background="{DynamicResource {x:Static nuget:Brushes.ContentBrushKey}}"
               CanContentScroll="True"
               VerticalScrollBarVisibility="Visible"
               HorizontalScrollBarVisibility="Disabled">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/NuGetProjectUpgradeWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/NuGetProjectUpgradeWindow.xaml
@@ -32,7 +32,6 @@
           BorderBrush="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}">
           <ScrollViewer
             Padding="3"
-            Background="{DynamicResource {x:Static nuget:Brushes.ContentBrushKey}}"
             CanContentScroll="False"
             VerticalScrollBarVisibility="Auto"
             HorizontalScrollBarVisibility="Disabled">
@@ -117,7 +116,6 @@
         </Style.Triggers>
       </Style>
       <Style x:Key="Migrator_DataGridColumnHeaderStyle" BasedOn="{StaticResource {x:Type DataGridColumnHeader}}" TargetType="DataGridColumnHeader">
-        <Setter Property="Background" Value="{DynamicResource {x:Static nuget:Brushes.ContentBrushKey}}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}"/>
         <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}" />
         <Setter Property="BorderThickness" Value="1,0,0,1"/>
@@ -227,8 +225,7 @@
         Visibility="{Binding HasIssues, Mode=OneTime, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"
         BorderThickness="1"
         Padding="3"
-        BorderBrush="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}"
-        Background="{DynamicResource {x:Static nuget:Brushes.ContentBrushKey}}">
+        BorderBrush="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}">
         <TextBlock
           Focusable="True"
           Text="{x:Static nuget:Resources.Text_NuGetUpgradeNoIssuesFound}" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagementFormatWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagementFormatWindow.xaml
@@ -1,4 +1,4 @@
-﻿<nuget:VsDialogWindow 
+<nuget:VsDialogWindow 
   x:Class="NuGet.PackageManagement.UI.PackageManagementFormatWindow"
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"
@@ -89,7 +89,6 @@
         HorizontalScrollBarVisibility="Auto"
         VerticalScrollBarVisibility="Visible"
         CanContentScroll="True"
-        Background="{DynamicResource {x:Static nuget:Brushes.ContentBrushKey}}"
         IsTabStop="True"
         Width="423"
         Height="70"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
@@ -1,4 +1,4 @@
-﻿<nuget:VsDialogWindow
+<nuget:VsDialogWindow
   x:Class="NuGet.PackageManagement.UI.PreviewWindow"
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -41,7 +41,6 @@
       BorderThickness="1">
       <ScrollViewer
         HorizontalScrollBarVisibility="Auto"
-        Background="{DynamicResource {x:Static nuget:Brushes.ContentBrushKey}}"
         IsTabStop="True">
         <ItemsControl
           ItemsSource="{Binding Path=PreviewResults}"


### PR DESCRIPTION
## Bug
Fixes: [Internal 497251](https://devdiv.visualstudio.com/DevDiv/NuGet/_workitems/edit/497251)

## Fix
Details: Updated nuget brushes to load used colors from system colors instead of loading a dll, also removed unnecessary brush. This PR does not change anything in our UI, it just avoids loading a dll on VS Start.
