### PR TITLE
Fixing the string formatting on Package metadata published date for Japanese

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/DateTimeConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/DateTimeConverter.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace NuGet.PackageManagement.UI
+{
+    /// <summary>
+    /// DateTime Converter for published date in package metadata.
+    /// </summary>
+    public class DateTimeConverter : IValueConverter
+    {
+        /// <summary>
+        /// Converts DateTime object into custom formatting.
+        /// Goal of the converter is to have custom formatting for japanese since "D" formatting does not include day of the week.
+        /// </summary>
+        /// <returns>string value of the date time.</returns>
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            var dateTime = DateTime.Parse(value.ToString());
+            if (string.Equals(culture.Name, "ja-JP"))
+            {
+                return $"{dateTime.ToString("D", culture)} {dateTime.ToString("dddd", culture)} ({ dateTime.ToString("d", culture)})";
+            }
+            else
+            {
+                return $"{dateTime.ToString("D", culture)} ({ dateTime.ToString("d", culture)})";
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.legacy.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -61,6 +61,7 @@
     <Compile Include="Common\NuGetEventTrigger.cs" />
     <Compile Include="Controls\TabItemButton.cs" />
     <Compile Include="Converters\BooleanToGridRowHeightConverter.cs" />
+    <Compile Include="Converters\DateTimeConverter.cs" />
     <Compile Include="Converters\InverseBooleanConverter.cs" />
     <Compile Include="Converters\RadioBoolToIntConverter.cs" />
     <Compile Include="Converters\TooltipConverter.cs" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
   x:Class="NuGet.PackageManagement.UI.PackageMetadataControl"
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -15,6 +15,7 @@
       <ResourceDictionary.MergedDictionaries>
         <nuget:SharedResources />
       </ResourceDictionary.MergedDictionaries>
+      <nuget:DateFormatter x:Key="DateFormatConverter" />
     </ResourceDictionary>
   </UserControl.Resources>
   <Grid>
@@ -163,9 +164,10 @@
         Margin="0,8,0,0"
         Text="{x:Static nuget:Resources.Label_DatePublished}" />
       <TextBox
+        Name="datePublished"
         Style="{DynamicResource SelectableTextBlockStyle}" 
         Visibility="{Binding Path=Published,Converter={StaticResource NullToVisibilityConverter}}"
-        Text="{Binding Path=Published,StringFormat={}{0:dddd}\, {0:MMMM} {0:dd}\, {0:yyyy} ({0:d})}"
+        Text="{Binding Path=Published,Converter={StaticResource DateFormatConverter}}"
         Margin="8,8,0,0"
         TextWrapping="Wrap"
         Grid.Row="5"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -165,7 +165,7 @@
       <TextBox
         Style="{DynamicResource SelectableTextBlockStyle}" 
         Visibility="{Binding Path=Published,Converter={StaticResource NullToVisibilityConverter}}"
-        Text="{Binding Path=Published,StringFormat={}{0:D} ({0:d})}"
+        Text="{Binding Path=Published,StringFormat={}{0:dddd}\, {0:MMMM} {0:dd}\, {0:yyyy} ({0:d})}"
         Margin="8,8,0,0"
         TextWrapping="Wrap"
         Grid.Row="5"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -15,7 +15,7 @@
       <ResourceDictionary.MergedDictionaries>
         <nuget:SharedResources />
       </ResourceDictionary.MergedDictionaries>
-      <nuget:DateFormatter x:Key="DateFormatConverter" />
+      <nuget:DateTimeConverter x:Key="DateFormatConverter" />
     </ResourceDictionary>
   </UserControl.Resources>
   <Grid>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
@@ -1,8 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -29,6 +32,29 @@ namespace NuGet.PackageManagement.UI
             {
                 Visibility = Visibility.Collapsed;
             }
+        }
+    }
+
+    public class DateFormatter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            var format = "{0:D} ({0:d})";
+
+            var name = culture.Name;
+
+            var dateTime = DateTime.Parse(value.ToString());
+            return dateTime.ToString(format, culture);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
@@ -1,11 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -32,40 +29,6 @@ namespace NuGet.PackageManagement.UI
             {
                 Visibility = Visibility.Collapsed;
             }
-        }
-    }
-
-    /// <summary>
-    /// DateTime Converter for published date in package metadata.
-    /// </summary>
-    public class DateTimeConverter : IValueConverter
-    {
-        /// <summary>
-        /// Converts DateTime object into custom formatting.
-        /// Goal of the converter is to have custom formatting for japanese since "D" formatting does not include day of the week.
-        /// </summary>
-        /// <returns>string value of the date time.</returns>
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            if (value == null)
-            {
-                return null;
-            }
-
-            var dateTime = DateTime.Parse(value.ToString());
-            if (string.Equals(culture.Name, "ja-JP"))
-            {
-                return $"{dateTime.ToString("D", culture)} {dateTime.ToString("dddd", culture)} ({ dateTime.ToString("d", culture)})";
-            }
-            else
-            {
-                return $"{dateTime.ToString("D", culture)} ({ dateTime.ToString("d", culture)})";
-            }
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
@@ -35,8 +35,16 @@ namespace NuGet.PackageManagement.UI
         }
     }
 
