### PR TITLE
Update UI after adding a source to enable buttons for selected source

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -332,6 +332,7 @@ namespace NuGet.Options
 
             // auto-select the newly-added item
             PackageSourcesListBox.SelectedIndex = PackageSourcesListBox.Items.Count - 1;
+            UpdateUI();
         }
 
         private Configuration.PackageSource CreateNewPackageSource()


### PR DESCRIPTION
## Bug
Fixes: [Internal 620255](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/620255)

## Fix
Details: When the first source was added in the tools->options window for nuget sources, the new source was selected, but the ellipsis and update button where not enabled. This PR updated the UI after adding a source so that this buttons are enabled every time a source is added.

**Before:**
![settings sources bug](https://user-images.githubusercontent.com/2132567/40675815-a23c9160-632d-11e8-8631-71e67ab0bf10.PNG)

**After:**
![settings sources fix](https://user-images.githubusercontent.com/2132567/40675818-a4408db8-632d-11e8-8dd1-79403c4cf09f.PNG)
