### PR TITLE
Fix InitializeResourceAsync() throttling in ResolverGather

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
@@ -573,6 +573,7 @@ namespace NuGet.PackageManagement
                     {
                         var task = Task.Run(async () => await source.GetResourceAsync<DependencyInfoResource>(token));
 
+                        getResourceTasks.Add(task);
                         depResources.Add(source, task);
 
                         // Limit the number of tasks to MaxThreads by awaiting each time we hit the limit


### PR DESCRIPTION
## Fix
The implemented throttling mechanism isn't working because nothing is ever added to `getResourceTasks` (so the condition in the while loop will always be false). By adding the task to the list, the throttling should work as intended.