### PR TITLE
Set proxy credentials when asking a plugin for credentials. 

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
@@ -12,7 +12,7 @@ namespace NuGet.Protocol.Plugins
 
         public static string GetInternalPlugins()
         {
-            var rootDirectory = InternalPluginDiscoveryRoot.Value ?? System.Reflection.Assembly.GetEntryAssembly()?.Location;
+            var rootDirectory = InternalPluginDiscoveryRoot?.Value ?? System.Reflection.Assembly.GetEntryAssembly()?.Location;
 
             return rootDirectory ?? Path.GetDirectoryName(rootDirectory);
         }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6923
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
Set the proxy credentials if any when querying for credentials. 

## Testing/Validation
Tests Added: Yes  
Reason for not adding tests:  
Validation done:  

TODO:
I will update the spec to call out this behavior. 

//cc 
@keithrob @pspill @emanuelquintero 
