### PR TITLE
Generate MSBuild property that has the path to a package

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
@@ -194,6 +194,8 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             var dependency = new LibraryDependency
             {
+                AutoReferenced = MSBuildStringUtility.IsTrue(GetReferenceMetadataValue(reference, ProjectItemProperties.IsImplicitlyDefined)),
+                GeneratePathProperty = MSBuildStringUtility.IsTrue(GetReferenceMetadataValue(reference, ProjectItemProperties.GeneratePathProperty)),
                 LibraryRange = new LibraryRange(
                     name: reference.Name,
                     versionRange: VersionRange.Parse(reference.Version),
@@ -206,7 +208,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 GetReferenceMetadataValue(reference, ProjectItemProperties.ExcludeAssets),
                 GetReferenceMetadataValue(reference, ProjectItemProperties.PrivateAssets));
 
-            dependency.AutoReferenced = MSBuildStringUtility.IsTrue(GetReferenceMetadataValue(reference, ProjectItemProperties.IsImplicitlyDefined));
 
             // Add warning suppressions
             foreach (var code in MSBuildStringUtility.GetNuGetLogCodes(GetReferenceMetadataValue(reference, ProjectItemProperties.NoWarn)))

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
@@ -59,11 +59,12 @@ namespace NuGet.PackageManagement.VisualStudio
 
         static VsManagedLanguagesProjectSystemServices()
         {
-            _referenceMetadata = Array.CreateInstance(typeof(string), 4);
+            _referenceMetadata = Array.CreateInstance(typeof(string), 5);
             _referenceMetadata.SetValue(ProjectItemProperties.IncludeAssets, 0);
             _referenceMetadata.SetValue(ProjectItemProperties.ExcludeAssets, 1);
             _referenceMetadata.SetValue(ProjectItemProperties.PrivateAssets, 2);
             _referenceMetadata.SetValue(ProjectItemProperties.NoWarn, 3);
+            _referenceMetadata.SetValue(ProjectItemProperties.GeneratePathProperty, 4);
         }
 
         public VsManagedLanguagesProjectSystemServices(

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -508,6 +508,8 @@ namespace NuGet.SolutionRestoreManager
 
                 // Mark packages coming from the SDK as AutoReferenced
                 AutoReferenced = GetPropertyBoolOrFalse(item, "IsImplicitlyDefined"),
+
+                GeneratePathProperty = GetPropertyBoolOrFalse(item, "GeneratePathProperty")
             };
 
             // Add warning suppressions
@@ -515,8 +517,6 @@ namespace NuGet.SolutionRestoreManager
             {
                 dependency.NoWarn.Add(code);
             }
-
-            dependency.GeneratePathProperty = GetPropertyBoolOrFalse(item, "GeneratePathProperty");
 
             MSBuildRestoreUtility.ApplyIncludeFlags(
                 dependency,

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -516,6 +516,8 @@ namespace NuGet.SolutionRestoreManager
                 dependency.NoWarn.Add(code);
             }
 
+            dependency.GeneratePathProperty = GetPropertyBoolOrFalse(item, "GeneratePathProperty");
+
             MSBuildRestoreUtility.ApplyIncludeFlags(
                 dependency,
                 includeAssets: GetPropertyValueOrNull(item, IncludeAssets),

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestorePackageReferencesTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestorePackageReferencesTask.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -68,6 +68,7 @@ namespace NuGet.Build.Tasks
                 BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "PrivateAssets");
                 BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "NoWarn");
                 BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "IsImplicitlyDefined");
+                BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "GeneratePathProperty");
 
                 entries.Add(new TaskItem(Guid.NewGuid().ToString(), properties));
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -383,10 +383,19 @@ namespace NuGet.Commands
 
             foreach (var file in package.Files)
             {
+                if (!lockFileLib.HasTools && HasTools(file))
+                {
+                    lockFileLib.HasTools = true;
+                }
                 lockFileLib.Files.Add(file);
             }
 
             return lockFileLib;
