### PR TITLE
Safeguard InfiniteScollList operations across multiple threads

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -67,7 +67,7 @@ namespace NuGet.PackageManagement.UI
 
             InitializeComponent();
 
-            BindingOperations.EnableCollectionSynchronization(Items, _itemsLock);
+            BindingOperations.EnableCollectionSynchronization(Items, _list.ItemsLock);
 
             DataContext = Items;
             CheckBoxesEnabled = false;
@@ -96,8 +96,6 @@ namespace NuGet.PackageManagement.UI
         }
 
         public bool IsSolution { get; set; }
-
-        private readonly SemaphoreSlim _itemsLock = new SemaphoreSlim(1, 1);
 
         public ObservableCollection<object> Items { get; } = new ObservableCollection<object>();
 
@@ -138,7 +136,7 @@ namespace NuGet.PackageManagement.UI
             _loadingStatusBar.Reset(loadingMessage, loader.IsMultiSource);
 
             var selectedPackageItem = SelectedPackageItem;
-            _itemsLock.Wait();
+            _list.ItemsLock.Wait();
 
             try
             {
@@ -146,7 +144,7 @@ namespace NuGet.PackageManagement.UI
             }
             finally
             {
-                _itemsLock.Release();
+                _list.ItemsLock.Release();
             }
 
             _selectedCount = 0;
@@ -359,7 +357,7 @@ namespace NuGet.PackageManagement.UI
 
                     if (!Items.Contains(_loadingStatusIndicator))
                     {
-                        await _itemsLock.WaitAsync();
+                        await _list.ItemsLock.WaitAsync();
 
                         try
                         {
@@ -367,7 +365,7 @@ namespace NuGet.PackageManagement.UI
                         }
                         finally
                         {
-                            _itemsLock.Release();
+                            _list.ItemsLock.Release();
                         }
                     }
                 }
@@ -406,7 +404,7 @@ namespace NuGet.PackageManagement.UI
             _joinableTaskFactory.Value.Run(async () =>
             {
                 // Synchronize updating Items list
-                await _itemsLock.WaitAsync();
+                await _list.ItemsLock.WaitAsync();
 
                 try
                 {
@@ -430,7 +428,7 @@ namespace NuGet.PackageManagement.UI
                 }
                 finally
                 {
-                    _itemsLock.Release();
+                    _list.ItemsLock.Release();
                 }
             });
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollListBox.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollListBox.cs
@@ -1,10 +1,13 @@
-﻿using System.Windows.Automation.Peers;
+using System.Threading;
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 
 namespace NuGet.PackageManagement.UI
 { 
     internal class InfiniteScrollListBox : ListBox
     {
+        public readonly SemaphoreSlim ItemsLock = new SemaphoreSlim(1, 1);
+
         protected override AutomationPeer OnCreateAutomationPeer()
         {
             return new InfiniteScrollListBoxAutomationPeer(this);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollListBoxAutomationPeer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollListBoxAutomationPeer.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
@@ -11,8 +11,19 @@ namespace NuGet.PackageManagement.UI
 
         protected override List<AutomationPeer> GetChildrenCore()
         {
-            // Don't return the LoadingStatusIndicator as an AutomationPeer, otherwise narrator will report it as an item in the list of packages, even when not visible
-            return base.GetChildrenCore()?.Where(lbiap => !(((ListBoxItemAutomationPeer)lbiap).Item is LoadingStatusIndicator)).ToList() ?? new List<AutomationPeer>();
+            var infiniteScrollListBox = Owner as InfiniteScrollListBox;
+
+            try
+            {
+                infiniteScrollListBox?.ItemsLock.Wait();
+
+                // Don't return the LoadingStatusIndicator as an AutomationPeer, otherwise narrator will report it as an item in the list of packages, even when not visible
+                return base.GetChildrenCore()?.Where(lbiap => !(((ListBoxItemAutomationPeer)lbiap).Item is LoadingStatusIndicator)).ToList() ?? new List<AutomationPeer>();
+            }
+            finally
+            {
+                infiniteScrollListBox?.ItemsLock.Release();
+            }
         }
     }
 }


### PR DESCRIPTION
## Bug
Fixes: [Watson] clr20r3: CLR_EXCEPTION_System.ArgumentException_80070057_PresentationFramework.dll!System.Windows.Data.ListCollectionView._.ctor_b__0_0 https://devdiv.visualstudio.com/DevDiv/NuGet/_workitems/edit/515179  
Regression: Yes, introduced in 15.4 release  
If Regression then when did it last work:  15.3
If Regression then how are we preventing it in future: 

## Fix
Details: After adding support of AutomationPeer in our InfiniteScrollList xaml component (represents list of packages in Manager UI), we introduced a race condition where list is being accessed without being thread safe. This PR makes InfiniteScrollList list operations thread safe across all operations.

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  Since this is a race condition between multi thread environment, it's hard to repro it locally or add automation tests. 
Validation done:  Manual testing

@rrelyea