### PR TITLE
Fixed project ids field in restore and action telemetry events

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/Telemetry/ActionEventBase.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Telemetry/ActionEventBase.cs
@@ -25,7 +25,6 @@ namespace NuGet.PackageManagement
             base(eventName, new Dictionary<string, object>
                 {
                     { nameof(OperationId), operationId },
-                    { nameof(ProjectIds), string.Join(",", projectIds) },
                     { nameof(PackagesCount), packageCount },
                     { nameof(Status), status },
                     { nameof(StartTime), startTime.ToString() },
@@ -34,11 +33,18 @@ namespace NuGet.PackageManagement
                     { nameof(ProjectsCount), projectIds.Length }
                 })
         {
+            ProjectIds = projectIds;
+
+            // log each project id separately so that it can be joined with ProjectInformation telemetry event
+            for (var i=0; i< projectIds.Length; i++)
+            {
+                this[$"ProjectId{i+1}"] = projectIds[i];
+            }
         }
 
         public string OperationId => (string)base[nameof(OperationId)];
 
-        public string ProjectIds => (string)base[nameof(ProjectIds)];
+        public string[] ProjectIds;
 
         public int PackagesCount => (int)base[nameof(PackagesCount)];
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/TestTelemetryUtility.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/TestTelemetryUtility.cs
@@ -15,12 +15,16 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             Assert.Equal(operationId, actual["OperationId"].ToString());
             Assert.Equal(expected.ProjectsCount, (int)actual["ProjectsCount"]);
-            Assert.Equal(string.Join(",", expected.ProjectIds), actual["ProjectIds"].ToString());
             Assert.Equal(expected.PackagesCount, (int)actual["PackagesCount"]);
             Assert.Equal(expected.Status.ToString(), actual["Status"].ToString());
             Assert.Equal(expected.StartTime, actual["StartTime"]);
             Assert.Equal(expected.EndTime, actual["EndTime"]);
             Assert.Equal(expected.Duration, (double)actual["Duration"]);
+
+            for (var i = 0; i < expected.ProjectsCount; i++)
+            {
+                Assert.Equal(expected.ProjectIds[i], actual["ProjectId" + (i + 1)].ToString());
+            }
         }
     }
 }


### PR DESCRIPTION
Currently there is single field in restore and action telemetry events which has list of all the encrypted project ids which is impossible to map with ProjectInformation event to know about the type of package format. So this PR creates separate fields for each project id for restore and action telemetry events.

@rrelyea 