### PR TITLE
Improve UI accesibility by letting keyboard focus textblocks and textboxes so narrator can narrate them

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
@@ -583,10 +583,11 @@
   -->
   <Style x:Key="SelectableTextBlockStyle" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
     <Setter Property="IsReadOnly" Value="True"/>
-    <Setter Property="IsTabStop" Value="False"/>
+    <Setter Property="IsTabStop" Value="True"/>
     <Setter Property="BorderThickness" Value="0"/>
     <Setter Property="Background" Value="Transparent"/>
     <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}"/>
+    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
     <Setter Property="Padding" Value="-2,0,-2,0"/>
     <Style.Triggers>
       <MultiTrigger>
@@ -606,7 +607,8 @@
                              FontWeight="{TemplateBinding FontWeight}"
                              TextWrapping="{TemplateBinding TextWrapping}"
                              Padding="0,0,0,0"
-                             />
+                             Focusable="{TemplateBinding Focusable}"
+                             AutomationProperties.Name="{TemplateBinding Text}" />
             </ControlTemplate>
           </Setter.Value>
         </Setter>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml
@@ -93,6 +93,10 @@
               <TextBlock
                 Margin="24,12,24,12"
                 TextWrapping="Wrap"
+                x:Name="_legalDisclaimerText"
+                Focusable="True"
+                AutomationProperties.Name="{Binding Text}"
+                FocusVisualStyle="{x:Null}"
                 Text="{x:Static nuget:Resources.Text_LegalDisclaimer}" />
               <CheckBox
                 Margin="24,0,24,12"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -33,6 +33,10 @@
     <!-- descriptions -->
     <TextBlock
       Grid.Row="0"
+      x:Name="_descriptionLabel"
+      Focusable="True"
+      AutomationProperties.Name="{Binding Text}"
+      FocusVisualStyle="{x:Null}"
       Text="{x:Static nuget:Resources.Label_Description}"
       FontWeight="Bold" />
     <TextBox
@@ -72,6 +76,10 @@
         Grid.Column="0"
         Margin="0,8,0,0"
         FontWeight="Bold"
+        x:Name="_versionLabel"
+        Focusable="True"
+        AutomationProperties.Name="{Binding Text}"
+        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_Version}" />
       <TextBox
         Style="{DynamicResource SelectableTextBlockStyle}" 
@@ -89,6 +97,10 @@
         Grid.Column="0"
         Margin="0,8,0,0"
         FontWeight="Bold"
+        x:Name="_ownersLabel"
+        Focusable="True"
+        AutomationProperties.Name="{Binding Text}"
+        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_Owners}" />
       <TextBox
         Style="{DynamicResource SelectableTextBlockStyle}" 
@@ -106,6 +118,10 @@
         Grid.Column="0"
         Margin="0,8,0,0"
         FontWeight="Bold"
+        x:Name="_authorsLabel"
+        Focusable="True"
+        AutomationProperties.Name="{Binding Text}"
+        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_Authors}" />
       <TextBox
         Style="{DynamicResource SelectableTextBlockStyle}" 
@@ -123,6 +139,10 @@
         Grid.Column="0"
         FontWeight="Bold"
         Margin="0,8,0,0"
+        x:Name="_licenseLabel"
+        Focusable="True"
+        AutomationProperties.Name="{Binding Text}"
+        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_License}" />
       <TextBlock
         Visibility="{Binding Path=LicenseUrl,Converter={StaticResource NullToVisibilityConverter}}"
@@ -145,6 +165,10 @@
         Grid.Column="0"
         FontWeight="Bold"
         Margin="0,8,0,0"
+        x:Name="_downloadsLabel"
+        Focusable="True"
+        AutomationProperties.Name="{Binding Text}"
+        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_Downloads}" />
       <TextBox
         Style="{DynamicResource SelectableTextBlockStyle}" 
@@ -162,6 +186,10 @@
         Grid.Column="0"
         FontWeight="Bold"
         Margin="0,8,0,0"
+        x:Name="_datePublishedLabel"
+        Focusable="True"
+        AutomationProperties.Name="{Binding Text}"
+        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_DatePublished}" />
       <TextBox
         Name="datePublished"
@@ -180,6 +208,10 @@
         Grid.Column="0"
         FontWeight="Bold"
         Margin="0,8,0,0"
