### PR TITLE
switch to UI thread when create VsAdapter

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
@@ -60,7 +60,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             Assumes.Present(dteProject);
 
-            _threadingService.ThrowIfNotOnUIThread();
+            await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             var vsHierarchyItem = VsHierarchyItem.FromDteProject(dteProject);
             Func<IVsHierarchy, EnvDTE.Project> loadDteProject = _ => dteProject;


### PR DESCRIPTION
EndToEnd test failed due to this commit: https://github.com/NuGet/NuGet.Client/commit/8eb983b272c60a5ffd07517bcb2c8ae31dcbabd5
IVs API call CreateAdapterForFullyLoadedProject() from background thread 
since we switch to UI thread in all other method in VsProjectAdapterProvider, the fix is do same thing in CreateAdapterForFullyLoadedProject()