+        }
+
+        private static bool HasTools(string file)
+        {
+            return file.StartsWith("tools/", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -507,7 +507,7 @@ namespace NuGet.Commands
 
                 // Find the packages with matching IDs in the list of sorted packages, filtering out ones that there was no match for or that don't exist
                 var packagePathProperties = localPackages
-                    .Where(pkg => packageIdsToCreatePropertiesFor.Contains(pkg.Value.Package.Id) && pkg.Exists())
+                    .Where(pkg => pkg?.Value?.Package != null && packageIdsToCreatePropertiesFor.Contains(pkg.Value.Package.Id) && pkg.Exists())
                     .Select(pkg => pkg.Value.Package)
                     // Get the property
                     .Select(GeneratePackagePathProperty);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -506,7 +506,7 @@ namespace NuGet.Commands
                 // Find the packages with matching IDs in the list of sorted packages, filtering out ones that there was no match for or that don't exist
                 var packagePathProperties = packageIdsToCreatePropertiesFor
                     // Cast sortedPackages as nullable
-                    .Select(packageId => sortedPackages.Cast<KeyValuePair<LockFileTargetLibrary, Lazy<LocalPackageSourceInfo>>?>().FirstOrDefault(pkg => pkg.Value.Key.Name.Equals(packageId, StringComparison.OrdinalIgnoreCase)))
+                    .Select(packageId => sortedPackages.Cast<KeyValuePair<LockFileTargetLibrary, Lazy<LocalPackageSourceInfo>>?>().FirstOrDefault(pkg => pkg != null && pkg.Value.Key.Name.Equals(packageId, StringComparison.OrdinalIgnoreCase)))
                     // Check if there was a match found and the package exists on disk
                     .Where(pkg => pkg != null && pkg.Value.Value.Exists())
                     // Select just the value of the nullable KeyValuePair<LockFileTargetLibrary, Lazy<LocalPackageSourceInfo>>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -575,22 +575,23 @@ namespace NuGet.Commands
         {
             foreach (var item in GetItemByType(items, "Dependency"))
             {
-                var dependency = new LibraryDependency();
+                var dependency = new LibraryDependency
+                {
+                    LibraryRange = new LibraryRange(
+                        name: item.GetProperty("Id"),
+                        versionRange: GetVersionRange(item),
+                        typeConstraint: LibraryDependencyTarget.Package),
 
-                dependency.LibraryRange = new LibraryRange(
-                    name: item.GetProperty("Id"),
-                    versionRange: GetVersionRange(item),
-                    typeConstraint: LibraryDependencyTarget.Package);
+                    AutoReferenced = IsPropertyTrue(item, "IsImplicitlyDefined"),
 
-                dependency.AutoReferenced = IsPropertyTrue(item, "IsImplicitlyDefined");
+                    GeneratePathProperty = IsPropertyTrue(item, "GeneratePathProperty")
+                };
 
                 // Add warning suppressions
                 foreach (var code in MSBuildStringUtility.GetNuGetLogCodes(item.GetProperty("NoWarn")))
                 {
                     dependency.NoWarn.Add(code);
                 }
-
-                dependency.GeneratePathProperty = IsPropertyTrue(item, "GeneratePathProperty");
 
                 ApplyIncludeFlags(dependency, item);
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -590,6 +590,8 @@ namespace NuGet.Commands
                     dependency.NoWarn.Add(code);
                 }
 
+                dependency.GeneratePathProperty = IsPropertyTrue(item, "GeneratePathProperty");
+
                 ApplyIncludeFlags(dependency, item);
 
                 var frameworks = GetFrameworks(item);

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
@@ -22,11 +22,13 @@ namespace NuGet.LibraryModel
         public IList<NuGetLogCode> NoWarn { get; set; } = new List<NuGetLogCode>();
 
         public string Name => LibraryRange.Name;
-        
+
         /// <summary>
         /// True if the PackageReference is added by the SDK and not the user.
         /// </summary>
         public bool AutoReferenced { get; set; }
+
+        public bool GeneratePathProperty { get; set; }
 
         public LibraryDependency() { }
 
@@ -36,7 +38,8 @@ namespace NuGet.LibraryModel
             LibraryIncludeFlags includeType,
             LibraryIncludeFlags suppressParent,
             IList<NuGetLogCode> noWarn,
-            bool autoReferenced)
+            bool autoReferenced,
+            bool generatePathProperty)
         {
             LibraryRange = libraryRange;
             Type = type;
@@ -44,6 +47,7 @@ namespace NuGet.LibraryModel
             SuppressParent = suppressParent;
             NoWarn = noWarn;
             AutoReferenced = autoReferenced;
+            GeneratePathProperty = generatePathProperty;
         }
 
         public override string ToString()
@@ -75,6 +79,7 @@ namespace NuGet.LibraryModel
             hashCode.AddObject(SuppressParent);
             hashCode.AddObject(AutoReferenced);
             hashCode.AddSequence(NoWarn);
+            hashCode.AddObject(GeneratePathProperty);
 
             return hashCode.CombinedHash;
         }
