### PR TITLE
Adding Verbose logs for package signature verification

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -1004,21 +1004,24 @@ namespace NuGet.Packaging
                        token,
                        parentId);
 
-                await LogPackageSignatureVerificationAsync(source, package, packageExtractionContext.Logger, verifyResult);
-
-                if (verifyResult.Valid)
+                if (verifyResult.Signed)
                 {
-                    // log any warnings
-                    var warnings = verifyResult.Results.SelectMany(r => r.GetWarningIssues());
+                    await LogPackageSignatureVerificationAsync(source, package, packageExtractionContext.Logger, verifyResult);
 
-                    foreach (var warning in warnings)
+                    if (verifyResult.Valid)
                     {
-                        await packageExtractionContext.Logger.LogAsync(warning);
+                        // log any warnings
+                        var warnings = verifyResult.Results.SelectMany(r => r.GetWarningIssues());
+
+                        foreach (var warning in warnings)
+                        {
+                            await packageExtractionContext.Logger.LogAsync(warning);
+                        }
                     }
-                }
-                else
-                {
-                    throw new SignatureException(verifyResult.Results, package);
+                    else
+                    {
+                        throw new SignatureException(verifyResult.Results, package);
+                    }
                 }
             }
         }
@@ -1031,7 +1034,7 @@ namespace NuGet.Packaging
         {
             await logger.LogAsync(
                 LogLevel.Verbose,
-                string.Format(CultureInfo.CurrentCulture, Strings.PackageSignatureVerificationLog, Environment.NewLine, package, source, verifyResult.Valid));
+                string.Format(CultureInfo.CurrentCulture, Strings.PackageSignatureVerificationLog, package, source, verifyResult.Valid));
         }
 
         private static RepositorySignatureInfo GetRepositorySignatureInfo(string source)

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -1004,6 +1004,8 @@ namespace NuGet.Packaging
                        token,
                        parentId);
 
+                await LogPackageSignatureVerificationAsync(source, package, packageExtractionContext.Logger, verifyResult);
+
                 if (verifyResult.Valid)
                 {
                     // log any warnings
@@ -1011,7 +1013,7 @@ namespace NuGet.Packaging
 
                     foreach (var warning in warnings)
                     {
-                        packageExtractionContext.Logger.Log(warning);
+                        await packageExtractionContext.Logger.LogAsync(warning);
                     }
                 }
                 else
@@ -1019,6 +1021,17 @@ namespace NuGet.Packaging
                     throw new SignatureException(verifyResult.Results, package);
                 }
             }
+        }
+
+        private static async Task LogPackageSignatureVerificationAsync(
+            string source,
+            PackageIdentity package,
+            ILogger logger,
+            VerifySignaturesResult verifyResult)
+        {
+            await logger.LogAsync(
+                LogLevel.Verbose,
+                string.Format(CultureInfo.CurrentCulture, Strings.PackageSignatureVerificationLog, Environment.NewLine, package, source, verifyResult.Valid));
         }
 
         private static RepositorySignatureInfo GetRepositorySignatureInfo(string source)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/PackageSignatureVerifier.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/PackageSignatureVerifier.cs
@@ -98,7 +98,7 @@ namespace NuGet.Packaging.Signing
                 var status = valid ? NuGetOperationStatus.Succeeded : NuGetOperationStatus.Failed;
                 telemetry.TelemetryEvent = new PackageSigningTelemetryEvent(isSigned ? PackageSignType.Signed : PackageSignType.Unsigned, status);
 
-                return new VerifySignaturesResult(valid, trustResults);
+                return new VerifySignaturesResult(valid, isSigned, trustResults);
             }
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/VerifySignaturesResult.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/VerifySignaturesResult.cs
@@ -18,18 +18,24 @@ namespace NuGet.Packaging.Signing
         public bool Valid { get; }
 
         /// <summary>
+        /// True if the package is signed.
+        /// </summary>
+        public bool Signed { get; }
+
+        /// <summary>
         /// Individual trust results.
         /// </summary>
         public IReadOnlyList<PackageVerificationResult> Results { get; }
 
-        public VerifySignaturesResult(bool valid)
-            : this(valid, results: Enumerable.Empty<PackageVerificationResult>())
+        public VerifySignaturesResult(bool valid, bool signed)
+            : this(valid, signed, results: Enumerable.Empty<PackageVerificationResult>())
         {
         }
 
