### PR TITLE
Fixed NuGet async package initialization on background thread

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -27,8 +27,6 @@ namespace NuGet.VisualStudio
             {
                 throw new ArgumentNullException(nameof(provider));
             }
-
-            ThreadHelper.ThrowIfNotOnUIThread();
 
             PackageServiceProvider = provider;
         }


### PR DESCRIPTION
While initializing on background thread as part of project retargeting auto load guid, we explicitly throws if not on UI thread which is not required since we just assign the `ServiceProvider` there.

Fixes: NuGet Visual Studio AsyncPackage fails to load when initialized off the UI thread [6976](https://github.com/NuGet/Home/issues/6976)
