### PR TITLE
Dev zhi warningfix

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -188,7 +188,7 @@ namespace NuGet.SolutionRestoreManager
 
             if (projectRestoreInfo.ToolReferences != null)
             {
-                var toolFramework = GetNonEvaluatedPropertyOrNull(
+                var toolFramework = GetSingleNonEvaluatedPropertyOrNull(
                     projectRestoreInfo.TargetFrameworks,
                     ProjectBuildProperties.DotnetCliToolTargetFramework,
                     NuGetFramework.Parse) ?? CommonFrameworks.NetCoreApp10;
@@ -248,7 +248,7 @@ namespace NuGet.SolutionRestoreManager
                 crossTargeting = true;
             }
 
-        
+
             var outputPath = Path.GetFullPath(
                                 Path.Combine(
                                     projectDirectory,
@@ -284,9 +284,9 @@ namespace NuGet.SolutionRestoreManager
                                     .Select(e => new PackageSource(e))
                                     .ToList(),
                     ProjectWideWarningProperties = WarningProperties.GetWarningProperties(
-                        treatWarningsAsErrors: GetNonEvaluatedPropertyOrNull(projectRestoreInfo.TargetFrameworks, TreatWarningsAsErrors, e => e),
-                        warningsAsErrors: GetNonEvaluatedPropertyOrNull(projectRestoreInfo.TargetFrameworks, WarningsAsErrors, e => e),
-                        noWarn: GetNonEvaluatedPropertyOrNull(projectRestoreInfo.TargetFrameworks, NoWarn, e => e)),
+                        treatWarningsAsErrors: GetSingleOrDefaultPropertyValue(projectRestoreInfo.TargetFrameworks, TreatWarningsAsErrors, e => e),
+                        warningsAsErrors: GetSingleOrDefaultNuGetLogCodes(projectRestoreInfo.TargetFrameworks, WarningsAsErrors, e => MSBuildStringUtility.GetNuGetLogCodes(e)),
+                        noWarn: GetSingleOrDefaultNuGetLogCodes(projectRestoreInfo.TargetFrameworks, NoWarn, e => MSBuildStringUtility.GetNuGetLogCodes(e))),
                     CacheFilePath = NoOpRestoreUtilities.GetProjectCacheFilePath(cacheRoot: outputPath, projectPath: projectFullPath)
                 },
                 RuntimeGraph = GetRuntimeGraph(projectRestoreInfo),
@@ -313,7 +313,7 @@ namespace NuGet.SolutionRestoreManager
 
         private static string GetPackageId(ProjectNames projectNames, IVsTargetFrameworks tfms)
         {
-            var packageId = GetNonEvaluatedPropertyOrNull(tfms, PackageId, v => v);
+            var packageId = GetSingleNonEvaluatedPropertyOrNull(tfms, PackageId, v => v);
             return packageId ?? projectNames.ShortName;
         }
 
@@ -321,15 +321,15 @@ namespace NuGet.SolutionRestoreManager
         {
             // $(PackageVersion) property if set overrides the $(Version)
             var versionPropertyValue =
-                GetNonEvaluatedPropertyOrNull(tfms, PackageVersion, NuGetVersion.Parse)
-                ?? GetNonEvaluatedPropertyOrNull(tfms, Version, NuGetVersion.Parse);
+                GetSingleNonEvaluatedPropertyOrNull(tfms, PackageVersion, NuGetVersion.Parse)
+                ?? GetSingleNonEvaluatedPropertyOrNull(tfms, Version, NuGetVersion.Parse);
 
             return versionPropertyValue ?? PackageSpec.DefaultVersion;
         }
 
         private static string GetRestoreProjectPath(IVsTargetFrameworks tfms)
         {
-            return GetNonEvaluatedPropertyOrNull(tfms, RestorePackagesPath, e => e);
+            return GetSingleNonEvaluatedPropertyOrNull(tfms, RestorePackagesPath, e => e);
         }
 
         /// <summary>
@@ -338,7 +338,7 @@ namespace NuGet.SolutionRestoreManager
         /// </summary>
         private static IEnumerable<string> GetRestoreSources(IVsTargetFrameworks tfms)
         {
-            var sources = HandleClear(MSBuildStringUtility.Split(GetNonEvaluatedPropertyOrNull(tfms, RestoreSources, e => e)));
+            var sources = HandleClear(MSBuildStringUtility.Split(GetSingleNonEvaluatedPropertyOrNull(tfms, RestoreSources, e => e)));
 
             // Read RestoreAdditionalProjectSources from the inner build, these may be different between frameworks.
             // Exclude is not allowed for sources
@@ -355,7 +355,7 @@ namespace NuGet.SolutionRestoreManager
         /// </summary>
         private static IEnumerable<string> GetRestoreFallbackFolders(IVsTargetFrameworks tfms)
         {
-            var folders = HandleClear(MSBuildStringUtility.Split(GetNonEvaluatedPropertyOrNull(tfms, RestoreFallbackFolders, e => e)));
+            var folders = HandleClear(MSBuildStringUtility.Split(GetSingleNonEvaluatedPropertyOrNull(tfms, RestoreFallbackFolders, e => e)));
 
             // Read RestoreAdditionalProjectFallbackFolders from the inner build.
             // Remove all excluded fallback folders listed in RestoreAdditionalProjectFallbackFoldersExcludes.
@@ -376,9 +376,28 @@ namespace NuGet.SolutionRestoreManager
             return input;
         }
 
-        // Trying to fetch a property value from tfm property bags.
-        // If defined the property should have identical values in all of the occurances.
-        private static TValue GetNonEvaluatedPropertyOrNull<TValue>(
+        private static TValue GetSingleOrDefaultPropertyValue<TValue>(
+            IVsTargetFrameworks tfms,
+            string propertyName,
+            Func<string, TValue> valueFactory)
+        {
+            var properties = GetNonEvaluatedPropertyOrNull(tfms, propertyName, valueFactory);
+
+            return properties.Count() > 1 ? default(TValue) : properties.SingleOrDefault();
+        }
+
+        private static IEnumerable<NuGetLogCode> GetSingleOrDefaultNuGetLogCodes(
+            IVsTargetFrameworks tfms,
+            string propertyName,
+            Func<string, IEnumerable<NuGetLogCode>> valueFactory)
+        {
+            var logCodeProperties = GetNonEvaluatedPropertyOrNull(tfms, propertyName, valueFactory);
+
+            return MSBuildStringUtility.GetDistinctNuGetLogCodesOrDefault(logCodeProperties);
+        }
+
+        // Trying to fetch a list of property value from all tfm property bags.
+        private static IEnumerable<TValue> GetNonEvaluatedPropertyOrNull<TValue>(
             IVsTargetFrameworks tfms,
             string propertyName,
             Func<string, TValue> valueFactory)
@@ -390,8 +409,17 @@ namespace NuGet.SolutionRestoreManager
                     var val = GetPropertyValueOrNull(tfm.Properties, propertyName);
                     return val != null ? valueFactory(val) : default(TValue);
                 })
-                .Distinct()
-                .SingleOrDefault();
+                .Distinct();
+        }
+
+        // Trying to fetch a property value from tfm property bags.
+        // If defined the property should have identical values in all of the occurances.
+        private static TValue GetSingleNonEvaluatedPropertyOrNull<TValue>(
+            IVsTargetFrameworks tfms,
+            string propertyName,
+            Func<string, TValue> valueFactory)
+        {
+            return GetNonEvaluatedPropertyOrNull(tfms, propertyName, valueFactory).SingleOrDefault();
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Common/MsBuildStringUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/MsBuildStringUtility.cs
@@ -112,5 +112,36 @@ namespace NuGet.Common
 
             return value.Replace(',', ';');
         }