-        public VerifySignaturesResult(bool valid, IEnumerable<PackageVerificationResult> results)
+        public VerifySignaturesResult(bool valid, bool signed, IEnumerable<PackageVerificationResult> results)
         {
             Valid = valid;
+            Signed = signed;
             Results = results?.ToList().AsReadOnly() ?? throw new ArgumentNullException(nameof(results));
         }
     }

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -782,6 +782,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to PackageSignatureVerificationLog:{0}PackageIdentitiy: {1}{0}Source: {2}{0}Valid: {3}.
+        /// </summary>
+        internal static string PackageSignatureVerificationLog {
+            get {
+                return ResourceManager.GetString("PackageSignatureVerificationLog", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Packages node does not exists in packages.config at {0}..
         /// </summary>
         internal static string PackagesNodeNotExist {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -782,7 +782,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to PackageSignatureVerificationLog:{0}PackageIdentity: {1}{0}Source: {2}{0}PackageSignatureValidity: {3}.
+        ///   Looks up a localized string similar to PackageSignatureVerificationLog: PackageIdentity: {0} Source: {1} PackageSignatureValidity: {2}.
         /// </summary>
         internal static string PackageSignatureVerificationLog {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -782,7 +782,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to PackageSignatureVerificationLog:{0}PackageIdentitiy: {1}{0}Source: {2}{0}Valid: {3}.
+        ///   Looks up a localized string similar to PackageSignatureVerificationLog:{0}PackageIdentity: {1}{0}Source: {2}{0}PackageSignatureValidity: {3}.
         /// </summary>
         internal static string PackageSignatureVerificationLog {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -689,10 +689,9 @@ Valid from:</comment>
     <comment>{0} and {1} are parameter names</comment>
   </data>
   <data name="PackageSignatureVerificationLog" xml:space="preserve">
-    <value>PackageSignatureVerificationLog:{0}PackageIdentity: {1}{0}Source: {2}{0}PackageSignatureValidity: {3}</value>
-    <comment>0 - line separator
-1 - package id and version
-2 - package source url
-3 - validation result as a bool</comment>
+    <value>PackageSignatureVerificationLog: PackageIdentity: {0} Source: {1} PackageSignatureValidity: {2}</value>
+    <comment>0 - package id and version
+1 - package source url
+2 - validation result as a bool</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -688,4 +688,11 @@ Valid from:</comment>
     <value>Invalid combination of arguments {0} and {1}.</value>
     <comment>{0} and {1} are parameter names</comment>
   </data>
+  <data name="PackageSignatureVerificationLog" xml:space="preserve">
+    <value>PackageSignatureVerificationLog:{0}PackageIdentitiy: {1}{0}Source: {2}{0}Valid: {3}</value>
+    <comment>0 - line separator
+1 - package id and version
+2 - package source url
+3 - validarion result as a bool</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -689,10 +689,10 @@ Valid from:</comment>
     <comment>{0} and {1} are parameter names</comment>
   </data>
   <data name="PackageSignatureVerificationLog" xml:space="preserve">
-    <value>PackageSignatureVerificationLog:{0}PackageIdentitiy: {1}{0}Source: {2}{0}Valid: {3}</value>
+    <value>PackageSignatureVerificationLog:{0}PackageIdentity: {1}{0}Source: {2}{0}PackageSignatureValidity: {3}</value>
     <comment>0 - line separator
 1 - package id and version
 2 - package source url
-3 - validarion result as a bool</comment>
+3 - validation result as a bool</comment>
   </data>
 </root>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/OriginalCaseGlobalPackageFolderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/OriginalCaseGlobalPackageFolderTests.cs
@@ -15,6 +15,7 @@ using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
+using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -55,7 +56,7 @@ namespace NuGet.Commands.Test
 
                 // Assert
                 Assert.True(File.Exists(resolver.GetPackageFilePath(identity.Id, identity.Version)));
-                Assert.Equal(2, logger.Messages.Count(x => x.Contains(identity.ToString())));
+                Assert.Equal(1, logger.Messages.Count(x => x.Contains(identity.ToString())));
             }
         }
 
@@ -96,7 +97,7 @@ namespace NuGet.Commands.Test
                 // Assert
                 Assert.False(File.Exists(resolver.GetPackageFilePath(identityA.Id, identityA.Version)));
                 Assert.True(File.Exists(resolver.GetPackageFilePath(identityB.Id, identityB.Version)));
-                Assert.Equal(2, logger.Messages.Count(x => x.Contains(identityB.ToString())));
+                Assert.Equal(1, logger.Messages.Count(x => x.Contains(identityB.ToString())));
             }
         }
 
@@ -171,7 +172,7 @@ namespace NuGet.Commands.Test
 
                 // Assert
                 Assert.True(File.Exists(resolver.GetPackageFilePath(identity.Id, identity.Version)));
-                Assert.Equal(2, logger.Messages.Count(x => x.Contains(identity.ToString())));
+                Assert.Equal(1, logger.Messages.Count(x => x.Contains(identity.ToString())));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/OriginalCaseGlobalPackageFolderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/OriginalCaseGlobalPackageFolderTests.cs
@@ -15,7 +15,6 @@ using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
-using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -56,7 +55,7 @@ namespace NuGet.Commands.Test
 
                 // Assert
                 Assert.True(File.Exists(resolver.GetPackageFilePath(identity.Id, identity.Version)));
-                Assert.Equal(1, logger.Messages.Count(x => x.Contains(identity.ToString())));
+                Assert.Equal(2, logger.Messages.Count(x => x.Contains(identity.ToString())));
             }
         }
 
