### PR TITLE
Let narrator announce file conflict dialog text

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FileConflictDialog.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FileConflictDialog.xaml
@@ -1,4 +1,4 @@
-﻿<ui:VsDialogWindow
+<ui:VsDialogWindow
   x:Class="NuGet.PackageManagement.UI.FileConflictDialog"
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -9,6 +9,7 @@
   Background="{DynamicResource {x:Static resx:Brushes.BackgroundBrushKey}}"
   Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
   Title="{x:Static resx:Resources.WindowTitle_FileConflict}"
+  AutomationProperties.LabeledBy="{Binding ElementName=QuestionText}"
   ShowInTaskbar="False"
   WindowStartupLocation="CenterOwner"
   MinHeight="180"
@@ -71,6 +72,7 @@
       DockPanel.Dock="Top"
       Margin="0,3,0,3"
       TextWrapping="Wrap"
-      VerticalAlignment="Top" />
+      VerticalAlignment="Top"
+      AutomationProperties.Name="{Binding Text}"/>
   </DockPanel>
 </ui:VsDialogWindow>


### PR DESCRIPTION
## Bug
Fixes: [Internal 208062](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/208062)

## Fix
Details: Add support for automation API in file conflict dialog to let screen readers announce text on it. This was tested with JAWS and Narrator.