### PR TITLE
Switching to UI thread before using MEF service to fix VS hang issue while restore

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
@@ -38,13 +38,12 @@ namespace NuGet.PackageManagement.VisualStudio
             _outputConsoleLogger = outputConsoleLogger ?? throw new ArgumentNullException(nameof(outputConsoleLogger));
         }
 
-        [SuppressMessage("Microsoft.VisualStudio.Threading.Analyzers", "VSTHRD010", Justification = "NuGet/Home#4833 Baseline")]
         public async Task<NuGet.Configuration.ICredentialService> GetCredentialServiceAsync()
         {
             // Initialize the credential providers.
             var credentialProviders = new List<ICredentialProvider>();
             var dte = await _asyncServiceProvider.GetDTEAsync();
-            var webProxy = (IVsWebProxy)await _asyncServiceProvider.GetServiceAsync(typeof(SVsWebProxy));
+            var webProxy = await _asyncServiceProvider.GetServiceAsync<SVsWebProxy, IVsWebProxy>();
 
             TryAddCredentialProviders(
                 credentialProviders,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceProviderExtensions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceProviderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -60,7 +60,15 @@ namespace NuGet.VisualStudio
             this Microsoft.VisualStudio.Shell.IAsyncServiceProvider site)
             where TInterface : class
         {
-            return await site.GetServiceAsync(typeof(TService)) as TInterface;
+            var service = await site.GetServiceAsync(typeof(TService));
+
+            if (service != null)
+            {
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                return service as TInterface;
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
As part of [this PR](https://github.com/NuGet/NuGet.Client/pull/2163) we regressed using synchronous services without switching to UI thread which include code to typecast to a specific Interface.

This PR fixes this issue by making sure we switch to UI thread before type casting to a specific interface. As part of this, I've also created another workitem# [621928](https://devdiv.visualstudio.com/DevDiv/NuGet/_workitems/edit/621928) to fix all threading analyzer critical warnings.

Fixes VS hangs while restoring a nuget package [621682](https://devdiv.visualstudio.com/DevDiv/NuGet/_workitems/edit/621682)

@rrelyea  @AArnott @lifengl