### PR TITLE
Fixed vs/nuget/nugetactionstep telemetry event for GDPR requirements

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -1139,7 +1139,7 @@ namespace NuGet.PackageManagement
                 stopWatch.Stop();
 
                 var gatherTelemetryEvent = new ActionTelemetryStepEvent(nuGetProjectContext.OperationId.ToString(),
-                    string.Format(TelemetryConstants.GatherDependencyStepName, projectId), stopWatch.Elapsed.TotalSeconds);
+                    TelemetryConstants.GatherDependencyStepName, stopWatch.Elapsed.TotalSeconds);
 
                 TelemetryActivity.EmitTelemetryEvent(gatherTelemetryEvent);
                 stopWatch.Restart();
@@ -1224,7 +1224,7 @@ namespace NuGet.PackageManagement
                 stopWatch.Stop();
 
                 var resolveTelemetryEvent = new ActionTelemetryStepEvent(nuGetProjectContext.OperationId.ToString(),
-                    string.Format(TelemetryConstants.ResolveDependencyStepName, projectId), stopWatch.Elapsed.TotalSeconds);
+                    TelemetryConstants.ResolveDependencyStepName, stopWatch.Elapsed.TotalSeconds);
 
                 TelemetryActivity.EmitTelemetryEvent(resolveTelemetryEvent);
                 stopWatch.Restart();
@@ -1261,7 +1261,7 @@ namespace NuGet.PackageManagement
                 stopWatch.Stop();
 
                 var actionTelemetryEvent = new ActionTelemetryStepEvent(nuGetProjectContext.OperationId.ToString(),
-                    string.Format(TelemetryConstants.ResolvedActionsStepName, projectId), stopWatch.Elapsed.TotalSeconds);
+                    TelemetryConstants.ResolvedActionsStepName, stopWatch.Elapsed.TotalSeconds);
 
                 TelemetryActivity.EmitTelemetryEvent(actionTelemetryEvent);
 
@@ -1640,7 +1640,7 @@ namespace NuGet.PackageManagement
                     // emit gather dependency telemetry event and restart timer
                     stopWatch.Stop();
                     var gatherTelemetryEvent = new ActionTelemetryStepEvent(nuGetProjectContext.OperationId.ToString(),
-                        string.Format(TelemetryConstants.GatherDependencyStepName, projectId), stopWatch.Elapsed.TotalSeconds);
+                        TelemetryConstants.GatherDependencyStepName, stopWatch.Elapsed.TotalSeconds);
 
                     TelemetryActivity.EmitTelemetryEvent(gatherTelemetryEvent);
 
@@ -1705,7 +1705,7 @@ namespace NuGet.PackageManagement
                     stopWatch.Stop();
 
                     var resolveTelemetryEvent = new ActionTelemetryStepEvent(nuGetProjectContext.OperationId.ToString(),
-                        string.Format(TelemetryConstants.ResolveDependencyStepName, projectId), stopWatch.Elapsed.TotalSeconds);
+                        TelemetryConstants.ResolveDependencyStepName, stopWatch.Elapsed.TotalSeconds);
 
                     TelemetryActivity.EmitTelemetryEvent(resolveTelemetryEvent);
 
@@ -1797,7 +1797,7 @@ namespace NuGet.PackageManagement
             stopWatch.Stop();
 
             var actionTelemetryEvent = new ActionTelemetryStepEvent(nuGetProjectContext.OperationId.ToString(),
-                string.Format(TelemetryConstants.ResolvedActionsStepName, projectId), stopWatch.Elapsed.TotalSeconds);
+                TelemetryConstants.ResolvedActionsStepName, stopWatch.Elapsed.TotalSeconds);
 
             TelemetryActivity.EmitTelemetryEvent(actionTelemetryEvent);
 
@@ -2453,7 +2453,7 @@ namespace NuGet.PackageManagement
 
             // emit resolve actions telemetry event
             var actionTelemetryEvent = new ActionTelemetryStepEvent(nuGetProjectContext.OperationId.ToString(),
-                string.Format(TelemetryConstants.ExecuteActionStepName, projectId), stopWatch.Elapsed.TotalSeconds);
+                TelemetryConstants.ExecuteActionStepName, stopWatch.Elapsed.TotalSeconds);
 
             TelemetryActivity.EmitTelemetryEvent(actionTelemetryEvent);
 
