### PR TITLE
Update Tools/Options UI to have smaller margings

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace NuGet.Options
+namespace NuGet.Options
 {
     partial class GeneralOptionControl
     {
@@ -36,14 +36,12 @@
             this.BindingRedirectsHeader = new System.Windows.Forms.Label();
             this.localsCommandButton = new System.Windows.Forms.Button();
             this.localsCommandStatusText = new System.Windows.Forms.RichTextBox();
-#if !VS14
             this.PackageManagementHeader = new System.Windows.Forms.Label();
             this.defaultPackageManagementFormatLabel = new System.Windows.Forms.Label();
             this.showPackageManagementChooser = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.defaultPackageManagementFormatItems = new System.Windows.Forms.ComboBox();
             this.tableLayoutPanel1.SuspendLayout();
-#endif
             this.SuspendLayout();
             // 
             // skipBindingRedirects
@@ -91,7 +89,6 @@
             this.localsCommandStatusText.ReadOnly = true;
             this.localsCommandStatusText.ContentsResized += new System.Windows.Forms.ContentsResizedEventHandler(this.localsCommandStatusText_ContentChanged);
             this.localsCommandStatusText.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.localsCommandStatusText_LinkClicked);
-#if !VS14
             // 
             // PackageManagementHeader
             // 
@@ -125,13 +122,6 @@
             resources.GetString("defaultPackageManagementFormatItems.Items"),
             resources.GetString("defaultPackageManagementFormatItems.Items1")});
             this.defaultPackageManagementFormatItems.Name = "defaultPackageManagementFormatItems";
-
-            this.Size = new System.Drawing.Size(463, 365);
-            this.skipBindingRedirects.Location = new System.Drawing.Point(19, 118);
-            this.BindingRedirectsHeader.Location = new System.Drawing.Point(2, 92);
-            this.localsCommandButton.Location = new System.Drawing.Point(5, 247);
-            this.localsCommandStatusText.Location = new System.Drawing.Point(5, 276);
-#endif
             // 
             // GeneralOptionControl
             // 
@@ -142,18 +132,17 @@
             this.Controls.Add(this.packageRestoreConsentCheckBox);
             this.Controls.Add(this.packageRestoreAutomaticCheckBox);
             this.Controls.Add(this.skipBindingRedirects);
-#if !VS14
             this.Controls.Add(this.PackageManagementHeader);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.showPackageManagementChooser);
-            this.tableLayoutPanel1.ResumeLayout(false);
-            this.tableLayoutPanel1.PerformLayout();
-#endif
             this.Controls.Add(this.localsCommandButton);
             this.Controls.Add(this.localsCommandStatusText);
             this.Name = "GeneralOptionControl";
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
+
         }
 
         #endregion

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.cs
@@ -35,6 +35,7 @@ namespace NuGet.Options
             _serviceprovider = serviceProvider;
             _outputConsoleLogger = ServiceLocator.GetInstance<INuGetUILogger>();
             _localsCommandRunner = new LocalsCommandRunner();
+            AutoScroll = true;
             Debug.Assert(_settings != null);
         }
 
@@ -185,6 +186,7 @@ namespace NuGet.Options
             localsCommandStatusText.AccessibleName = statusText;
             localsCommandStatusText.Visible = visibility;
             localsCommandStatusText.Text = statusText;
+            localsCommandStatusText.Anchor = AnchorStyles.Top|AnchorStyles.Left;
             localsCommandStatusText.Refresh();
         }
 
@@ -206,8 +208,6 @@ namespace NuGet.Options
         private void localsCommandStatusText_ContentChanged(object sender, ContentsResizedEventArgs e)
         {
             localsCommandStatusText.Height = e.NewRectangle.Height + localsCommandStatusText.Margin.Top + localsCommandStatusText.Margin.Bottom;
-            localsCommandStatusText.Width = e.NewRectangle.Width + localsCommandStatusText.Margin.Left + localsCommandStatusText.Margin.Right;
         }
-
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.resx
@@ -123,7 +123,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="skipBindingRedirects.Location" type="System.Drawing.Point, System.Drawing">
-    <value>19, 118</value>
+    <value>19, 96</value>
   </data>
   <data name="skipBindingRedirects.Size" type="System.Drawing.Size, System.Drawing">
     <value>169, 17</value>
@@ -184,7 +184,7 @@
     <value>True</value>
   </data>
   <data name="packageRestoreConsentCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>19, 37</value>
