### PR TITLE
2018-06-19: GS - Update localized string for 'Package Source' for add…

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -12323,7 +12323,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package Source with Name: {0} added successfully..
+        ///   Looks up a localized string similar to Package source with Name: {0} added successfully..
         /// </summary>
         public static string SourcesCommandSourceAddedSuccessfully {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -316,7 +316,7 @@
     <value>The name specified cannot be empty. Please provide a valid name.</value>
   </data>
   <data name="SourcesCommandSourceAddedSuccessfully" xml:space="preserve">
-    <value>Package Source with Name: {0} added successfully.</value>
+    <value>Package source with Name: {0} added successfully.</value>
   </data>
   <data name="SourcesCommandSourceRequired" xml:space="preserve">
     <value>The source specified cannot be empty. Please provide a valid source.</value>


### PR DESCRIPTION
…ing packages to 'Package source' to reflect the same other 3 actions.

## Bug
Fixes: No Bug created
Regression: No  
If Regression then when did it last work:   N/A
If Regression then how are we preventing it in future:   N/A

## Fix
Details: Update localized string for 'Package Source' for adding packages to 'Package source' to reflect the same other 3 actions.

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  String display update.
Validation done:  N/A
