### PR TITLE
Let Ok button close if apply settings succeded

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -232,11 +232,13 @@ namespace NuGet.Options
         {
             // if user presses Enter after filling in Name/Source but doesn't click Update
             // the options will be closed without adding the source, try adding before closing
-            // Only apply if nothing was added
+            // Only apply if nothing was updated or the update was successfull
             var result = TryUpdateSource();
             if (result != TryUpdateSourceResults.NotUpdated
                 &&
-                result != TryUpdateSourceResults.Unchanged)
+                result != TryUpdateSourceResults.Unchanged
+                &&
+                result != TryUpdateSourceResults.Successful)
             {
                 return false;
             }


### PR DESCRIPTION
## Bug
Fixes: [Internal 620257](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/620257)

## Fix
Details: If the sources are updated and the "Ok" button is clicked it should work like as "Apply and close" behavior instead of having the first click to "Ok" be the apply and the second be the close. This PR updates the behavior of this button to persist the source updates if the result is successful.
