### PR TITLE
Renaming ActionTelemetryStepEvent OperationId to ParentId

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/Telemetry/ActionTelemetryStepEvent.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Telemetry/ActionTelemetryStepEvent.cs
@@ -8,10 +8,10 @@ namespace NuGet.PackageManagement
 {
     public class ActionTelemetryStepEvent : TelemetryEvent
     {
-        public ActionTelemetryStepEvent(string operationId, string stepName, double duration) :
+        public ActionTelemetryStepEvent(string parentId, string stepName, double duration) :
             base(NugetActionStepsEventName, new Dictionary<string, object>
                 {
-                    { nameof(OperationId), operationId },
+                    { nameof(ParentId), parentId },
                     { nameof(SubStepName), string.Join(",", stepName) },
                     { nameof(Duration), duration }
                 })
@@ -22,6 +22,6 @@ namespace NuGet.PackageManagement
 
         public string SubStepName => (string)base[nameof(SubStepName)];
         public double Duration => (double)base[nameof(Duration)];
-        public string OperationId => (string)base[nameof(OperationId)];
+        public string ParentId => (string)base[nameof(ParentId)];
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/ActionsTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/ActionsTelemetryServiceTests.cs
@@ -134,17 +134,17 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var duration = 1.12;
             var service = new NuGetVSTelemetryService(telemetrySession.Object);
 
-            var operationId = Guid.NewGuid().ToString();
+            var parentId = Guid.NewGuid().ToString();
 
             // Act
-            service.EmitTelemetryEvent(new ActionTelemetryStepEvent(operationId, stepName, duration));
+            service.EmitTelemetryEvent(new ActionTelemetryStepEvent(parentId, stepName, duration));
 
             // Assert
             Assert.NotNull(lastTelemetryEvent);
             Assert.Equal(ActionTelemetryStepEvent.NugetActionStepsEventName, lastTelemetryEvent.Name);
             Assert.Equal(3, lastTelemetryEvent.Count);
 
-            Assert.Equal(operationId, lastTelemetryEvent["OperationId"].ToString());
+            Assert.Equal(parentId, lastTelemetryEvent["ParentId"].ToString());
             Assert.Equal(stepName, lastTelemetryEvent["SubStepName"].ToString());
             Assert.Equal(duration, (double)lastTelemetryEvent["Duration"]);
         }


### PR DESCRIPTION
`ActionTelemetryStepEvent` is using the parent id as its `OperationId`, which is wrong. The PR fixes the property name  to allow correct correlation.