@@ -101,7 +106,8 @@ namespace NuGet.LibraryModel
                    EqualityUtility.EqualsWithNullCheck(Type, other.Type) &&
                    IncludeType == other.IncludeType &&
                    SuppressParent == other.SuppressParent &&
-                   NoWarn.SequenceEqualWithNullCheck(other.NoWarn);
+                   NoWarn.SequenceEqualWithNullCheck(other.NoWarn) &&
+                   GeneratePathProperty == other.GeneratePathProperty;
         }
 
         public LibraryDependency Clone()
@@ -109,7 +115,7 @@ namespace NuGet.LibraryModel
             var clonedLibraryRange = new LibraryRange(LibraryRange.Name, LibraryRange.VersionRange, LibraryRange.TypeConstraint);
             var clonedNoWarn = new List<NuGetLogCode>(NoWarn);
 
-            return new LibraryDependency(clonedLibraryRange, Type, IncludeType, SuppressParent, clonedNoWarn, AutoReferenced);
+            return new LibraryDependency(clonedLibraryRange, Type, IncludeType, SuppressParent, clonedNoWarn, AutoReferenced, GeneratePathProperty);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectItemProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectItemProperties.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 
@@ -14,5 +14,6 @@ namespace NuGet.ProjectManagement
         public const string PrivateAssets = "PrivateAssets";
         public const string IsImplicitlyDefined = nameof(IsImplicitlyDefined);
         public const string NoWarn = nameof(NoWarn);
+        public const string GeneratePathProperty = "GeneratePathProperty";
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -463,7 +463,7 @@ namespace NuGet.ProjectModel
                     var dependencyExcludeFlagsValue = LibraryIncludeFlags.None;
                     var suppressParentFlagsValue = LibraryIncludeFlagUtils.DefaultSuppressParent;
                     var noWarn = new List<NuGetLogCode>();
-
+                    
                     // This method handles both the dependencies and framework assembly sections.
                     // Framework references should be limited to references.
                     // Dependencies should allow everything but framework references.
@@ -472,6 +472,7 @@ namespace NuGet.ProjectModel
                                                     : LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference;
 
                     var autoReferenced = false;
+                    var generatePathProperty = false;
 
                     string dependencyVersionValue = null;
                     var dependencyVersionToken = dependencyValue;
@@ -553,6 +554,8 @@ namespace NuGet.ProjectModel
                         }
 
                         autoReferenced = GetBoolOrFalse(dependencyValue, "autoReferenced", packageSpecPath);
+
+                        generatePathProperty = GetBoolOrFalse(dependencyValue, "generatePathProperty", packageSpecPath);
                     }
 
                     VersionRange dependencyVersionRange = null;
@@ -604,7 +607,8 @@ namespace NuGet.ProjectModel
                         IncludeType = includeFlags,
                         SuppressParent = suppressParentFlagsValue,
                         AutoReferenced = autoReferenced,
-                        NoWarn = noWarn.ToList()
+                        NoWarn = noWarn.ToList(),
+                        GeneratePathProperty = generatePathProperty
                     });
                 }
             }

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -32,6 +32,7 @@ namespace NuGet.ProjectModel
         private const string ServicableProperty = "servicable";
         private const string Sha512Property = "sha512";
         private const string FilesProperty = "files";
+        private const string HasToolsProperty = "hasTools";
         private const string DependenciesProperty = "dependencies";
         private const string FrameworkAssembliesProperty = "frameworkAssemblies";
         private const string RuntimeProperty = "runtime";
@@ -240,6 +241,7 @@ namespace NuGet.ProjectModel
             library.IsServiceable = ReadBool(json, ServicableProperty, defaultValue: false);
             library.Files = ReadPathArray(json[FilesProperty] as JArray, ReadString);
 
+            library.HasTools = ReadBool(json, HasToolsProperty, defaultValue: false);
             return library;
         }
 
@@ -266,6 +268,11 @@ namespace NuGet.ProjectModel
             if (library.MSBuildProject != null)
             {
                 json[MSBuildProjectProperty] = WriteString(library.MSBuildProject);
+            }
+
+            if (library.HasTools)
+            {
+                WriteBool(json, HasToolsProperty, library.HasTools);
             }
 
             WritePathArray(json, FilesProperty, library.Files, WriteString);

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileLibrary.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileLibrary.cs
@@ -33,6 +33,8 @@ namespace NuGet.ProjectModel
         /// </summary>
         public string MSBuildProject { get; set; }
 
