### PR TITLE
Allowing search tool tip tip to be localized

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1179,6 +1179,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Type words to search for.
+        /// </summary>
+        public static string Search_ToolTipProperty {
+            get {
+                return ResourceManager.GetString("Search_ToolTipProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show Details.
         /// </summary>
         public static string ShowDetails {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -799,4 +799,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="ShowError_SettingActivatedFailed" xml:space="preserve">
     <value>Failed to initialize NuGet Package Manager Settings. Please report a problem using Help &gt; Send Feedback &gt; Report a Problem.</value>
   </data>
+  <data name="Search_ToolTipProperty" xml:space="preserve">
+    <value>Type words to search for</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -944,6 +944,7 @@ namespace NuGet.PackageManagement.UI
             settings.ControlMinWidth = (uint)_topPanel.SearchControlParent.MinWidth;
             settings.ControlMaxWidth = uint.MaxValue;
             settings.SearchWatermark = GetSearchText();
+            settings.SearchTooltip = Resx.Resources.Search_ToolTipProperty;
         }
 
         // Returns the text to be displayed in the search box.


### PR DESCRIPTION
## Bug
Fixes: [615833](https://devdiv.visualstudio.com/DevDiv/NuGet/_workitems/edit/615833)
Regression: No

## Fix
Details: The tool tip for the search bar in the PM UI was a default string which is not localized. This change moves the string as a resource. This will allow the string to be localized.

## Testing/Validation
Tests Added: No
Reason for not adding tests:  UI change.
