### PR TITLE
Add basic capabilities caching for plugins

### DIFF
--- a/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
@@ -82,9 +82,9 @@ namespace NuGet.Credentials
 
             var creationResult = await _pluginManager.TryGetSourceAgnosticPluginAsync(_discoveredPlugin, OperationClaim.Authentication, cancellationToken);
 
-            if (creationResult.Item1)
+            if (creationResult.Item1) // status of the source creation
             {
-                var plugin = creationResult.Item2;
+                var plugin = creationResult.Item2; // plugin creation result
                 if (!string.IsNullOrEmpty(plugin.Message))
                 {
                     // There is a potential here for double logging as the CredentialService itself catches the exceptions and tries to log it.

--- a/src/NuGet.Core/NuGet.Common/PathUtil/NuGetEnvironment.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/NuGetEnvironment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -57,6 +57,12 @@ namespace NuGet.Common
                         GetFolderPath(SpecialFolder.LocalApplicationData),
                         "NuGet",
                         "v3-cache");
+
+                case NuGetFolderPath.NuGetPluginsCacheDirectory:
+                    return Path.Combine(
+                        GetFolderPath(SpecialFolder.LocalApplicationData),
+                        "NuGet",
+                        "plugins-cache");
 
                 case NuGetFolderPath.DefaultMsBuildPath:
                     var programFilesPath = GetFolderPath(SpecialFolder.ProgramFilesX86);

--- a/src/NuGet.Core/NuGet.Common/PathUtil/NuGetFolderPath.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/NuGetFolderPath.cs
@@ -11,6 +11,7 @@ namespace NuGet.Common
         HttpCacheDirectory,
         NuGetHome,
         DefaultMsBuildPath,
-        Temp
+        Temp,
+        NuGetPluginsCacheDirectory
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -246,16 +246,12 @@ namespace NuGet.Configuration
             {
                 // Verify the path is absolute
                 VerifyPathIsRooted(PluginsCacheEnvironmentKey, path);
-            }
-
-            if (!string.IsNullOrEmpty(path))
-            {
-                path = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+                path = PathUtility.GetPathWithDirectorySeparator(path);
                 path = Path.GetFullPath(path);
                 return path;
             }
 
-            return NuGetEnvironment.GetFolderPath(NuGetFolderPath.HttpCacheDirectory);
+            return NuGetEnvironment.GetFolderPath(NuGetFolderPath.NuGetPluginsCacheDirectory);
         }
 
         public static IEnumerable<PackageSource> GetEnabledSources(ISettings settings)

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -17,6 +17,7 @@ namespace NuGet.Configuration
         private const string GlobalPackagesFolderEnvironmentKey = "NUGET_PACKAGES";
         private const string FallbackPackagesFolderEnvironmentKey = "NUGET_FALLBACK_PACKAGES";
         private const string HttpCacheEnvironmentKey = "NUGET_HTTP_CACHE_PATH";
+        private const string PluginsCacheEnvironmentKey = "NUGET_PLUGINS_CACHE_PATH";
         private const string RepositoryPathKey = "repositoryPath";
         public static readonly string DefaultGlobalPackagesFolderPath = "packages" + Path.DirectorySeparatorChar;
 
@@ -238,8 +239,24 @@ namespace NuGet.Configuration
         /// <summary>
         ///  Get plugins cache folder
         /// </summary>
-        
+        public static string GetPluginsCacheFolder()
+        {
+            var path = Environment.GetEnvironmentVariable(PluginsCacheEnvironmentKey);
+            if (!string.IsNullOrEmpty(path))
+            {
+                // Verify the path is absolute
+                VerifyPathIsRooted(PluginsCacheEnvironmentKey, path);
+            }
 
+            if (!string.IsNullOrEmpty(path))
+            {
+                path = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+                path = Path.GetFullPath(path);
+                return path;
+            }
+
+            return NuGetEnvironment.GetFolderPath(NuGetFolderPath.HttpCacheDirectory);
+        }
 
         public static IEnumerable<PackageSource> GetEnabledSources(ISettings settings)
         {

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -235,6 +235,12 @@ namespace NuGet.Configuration
             return NuGetEnvironment.GetFolderPath(NuGetFolderPath.HttpCacheDirectory);
         }
 
+        /// <summary>
+        ///  Get plugins cache folder
+        /// </summary>
+        
+
+
         public static IEnumerable<PackageSource> GetEnabledSources(ISettings settings)
         {
             var provider = new PackageSourceProvider(settings);

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpCacheUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpCacheUtility.cs
@@ -23,7 +23,7 @@ namespace NuGet.Protocol
             Uri sourceUri,
             string cacheKey,
             HttpSourceCacheContext context)
