### PR TITLE
Ensure Package ID is logged into assets file for signature errors/warnings

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
@@ -136,7 +136,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                     Log(LogUtility.LogLevelToMessageLevel(LogLevel.Error), ex.AsLogMessage().FormatWithCode());
                 }
 
-                var logMessages = ex.Results.SelectMany(p => p.Issues).Select(p => p.ToLogMessage()).ToList();
+                var logMessages = ex.Results.SelectMany(p => p.Issues).ToList();
 
                 logMessages.ForEach(p => Log(LogUtility.LogLevelToMessageLevel(p.Level), p.FormatWithCode()));
             }
@@ -194,7 +194,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                     Log(LogUtility.LogLevelToMessageLevel(LogLevel.Error), ex.AsLogMessage().FormatWithCode());
                 }
 
-                var logMessages = ex.Results.SelectMany(p => p.Issues).Select(p => p.ToLogMessage()).ToList();
+                var logMessages = ex.Results.SelectMany(p => p.Issues).ToList();
 
                 logMessages.ForEach(p => Log(LogUtility.LogLevelToMessageLevel(p.Level), p.FormatWithCode()));
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
@@ -214,7 +214,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                     Log(LogUtility.LogLevelToMessageLevel(LogLevel.Error), ex.AsLogMessage().FormatWithCode());
                 }
 
-                var logMessages = ex.Results.SelectMany(p => p.Issues).Select(p => p.ToLogMessage()).ToList();
+                var logMessages = ex.Results.SelectMany(p => p.Issues).ToList();
 
                 logMessages.ForEach(p => Log(LogUtility.LogLevelToMessageLevel(p.Level), p.FormatWithCode()));
             }
@@ -261,7 +261,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                     Log(LogUtility.LogLevelToMessageLevel(LogLevel.Error), ex.AsLogMessage().FormatWithCode());
                 }
 
-                var logMessages = ex.Results.SelectMany(p => p.Issues).Select(p => p.ToLogMessage()).ToList();
+                var logMessages = ex.Results.SelectMany(p => p.Issues).ToList();
 
                 logMessages.ForEach(p => Log(LogUtility.LogLevelToMessageLevel(p.Level), p.FormatWithCode()));
             }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -399,7 +399,7 @@ namespace NuGet.SolutionRestoreManager
                     _logger.Log(ex.AsLogMessage());
                 }
 
-                ex.Results.SelectMany(p => p.Issues).ToList().ForEach(p => _logger.Log(p.ToLogMessage()));
+                ex.Results.SelectMany(p => p.Issues).ToList().ForEach(p => _logger.Log(p));
 
                 return;
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/RestoreCollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/RestoreCollectorLogger.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Common;
+using NuGet.Packaging.Signing;
 using NuGet.ProjectModel;
 using NuGet.Shared;
 
@@ -243,14 +244,23 @@ namespace NuGet.Commands
 
         private static IRestoreLogMessage ToRestoreLogMessage(ILogMessage message)
         {
-            var restoreLogMessage = message as IRestoreLogMessage;
-
-            if (restoreLogMessage == null)
+            if (message is IRestoreLogMessage)
             {
-                restoreLogMessage = new RestoreLogMessage(message.Level, message.Code, message.Message);
+                return message as IRestoreLogMessage;
             }
-
-            return restoreLogMessage;
+            else if (message is SignatureLog)
+            {
+                return (message as SignatureLog).AsRestoreLogMessage();
+            }
+            else
+            {
+                return new RestoreLogMessage(message.Level, message.Code, message.Message)
+                {
+                    Time = message.Time,
+                    WarningLevel = message.WarningLevel,
+                    ProjectPath = message.ProjectPath
+                };
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
@@ -310,7 +310,7 @@ namespace NuGet.Commands
                         await _logger.LogAsync(e.AsLogMessage());
                     }
 
-                    await _logger.LogMessagesAsync(e.Results.SelectMany(p => p.Issues).Select(p => p.ToLogMessage()));
+                    await _logger.LogMessagesAsync(e.Results.SelectMany(p => p.Issues));
                     return false;
                 }
             }

