### PR TITLE
Moving solution check into projects.Any() condition in restore

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -152,19 +152,16 @@ namespace NuGet.SolutionRestoreManager
                 // Note that projects that are not supported by NuGet, will not show up in this list
                 projects = await _solutionManager.GetNuGetProjectsAsync();
 
-                if (projects.Any())
+                if (projects.Any() && solutionDirectory == null)
                 {
-                    if (solutionDirectory == null)
+                    await _logger.DoAsync((l, _) =>
                     {
-                        await _logger.DoAsync((l, _) =>
-                        {
-                            _status = NuGetOperationStatus.Failed;
-                            l.ShowError(Resources.SolutionIsNotSaved);
-                            l.WriteLine(VerbosityLevel.Minimal, Resources.SolutionIsNotSaved);
-                        });
+                        _status = NuGetOperationStatus.Failed;
+                        l.ShowError(Resources.SolutionIsNotSaved);
+                        l.WriteLine(VerbosityLevel.Minimal, Resources.SolutionIsNotSaved);
+                    });
 
-                        return;
-                    }
+                    return;
                 }
 
                 // Check if there are any projects that are not INuGetIntegratedProject, that is,

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -157,6 +157,18 @@ namespace NuGet.SolutionRestoreManager
                 // any of the deferred project is type of packages.config, If so, perform package restore on them
                 if (projects.Any(project => !(project is INuGetIntegratedProject)))
                 {
+                    if (solutionDirectory == null)
+                    {
+                        await _logger.DoAsync((l, _) =>
+                        {
+                            _status = NuGetOperationStatus.Failed;
+                            l.ShowError(Resources.SolutionIsNotSaved);
+                            l.WriteLine(VerbosityLevel.Minimal, Resources.SolutionIsNotSaved);
+                        });
+                        
+                        return;
+                    }
+
                     await RestorePackagesOrCheckForMissingPackagesAsync(
                         solutionDirectory,
                         isSolutionAvailable,
@@ -179,6 +191,7 @@ namespace NuGet.SolutionRestoreManager
                             l.ShowError(Resources.SolutionIsNotSaved);
                             l.WriteLine(VerbosityLevel.Minimal, Resources.SolutionIsNotSaved);
                         });
+
                         return;
                     }
 


### PR DESCRIPTION
Fixes: [410268](https://devdiv.visualstudio.com/DevDiv/NuGet/_queries/edit/410268/?triage=true)

This PR improves on the work done in https://github.com/NuGet/NuGet.Client/pull/1226. The solution check in `SolutionRestoreJob.RestoreAsync` is moved from the beginning to a later stage and inside a condition that checks for `BuildIntegratedProjects`