### PR TITLE
Fixed NuGet manager UI for unsaved solutions with only net core project

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -415,7 +415,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
-        private async Task<string> GetSolutionFilePathAsync()
+        public async Task<string> GetSolutionFilePathAsync()
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -692,7 +692,7 @@ namespace NuGetVSExtension
             var guidEditorType = GuidList.guidNuGetEditorType;
             var guidCommandUI = Guid.Empty;
             var caption = Resx.Label_SolutionNuGetWindowCaption;
-            var documentName = _dte.Solution.FullName;
+            var documentName = await SolutionManager.Value.GetSolutionFilePathAsync();
 
             var ppunkDocView = IntPtr.Zero;
             var ppunkDocData = IntPtr.Zero;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
@@ -80,5 +80,11 @@ namespace NuGet.PackageManagement.VisualStudio
         /// Return true if all the .net core projects are nominated.
         /// </summary>
         Task<bool> IsAllProjectsNominatedAsync();
+
+        /// <summary>
+        /// Retruns Solution FullName
+        /// </summary>
+        /// <returns></returns>
+        Task<string> GetSolutionFilePathAsync();
     }
 }


### PR DESCRIPTION
Currently it throws `System.ArgumentException` when trying to open NuGet manager UI at solution level for a net core project without `.sln` file because it tries to get the solution full path through `FullName` property which doesn't return anything. So this PR instead use `Path Properties` which gives the correct data.

Fixes Confusing error message on opening NuGet Package Manager for not saved Core Solution [620380](https://devdiv.visualstudio.com/DevDiv/NuGet/_workitems/edit/620380)

@rrelyea 