--- a/src/NuGet.Core/NuGet.Commands/Utility/Extensions.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/Extensions.cs
@@ -9,6 +9,7 @@ using NuGet.Common;
 using NuGet.DependencyResolver;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.Packaging.Signing;
 using NuGet.ProjectModel;
 
 namespace NuGet.Commands
@@ -72,6 +73,37 @@ namespace NuGet.Commands
                 StartColumnNumber = logMessage.StartColumnNumber,
                 EndLineNumber = logMessage.EndLineNumber,
                 EndColumnNumber = logMessage.EndColumnNumber
+            };
+        }
+
+        /// <summary>
+        /// Converts an LogMessage into a RestoreLogMessage.
+        /// This is needed when an LogMessage needs to be logged and loggers do not have visibility to LogMessage.
+        /// </summary>
+        /// <param name="logMessage">LogMessage to be converted.</param>
+        /// <returns>RestoreLogMessage equivalent to the LogMessage.</returns>
+        public static RestoreLogMessage AsRestoreLogMessage(this LogMessage logMessage)
+        {
+            return new RestoreLogMessage(logMessage.Level, logMessage.Code, logMessage.Message)
+            {
+                ProjectPath = logMessage.ProjectPath,
+                WarningLevel = logMessage.WarningLevel
+            };
+        }
+
+        /// <summary>
+        /// Converts an SignatureLog into a RestoreLogMessage.
+        /// This is needed when an SignatureLog needs to be logged and loggers do not have visibility to SignatureLog.
+        /// </summary>
+        /// <param name="logMessage">SignatureLog to be converted.</param>
+        /// <returns>RestoreLogMessage equivalent to the SignatureLog.</returns>
+        public static RestoreLogMessage AsRestoreLogMessage(this SignatureLog logMessage)
+        {
+            return new RestoreLogMessage(logMessage.Level, logMessage.Code, logMessage.Message)
+            {
+                ProjectPath = logMessage.ProjectPath,
+                WarningLevel = logMessage.WarningLevel,
+                LibraryId = logMessage.LibraryId
             };
         }
     }

--- a/src/NuGet.Core/NuGet.Commands/VerifyCommand/VerifyCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/VerifyCommand/VerifyCommandRunner.cs
@@ -81,7 +81,7 @@ namespace NuGet.Commands
                     packageIdentity.ToString()));
                 logger.LogInformation($"{packagePath}{Environment.NewLine}");
 
-                var logMessages = verificationResult.Results.SelectMany(p => p.Issues).Select(p => p.ToLogMessage()).ToList();
+                var logMessages = verificationResult.Results.SelectMany(p => p.Issues).ToList();
                 await logger.LogMessagesAsync(logMessages);
 
                 if (logMessages.Any(m => m.Level >= LogLevel.Warning))

--- a/src/NuGet.Core/NuGet.Common/Errors/PackagingLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/PackagingLogMessage.cs
@@ -30,7 +30,7 @@ namespace NuGet.Common
             Level = logLevel;
             Code = logCode;
             Message = message;
-            Time = DateTimeOffset.Now;
+            Time = DateTimeOffset.UtcNow;
         }
 
         private PackagingLogMessage(LogLevel logLevel, string message)
@@ -38,7 +38,7 @@ namespace NuGet.Common
             Message = message;
             Code = NuGetLogCode.Undefined;
             Level = logLevel;
-            Time = DateTimeOffset.Now;
+            Time = DateTimeOffset.UtcNow;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Common/Errors/PackagingLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/PackagingLogMessage.cs
@@ -30,7 +30,7 @@ namespace NuGet.Common
             Level = logLevel;
             Code = logCode;
             Message = message;
