### PR TITLE
added long path package validation warning to RuleSet

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -666,6 +666,11 @@ namespace NuGet.Common
         NU5122 = 5122,
 
         /// <summary>
+        /// Warning_FilePathTooLong
+        /// </summary>
+        NU5123 = 5123,
+
+        /// <summary>
         /// Undefined package warning
         /// </summary>
         NU5500 = 5500

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
@@ -89,6 +89,15 @@ namespace NuGet.Packaging.Rules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The file &apos;{0}&apos; path, name, or both are too long. Your package might not work without long file path support. Please shorten the file path or file name..
+        /// </summary>
+        public static string FilePathTooLongWarning {
+            get {
+                return ResourceManager.GetString("FilePathTooLongWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The folder &apos;{0}&apos; under &apos;lib&apos; is not recognized as a valid framework name or a supported culture identifier. Rename it to a valid framework name or culture identifier..
         /// </summary>
         public static string InvalidFrameworkWarning {

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
@@ -126,6 +126,9 @@
   <data name="DefaultSpecValueWarning" xml:space="preserve">
     <value>The value "{0}" for {1} is a sample value and should be removed. Replace it with an appropriate value or remove it and rebuild your package.</value>
   </data>
+  <data name="FilePathTooLongWarning" xml:space="preserve">
+    <value>The file '{0}' path, name, or both are too long. Your package might not work without long file path support. Please shorten the file path or file name.</value>
+  </data>
   <data name="InvalidFrameworkWarning" xml:space="preserve">
     <value>The folder '{0}' under 'lib' is not recognized as a valid framework name or a supported culture identifier. Rename it to a valid framework name or culture identifier.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Packaging/Rules/PathTooLongRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/PathTooLongRule.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using NuGet.Common;
+
+namespace NuGet.Packaging.Rules
+{
+    public class PathTooLongRule : IPackageRule
+    {
+        private const int _pathLenghtWarningThreshold = 200;
+        public string MessageFormat { get; }
+
+        public PathTooLongRule(string messageFormat)
+        {
+            MessageFormat = messageFormat;
+        }
+
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
+        {
+            var packageIdentity = builder.GetIdentity();
+            var versionFolderPathResolver = new VersionFolderPathResolver(string.Empty);
+            var installedPath = versionFolderPathResolver.GetInstallPath(packageIdentity.Id, packageIdentity.Version);
+
+            foreach (var file in builder.GetFiles())
+            {
+                if (Path.Combine(installedPath, file).Length > _pathLenghtWarningThreshold)
+                {
+                    yield return CreatePackageIssueForPathTooLong(file);
+                }
+            }
+        }
+
+        private PackagingLogMessage CreatePackageIssueForPathTooLong(string target)
+        {
+            return PackagingLogMessage.CreateWarning(
+               string.Format(CultureInfo.CurrentCulture, MessageFormat, target),
+               NuGetLogCode.NU5123);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Rules/RuleSet.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/RuleSet.cs
@@ -23,7 +23,8 @@ namespace NuGet.Packaging.Rules
                 new LegacyVersionRule(AnalysisResources.LegacyVersionWarning),
                 new InvalidPrereleaseDependencyRule(AnalysisResources.InvalidPrereleaseDependencyWarning),
                 new UnspecifiedDependencyVersionRule(AnalysisResources.UnspecifiedDependencyVersionWarning),
-                new UnrecognizedScriptFileRule(AnalysisResources.UnrecognizedScriptWarning)
+                new UnrecognizedScriptFileRule(AnalysisResources.UnrecognizedScriptWarning),
+                new PathTooLongRule(AnalysisResources.FilePathTooLongWarning)
             }
         );
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/RuleSetTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/RuleSetTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Common;
+using NuGet.Packaging.Rules;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class RuleSetTests
+    {
+        [Fact]
+        public void PathTooLongWarning_PackageWithLongPath_Warn()
+        {
+            using (var packageFile = TestPackagesCore.GetPackageCoreReaderLongPathTestPackage())
+            {
+                var zip = TestPackagesCore.GetZip(packageFile);
+                var ruleSet = RuleSet.PackageCreationRuleSet;
+
+                using (var reader = new PackageArchiveReader(zip))
+                {
+                    var issues = new List<PackagingLogMessage>();
+
+                    foreach (var rule in ruleSet)
+                    {
+                        issues.AddRange(rule.Validate(reader).OrderBy(p => p.Code.ToString(), StringComparer.CurrentCulture));
+                    }
+
+                    Assert.True(issues.Any(p => p.Code == NuGetLogCode.NU5123));
+                }
+            }
+        }
+
+        [Fact]
+        public void PathTooLongWarning_PackageWithOutLongPath_NoWarn()
+        {
+            using (var packageFile = TestPackagesCore.GetPackageCoreReaderTestPackage())
+            {
+                var zip = TestPackagesCore.GetZip(packageFile);
+                var ruleSet = RuleSet.PackageCreationRuleSet;
+
+                using (var reader = new PackageArchiveReader(zip))
+                {
+                    var issues = new List<PackagingLogMessage>();
+
+                    foreach (var rule in ruleSet)
+                    {
+                        issues.AddRange(rule.Validate(reader).OrderBy(p => p.Code.ToString(), StringComparer.CurrentCulture));
+                    }
+
+                    Assert.False(issues.Any(p => p.Code == NuGetLogCode.NU5123));
+                }
+            }
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/TestPackagesCore.cs
+++ b/test/TestUtilities/Test.Utility/TestPackagesCore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -227,6 +227,33 @@ namespace NuGet.Test.Utility
                               <metadata minClientVersion=""1.2.3"">
                                 <id>Aa</id>
                                 <version>4.5.6</version>
+                                <authors>author</authors>
+                                <description>description</description>
+                                <packageTypes>
+                                  <packageType name=""Bb"" />
+                                  <packageType name=""Cc"" version=""7.8.9"" />
+                                </packageTypes>
+                              </metadata>
+                            </package>", Encoding.UTF8);
+            }
+
+            return file;
+        }
+
+        public static TempFile GetPackageCoreReaderLongPathTestPackage()
+        {
+            var file = new TempFile();
+
+            using (var zip = new ZipArchive(File.Create(file), ZipArchiveMode.Create))
+            {
+                zip.AddEntry("lib/net45/a.dll", ZeroContent);
+                zip.AddEntry("content/2.5.6/core/store/x64/netcoreapp2.0/microsoft.extensions.configuration.environmentvariables/2.0.0/lib/netstandard2.0/Microsoft.Extensions.Configuration.EnvironmentVariables.dll ", ZeroContent);
+
+                zip.AddEntry("Aa.nuspec", @"<?xml version=""1.0"" encoding=""utf-8""?>
+                            <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+                              <metadata minClientVersion=""1.2.3"">
+                                <id>microsoft.dadsdasfihfhofhoashfosfho.dsahodfhasfhasof</id>
+                                <version>2.5.6</version>
                                 <authors>author</authors>
                                 <description>description</description>
                                 <packageTypes>


### PR DESCRIPTION
After checked all packages in nuget.org, we think "200 chars" is good threshold for path too long warning.
this pr is for warning the package author if his package contains any file which id length + version length+ file path length > 200.