+        x:Name="_projectUrlLabel"
+        Focusable="True"
+        AutomationProperties.Name="{Binding Text}"
+        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_ProjectUrl}" />
 
       <TextBlock
@@ -203,6 +235,10 @@
         Grid.Column="0"
         FontWeight="Bold"
         Margin="0,8,0,0"
+        x:Name="_reportAbuseLabel"
+        Focusable="True"
+        AutomationProperties.Name="{Binding Text}"
+        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_ReportAbuse}" />
 
       <TextBlock
@@ -226,6 +262,10 @@
         Grid.Column="0"
         FontWeight="Bold"
         Margin="0,8,0,0"
+        x:Name="_tagsLabel"
+        Focusable="True"
+        AutomationProperties.Name="{Binding Text}"
+        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_Tags}" />
       <TextBox
         Style="{DynamicResource SelectableTextBlockStyle}" 
@@ -244,6 +284,10 @@
       <TextBlock
         FontWeight="Bold"
         Margin="0,8,0,0"
+        x:Name="_dependenciesLabel"
+        Focusable="True"
+        AutomationProperties.Name="{Binding Text}"
+        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_Dependencies}" />
 
       <ItemsControl
@@ -259,13 +303,18 @@
               <TextBlock
                 Text="{Binding TargetFramework,Converter={StaticResource NuGetFrameworkToStringConverter}}"
                 FontWeight="Bold"
+                x:Name="_targetFramework"
+                Focusable="True"
+                AutomationProperties.Name="{Binding Text}"
+                FocusVisualStyle="{x:Null}"
                 Visibility="{Binding TargetFramework,Converter={StaticResource NuGetFrameworkToVisibilityConverter}}" />
               <ItemsControl
                 ItemsSource="{Binding Dependencies}"
                 IsTabStop="False">
                 <ItemsControl.ItemTemplate>
                   <DataTemplate>
-                    <TextBox 
+                    <TextBox
+                      x:Name="_dependencies"
                       Style="{DynamicResource SelectableTextBlockStyle}"
                       Text="{Binding Mode=OneWay}"/>
                   </DataTemplate>
@@ -274,6 +323,10 @@
               <TextBlock
                 FontStyle="Italic"
                 Text="{x:Static nuget:Resources.Text_NoDependencies}"
+                x:Name="_noDependencies"
+                Focusable="True"
+                AutomationProperties.Name="{Binding Text}"
+                FocusVisualStyle="{x:Null}"
                 Visibility="{Binding Dependencies,Converter={StaticResource EmptyEnumerableToVisibilityConverter}}" />
             </StackPanel>
           </DataTemplate>
@@ -284,6 +337,10 @@
         Margin="0,8,0,0"
         Visibility="{Binding Path=HasDependencies,Converter={StaticResource InvertedBooleanToVisibilityConverter}}"
         FontStyle="Italic"
+        x:Name="_hasDependencies"
+        Focusable="True"
+        AutomationProperties.Name="{Binding Text}"
+        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Text_NoDependencies}" />
     </StackPanel>
   </Grid>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
@@ -178,6 +178,10 @@
     </Grid.RowDefinitions>
 
     <TextBlock
+      x:Name="_installedVersionsCount"
+      Focusable="True"
+      AutomationProperties.Name="{Binding Text}"
+      FocusVisualStyle="{x:Null}"
       Grid.Row="0"
       Text="{Binding InstalledVersionsCount, Converter={StaticResource InstalledVersionsCountConverter}}" />
 


### PR DESCRIPTION
## Bug
Fixes: [Internal 503976](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/503976)

## Fix
Details: The textblocks and textboxes in the nuget UI are not focusable, therefore there is no way to access them with the keyboard. If you are using only keyboard navigation and reading the screen with narrator, there is no way for narrator to narrates this elements. This is evident with the EULA in the PMUI because the "Do not show this again" checkbox is focusable while the texblock with the actual legal disclaimer is not. Other textblocks and textboxes with these issue are in the metadata for the details control.

This PR fixes this by letting the user navigate to the keyboard to this controls. This PR does not make any visual changes to the UI, it only updates the appropriate for selection to be possible in order to allow narrator to work better with PMUI.