### PR TITLE
Fix suffix for --no-service-endpoint option description

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -469,6 +469,6 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
 {1} - Project path</comment>
   </data>
   <data name="NoServiceEndpoint_Description" xml:space="preserve">
-    <value>--no-service-endpoint does not append "api/v2/packages" to the source URL.</value>
+    <value>Does not append "api/v2/package" to the source URL.</value>
   </data>
 </root>


### PR DESCRIPTION
Fixing suffix used for --no-service-endpoint option description (see https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs#L27 for the correct one)

Also removed the redundant part
![image](https://user-images.githubusercontent.com/12971179/40859173-b2e37604-6595-11e8-8a57-2f08d1286228.png)

