### PR TITLE
reset project autoreferenced if a package without installed versions is selected

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -80,6 +80,7 @@ namespace NuGet.PackageManagement.UI
                     else
                     {
                         project.InstalledVersion = null;
+                        project.AutoReferenced = false;
                     }
                 }
                 catch(Exception ex)


### PR DESCRIPTION
## Bug
Fixes:  [Internal 615109](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/615109)

## Fix
Details: When an autoreferenced package is selected the PMUI should ignore actions on it. When a autoreferenced package was selected by the user and then the selection changed to packages without any installed version across the project in the solution, the PMUI stayed in a bad state where install was ignored. This PR fixes that by resetting the `autoreferenced` property on the project to false when the selected package does not have any version installed.