@@ -97,7 +96,7 @@ namespace NuGet.Commands.Test
                 // Assert
                 Assert.False(File.Exists(resolver.GetPackageFilePath(identityA.Id, identityA.Version)));
                 Assert.True(File.Exists(resolver.GetPackageFilePath(identityB.Id, identityB.Version)));
-                Assert.Equal(1, logger.Messages.Count(x => x.Contains(identityB.ToString())));
+                Assert.Equal(2, logger.Messages.Count(x => x.Contains(identityB.ToString())));
             }
         }
 
@@ -172,7 +171,7 @@ namespace NuGet.Commands.Test
 
                 // Assert
                 Assert.True(File.Exists(resolver.GetPackageFilePath(identity.Id, identity.Version)));
-                Assert.Equal(1, logger.Messages.Count(x => x.Contains(identity.ToString())));
+                Assert.Equal(2, logger.Messages.Count(x => x.Contains(identity.ToString())));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1015,7 +1015,7 @@ namespace NuGet.Commands.Test
                     It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, _defaultSettings)),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(false));
+                    ReturnsAsync(new VerifySignaturesResult(valid: false, signed: true));
 
                 var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger)
                 {
@@ -1084,7 +1084,7 @@ namespace NuGet.Commands.Test
                     It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, _defaultSettings)),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(true));
+                    ReturnsAsync(new VerifySignaturesResult(valid: true, signed: true));
 
                 var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger)
                 {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -2043,7 +2043,7 @@ namespace NuGet.Packaging.Test
                     It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, signedPackageVerifierSettings)),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(true));
+                    ReturnsAsync(new VerifySignaturesResult(valid: true, signed: true));
 
                 var packageFileInfo = await SimpleTestPackageUtility.CreateFullPackageAsync(root, nupkg);
 
@@ -2095,7 +2095,7 @@ namespace NuGet.Packaging.Test
                     It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, signedPackageVerifierSettings)),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(false));
+                    ReturnsAsync(new VerifySignaturesResult(valid: false, signed: true));
 
                 var identity = new PackageIdentity("A", new NuGetVersion("1.0.0"));
 
@@ -2148,7 +2148,7 @@ namespace NuGet.Packaging.Test
                     It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, signedPackageVerifierSettings)),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(false));
+                    ReturnsAsync(new VerifySignaturesResult(valid: false, signed: true));
 
                 var packageFileInfo = await SimpleTestPackageUtility.CreateFullPackageAsync(root, nupkg);
 
@@ -2199,7 +2199,7 @@ namespace NuGet.Packaging.Test
                     It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, signedPackageVerifierSettings)),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(true));
+                    ReturnsAsync(new VerifySignaturesResult(valid: true, signed: true));
 
                 var packageFileInfo = await SimpleTestPackageUtility.CreateFullPackageAsync(root, nupkg);
 
@@ -2247,7 +2247,7 @@ namespace NuGet.Packaging.Test
                     It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, signedPackageVerifierSettings)),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(false));
