### PR TITLE
Make accept button default focus in opened windows

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
@@ -18,7 +18,8 @@
   KeyDown="OnButtonKeyDown"
   Title="{x:Static nuget:Resources.WindowTitle_LicenseAcceptance}"
   d:DesignHeight="300"
-  d:DesignWidth="300">
+  d:DesignWidth="300"
+  FocusManager.FocusedElement="{Binding ElementName=_acceptButton}">
   <Window.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
@@ -120,6 +121,7 @@
       </Grid.ColumnDefinitions>
 
       <Button
+        Name="_acceptButton"
         Grid.Column="1"
         MinWidth="86"
         MinHeight="24"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
@@ -11,7 +11,8 @@
   WindowStartupLocation="CenterOwner"
   Title="{Binding Title}"
   Height="500"
-  Width="500">
+  Width="500"
+  FocusManager.FocusedElement="{Binding ElementName=_okButton}">
   <Window.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
@@ -122,6 +123,7 @@
         Checked="DoNotShowCheckBox_Checked"
         Unchecked="DoNotShowCheckBox_Unchecked" />
       <Button
+        Name="_okButton"
         Grid.Column="2"
         MinWidth="86"
         MinHeight="24"


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6893

## Fix
Details: Makes the accept button the default selected button when the LicenseAcceptanceWindow or the PreviewWindow opens. This does not change anything visually in the UI, just makes those dialogs more keyboard friendly by allowing users to have an easier interaction with the accept button.