### PR TITLE
Don't let user tab into non-interactive elements and add automation properties to elements in ui

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -61,6 +61,78 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package icon.
+        /// </summary>
+        public static string Accessibility_PackageIcon {
+            get {
+                return ResourceManager.GetString("Accessibility_PackageIcon", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package manager.
+        /// </summary>
+        public static string Accessibility_PackageManager {
+            get {
+                return ResourceManager.GetString("Accessibility_PackageManager", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package metadata.
+        /// </summary>
+        public static string Accessibility_PackageMetadata {
+            get {
+                return ResourceManager.GetString("Accessibility_PackageMetadata", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package details.
+        /// </summary>
+        public static string Accessibility_PackagesDetails {
+            get {
+                return ResourceManager.GetString("Accessibility_PackagesDetails", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Packages list.
+        /// </summary>
+        public static string Accessibility_PackagesList {
+            get {
+                return ResourceManager.GetString("Accessibility_PackagesList", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Prefix reserved.
+        /// </summary>
+        public static string Accessibility_PrefixReserved {
+            get {
+                return ResourceManager.GetString("Accessibility_PrefixReserved", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use arrow keys to change the size of the sections.
+        /// </summary>
+        public static string Accessibility_ThumbHelp {
+            get {
+                return ResourceManager.GetString("Accessibility_ThumbHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Thumb.
+        /// </summary>
+        public static string Accessibility_ThumbName {
+            get {
+                return ResourceManager.GetString("Accessibility_ThumbName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Consolidate.
         /// </summary>
         public static string Action_Consolidate {
@@ -709,7 +781,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Version(s) - {0}.
+        ///   Looks up a localized string similar to Versions - {0}.
         /// </summary>
         public static string Label_InstalledVersionsCount {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -486,7 +486,7 @@ Packages installed into Website projects will not be restored during build. Cons
     <value>Learn about Uninstall Options</value>
   </data>
   <data name="Label_InstalledVersionsCount" xml:space="preserve">
-    <value>Version(s) - {0}</value>
+    <value>Versions - {0}</value>
   </data>
   <data name="GroupBoxHeader_InstallOptions" xml:space="preserve">
     <value>Install and Update Options</value>
@@ -798,5 +798,29 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   </data>
   <data name="ShowError_SettingActivatedFailed" xml:space="preserve">
     <value>Failed to initialize NuGet Package Manager Settings. Please report a problem using Help &gt; Send Feedback &gt; Report a Problem.</value>
+  </data>
+  <data name="Accessibility_PackageIcon" xml:space="preserve">
+    <value>Package icon</value>
+  </data>
+  <data name="Accessibility_PackageManager" xml:space="preserve">
+    <value>Package manager</value>
+  </data>
+  <data name="Accessibility_PackageMetadata" xml:space="preserve">
+    <value>Package metadata</value>
+  </data>
+  <data name="Accessibility_PackagesDetails" xml:space="preserve">
+    <value>Package details</value>
+  </data>
+  <data name="Accessibility_PackagesList" xml:space="preserve">
+    <value>Packages list</value>
+  </data>
+  <data name="Accessibility_PrefixReserved" xml:space="preserve">
+    <value>Prefix reserved</value>
+  </data>
+  <data name="Accessibility_ThumbHelp" xml:space="preserve">
+    <value>Use arrow keys to change the size of the sections</value>
+  </data>
+  <data name="Accessibility_ThumbName" xml:space="preserve">
+    <value>Thumb</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
@@ -587,11 +587,10 @@
   -->
   <Style x:Key="SelectableTextBlockStyle" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
     <Setter Property="IsReadOnly" Value="True"/>
-    <Setter Property="IsTabStop" Value="True"/>
+    <Setter Property="IsTabStop" Value="False"/>
     <Setter Property="BorderThickness" Value="0"/>
     <Setter Property="Background" Value="Transparent"/>
     <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}"/>
-    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
     <Setter Property="Padding" Value="-2,0,-2,0"/>
     <Style.Triggers>
       <MultiTrigger>
@@ -611,9 +610,7 @@
                              FontWeight="{TemplateBinding FontWeight}"
                              TextWrapping="{TemplateBinding TextWrapping}"
                              TextTrimming="CharacterEllipsis"
-                             Padding="0,0,0,0"
-                             Focusable="{TemplateBinding Focusable}"
-                             AutomationProperties.Name="{TemplateBinding Text}" />
+                             Padding="0,0,0,0" />
             </ControlTemplate>
           </Setter.Value>
         </Setter>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml
@@ -25,7 +25,8 @@
   </UserControl.CommandBindings>
   <ScrollViewer
     x:Name="_root"
-    HorizontalScrollBarVisibility="Disabled">
+    HorizontalScrollBarVisibility="Disabled"
+    AutomationProperties.Name="{Binding Text, ElementName=_packageId}">
     <Grid
       Margin="24,0,7,0">
       <Grid.RowDefinitions>
@@ -58,9 +59,12 @@
         <Image
           Grid.Column="0"
           Margin="0,0,8,0"
+          AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PackageIcon}"
           Style="{StaticResource PackageIconImageStyle}" />
         <TextBox
           Grid.Column="1"
+          Name="_packageId"
+          AutomationProperties.Name="{Binding Path=Id, Mode=OneWay}"
           Style="{DynamicResource SelectableTextBlockStyle}"
           Text="{Binding Path=Id, Mode=OneWay}"
           FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font155PercentSizeConverter}}" />
@@ -72,6 +76,7 @@
           Width="16"
           Height="16"
           VerticalAlignment="Top"
+          AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PrefixReserved}"
           Visibility="{Binding Path=PrefixReserved, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
           ToolTip="{x:Static nuget:Resources.Tooltip_PrefixReserved}"
           Moniker="{x:Static nuget:PackageIconMonikers.PrefixReservedIndicator}" />
@@ -102,6 +107,8 @@
         HorizontalAlignment="Stretch"
         VerticalAlignment="Top"
         Margin="-24,0,-7,0"
+        AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_ThumbName}"
+        AutomationProperties.HelpText="{x:Static nuget:Resources.Accessibility_ThumbHelp}"
         Visibility="{Binding Path=IsSolution,Converter={StaticResource BooleanToVisibilityConverter}}"
         Background="{DynamicResource {x:Static nuget:Brushes.SplitterBackgroundKey}}"
         BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
@@ -118,6 +125,7 @@
             x:Name="_optionsBlockedTextBox"
             Margin="0,12,0,16"
             TextWrapping="WrapWithOverflow"
+            AutomationProperties.Name="{Binding OptionsBlockedMessage}"
             Visibility="{Binding Path=OptionsBlockedMessage,Converter={StaticResource NullToVisibilityConverter}}">
             <Run Text="{Binding OptionsBlockedMessage}"/>
             <Hyperlink
@@ -137,6 +145,7 @@
       
       <nuget:PackageMetadataControl
         Grid.Row="5"
+        AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PackageMetadata}"
         Margin="0,12,0,0"
         DataContext="{Binding PackageMetadata}" />
     </Grid>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FilterLabel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FilterLabel.xaml
@@ -23,8 +23,13 @@
       Grid.Row="0"
       Click="ButtonClicked"
       AutomationProperties.AutomationId="{Binding ElementName=_labelText, Path=Text}"
-      AutomationProperties.Name="{Binding ElementName=_labelText, Path=Text}"
       FocusVisualStyle="{DynamicResource ControlsFocusVisualStyle}">
+      <AutomationProperties.Name>
+        <MultiBinding StringFormat=" {0} {1}">
+          <Binding ElementName="_labelText" Path="Text" />
+          <Binding ElementName="_textBlockCount" Path="Text" />
+        </MultiBinding>
+      </AutomationProperties.Name>
       <nuget:TabItemButton.Template>
         <ControlTemplate TargetType="{x:Type Button}">
           <ContentPresenter />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml
@@ -10,7 +10,8 @@
   x:Name="_self"
   mc:Ignorable="d"
   d:DesignHeight="523"
-  d:DesignWidth="900">
+  d:DesignWidth="900"
+  AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PackageManager}">
   <UserControl.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
@@ -94,9 +95,10 @@
             <nuget:InfiniteScrollList
               Grid.Row="0"
               x:Name="_packageList"
+              AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PackagesList}"
               SelectionChanged="PackageList_SelectionChanged"
               UpdateButtonClicked="PackageList_UpdateButtonClicked"
-              Width="{Binding ActualWidth, ElementName=_left_side}"/>
+              Width="{Binding ActualWidth, ElementName=_left_side}" />
 
             <Border
               Grid.Row="2"
@@ -105,27 +107,20 @@
               BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
               Background="{DynamicResource {x:Static nuget:Brushes.LegalMessageBackground}}"
               Width="{Binding ActualWidth, ElementName=_leftSide}">
-              <Grid>
-                <Grid.RowDefinitions>
-                  <RowDefinition Height="Auto" />
-                  <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-                <TextBlock
-                  Grid.Row="0"
-                  Margin="24,12,24,12"
-                  TextWrapping="Wrap"
+              <TextBlock
+                TextWrapping="Wrap"
+                Margin="24,12,24,12">
+                <Run
                   x:Name="_legalDisclaimerText"
-                  Focusable="True"
-                  AutomationProperties.Name="{Binding Text}"
-                  FocusVisualStyle="{x:Null}"
                   Text="{x:Static nuget:Resources.Text_LegalDisclaimer}" />
+                <LineBreak />
                 <CheckBox
-                  Grid.Row="1"
-                  Margin="24,0,24,12"
+                  Margin="0,12,0,12"
+                  AutomationProperties.LabeledBy="{Binding ElementName=_legalDisclaimerText}"
                   Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
                   Content="{x:Static nuget:Resources.DoNotShowThisAgain}"
                   Checked="SuppressDisclaimerChecked" />
-              </Grid>
+              </TextBlock>
             </Border>
           </Grid>
 
@@ -135,6 +130,8 @@
             Grid.RowSpan="2"
             HorizontalAlignment="Center"
             VerticalAlignment="Stretch"
+            AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_ThumbName}"
+            AutomationProperties.HelpText="{x:Static nuget:Resources.Accessibility_ThumbHelp}"
             Background="{DynamicResource {x:Static nuget:Brushes.SplitterBackgroundKey}}"
             BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
             BorderThickness="1,0" />
@@ -142,6 +139,7 @@
           <!-- right side -->
           <nuget:DetailControl
             x:Name="_packageDetail"
+            AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PackagesDetails}"
             Grid.Column="2"
             Grid.RowSpan="2" />
         </Grid>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml
@@ -98,7 +98,7 @@
               AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PackagesList}"
               SelectionChanged="PackageList_SelectionChanged"
               UpdateButtonClicked="PackageList_UpdateButtonClicked"
-              Width="{Binding ActualWidth, ElementName=_left_side}" />
+              Width="{Binding ActualWidth, ElementName=_left_side}"/>
 
             <Border
               Grid.Row="2"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -34,15 +34,15 @@
     <TextBlock
       Grid.Row="0"
       x:Name="_descriptionLabel"
-      Focusable="True"
       AutomationProperties.Name="{Binding Text}"
-      FocusVisualStyle="{x:Null}"
       Text="{x:Static nuget:Resources.Label_Description}"
       FontWeight="Bold" />
     <TextBox
       Style="{DynamicResource SelectableTextBlockStyle}" 
       Grid.Row="1"
       x:Name="_description"
+      AutomationProperties.Name="{Binding Path=Description}"
+      AutomationProperties.LabeledBy="{Binding ElementName=_descriptionLabel}"
       Margin="0,8,0,0"
       TextWrapping="Wrap"
       Text="{Binding Path=Description}" />
@@ -77,15 +77,15 @@
         Margin="0,8,0,0"
         FontWeight="Bold"
         x:Name="_versionLabel"
-        Focusable="True"
         AutomationProperties.Name="{Binding Text}"
-        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_Version}" />
       <TextBox
         Style="{DynamicResource SelectableTextBlockStyle}" 
         Grid.Row="0"
         Grid.Column="1"
         Visibility="{Binding Path=Version,Converter={StaticResource NullToVisibilityConverter}}"
+        AutomationProperties.Name="{Binding Path=Version,Converter={StaticResource VersionToStringConverter},ConverterParameter=F}"
+        AutomationProperties.LabeledBy="{Binding ElementName=_versionLabel}"
         Text="{Binding Path=Version,Converter={StaticResource VersionToStringConverter},ConverterParameter=F}"
         Margin="8,8,0,0"
         TextWrapping="Wrap" />
@@ -98,13 +98,13 @@
         Margin="0,8,0,0"
         FontWeight="Bold"
         x:Name="_ownersLabel"
-        Focusable="True"
         AutomationProperties.Name="{Binding Text}"
-        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_Owners}" />
       <TextBox
         Style="{DynamicResource SelectableTextBlockStyle}" 
         Visibility="{Binding Path=Owners,Converter={StaticResource NullToVisibilityConverter}}"
+        AutomationProperties.Name="{Binding Path=Owners}"
+        AutomationProperties.LabeledBy="{Binding ElementName=_ownersLabel}"
         Text="{Binding Path=Owners}"
         Margin="8,8,0,0"
         TextWrapping="Wrap"
@@ -119,13 +119,13 @@
         Margin="0,8,0,0"
         FontWeight="Bold"
         x:Name="_authorsLabel"
-        Focusable="True"
         AutomationProperties.Name="{Binding Text}"
-        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_Authors}" />
       <TextBox
         Style="{DynamicResource SelectableTextBlockStyle}" 
         Visibility="{Binding Path=Authors,Converter={StaticResource NullToVisibilityConverter}}"
+        AutomationProperties.Name="{Binding Path=Authors}"
+        AutomationProperties.LabeledBy="{Binding ElementName=_authorsLabel}"
         Text="{Binding Path=Authors}"
         Margin="8,8,0,0"
         TextWrapping="Wrap"
@@ -140,16 +140,15 @@
         FontWeight="Bold"
         Margin="0,8,0,0"
         x:Name="_licenseLabel"
-        Focusable="True"
         AutomationProperties.Name="{Binding Text}"
-        FocusVisualStyle="{x:Null}"
-        Text="{x:Static nuget:Resources.Label_License}" />
+        Text="{x:Static nuget:Resources.Label_License}"/>
       <TextBlock
         Visibility="{Binding Path=LicenseUrl,Converter={StaticResource NullToVisibilityConverter}}"
         TextWrapping="Wrap"
         Margin="8,8,0,0"
         Grid.Row="3"
-        Grid.Column="1">
+        Grid.Column="1"
+        AutomationProperties.LabeledBy="{Binding ElementName=_licenseLabel}">
         <Hyperlink
           NavigateUri="{Binding Path=LicenseUrl}"
           Style="{StaticResource HyperlinkStyle}"
@@ -157,6 +156,8 @@
           <Run Text="{Binding Path=LicenseUrl}" />
         </Hyperlink>
       </TextBlock>
+
+
 
       <!-- downloads -->
       <TextBlock
@@ -166,13 +167,13 @@
         FontWeight="Bold"
         Margin="0,8,0,0"
         x:Name="_downloadsLabel"
-        Focusable="True"
         AutomationProperties.Name="{Binding Text}"
-        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_Downloads}" />
       <TextBox
         Style="{DynamicResource SelectableTextBlockStyle}" 
         Visibility="{Binding Path=DownloadCount,Converter={StaticResource DownloadCountToVisibilityConverter}}"
+        AutomationProperties.Name="{Binding Path=DownloadCount,StringFormat={}{0:N0}}"
+        AutomationProperties.LabeledBy="{Binding ElementName=_downloadsLabel}"
         Text="{Binding Path=DownloadCount,StringFormat={}{0:N0}}"
         Margin="8,8,0,0"
         TextWrapping="Wrap"
@@ -187,15 +188,15 @@
         FontWeight="Bold"
         Margin="0,8,0,0"
         x:Name="_datePublishedLabel"
-        Focusable="True"
         AutomationProperties.Name="{Binding Text}"
-        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_DatePublished}" />
       <TextBox
         Name="datePublished"
         Style="{DynamicResource SelectableTextBlockStyle}" 
         Visibility="{Binding Path=Published,Converter={StaticResource NullToVisibilityConverter}}"
         Text="{Binding Path=Published,Converter={StaticResource DateFormatConverter}}"
+        AutomationProperties.Name="{Binding Path=Published,Converter={StaticResource DateFormatConverter}}"
+        AutomationProperties.LabeledBy="{Binding ElementName=_datePublishedLabel}"
         Margin="8,8,0,0"
         TextWrapping="Wrap"
         Grid.Row="5"
@@ -209,9 +210,7 @@
         FontWeight="Bold"
         Margin="0,8,0,0"
         x:Name="_projectUrlLabel"
-        Focusable="True"
         AutomationProperties.Name="{Binding Text}"
-        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_ProjectUrl}" />
 
       <TextBlock
@@ -219,7 +218,8 @@
         TextWrapping="Wrap"
         Margin="8,8,0,0"
         Grid.Row="6"
-        Grid.Column="1">
+        Grid.Column="1"
+        AutomationProperties.LabeledBy="{Binding ElementName=_projectUrlLabel}">
         <Hyperlink
           NavigateUri="{Binding Path=ProjectUrl}"
           Style="{StaticResource HyperlinkStyle}"
@@ -236,9 +236,7 @@
         FontWeight="Bold"
         Margin="0,8,0,0"
         x:Name="_reportAbuseLabel"
-        Focusable="True"
         AutomationProperties.Name="{Binding Text}"
-        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_ReportAbuse}" />
 
       <TextBlock
@@ -246,7 +244,8 @@
         TextWrapping="Wrap"
         Margin="8,8,0,0"
         Grid.Row="7"
-        Grid.Column="1">
+        Grid.Column="1"
+        AutomationProperties.LabeledBy="{Binding ElementName=_reportAbuseLabel}">
         <Hyperlink
           NavigateUri="{Binding Path=ReportAbuseUrl}"
           Style="{StaticResource HyperlinkStyle}"
@@ -263,13 +262,13 @@
         FontWeight="Bold"
         Margin="0,8,0,0"
         x:Name="_tagsLabel"
-        Focusable="True"
         AutomationProperties.Name="{Binding Text}"
-        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_Tags}" />
       <TextBox
         Style="{DynamicResource SelectableTextBlockStyle}" 
         Visibility="{Binding Path=Tags,Converter={StaticResource NullToVisibilityConverter}}"
+        AutomationProperties.Name="{Binding Path=Tags}"
+        AutomationProperties.LabeledBy="{Binding ElementName=_tagsLabel}"
         Text="{Binding Path=Tags}"
         Margin="8,8,0,0"
         TextWrapping="Wrap"
@@ -285,16 +284,15 @@
         FontWeight="Bold"
         Margin="0,8,0,0"
         x:Name="_dependenciesLabel"
-        Focusable="True"
         AutomationProperties.Name="{Binding Text}"
-        FocusVisualStyle="{x:Null}"
         Text="{x:Static nuget:Resources.Label_Dependencies}" />
 
       <ItemsControl
         ItemsSource="{Binding Path=DependencySets}"
         Visibility="{Binding Path=HasDependencies,Converter={StaticResource BooleanToVisibilityConverter}}"
         IsTabStop="False"
-        Margin="8,0,0,0">
+        Margin="8,0,0,0"
+        AutomationProperties.LabeledBy="{Binding ElementName=_dependenciesLabel}">
         <ItemsControl.ItemTemplate>
           <DataTemplate>
             <StackPanel
@@ -304,18 +302,18 @@
                 Text="{Binding TargetFramework,Converter={StaticResource NuGetFrameworkToStringConverter}}"
                 FontWeight="Bold"
                 x:Name="_targetFramework"
-                Focusable="True"
                 AutomationProperties.Name="{Binding Text}"
-                FocusVisualStyle="{x:Null}"
                 Visibility="{Binding TargetFramework,Converter={StaticResource NuGetFrameworkToVisibilityConverter}}" />
               <ItemsControl
                 ItemsSource="{Binding Dependencies}"
-                IsTabStop="False">
+                IsTabStop="False"
+                AutomationProperties.LabeledBy="{Binding ElementName=_targetFramework}">
                 <ItemsControl.ItemTemplate>
                   <DataTemplate>
                     <TextBox
                       x:Name="_dependencies"
                       Style="{DynamicResource SelectableTextBlockStyle}"
+                      AutomationProperties.Name="{Binding Text}"
                       Text="{Binding Mode=OneWay}"/>
                   </DataTemplate>
                 </ItemsControl.ItemTemplate>
@@ -324,9 +322,7 @@
                 FontStyle="Italic"
                 Text="{x:Static nuget:Resources.Text_NoDependencies}"
                 x:Name="_noDependencies"
-                Focusable="True"
                 AutomationProperties.Name="{Binding Text}"
-                FocusVisualStyle="{x:Null}"
                 Visibility="{Binding Dependencies,Converter={StaticResource EmptyEnumerableToVisibilityConverter}}" />
             </StackPanel>
           </DataTemplate>
@@ -338,9 +334,8 @@
         Visibility="{Binding Path=HasDependencies,Converter={StaticResource InvertedBooleanToVisibilityConverter}}"
         FontStyle="Italic"
         x:Name="_hasDependencies"
-        Focusable="True"
         AutomationProperties.Name="{Binding Text}"
-        FocusVisualStyle="{x:Null}"
+        AutomationProperties.LabeledBy="{Binding ElementName=_dependenciesLabel}"
         Text="{x:Static nuget:Resources.Text_NoDependencies}" />
     </StackPanel>
   </Grid>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
@@ -179,9 +179,6 @@
 
     <TextBlock
       x:Name="_installedVersionsCount"
-      Focusable="True"
-      AutomationProperties.Name="{Binding Text}"
-      FocusVisualStyle="{x:Null}"
       Grid.Row="0"
       Text="{Binding InstalledVersionsCount, Converter={StaticResource InstalledVersionsCountConverter}}" />
 
@@ -194,6 +191,7 @@
       ItemsSource="{Binding Projects}"
       Background="{DynamicResource {x:Static local:Brushes.ListPaneBackground}}"
       Foreground="{DynamicResource {x:Static local:Brushes.UIText}}"
+      AutomationProperties.LabeledBy="{Binding ElementName=_installedVersionsCount}"
       KeyboardNavigation.TabNavigation="Local"
       SelectionMode="Single">
 


### PR DESCRIPTION
As part of https://github.com/NuGet/NuGet.Client/pull/2280 non-interactive text elements where made focusable in order to let a screen reader announce them. After investigating on best practices on accessibility and usability I found that only UI elements that a user can interact with should be focused or tabbed into. 

This PR reverts the changes from that past PR and fixes its issues in the correct way by using WPF UI Automation API, which gives information to the screen reader about the elements on the UI tree and does not affect the keyboard navigation.