### PR TITLE
NuGet update performance improvement for PackageReference

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -288,11 +288,11 @@ namespace NuGet.SolutionRestoreManager
                     {
                         shouldStartNewBGJobRunner = false;
                     }
-                    else if (_lockService.Value.IsLockHeld)
+                    else if (_lockService.Value.IsLockHeld && _lockService.Value.LockCount > 0)
                     {
-                        // when restore is not running but NuGet lock is still held, then it means other
-                        // NuGet operation like Install or Update are in progress which will take care of running
-                        // restore for appropriate projects so skipping auto restore in that case.
+                        // when restore is not running but NuGet lock is still held for the current async operation,
+                        // then it means other NuGet operation like Install or Update are in progress which will
+                        // take care of running restore for appropriate projects so skipping auto restore in that case.
                         return true;
                     }
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -288,6 +288,13 @@ namespace NuGet.SolutionRestoreManager
                     {
                         shouldStartNewBGJobRunner = false;
                     }
+                    else if (_lockService.Value.IsLockHeld)
+                    {
+                        // when restore is not running but NuGet lock is still held, then it means other
+                        // NuGet operation like Install or Update are in progress which will take care of running
+                        // restore for appropriate projects so skipping auto restore in that case.
+                        return true;
+                    }
 
                     // on-board request onto pending restore operation
                     _pendingRequests.Value.TryAdd(request);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/INuGetLockService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/INuGetLockService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -16,6 +16,11 @@ namespace NuGet.VisualStudio
         /// Gets a value indicating whether any kind of lock is held.
         /// </summary>
         bool IsLockHeld { get; }
+
+        /// <summary>
+        /// Returns the total lock count for current async NuGet operation.
+        /// </summary>
+        int LockCount { get; }
 
         /// <summary>
         /// Obtains NuGet specific lock and execute action.


### PR DESCRIPTION
Currently we're running too many restores while updating NuGet package to a specific version at solution level for few projects for a solution full of sdk based projects. And the reason is, everytime we update the project file for newer version, we make sure to run restore for all the parent projects to get the update and at the same time, it also triggers multiple auto restores since sdk project system will also nominate this change. So for a solution with 58 sdk based projects, updating a single NuGet dependency for 8 projects took about ~10mins to complete.

With this PR, for the same scenario, it brings down the total time to ~3mins. I tried it for other solutions with similar scenario and saw ~60% improvement overall for install/ update operations for sdk based projects. This fix is in 2 parts:
a. Sort the projects in topological sort before updating packages so that leaf node project is updated first which avoids running multiple restores for the same project over and over.
b. Skip auto restore when NuGet itself is installing or updating the project since NuGet itself will take care of updating all the impacted projects in the solution as it does for non-sdk based projects with `PackageReference`. So running multiple auto restores at that time is irrelevant and over-kill.

Fixes [Feedback] Nuget package update is very slow https://devdiv.visualstudio.com/DevDiv/NuGet/_workitems/edit/494868 

@rrelyea 