### PR TITLE
Filter unlisted versions while updating a package through PMC

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -1178,6 +1178,12 @@ namespace NuGet.PackageManagement
                         isUpdateAll);
                 }
 
+                // Prune unlisted versions if IncludeUnlisted flag is not set.
+                if (!resolutionContext.IncludeUnlisted)
+                {
+                    prunedAvailablePackages = prunedAvailablePackages.Where(p => p.Listed);
+                }
+
                 // Remove packages that do not meet the constraints specified in the UpdateConstrainst
                 prunedAvailablePackages = PrunePackageTree.PruneByUpdateConstraints(prunedAvailablePackages, projectInstalledPackageReferences, resolutionContext.VersionConstraints);
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -6370,6 +6370,58 @@ namespace NuGet.Test
             }
         }
 
+        [Fact]
+        public async Task TestPacMan_PreviewUpdatePackage_UnlistedPackage()
+        {
+            // Arrange
+
+            // Set up Package Source
+            var packages = new List<SourcePackageDependencyInfo>
+            {
+                new SourcePackageDependencyInfo("a", new NuGetVersion(1, 0, 0), new Packaging.Core.PackageDependency[] { }, true, null),
+                new SourcePackageDependencyInfo("a", new NuGetVersion(2, 0, 0), new Packaging.Core.PackageDependency[] { }, false, null)
+            };
+
+            var sourceRepositoryProvider = CreateSource(packages);
+
+            // Set up NuGetProject
+            var fwk45 = NuGetFramework.Parse("net45");
+
+            var installedPackage1 = new PackageIdentity("a", new NuGetVersion(1, 0, 0));
+
+            var installedPackages = new List<NuGet.Packaging.PackageReference>
+            {
+                new NuGet.Packaging.PackageReference(installedPackage1, fwk45, true)
+            };
+
+            var nuGetProject = new TestNuGetProject(installedPackages);
+
+            // Create Package Manager
+            using (var solutionManager = new TestSolutionManager(true))
+            {
+                var nuGetPackageManager = new NuGetPackageManager(
+                    sourceRepositoryProvider,
+                    NullSettings.Instance,
+                    solutionManager,
+                    new TestDeleteOnRestartManager());
+
+                // Main Act
+                var targetPackageId = "a";
+
+                var result = (await nuGetPackageManager.PreviewUpdatePackagesAsync(
+                    targetPackageId,
+                    new List<NuGetProject> { nuGetProject },
+                    new ResolutionContext(DependencyBehavior.Lowest, false, false, VersionConstraints.None),
+                    new TestNuGetProjectContext(),
+                    sourceRepositoryProvider.GetRepositories(),
+                    sourceRepositoryProvider.GetRepositories(),
+                    CancellationToken.None)).ToList();
+
+                // Assert
+                Assert.Equal(0, result.Count);
+            }
+        }
+
         private void VerifyPreviewActionsTelemetryEvents_PackagesConfig(IEnumerable<string> actual)
         {
             Assert.True(actual.Contains(TelemetryConstants.GatherDependencyStepName));


### PR DESCRIPTION
Currently Manager UI never shows updates for unlisted versions of a package, but running `Update-Package` command from PMC allows you to update to unlisted version. This PR fixes it by filtering unlisted versions of packages during PMC update operation.

Fixes: [#4553](https://github.com/NuGet/Home/issues/4553) Can update to unlisted NuGet package from the Package Manager Console

@rrelyea 