+        public bool HasTools { get; set; }
+
         public bool Equals(LockFileLibrary other)
         {
             if (other == null)
@@ -50,6 +52,7 @@ namespace NuGet.ProjectModel
                 && string.Equals(Path, other.Path, StringComparison.Ordinal)
                 && string.Equals(MSBuildProject, other.MSBuildProject, StringComparison.Ordinal)
                 && IsServiceable == other.IsServiceable
+                && HasTools == other.HasTools
                 && string.Equals(Sha512, other.Sha512, StringComparison.Ordinal)
                 && Version == other.Version)
             {
@@ -72,6 +75,7 @@ namespace NuGet.ProjectModel
             combiner.AddStringIgnoreCase(Type);
             combiner.AddObject(Sha512);
             combiner.AddObject(IsServiceable);
+            combiner.AddObject(HasTools);
             combiner.AddObject(Version);
             combiner.AddObject(Path);
             combiner.AddObject(MSBuildProject);
@@ -96,6 +100,7 @@ namespace NuGet.ProjectModel
                 Type = Type,
                 Version = Version,
                 IsServiceable = IsServiceable,
+                HasTools = HasTools,
                 Sha512 = Sha512,
                 Files = Files != null ? new List<string>(Files) : null,
                 Path = Path,

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -415,6 +415,8 @@ namespace NuGet.ProjectModel
                             .Where(s => !string.IsNullOrEmpty(s)));
                     }
 
+                    SetValueIfTrue(writer, "generatePathProperty", dependency.GeneratePathProperty);
+
                     writer.WriteObjectEnd();
                 }
                 else

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -627,7 +627,7 @@ namespace NuGet.Commands.Test
             using (var randomProjectDirectory = TestDirectory.Create())
             {
                 // Arrange
-                var identity = new PackageIdentity("PackageA", NuGetVersion.Parse("1.0.0"));
+                var identity = new PackageIdentity("packagea", NuGetVersion.Parse("1.0.0"));
 
                 var packageDirectory = Directory.CreateDirectory(Path.Combine(pathContext.UserPackagesFolder, identity.Id, identity.Version.ToNormalizedString()));
 
@@ -649,6 +649,8 @@ namespace NuGet.Commands.Test
                     new List<string>() { pathContext.FallbackFolder },
                     new List<PackageSource>() { new PackageSource(pathContext.PackageSource) },
                     projectWideWarningProperties: null);