+
+        /// <summary>
+        /// Return empty list of NuGetLogCode if all lists of NuGetLogCode are not the same. 
+        /// </summary>
+        public static IEnumerable<NuGetLogCode> GetDistinctNuGetLogCodesOrDefault(IEnumerable<IEnumerable<NuGetLogCode>> nugetLogCodeLists)
+        {
+            if (nugetLogCodeLists.Count() > 0)
+            {
+                var result = Enumerable.Empty<NuGetLogCode>();
+                var first = true;
+
+                foreach (var logCodeList in nugetLogCodeLists)
+                {
+                    // If this is first item, assign it to result
+                    if (first)
+                    {
+                        result = logCodeList;
+                        first = false;
+                    }
+                    // Compare the rest items to the first one.
+                    else if (result == null || logCodeList == null || result.Count() != logCodeList.Count() || !result.All(logCodeList.Contains))
+                    {
+                        return Enumerable.Empty<NuGetLogCode>();
+                    }
+                }
+
+                return result ?? Enumerable.Empty<NuGetLogCode>();
+            }
+
+            return Enumerable.Empty<NuGetLogCode>();
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/WarningProperties.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/WarningProperties.cs
@@ -87,13 +87,21 @@ namespace NuGet.ProjectModel
         /// </summary>
         public static WarningProperties GetWarningProperties(string treatWarningsAsErrors, string warningsAsErrors, string noWarn)
         {
+            return GetWarningProperties(treatWarningsAsErrors, MSBuildStringUtility.GetNuGetLogCodes(warningsAsErrors), (MSBuildStringUtility.GetNuGetLogCodes(noWarn)));
+        }
+
+        /// <summary>
+        /// Create warning properties from NuGetLogCode collection.
+        /// </summary>
+        public static WarningProperties GetWarningProperties(string treatWarningsAsErrors, IEnumerable<NuGetLogCode> warningsAsErrors, IEnumerable<NuGetLogCode> noWarn)
+        {
             var props = new WarningProperties()
             {
                 AllWarningsAsErrors = MSBuildStringUtility.IsTrue(treatWarningsAsErrors)
             };
 
-            props.WarningsAsErrors.UnionWith(MSBuildStringUtility.GetNuGetLogCodes(warningsAsErrors));
-            props.NoWarn.UnionWith(MSBuildStringUtility.GetNuGetLogCodes(noWarn));
+            props.WarningsAsErrors.UnionWith(warningsAsErrors);
+            props.NoWarn.UnionWith(noWarn);
 
             return props;
         }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/MSBuildStringUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/MSBuildStringUtilityTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace NuGet.Common.Test
+{
+    public class MSBuildStringUtilityTests
+    {
+        [Fact]
+        public void GetDistinctNuGetLogCodesOrDefault_SameLogCodes()
+        {
+            // Arrange
+            var logCodes1 = new List<NuGetLogCode>() { NuGetLogCode.NU1000, NuGetLogCode.NU1001};
+            var logCodes2 = new List<NuGetLogCode>() { NuGetLogCode.NU1001, NuGetLogCode.NU1000,};
+
+            var logCodesList = new List<IEnumerable<NuGetLogCode>>() { logCodes1, logCodes2 };
+
+            // Act
+            var result = MSBuildStringUtility.GetDistinctNuGetLogCodesOrDefault(logCodesList);
+
+            // Assert
+            Assert.Equal(2, result.Count());
+            Assert.True(result.All(logCodes2.Contains));
+        }
+
+        [Fact]
+        public void GetDistinctNuGetLogCodesOrDefault_EmptyLogCodes()
+        {
+            // Arrange
+            var logCodesList = new List<IEnumerable<NuGetLogCode>>();
+
+            // Act
+            var result = MSBuildStringUtility.GetDistinctNuGetLogCodesOrDefault(logCodesList);
+
+            // Assert
+            Assert.Equal(0, result.Count());
+        }
+
+        [Fact]
+        public void GetDistinctNuGetLogCodesOrDefault_DiffLogCodes()
+        {
+            // Arrange
+            var logCodes1 = new List<NuGetLogCode>() { NuGetLogCode.NU1000};
+            var logCodes2 = new List<NuGetLogCode>() { NuGetLogCode.NU1001, NuGetLogCode.NU1000 };
+
+            var logCodesList = new List<IEnumerable<NuGetLogCode>>() { logCodes1, logCodes2 };
+
+            // Act
+            var result = MSBuildStringUtility.GetDistinctNuGetLogCodesOrDefault(logCodesList);
+
+            // Assert
+            Assert.Equal(0, result.Count());
+        }
+
+        [Fact]
+        public void GetDistinctNuGetLogCodesOrDefault_OneNullCode()
+        {
+            // Arrange
+            var logCodes1 = new List<NuGetLogCode>() { NuGetLogCode.NU1001, NuGetLogCode.NU1000 };
+
+            var logCodesList = new List<IEnumerable<NuGetLogCode>>() { null, logCodes1 };
+
+            // Act
+            var result = MSBuildStringUtility.GetDistinctNuGetLogCodesOrDefault(logCodesList);
+
+            // Assert
+            Assert.Equal(0, result.Count());
+        }
+
+        [Fact]
+        public void GetDistinctNuGetLogCodesOrDefault_AllNullCodes()
+        {
+            // Arrange
+            var logCodesList = new List<IEnumerable<NuGetLogCode>>() { null, null };
+
+            // Act
+            var result = MSBuildStringUtility.GetDistinctNuGetLogCodesOrDefault(logCodesList);
+
+            // Assert
+            Assert.Equal(0, result.Count());
+        }
+
+        [Fact]
+        public void GetDistinctNuGetLogCodesOrDefault_NullCodesAfterFirst()
+        {
+            // Arrange
+            var logCodes1 = new List<NuGetLogCode>() { NuGetLogCode.NU1001, NuGetLogCode.NU1000 };
+            var logCodesList = new List<IEnumerable<NuGetLogCode>>() { logCodes1, null };
+
+            // Act
+            var result = MSBuildStringUtility.GetDistinctNuGetLogCodesOrDefault(logCodesList);
+
+            // Assert
+            Assert.Equal(0, result.Count());
+        }
+    }
+}


### PR DESCRIPTION
VSTS 611662

the issue is if user set nowarn/warningAsError conditional on targetframework in csproj,
nuget.exe and dotnet cli ignore them, and restore works well.
But it breaks VS for SDK project due to SingleOrDefault exception.

The fix here is let VS follow the nuget.exe/dotnet cli behavior. 