-        {
+        {     
             // When the MaxAge is TimeSpan.Zero, this means the caller is passing is using a temporary directory for
             // cache files, instead of the global HTTP cache used by default. Additionally, the cleaning up of this
             // directory is the responsibility of the caller.
@@ -75,7 +75,7 @@ namespace NuGet.Protocol
                 .Replace("__", "_");
         }
 
-        public static Stream TryReadCacheFile(string uri, TimeSpan maxAge, string cacheFile)
+        public static Stream TryReadCacheFile(TimeSpan maxAge, string cacheFile)
         {
             var fileInfo = new FileInfo(cacheFile);
 

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
@@ -376,7 +376,7 @@ namespace NuGet.Protocol
         protected virtual Stream TryReadCacheFile(string uri, TimeSpan maxAge, string cacheFile)
         {
             // Do not need the uri here
-            return HttpCacheUtility.TryReadCacheFile(maxAge, cacheFile);
+            return CachingUtility.TryReadCacheFile(maxAge, cacheFile);
         }
 
         public static HttpSource Create(SourceRepository source)

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
@@ -375,7 +375,8 @@ namespace NuGet.Protocol
 
         protected virtual Stream TryReadCacheFile(string uri, TimeSpan maxAge, string cacheFile)
         {
-            return HttpCacheUtility.TryReadCacheFile(uri, maxAge, cacheFile);
+            // Do not need the uri here
+            return HttpCacheUtility.TryReadCacheFile(maxAge, cacheFile);
         }
 
         public static HttpSource Create(SourceRepository source)

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
@@ -376,7 +376,7 @@ namespace NuGet.Protocol
         protected virtual Stream TryReadCacheFile(string uri, TimeSpan maxAge, string cacheFile)
         {
             // Do not need the uri here
-            return CachingUtility.TryReadCacheFile(maxAge, cacheFile);
+            return CachingUtility.ReadCacheFile(maxAge, cacheFile);
         }
 
         public static HttpSource Create(SourceRepository source)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginManager.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginManager.cs
@@ -37,6 +37,6 @@ namespace NuGet.Protocol.Plugins
         /// <param name="pluginDiscoveryResult"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>A PluginCreationResult</returns>
-        Task<PluginCreationResult> CreateSourceAgnosticPluginAsync(PluginDiscoveryResult pluginDiscoveryResult, CancellationToken cancellationToken);
+        Task<Tuple<bool, PluginCreationResult>> TryGetSourceAgnosticPluginAsync(PluginDiscoveryResult pluginDiscoveryResult, OperationClaim requestedOperationClaim, CancellationToken cancellationToken);
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheEntry.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheEntry.cs
@@ -1,0 +1,106 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NuGet.Common;
+
+namespace NuGet.Protocol.Plugins
+{
+    public sealed class PluginCacheEntry
+    {
+        public PluginCacheEntry(string rootCacheFolder, string pluginFilePath, string requestKey)
+        {
+            RootFolder = Path.Combine(rootCacheFolder, CachingUtility.RemoveInvalidFileNameChars(CachingUtility.ComputeHash(pluginFilePath)));
+            CacheFileName = Path.Combine(RootFolder, CachingUtility.RemoveInvalidFileNameChars(requestKey) + ".dat");
+            NewCacheFileName = CacheFileName + "-new";
+        }
+
+        internal TimeSpan MaxAge { get; set; } = TimeSpan.FromDays(30);
+        internal string CacheFileName { get; }
+        private string RootFolder { get; }
+        private string NewCacheFileName { get; }
+
+        public IReadOnlyList<OperationClaim> OperationClaims { get; private set; }
+
+        public void LoadFromFile()
+        {
+            Stream content = null;
+            try
+            {
+                content = CachingUtility.ReadCacheFile(MaxAge, CacheFileName);
+                if (content != null)
+                {
+                    ProcessContent(content);
+                }
+            }
+            finally
+            {
+                content?.Dispose();
+            }
+        }
+
+        private void ProcessContent(Stream content)
+        {
+            var serializer = new JsonSerializer();
+            using (var sr = new StreamReader(content))
+            using (var jsonTextReader = new JsonTextReader(sr))
+            {
+                OperationClaims = serializer.Deserialize<IReadOnlyList<OperationClaim>>(jsonTextReader);
+            }
+        }
+
+        public void AddOrUpdateOperationClaims(IReadOnlyList<OperationClaim> operationClaims)
+        {
+            OperationClaims = operationClaims;
+        }
+
+        public async Task UpdateCacheFileAsync()
+        {
+            if (OperationClaims != null)
+            {
+                // Make sure the cache file directory is created before writing a file to it.
+                DirectoryUtility.CreateSharedDirectory(RootFolder);
+
+                // The update of a cached file is divided into two steps:
+                // 1) Delete the old file.
+                // 2) Create a new file with the same name.
+                using (var fileStream = new FileStream(
+                    NewCacheFileName,
+                    FileMode.Create,
+                    FileAccess.ReadWrite,
+                    FileShare.None,
+                    CachingUtility.BufferSize,
+                    useAsync: true))
+                {
+                    var json = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(OperationClaims, Formatting.Indented));
+                    await fileStream.WriteAsync(json, 0, json.Length);
+                }
+
+                if (File.Exists(CacheFileName))
+                {
+                    // Process B can perform deletion on an opened file if the file is opened by process A
+                    // with FileShare.Delete flag. However, the file won't be actually deleted until A close it.
+                    // This special feature can cause race condition, so we never delete an opened file.
+                    if (!CachingUtility.IsFileAlreadyOpen(CacheFileName))
+                    {
+                        File.Delete(CacheFileName);
+                    }
+                }
+
+                // If the destination file doesn't exist, we can safely perform moving operation.
+                // Otherwise, moving operation will fail.
+                if (!File.Exists(CacheFileName))
+                {
+                    File.Move(
+                        NewCacheFileName,
+                        CacheFileName);
+                }
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheEntry.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheEntry.cs
@@ -11,8 +11,18 @@ using NuGet.Common;
 
 namespace NuGet.Protocol.Plugins
 {
+    /// <summary>
+    /// This class represents a plugin operations cache entry.
+    /// It contains expiry logic, read/write/update logic.
+    /// </summary>
     public sealed class PluginCacheEntry
     {
+        /// <summary>
+        /// Create a plugin cache entry.
+        /// </summary>
+        /// <param name="rootCacheFolder">The root cache folder, normally /localappdata/nuget/plugins-cache</param>
+        /// <param name="pluginFilePath">The full plugin file path, which will be used to create a key for the folder created in the root folder itself </param>
+        /// <param name="requestKey">A unique request key for the operation claims. Ideally the packageSourceRepository value of the PluginRequestKey. Example https://protected.package.feed/index.json, or Source-Agnostic</param>
         public PluginCacheEntry(string rootCacheFolder, string pluginFilePath, string requestKey)
         {
             RootFolder = Path.Combine(rootCacheFolder, CachingUtility.RemoveInvalidFileNameChars(CachingUtility.ComputeHash(pluginFilePath)));
@@ -25,8 +35,12 @@ namespace NuGet.Protocol.Plugins
         private string RootFolder { get; }
         private string NewCacheFileName { get; }
 
-        public IReadOnlyList<OperationClaim> OperationClaims { get; private set; }
+        public IReadOnlyList<OperationClaim> OperationClaims { get; set; }
 
+        /// <summary>
+        /// Loads and processes the contet from the generated file if it exists.
+        /// Even after this method is invoked, the operation claims might be null. 
+        /// </summary>
         public void LoadFromFile()
         {
             Stream content = null;
@@ -54,11 +68,10 @@ namespace NuGet.Protocol.Plugins
             }
         }
 
-        public void AddOrUpdateOperationClaims(IReadOnlyList<OperationClaim> operationClaims)
-        {
-            OperationClaims = operationClaims;
-        }
-
+        /// <summary>
+        /// Updates the cache file with the current value in the operation claims if the operationn claims is not null.
+        /// </summary>
+        /// <returns>Task</returns>
         public async Task UpdateCacheFileAsync()
         {
             if (OperationClaims != null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
@@ -2,12 +2,18 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Packaging;
@@ -139,9 +145,16 @@ namespace NuGet.Protocol.Core.Types
 
                     foreach (var result in results)
                     {
-                        var pluginCreationResult = await CreatePluginAsync(result, new PluginRequestKey(result.PluginFile.Path, source.PackageSource.Source), source.PackageSource.Source, serviceIndexJson, cancellationToken);
+                        var pluginCreationResult = await CreatePluginAsync(
+                            result,
+                            OperationClaim.DownloadPackage,
+                            new PluginRequestKey(result.PluginFile.Path, source.PackageSource.Source),
+                            source.PackageSource.Source,
+                            serviceIndexJson,
+                            cancellationToken);
 
                         pluginCreationResults.Add(pluginCreationResult);
+
                     }
                 }
             }
@@ -157,52 +170,119 @@ namespace NuGet.Protocol.Core.Types
         /// <returns>A PluginCreationResult</returns>
         public Task<PluginCreationResult> CreateSourceAgnosticPluginAsync(PluginDiscoveryResult pluginDiscoveryResult, CancellationToken cancellationToken)
         {
-            if(pluginDiscoveryResult == null)
+            if (pluginDiscoveryResult == null)
             {
                 throw new ArgumentNullException(nameof(pluginDiscoveryResult));
             }
-            return CreatePluginAsync(pluginDiscoveryResult, new PluginRequestKey(pluginDiscoveryResult.PluginFile.Path, "Source-Agnostic"), null, null, cancellationToken);
+            // Provide requested Plugin Operation
+            // here check if a plugin contains non source agnostic 
+            return CreatePluginAsync(pluginDiscoveryResult, OperationClaim.Authentication, new PluginRequestKey(pluginDiscoveryResult.PluginFile.Path, "Source-Agnostic"), null, null, cancellationToken);
         }
 
-        private async Task<PluginCreationResult> CreatePluginAsync(PluginDiscoveryResult result, PluginRequestKey requestKey, string packageSourceRepository, JObject serviceIndex, CancellationToken cancellationToken)
+        private Lazy<string> _pluginsCacheDirectory = new Lazy<string>(() => NuGetEnvironment.GetFolderPath(NuGetFolderPath.NuGetPluginsCacheDirectory));
+
+        // TODO NK - Moved this into a shared utility
+        private static string ComputeHash(string value)
+        {
+            var trailing = value.Length > 32 ? value.Substring(value.Length - 32) : value;
+            byte[] hash;
+            using (var sha = SHA1.Create())
+            {
+                hash = sha.ComputeHash(Encoding.UTF8.GetBytes(value));
+            }
+
+            const string hex = "0123456789abcdef";
+            return hash.Aggregate("$" + trailing, (result, ch) => "" + hex[ch / 0x10] + hex[ch % 0x10] + result);
+        }
+        private async Task<PluginCreationResult> CreatePluginAsync(
+            PluginDiscoveryResult result,
+            OperationClaim requestedOperationClaim,
+            PluginRequestKey requestKey,
+            string packageSourceRepository,
+            JObject serviceIndex,
+            CancellationToken cancellationToken)
         {
             PluginCreationResult pluginCreationResult = null;
+            var context = new PluginCacheContext(_pluginsCacheDirectory.Value, result.PluginFile.Path);
+            var cacheResult = new PluginCacheResult(context.RootFolder, context.CacheFileName);
 
-            if (result.PluginFile.State.Value == PluginFileState.Valid)
-            {
-                var plugin = await _pluginFactory.GetOrCreateAsync(
-                    result.PluginFile.Path,
-                    PluginConstants.PluginArguments,
-                    new RequestHandlers(),
-                    _connectionOptions,
-                    cancellationToken);
+            return await ConcurrencyUtilities.ExecuteWithFileLockedAsync(
+                context.CacheFileName,
+                action: async lockedToken =>
+                {
 
-                var utilities = await PerformOneTimePluginInitializationAsync(plugin, cancellationToken);
+                    IList<OperationClaim> cachedOperationClaims;
+                    Stream content = null;
+                    try
+                    {
+                        content = HttpCacheUtility.TryReadCacheFile(context.MaxAge, context.CacheFileName);
+                        if (content != null)
+                        {
+                            cacheResult.ProcessContent(content);
+                        }
+                    }
+                    catch
+                    {
+                        content?.Dispose();
+                    }
+                    finally
+                    {
+                        content?.Dispose();
+                    }
 
-                var lazyOperationClaims = _pluginOperationClaims.GetOrAdd(
-                        requestKey,
-                        key => new Lazy<Task<IReadOnlyList<OperationClaim>>>(() =>
-                        GetPluginOperationClaimsAsync(
-                            plugin,
-                            packageSourceRepository,
-                            serviceIndex,
-                            cancellationToken)));
+                    cachedOperationClaims = cacheResult.GetOperationClaims(requestKey);
+                    if (cachedOperationClaims == null || cachedOperationClaims.Contains(requestedOperationClaim))
+                    {
+                        if (result.PluginFile.State.Value == PluginFileState.Valid)
+                        {
+                            var plugin = await _pluginFactory.GetOrCreateAsync(
+                                result.PluginFile.Path,
+                                PluginConstants.PluginArguments,
+                                new RequestHandlers(),
+                                _connectionOptions,
+                                cancellationToken);
 
-                await lazyOperationClaims.Value;
+                            var utilities = await PerformOneTimePluginInitializationAsync(plugin, cancellationToken);
 
-                pluginCreationResult = new PluginCreationResult(
-                    plugin,
-                    utilities.Value,
-                    lazyOperationClaims.Value.Result);
-            }
-            else
-            {
-                pluginCreationResult = new PluginCreationResult(result.Message);
-            }
+                            // We still make the GetOperationClaims call even if we have the operation claims cached. This is a way to self-update the cache.
+                             var lazyOperationClaims = _pluginOperationClaims.GetOrAdd(
+                                    requestKey,
+                                    key => new Lazy<Task<IReadOnlyList<OperationClaim>>>(() =>
+                                    GetPluginOperationClaimsAsync(
+                                        plugin,
+                                        packageSourceRepository,
+                                        serviceIndex,
+                                        cancellationToken)));
 
-            return pluginCreationResult;
+                            // Why does this not work?
+                            var operationClaims = await lazyOperationClaims.Value;
+
+                            if (!EqualityUtility.SequenceEqualWithNullCheck(operationClaims, cachedOperationClaims))
+                            {
+                                cacheResult.AddOrUpdateOperationClaims(requestKey, operationClaims.AsList());
+                                await cacheResult.UpdateCacheFileAsync();
+                            }
+
+                            pluginCreationResult = new PluginCreationResult(
+                                plugin,
+                                utilities.Value,
+                                operationClaims);
+                        }
+                        else
+                        {
+                            pluginCreationResult = new PluginCreationResult(result.Message);
+                        }
+                    }
+
+                    // Return a dummy uninitialized result if the plugin was not started because the supported operation is not available.
+                    return pluginCreationResult ?? new PluginCreationResult(
+                                NoOpPlugin.Instance,
+                                NoOpIPluginMulticlientUtilities.Instance,
+                                Array.Empty<OperationClaim>());
+                },
+                token: cancellationToken
+                );
         }
-
 
         private async Task<Lazy<IPluginMulticlientUtilities>> PerformOneTimePluginInitializationAsync(IPlugin plugin, CancellationToken cancellationToken)
         {
@@ -319,6 +399,184 @@ namespace NuGet.Protocol.Core.Types
             }
 
             plugin.Connection.Options.SetRequestTimeout(requestTimeout);
+        }
+
+        private sealed class NoOpPlugin : IPlugin
+        {
+            internal static readonly NoOpPlugin Instance = new NoOpPlugin();
+
+            private static string UniqueName = Guid.NewGuid().ToString();
+
+            public IConnection Connection => throw new NotImplementedException();
+
+            public string FilePath => UniqueName;
+
+            public string Id => UniqueName;
+
+            public string Name => UniqueName;
+
+            public event EventHandler BeforeClose
+            {
+                add
+                {
+                }
+                remove
+                {
+                }
+            }
+
+            public event EventHandler Closed
+            {
+                add
+                {
+                }
+                remove
+                {
+                }
+            }
+
+            public void Close()
+            {
+                // do nothing
+            }
+
+            public void Dispose()
+            {
+                // do nothing
+            }
+        }
+
+        private sealed class NoOpIPluginMulticlientUtilities : IPluginMulticlientUtilities
+        {
+
+            internal static readonly NoOpIPluginMulticlientUtilities Instance = new NoOpIPluginMulticlientUtilities();
+
+            public Task DoOncePerPluginLifetimeAsync(string key, Func<Task> taskFunc, CancellationToken cancellationToken)
+            {
+                // do nothing
+                return Task.CompletedTask;
+            }
+        }
+        private sealed class PluginCacheContext
+        {
+            public TimeSpan MaxAge { get; set; } = TimeSpan.FromDays(30);
+            public string RootFolder { get; }
+            public string CacheFileName { get; }
+
+            public PluginCacheContext(string rootCacheFolder, string pluginFilePath)
+            {
+                RootFolder = rootCacheFolder;
+                CacheFileName = Path.Combine(rootCacheFolder, ComputeHash(pluginFilePath) + ".dat");
+            }
+        }
+
+        private sealed class PluginCacheResult
+        {
+            private const int BufferSize = 8192;
+
+            public PluginCacheResult(string rootFolder, string cacheFileName)
+            {
+                RootFolder = rootFolder;
+                CacheFileName = cacheFileName;
+                NewCacheFileName = cacheFileName + "-new";
+            }
+
+            internal string RootFolder { get; }
+            internal string CacheFileName { get; }
+            internal string NewCacheFileName { get; }
+
+            private Dictionary<string, IList<OperationClaim>> _operationClaims;
+
+            internal void ProcessContent(Stream content)
+            {
+                var serializer = new JsonSerializer();
+                using (var sr = new StreamReader(content))
+                using (var jsonTextReader = new JsonTextReader(sr))
+                {
+                    _operationClaims = serializer.Deserialize<Dictionary<string, IList<OperationClaim>>>(jsonTextReader);
+                }
+            }
+
+            internal IList<OperationClaim> GetOperationClaims(PluginRequestKey requestKey)
+            {
+                IList<OperationClaim> claims = null;
+                _operationClaims?.TryGetValue(requestKey.PackageSourceRepository, out claims);
+                return claims;
+            }
+
+            internal void AddOrUpdateOperationClaims(PluginRequestKey requestKey, IList<OperationClaim> operationClaims)
+            {
+                if (_operationClaims == null)
+                {
+                    _operationClaims = new Dictionary<string, IList<OperationClaim>>();
+                }
+                _operationClaims[requestKey.PackageSourceRepository] = operationClaims;
+            }
+
+            internal async Task UpdateCacheFileAsync()
+            {
+                // Make sure the cache file directory is created before writing a file to it.
+                DirectoryUtility.CreateSharedDirectory(RootFolder);
+
+                // The update of a cached file is divided into two steps:
+                // 1) Delete the old file.
+                // 2) Create a new file with the same name.
+                using (var fileStream = new FileStream(
+                    NewCacheFileName,
+                    FileMode.Create,
+                    FileAccess.ReadWrite,
+                    FileShare.None,
+                    BufferSize,
+                    useAsync: true))
+                {
+                    var json = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(_operationClaims, Formatting.Indented));
+                    await fileStream.WriteAsync(json, 0, json.Length);
+                    //fileStream.FlushAsync();
+                }
+
+                if (File.Exists(CacheFileName))
+                {
+                    // Process B can perform deletion on an opened file if the file is opened by process A
+                    // with FileShare.Delete flag. However, the file won't be actually deleted until A close it.
+                    // This special feature can cause race condition, so we never delete an opened file.
+                    if (!IsFileAlreadyOpen(CacheFileName))
+                    {
+                        File.Delete(CacheFileName);
+                    }
+                }
+
+                // If the destination file doesn't exist, we can safely perform moving operation.
+                // Otherwise, moving operation will fail.
+                if (!File.Exists(CacheFileName))
+                {
+                    File.Move(
+                        NewCacheFileName,
+                        CacheFileName);
+                }
+            }
+
+            private static bool IsFileAlreadyOpen(string filePath)
+            {
+                FileStream stream = null;
+
+                try
+                {
+                    stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+                }
+                catch
+                {
+                    return true;
+                }
+                finally
+                {
+                    if (stream != null)
+                    {
+                        stream.Dispose();
+                    }
+                }
+
+                return false;
+            }
         }
 
         private sealed class PluginRequestKey : IEquatable<PluginRequestKey>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
@@ -237,7 +237,7 @@ namespace NuGet.Protocol.Core.Types
 
                             if (!EqualityUtility.SequenceEqualWithNullCheck(operationClaims, cacheEntry.OperationClaims))
                             {
-                                cacheEntry.AddOrUpdateOperationClaims(operationClaims);
+                                cacheEntry.OperationClaims = operationClaims;
                                 await cacheEntry.UpdateCacheFileAsync();
                             }
 

--- a/src/NuGet.Core/NuGet.Protocol/Utility/CachingUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/CachingUtility.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace NuGet.Protocol
+{
+    public class CachingUtility
+    {
+        private const int BufferSize = 8192;
+
+        public static string ComputeHash(string value)
+        {
+            var trailing = value.Length > 32 ? value.Substring(value.Length - 32) : value;
+            byte[] hash;
+            using (var sha = SHA1.Create())
+            {
+                hash = sha.ComputeHash(Encoding.UTF8.GetBytes(value));
+            }
+
+            const string hex = "0123456789abcdef";
+            return hash.Aggregate("$" + trailing, (result, ch) => "" + hex[ch / 0x10] + hex[ch % 0x10] + result);
+        }
+
+        public static Stream TryReadCacheFile(TimeSpan maxAge, string cacheFile)
+        {
+            var fileInfo = new FileInfo(cacheFile);
+
+            if (fileInfo.Exists)
+            {
+                var age = DateTime.UtcNow.Subtract(fileInfo.LastWriteTimeUtc);
+                if (age < maxAge)
+                {
+                    var stream = new FileStream(
+                        cacheFile,
+                        FileMode.Open,
+                        FileAccess.Read,
+                        FileShare.Read | FileShare.Delete,
+                        BufferSize,
+                        useAsync: true);
+
+                    return stream;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Utility/CachingUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/CachingUtility.cs
@@ -11,7 +11,7 @@ namespace NuGet.Protocol
 {
     public class CachingUtility
     {
-        private const int BufferSize = 8192;
+        public static readonly int BufferSize = 8192;
 
         public static string ComputeHash(string value)
         {
@@ -26,7 +26,7 @@ namespace NuGet.Protocol
             return hash.Aggregate("$" + trailing, (result, ch) => "" + hex[ch / 0x10] + hex[ch % 0x10] + result);
         }
 
-        public static Stream TryReadCacheFile(TimeSpan maxAge, string cacheFile)
+        public static Stream ReadCacheFile(TimeSpan maxAge, string cacheFile)
         {
             var fileInfo = new FileInfo(cacheFile);
 
@@ -48,6 +48,43 @@ namespace NuGet.Protocol
             }
 
             return null;
+        }
+
+        public static bool IsFileAlreadyOpen(string filePath)
+        {
+            FileStream stream = null;
+
+            try
+            {
+                stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            }
+            catch(FileNotFoundException)
+            {
+                return false;
+            }
+            catch
+            {
+                return true;
+            }
+            finally
+            {
+                if (stream != null)
+                {
+                    stream.Dispose();
+                }
+            }
+
+            return false;
+        }
+
+        public static string RemoveInvalidFileNameChars(string value)
+        {
+            var invalid = Path.GetInvalidFileNameChars();
+            return new string(
+                value.Select(ch => invalid.Contains(ch) ? '_' : ch).ToArray()
+                )
+                .Replace("__", "_")
+                .Replace("__", "_");
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Utility/CachingUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/CachingUtility.cs
@@ -11,8 +11,13 @@ namespace NuGet.Protocol
 {
     public class CachingUtility
     {
-        public static readonly int BufferSize = 8192;
+        public const int BufferSize = 8192;
 
+        /// <summary>
+        /// Given a string, it hashes said string and appends identifiable characters to make the root of the cache more human readable
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns>hash</returns>
         public static string ComputeHash(string value)
         {
             var trailing = value.Length > 32 ? value.Substring(value.Length - 32) : value;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGet.Protocol.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGet.Protocol.Tests.csproj
@@ -28,9 +28,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDirectory)\EqualityUtility.cs">
+      <Link>EqualityUtility.cs</Link>
+    </Compile>
+  </ItemGroup>
+  
+  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCacheEntryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCacheEntryTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using NuGet.Protocol.Plugins;
+using NuGet.Shared;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Tests.Plugins
+{
+    public class PluginCacheEntryTests
+    {
+        [Fact]
+        public void PluginCacheEntry_DoesNotThrowWithNoFile()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var entry = new PluginCacheEntry(testDirectory.Path, "a", "b");
+                entry.LoadFromFile();
+                Assert.Null(entry.OperationClaims);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetsRoundTripsValuesData))]
+        public async Task PluginCacheEntry_RoundTripsValuesAsync(string[] values)
+        {
+            var list = new List<OperationClaim>();
+            foreach (var val in values)
+            {
+                Enum.TryParse(val, out OperationClaim result);
+                list.Add(result);
+            }
+
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var entry = new PluginCacheEntry(testDirectory.Path, "a", "b");
+                entry.LoadFromFile();
+                entry.AddOrUpdateOperationClaims(list);
+                await entry.UpdateCacheFileAsync();
+
+                var newEntry = new PluginCacheEntry(testDirectory.Path, "a", "b");
+                newEntry.LoadFromFile();
+
+                Assert.True(EqualityUtility.SequenceEqualWithNullCheck(entry.OperationClaims, newEntry.OperationClaims));
+            }
+        }
+
+        [Fact]
+        public async Task PluginCacheEntry_DoesNotDeleteAnOpenedFile()
+        {
+            var list = new List<OperationClaim>() { OperationClaim.Authentication };
+
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var entry = new PluginCacheEntry(testDirectory.Path, "a", "b");
+                entry.LoadFromFile();
+                entry.AddOrUpdateOperationClaims(list);
+                await entry.UpdateCacheFileAsync();
+
+                var CacheFileName = Path.Combine(Path.Combine(testDirectory.Path, CachingUtility.RemoveInvalidFileNameChars(CachingUtility.ComputeHash("a"))), CachingUtility.RemoveInvalidFileNameChars("b") + ".dat");
+
+                Assert.True(File.Exists(CacheFileName));
+
+                using (var fileStream = new FileStream(
+                   CacheFileName,
+                   FileMode.Open,
+                   FileAccess.ReadWrite,
+                   FileShare.None,
+                   CachingUtility.BufferSize,
+                   useAsync: true))
+                {
+                    list.Add(OperationClaim.DownloadPackage);
+                    entry.AddOrUpdateOperationClaims(list);
+                    await entry.UpdateCacheFileAsync(); // this should not update
+                }
+
+                entry.LoadFromFile();
+                Assert.True(EqualityUtility.SequenceEqualWithNullCheck(entry.OperationClaims, new List<OperationClaim>() { OperationClaim.Authentication }));
+            }
+        }
+
+        public static IEnumerable<object[]> GetsRoundTripsValuesData()
+        {
+            yield return new object[] { new string[] { "Authentication", "DownloadPackage" } };
+            yield return new object[] { new string[] { "Authentication" } };
+            yield return new object[] { new string[] { "DownloadPackage" } };
+            yield return new object[] { new string[] { } };
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCacheEntryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCacheEntryTests.cs
@@ -40,7 +40,7 @@ namespace NuGet.Protocol.Tests.Plugins
             {
                 var entry = new PluginCacheEntry(testDirectory.Path, "a", "b");
                 entry.LoadFromFile();
-                entry.AddOrUpdateOperationClaims(list);
+                entry.OperationClaims = list;
                 await entry.UpdateCacheFileAsync();
 
                 var newEntry = new PluginCacheEntry(testDirectory.Path, "a", "b");
@@ -59,7 +59,7 @@ namespace NuGet.Protocol.Tests.Plugins
             {
                 var entry = new PluginCacheEntry(testDirectory.Path, "a", "b");
                 entry.LoadFromFile();
-                entry.AddOrUpdateOperationClaims(list);
+                entry.OperationClaims = list;
                 await entry.UpdateCacheFileAsync();
 
                 var CacheFileName = Path.Combine(Path.Combine(testDirectory.Path, CachingUtility.RemoveInvalidFileNameChars(CachingUtility.ComputeHash("a"))), CachingUtility.RemoveInvalidFileNameChars("b") + ".dat");
@@ -75,7 +75,7 @@ namespace NuGet.Protocol.Tests.Plugins
                    useAsync: true))
                 {
                     list.Add(OperationClaim.DownloadPackage);
-                    entry.AddOrUpdateOperationClaims(list);
+                    entry.OperationClaims = list;
                     await entry.UpdateCacheFileAsync(); // this should not update
                 }
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginResourceProviderTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -344,6 +345,7 @@ namespace NuGet.Protocol.Plugins.Tests
             private readonly Mock<IPlugin> _plugin;
             private readonly Mock<IPluginDiscoverer> _pluginDiscoverer;
             private readonly Mock<IEnvironmentVariableReader> _reader;
+            private readonly string _pluginFilePath;
 
             internal PluginResourceProvider Provider { get; }
             internal PluginManager PluginManager { get; }
@@ -354,7 +356,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 IEnumerable<PositiveTestExpectation> expectations)
             {
                 _expectations = expectations;
-
+                _pluginFilePath = pluginFilePath;
                 _reader = new Mock<IEnvironmentVariableReader>(MockBehavior.Strict);
 
                 _reader.Setup(x => x.GetEnvironmentVariable(
@@ -450,6 +452,11 @@ namespace NuGet.Protocol.Plugins.Tests
 
             public void Dispose()
             {
+                LocalResourceUtils.DeleteDirectoryTree(
+                    Path.Combine(
+                        SettingsUtility.GetPluginsCacheFolder(),
+                        CachingUtility.RemoveInvalidFileNameChars(CachingUtility.ComputeHash(_pluginFilePath))),
+                    new List<string>());
                 PluginManager.Dispose();
                 GC.SuppressFinalize(this);
 


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6796  
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
Added a directory for the capabilities caching of plugins. The location is `%localdata%/NuGet/plugins-cache`. On the same level as the v3-cache. 
Added an environment variable for the plugins cache location. 

Extracted methods commonly used in both the http caching and the plugin caching to a separate class.

The caching strategy is the following: 
Each plugin has a folder. 
Each operation claim request has a cache file with a list of the valid operation claims
The cache gets invalidated every 30 days.
The cache value gets updated every time we launch the plugin. 

## Testing/Validation
Tests Added: Adding tests now. wanted a look at the core logic.  
Reason for not adding tests:  
Validation done:  Yes, manual + adding manual tests rn.
