### PR TITLE
Add styling for disabled listview

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -35,6 +35,7 @@
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="PresentationFramework.Aero" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.IO.Compression" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -35,7 +35,6 @@
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="PresentationFramework.Aero2" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.IO.Compression" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -35,7 +35,7 @@
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="PresentationFramework.Aero" />
+    <Reference Include="PresentationFramework.Aero2" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.IO.Compression" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:NuGet.PackageManagement.UI"
+             xmlns:theme="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero"
              mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="500">
   <UserControl.Resources>
@@ -185,13 +186,54 @@
       Grid.Row="1"
       x:Name="_projectList"
       Margin="0,8,0,0"
-      ScrollViewer.VerticalScrollBarVisibility="Visible"
+      ScrollViewer.VerticalScrollBarVisibility="Auto"
       PreviewKeyUp="ProjectList_PreviewKeyUp"
       ItemsSource="{Binding Projects}"
       Background="{DynamicResource {x:Static local:Brushes.ListPaneBackground}}"
       Foreground="{DynamicResource {x:Static local:Brushes.UIText}}"
       KeyboardNavigation.TabNavigation="Local"
       SelectionMode="Single">
+
+      <ListView.Style>
+        <Style TargetType="{x:Type ListView}">
+          <Setter Property="Template">
+            <Setter.Value>
+              <ControlTemplate TargetType="{x:Type ListView}">
+                <theme:ListBoxChrome
+                  x:Name="Bd"
+                  BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}"
+                  Background="{TemplateBinding Background}"
+                  RenderMouseOver="{TemplateBinding IsMouseOver}"
+                  RenderFocused="{TemplateBinding IsKeyboardFocusWithin}"
+                  SnapsToDevicePixels="true">
+                  <ScrollViewer Padding="{TemplateBinding Padding}"
+                                BorderBrush="{DynamicResource {x:Static local:Brushes.ListPaneBackground}}"
+                                Background="{DynamicResource {x:Static local:Brushes.ListPaneBackground}}"
+                                Style="{DynamicResource {x:Static GridView.GridViewScrollViewerStyleKey}}">
+                    <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                      <ItemsPresenter.Resources>
+                        <Style TargetType="{x:Type Grid}">
+                          <Setter Property="Background" Value="{DynamicResource {x:Static local:Brushes.ListPaneBackground}}" />
+                        </Style>
+                      </ItemsPresenter.Resources>
+                    </ItemsPresenter>
+                  </ScrollViewer>
+                </theme:ListBoxChrome>
+                <ControlTemplate.Triggers>
+                  <Trigger Property="IsGrouping" Value="true">
+                    <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
+                  </Trigger>
+                  <Trigger Property="IsEnabled" Value="false">
+                    <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static local:Brushes.ListPaneBackground}}"/>
+                  </Trigger>
+                </ControlTemplate.Triggers>
+
+              </ControlTemplate>
+            </Setter.Value>
+          </Setter>
+        </Style>
+      </ListView.Style>
       
       <!-- set the list view item style -->
       <ListView.ItemContainerStyle>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
@@ -4,7 +4,6 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:NuGet.PackageManagement.UI"
-             xmlns:Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero2"
              mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="500">
   <UserControl.Resources>
@@ -199,13 +198,11 @@
           <Setter Property="Template">
             <Setter.Value>
               <ControlTemplate TargetType="{x:Type ListView}">
-                <Themes:ListBoxChrome
+                <Border
                   x:Name="Bd"
                   BorderBrush="{TemplateBinding BorderBrush}"
                   BorderThickness="{TemplateBinding BorderThickness}"
                   Background="{TemplateBinding Background}"
-                  RenderMouseOver="{TemplateBinding IsMouseOver}"
-                  RenderFocused="{TemplateBinding IsKeyboardFocusWithin}"
                   SnapsToDevicePixels="true">
                   <ScrollViewer Padding="{TemplateBinding Padding}"
                                 BorderBrush="{DynamicResource {x:Static local:Brushes.ListPaneBackground}}"
@@ -219,7 +216,7 @@
                       </ItemsPresenter.Resources>
                     </ItemsPresenter>
                   </ScrollViewer>
-                </Themes:ListBoxChrome>
+                </Border>
                 <ControlTemplate.Triggers>
                   <Trigger Property="IsEnabled" Value="false">
                     <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static local:Brushes.ListPaneBackground}}"/>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
@@ -4,7 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:NuGet.PackageManagement.UI"
-             xmlns:theme="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero"
+             xmlns:Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero2"
              mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="500">
   <UserControl.Resources>
@@ -199,7 +199,7 @@
           <Setter Property="Template">
             <Setter.Value>
               <ControlTemplate TargetType="{x:Type ListView}">
-                <theme:ListBoxChrome
+                <Themes:ListBoxChrome
                   x:Name="Bd"
                   BorderBrush="{TemplateBinding BorderBrush}"
                   BorderThickness="{TemplateBinding BorderThickness}"
@@ -219,16 +219,19 @@
                       </ItemsPresenter.Resources>
                     </ItemsPresenter>
                   </ScrollViewer>
-                </theme:ListBoxChrome>
+                </Themes:ListBoxChrome>
                 <ControlTemplate.Triggers>
-                  <Trigger Property="IsGrouping" Value="true">
-                    <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
-                  </Trigger>
                   <Trigger Property="IsEnabled" Value="false">
                     <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static local:Brushes.ListPaneBackground}}"/>
                   </Trigger>
+                  <MultiTrigger>
+                    <MultiTrigger.Conditions>
+                      <Condition Property="IsGrouping" Value="true"/>
+                      <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false"/>
+                    </MultiTrigger.Conditions>
+                    <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
+                  </MultiTrigger>
                 </ControlTemplate.Triggers>
-
               </ControlTemplate>
             </Setter.Value>
           </Setter>


### PR DESCRIPTION
## Bug
Fixes: [Internal 620265](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/620265)

## Fix
Details: In the PMUI in solution view, when the install or uninstall button gets clicked, we disable the whole UI while the action is being performed. When this is done, every element on the UI changes to its disabled state. The `ListView` on the detail control has a disabled state of setting up the background as white. This behavior is not relevant in light and blue themes because the white color of the disabled `ListView` does not have enough contrast with the background to be noticed by the average user, nevertheless it was easily noticeable in the dark theme.

This PR overwrites the default style for the `ListView` in disabled mode to have the same background color as the enabled mode. The change in style between these two modes is now based on a small change in the border color, which gives a better experience across all themes.

**Before:**
![listview-disabled-bug](https://user-images.githubusercontent.com/2132567/40740340-6b4ad11e-63fd-11e8-9c1d-bb78c307edc0.gif)

**After:**
![listview-solved-dark](https://user-images.githubusercontent.com/2132567/40740337-6998e5fe-63fd-11e8-9c72-d5b942a56b3a.gif)
