### PR TITLE
Skipping NuGetPackage MEFs initialization during solution or VS close

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -1027,12 +1027,12 @@ namespace NuGetVSExtension
         // know which options keys it will use in the suo file.
         public int SaveUserOptions(IVsSolutionPersistence pPersistence)
         {
-            if (ShouldMEFBeInitialized())
+            if (SolutionUserOptions != null && SolutionUserOptions.IsValueCreated)
             {
-                NuGetUIThreadHelper.JoinableTaskFactory.Run(InitializeMEFAsync);
+                return SolutionUserOptions.Value.SaveUserOptions(pPersistence);
             }
 
-            return SolutionUserOptions.Value.SaveUserOptions(pPersistence);
+            return VSConstants.S_OK;
         }
 
         public int WriteUserOptions(IStream _, string __)


### PR DESCRIPTION
This is the improvement over [PR#2232](https://github.com/NuGet/NuGet.Client/pull/2232), This PR will skip NuGetPackage MEFs initialization altogether during solution or VS close.

@rrelyea @DoRonMotter 