### PR TITLE
Update the discovery of built in plugins

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -190,7 +190,7 @@ namespace NuGet.CommandLine
         /// </summary>
         protected void SetDefaultCredentialProvider(Lazy<string> msbuildDirectory)
         {
-            Protocol.Plugins.PluginDiscoveryUtility.InternalPluginDiscoveryRoot = msbuildDirectory;
+            Protocol.Plugins.PluginDiscoveryUtility.InternalPluginDiscoveryRoot = new Lazy<string>(() => Protocol.Plugins.PluginDiscoveryUtility.GetInternalPluginRelativeToMSBuildExe(msbuildDirectory.Value));
             CredentialService = new CredentialService(new AsyncLazy<IEnumerable<ICredentialProvider>>(() => GetCredentialProvidersAsync()), NonInteractive, handlesDefaultCredentials: PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders);
 
             CoreV2.NuGet.HttpClient.DefaultCredentialProvider = new CredentialServiceAdapter(CredentialService);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.Designer.cs
@@ -142,6 +142,15 @@ namespace NuGet.PackageManagement.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The plugin credential providers could not be loaded..
+        /// </summary>
+        public static string CredentialProviderFailed_PluginCredentialProvider {
+            get {
+                return ResourceManager.GetString("CredentialProviderFailed_PluginCredentialProvider", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The Visual Studio or VSTS account provider failed to load..
         /// </summary>
         public static string CredentialProviderFailed_VisualStudioAccountProvider {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.resx
@@ -286,4 +286,7 @@
 {3} is the project full path
 {4} is the reference assembly full path</comment>
   </data>
+  <data name="CredentialProviderFailed_PluginCredentialProvider" xml:space="preserve">
+    <value>The plugin credential providers could not be loaded.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
@@ -21,7 +21,7 @@ namespace NuGet.Protocol.Plugins
 
 #if IS_DESKTOP
         /// <summary>
-        /// Given Visual Studio 2017 MSBuild.exe path, return the NuGet plugins directory which is in CommonExtensions\NuGet\NuGetPluginsDirectory
+        /// Given Visual Studio 2017 MSBuild.exe path, return the NuGet plugins directory which is in CommonExtensions\NuGet\NuGetPlugins
         /// </summary>
         /// <param name="msbuildExePath">The MsBuildExe path. Needs to be a valid path. file:// not supported.</param>
         /// <returns>The NuGet plugins directory, null if <paramref name="msbuildExePath"/> is null</returns>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
@@ -21,18 +21,18 @@ namespace NuGet.Protocol.Plugins
 
 #if IS_DESKTOP
         /// <summary>
-        /// Given Visual Studio 2017 MSBuild.exe path, return the NuGet plugins directory which is in CommonExtensions/NuGetPluginsDirectory
+        /// Given Visual Studio 2017 MSBuild.exe path, return the NuGet plugins directory which is in CommonExtensions\NuGet\NuGetPluginsDirectory
         /// </summary>
         /// <param name="msbuildExePath">The MsBuildExe path. Needs to be a valid path. file:// not supported.</param>
         /// <returns>The NuGet plugins directory, null if <paramref name="msbuildExePath"/> is null</returns>
-        /// <remarks>The MSBuild.exe is in MSBuild\15.0\Bin\MsBuild.exe, the NuGetPlugins directory is in Common7\IDE\CommonExtensions\Microsoft\NuGetPlugins</remarks>
+        /// <remarks>The MSBuild.exe is in MSBuild\15.0\Bin\MsBuild.exe, the NuGetPlugins directory is in Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGetPlugins</remarks>
         public static string GetInternalPluginRelativeToMSBuildExe(string msbuildExePath)
         {
             var parentDirectory = "..";
             return !string.IsNullOrEmpty(msbuildExePath) ?
                 PathUtility.GetAbsolutePath(
                     Path.GetDirectoryName(msbuildExePath),
-                    Path.Combine(parentDirectory, parentDirectory, parentDirectory, "Common7", "CommonExtensions", "Microsoft", "NuGet", NuGetPluginsDirectory)
+                    Path.Combine(parentDirectory, parentDirectory, parentDirectory, "Common7", "IDE", "CommonExtensions", "Microsoft", "NuGet", NuGetPluginsDirectory)
                     ) :
                 null;
         }
@@ -41,7 +41,7 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Given a NuGet assembly path, returns the NuGet plugins directory
         /// </summary>
-        /// <param name="nugetAssemblyPath">The path to a NuGet assembly in CommonExtensions\NuGet</param>
+        /// <param name="nugetAssemblyPath">The path to a NuGet assembly in CommonExtensions\NuGet, needs to be a valid path. file:// not supported</param>
         /// <returns>The NuGet plugins directory in CommonExtensions\NuGet\NuGetPlugins, null if the <paramref name="nugetAssemblyPath"/> is null</returns>
         public static string GetNuGetPluginsDirectoryRelativeToNuGetAssembly(string nugetAssemblyPath)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
@@ -18,7 +18,6 @@ namespace NuGet.Protocol.Plugins
             return InternalPluginDiscoveryRoot?.Value ??
                 GetNuGetPluginsDirectoryRelativeToNuGetAssembly(typeof(PluginDiscoveryUtility).GetTypeInfo().Assembly.Location); // NuGet.*.dll
         }
-
 #if IS_DESKTOP
         /// <summary>
         /// Given Visual Studio 2017 MSBuild.exe path, return the NuGet plugins directory which is in CommonExtensions\NuGet\NuGetPlugins
@@ -30,10 +29,10 @@ namespace NuGet.Protocol.Plugins
         {
             var parentDirectory = "..";
             return !string.IsNullOrEmpty(msbuildExePath) ?
-                PathUtility.GetAbsolutePath(
+                Path.GetFullPath(Path.Combine(
                     Path.GetDirectoryName(msbuildExePath),
                     Path.Combine(parentDirectory, parentDirectory, parentDirectory, "Common7", "IDE", "CommonExtensions", "Microsoft", "NuGet", NuGetPluginsDirectory)
-                    ) :
+                    )) :
                 null;
         }
 #endif

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
@@ -12,11 +12,13 @@ namespace NuGet.Protocol.Plugins
 
         public static string GetInternalPlugins()
         {
-            var rootDirectory = InternalPluginDiscoveryRoot?.Value ?? System.Reflection.Assembly.GetEntryAssembly()?.Location;
-
+#if IS_DESKTOP
+            var rootDirectory = InternalPluginDiscoveryRoot?.Value ?? System.Reflection.Assembly.GetExecutingAssembly()?.Location; // This is NuGet.Protocol.dll
+#else
+            var rootDirectory = InternalPluginDiscoveryRoot?.Value ?? System.Reflection.Assembly.GetEntryAssembly()?.Location; // This is msbuild.dll
+#endif
             return rootDirectory ?? Path.GetDirectoryName(rootDirectory);
         }
-
         public static string GetNuGetHomePluginsPath()
         {
             var nuGetHome = NuGetEnvironment.GetFolderPath(NuGetFolderPath.NuGetHome);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
@@ -16,7 +16,7 @@ namespace NuGet.Protocol.Plugins
         public static string GetInternalPlugins()
         {
             return InternalPluginDiscoveryRoot?.Value ??
-                GetNuGetPluginsDirectory(typeof(PluginDiscoveryUtility).GetTypeInfo().Assembly.Location); // NuGet.*.dll would return null if called from unmanaged code
+                GetNuGetPluginsDirectoryRelativeToNuGetAssembly(typeof(PluginDiscoveryUtility).GetTypeInfo().Assembly.Location); // NuGet.*.dll
         }
 
 #if IS_DESKTOP
@@ -32,22 +32,22 @@ namespace NuGet.Protocol.Plugins
             return !string.IsNullOrEmpty(msbuildExePath) ?
                 PathUtility.GetAbsolutePath(
                     Path.GetDirectoryName(msbuildExePath),
-                    Path.Combine(parentDirectory, parentDirectory, parentDirectory, "Common7", "CommonExtensions", "Microsoft", NuGetPluginsDirectory)
+                    Path.Combine(parentDirectory, parentDirectory, parentDirectory, "Common7", "CommonExtensions", "Microsoft", "NuGet", NuGetPluginsDirectory)
                     ) :
                 null;
         }
 #endif
 
         /// <summary>
-        /// Given the NuGet assemblies directory, returns the NuGet plugins directory
+        /// Given a NuGet assembly path, returns the NuGet plugins directory
         /// </summary>
-        /// <param name="nuGetAssembliesDirectory">The NuGet assemblies directory in CommonExtensions\NuGet</param>
-        /// <returns>The NuGet plugins directory in CommonExtensions\NuGetPlugins, null if the <paramref name="nuGetAssembliesDirectory"/> is null</returns>
-        private static string GetNuGetPluginsDirectory(string nuGetAssembliesDirectory)
+        /// <param name="nugetAssemblyPath">The path to a NuGet assembly in CommonExtensions\NuGet</param>
+        /// <returns>The NuGet plugins directory in CommonExtensions\NuGet\NuGetPlugins, null if the <paramref name="nugetAssemblyPath"/> is null</returns>
+        public static string GetNuGetPluginsDirectoryRelativeToNuGetAssembly(string nugetAssemblyPath)
         {
-            return !string.IsNullOrEmpty(nuGetAssembliesDirectory) ?
+            return !string.IsNullOrEmpty(nugetAssemblyPath) ?
                     Path.Combine(
-                        Path.GetDirectoryName(nuGetAssembliesDirectory),
+                        Path.GetDirectoryName(nugetAssemblyPath),
                         NuGetPluginsDirectory
                         ) :
                     null;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
@@ -3,8 +3,6 @@ using NuGet.Test.Utility;
 using Xunit;
 using System.Linq;
 using System;
-using NuGet.Common;
-using System.Diagnostics;
 
 namespace NuGet.Protocol.Plugins.Tests
 {
@@ -20,7 +18,7 @@ namespace NuGet.Protocol.Plugins.Tests
         [Theory]
         [InlineData("VSTSCredProv", "VSTSCredProv", true)]
         [InlineData("VSTSCredProv", "MyGetProv", false)]
-        public void PluginDiscoveryUtilitySimpleTest(string pluginFolderName, string pluginFileName, bool success)
+        public void PluginDiscoveryUtility_SimpleTest(string pluginFolderName, string pluginFileName, bool success)
         {
             using (var test = TestDirectory.Create())
             {
@@ -44,7 +42,7 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
         [Fact]
-        public void PluginDiscoveryUtilityGetsNuGetHomePluginPath()
+        public void PluginDiscoveryUtility_GetsNuGetHomePluginPath()
         {
             var result = PluginDiscoveryUtility.GetNuGetHomePluginsPath();
 
@@ -56,5 +54,36 @@ namespace NuGet.Protocol.Plugins.Tests
 #endif
                 ), result);
         }
+
+        [Theory]
+        [InlineData(@"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.Protocol.dll",
+            @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGetPlugins")]
+        [InlineData(null, null)]
+        public void PluginDiscoveryUtility_GetsNuGetPluginPathGivenNuGetAssemblies(string given, string expected)
+        {
+            var result = PluginDiscoveryUtility.GetNuGetPluginsDirectoryRelativeToNuGetAssembly(given);
+            Assert.Equal(expected, result);
+        }
+
+#if IS_DESKTOP
+        [Theory]
+        [InlineData(@"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe",
+            @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGetPlugins")]
+        [InlineData(null, null)]
+        public void PluginDiscoveryUtility_GetsNuGetPluginPathGivenMSBuildExeLocation(string given, string expected)
+        {
+            var result = PluginDiscoveryUtility.GetInternalPluginRelativeToMSBuildExe(given);
+            Assert.Equal(expected, result);
+        }
+#endif
+        [Fact]
+        public void Test()
+        {
+            var path = @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet";
+
+            var newPath = Path.GetDirectoryName(path);
+            string.Equals(path, newPath);
+        }
+
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
@@ -55,9 +55,19 @@ namespace NuGet.Protocol.Plugins.Tests
                 ), result);
         }
 
-        [Theory]
+        [PlatformTheory(Platform.Linux, Platform.Darwin)]
+        [InlineData(@"/opt/coolpath/dotnet/sdk/2.0.0/NuGet.Protocol.dll",
+            @"/opt/coolpath/dotnet/sdk/2.0.0/NuGetPlugins")]
+        [InlineData(null, null)]
+        public void PluginDiscoveryUtility_GetsNuGetPluginPathGivenNuGetAssembliesInXPLATSDK(string given, string expected)
+        {
+            var result = PluginDiscoveryUtility.GetNuGetPluginsDirectoryRelativeToNuGetAssembly(given);
+            Assert.Equal(expected, result);
+        }
+
+        [PlatformTheory(Platform.Windows)]
         [InlineData(@"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.Protocol.dll",
-            @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGetPlugins")]
+    @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGetPlugins")]
         [InlineData(null, null)]
         public void PluginDiscoveryUtility_GetsNuGetPluginPathGivenNuGetAssemblies(string given, string expected)
         {
@@ -76,14 +86,5 @@ namespace NuGet.Protocol.Plugins.Tests
             Assert.Equal(expected, result);
         }
 #endif
-        [Fact]
-        public void Test()
-        {
-            var path = @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet";
-
-            var newPath = Path.GetDirectoryName(path);
-            string.Equals(path, newPath);
-        }
-
     }
 }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6704
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
Last part of the discovery of plugins for VS and SDK. 
Also adding the plugins as a fallback in Visual Studio

The directory for the built-in plugins will be next to the NuGet assembly in the NuGetPlugins folder. 
That's consistent in all cases (VS and SDK)

Related [info ](https://github.com/NuGet/Engineering/pull/1451
)about the discovery directories. 

## Testing/Validation
Tests Added: Yes  
Reason for not adding tests:  
Validation done: Tests, manual 
