### PR TITLE
add options to suppress dependencies in package

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
@@ -27,6 +27,8 @@ namespace NuGet.Build.Tasks.Pack
         string Description { get; }
         bool DevelopmentDependency { get; }
         TItem[] FrameworkAssemblyReferences { get; }
+        TItem[] FrameworksWithSuppressedAssemblyReferences { get; }
+        TItem[] FrameworksWithSuppressedDependencies { get; }
         string IconUrl { get; }
         bool IncludeBuildOutput { get; }
         bool IncludeSource { get; }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
@@ -27,7 +27,6 @@ namespace NuGet.Build.Tasks.Pack
         string Description { get; }
         bool DevelopmentDependency { get; }
         TItem[] FrameworkAssemblyReferences { get; }
-        TItem[] FrameworksWithSuppressedAssemblyReferences { get; }
         TItem[] FrameworksWithSuppressedDependencies { get; }
         string IconUrl { get; }
         bool IncludeBuildOutput { get; }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -216,7 +216,6 @@ Copyright (c) .NET Foundation. All rights reserved.
               ProjectReferencesWithVersions="@(_ProjectReferencesWithVersions)"
               TargetPathsToSymbols="@(_TargetPathsToSymbols)"
               TargetFrameworks="@(_TargetFrameworks)"
-              FrameworksWithSuppressedAssemblyReferences="@(_FrameworksWithSuppressedAssemblyReferences)"
               FrameworksWithSuppressedDependencies="@(_FrameworksWithSuppressedDependencies)"
               AssemblyName="$(AssemblyName)"
               PackageOutputPath="$(PackageOutputAbsolutePath)"

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -1,4 +1,4 @@
-﻿
+
 <!--
 ***********************************************************************************************
 NuGet.targets
