### PR TITLE
Improve responsiveness of PMUI top panel

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
@@ -73,95 +73,117 @@
         HorizontalAlignment="Right"
         VerticalAlignment="Center"
         FontSize="{Binding FontSize,RelativeSource={RelativeSource AncestorType=UserControl},Converter={StaticResource Font155PercentSizeConverter}}"
-        Margin="20,0,0,0">Package Manager</TextBlock>
+        Margin="20,0,0,0"
+        TextTrimming="CharacterEllipsis">
+        Package Manager
+      </TextBlock>
     </Grid>
 
     <!-- search control and include prerelease checkbox -->
     <Grid Grid.Row="2">
       <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="auto" />
-        <ColumnDefinition Width="auto" />
-        <ColumnDefinition Width="auto" />
-        <ColumnDefinition Width="*" MinWidth="20" />
-        <ColumnDefinition Width="auto" />
-        <ColumnDefinition Width="auto" />
-        <ColumnDefinition Width="auto" />
-        <ColumnDefinition Width="auto" />
+        <ColumnDefinition Width="*" MinWidth="269"/>
+        <ColumnDefinition Width="0.01*" MinWidth="5" />
+        <ColumnDefinition Width="*" MinWidth="192" />
       </Grid.ColumnDefinitions>
 
-      <!-- container of the search control -->
-      <Border
-        Grid.Column="0"
-        x:Name="_searchControlParent"
-        VerticalAlignment="Center"
-        Width="320"
-        MinHeight="22"
-        MinWidth="224" />
+      <Grid
+        Grid.Column="0">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*" MaxWidth="320" MinWidth="118"/>
+          <ColumnDefinition Width="auto" />
+          <ColumnDefinition Width="auto" />
+        </Grid.ColumnDefinitions>
+        <!-- container of the search control -->
+          <Border
+          Grid.Column="0"
+          x:Name="_searchControlParent"
+          VerticalAlignment="Center"
+          MinHeight="22"
+          MinWidth="118"/>
 
-      <Button
-        Grid.Column="1"
-        x:Name="_refreshButton"
-        AutomationProperties.AutomationId="Button_Retry"
-        Margin="3,0"
-        VerticalAlignment="Center"
-        Padding="0"
-        ToolTip="{x:Static nuget:Resources.ToolTip_Refresh}"
-        AutomationProperties.Name="{x:Static nuget:Resources.ToolTip_Refresh}"
-        Style="{StaticResource ToolBarButtonStyle}"
-        Command="{x:Static nuget:Commands.RestartSearchCommand}">
-        <Image
-          Source="{StaticResource BitmapImage_Refresh}"
-          Margin="2"
-          Height="16"
-          Width="16" />
-      </Button>
+          <Button
+          Grid.Column="1"
+          x:Name="_refreshButton"
+          AutomationProperties.AutomationId="Button_Retry"
+          Margin="3,0"
+          VerticalAlignment="Center"
+          Padding="0"
+          ToolTip="{x:Static nuget:Resources.ToolTip_Refresh}"
+          AutomationProperties.Name="{x:Static nuget:Resources.ToolTip_Refresh}"
+          Style="{StaticResource ToolBarButtonStyle}"
+          Command="{x:Static nuget:Commands.RestartSearchCommand}">
+            <Image
+            Source="{StaticResource BitmapImage_Refresh}"
+            Margin="2"
+            Height="16"
+            Width="16" />
+          </Button>
 
-      <!-- prerelease checkbox -->
-      <CheckBox
+          <!-- prerelease checkbox -->
+          <CheckBox
+          Grid.Column="2"
+          x:Name="_checkboxPrerelease"
+          AutomationProperties.AutomationId="CheckBox_Prerelease"
+          Margin="3,0"
+          VerticalAlignment="Center"
+          Content="{x:Static nuget:Resources.Checkbox_IncludePrerelease}"
+          Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
+          VerticalContentAlignment="Center"
+          Checked="_checkboxPrerelease_Checked"
+          Unchecked="_checkboxPrerelease_Unchecked"
+          IsChecked="True" />
+      </Grid>
+
+
+      <Grid
         Grid.Column="2"
-        x:Name="_checkboxPrerelease"
-        AutomationProperties.AutomationId="CheckBox_Prerelease"
-        Margin="3,0"
         VerticalAlignment="Center"
-        Content="{x:Static nuget:Resources.Checkbox_IncludePrerelease}"
-        Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
-        VerticalContentAlignment="Center"
-        Checked="_checkboxPrerelease_Checked"
-        Unchecked="_checkboxPrerelease_Unchecked"
-        IsChecked="True" />
+        HorizontalAlignment="Right">
 
-      <TextBlock
-        Grid.Column="4"
-        VerticalAlignment="Center"
-        Text="{x:Static nuget:Resources.Label_Repository}" />
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="auto" />
+          <ColumnDefinition Width="*" MinWidth="50" />
+          <ColumnDefinition Width="auto" />
+        </Grid.ColumnDefinitions>
 
