### PR TITLE
fix update package reinstall bug

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -1016,6 +1016,12 @@ namespace NuGet.PackageManagement
                         preferredVersions.Remove(packageId);
                     }
                 }
+                else
+                {
+                    // we return an empty list here because this is trying to update a specific package in a project here which is not even installed in the project.
+                    // Bug: https://github.com/NuGet/Home/issues/737
+                    return new List<NuGetProjectAction>();
+                }
             }
             // We are apply update logic to the complete project - attempting to resolver all updates together
             else

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -1018,9 +1018,10 @@ namespace NuGet.PackageManagement
                 }
                 else
                 {
-                    // we return an empty list here because this is trying to update a specific package in a project here which is not even installed in the project.
+                    // This is the scenario where a specific package is being updated in a project with a -reinstall flag and the -projectname has not been specified.
+                    // In this case, NuGet should bail out if the package does not exist in this project instead of re-installing all packages of the project.
                     // Bug: https://github.com/NuGet/Home/issues/737
-                    return new List<NuGetProjectAction>();
+                    return Enumerable.Empty<NuGetProjectAction>();
                 }
             }
             // We are apply update logic to the complete project - attempting to resolver all updates together


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/737 

Doing an update-package -id <id> -reinstall was causing all packages of all projects in the solution to get reinstalled.