+
+                spec.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
 
                 spec.Dependencies.Add(new LibraryDependency
                 {
@@ -699,7 +701,10 @@ namespace NuGet.Commands.Test
                     new NuGetv3LocalRepository(pathContext.UserPackagesFolder)
                 };
 
-                var restoreRequest = new TestRestoreRequest(spec, new[] { new PackageSource(pathContext.PackageSource) }, pathContext.PackagesV2, logger);
+                var restoreRequest = new TestRestoreRequest(spec, new[] { new PackageSource(pathContext.PackageSource) }, pathContext.PackagesV2, logger)
+                {
+                    ProjectStyle = spec.RestoreMetadata.ProjectStyle
+                };
 
                 var assetsFilePath = Path.Combine(randomProjectDirectory, "obj", "project.assets.json");
 
@@ -732,7 +737,7 @@ namespace NuGet.Commands.Test
             using (var randomProjectDirectory = TestDirectory.Create())
             {
                 // Arrange
-                var identity = new PackageIdentity("PackageA", NuGetVersion.Parse("1.0.0"));
+                var identity = new PackageIdentity("packagea", NuGetVersion.Parse("1.0.0"));
 
                 var packageDirectory = Directory.CreateDirectory(Path.Combine(pathContext.UserPackagesFolder, identity.Id, identity.Version.ToNormalizedString()));
 
@@ -754,6 +759,8 @@ namespace NuGet.Commands.Test
                     new List<string>() { pathContext.FallbackFolder },
                     new List<PackageSource>() { new PackageSource(pathContext.PackageSource) },
                     projectWideWarningProperties: null);
+
+                spec.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
 
                 spec.Dependencies.Add(new LibraryDependency
                 {
@@ -804,7 +811,10 @@ namespace NuGet.Commands.Test
                     new NuGetv3LocalRepository(pathContext.UserPackagesFolder)
                 };
 
-                var restoreRequest = new TestRestoreRequest(spec, new[] { new PackageSource(pathContext.PackageSource) }, pathContext.PackagesV2, logger);
+                var restoreRequest = new TestRestoreRequest(spec, new[] { new PackageSource(pathContext.PackageSource) }, pathContext.PackagesV2, logger)
+                {
+                    ProjectStyle = spec.RestoreMetadata.ProjectStyle
+                };
 
                 var assetsFilePath = Path.Combine(randomProjectDirectory, "obj", "project.assets.json");
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -3,13 +3,21 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
+using NuGet.Repositories;
+using NuGet.RuntimeModel;
 using NuGet.Test.Utility;
+using NuGet.Versioning;
 using Xunit;
 
 namespace NuGet.Commands.Test
@@ -609,6 +617,109 @@ namespace NuGet.Commands.Test
                 Assert.Equal("a", targetItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
                 Assert.Equal("b", targetItemGroups[2].Attribute(XName.Get("Condition")).Value.Trim());
                 Assert.Equal("x", targetItemGroups[3].Attribute(XName.Get("Condition")).Value.Trim());
+            }
+        }
+
+        [Fact]
+        public async Task BuildAssetsUtils_GeneratePathProperty()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            using (var randomProjectDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                var identity = new PackageIdentity("PackageA", NuGetVersion.Parse("1.0.0"));
+
+                var packageDirectory = Directory.CreateDirectory(Path.Combine(pathContext.UserPackagesFolder, identity.Id, identity.Version.ToNormalizedString()));
+
+                File.WriteAllText(Path.Combine(packageDirectory.FullName, $"{identity.Id}.{identity.Version.ToNormalizedString()}.nupkg.sha512"), string.Empty);
+
+                var packagePath = await SimpleTestPackageUtility.CreateFullPackageAsync(
+                    packageDirectory.FullName,
+                    identity.Id,
+                    identity.Version.ToString());
+
+                var logger = new TestLogger();
+
+                var spec = ToolRestoreUtility.GetSpec(
+                    Path.Combine(pathContext.SolutionRoot, "tool", "fake.csproj"),
+                    "a",
+                    VersionRange.Parse("1.0.0"),
+                    NuGetFramework.Parse("netcoreapp1.0"),
+                    pathContext.UserPackagesFolder,
+                    new List<string>() { pathContext.FallbackFolder },
+                    new List<PackageSource>() { new PackageSource(pathContext.PackageSource) },
+                    projectWideWarningProperties: null);
+
+                spec.Dependencies.Add(new LibraryDependency
+                {
+                    GeneratePathProperty = true,
+                    IncludeType = LibraryIncludeFlags.All,
+                    LibraryRange = new LibraryRange(identity.Id, new VersionRange(identity.Version), LibraryDependencyTarget.Package)
+                });
+
+                var targetGraphs = new List<RestoreTargetGraph>
+                {
+                    OriginalCaseGlobalPackageFolderTests.GetRestoreTargetGraph(pathContext.PackageSource, identity, packagePath, logger)
+                };
+
+                targetGraphs[0].Graphs.FirstOrDefault().Item.Data.Dependencies = spec.Dependencies;
+
+                var lockFile = new LockFile
+                {
+                    Libraries =
+                    {
+                        new LockFileLibrary
+                        {
+                            Name = identity.Id,
+                            Version = identity.Version,
+                            Path = $"{identity.Id.ToLowerInvariant()}/{identity.Version.ToNormalizedString()}",
+                            Type = LibraryType.Package
+                        }
+                    },
+                    Targets =
+                    {
+                        new LockFileTarget
+                        {
+                            RuntimeIdentifier = targetGraphs[0].RuntimeIdentifier,
+                            TargetFramework = targetGraphs[0].Framework,
+                            Libraries =
+                            {
+                                new LockFileTargetLibrary
+                                {
+                                    Name = identity.Id,
+                                    Version = identity.Version
+                                }
+                            }
+                        }
+                    }
+                };
+
+                var repositories = new List<NuGetv3LocalRepository>
+                {
+                    new NuGetv3LocalRepository(pathContext.UserPackagesFolder)
+                };
+
+                var restoreRequest = new TestRestoreRequest(spec, new[] { new PackageSource(pathContext.PackageSource) }, pathContext.PackagesV2, logger);
+
+                var assetsFilePath = Path.Combine(randomProjectDirectory, "obj", "project.assets.json");
+
+                // Act
+                var outputFiles = BuildAssetsUtils.GetMSBuildOutputFiles(spec, lockFile, targetGraphs, repositories, restoreRequest, assetsFilePath, true, logger);
+
+                // Assert
+                var expectedPropertyGroup = outputFiles.FirstOrDefault().Content.Root.Elements().LastOrDefault();
+
+                Assert.NotNull(expectedPropertyGroup);
+                
+                Assert.Equal(" '$(ExcludeRestorePackageImports)' != 'true' ", expectedPropertyGroup.Attribute("Condition")?.Value);
+
+                var expectedProperty = expectedPropertyGroup.Elements().FirstOrDefault();
+
+                Assert.Equal($"Pkg{identity.Id.Replace(".", "_")}", expectedProperty.Name.LocalName);
+
+                Assert.Equal($" '$({expectedProperty.Name.LocalName})' == '' ", expectedProperty.Attribute("Condition")?.Value);
+
+                Assert.Equal(packageDirectory.FullName, expectedProperty?.Value, ignoreCase: true);
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/OriginalCaseGlobalPackageFolderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/OriginalCaseGlobalPackageFolderTests.cs
@@ -224,7 +224,7 @@ namespace NuGet.Commands.Test
             };
         }
 