+                    ReturnsAsync(new VerifySignaturesResult(valid: false, signed: true));
 
                 var packageFileInfo = await SimpleTestPackageUtility.CreateFullPackageAsync(root, nupkg);
 
@@ -2295,7 +2295,7 @@ namespace NuGet.Packaging.Test
                     It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, signedPackageVerifierSettings)),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(false));
+                    ReturnsAsync(new VerifySignaturesResult(valid: false, signed: true));
 
                 var packageFileInfo = await SimpleTestPackageUtility.CreateFullPackageAsync(root, nupkg);
 
@@ -2346,7 +2346,7 @@ namespace NuGet.Packaging.Test
                     It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, signedPackageVerifierSettings)),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(true));
+                    ReturnsAsync(new VerifySignaturesResult(valid: true, signed: true));
 
                 var resolver = new PackagePathResolver(root);
                 var identity = new PackageIdentity("A", new NuGetVersion("1.0.0"));
@@ -2394,7 +2394,7 @@ namespace NuGet.Packaging.Test
                     It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, signedPackageVerifierSettings)),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(false));
+                    ReturnsAsync(new VerifySignaturesResult(valid: false, signed: true));
 
                 var resolver = new PackagePathResolver(root);
                 var identity = new PackageIdentity("A", new NuGetVersion("1.0.0"));
@@ -2438,7 +2438,7 @@ namespace NuGet.Packaging.Test
                     It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, signedPackageVerifierSettings)),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(true));
+                    ReturnsAsync(new VerifySignaturesResult(valid: true, signed: true));
 
                 var resolver = new PackagePathResolver(root);
                 var identity = new PackageIdentity("A", new NuGetVersion("1.0.0"));
@@ -2486,7 +2486,7 @@ namespace NuGet.Packaging.Test
                     It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, signedPackageVerifierSettings)),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(false));
+                    ReturnsAsync(new VerifySignaturesResult(valid: false, signed: true));
 
                 var resolver = new PackagePathResolver(root);
                 var identity = new PackageIdentity("A", new NuGetVersion("1.0.0"));
@@ -2530,7 +2530,7 @@ namespace NuGet.Packaging.Test
                     It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, signedPackageVerifierSettings)),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(true));
+                    ReturnsAsync(new VerifySignaturesResult(valid: true, signed: true));
 
                 var resolver = new PackagePathResolver(root);
                 var identity = new PackageIdentity("A", new NuGetVersion("1.0.0"));
@@ -2579,7 +2579,7 @@ namespace NuGet.Packaging.Test
                     It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, signedPackageVerifierSettings)),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(false));
+                    ReturnsAsync(new VerifySignaturesResult(valid: false, signed: true));
 
                 var resolver = new PackagePathResolver(root);
                 var identity = new PackageIdentity("A", new NuGetVersion("1.0.0"));
@@ -2627,7 +2627,7 @@ namespace NuGet.Packaging.Test
                     It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, signedPackageVerifierSettings)),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(true));
+                    ReturnsAsync(new VerifySignaturesResult(valid: true, signed: true));
 
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 using (var packageReader = new PackageArchiveReader(packageStream))
@@ -2676,7 +2676,7 @@ namespace NuGet.Packaging.Test
                     It.IsAny<SignedPackageVerifierSettings>(),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(true));
+                    ReturnsAsync(new VerifySignaturesResult(valid: true, signed: true));
 
                 var repositorySignatureInfoAndAllowList = CreateTestRepositorySignatureInfoAndExpectedAllowList();
                 var repositorySignatureInfo = repositorySignatureInfoAndAllowList.Item1;
@@ -2749,7 +2749,7 @@ namespace NuGet.Packaging.Test
                     It.IsAny<SignedPackageVerifierSettings>(),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(true));
+                    ReturnsAsync(new VerifySignaturesResult(valid: true, signed: true));
 
                 var repositorySignatureInfoAndAllowList = CreateTestRepositorySignatureInfoAndExpectedAllowList();
                 var repositorySignatureInfo = repositorySignatureInfoAndAllowList.Item1;


### PR DESCRIPTION
Adds the following verbose logs for each signed package that is extracted during restore -

`
  PackageSignatureVerificationLog: PackageIdentitiy: <Id>.<Version> Source: <Source> PackageSignatureValidity: <Verification_Result_As_Bool>
`