### PR TITLE
Add explicit IsPackable prop for the Test.Utility.csproj because now the xunit imports work 

### DIFF
--- a/test/TestUtilities/Test.Utility/Test.Utility.csproj
+++ b/test/TestUtilities/Test.Utility/Test.Utility.csproj
@@ -8,6 +8,7 @@
     <NoWarn Condition="'$(TargetFramework)' == 'netstandard1.6'">$(NoWarn);CS1998</NoWarn>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6948
Regression: No 
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details:

The root cause here is that we had a bug where the targets/props weren't imported in our build but they are now after [this commit](https://github.com/NuGet/NuGet.Client/commit/5aaced85e5f9f150dc32faa6b45640803f22a23e).

Xunit sets a IsTestProject property. 

Setting it explicitly overrides it.

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  Infra
Validation done:  


