### PR TITLE
Add interactive flag for dotnet.exe and the restore task, unix platforms CS verification

### DIFF
--- a/src/NuGet.Clients/NuGet.Credentials/DefaultCredentialServiceUtility.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/DefaultCredentialServiceUtility.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NuGet.Clients/NuGet.Credentials/DefaultCredentialServiceUtility.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/DefaultCredentialServiceUtility.cs
@@ -35,7 +35,7 @@ namespace NuGet.Credentials
             var securePluginProviders = await (new SecureCredentialProviderBuilder(PluginManager.Instance, logger)).BuildAll();
             providers.AddRange(securePluginProviders);
 
-            if (securePluginProviders.Any())
+            if (providers.Any())
             {
                 if (PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders)
                 {

--- a/src/NuGet.Clients/NuGet.Credentials/DefaultCredentialServiceUtility.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/DefaultCredentialServiceUtility.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.Credentials
+{
+    public class DefaultCredentialServiceUtility
+    {
+        public static void SetupDefaultCredentialService(ILogger logger, bool nonInteractive)
+        {
+            if (HttpHandlerResourceV3.CredentialService == null)
+            {
+                var providers = new AsyncLazy<IEnumerable<ICredentialProvider>>(async () => await GetCredentialProvidersAsync(logger));
+                HttpHandlerResourceV3.CredentialService = new Lazy<ICredentialService>(
+                    () => new CredentialService(
+                        providers: providers,
+                        nonInteractive: nonInteractive,
+                        handlesDefaultCredentials: PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders));
+            }
+        }
+
+        // Add only the secure plugin. This will be done when there's nothing set
+        private static async Task<IEnumerable<ICredentialProvider>> GetCredentialProvidersAsync(ILogger logger)
+        {
+            var providers = new List<ICredentialProvider>();
+
+            var securePluginProviders = await (new SecureCredentialProviderBuilder(PluginManager.Instance, logger)).BuildAll();
+            providers.AddRange(securePluginProviders);
+
+            if (securePluginProviders.Any())
+            {
+                if (PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders)
+                {
+                    providers.Add(new DefaultCredentialsCredentialProvider());
+                }
+            }
+            return providers;
+        }
+
+    }
+}

--- a/src/NuGet.Clients/NuGet.Credentials/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/Resources.Designer.cs
@@ -170,7 +170,7 @@ namespace NuGet.Credentials {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with --interactive..
+        ///   Looks up a localized string similar to The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with --interactive or /p:NuGetInteractive=&quot;true&quot;.
         /// </summary>
         internal static string SecurePluginWarning_UseInteractiveOption {
             get {

--- a/src/NuGet.Clients/NuGet.Credentials/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/Resources.Designer.cs
@@ -170,7 +170,7 @@ namespace NuGet.Credentials {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The plugin credential provider could not provide credentials. Authentication may require manual action. Consider re-running the command with the {0} flag..
+        ///   Looks up a localized string similar to The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with {0}.
         /// </summary>
         internal static string SecurePluginWarning_UseInteractiveOption {
             get {

--- a/src/NuGet.Clients/NuGet.Credentials/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/Resources.Designer.cs
@@ -170,7 +170,7 @@ namespace NuGet.Credentials {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with --interactive in dotnet.exe, /p:NuGetInteractive=&quot;true&quot; in MSBuild or removing the -NonInteractive switch in NuGet.exe.
+        ///   Looks up a localized string similar to The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive=&quot;true&quot; for MSBuild or removing the -NonInteractive switch for `NuGet`.
         /// </summary>
         internal static string SecurePluginWarning_UseInteractiveOption {
             get {

--- a/src/NuGet.Clients/NuGet.Credentials/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/Resources.Designer.cs
@@ -170,7 +170,7 @@ namespace NuGet.Credentials {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with {0}.
+        ///   Looks up a localized string similar to The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with --interactive..
         /// </summary>
         internal static string SecurePluginWarning_UseInteractiveOption {
             get {

--- a/src/NuGet.Clients/NuGet.Credentials/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/Resources.Designer.cs
@@ -170,7 +170,7 @@ namespace NuGet.Credentials {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with --interactive or /p:NuGetInteractive=&quot;true&quot;.
+        ///   Looks up a localized string similar to The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with --interactive in dotnet.exe, /p:NuGetInteractive=&quot;true&quot; in MSBuild or removing the -NonInteractive switch in NuGet.exe.
         /// </summary>
         internal static string SecurePluginWarning_UseInteractiveOption {
             get {

--- a/src/NuGet.Clients/NuGet.Credentials/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/Resources.Designer.cs
@@ -168,5 +168,14 @@ namespace NuGet.Credentials {
                 return ResourceManager.GetString("SecurePluginNotice_UsingPluginAsProvider", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The plugin credential provider could not provide credentials. Authentication may require manual action. Consider re-running the command with the {0} flag..
+        /// </summary>
+        internal static string SecurePluginWarning_UseInteractiveOption {
+            get {
+                return ResourceManager.GetString("SecurePluginWarning_UseInteractiveOption", resourceCulture);
+            }
+        }
     }
 }

--- a/src/NuGet.Clients/NuGet.Credentials/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Credentials/Resources.resx
@@ -155,6 +155,6 @@
     <comment>{0} - plugin path</comment>
   </data>
   <data name="SecurePluginWarning_UseInteractiveOption" xml:space="preserve">
-    <value>The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with --interactive in dotnet.exe, /p:NuGetInteractive="true" in MSBuild or removing the -NonInteractive switch in NuGet.exe</value>
+    <value>The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive="true" for MSBuild or removing the -NonInteractive switch for `NuGet`</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.Credentials/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Credentials/Resources.resx
@@ -155,6 +155,6 @@
     <comment>{0} - plugin path</comment>
   </data>
   <data name="SecurePluginWarning_UseInteractiveOption" xml:space="preserve">
-    <value>The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with --interactive or /p:NuGetInteractive="true"</value>
+    <value>The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with --interactive in dotnet.exe, /p:NuGetInteractive="true" in MSBuild or removing the -NonInteractive switch in NuGet.exe</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.Credentials/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Credentials/Resources.resx
@@ -155,7 +155,6 @@
     <comment>{0} - plugin path</comment>
   </data>
   <data name="SecurePluginWarning_UseInteractiveOption" xml:space="preserve">
-    <value>The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with {0}</value>
-    <comment>{0} - the flag or switch</comment>
+    <value>The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with --interactive.</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.Credentials/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Credentials/Resources.resx
@@ -154,4 +154,8 @@
     <value>Using {0} as a credential provider plugin.</value>
     <comment>{0} - plugin path</comment>
   </data>
+  <data name="SecurePluginWarning_UseInteractiveOption" xml:space="preserve">
+    <value>The plugin credential provider could not provide credentials. Authentication may require manual action. Consider re-running the command with the {0} flag.</value>
+    <comment>{0} - the flag itself...Interactive maybe?</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.Credentials/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Credentials/Resources.resx
@@ -155,6 +155,6 @@
     <comment>{0} - plugin path</comment>
   </data>
   <data name="SecurePluginWarning_UseInteractiveOption" xml:space="preserve">
-    <value>The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with --interactive.</value>
+    <value>The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with --interactive or /p:NuGetInteractive="true"</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.Credentials/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Credentials/Resources.resx
@@ -155,7 +155,7 @@
     <comment>{0} - plugin path</comment>
   </data>
   <data name="SecurePluginWarning_UseInteractiveOption" xml:space="preserve">
-    <value>The plugin credential provider could not provide credentials. Authentication may require manual action. Consider re-running the command with the {0} flag.</value>
-    <comment>{0} - the flag itself...Interactive maybe?</comment>
+    <value>The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with {0}</value>
+    <comment>{0} - the flag or switch</comment>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.Credentials/SecureCredentialProviderBuilder.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/SecureCredentialProviderBuilder.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Plugins;
 
 namespace NuGet.Credentials
@@ -49,6 +48,5 @@ namespace NuGet.Credentials
 
             return plugins;
         }
-
     }
 }

--- a/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Net;

--- a/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
@@ -86,7 +86,7 @@ namespace NuGet.Credentials
             {
                 // There is a potential here for double logging as the CredentialService itself catches the exceptions and tries to log it.
                 // In reality the logger in the Credential Service will be null because the first request always comes from a resource provider (ServiceIndex provider) 
-                _logger.LogError(plugin.Message); 
+                _logger.LogError(plugin.Message);
                 throw new PluginException(plugin.Message); // Throwing here will block authentication and ensure that the complete operation fails 
             }
 
@@ -107,13 +107,13 @@ namespace NuGet.Credentials
                     MessageMethod.GetAuthenticationCredentials,
                     request,
                     cancellationToken);
-                if(credentialResponse.ResponseCode == MessageResponseCode.NotFound && nonInteractive)
+                if (credentialResponse.ResponseCode == MessageResponseCode.NotFound && nonInteractive)
                 {
                     _logger.LogWarning(
                         string.Format(
                                 CultureInfo.CurrentCulture,
-                                Resources.SecurePluginWarning_UseInteractiveOption,
-                                "--interactive or NuGetInteractive=true"));
+                                Resources.SecurePluginWarning_UseInteractiveOption)
+                                );
                 }
 
                 taskResponse = GetAuthenticationCredentialsResponseToCredentialResponse(credentialResponse);

--- a/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -81,11 +83,20 @@ namespace NuGet.Credentials
 
             var plugin = await _pluginManager.CreateSourceAgnosticPluginAsync(_discoveredPlugin, cancellationToken);
 
+            if (!string.IsNullOrEmpty(plugin.Message))
+            {
+                // There is a potential here for double logging as the CredentialService itself catches the exceptions and tries to log it.
+                // In reality the logger in the Credential Service will be null because the first request always comes from a resource provider (ServiceIndex provider) 
+                _logger.LogError(plugin.Message); 
+                throw new PluginException(plugin.Message); // Throwing here will block authentication and ensure that the complete operation fails 
+            }
+
             _isAnAuthenticationPlugin = plugin.Claims.Contains(OperationClaim.Authentication);
 
             if (_isAnAuthenticationPlugin)
             {
                 AddOrUpdateLogger(plugin.Plugin);
+                await SetPluginLogLevelAsync(plugin, _logger, cancellationToken);
 
                 if (proxy != null)
                 {
@@ -93,12 +104,21 @@ namespace NuGet.Credentials
                 }
 
                 var request = new GetAuthenticationCredentialsRequest(uri, isRetry, nonInteractive);
-
                 var credentialResponse = await plugin.Plugin.Connection.SendRequestAndReceiveResponseAsync<GetAuthenticationCredentialsRequest, GetAuthenticationCredentialsResponse>(
                     MessageMethod.GetAuthenticationCredentials,
                     request,
                     cancellationToken);
+                if(credentialResponse.ResponseCode == MessageResponseCode.NotFound && nonInteractive)
+                {
+                    _logger.LogWarning(
+                        string.Format(
+                                CultureInfo.CurrentCulture,
+                                Resources.SecurePluginWarning_UseInteractiveOption,
+                                "Interactive"));
+                }
+
                 taskResponse = GetAuthenticationCredentialsResponseToCredentialResponse(credentialResponse);
+
             }
             else
             {
@@ -106,6 +126,20 @@ namespace NuGet.Credentials
             }
 
             return taskResponse;
+        }
+
+        private async Task SetPluginLogLevelAsync(PluginCreationResult plugin, ILogger logger, CancellationToken cancellationToken)
+        {
+            var logLevel = LogRequestHandler.GetLogLevel(logger);
+
+            await plugin.PluginMulticlientUtilities.DoOncePerPluginLifetimeAsync(
+               MessageMethod.SetLogLevel.ToString(),
+               () => plugin.Plugin.Connection.SendRequestAndReceiveResponseAsync<SetLogLevelRequest, SetLogLevelResponse>(
+                MessageMethod.SetLogLevel,
+                new SetLogLevelRequest(logLevel),
+                cancellationToken)
+                ,
+               cancellationToken);
         }
 
         private void AddOrUpdateLogger(IPlugin plugin)

--- a/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
@@ -132,13 +132,12 @@ namespace NuGet.Credentials
             var logLevel = LogRequestHandler.GetLogLevel(logger);
 
             await plugin.PluginMulticlientUtilities.DoOncePerPluginLifetimeAsync(
-               MessageMethod.SetLogLevel.ToString(),
-               () => plugin.Plugin.Connection.SendRequestAndReceiveResponseAsync<SetLogLevelRequest, SetLogLevelResponse>(
-                MessageMethod.SetLogLevel,
-                new SetLogLevelRequest(logLevel),
-                cancellationToken)
-                ,
-               cancellationToken);
+                MessageMethod.SetLogLevel.ToString(),
+                () => plugin.Plugin.Connection.SendRequestAndReceiveResponseAsync<SetLogLevelRequest, SetLogLevelResponse>(
+                    MessageMethod.SetLogLevel,
+                    new SetLogLevelRequest(logLevel),
+                    cancellationToken),
+                cancellationToken);
         }
 
         private void AddOrUpdateLogger(IPlugin plugin)

--- a/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
@@ -114,7 +114,7 @@ namespace NuGet.Credentials
                         string.Format(
                                 CultureInfo.CurrentCulture,
                                 Resources.SecurePluginWarning_UseInteractiveOption,
-                                "Interactive"));
+                                "--interactive or NuGetInteractive=true"));
                 }
 
                 taskResponse = GetAuthenticationCredentialsResponseToCredentialResponse(credentialResponse);

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -118,7 +118,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       RestoreIgnoreFailedSources="$(RestoreIgnoreFailedSources)"
       RestoreRecursive="$(RestoreRecursive)"
       RestoreForce="$(RestoreForce)"
-      HideWarningsAndErrors="$(HideWarningsAndErrors)"/>
+      HideWarningsAndErrors="$(HideWarningsAndErrors)"
+      NuGetInteractive="$(NuGetInteractive)"/>
   </Target>
 
   <!--

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -119,7 +119,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       RestoreRecursive="$(RestoreRecursive)"
       RestoreForce="$(RestoreForce)"
       HideWarningsAndErrors="$(HideWarningsAndErrors)"
-      NuGetInteractive="$(NuGetInteractive)"/>
+      Interactive="$(NuGetInteractive)"/>
   </Target>
 
   <!--

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -12,6 +12,7 @@ using Newtonsoft.Json;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.Credentials;
 using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -61,12 +62,17 @@ namespace NuGet.Build.Tasks
         /// Force restore, skip no op
         /// </summary>
         public bool RestoreForce { get; set; }
-        
+
         /// <summary>
         /// Do not display Errors and Warnings to the user. 
         /// The Warnings and Errors are written into the assets file and will be read by an sdk target.
         /// </summary>
         public bool HideWarningsAndErrors { get; set; }
+
+        /// <summary>
+        /// Set this property if you want to get an interactive restore
+        /// </summary>
+        public bool NuGetInteractive { get; set; }
 
         public override bool Execute()
         {
@@ -161,6 +167,8 @@ namespace NuGet.Build.Tasks
                     HttpSourceResourceProvider.Throttle = SemaphoreSlimThrottle.CreateBinarySemaphore();
                 }
 
+                DefaultCredentialServiceUtility.SetupDefaultCredentialService(log, !NuGetInteractive);
+
                 _cts.Token.ThrowIfCancellationRequested();
 
                 var restoreSummaries = await RestoreRunner.RunAsync(restoreContext, _cts.Token);
@@ -171,7 +179,6 @@ namespace NuGet.Build.Tasks
                 return restoreSummaries.All(x => x.Success);
             }
         }
-
         private static void ConfigureProtocol()
         {
             // Set connection limit

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -72,7 +72,7 @@ namespace NuGet.Build.Tasks
         /// <summary>
         /// Set this property if you want to get an interactive restore
         /// </summary>
-        public bool NuGetInteractive { get; set; }
+        public bool Interactive { get; set; }
 
         public override bool Execute()
         {
@@ -167,7 +167,7 @@ namespace NuGet.Build.Tasks
                     HttpSourceResourceProvider.Throttle = SemaphoreSlimThrottle.CreateBinarySemaphore();
                 }
 
-                DefaultCredentialServiceUtility.SetupDefaultCredentialService(log, !NuGetInteractive);
+                DefaultCredentialServiceUtility.SetupDefaultCredentialService(log, !Interactive);
 
                 _cts.Token.ThrowIfCancellationRequested();
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommand.cs
@@ -66,6 +66,11 @@ namespace NuGet.CommandLine.XPlat
                     Strings.AddPkg_PackageDirectoryDescription,
                     CommandOptionType.SingleValue);
 
+                var interactive = addpkg.Option(
+                    "--interactive",
+                    Strings.AddPkg_InteractiveDescription,
+                    CommandOptionType.NoValue);
+
                 addpkg.OnExecute(() =>
                 {
                     ValidateArgument(id, addpkg.Name);
@@ -86,7 +91,8 @@ namespace NuGet.CommandLine.XPlat
                         PackageDirectory = packageDirectory.Value(),
                         NoRestore = noRestore.HasValue(),
                         NoVersion = noVersion,
-                        DgFilePath = dgFilePath.Value()
+                        DgFilePath = dgFilePath.Value(),
+                        Interactive = interactive.HasValue()
                     };
                     var msBuild = new MSBuildAPIUtility(logger);
                     var addPackageRefCommandRunner = getCommandRunner();

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -10,10 +10,10 @@ using System.Threading.Tasks;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.Credentials;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Packaging;
-using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -291,6 +291,9 @@ namespace NuGet.CommandLine.XPlat
 
                 // Generate Restore Requests. There will always be 1 request here since we are restoring for 1 project.
                 var restoreRequests = await RestoreRunner.GetRequests(restoreContext);
+
+                //Setup the Credential Service
+                DefaultCredentialServiceUtility.SetupDefaultCredentialService(restoreContext.Log, packageReferenceArgs.Interactive);
 
                 // Run restore without commit. This will always return 1 Result pair since we are restoring for 1 request.
                 var restoreResult = await RestoreRunner.RunWithoutCommit(restoreRequests, restoreContext);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/PackageReferenceArgs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/PackageReferenceArgs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -20,6 +20,8 @@ namespace NuGet.CommandLine.XPlat
         public string[] Sources { get; set; }
         public string PackageDirectory { get; set; }
         public bool NoRestore { get; set; }
+
+        public bool Interactive { get; set; }
 
         public PackageReferenceArgs(string projectPath, PackageDependency packageDependency, ILogger logger, bool noVersion)
         {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -98,6 +98,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allow manual user action for operations like authentication..
+        /// </summary>
+        internal static string AddPkg_InteractiveDescription {
+            get {
+                return ResourceManager.GetString("AddPkg_InteractiveDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Do not perform restore preview and compatibility check. The added package reference will be unconditional..
         /// </summary>
         internal static string AddPkg_NoRestoreDescription {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -98,7 +98,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Allow manual user action for operations like authentication..
+        ///   Looks up a localized string similar to Allow the command to block and require manual action for operations like authentication..
         /// </summary>
         internal static string AddPkg_InteractiveDescription {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -471,4 +471,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="NoServiceEndpoint_Description" xml:space="preserve">
     <value>--no-service-endpoint does not append "api/v2/packages" to the source URL.</value>
   </data>
+  <data name="AddPkg_InteractiveDescription" xml:space="preserve">
+    <value>Allow manual user action for operations like authentication.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -472,6 +472,6 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>--no-service-endpoint does not append "api/v2/packages" to the source URL.</value>
   </data>
   <data name="AddPkg_InteractiveDescription" xml:space="preserve">
-    <value>Allow manual user action for operations like authentication.</value>
+    <value>Allow the command to block and require manual action for operations like authentication.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -10,11 +10,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
-using NuGet.Configuration;
-using NuGet.Credentials;
 using NuGet.ProjectModel;
-using NuGet.Protocol;
-using NuGet.Protocol.Core.Types;
 
 namespace NuGet.Commands
 {
@@ -44,33 +40,6 @@ namespace NuGet.Commands
             return await RunAsync(restoreContext, CancellationToken.None);
         }
 
-        private static void SetDefaultCredentialProvider(ILogger logger)
-        {
-            if (HttpHandlerResourceV3.CredentialService == null)
-            {
-                var providers = new AsyncLazy<IEnumerable<ICredentialProvider>>( async () =>  await GetCredentialProvidersAsync(logger));
-                HttpHandlerResourceV3.CredentialService = new Lazy<ICredentialService>(() => new CredentialService(providers, nonInteractive: false, handlesDefaultCredentials: PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders));
-            }
-        }
-
-        // Add only the secure plugin. This will be done when there's nothing set
-        private static async Task<IEnumerable<ICredentialProvider>> GetCredentialProvidersAsync(ILogger logger)
-        {
-            var providers = new List<ICredentialProvider>();
-
-            var securePluginProviders = await (new SecureCredentialProviderBuilder(PluginManager.Instance, logger)).BuildAll();
-            providers.AddRange(securePluginProviders);
-
-            if (securePluginProviders.Any())
-            {
-                if (PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders)
-                {
-                    providers.Add(new DefaultCredentialsCredentialProvider());
-                }
-            }
-            return providers;
-        }
-
         /// <summary>
         /// Execute and commit restore requests.
         /// </summary>
@@ -80,8 +49,6 @@ namespace NuGet.Commands
             CancellationToken token)
         {
             var maxTasks = GetMaxTaskCount(restoreContext);
-
-            SetDefaultCredentialProvider(restoreContext.Log);
 
             var log = restoreContext.Log;
 
@@ -137,8 +104,6 @@ namespace NuGet.Commands
             RestoreArgs restoreContext)
         {
             var maxTasks = GetMaxTaskCount(restoreContext);
-
-            SetDefaultCredentialProvider(restoreContext.Log);
 
             var log = restoreContext.Log;
 

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -93,6 +93,7 @@ namespace NuGet.Protocol
                 if (response.StatusCode == HttpStatusCode.Unauthorized ||
                     (configuration.PromptOn403 && response.StatusCode == HttpStatusCode.Forbidden))
                 {
+                    // Why is this null
                     promptCredentials = await AcquireCredentialsAsync(
                         response.StatusCode,
                         beforeLockVersion,

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -93,7 +93,6 @@ namespace NuGet.Protocol
                 if (response.StatusCode == HttpStatusCode.Unauthorized ||
                     (configuration.PromptOn403 && response.StatusCode == HttpStatusCode.Forbidden))
                 {
-                    // Why is this null
                     promptCredentials = await AcquireCredentialsAsync(
                         response.StatusCode,
                         beforeLockVersion,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/EmbeddedSignatureVerifier.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/EmbeddedSignatureVerifier.cs
@@ -32,7 +32,7 @@ namespace NuGet.Protocol.Plugins
                 return new WindowsEmbeddedSignatureVerifier();
             }
 
-            if(RuntimeEnvironmentHelper.IsLinux || RuntimeEnvironmentHelper.IsMacOSX)
+            if (RuntimeEnvironmentHelper.IsLinux || RuntimeEnvironmentHelper.IsMacOSX)
             {
                 return new UnixPlatformsEmbeddedSignatureVerifier();
             }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/EmbeddedSignatureVerifier.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/EmbeddedSignatureVerifier.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -30,6 +30,11 @@ namespace NuGet.Protocol.Plugins
             if (RuntimeEnvironmentHelper.IsWindows)
             {
                 return new WindowsEmbeddedSignatureVerifier();
+            }
+
+            if(RuntimeEnvironmentHelper.IsLinux || RuntimeEnvironmentHelper.IsMacOSX)
+            {
+                return new UnixPlatformsEmbeddedSignatureVerifier();
             }
 
             return new FallbackEmbeddedSignatureVerifier();

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
@@ -179,8 +179,6 @@ namespace NuGet.Protocol.Core.Types
 
                 var utilities = await PerformOneTimePluginInitializationAsync(plugin, cancellationToken);
 
-                plugin.Connection.ProtocolVersion.Equals(Plugins.ProtocolConstants.CurrentVersion);
-
                 var lazyOperationClaims = _pluginOperationClaims.GetOrAdd(
                         requestKey,
                         key => new Lazy<Task<IReadOnlyList<OperationClaim>>>(() =>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/UnixPlatformsEmbeddedSignatureVerifier.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/UnixPlatformsEmbeddedSignatureVerifier.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace NuGet.Protocol.Plugins
+{
+    /// <summary>
+    /// Embedded Signature Verifier for the MacOS and Linux platforms.
+    /// </summary>
+    public class UnixPlatformsEmbeddedSignatureVerifier : EmbeddedSignatureVerifier
+    {
+        /// <summary>
+        /// Checks if a file has a valid embedded signature.
+        /// </summary>
+        /// <param name="filePath">The path of a file to be checked.</param>
+        /// <returns><c>true</c> if the file has a valid signature; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="filePath" />
+        /// is either <c>null</c> or an empty string.</exception>
+        /// <exception cref="PlatformNotSupportedException">Thrown if the current platform is unsupported.</exception>
+        public override bool IsValid(string filePath)
+        {
+            // There's no embedded signature verification on Linux and MacOS platforms
+            return true;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/UnixPlatformsEmbeddedSignatureVerifier.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/UnixPlatformsEmbeddedSignatureVerifier.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace NuGet.Protocol.Plugins

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/UnixPlatformsEmbeddedSignatureVerifier.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/UnixPlatformsEmbeddedSignatureVerifier.cs
@@ -20,6 +20,10 @@ namespace NuGet.Protocol.Plugins
         /// <exception cref="PlatformNotSupportedException">Thrown if the current platform is unsupported.</exception>
         public override bool IsValid(string filePath)
         {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                throw new ArgumentException(nameof(filePath));
+            }
             // There's no embedded signature verification on Linux and MacOS platforms
             return true;
         }

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/PluginManagerMock.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/PluginManagerMock.cs
@@ -108,6 +108,15 @@ namespace NuGet.Credentials.Test
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new GetOperationClaimsResponse(expectations.OperationClaims.ToArray()));
 
+            if (_expectations.Success)
+            {
+                _connection.Setup(x => x.SendRequestAndReceiveResponseAsync<SetLogLevelRequest, SetLogLevelResponse>(
+                        It.Is<MessageMethod>(m => m == MessageMethod.SetLogLevel),
+                        It.IsAny<SetLogLevelRequest>(),
+                        It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new SetLogLevelResponse(MessageResponseCode.Success));
+            }
+
             if (expectations.ProxyUsername != null && expectations.ProxyPassword != null)
             {
                 _connection.Setup(x => x.SendRequestAndReceiveResponseAsync<SetCredentialsRequest, SetCredentialsResponse>(
@@ -145,6 +154,15 @@ namespace NuGet.Credentials.Test
                 It.Is<GetOperationClaimsRequest>(
                     g => g.PackageSourceRepository == null), // The source repository should be null in the context of credential plugins
                 It.IsAny<CancellationToken>()), Times.Once());
+
+            if (_expectations.Success)
+            {
+                _connection.Verify(x => x.SendRequestAndReceiveResponseAsync<SetLogLevelRequest, SetLogLevelResponse>(
+                        It.Is<MessageMethod>(m => m == MessageMethod.SetLogLevel),
+                        It.IsAny<SetLogLevelRequest>(),
+                        It.IsAny<CancellationToken>()),
+                    Times.Once()); // The log level should be set once!
+            }
 
             if (_expectations.Success)
             {

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderTests.cs
@@ -98,7 +98,6 @@ namespace NuGet.Credentials.Test
             }
         }
 
-
         [PlatformFact(Platform.Windows)]
         public void TryCreate_DoesNotCreateNonCredentialsPluginTwice()
         {

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -31,20 +31,21 @@ namespace NuGet.XPlat.FuncTest
         // Argument parsing related tests
 
         [Theory]
-        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "--dg-file", "dgfile_foo", "--project", "project_foo.csproj", "", "", "", "", "", "", "")]
-        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "", "", "", "", "", "", "")]
-        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "--framework", "net46;netcoreapp1.0", "", "", "", "", "")]
-        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "-f", "net46 ; netcoreapp1.0 ; ", "", "", "", "", "")]
-        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "-f", "net46", "", "", "", "", "")]
-        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "", "", "--source", "a;b", "", "", "")]
-        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "", "", "-s", "a ; b ;", "", "", "")]
-        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "", "", "-s", "a", "", "", "")]
-        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "", "", "", "", "--package-directory", @"foo\dir", "")]
-        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "", "", "", "", "", "", "--no-restore")]
-        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "", "", "", "", "", "", "-n")]
+        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "--dg-file", "dgfile_foo", "--project", "project_foo.csproj", "", "", "", "", "", "", "", "")]
+        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "", "", "", "", "", "", "", "")]
+        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "--framework", "net46;netcoreapp1.0", "", "", "", "", "", "")]
+        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "-f", "net46 ; netcoreapp1.0 ; ", "", "", "", "", "", "")]
+        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "-f", "net46", "", "", "", "", "", "")]
+        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "", "", "--source", "a;b", "", "", "", "")]
+        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "", "", "-s", "a ; b ;", "", "", "", "")]
+        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "", "", "-s", "a", "", "", "", "")]
+        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "", "", "", "", "--package-directory", @"foo\dir", "", "")]
+        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "", "", "", "", "", "", "--no-restore", "")]
+        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "", "", "", "", "", "", "-n", "")]
+        [InlineData("--package", "package_foo", "--version", "1.0.0-foo", "-d", "dgfile_foo", "-p", "project_foo.csproj", "", "", "", "", "", "", "-n", "--interactive")]
         public void AddPkg_ArgParsing(string packageOption, string package, string versionOption, string version, string dgFileOption,
         string dgFilePath, string projectOption, string project, string frameworkOption, string frameworkString, string sourceOption,
-        string sourceString, string packageDirectoryOption, string packageDirectory, string noRestoreSwitch)
+        string sourceString, string packageDirectoryOption, string packageDirectory, string noRestoreSwitch, string interactiveSwitch)
         {
             // Arrange
             var projectPath = Path.Combine(Path.GetTempPath(), project);
@@ -88,6 +89,10 @@ namespace NuGet.XPlat.FuncTest
             if (!string.IsNullOrEmpty(noRestoreSwitch))
             {
                 argList.Add(noRestoreSwitch);
+            }
+            if (!string.IsNullOrEmpty(interactiveSwitch))
+            {
+                argList.Add(interactiveSwitch);
             }
 
             var logger = new TestCommandOutputLogger();

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/EmbeddedSignatureVerifierTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/EmbeddedSignatureVerifierTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Test.Utility;
@@ -17,19 +17,19 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
         [PlatformFact(Platform.Darwin)]
-        public void Create_ReturnsFallbackEmbeddedSignatureVerifierOnMacOS()
+        public void Create_ReturnsUnixPlatformsEmbeddedSignatureVerifierOnMacOS()
         {
             var verifier = EmbeddedSignatureVerifier.Create();
 
-            Assert.IsType<FallbackEmbeddedSignatureVerifier>(verifier);
+            Assert.IsType<UnixPlatformsEmbeddedSignatureVerifier>(verifier);
         }
 
         [PlatformFact(Platform.Linux)]
-        public void Create_ReturnsFallbackEmbeddedSignatureVerifierOnLinux()
+        public void Create_ReturnsUnixPlatformsEmbeddedSignatureVerifierOnLinux()
         {
             var verifier = EmbeddedSignatureVerifier.Create();
 
-            Assert.IsType<FallbackEmbeddedSignatureVerifier>(verifier);
+            Assert.IsType<UnixPlatformsEmbeddedSignatureVerifier>(verifier);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryResultTests.cs
@@ -26,6 +26,5 @@ namespace NuGet.Protocol.Plugins.Tests
 
             Assert.Same(pluginFile, result.PluginFile);
         }
-        // TODO NK - Add message tests
     }
 }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6956, https://github.com/NuGet/Home/issues/7017
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
There's a bunch of things going on here. 

- Moved the credentialservice setup from RestoreRunner to RestoreTask as it should be the application that sets that up. 
- Added the CredentialService initialization in the add package command.
- Extracted the common logic for the CredentialService setup
- Added logging when plugin is not succesfully validated, and blocked authentication completely in that case.
- Add an interactive flag in both the restore task and addpkgref command
- Added a log message indicating that the user should consider running with an interactive switch/property when the provider cannot provide credentials
- Set the log level to the plugin to minimize the log messages count
- Added a permissive unix platforms embedded signature verifier on linux and mac. 
In the short term, we won't be validating there.

## Testing/Validation
Tests Added: Yes  
Reason for not adding tests:  
Validation done:  Yes, manual and tests

//cc @livarcocc @kathleendollard @jeffkl @dsplaisted 