@@ -45,6 +45,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ImportNuGetBuildTasksPackTargetsFromSdk Condition="'$(ImportNuGetBuildTasksPackTargetsFromSdk)' == ''">false</ImportNuGetBuildTasksPackTargetsFromSdk>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>.dll; .exe; .winmd; .json; .pri; .xml; $(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>.pdb; .mdb; $(AllowedOutputExtensionsInPackageBuildOutputFolder); $(AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder)</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
+    <SuppressDependenciesOnPacking Condition="'$(SuppressDependenciesOnPacking)' == ''">false</SuppressDependenciesOnPacking>
   </PropertyGroup>
   <PropertyGroup Condition="'$(NoBuild)' == 'true' ">
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
@@ -215,6 +216,8 @@ Copyright (c) .NET Foundation. All rights reserved.
               ProjectReferencesWithVersions="@(_ProjectReferencesWithVersions)"
               TargetPathsToSymbols="@(_TargetPathsToSymbols)"
               TargetFrameworks="@(_TargetFrameworks)"
+              FrameworksWithSuppressedAssemblyReferences="@(_FrameworksWithSuppressedAssemblyReferences)"
+              FrameworksWithSuppressedDependencies="@(_FrameworksWithSuppressedDependencies)"
               AssemblyName="$(AssemblyName)"
               PackageOutputPath="$(PackageOutputAbsolutePath)"
               IncludeSymbols="$(IncludeSymbols)"
@@ -372,6 +375,23 @@ Copyright (c) .NET Foundation. All rights reserved.
           TaskParameter="TargetOutputs"
           ItemName="_FrameworkAssemblyReferences" />
     </MSBuild>
+
+    <MSBuild
+      Projects="$(MSBuildProjectFullPath)"
+      Targets="_GetFrameworksWithSuppressedDependencies"
+      Properties="TargetFramework=%(_TargetFrameworks.Identity);
+                  BuildProjectReferences=false;">
+
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="_FrameworksWithSuppressedDependencies" />
+    </MSBuild>
+  </Target>
+
+  <Target Name ="_GetFrameworksWithSuppressedDependencies" Returns="@(_TfmWithDependenciesSuppressed)">
+    <ItemGroup>
+      <_TfmWithDependenciesSuppressed Include="$(TargetFramework)" Condition="'$(SuppressDependenciesOnPacking)' == 'true'"/>
+    </ItemGroup>
   </Target>
 
   <Target Name ="_GetFrameworkAssemblyReferences" DependsOnTargets="ResolveReferences" Returns="@(TfmSpecificFrameworkAssemblyReferences)">

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -45,7 +45,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ImportNuGetBuildTasksPackTargetsFromSdk Condition="'$(ImportNuGetBuildTasksPackTargetsFromSdk)' == ''">false</ImportNuGetBuildTasksPackTargetsFromSdk>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>.dll; .exe; .winmd; .json; .pri; .xml; $(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>.pdb; .mdb; $(AllowedOutputExtensionsInPackageBuildOutputFolder); $(AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder)</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
-    <SuppressDependenciesOnPacking Condition="'$(SuppressDependenciesOnPacking)' == ''">false</SuppressDependenciesOnPacking>
+    <SuppressDependenciesWhenPacking Condition="'$(SuppressDependenciesWhenPacking)' == ''">false</SuppressDependenciesWhenPacking>
   </PropertyGroup>
   <PropertyGroup Condition="'$(NoBuild)' == 'true' ">
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
@@ -389,7 +389,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name ="_GetFrameworksWithSuppressedDependencies" Returns="@(_TfmWithDependenciesSuppressed)">
     <ItemGroup>
-      <_TfmWithDependenciesSuppressed Include="$(TargetFramework)" Condition="'$(SuppressDependenciesOnPacking)' == 'true'"/>
+      <_TfmWithDependenciesSuppressed Include="$(TargetFramework)" Condition="'$(SuppressDependenciesWhenPacking)' == 'true'"/>
     </ItemGroup>
   </Target>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
@@ -37,7 +37,6 @@ namespace NuGet.Build.Tasks.Pack
         public string[] Tags { get; set; }
         public string ReleaseNotes { get; set; }
         public ITaskItem[] TargetPathsToSymbols { get; set; }
-        public ITaskItem[] FrameworksWithSuppressedAssemblyReferences { get; set; }
         public ITaskItem[] FrameworksWithSuppressedDependencies { get; set; }
         public string AssemblyName { get; set; }
         public string PackageOutputPath { get; set; }
@@ -163,7 +162,6 @@ namespace NuGet.Build.Tasks.Pack
                 Description = MSBuildStringUtility.TrimAndGetNullForEmpty(Description),
                 DevelopmentDependency = DevelopmentDependency,
                 FrameworkAssemblyReferences = MSBuildUtility.WrapMSBuildItem(FrameworkAssemblyReferences),
-                FrameworksWithSuppressedAssemblyReferences = MSBuildUtility.WrapMSBuildItem(FrameworksWithSuppressedAssemblyReferences),
                 FrameworksWithSuppressedDependencies = MSBuildUtility.WrapMSBuildItem(FrameworksWithSuppressedDependencies),
                 IconUrl = MSBuildStringUtility.TrimAndGetNullForEmpty(IconUrl),
                 IncludeBuildOutput = IncludeBuildOutput,

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
@@ -37,6 +37,8 @@ namespace NuGet.Build.Tasks.Pack
         public string[] Tags { get; set; }
         public string ReleaseNotes { get; set; }
         public ITaskItem[] TargetPathsToSymbols { get; set; }
+        public ITaskItem[] FrameworksWithSuppressedAssemblyReferences { get; set; }
+        public ITaskItem[] FrameworksWithSuppressedDependencies { get; set; }
         public string AssemblyName { get; set; }
         public string PackageOutputPath { get; set; }
         public bool IsTool { get; set; }
@@ -161,6 +163,8 @@ namespace NuGet.Build.Tasks.Pack
                 Description = MSBuildStringUtility.TrimAndGetNullForEmpty(Description),
                 DevelopmentDependency = DevelopmentDependency,
                 FrameworkAssemblyReferences = MSBuildUtility.WrapMSBuildItem(FrameworkAssemblyReferences),
+                FrameworksWithSuppressedAssemblyReferences = MSBuildUtility.WrapMSBuildItem(FrameworksWithSuppressedAssemblyReferences),
+                FrameworksWithSuppressedDependencies = MSBuildUtility.WrapMSBuildItem(FrameworksWithSuppressedDependencies),
                 IconUrl = MSBuildStringUtility.TrimAndGetNullForEmpty(IconUrl),
                 IncludeBuildOutput = IncludeBuildOutput,
                 IncludeSource = IncludeSource,

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -208,7 +208,6 @@ namespace NuGet.Build.Tasks.Pack
             }
             var nuGetFrameworkComparer = new NuGetFrameworkFullComparer();
             var frameworksWithSuppressedDependencies = new HashSet<NuGetFramework>(nuGetFrameworkComparer);
-            var frameworksWithSuppressedAssemblyReferences = new HashSet<NuGetFramework>(nuGetFrameworkComparer);
             if (request.FrameworksWithSuppressedDependencies != null && request.FrameworksWithSuppressedDependencies.Any())
             {
                 frameworksWithSuppressedDependencies =

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
@@ -62,5 +62,7 @@ namespace NuGet.Build.Tasks.Pack
         public string NoWarn { get; set; }
         public string TreatWarningsAsErrors { get; set; }
         public string WarningsAsErrors { get; set; }
+        public IMSBuildItem[] FrameworksWithSuppressedAssemblyReferences { get; set; }
+        public IMSBuildItem[] FrameworksWithSuppressedDependencies { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
@@ -62,7 +62,6 @@ namespace NuGet.Build.Tasks.Pack
         public string NoWarn { get; set; }
         public string TreatWarningsAsErrors { get; set; }
         public string WarningsAsErrors { get; set; }
-        public IMSBuildItem[] FrameworksWithSuppressedAssemblyReferences { get; set; }
         public IMSBuildItem[] FrameworksWithSuppressedDependencies { get; set; }
     }
 }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -2761,11 +2761,11 @@ namespace ClassLibrary
                     ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "net45;netstandard1.3");
                     if(!string.IsNullOrEmpty(frameworkToSuppress))
                     {
-                        ProjectFileUtils.AddProperty(xml, "SuppressDependenciesOnPacking", "true", $"'$(TargetFramework)'=='{frameworkToSuppress}'");
+                        ProjectFileUtils.AddProperty(xml, "SuppressDependenciesWhenPacking", "true", $"'$(TargetFramework)'=='{frameworkToSuppress}'");
                     }
                     else
                     {
-                        ProjectFileUtils.AddProperty(xml, "SuppressDependenciesOnPacking", "true");
+                        ProjectFileUtils.AddProperty(xml, "SuppressDependenciesWhenPacking", "true");
                     }
                     
                     var attributes = new Dictionary<string, string>();

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -361,8 +361,10 @@ namespace NuGet.Build.Tasks.Pack.Test
                 Tags = Array.Empty<string>(),
                 TargetFrameworks = Array.Empty<string>(),
                 BuildOutputInPackage = new ITaskItem[0],
-                TargetPathsToSymbols = new ITaskItem[0]
-            };
+                TargetPathsToSymbols = new ITaskItem[0],
+                FrameworksWithSuppressedAssemblyReferences = new ITaskItem[0],
+                FrameworksWithSuppressedDependencies = new ITaskItem[0]
+    };
 
             var settings = new JsonSerializerSettings
             {

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -362,7 +362,6 @@ namespace NuGet.Build.Tasks.Pack.Test
                 TargetFrameworks = Array.Empty<string>(),
                 BuildOutputInPackage = new ITaskItem[0],
                 TargetPathsToSymbols = new ITaskItem[0],
-                FrameworksWithSuppressedAssemblyReferences = new ITaskItem[0],
                 FrameworksWithSuppressedDependencies = new ITaskItem[0]
     };
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/6354
Introduces a new property called ``` SuppressDependenciesOnPacking ``` that allows you to suppress dependency for a particular framework, or all of them.

You can condition this property for a target framework like you can any other property:

``` <SuppressDependenciesOnPacking Condition="'$(TargetFramework)'=='net46'>true</SuppressDependenciesOnPacking> ```

CC: @wli3