-        private static RestoreTargetGraph GetRestoreTargetGraph(
+        public static RestoreTargetGraph GetRestoreTargetGraph(
             string source,
             PackageIdentity identity,
             FileInfo packagePath,

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -131,7 +131,9 @@ namespace NuGet.ProjectModel.Test
                 includeType: LibraryIncludeFlags.None,
                 suppressParent: LibraryIncludeFlags.ContentFiles,
                 noWarn: new List<NuGetLogCode>() { NuGetLogCode.NU1000, NuGetLogCode.NU1001, NuGetLogCode.NU1002 },
-                autoReferenced: false);
+                autoReferenced: false,
+                generatePathProperty: false
+                );
 
             return dependency;
         }
@@ -599,7 +601,8 @@ namespace NuGet.ProjectModel.Test
                 includeType: LibraryIncludeFlags.None,
                 suppressParent: LibraryIncludeFlags.ContentFiles,
                 noWarn: new List<NuGetLogCode>() { NuGetLogCode.NU1000, NuGetLogCode.NU1001 },
-                autoReferenced: false);
+                autoReferenced: false,
+                generatePathProperty: false);
             var imports = NuGetFramework.Parse("net45"); // This makes no sense in the context of fallback, just for testing :)
 
             var originalTargetFrameworkInformation = new TargetFrameworkInformation();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/CommonUtility.cs
@@ -204,7 +204,8 @@ namespace NuGet.Tests.Apex
                         LibraryIncludeFlags.All,
                         LibraryIncludeFlags.None,
                         new List<NuGetLogCode>(),
-                        autoReferenced: false))
+                        autoReferenced: false,
+                        generatePathProperty: false))
                 .ToList();
         }
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/6949

Some packages have a weird layout.  They are in use via `packages.config` because you can guess the path with something like `..\packages\Some.Bad.Package.1.0.0\something.exe`.  When migrating to `PackageReference`, these packages are very hard to consume.  Not all of these packages can be updated so there's a need to add a feature to NuGet so you can use them.

This change adds a `GeneratePathProperty` metadata item to `<PackageReference />` and then generates a property in the `.g.props`.

Example:

```xml
<Project>
  <ItemGroup>
      <PackageReference Include="Some.Bad.Package" Version="1.0.0" GeneratePathProperty="true" />
  </ItemGroup>

  <Target Name="TakeAction" AfterTargets="Build">
    <Exec Command="$(PkgSome_Bad_Package)\something.exe" />
  </Target>
</Project>
```

The resulting `nuget.g.props` contains:

```xml
<PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
    <PkgSome_Bad_Package Condition=" '$(PkgSome_Bad_Package)' == '' ">C:\Users\Bill\.nuget\packages\Some.Bad.Package\1.0.0</PkgSome_Bad_Package>
</PropertyGroup>
```

This change also generates a path property for any package that has a `tools` folder.

Example:

```xml
<Project>
  <ItemGroup>
      <PackageReference Include="ILMerge" Version="2.14.1208" />
  </ItemGroup>

  <Target Name="TakeAction" AfterTargets="Build">
    <Exec Command="$(PkgIlMerge)\tools\ilmerge.exe" />
  </Target>
</Project>
```