-      <ComboBox
-        Grid.Column="5"
-        x:Name="_sourceRepoList"
-        Margin="6,0,0,0"
-        AutomationProperties.AutomationId="ComboBox_PackageSource"
-        VerticalAlignment="Center"
-        DisplayMemberPath="SourceName"
-        MinWidth="130"
-        MinHeight="22"
-        AutomationProperties.Name="{x:Static nuget:Resources.Label_Repository}"
-        SelectionChanged="_sourceRepoList_SelectionChanged">
-        <ComboBox.ToolTip>
-          <ToolTip
-            x:Name="_sourceTooltip">
-            <TextBlock
-              Text="{Binding}" />
-          </ToolTip>
-        </ComboBox.ToolTip>
-        <ComboBox.ItemContainerStyle>
-          <Style TargetType="{x:Type ComboBoxItem}" BasedOn="{StaticResource ComboBoxItemStyle}"> 
-            <Setter Property="AutomationProperties.Name" Value="{Binding SourceName}"/>
-          </Style>
-        </ComboBox.ItemContainerStyle>
-      </ComboBox>
+        <TextBlock
+          Grid.Column="0"
+          Text="{x:Static nuget:Resources.Label_Repository}"
+          Margin="0,4,0,0"
+          HorizontalAlignment="Right"/>
 
-      <Button
-        Grid.Column="6"
+        <ComboBox
+          Grid.Column="1"
+          x:Name="_sourceRepoList"
+          Margin="6,0,0,0"
+          AutomationProperties.AutomationId="ComboBox_PackageSource"
+          MinHeight="22"
+          AutomationProperties.Name="{x:Static nuget:Resources.Label_Repository}"
+          SelectionChanged="_sourceRepoList_SelectionChanged"
+          HorizontalAlignment="Right">
+          <ComboBox.ItemTemplate>
+            <DataTemplate>
+              <TextBlock
+                Text="{Binding SourceName}"
+                TextTrimming="CharacterEllipsis" />
+            </DataTemplate>
+          </ComboBox.ItemTemplate>
+          <ComboBox.ToolTip>
+            <ToolTip
+              x:Name="_sourceTooltip">
+              <TextBlock
+                Text="{Binding}" />
+            </ToolTip>
+          </ComboBox.ToolTip>
+          <ComboBox.ItemContainerStyle>
+            <Style TargetType="{x:Type ComboBoxItem}" BasedOn="{StaticResource ComboBoxItemStyle}">
+              <Setter Property="AutomationProperties.Name" Value="{Binding SourceName}"/>
+            </Style>
+          </ComboBox.ItemContainerStyle>
+        </ComboBox>
+        <Button
+        Grid.Column="3"
         x:Name="_settingsButton"
         Margin="12,0,0,0"
         AutomationProperties.AutomationId="Button_Settings"
@@ -171,36 +193,37 @@
         AutomationProperties.Name="{x:Static nuget:Resources.ToolTip_Settings}"
         Style="{StaticResource ToolBarButtonStyle}"
         Click="_settingsButton_Click">
-        <Rectangle
+          <Rectangle
           Width="{Binding FontSize,RelativeSource={RelativeSource AncestorType=UserControl},Converter={StaticResource Font122PercentSizeConverter}}"
           Height="{Binding FontSize,RelativeSource={RelativeSource AncestorType=UserControl},Converter={StaticResource Font122PercentSizeConverter}}">
-          <Rectangle.Fill>
-            <DrawingBrush>
-              <DrawingBrush.Drawing>
-                <DrawingGroup>
-                  <DrawingGroup.Children>
-                    <GeometryDrawing
+            <Rectangle.Fill>
+              <DrawingBrush>
+                <DrawingBrush.Drawing>
+                  <DrawingGroup>
+                    <DrawingGroup.Children>
+                      <GeometryDrawing
                           Brush="#00FFFFFF"
                           Geometry="F1M16,16L0,16 0,0 16,0z" />
-                    <GeometryDrawing
+                      <GeometryDrawing
                           Brush="#FFF6F6F6"
                           Geometry="F1M15.9434,7.0796L15.8734,6.4596 13.6374,5.6646 14.6544,3.5256 14.2684,3.0376C13.8854,2.5536,13.4464,2.1146,12.9644,1.7316L12.4754,1.3456 10.3354,2.3626 9.5414,0.1286 8.9224,0.057599999999999C8.6194,0.0215999999999994 8.3124,-0.000400000000000844 8.0004,-0.000400000000000844 7.6894,-0.000400000000000844 7.3824,0.0215999999999994 7.0804,0.0565999999999995L6.4614,0.126599999999999 5.6664,2.3626 3.5254,1.3456 3.0374,1.7316C2.5554,2.1126,2.1164,2.5516,1.7324,3.0366L1.3454,3.5246 2.3624,5.6646 0.1274,6.4596 0.0564,7.0796C0.0224000000000011,7.3816 0.000400000000000844,7.6876 0.000400000000000844,7.9996 0.000400000000000844,8.3116 0.0224000000000011,8.6186 0.0564,8.9206L0.1274,9.5396 2.3624,10.3346 1.3454,12.4746 1.7324,12.9626C2.1144,13.4466,2.5534,13.8846,3.0374,14.2676L3.5254,14.6556 5.6664,13.6376 6.4614,15.8726 7.0804,15.9436C7.3824,15.9786 7.6894,15.9996 8.0004,15.9996 8.3134,15.9996 8.6204,15.9786 8.9244,15.9426L9.5424,15.8706 10.3364,13.6366 12.4754,14.6556 12.9644,14.2676C13.4484,13.8836,13.8874,13.4446,14.2684,12.9616L14.6544,12.4736 13.6374,10.3346 15.8734,9.5396 15.9434,8.9206C15.9784,8.6186 16.0004,8.3116 16.0004,7.9996 16.0004,7.6876 15.9784,7.3816 15.9434,7.0796" />
