### PR TITLE
Add margin to prerelase label

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
   x:Class="NuGet.PackageManagement.UI.PackageItemControl"
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -136,7 +136,7 @@
                       Grid.Row="1"
                       Text="{x:Static nuget:Resources.Label_PackagePrerelease}"
                       FontSize="9"
-                      Margin="0,3,0,0"
+                      Margin="0,3,5,0"
                       HorizontalAlignment="Left"
                       Visibility="{Binding Version.IsPrerelease, Converter={StaticResource BooleanToVisibilityConverter}}" />
                   </Grid>


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/4504

## Fix
*Details:* Added a margin to the right to the prerelease label. In languages where the word "Prerelease" is bigger than the size of the icon, the text was overlapping with the text description of the package.

**Before:**
![prerelase-bug](https://user-images.githubusercontent.com/2132567/40076392-9dc830d0-5833-11e8-9ecd-95484b12790c.PNG)

**After:**
![margin-fixed](https://user-images.githubusercontent.com/2132567/40076336-7e6369bc-5833-11e8-84f1-65701033b9be.PNG)
