### PR TITLE
Fix NPE when the package is not found with restore ignore failed sources

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
@@ -179,6 +179,15 @@ namespace NuGet.Commands
             ILogger logger,
             CancellationToken token)
         {
+            Console.WriteLine("Waiting for debugger to attach.");
+            Console.WriteLine($"Process ID: { System.Diagnostics.Process.GetCurrentProcess().Id}");
+
+            while (!System.Diagnostics.Debugger.IsAttached)
+            {
+                System.Threading.Thread.Sleep(100);
+            }
+            System.Diagnostics.Debugger.Break();
+
             var sources = new List<KeyValuePair<PackageSource, SortedSet<NuGetVersion>>>();
 
             // Get versions from all sources. These should be cached by the providers already.
@@ -208,7 +217,7 @@ namespace NuGet.Commands
             CancellationToken token)
         {
             // Find all versions from a source.
-            var versions = await provider.GetAllVersionsAsync(id, cacheContext, logger, token);
+            var versions = await provider.GetAllVersionsAsync(id, cacheContext, logger, token) ?? Enumerable.Empty<NuGetVersion>();
 
             return new KeyValuePair<PackageSource, SortedSet<NuGetVersion>>(
                 provider.Source,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
@@ -179,15 +179,6 @@ namespace NuGet.Commands
             ILogger logger,
             CancellationToken token)
         {
-            Console.WriteLine("Waiting for debugger to attach.");
-            Console.WriteLine($"Process ID: { System.Diagnostics.Process.GetCurrentProcess().Id}");
-
-            while (!System.Diagnostics.Debugger.IsAttached)
-            {
-                System.Threading.Thread.Sleep(100);
-            }
-            System.Diagnostics.Debugger.Break();
-
             var sources = new List<KeyValuePair<PackageSource, SortedSet<NuGetVersion>>>();
 
             // Get versions from all sources. These should be cached by the providers already.


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6874
Regression: Don't know  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
Fix an NPE when the package is not found with restore ignore failed sources. 

## Testing/Validation
Tests Added: Yes
Reason for not adding tests:  
Validation done:  