+    <value>19, 32</value>
   </data>
   <data name="packageRestoreConsentCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -214,13 +214,13 @@
     <value>NoControl</value>
   </data>
   <data name="packageRestoreAutomaticCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>19, 56</value>
+    <value>19, 51</value>
   </data>
   <data name="packageRestoreAutomaticCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
   </data>
   <data name="packageRestoreAutomaticCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>355, 34</value>
+    <value>355, 22</value>
   </data>
   <data name="packageRestoreAutomaticCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -250,7 +250,7 @@
     <value>NoControl</value>
   </data>
   <data name="BindingRedirectsHeader.Location" type="System.Drawing.Point, System.Drawing">
-    <value>2, 92</value>
+    <value>2, 77</value>
   </data>
   <data name="BindingRedirectsHeader.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 0, 2, 0</value>
@@ -283,7 +283,7 @@
     <value>System</value>
   </data>
   <data name="localsCommandButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 247</value>
+    <value>5, 182</value>
   </data>
   <data name="localsCommandButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>138, 23</value>
@@ -310,10 +310,10 @@
     <value>True</value>
   </data>
   <data name="localsCommandStatusText.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 276</value>
+    <value>5, 213</value>
   </data>
   <data name="localsCommandStatusText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>432, 62</value>
+    <value>369, 67</value>
   </data>
   <data name="localsCommandStatusText.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -346,7 +346,7 @@
     <value>NoControl</value>
   </data>
   <data name="PackageManagementHeader.Location" type="System.Drawing.Point, System.Drawing">
-    <value>2, 151</value>
+    <value>2, 119</value>
   </data>
   <data name="PackageManagementHeader.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 0, 2, 0</value>
@@ -409,7 +409,7 @@
     <value>True</value>
   </data>
   <data name="showPackageManagementChooser.Location" type="System.Drawing.Point, System.Drawing">
-    <value>19, 206</value>
+    <value>19, 160</value>
   </data>
   <data name="showPackageManagementChooser.Size" type="System.Drawing.Size, System.Drawing">
     <value>236, 17</value>
@@ -441,6 +441,45 @@
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
+  <data name="&gt;&gt;defaultPackageManagementFormatItems.Name" xml:space="preserve">
+    <value>defaultPackageManagementFormatItems</value>
+  </data>
+  <data name="&gt;&gt;defaultPackageManagementFormatItems.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;defaultPackageManagementFormatItems.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;defaultPackageManagementFormatItems.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 133</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>318, 27</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="defaultPackageManagementFormatItems" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="defaultPackageManagementFormatLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="Percent,100,Absolute,27" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
   <data name="defaultPackageManagementFormatItems.AccessibleName" xml:space="preserve">
     <value>Default Package Management Format</value>
   </data>
@@ -470,33 +509,6 @@
   </data>
   <data name="&gt;&gt;defaultPackageManagementFormatItems.ZOrder" xml:space="preserve">
     <value>0</value>
-  </data>
-  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 172</value>
-  </data>
-  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>318, 27</value>
-  </data>
-  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="defaultPackageManagementFormatItems" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="defaultPackageManagementFormatLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="Percent,100,Absolute,27" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/5938

## Fix
Details: Currently the UI for the tools/options/nuget window has an issue where if the text is bigger than the current size of the window, it gets hidden and the only way to see it is to resize the window. Given that we don't have control over the minimum size (is the same for all the tabs), and to be more consistent with what other tabs look like, this PR makes two changes:

1. Updates the margins on the current elements to be closer to each other and not waste vertical space. This will help the success scenario or when small error messages appear to be part of the screen.
2. Add a scroll bar so that when text is bigger the user can see it by either scrolling or making the window bigger.

Note: For usability this PR also makes it so that the message label keeps the same width and only grows in height, that way the user should only need vertical scroll bars.


**Before:**
![tools_big_error_hidden](https://user-images.githubusercontent.com/2132567/40022523-1f99bd52-577d-11e8-9771-0c7c61089a4f.PNG)
*There is a hidden error message beneath the fail message*
**After:**
![tools_fixed_long_error](https://user-images.githubusercontent.com/2132567/40022567-3dfc34b4-577d-11e8-95c7-a69f43573292.PNG)

![tools_fixed_success](https://user-images.githubusercontent.com/2132567/40022525-2184d8c2-577d-11e8-9cb9-5fcc154367a1.PNG)