@@ -2681,7 +2681,7 @@ namespace NuGet.PackageManagement
             stopWatch.Stop();
 
             var actionTelemetryEvent = new ActionTelemetryStepEvent(nuGetProjectContext.OperationId.ToString(),
-                string.Format(TelemetryConstants.PreviewBuildIntegratedStepName, projectId), stopWatch.Elapsed.TotalSeconds);
+                TelemetryConstants.PreviewBuildIntegratedStepName, stopWatch.Elapsed.TotalSeconds);
 
             TelemetryActivity.EmitTelemetryEvent(actionTelemetryEvent);
 

--- a/src/NuGet.Core/NuGet.PackageManagement/Telemetry/ActionTelemetryStepEvent.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Telemetry/ActionTelemetryStepEvent.cs
@@ -12,7 +12,7 @@ namespace NuGet.PackageManagement
             base(NugetActionStepsEventName, new Dictionary<string, object>
                 {
                     { nameof(OperationId), operationId },
-                    { nameof(StepName), string.Join(",", stepName) },
+                    { nameof(SubStepName), string.Join(",", stepName) },
                     { nameof(Duration), duration }
                 })
         {
@@ -20,7 +20,7 @@ namespace NuGet.PackageManagement
 
         public const string NugetActionStepsEventName = "NugetActionSteps";
 
-        public string StepName => (string)base[nameof(StepName)];
+        public string SubStepName => (string)base[nameof(SubStepName)];
         public double Duration => (double)base[nameof(Duration)];
         public string OperationId => (string)base[nameof(OperationId)];
     }

--- a/src/NuGet.Core/NuGet.PackageManagement/Telemetry/TelemetryConstants.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Telemetry/TelemetryConstants.cs
@@ -9,10 +9,10 @@ namespace NuGet.PackageManagement
     public static class TelemetryConstants
     {
         // nuget action step event data
-        public static readonly string PreviewBuildIntegratedStepName = "Preview build integrated action for project {0} time";
-        public static readonly string GatherDependencyStepName = "Gather dependency action for project {0} time";
-        public static readonly string ResolveDependencyStepName = "Resolve dependency action for project {0} time";
-        public static readonly string ResolvedActionsStepName = "Resolved nuget actions for project {0} time";
-        public static readonly string ExecuteActionStepName = "Executing nuget actions for project {0} time";
+        public static readonly string PreviewBuildIntegratedStepName = "Preview build integrated action time";
+        public static readonly string GatherDependencyStepName = "Gather dependency action time";
+        public static readonly string ResolveDependencyStepName = "Resolve dependency action time";
+        public static readonly string ResolvedActionsStepName = "Resolved nuget actions time";
+        public static readonly string ExecuteActionStepName = "Executing nuget actions time";
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/ActionsTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/ActionsTelemetryServiceTests.cs
@@ -132,13 +132,12 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 .Callback<TelemetryEvent>(x => lastTelemetryEvent = x);
 
             var duration = 1.12;
-            var stepNameWithProject = string.Format(stepName, "testProject");
             var service = new NuGetVSTelemetryService(telemetrySession.Object);
 
             var operationId = Guid.NewGuid().ToString();
 
             // Act
-            service.EmitTelemetryEvent(new ActionTelemetryStepEvent(operationId,stepNameWithProject, duration));
+            service.EmitTelemetryEvent(new ActionTelemetryStepEvent(operationId, stepName, duration));
 
             // Assert
             Assert.NotNull(lastTelemetryEvent);
@@ -146,7 +145,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.Equal(3, lastTelemetryEvent.Count);
 
             Assert.Equal(operationId, lastTelemetryEvent["OperationId"].ToString());
-            Assert.Equal(stepNameWithProject, lastTelemetryEvent["StepName"].ToString());
+            Assert.Equal(stepName, lastTelemetryEvent["SubStepName"].ToString());
             Assert.Equal(duration, (double)lastTelemetryEvent["Duration"]);
         }
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -6042,7 +6042,7 @@ namespace NuGet.Test
                 Assert.Equal(3, telemetryEvents.Count);
                 var projectId = string.Empty;
                 nugetProject.TryGetMetadata<string>(NuGetProjectMetadataKeys.ProjectId, out projectId);
-                VerifyPreviewActionsTelemetryEvents_PackagesConfig(projectId, telemetryEvents.Select(p => (string)p["StepName"]));
+                VerifyPreviewActionsTelemetryEvents_PackagesConfig(telemetryEvents.Select(p => (string)p["SubStepName"]));
             }
         }
 
