### PR TITLE
Make DeprecatedFrameworkWindow, PackageManagmentWindow and NuGetProjectUpgradeWindow accessible

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -113,6 +113,24 @@ namespace NuGet.PackageManagement.UI {
                 return ResourceManager.GetString("Accessibility_PrefixReserved", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Promote all to top level dependency.
+        /// </summary>
+        public static string Accessibility_PromoteAllToTopLevel {
+            get {
+                return ResourceManager.GetString("Accessibility_PromoteAllToTopLevel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Promote to top level dependency.
+        /// </summary>
+        public static string Accessibility_PromoteToTopLevel {
+            get {
+                return ResourceManager.GetString("Accessibility_PromoteToTopLevel", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Use arrow keys to change the size of the sections.
@@ -131,7 +149,7 @@ namespace NuGet.PackageManagement.UI {
                 return ResourceManager.GetString("Accessibility_ThumbName", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Consolidate.
         /// </summary>
@@ -660,6 +678,15 @@ namespace NuGet.PackageManagement.UI {
         public static string IgnoreUpgrade {
             get {
                 return ResourceManager.GetString("IgnoreUpgrade", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Help icon.
+        /// </summary>
+        public static string ImageCaption_HelpIcon {
+            get {
+                return ResourceManager.GetString("ImageCaption_HelpIcon", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -113,18 +113,18 @@ namespace NuGet.PackageManagement.UI {
                 return ResourceManager.GetString("Accessibility_PrefixReserved", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Promote all to top level dependency.
+        ///   Looks up a localized string similar to Promote all to top level dependencies.
         /// </summary>
         public static string Accessibility_PromoteAllToTopLevel {
             get {
                 return ResourceManager.GetString("Accessibility_PromoteAllToTopLevel", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Promote to top level dependency.
+        ///   Looks up a localized string similar to Promote to a top level dependency.
         /// </summary>
         public static string Accessibility_PromoteToTopLevel {
             get {
@@ -149,7 +149,7 @@ namespace NuGet.PackageManagement.UI {
                 return ResourceManager.GetString("Accessibility_ThumbName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Consolidate.
         /// </summary>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -827,9 +827,9 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <value>Help icon</value>
   </data>
   <data name="Accessibility_PromoteAllToTopLevel" xml:space="preserve">
-    <value>Promote all to top level dependency</value>
+    <value>Promote all to top level dependencies</value>
   </data>
   <data name="Accessibility_PromoteToTopLevel" xml:space="preserve">
-    <value>Promote to top level dependency</value>
+    <value>Promote to a top level dependency</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -823,4 +823,13 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="Accessibility_ThumbName" xml:space="preserve">
     <value>Thumb</value>
   </data>
+  <data name="ImageCaption_HelpIcon" xml:space="preserve">
+    <value>Help icon</value>
+  </data>
+  <data name="Accessibility_PromoteAllToTopLevel" xml:space="preserve">
+    <value>Promote all to top level dependency</value>
+  </data>
+  <data name="Accessibility_PromoteToTopLevel" xml:space="preserve">
+    <value>Promote to top level dependency</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DeprecatedFrameworkWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DeprecatedFrameworkWindow.xaml
@@ -11,7 +11,8 @@
   WindowStartupLocation="CenterOwner"
   Title="{x:Static nuget:Resources.WindowTitle_DeprecatedFramework}"
   Height="500"
-  Width="500">
+  Width="500"
+  MinWidth="388">
   <Window.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
@@ -31,13 +32,20 @@
       Grid.Row="0"
       Margin="12,4,12,0"
       TextWrapping="Wrap">
-        <Run Text="{Binding TextBeforeLink, Mode=OneTime}" /><Hyperlink AutomationProperties.AutomationId="MigrationLink"
+        <Run
+          Text="{Binding TextBeforeLink, Mode=OneWay}"
+          AutomationProperties.Name="{Binding Text, Source={RelativeSource Self}}"
+          x:Name="_migrationLinkLabel"/>
+        <Hyperlink AutomationProperties.AutomationId="MigrationLink"
                    NavigateUri="{Binding MigrationUrl, Mode=OneTime}"
                    Style="{StaticResource HyperlinkStyle}"
-                   RequestNavigate="OnMigrationUrlNavigate"><Run Text="{Binding LinkText, Mode=OneTime}" />
+                   RequestNavigate="OnMigrationUrlNavigate"
+                   AutomationProperties.LabeledBy="{Binding ElementName=_migrationLinkLabel}">
+          <Run Text="{Binding LinkText, Mode=OneTime}" />
         </Hyperlink><Run Text="{Binding TextAfterLink, Mode=OneTime}" />
     </TextBlock>
     <TextBlock
+      x:Name="_projectListText"
       Grid.Row="1"
       Margin="12,4,12,0"
       TextWrapping="Wrap"
@@ -50,14 +58,15 @@
       BorderThickness="1">
       <ScrollViewer
         HorizontalScrollBarVisibility="Auto"
-        IsTabStop="True">
+        IsTabStop="True"
+        AutomationProperties.HelpText="{Binding ElementName=_projectListText}">
         <ItemsControl
           ItemsSource="{Binding Path=Projects}"
           IsTabStop="False">
           <ItemsControl.ItemTemplate>
             <DataTemplate>
                 <StackPanel Margin="6, 6">
-                    <TextBlock Text="{Binding}" />
+                    <TextBlock Text="{Binding}" AutomationProperties.Name="{Binding Text}" />
                 </StackPanel>
             </DataTemplate>
           </ItemsControl.ItemTemplate>
@@ -68,25 +77,21 @@
     <Grid
       Grid.Row="3">
       <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" MinWidth="180 "/>
         <ColumnDefinition Width="auto" />
-        <ColumnDefinition />
-        <ColumnDefinition
-          Width="auto" />
-        <ColumnDefinition
-          Width="auto" />
+        <ColumnDefinition Width="auto" />
       </Grid.ColumnDefinitions>
       <CheckBox
         x:Name="_doNotShowCheckBox"
         Grid.Column="0"
         Margin="12"
-        MinWidth="180"
         VerticalAlignment="Center"
         Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
         Content="{x:Static nuget:Resources.DoNotShowThisAgain}"
         Checked="DoNotShowCheckBox_Checked"
         Unchecked="DoNotShowCheckBox_Unchecked" />
       <Button
-        Grid.Column="2"
+        Grid.Column="1"
         MinWidth="86"
         MinHeight="24"
         Margin="0,12"
@@ -94,7 +99,7 @@
         Content="{x:Static nuget:Resources.Button_OK}"
         Click="OkButtonClicked" />
       <Button
-        Grid.Column="3"
+        Grid.Column="2"
         MinWidth="86"
         MinHeight="24"
         Margin="6,12,12,12"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/NuGetProjectUpgradeWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/NuGetProjectUpgradeWindow.xaml
@@ -28,13 +28,15 @@
         x:Key="StandardItemsControlTemplate"
         TargetType="{x:Type ItemsControl}">
         <Border
-          BorderThickness="1"
-          BorderBrush="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}">
+          BorderThickness="0"
+          BorderBrush="{x:Null}">
           <ScrollViewer
             Padding="3"
             CanContentScroll="False"
             VerticalScrollBarVisibility="Auto"
-            HorizontalScrollBarVisibility="Disabled">
+            HorizontalScrollBarVisibility="Disabled"
+            IsTabStop="False"
+            AutomationProperties.LabeledBy="{Binding ElementName=_packageCompatibilityIssuesLabel}">
             <ItemsPresenter />
           </ScrollViewer>
         </Border>
@@ -97,7 +99,8 @@
             Margin="18,0,0,0"
             Grid.Row="1"
             Visibility="Collapsed"
-            DockPanel.Dock="Bottom" />
+            DockPanel.Dock="Bottom"
+            Focusable="False"/>
         </Grid>
         <ControlTemplate.Triggers>
           <Trigger Property="IsExpanded" Value="True">
@@ -107,7 +110,7 @@
       </ControlTemplate>
       <Style TargetType="DataGridCell" x:Key="UpgraderDataGridCellStyle">
         <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}" />
-        <Setter Property="Focusable" Value="True"/>
+        <Setter Property="Focusable" Value="False" />
         <Style.Triggers>
           <Trigger Property="IsSelected" Value="True">
             <Setter Property="Background" Value="{x:Null}" />
@@ -119,7 +122,6 @@
         <Setter Property="BorderBrush" Value="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}"/>
         <Setter Property="Foreground" Value="{DynamicResource {x:Static nuget:Brushes.UIText}}" />
         <Setter Property="BorderThickness" Value="1,0,0,1"/>
-        <Setter Property="Focusable" Value="True"/>
         <Setter Property="Padding" Value="3,2,2,4"/>
         <Style.Triggers>
           <Trigger Property="IsMouseOver" Value="True">
@@ -153,16 +155,41 @@
       </Grid.RowDefinitions>
       <TextBlock
         x:Name="_directDependenciesLabel"
-        Focusable="True"
         AutomationProperties.Name="{Binding Text}"
         Grid.Row="0"
         Margin="0,0,0,4"
         Text="{x:Static nuget:Resources.Text_DirectDependencies}" />
-      <DataGrid Grid.Row="1" ItemsSource="{Binding DirectDependencies}" AutoGenerateColumns="False" RowHeaderWidth="0" GridLinesVisibility="None" Background="Transparent" RowBackground="Transparent" BorderBrush="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}"
-                ColumnHeaderStyle="{StaticResource Migrator_DataGridColumnHeaderStyle}" Focusable="True" Margin="0,2,0,0">
+      <DataGrid
+        Grid.Row="1"
+        ItemsSource="{Binding DirectDependencies}"
+        AutoGenerateColumns="False"
+        RowHeaderWidth="0"
+        GridLinesVisibility="None"
+        Background="Transparent"
+        RowBackground="Transparent"
+        BorderBrush="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}"
+        ColumnHeaderStyle="{StaticResource Migrator_DataGridColumnHeaderStyle}"
+        Margin="0,2,0,0"
+        AutomationProperties.LabeledBy="{Binding ElementName=_directDependenciesLabel}"
+        KeyboardNavigation.TabNavigation="Local"
+        SelectionMode="Single"
+        SelectionUnit="FullRow">
         <DataGrid.Columns>
-          <DataGridTextColumn x:Name="directDependency_id" Binding="{Binding Id}" Header="{x:Static nuget:Resources.Migrator_PackageIdColumnHeader}" MinWidth="20" Width="4*" IsReadOnly="True" CellStyle="{StaticResource UpgraderDataGridCellStyle}"/>
-          <DataGridTextColumn x:Name="directDependency_version" Binding="{Binding Version}" Header="{x:Static nuget:Resources.Migrator_VersionColumnHeader}" Width="*" IsReadOnly="True" CellStyle="{StaticResource UpgraderDataGridCellStyle}"/>
+          <DataGridTextColumn
+            x:Name="directDependency_id"
+            Binding="{Binding Id}"
+            Header="{x:Static nuget:Resources.Migrator_PackageIdColumnHeader}"
+            MinWidth="20"
+            Width="4*"
+            IsReadOnly="True"
+            CellStyle="{StaticResource UpgraderDataGridCellStyle}"/>
+          <DataGridTextColumn
+            x:Name="directDependency_version"
+            Binding="{Binding Version}"
+            Header="{x:Static nuget:Resources.Migrator_VersionColumnHeader}"
+            Width="*"
+            IsReadOnly="True"
+            CellStyle="{StaticResource UpgraderDataGridCellStyle}"/>
         </DataGrid.Columns>
       </DataGrid>
     </Grid>
@@ -176,36 +203,83 @@
       <TextBlock
         x:Name="_transitiveDependenciesLabel"
         AutomationProperties.Name="{Binding Text}"
-        Focusable="True"
         Grid.Row="0"
         Margin="0,0,0,4"
         Text="{x:Static nuget:Resources.Text_TransitiveDependencies}" />
-      <DataGrid Grid.Row="1" ItemsSource="{Binding TransitiveDependencies}" AutoGenerateColumns="False" RowHeaderWidth="0" GridLinesVisibility="None" Background="Transparent" RowBackground="Transparent"
-                Margin="0,2,0,0"
-                Focusable="True"
-                BorderBrush="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}"
-                ColumnHeaderStyle="{StaticResource Migrator_DataGridColumnHeaderStyle}">
+      <DataGrid
+        Grid.Row="1"
+        ItemsSource="{Binding TransitiveDependencies}"
+        AutoGenerateColumns="False"
+        RowHeaderWidth="0"
+        GridLinesVisibility="None"
+        Background="Transparent"
+        RowBackground="Transparent"
+        Margin="0,2,0,0"
+        BorderBrush="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}"
+        ColumnHeaderStyle="{StaticResource Migrator_DataGridColumnHeaderStyle}"
+        AutomationProperties.LabeledBy="{Binding ElementName=_transitiveDependenciesLabel}"
+        KeyboardNavigation.TabNavigation="Local"
+        SelectionMode="Single"
+        SelectionUnit="FullRow">
         <DataGrid.Columns>
-          <DataGridTextColumn x:Name="transitiveDependency_id" Binding="{Binding Id}" Header="{x:Static nuget:Resources.Migrator_PackageIdColumnHeader}" MinWidth="20" Width="4*" IsReadOnly="True" CellStyle="{StaticResource UpgraderDataGridCellStyle}"/>
-          <DataGridTextColumn x:Name="transitiveDependency_version" Binding="{Binding Version}" Header="{x:Static nuget:Resources.Migrator_VersionColumnHeader}" Width="*" IsReadOnly="True" CellStyle="{StaticResource UpgraderDataGridCellStyle}"/>
-          <DataGridTemplateColumn CellStyle="{StaticResource UpgraderDataGridCellStyle}" Width="*" IsReadOnly="True">
+          <DataGridTextColumn
+            x:Name="transitiveDependency_id"
+            Binding="{Binding Id}"
+            Header="{x:Static nuget:Resources.Migrator_PackageIdColumnHeader}"
+            MinWidth="20"
+            Width="4*"
+            IsReadOnly="True"
+            CellStyle="{StaticResource UpgraderDataGridCellStyle}"/>
+          <DataGridTextColumn
+            x:Name="transitiveDependency_version"
+            Binding="{Binding Version}"
+            Header="{x:Static nuget:Resources.Migrator_VersionColumnHeader}"
+            Width="*"
+            IsReadOnly="True"
+            CellStyle="{StaticResource UpgraderDataGridCellStyle}"/>
+          <DataGridTemplateColumn
+            Width="*"
+            IsReadOnly="True">
             <DataGridTemplateColumn.Header>
               <StackPanel Orientation="Horizontal">
-                <CheckBox IsChecked="False" Checked="PromoteAllToTopLevel_Checked" Unchecked="PromoteAllToTopLevel_Checked"/>
-                <TextBlock Text="{x:Static nuget:Resources.Migrator_TopLevelColumnHeader}" Margin="4,0,0,0"/>
+                <CheckBox
+                  AutomationProperties.LabeledBy="{Binding ElementName=_topLevelColumnHeader}"
+                  IsChecked="False"
+                  Checked="PromoteAllToTopLevel_Checked"
+                  Unchecked="PromoteAllToTopLevel_Checked"
+                  IsTabStop="True" />
+                <TextBlock
+                  x:Name="_topLevelColumnHeader"
+                  Text="{x:Static nuget:Resources.Migrator_TopLevelColumnHeader}"
+                  Margin="4,0,0,0"
+                  AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PromoteAllToTopLevel}"
+                  AutomationProperties.IsColumnHeader="True"/>
               </StackPanel>
             </DataGridTemplateColumn.Header>
             <DataGridTemplateColumn.HeaderStyle>
               <Style TargetType="DataGridColumnHeader" BasedOn="{StaticResource Migrator_DataGridColumnHeaderStyle}">
                 <Setter Property="HorizontalContentAlignment" Value="Center" />
                 <Setter Property="VerticalContentAlignment" Value="Center" />
+                <Setter Property="AutomationProperties.Name" Value="{x:Static nuget:Resources.Accessibility_PromoteAllToTopLevel}" />
+                <Setter Property="AutomationProperties.IsColumnHeader" Value="True" />
               </Style>
             </DataGridTemplateColumn.HeaderStyle>
             <DataGridTemplateColumn.CellTemplate>
               <DataTemplate>
-                <CheckBox HorizontalAlignment="Center" VerticalAlignment="Center" IsChecked="{Binding Mode=TwoWay, Path=InstallAsTopLevel, UpdateSourceTrigger=PropertyChanged}"/>
+                <CheckBox
+                  HorizontalAlignment="Center"
+                  VerticalAlignment="Center"
+                  AutomationProperties.AutomationId="{Binding Mode=OneWay, StringFormat='TopLevelCheckBox_{0}'}"
+                  IsChecked="{Binding Mode=TwoWay, Path=InstallAsTopLevel, UpdateSourceTrigger=PropertyChanged}"
+                  AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PromoteToTopLevel}"
+                  IsTabStop="True" />
               </DataTemplate>
             </DataGridTemplateColumn.CellTemplate>
+            <DataGridTemplateColumn.CellStyle>
+              <Style TargetType="DataGridCell" BasedOn="{StaticResource UpgraderDataGridCellStyle}">
+                <Setter Property="AutomationProperties.Name" Value="{x:Static nuget:Resources.Accessibility_PromoteToTopLevel}" />
+              </Style>
+            </DataGridTemplateColumn.CellStyle>
           </DataGridTemplateColumn>
         </DataGrid.Columns>
       </DataGrid>
@@ -218,58 +292,63 @@
         <RowDefinition Height="Auto" />
       </Grid.RowDefinitions>
 
-      <TextBlock x:Name="_packageCompatibilityIssuesLabel" Focusable="True" AutomationProperties.Name="{Binding Text}" Margin="0,0,4,8" Grid.Row="0" Text="{x:Static nuget:Resources.Text_NuGetUpgradeIssues}" />
+      <TextBlock
+        x:Name="_packageCompatibilityIssuesLabel"
+        AutomationProperties.Name="{Binding Text}"
+        Margin="0,0,4,8" Grid.Row="0"
+        Text="{x:Static nuget:Resources.Text_NuGetUpgradeIssues}" />
 
       <Border
         Grid.Row="1"
-        Visibility="{Binding HasIssues, Mode=OneTime, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"
         BorderThickness="1"
         Padding="3"
         BorderBrush="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}">
-        <TextBlock
-          Focusable="True"
-          Text="{x:Static nuget:Resources.Text_NuGetUpgradeNoIssuesFound}" />
-      </Border>
-
-      <ItemsControl
-        Grid.Row="1"
-        IsTabStop="True"
-        ItemsSource="{Binding UpgradeDependencyItems}"
-        Visibility="{Binding HasIssues, Mode=OneTime, Converter={StaticResource BooleanToVisibilityConverter}}"
-        x:Name="_packageIssuesItemControl"
-        AutomationProperties.AutomationId="{Binding Name}"
-        Template="{StaticResource StandardItemsControlTemplate}">
-        <ItemsControl.ItemTemplate>
-          <DataTemplate>
-            <Expander
-              x:Name="_packageIssuesExpander"
-              Margin="4,4,8,0"
-              Template="{StaticResource SimpleExpander}"
-              Header="{Binding Path=Id}"
-              Visibility="{Binding Path=Issues, Converter={StaticResource EnumerableToVisibilityConverter}}"
-              Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
-              AutomationProperties.AutomationId="_packageIssuesItemControlExpander"
-              IsExpanded="True">
-              <ItemsControl
-                Margin="8,4,16,4"
+        <Grid>
+          <TextBlock
+            Text="{x:Static nuget:Resources.Text_NuGetUpgradeNoIssuesFound}"
+            Visibility="{Binding HasIssues, Mode=OneTime, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"
+            AutomationProperties.Name="{x:Static nuget:Resources.Text_NuGetUpgradeNoIssuesFound}"
+            AutomationProperties.LabeledBy="{Binding ElementName=_packageCompatibilityIssuesLabel}"/>
+          <ItemsControl
+            ItemsSource="{Binding UpgradeDependencyItems}"
+            Visibility="{Binding HasIssues, Mode=OneTime, Converter={StaticResource BooleanToVisibilityConverter}}"
+            x:Name="_packageIssuesItemControl"
+            AutomationProperties.AutomationId="{Binding Name}"
+            AutomationProperties.LabeledBy="{Binding ElementName=_packageCompatibilityIssuesLabel}"
+            Template="{StaticResource StandardItemsControlTemplate}"
+            IsTabStop="False">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate>
+                <Expander
+                x:Name="_packageIssuesExpander"
+                Margin="4,4,8,0"
+                Template="{StaticResource SimpleExpander}"
+                Header="{Binding Path=Id}"
+                Visibility="{Binding Path=Issues, Converter={StaticResource EnumerableToVisibilityConverter}}"
                 Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
-                ItemsSource="{Binding Path=Issues}"
-                x:Name="_packageIssuesExpanderItemControl"
-                AutomationProperties.AutomationId="{Binding Name}"
-                Focusable="True"
-                IsTabStop="True">
-                <ItemsControl.ItemTemplate>
-                  <DataTemplate>
-                    <StackPanel x:Name="_packageIssuesStackPanel" Orientation="Vertical">
-                      <TextBlock x:Name="_packageIssueDescriptionText" Focusable="True" AutomationProperties.Name="{Binding Text}" AutomationProperties.AutomationId="{Binding Name}" Text="{Binding Path=Message}" Margin="0,2,0,2" TextWrapping="Wrap"/>
-                    </StackPanel>
-                  </DataTemplate>
-                </ItemsControl.ItemTemplate>
-              </ItemsControl>
-            </Expander>
-          </DataTemplate>
-        </ItemsControl.ItemTemplate>
-      </ItemsControl>
+                AutomationProperties.AutomationId="_packageIssuesItemControlExpander"
+                IsExpanded="True">
+                  <ItemsControl
+                  Margin="8,4,16,4"
+                  Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
+                  ItemsSource="{Binding Path=Issues}"
+                  x:Name="_packageIssuesExpanderItemControl"
+                  AutomationProperties.AutomationId="{Binding Name}"
+                  IsTabStop="False">      
+                    <ItemsControl.ItemTemplate>
+                      <DataTemplate>
+                        <StackPanel x:Name="_packageIssuesStackPanel" Orientation="Vertical">
+                          <TextBlock x:Name="_packageIssueDescriptionText" AutomationProperties.Name="{Binding Text}" AutomationProperties.AutomationId="{Binding Name}" Text="{Binding Path=Message}" Margin="0,2,0,2" TextWrapping="Wrap"/>
+                        </StackPanel>
+                      </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                  </ItemsControl>
+                </Expander>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+        </Grid>
+      </Border>
     </Grid>
 
     <Grid x:Name="PackageUpgraderFooterGrid" Grid.Row="3">
@@ -284,7 +363,8 @@
           Margin="0,0,2,0"
           Width="16"
           Height="16"
-          Moniker="{x:Static nuget:PackageIconMonikers.MigratorHelpIcon}" />
+          Moniker="{x:Static nuget:PackageIconMonikers.MigratorHelpIcon}"
+          AutomationProperties.Name="{x:Static nuget:Resources.ImageCaption_HelpIcon}"/>
         <TextBlock Margin="4,0,0,0">
           <Hyperlink
             NavigateUri="https://aka.ms/nuget-pc2pr-migrator"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagementFormatWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagementFormatWindow.xaml
@@ -38,7 +38,7 @@
 
     <TextBlock 
       Grid.Row="0" 
-      x:Name="textBlock" 
+      x:Name="_packageRefSuport" 
       Margin="12,12,12,0" 
       TextWrapping="Wrap"
       Text="{x:Static nuget:Resources.Text_PackageRefSupport}">
@@ -46,12 +46,14 @@
       <Hyperlink
         NavigateUri="{Binding Path=PackageRefUri, Mode=OneTime}"
         Style="{StaticResource HyperlinkStyle}"
-        Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}">
+        Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
+        AutomationProperties.LabeledBy="{Binding ElementName=_packageRefSuport}">
         <Run Text="{x:Static nuget:Resources.Text_PackageRefSupport_DocumentLink}" />
       </Hyperlink>
     </TextBlock>
 
     <TextBlock
+      x:Name="_packageFormatSelectorLabel"
       Grid.Row="1"
       Margin="12,12,12,0"
       TextWrapping="Wrap"
@@ -62,15 +64,20 @@
       <RadioButton
         IsChecked="{Binding Path=SelectedPackageManagementFormat, Converter={StaticResource RadioBoolToIntConverter}, ConverterParameter=0}"
         Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
+        AutomationProperties.HelpText="{Binding Text, ElementName=_packageFormatSelectorLabel}"
+        AutomationProperties.Name="{x:Static nuget:Resources.RadioBtn_PackagesConfig}"
         Content="{x:Static nuget:Resources.RadioBtn_PackagesConfig}" />
       <RadioButton
         Margin="0,6"
         IsChecked="{Binding Path=SelectedPackageManagementFormat, Converter={StaticResource RadioBoolToIntConverter}, ConverterParameter=1}"
         Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
+        AutomationProperties.HelpText="{Binding Text,ElementName=_packageFormatSelectorLabel}"
+        AutomationProperties.Name="{x:Static nuget:Resources.RadioBtn_PackageRef}"
         Content="{x:Static nuget:Resources.RadioBtn_PackageRef}"/>
     </StackPanel>
 
     <TextBlock
+      x:Name="_packageFormatApply"
       Grid.Row="3"
       Margin="12,8,12,0"
       TextWrapping="Wrap"
@@ -96,7 +103,8 @@
         <ItemsControl
           Margin="6,6,0,0"
           ItemsSource="{Binding Path=ProjectNames}"
-          IsTabStop="False" />
+          IsTabStop="False"
+          AutomationProperties.LabeledBy="{Binding ElementName=_packageFormatApply}"/>
       </ScrollViewer>
     </Border>
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.Designer.cs
@@ -421,7 +421,7 @@ namespace NuGet.PackageManagement.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The NuGet operation failed due to one or more packages being incompatible with your project. The &apos;{0}&apos; (&apos;{1}&apos;) project framework is deprecated. For more information about how to migrate your projects to a supported framework, please refer to the .
+        ///   Looks up a localized string similar to The NuGet operation failed due to one or more packages being incompatible with your project. The &apos;{0}&apos; (&apos;{1}&apos;) project framework is deprecated. For more information about how to migrate your projects to a supported framework, please refer to the.
         /// </summary>
         public static string Text_DeprecatedFramework_DocumentLink_Before {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.resx
@@ -267,7 +267,7 @@
     <comment>This test goes immediately after the document link.</comment>
   </data>
   <data name="Text_DeprecatedFramework_DocumentLink_Before" xml:space="preserve">
-    <value>The NuGet operation failed due to one or more packages being incompatible with your project. The '{0}' ('{1}') project framework is deprecated. For more information about how to migrate your projects to a supported framework, please refer to the </value>
+    <value>The NuGet operation failed due to one or more packages being incompatible with your project. The '{0}' ('{1}') project framework is deprecated. For more information about how to migrate your projects to a supported framework, please refer to the</value>
     <comment>This text goes immediately before the document link.
 {0} is the full name of the deprecated framework (e.g. ".NETFramework,Version=v4.5").
 {1} is the short folder representation of the framework (e.g. "net45").</comment>


### PR DESCRIPTION
Added support for WPF automation api in the UI for these three windows
and made sure they had a good keyboard navigation and where usable with
screen readers such as narrator and jaws