### PR TITLE
Add DOTNET_CLI_HOME to the probing of GetHome

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PathUtil/NuGetEnvironment.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/NuGetEnvironment.cs
@@ -155,6 +155,7 @@ namespace NuGet.Common
         {
             return Environment.GetEnvironmentVariable(DotNetHome);
         }
+
 #else
 
         private static string GetFolderPath(SpecialFolder folder)
@@ -208,11 +209,11 @@ namespace NuGet.Common
 #if IS_CORECLR
             if (RuntimeEnvironmentHelper.IsWindows)
             {
-                return GetDotNetHome() ?? GetValueOrThrowMissingEnvVar(() => GetHomeWindows(), UserProfile);
+                return GetValueOrThrowMissingEnvVarsDotnet(() => GetDotNetHome() ?? GetHomeWindows(), UserProfile, DotNetHome);
             }
             else
             {
-                return GetDotNetHome() ?? GetValueOrThrowMissingEnvVar(() => Environment.GetEnvironmentVariable(Home), Home);
+                return GetValueOrThrowMissingEnvVarsDotnet(() => GetDotNetHome() ?? Environment.GetEnvironmentVariable(Home), Home, DotNetHome);
             }
 #else
             if (RuntimeEnvironmentHelper.IsWindows)
@@ -237,6 +238,21 @@ namespace NuGet.Common
             {
                 return Environment.GetEnvironmentVariable("HOMEDRIVE") + Environment.GetEnvironmentVariable("HOMEPATH");
             }
+        }
+
+        /// <summary>
+        /// Throw a helpful message if the required env vars are not set.
+        /// </summary>
+        private static string GetValueOrThrowMissingEnvVarsDotnet(Func<string> getValue, string home, string dotnetHome)
+        {
+            var value = getValue();
+
+            if (string.IsNullOrEmpty(value))
+            {
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.MissingRequiredEnvVarsDotnet, home, dotnetHome));
+            }
+
+            return value;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Common/PathUtil/NuGetEnvironment.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/NuGetEnvironment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -12,6 +12,7 @@ namespace NuGet.Common
         private const string DotNet = "dotnet";
         private const string DotNetExe = "dotnet.exe";
         private const string Home = "HOME";
+        private const string DotNetHome = "DOTNET_CLI_HOME";
         private const string UserProfile = "USERPROFILE";
         private static readonly Lazy<string> _getHome = new Lazy<string>(() => GetHome());
 
@@ -150,6 +151,10 @@ namespace NuGet.Common
             }
         }
 
+        private static string GetDotNetHome()
+        {
+            return Environment.GetEnvironmentVariable(DotNetHome);
+        }
 #else
 
         private static string GetFolderPath(SpecialFolder folder)
@@ -200,6 +205,16 @@ namespace NuGet.Common
 
         private static string GetHome()
         {
+#if IS_CORECLR
+            if (RuntimeEnvironmentHelper.IsWindows)
+            {
+                return GetDotNetHome() ?? GetValueOrThrowMissingEnvVar(() => GetHomeWindows(), UserProfile);
+            }
+            else
+            {
+                return GetDotNetHome() ?? GetValueOrThrowMissingEnvVar(() => Environment.GetEnvironmentVariable(Home), Home);
+            }
+#else
             if (RuntimeEnvironmentHelper.IsWindows)
             {
                 return GetValueOrThrowMissingEnvVar(() => GetHomeWindows(), UserProfile);
@@ -208,6 +223,7 @@ namespace NuGet.Common
             {
                 return GetValueOrThrowMissingEnvVar(() => Environment.GetEnvironmentVariable(Home), Home);
             }
+#endif
         }
 
         private static string GetHomeWindows()

--- a/src/NuGet.Core/NuGet.Common/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Common/Strings.Designer.cs
@@ -107,6 +107,15 @@ namespace NuGet.Common {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Required environment variable &apos;{0}&apos; is not set. Try setting &apos;{1}&apos; or &apos;{0}&apos; and running the operation.
+        /// </summary>
+        internal static string MissingRequiredEnvVarsDotnet {
+            get {
+                return ResourceManager.GetString("MissingRequiredEnvVarsDotnet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to At least one package folder path must be provided..
         /// </summary>
         internal static string NoPackageFoldersFound {

--- a/src/NuGet.Core/NuGet.Common/Strings.resx
+++ b/src/NuGet.Core/NuGet.Common/Strings.resx
@@ -132,6 +132,9 @@
   <data name="MissingRequiredEnvVar" xml:space="preserve">
     <value>Required environment variable '{0}' is not set. Try setting '{0}' and running the operation again.</value>
   </data>
+  <data name="MissingRequiredEnvVarsDotnet" xml:space="preserve">
+    <value>Required environment variable '{0}' is not set. Try setting '{1}' or '{0}' and running the operation</value>
+  </data>
   <data name="NoPackageFoldersFound" xml:space="preserve">
     <value>At least one package folder path must be provided.</value>
   </data>


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6989
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
In the dotnet.exe use-cases, NuGet needs to respect the DOTNET_CLI_HOME variable (it takes priority over the HOME variable). 

I have also added a helpful error message if both variables are not set. 

Example on nix platforms
```
Required environment variable 'HOME' is not set. Try setting 'DOTNET_CLI_HOME' or 'HOME' and running the operation
```

The message structure is similar to the already existing error message. 

//cc @peterhuene 

Can you please take a look. 

## Testing/Validation
Tests Added: No
Reason for not adding tests:  No infra for such tests
Validation done: Manually
