### PR TITLE
Updating DefaultMaxDegreeOfParallelism to ProcessorCount instead of hard code number

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/PackageManagementConstants.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/PackageManagementConstants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -10,7 +10,7 @@ namespace NuGet.PackageManagement
         /// <summary>
         /// Default MaxDegreeOfParallelism to use for restores and other threaded operations.
         /// </summary>
-        public static readonly int DefaultMaxDegreeOfParallelism = 16;
+        public static readonly int DefaultMaxDegreeOfParallelism = Environment.ProcessorCount;
 
         /// <summary>
         /// Default amount of time a source request can take before timing out. This includes both UNC shares


### PR DESCRIPTION
With large solutions having more than 100 satellite packages dependencies, is often faulting in Visual Studio hang while opening this solution, and specially on machines with less resources like processor. The reason is, during auto restore on solution load, NuGet by default have 16 parallel threads doing heavy I/o operations to copy satellite resources from these packages on disk which often triggers too many jitting events which eventually block main thread to proceed and hence most time VS is hung until whole NuGet restore is completed.

This PR updates this `DefaultMaxDegreeOfParallelism` from hard code number of 16 to be based on `ProcessorCount` of the machine which will give a balanced approach to parallelism and performance.

Fixes [Feedback] Visual Studio hangs when opening projects https://devdiv.visualstudio.com/DevDiv/NuGet/_workitems/edit/581285 

@rrelyea 