### PR TITLE
Switching to UI thread before calling MenuCommandService AddCommand api

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -224,6 +224,10 @@ namespace NuGetVSExtension
             _mcs = await GetServiceAsync(typeof(IMenuCommandService)) as OleMenuCommandService;
             if (null != _mcs)
             {
+                // Switch to Main Thread before calling AddCommand which calls GetService() which should
+                // always be called on UI thread.
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
                 // menu command for upgrading packages.config files to PackageReference - References context menu
                 var upgradeNuGetProjectCommandID = new CommandID(GuidList.guidNuGetDialogCmdSet, PkgCmdIDList.cmdidUpgradeNuGetProject);
                 var upgradeNuGetProjectCommand = new OleMenuCommand(ExecuteUpgradeNuGetProjectCommandAsync, null,


### PR DESCRIPTION
After we changed to load our NuGetPackage asynchronously, it started calling AddCommand api from MenuCommandService on BG thread which throws InvalidOperationException because it then tries to call GetService() from BG thread.

Although the complete fix would be to make MenuCommandService more async and add AddCommandAsync api or make AddCommand call GetServiceAsync instead of GetService but that'd be a much bigger design change and had to be driven from .net framework itself. So for now, we're making sure to explicitly switching to UI thread before calling AddCommand api which will resolve throwing InvalidOperationException and allow us to still load NuGetPackage on BG thread.

Fixes - "The 'NuGetPackage' package did not load correctly" error when doing some NuGet operations [619491](https://devdiv.visualstudio.com/DevDiv/NuGet/_workitems/edit/619491)

@rrelyea 