-    public class DateFormatter : IValueConverter
+    /// <summary>
+    /// DateTime Converter for published date in package metadata.
+    /// </summary>
+    public class DateTimeConverter : IValueConverter
     {
+        /// <summary>
+        /// Converts DateTime object into custom formatting.
+        /// Goal of the converter is to have custom formatting for japanese since "D" formatting does not include day of the week.
+        /// </summary>
+        /// <returns>string value of the date time.</returns>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (value == null)
@@ -44,17 +52,15 @@ namespace NuGet.PackageManagement.UI
                 return null;
             }
 
-            var format = "{0:D} ({0:d})";
-
-            var name = culture.Name;
-
-            if (string.Equals(culture.Name, "jp-JP"))
-            {
-                format = "{0:D} {0:dddd} ({0:d})";
-            }
-
             var dateTime = DateTime.Parse(value.ToString());
-            return dateTime.ToString(format, culture);
+            if (string.Equals(culture.Name, "ja-JP"))
+            {
+                return $"{dateTime.ToString("D", culture)} {dateTime.ToString("dddd", culture)} ({ dateTime.ToString("d", culture)})";
+            }
+            else
+            {
+                return $"{dateTime.ToString("D", culture)} ({ dateTime.ToString("d", culture)})";
+            }
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
@@ -48,6 +48,11 @@ namespace NuGet.PackageManagement.UI
 
             var name = culture.Name;
 
+            if (string.Equals(culture.Name, "jp-JP"))
+            {
+                format = "{0:D} {0:dddd} ({0:d})";
+            }
+
             var dateTime = DateTime.Parse(value.ToString());
             return dateTime.ToString(format, culture);
         }


### PR DESCRIPTION
## Bug
Fixes: [57506](https://devdiv.visualstudio.com/DevDiv/NuGet/_workitems/edit/457506)
Regression: No  

## Fix
Details: Fixes the string formatting over the published date in the package metadata page. This PR adds a custom formatting for ja-JP as requested by loicalization vendors.

### Screenshots - 
#### English -
![en](https://user-images.githubusercontent.com/10507120/39898158-6fda3f46-546a-11e8-83d9-d4bf86e676fc.PNG)

#### Turkish-
![tr](https://user-images.githubusercontent.com/10507120/39898171-7d97bbae-546a-11e8-8818-4a88f1360dd9.PNG)

#### Japanese-
![jp](https://user-images.githubusercontent.com/10507120/39898180-85c3723c-546a-11e8-9437-58c79c406601.PNG)

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  UI text changes.
Validation done:  Manual validation in ENG, TRK and JP.
