### PR TITLE
Fix serialization bug, add serialization tests for the  credentials messages

### DIFF
--- a/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
@@ -160,7 +160,7 @@ namespace NuGet.Credentials
         private static CredentialResponse GetAuthenticationCredentialsResponseToCredentialResponse(GetAuthenticationCredentialsResponse credentialResponse)
         {
             CredentialResponse taskResponse;
-            if (credentialResponse.IsValid)
+            if (credentialResponse.IsValid())
             {
                 ICredentials result = new NetworkCredential(credentialResponse.Username, credentialResponse.Password);
                 if (credentialResponse.AuthenticationTypes != null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetAuthenticationCredentialsRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetAuthenticationCredentialsRequest.cs
@@ -34,14 +34,14 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="uri"></param>
         /// <param name="isRetry"></param>
-        /// <param name="nonInteractive"></param>
+        /// <param name="isNonInteractive"></param>
         /// <exception cref="ArgumentNullException"> if <paramref name="uri"/> is null</exception>
         [JsonConstructor]
-        public GetAuthenticationCredentialsRequest(Uri uri, bool isRetry, bool nonInteractive)
+        public GetAuthenticationCredentialsRequest(Uri uri, bool isRetry, bool isNonInteractive)
         {
             Uri = uri ?? throw new ArgumentNullException(nameof(uri));
             IsRetry = isRetry;
-            IsNonInteractive = nonInteractive;
+            IsNonInteractive = isNonInteractive;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetAuthenticationCredentialsResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetAuthenticationCredentialsResponse.cs
@@ -77,7 +77,7 @@ namespace NuGet.Protocol.Plugins
         /// Either Username or Password (or both) must be set, and AuthTypes must either be null or contain at least
         /// one element
         /// </remarks>
-        public bool IsValid => ResponseCode == MessageResponseCode.Success && (!string.IsNullOrWhiteSpace(Username) || !string.IsNullOrWhiteSpace(Password))
+        public bool IsValid() => ResponseCode == MessageResponseCode.Success && (!string.IsNullOrWhiteSpace(Username) || !string.IsNullOrWhiteSpace(Password))
                                && (AuthenticationTypes == null || AuthenticationTypes.Any());
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetAuthenticationCredentialsRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetAuthenticationCredentialsRequestTests.cs
@@ -3,9 +3,10 @@
 
 using System;
 using NuGet.Protocol.Plugins;
+using NuGet.Protocol.Plugins.Tests;
 using Xunit;
 
-namespace NuGet.Protocol.Tests.Plugins.Messages
+namespace NuGet.Protocol.Tests.Plugins
 {
     public class GetAuthenticationCredentialsRequestTests
     {
@@ -18,10 +19,47 @@ namespace NuGet.Protocol.Tests.Plugins.Messages
                 () => new GetAuthenticationCredentialsRequest(
                     uri: uri,
                     isRetry: false,
-                    nonInteractive: false
+                    isNonInteractive: false
                     ));
             Assert.Equal("uri", exception.ParamName);
         }
 
+        [Theory]
+        [InlineData(@"http://api.nuget.org/v3/index.json", false, false)]
+        [InlineData(@"http://api.nuget.org/v3/index.json", true, false)]
+        [InlineData(@"http://api.nuget.org/v3/index.json", false, true)]
+        [InlineData(@"http://api.nuget.org/v3/index.json", true, true)]
+        public void AJsonSerialization_ReturnsCorrectJson(
+            string uri,
+            bool isRetry,
+            bool isNonInteractive)
+        {
+            var expectedJson = "{\"Uri\":\"" + uri + "\",\"IsRetry\":" + isRetry.ToString().ToLowerInvariant() + ",\"IsNonInteractive\":" + isNonInteractive.ToString().ToLowerInvariant() + "}";
+
+            var request = new GetAuthenticationCredentialsRequest(new Uri(uri), isRetry, isNonInteractive);
+
+
+            var actualJson = TestUtilities.Serialize(request);
+
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Theory]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":true,\"IsNonInteractive\":true}", "http://api.nuget.org/v3/index.json", true, true)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":true,\"IsNonInteractive\":false}", "http://api.nuget.org/v3/index.json", true, false)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":false,\"IsNonInteractive\":false}", "http://api.nuget.org/v3/index.json", false, false)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":false,\"IsNonInteractive\":true}", "http://api.nuget.org/v3/index.json", false, true)]
+        public void AJsonDeserialization_ReturnsCorrectObject(
+            string json,
+            string packageSourceRepository,
+            bool isRetry,
+            bool isNonInteractive)
+        {
+            var request = JsonSerializationUtilities.Deserialize<GetAuthenticationCredentialsRequest>(json);
+
+            Assert.Equal(packageSourceRepository, request.Uri.ToString());
+            Assert.Equal(isRetry, request.IsRetry);
+            Assert.Equal(isNonInteractive, request.IsNonInteractive);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetAuthenticationCredentialsResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetAuthenticationCredentialsResponseTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Text;
+using NuGet.Protocol.Plugins;
+using NuGet.Protocol.Plugins.Tests;
+using Xunit;
+
+namespace NuGet.Protocol.Tests.Plugins
+{
+    public class GetAuthenticationCredentialsResponseTests
+    {
+        [Theory]
+        [InlineData("user", "pass", "msg", null, MessageResponseCode.Success)]
+        [InlineData("user", "pass", "msg", new string[] { "basic" }, MessageResponseCode.Success)]
+        [InlineData("user", "pass", "msg", new string[] { "basic", "digest" }, MessageResponseCode.Success)]
+        public void AJsonSerialization_ReturnsCorrectJson(
+            string username,
+            string password,
+            string message,
+            string[] authenticationTypes,
+            MessageResponseCode messageResponseCode
+            )
+        {
+
+            var authTypesBuilder = new StringBuilder();
+            if (authenticationTypes != null)
+            {
+                authTypesBuilder.Append("\",\"AuthenticationTypes\":[\"");
+                authTypesBuilder.Append(string.Join("\",\"", authenticationTypes));
+                authTypesBuilder.Append("\"]");
+            }
+            else
+            {
+                authTypesBuilder.Append("\"");
+            }
+
+            var expectedJson =
+                "{\"Username\":\"" + username
+                + "\",\"Password\":\"" + password
+                + "\",\"Message\":\"" + message
+                + authTypesBuilder.ToString()
+                + ",\"ResponseCode\":\"" + messageResponseCode + "\"}";
+
+            var response = new GetAuthenticationCredentialsResponse(
+                username,
+                password,
+                message,
+                authenticationTypes,
+                messageResponseCode);
+
+            var actualJson = TestUtilities.Serialize(response);
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Theory]
+        [InlineData("{\"Username\":\"user\",\"Password\":\"pass\",\"Message\":\"msg\",\"AuthenticationTypes\":[\"basic\",\"digest\"],\"ResponseCode\":\"Success\"}", "user", "pass", "msg", new string[] { "basic", "digest" }, MessageResponseCode.Success)]
+        public void AJsonDeserialization_ReturnsCorrectObject(
+            string json,
+            string username,
+            string password,
+            string message,
+            string[] authenticationTypes,
+            MessageResponseCode messageResponseCode)
+        {
+            var response = JsonSerializationUtilities.Deserialize<GetAuthenticationCredentialsResponse>(json);
+            Assert.Equal(response.Username, username);
+            Assert.Equal(response.Password, password);
+            Assert.Equal(response.Message, message);
+            Assert.Equal(response.AuthenticationTypes, authenticationTypes);
+            Assert.Equal(response.ResponseCode, messageResponseCode);
+
+        }
+    }
+}


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6983
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
In the code review, the parameter name in the constructor was changed, but the property wasn't.

This means that isNonInteractive will always be false.

https://github.com/NuGet/NuGet.Client/blob/3db1528ee90a4858f620362bf49876099c8e5f67/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetAuthenticationCredentialsRequest.cs#L30

https://github.com/NuGet/NuGet.Client/blob/3db1528ee90a4858f620362bf49876099c8e5f67/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetAuthenticationCredentialsRequest.cs#L40

## Testing/Validation
Tests Added: Yes  
Reason for not adding tests:  
Validation done:  