-                    <GeometryDrawing
+                      <GeometryDrawing
                           Brush="#FF414141"
                           Geometry="F1M8,5C6.343,5 5,6.343 5,8 5,9.657 6.343,11 8,11 9.657,11 11,9.657 11,8 11,6.343 9.657,5 8,5 M12.714,9.603C12.644,9.81,12.563,10.01,12.468,10.203L13.484,12.342C13.149,12.766,12.767,13.148,12.343,13.484L10.203,12.467C10.01,12.563,9.81,12.643,9.603,12.714L8.808,14.949C8.542,14.98 8.273,15 8,15 7.728,15 7.459,14.98 7.194,14.95L6.399,12.715C6.192,12.644,5.991,12.564,5.798,12.468L3.658,13.484C3.234,13.148,2.852,12.766,2.516,12.342L3.532,10.203C3.437,10.01,3.356,9.81,3.286,9.603L1.05,8.807C1.02,8.542 1,8.273 1,8 1,7.727 1.02,7.458 1.05,7.193L3.286,6.397C3.356,6.19,3.437,5.991,3.532,5.797L2.516,3.658C2.852,3.234,3.234,2.851,3.658,2.516L5.798,3.532C5.991,3.436,6.191,3.356,6.399,3.286L7.194,1.05C7.459,1.02 7.728,1 8,1 8.273,1 8.542,1.02 8.808,1.05L9.603,3.287C9.81,3.357,10.01,3.437,10.203,3.533L12.343,2.516C12.767,2.852,13.149,3.235,13.484,3.658L12.468,5.797C12.563,5.991,12.644,6.19,12.714,6.397L14.95,7.193C14.98,7.458 15,7.727 15,8 15,8.273 14.98,8.542 14.95,8.807z" />
-                    <GeometryDrawing
+                      <GeometryDrawing
                           Brush="#FF414141"
                           Geometry="F1M9.5,8C9.5,8.828 8.829,9.5 8,9.5 7.171,9.5 6.5,8.828 6.5,8 6.5,7.172 7.171,6.5 8,6.5 8.829,6.5 9.5,7.172 9.5,8" />
-                    <GeometryDrawing
+                      <GeometryDrawing
                           Brush="#FFF0EFF1"
                           Geometry="F1M8,9.5C7.172,9.5 6.5,8.828 6.5,8 6.5,7.172 7.172,6.5 8,6.5 8.828,6.5 9.5,7.172 9.5,8 9.5,8.828 8.828,9.5 8,9.5 M8,5C6.343,5 5,6.343 5,8 5,9.656 6.343,11 8,11 9.657,11 11,9.656 11,8 11,6.343 9.657,5 8,5" />
-                  </DrawingGroup.Children>
-                </DrawingGroup>
-              </DrawingBrush.Drawing>
-            </DrawingBrush>
-          </Rectangle.Fill>
-        </Rectangle>
-      </Button>
+                    </DrawingGroup.Children>
+                  </DrawingGroup>
+                </DrawingBrush.Drawing>
+              </DrawingBrush>
+            </Rectangle.Fill>
+          </Rectangle>
+        </Button>
+      </Grid>
     </Grid>
   </Grid>
 </UserControl>


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/4502

## Fix
The top panel for PM UI was not really responsive, when the window was small enough the inner elements where cropped in ways that made the product unusable for some scenarios. This was evident of languages that have words with lots of characters like RUS, and when using PMUI in small screens (like laptops). This PR improves the usability of the top panel of the PMUI by making it more responsive to different window sizes.

**Before:**
![issue-ui](https://user-images.githubusercontent.com/2132567/40141144-c97ee65c-5909-11e8-88a4-fd8fa826bb4f.gif)
*Pay attention on how the top panel search, combo box and titles behave on smaller screens.*

**After:**
![fixed-responsive-ui](https://user-images.githubusercontent.com/2132567/40141142-c7d53c3e-5909-11e8-9766-9312203a1e51.gif)
*Pay attention how all truncated text use ellipses and how empty spaces are minimized before resizing controls, and also controls resize to a minimum size before being truncated by the window size.*

cc. @rrelyea 