### PR TITLE
Changing log codes to HashSet and removing log messages from projectrestoreinformation

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -39,9 +39,7 @@ namespace NuGet.Commands
         // names for ProjectRestoreInformation and intervals
         private const string ProjectRestoreInformation = "ProjectRestoreInformation";
         private const string ErrorCodes = "ErrorCodes";
-        private const string ErrorMessages = "ErrorMessages";
         private const string WarningCodes = "WarningCodes";
-        private const string WarningMessages = "WarningMessages";
         private const string RestoreSuccess = "RestoreSuccess";
 
         // names for child events for ProjectRestoreInformation
@@ -249,21 +247,17 @@ namespace NuGet.Commands
                         cacheFile.Success = _success;
                     }
 
-                    var errorCodes = ConcatAsString(logs.Where(l => l.Level == LogLevel.Error).Select(l => l.Code));
-                    var errorMessages = ConcatAsString(logs.Where(l => l.Level == LogLevel.Error).Select(l => l.Message));
-                    var warningCodes = ConcatAsString(logs.Where(l => l.Level == LogLevel.Warning).Select(l => l.Code));
-                    var warningMessages = ConcatAsString(logs.Where(l => l.Level == LogLevel.Warning).Select(l => l.Message));
+                    var errorCodes = ConcatAsString(new HashSet<NuGetLogCode>(logs.Where(l => l.Level == LogLevel.Error).Select(l => l.Code)));
+                    var warningCodes = ConcatAsString(new HashSet<NuGetLogCode>(logs.Where(l => l.Level == LogLevel.Warning).Select(l => l.Code)));
 
                     if (!string.IsNullOrEmpty(errorCodes))
                     {
                         telemetry.TelemetryEvent[ErrorCodes] = errorCodes;
-                        telemetry.TelemetryEvent.AddPiiData(ErrorMessages, errorMessages);
                     }
 
                     if (!string.IsNullOrEmpty(warningCodes))
                     {
                         telemetry.TelemetryEvent[WarningCodes] = warningCodes;
-                        telemetry.TelemetryEvent.AddPiiData(WarningMessages, warningMessages);
                     }
 
                     telemetry.TelemetryEvent[RestoreSuccess] = _success;

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Moq;
+using Newtonsoft.Json.Linq;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -6099,6 +6100,297 @@ namespace NuGet.Test
 
                 Assert.True(telemetryEvents.Where(p => p.Name == "NugetActionSteps").
                     Any(p => (string)p["SubStepName"] == TelemetryConstants.PreviewBuildIntegratedStepName));