-            Time = DateTimeOffset.UtcNow;
+            Time = DateTimeOffset.Now;
         }
 
         private PackagingLogMessage(LogLevel logLevel, string message)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NuGet.Common;
 using NuGet.Packaging.Core;
+using NuGet.Shared;
 
 namespace NuGet.Packaging.Signing
 {
@@ -43,6 +45,7 @@ namespace NuGet.Packaging.Signing
         {
             Results = results;
             PackageIdentity = package;
+            results.SelectMany(r => r.Issues).ForEach(l => l.LibraryId = package.ToString());
         }
 
         public SignatureException(NuGetLogCode code, string message, PackageIdentity package)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureLog.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureLog.cs
@@ -3,11 +3,15 @@
 
 using System;
 using NuGet.Common;
+using NuGet.Shared;
 
 namespace NuGet.Packaging.Signing
 {
+    /// <summary>
+    /// Log message for signature verification.
+    /// </summary>
     public class SignatureLog : ILogMessage, IEquatable<SignatureLog>
-    {
+    { 
         public LogLevel Level { get; set; }
 
         public string Message { get; set; }
@@ -44,6 +48,7 @@ namespace NuGet.Packaging.Signing
 
         public static SignatureLog DebugLog(string message)
         {
+            // create a log message and make the code undefined to not display the code in any logger
             return new SignatureLog(LogLevel.Debug, NuGetLogCode.Undefined, message);
         }
 
@@ -62,10 +67,20 @@ namespace NuGet.Packaging.Signing
 
         public bool Equals(SignatureLog other)
         {
-            return other != null &&
-                Equals(Level, other.Level) &&
+            if (other == null)
+            {
+                return false;
+            }
+            else if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return Equals(Level, other.Level) &&
                 Equals(Code, other.Code) &&
-                string.Equals(Message, other.Message, StringComparison.Ordinal);
+                EqualityUtility.EqualsWithNullCheck(LibraryId, other.LibraryId) &&
+                EqualityUtility.EqualsWithNullCheck(ProjectPath, other.ProjectPath) &&
+                EqualityUtility.EqualsWithNullCheck(Message, other.Message);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureLog.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureLog.cs
@@ -6,19 +6,28 @@ using NuGet.Common;
 
 namespace NuGet.Packaging.Signing
 {
-    public class SignatureLog : IEquatable<SignatureLog>
+    public class SignatureLog : ILogMessage, IEquatable<SignatureLog>
     {
-        public LogLevel Level { get; }
+        public LogLevel Level { get; set; }
 
-        public string Message { get; }
+        public string Message { get; set; }
 
-        public NuGetLogCode Code { get; }
+        public NuGetLogCode Code { get; set; }
+
+        public WarningLevel WarningLevel { get; set; }
+
+        public string ProjectPath { get; set; }
+
+        public DateTimeOffset Time { get; set; }
+
+        public string LibraryId { get; set; }
 
         private SignatureLog(LogLevel level, NuGetLogCode code, string message)
         {
             Level = level;
             Code = code;
             Message = message;
+            Time = DateTimeOffset.Now;
         }
 
         public static SignatureLog InformationLog(string message)
@@ -49,22 +58,6 @@ namespace NuGet.Packaging.Signing
         public static SignatureLog Error(NuGetLogCode code, string message)
         {
             return new SignatureLog(LogLevel.Error, code, message);
-        }
-
-        public ILogMessage ToLogMessage()
-        {
-            if (Level == LogLevel.Error)
-            {
-                return LogMessage.CreateError(Code, Message);
-            }
-            else if (Level == LogLevel.Warning)
-            {
-                return LogMessage.CreateWarning(Code, Message);
-            }
-            else
-            {
-                return new LogMessage(Level, Message);
-            }
         }
 
         public bool Equals(SignatureLog other)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureLog.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureLog.cs
@@ -31,7 +31,7 @@ namespace NuGet.Packaging.Signing
             Level = level;
             Code = code;
             Message = message;
-            Time = DateTimeOffset.Now;
+            Time = DateTimeOffset.UtcNow;
         }
 
         public static SignatureLog InformationLog(string message)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/PackageVerificationResult.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/PackageVerificationResult.cs
@@ -34,12 +34,12 @@ namespace NuGet.Packaging.Signing
 
         public IEnumerable<ILogMessage> GetWarningIssues()
         {
-            return Issues.Where(p => p.Level==LogLevel.Warning).Select(p => p.ToLogMessage());
+            return Issues.Where(p => p.Level==LogLevel.Warning);
         }
 
         public IEnumerable<ILogMessage> GetErrorIssues()
         {
-            return Issues.Where(p => p.Level == LogLevel.Error).Select(p => p.ToLogMessage());
+            return Issues.Where(p => p.Level == LogLevel.Error);
         }
     }
 }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -1,0 +1,129 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using Test.Utility.Signing;
+using Xunit;
+
+namespace NuGet.CommandLine.FuncTest.Commands
+{
+    /// <summary>
+    /// Tests restore command
+    /// These tests require admin privilege as the certs need to be added to the root store location
+    /// </summary>
+    [Collection(SignCommandTestCollection.Name)]
+    public class RestoreCommandTests
+    {
+        private static readonly string _NU3008Message = "The package integrity check failed.";
+        private static readonly string _NU3008 = $"NU3008: {_NU3008Message}";
+        private static readonly string _NU3027Message = "The signature should be timestamped to enable long-term signature validity after the certificate has expired.";
+        private static readonly string _NU3027 = $"NU3027: {_NU3027Message}";
+
+        private SignCommandTestFixture _testFixture;
+        private TrustedTestCert<TestCertificate> _trustedTestCert;
+        private readonly string _nugetExePath;
+
+        public RestoreCommandTests(SignCommandTestFixture fixture)
+        {
+            _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+            _trustedTestCert = SigningTestUtility.GenerateTrustedTestCertificate();
+            _nugetExePath = _testFixture.NuGetExePath;
+        }
+
+        [CIOnlyFact]
+        public async Task Restore_TamperedPackage_FailsAsync()
+        {
+            // Arrange
+            var nupkg = new SimpleTestPackageContext("A", "1.0.0");
+
+            using (var pathContext = new SimpleTestPathContext())
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("NETStandard2.0"));
+
+                var packageX = new SimpleTestPackageContext("X", "9.0.0");
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, packageX, pathContext.PackageSource);
+                SignedArchiveTestUtility.TamperWithPackage(signedPackagePath);
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                var args = new string[]
+                {
+                    projectA.ProjectPath,
+                    "-Source",
+                    pathContext.PackageSource
+                };
+
+                // Act
+                var result = RunRestore(_nugetExePath, pathContext, expectedExitCode: 1, additionalArgs: args);
+                var reader = new LockFileFormat();
+                var lockFile = reader.Read(projectA.AssetsFileOutputPath);
+                var errors = lockFile.LogMessages.Where(m => m.Level == LogLevel.Error);
+                var warnings = lockFile.LogMessages.Where(m => m.Level == LogLevel.Warning);
+            
+                // Assert
+                result.ExitCode.Should().Be(1);
+                result.Errors.Should().Contain(_NU3008);
+                result.AllOutput.Should().Contain($"WARNING: {_NU3027}");
+
+                errors.Count().Should().Be(1);
+                errors.First().Code.Should().Be(NuGetLogCode.NU3008);
+                errors.First().Message.Should().Be(_NU3008Message);
+                errors.First().LibraryId.Should().Be(packageX.ToString());
+
+                warnings.Count().Should().Be(1);
+                warnings.First().Code.Should().Be(NuGetLogCode.NU3027);
+                warnings.First().Message.Should().Be(_NU3027Message);
+                warnings.First().LibraryId.Should().Be("X.9.0.0");
+            }
+        }
+
+        public static CommandRunnerResult RunRestore(string nugetExe, SimpleTestPathContext pathContext, int expectedExitCode = 0, params string[] additionalArgs)
+        {
+            // Store the dg file for debugging
+            var envVars = new Dictionary<string, string>()
+            {
+                { "NUGET_HTTP_CACHE_PATH", pathContext.HttpCacheFolder }
+            };
+
+            var args = new string[]
+            {
+                "restore",
+                "-Verbosity",
+                "detailed"
+            };
+
+            args = args.Concat(additionalArgs).ToArray();
+
+            // Act
+            var r = CommandRunner.Run(
+                nugetExe,
+                pathContext.WorkingDirectory,
+                string.Join(" ", args),
+                waitForExit: true,
+                environmentVariables: envVars);
+
+            // Assert
+            Assert.True(expectedExitCode == r.ExitCode, r.AllOutput);
+
+            return r;
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureLogTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureLogTests.cs
@@ -1,0 +1,182 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class SignatureLogTests
+    {
+        [Fact]
+        public void InformationLog_InitializesProperties()
+        {
+            // Arrange
+            var message = "unit_test_message";
+
+            // Act
+            var log = SignatureLog.InformationLog(message);
+
+            // Assert
+            log.Message.Should().Be(message);
+            log.Code.Should().Be(NuGetLogCode.Undefined);
+            log.Level.Should().Be(LogLevel.Information);
+        }
+
+        [Fact]
+        public void DetailedLog_InitializesProperties()
+        {
+            // Arrange
+            var message = "unit_test_message";
+
+            // Act
+            var log = SignatureLog.DetailedLog(message);
+
+            // Assert
+            log.Message.Should().Be(message);
+            log.Code.Should().Be(NuGetLogCode.Undefined);
+            log.Level.Should().Be(LogLevel.Verbose);
+        }
+
+        [Fact]
+        public void DebugLog_InitializesProperties()
+        {
+            // Arrange
+            var message = "unit_test_message";
+
+            // Act
+            var log = SignatureLog.DebugLog(message);
+
+            // Assert
+            log.Message.Should().Be(message);
+            log.Code.Should().Be(NuGetLogCode.Undefined);
+            log.Level.Should().Be(LogLevel.Debug);
+        }
+
+        [Theory]
+        [InlineData(true, NuGetLogCode.NU3000, "unit_test_message")]
+        [InlineData(false, NuGetLogCode.NU3000, "unit_test_message")]
+        public void Issue_InitializesProperties(bool fatal, NuGetLogCode code, string message)
+        {
+            // Arrange
+            var expectedLevel = fatal ? LogLevel.Error : LogLevel.Warning;
+
+            // Act
+            var log = SignatureLog.Issue(fatal, code, message);
+
+            // Assert
+            log.Message.Should().Be(message);
+            log.Code.Should().Be(code);
+            log.Level.Should().Be(expectedLevel);
+        }
+
+        [Fact]
+        public void Error_InitializesProperties()
+        {
+            // Arrange
+            var message = "unit_test_message";
+            var code = NuGetLogCode.NU3000;
+
+            // Act
+            var log = SignatureLog.Error(code, message);
+
+            // Assert
+            log.Message.Should().Be(message);
+            log.Code.Should().Be(code);
+            log.Level.Should().Be(LogLevel.Error);
+        }
+
+        [Fact]
+        public void Equals_OtherIsNull_ReturnsFalse()
+        {
+            // Arrange
+            var message = "unit_test_message";
+            var code = NuGetLogCode.NU3000;
+            var log = SignatureLog.Error(code, message);
+
+            // Act
+            var equals = log.Equals(null);
+
+            // Assert
+            equals.Should().BeFalse();
+        }
+
+        [Theory]
+        [MemberData(nameof(SignatureLogCombinations))]
+        public void Equals_OtherIsDifferent_ReturnsFalse(SignatureLog other)
+        {
+            // Arrange
+            var log = SignatureLog.Error(NuGetLogCode.NU3000, "unit_test_message");
+            log.ProjectPath = Guid.NewGuid().ToString();
+            log.LibraryId = Guid.NewGuid().ToString();
+
+            // Act
+            var equals = log.Equals(other);
+
+            // Assert
+            equals.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Equals_OtherIsSame_ReturnsTrue()
+        {
+            // Arrange
+            var log = SignatureLog.Error(NuGetLogCode.NU3000, "unit_test_message");
+
+            // Act
+            var equals = log.Equals(log);
+
+            // Assert
+            equals.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Equals_OtherIsEquivalent_ReturnsFalse()
+        {
+            // Arrange
+            var log = SignatureLog.Error(NuGetLogCode.NU3000, "unit_test_message");
+            log.ProjectPath = "unit_test_project_path";
+            log.LibraryId = "unit_test_library_id";
+
+            var other = SignatureLog.Error(NuGetLogCode.NU3000, "unit_test_message");
+            other.ProjectPath = "unit_test_project_path";
+            other.LibraryId = "unit_test_library_id";
+
+            // Act
+            var equals = log.Equals(log);
+
+            // Assert
+            equals.Should().BeTrue();
+        }
+
+        public static IEnumerable<object[]> SignatureLogCombinations()
+        {
+            yield return new object[]
+            { SignatureLog.DebugLog(string.Empty) };
+            yield return new object[]
+            { SignatureLog.InformationLog(string.Empty) };
+            yield return new object[]
+            { SignatureLog.DetailedLog(string.Empty) };
+            yield return new object[]
+            { SignatureLog.Issue(false, NuGetLogCode.NU1000, string.Empty) };
+            yield return new object[]
+            { SignatureLog.Issue(true, NuGetLogCode.NU1000, string.Empty) };
+            yield return new object[]
+            { SignatureLog.Issue(true, NuGetLogCode.NU3000, string.Empty) };
+            yield return GenerateSignatureLogWithMetadata();
+        }
+
+        private static object[] GenerateSignatureLogWithMetadata()
+        {
+            var log = SignatureLog.Issue(true, NuGetLogCode.NU3000, string.Empty);
+            log.ProjectPath = Guid.NewGuid().ToString();
+            log.LibraryId = Guid.NewGuid().ToString();
+
+            return new object[] { log };
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageContext.cs
@@ -141,5 +141,10 @@ namespace NuGet.Test.Utility
 
             return packageFile;
         }
+
+        public new string ToString()
+        {
+            return $"{Id}.{Version}";
+        }
     }
 }


### PR DESCRIPTION
Currently package signature verification logs do not indicate what package caused the failure. This PR improves this by adding package identity to the assets file in case of a restore failure.

In the PR `SignatureLog` has been updated to be of type `ILogMessage` and a helper method has been added to transform a `SignatureLog` into a `RestoreLogMessage`, which is then written into the assets file.

Before - 
```
  "logs": [
    {
      "code": "NU3008",
      "level": "Error",
      "message": "The package integrity check failed."
    },
    {
      "code": "NU3027",
      "level": "Warning",
      "warningLevel": 1,
      "message": "The signature should be timestamped to enable long-term signature validity after the certificate has expired."
    }
  ]
```

After - 
```
  "logs": [
    {
      "code": "NU3008",
      "level": "Error",
      "message": "The package integrity check failed.",
      "libraryId": "X.9.0.0"
    },
    {
      "code": "NU3027",
      "level": "Warning",
      "warningLevel": 0,
      "message": "The signature should be timestamped to enable long-term signature validity after the certificate has expired.",
      "libraryId": "X.9.0.0"
    }
  ]
```

Issue for improving overall signing errors content: https://github.com/NuGet/Home/issues/6906