@@ -6099,10 +6099,8 @@ namespace NuGet.Test
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "CreateRestoreTargetGraph").Count());
                 Assert.Equal(1, telemetryEvents.Where(p => p.Name == "NugetActionSteps").Count());
 
-                var projectId = string.Empty;
-                buildIntegratedProject.TryGetMetadata(NuGetProjectMetadataKeys.ProjectId, out projectId);
                 Assert.True(telemetryEvents.Where(p => p.Name == "NugetActionSteps").
-                    Any(p => (string)p["StepName"] == string.Format(TelemetryConstants.PreviewBuildIntegratedStepName, projectId)));
+                    Any(p => (string)p["SubStepName"] == TelemetryConstants.PreviewBuildIntegratedStepName));
             }
         }
 
@@ -6171,7 +6169,7 @@ namespace NuGet.Test
                 Assert.Equal(3, telemetryEvents.Count);
                 var projectId = string.Empty;
                 nuGetProject.TryGetMetadata<string>(NuGetProjectMetadataKeys.ProjectId, out projectId);
-                VerifyPreviewActionsTelemetryEvents_PackagesConfig(projectId, telemetryEvents.Select(p => (string)p["StepName"]));
+                VerifyPreviewActionsTelemetryEvents_PackagesConfig(telemetryEvents.Select(p => (string)p["SubStepName"]));
             }
         }
 
@@ -6229,7 +6227,7 @@ namespace NuGet.Test
                 Assert.Equal(1, telemetryEvents.Where(p => p.Name == "PackageExtractionInformation").Count());
                 Assert.Equal(1, telemetryEvents.Where(p => p.Name == "NugetActionSteps").Count());
                 Assert.True(telemetryEvents.Where(p => p.Name == "NugetActionSteps").
-                     Any(p => (string)p["StepName"] == string.Format(TelemetryConstants.ExecuteActionStepName, projectId)));
+                     Any(p => (string)p["SubStepName"] == TelemetryConstants.ExecuteActionStepName));
             }
         }
 
@@ -6289,9 +6287,6 @@ namespace NuGet.Test
                     token);
 
                 // Assert
-                var projectId = string.Empty;
-                buildIntegratedProject.TryGetMetadata(NuGetProjectMetadataKeys.ProjectId, out projectId);
-
                 Assert.Equal(16, telemetryEvents.Count);
 
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
@@ -6305,9 +6300,9 @@ namespace NuGet.Test
 
 
                 Assert.True(telemetryEvents.Where(p => p.Name == "NugetActionSteps").
-                    Any(p => (string)p["StepName"] == string.Format(TelemetryConstants.PreviewBuildIntegratedStepName, projectId)));
+                    Any(p => (string)p["SubStepName"] == TelemetryConstants.PreviewBuildIntegratedStepName));
                 Assert.True(telemetryEvents.Where(p => p.Name == "NugetActionSteps").
-                    Any(p => (string)p["StepName"] == string.Format(TelemetryConstants.ExecuteActionStepName, projectId)));
+                    Any(p => (string)p["SubStepName"] == TelemetryConstants.ExecuteActionStepName));
             }
         }
 
@@ -6375,16 +6370,11 @@ namespace NuGet.Test
             }
         }
 
-        private void VerifyPreviewActionsTelemetryEvents_PackagesConfig(string operationId, IEnumerable<string> actual)
+        private void VerifyPreviewActionsTelemetryEvents_PackagesConfig(IEnumerable<string> actual)
         {
-            var key = string.Format(TelemetryConstants.GatherDependencyStepName, operationId);
-            Assert.True(actual.Contains(key));
-
-            key = string.Format(TelemetryConstants.ResolveDependencyStepName, operationId);
-            Assert.True(actual.Contains(key));
-
-            key = string.Format(TelemetryConstants.ResolvedActionsStepName, operationId);
-            Assert.True(actual.Contains(key));
+            Assert.True(actual.Contains(TelemetryConstants.GatherDependencyStepName));
+            Assert.True(actual.Contains(TelemetryConstants.ResolveDependencyStepName));
+            Assert.True(actual.Contains(TelemetryConstants.ResolvedActionsStepName));
         }
 
         private static void AddToPackagesFolder(PackageIdentity package, string root)


### PR DESCRIPTION
Fixed vs/nuget/nugetactionstep telemetry event for GDPR requirements to avoid adding ProjectId as part of vs.nuget.stepname field.

@rrelyea @DoRonMotter 