### PR TITLE
Making sure NuGetPackage MEF is initialized before accessing it

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -1027,6 +1027,11 @@ namespace NuGetVSExtension
         // know which options keys it will use in the suo file.
         public int SaveUserOptions(IVsSolutionPersistence pPersistence)
         {
+            if (ShouldMEFBeInitialized())
+            {
+                NuGetUIThreadHelper.JoinableTaskFactory.Run(InitializeMEFAsync);
+            }
+
             return SolutionUserOptions.Value.SaveUserOptions(pPersistence);
         }
 


### PR DESCRIPTION
In some cases, NuGetPackage is being loaded but not initialized meaning no NuGet specific operation has been performed. But when user tries to close this solution, NuGet tries to persist it's settings in .suo file without resolving all it's MEFs. 

So the fix is to make sure MEF is initialized before accessing it.  

Fixes: [Watson] crash32: INVALID_POINTER_READ_4000001f_NuGet.Tools.dll!NuGetVSExtension.NuGetPackage.SaveUserOptions https://devdiv.visualstudio.com/DevDiv/_workitems/edit/614431  

@rrelyea 