+            }
+        }
+
+        [Fact]
+        public async Task TestPacMan_PreviewInstallPackage_BuildIntegrated_RaiseTelemetryEventsWithErrorCode()
+        {
+
+            // Arrange
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
+
+            // set up telemetry service
+            var telemetrySession = new Mock<ITelemetrySession>();
+
+            var telemetryEvents = new List<TelemetryEvent>();
+            telemetrySession
+                .Setup(x => x.PostEvent(It.IsAny<TelemetryEvent>()))
+                .Callback<TelemetryEvent>(x => telemetryEvents.Add(x));
+
+            var nugetProjectContext = new TestNuGetProjectContext();
+            var telemetryService = new NuGetVSTelemetryService(telemetrySession.Object);
+            TelemetryActivity.NuGetTelemetryService = telemetryService;
+
+            // Create Package Manager
+            using (var solutionManager = new TestSolutionManager(true))
+            {
+                var nuGetPackageManager = new NuGetPackageManager(
+                    sourceRepositoryProvider,
+                    NullSettings.Instance,
+                    solutionManager,
+                    new TestDeleteOnRestartManager());
+
+                var json = new JObject
+                {
+                    ["dependencies"] = new JObject(),
+                    ["frameworks"] = new JObject
+                    {
+                        ["net46"] = new JObject()
+                    }
+                };
+
+                var buildIntegratedProject = solutionManager.AddBuildIntegratedProject(json: json);
+
+                // Act
+                var target = new PackageIdentity("NuGet.Versioning", new NuGetVersion("99.9.9"));
+
+                await nuGetPackageManager.PreviewInstallPackageAsync(
+                    buildIntegratedProject,
+                    target,
+                    new ResolutionContext(),
+                    nugetProjectContext,
+                    sourceRepositoryProvider.GetRepositories(),
+                    sourceRepositoryProvider.GetRepositories(),
+                    CancellationToken.None);
+
+                // Assert
+                Assert.Equal(15, telemetryEvents.Count);
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateRestoreGraph").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateAssetsFile").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ValidateRestoreGraphs").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "CreateRestoreResult").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreNoOpInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "CreateRestoreTargetGraph").Count());
+                Assert.Equal(1, telemetryEvents.Where(p => p.Name == "NugetActionSteps").Count());
+
+                Assert.True(telemetryEvents.Where(p => p.Name == "NugetActionSteps").
+                    Any(p => (string)p["SubStepName"] == TelemetryConstants.PreviewBuildIntegratedStepName));
+
+                Assert.True((string)telemetryEvents
+                    .Where(p => p.Name == "ProjectRestoreInformation").
+                    Last()["ErrorCodes"] == NuGetLogCode.NU1100.ToString());
+            }
+        }
+
+        [Fact]
+        public async Task TestPacMan_PreviewInstallPackage_BuildIntegrated_RaiseTelemetryEventsWithDupedErrorCodes()
+        {
+
+            // Arrange
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
+
+            // set up telemetry service
+            var telemetrySession = new Mock<ITelemetrySession>();
+
+            var telemetryEvents = new List<TelemetryEvent>();
+            telemetrySession
+                .Setup(x => x.PostEvent(It.IsAny<TelemetryEvent>()))
+                .Callback<TelemetryEvent>(x => telemetryEvents.Add(x));
+
+            var nugetProjectContext = new TestNuGetProjectContext();
+            var telemetryService = new NuGetVSTelemetryService(telemetrySession.Object);
+            TelemetryActivity.NuGetTelemetryService = telemetryService;
+
+            // Create Package Manager
+            using (var solutionManager = new TestSolutionManager(true))
+            {
+                var nuGetPackageManager = new NuGetPackageManager(
+                    sourceRepositoryProvider,
+                    NullSettings.Instance,
+                    solutionManager,
+                    new TestDeleteOnRestartManager());
+
+                var json = new JObject
+                {
+                    ["dependencies"] = new JObject()
+                    {
+                        new JProperty("NuGet.Frameworks", "99.0.0")
+                    },
+                    ["frameworks"] = new JObject
+                    {
+                        ["net46"] = new JObject()
+                    }
+                };
+
+                var buildIntegratedProject = solutionManager.AddBuildIntegratedProject(json: json);
+
+                // Act
+                var target = new PackageIdentity("NuGet.Versioning", new NuGetVersion("99.9.9"));
+
+                await nuGetPackageManager.PreviewInstallPackageAsync(
+                    buildIntegratedProject,
+                    target,
+                    new ResolutionContext(),
+                    nugetProjectContext,
+                    sourceRepositoryProvider.GetRepositories(),
+                    sourceRepositoryProvider.GetRepositories(),
+                    CancellationToken.None);
+
+                // Assert
+                Assert.Equal(15, telemetryEvents.Count);
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateRestoreGraph").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateAssetsFile").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ValidateRestoreGraphs").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "CreateRestoreResult").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreNoOpInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "CreateRestoreTargetGraph").Count());
+                Assert.Equal(1, telemetryEvents.Where(p => p.Name == "NugetActionSteps").Count());
+
+                Assert.True(telemetryEvents.Where(p => p.Name == "NugetActionSteps").
+                    Any(p => (string)p["SubStepName"] == TelemetryConstants.PreviewBuildIntegratedStepName));
+
+                Assert.True((string)telemetryEvents
+                    .Where(p => p.Name == "ProjectRestoreInformation").
+                    Last()["ErrorCodes"] == NuGetLogCode.NU1100.ToString());
+            }
+        }
+
+
+        [Fact]
+        public async Task TestPacMan_PreviewInstallPackage_BuildIntegrated_RaiseTelemetryEventsWithWarningCode()
+        {
+
+            // Arrange
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
+
+            // set up telemetry service
+            var telemetrySession = new Mock<ITelemetrySession>();
+
+            var telemetryEvents = new List<TelemetryEvent>();
+            telemetrySession
+                .Setup(x => x.PostEvent(It.IsAny<TelemetryEvent>()))
+                .Callback<TelemetryEvent>(x => telemetryEvents.Add(x));
+
+            var nugetProjectContext = new TestNuGetProjectContext();
+            var telemetryService = new NuGetVSTelemetryService(telemetrySession.Object);
+            TelemetryActivity.NuGetTelemetryService = telemetryService;
+
+            // Create Package Manager
+            using (var solutionManager = new TestSolutionManager(true))
+            {
+                var nuGetPackageManager = new NuGetPackageManager(
+                    sourceRepositoryProvider,
+                    NullSettings.Instance,
+                    solutionManager,
+                    new TestDeleteOnRestartManager());
+
+                var json = new JObject
+                {
+                    ["dependencies"] = new JObject(),
+                    ["frameworks"] = new JObject
+                    {
+                        ["net46"] = new JObject()
+                    }
+                };
+
+                var buildIntegratedProject = solutionManager.AddBuildIntegratedProject(json: json);
+
+                // Act
+                var target = new PackageIdentity("NuGet.Versioning", new NuGetVersion("4.6.9"));
+
+                await nuGetPackageManager.PreviewInstallPackageAsync(
+                    buildIntegratedProject,
+                    target,
+                    new ResolutionContext(),
+                    nugetProjectContext,
+                    sourceRepositoryProvider.GetRepositories(),
+                    sourceRepositoryProvider.GetRepositories(),
+                    CancellationToken.None);
+
+                // Assert
+                Assert.Equal(15, telemetryEvents.Count);
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateRestoreGraph").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateAssetsFile").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ValidateRestoreGraphs").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "CreateRestoreResult").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreNoOpInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "CreateRestoreTargetGraph").Count());
+                Assert.Equal(1, telemetryEvents.Where(p => p.Name == "NugetActionSteps").Count());
+
+                Assert.True(telemetryEvents.Where(p => p.Name == "NugetActionSteps").
+                    Any(p => (string)p["SubStepName"] == TelemetryConstants.PreviewBuildIntegratedStepName));
+
+                Assert.True((string)telemetryEvents
+                    .Where(p => p.Name == "ProjectRestoreInformation").
+                    Last()["WarningCodes"] == NuGetLogCode.NU1603.ToString());
+            }
+        }
+
+        [Fact]
+        public async Task TestPacMan_PreviewInstallPackage_BuildIntegrated_RaiseTelemetryEventsWithDupedWarningCodes()
+        {
+
+            // Arrange
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
+
+            // set up telemetry service
+            var telemetrySession = new Mock<ITelemetrySession>();
+
+            var telemetryEvents = new List<TelemetryEvent>();
+            telemetrySession
+                .Setup(x => x.PostEvent(It.IsAny<TelemetryEvent>()))
+                .Callback<TelemetryEvent>(x => telemetryEvents.Add(x));
+
+            var nugetProjectContext = new TestNuGetProjectContext();
+            var telemetryService = new NuGetVSTelemetryService(telemetrySession.Object);
+            TelemetryActivity.NuGetTelemetryService = telemetryService;
+
+            // Create Package Manager
+            using (var solutionManager = new TestSolutionManager(true))
+            {
+                var nuGetPackageManager = new NuGetPackageManager(
+                    sourceRepositoryProvider,
+                    NullSettings.Instance,
+                    solutionManager,
+                    new TestDeleteOnRestartManager());
+
+                var json = new JObject
+                {
+                    ["dependencies"] = new JObject()
+                    {
+                        new JProperty("NuGet.Frameworks", "4.6.9")
+                    },
+                    ["frameworks"] = new JObject
+                    {
+                        ["net46"] = new JObject()
+                    }
+                };
+
+                var buildIntegratedProject = solutionManager.AddBuildIntegratedProject(json: json);
+
+                // Act
+                var target = new PackageIdentity("NuGet.Versioning", new NuGetVersion("4.6.9"));
+
+                await nuGetPackageManager.PreviewInstallPackageAsync(
+                    buildIntegratedProject,
+                    target,
+                    new ResolutionContext(),
+                    nugetProjectContext,
+                    sourceRepositoryProvider.GetRepositories(),
+                    sourceRepositoryProvider.GetRepositories(),
+                    CancellationToken.None);
+
+                // Assert
+                Assert.Equal(15, telemetryEvents.Count);
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateRestoreGraph").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateAssetsFile").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ValidateRestoreGraphs").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "CreateRestoreResult").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "RestoreNoOpInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "CreateRestoreTargetGraph").Count());
+                Assert.Equal(1, telemetryEvents.Where(p => p.Name == "NugetActionSteps").Count());
+
+                Assert.True(telemetryEvents.Where(p => p.Name == "NugetActionSteps").
+                    Any(p => (string)p["SubStepName"] == TelemetryConstants.PreviewBuildIntegratedStepName));
+
+                Assert.True((string)telemetryEvents
+                    .Where(p => p.Name == "ProjectRestoreInformation").
+                    Last()["WarningCodes"] == NuGetLogCode.NU1603.ToString());
             }
         }
 


### PR DESCRIPTION
Fixes 2 problems - 
1. Error/Warning codes were being concatenated as an array. This could easily exceed the 1K column length limit. Making them a set, prevents that.
2. Error/Warning messages would also face the same problem.
