### PR TITLE
Add error codes for install failures and hyperlink to all error codes

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -337,7 +337,7 @@ namespace NuGet.PackageManagement.UI
                         {
                             if (message.Level == LogLevel.Error)
                             {
-                                UILogger.ReportError(message.Message);
+                                UILogger.ReportError(message);
                             }
                         }
                     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -335,7 +335,7 @@ namespace NuGet.PackageManagement.UI
                     {
                         foreach (var message in rollbackException.LogMessages)
                         {
-                            if (message.Level == LogLevel.Error)
+                            if (message.Level == LogLevel.Error || message.Level == LogLevel.Warning)
                             {
                                 UILogger.ReportError(message);
                             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -355,7 +355,7 @@ namespace NuGet.PackageManagement.UI
         {
             if (!string.IsNullOrEmpty(ex.Message))
             {
-                UILogger.ReportError(ex.AsLogMessage().FormatWithCode());
+                UILogger.ReportError(ex.AsLogMessage());
                 ProjectContext.Log(MessageLevel.Error, ex.AsLogMessage().FormatWithCode());
             }
 
@@ -364,7 +364,7 @@ namespace NuGet.PackageManagement.UI
                 var errorList = result.GetErrorIssues().ToList();
                 var warningList = result.GetWarningIssues().ToList();
 
-                errorList.ForEach(p => UILogger.ReportError(p.FormatWithCode()));
+                errorList.ForEach(p => UILogger.ReportError(p));
 
                 errorList.ForEach(p => ProjectContext.Log(MessageLevel.Error, p.FormatWithCode()));
                 warningList.ForEach(p => ProjectContext.Log(MessageLevel.Warning, p.FormatWithCode()));

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/ErrorListTableDataSource.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/ErrorListTableDataSource.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/ErrorListTableEntry.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/ErrorListTableEntry.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
 using System;
+using System.Globalization;
 using System.IO;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.TableControl;
@@ -13,6 +14,7 @@ namespace NuGet.SolutionRestoreManager
     public class ErrorListTableEntry : ITableEntry
     {
         internal const string ErrorSouce = "NuGet";
+        internal const string HelpLink = "https://msdn.microsoft.com/query/dev15.query?appId=Dev15IDEF1&l={0}&k=k({1})&rd=true";
 
         public ILogMessage Message { get; }
 
@@ -39,19 +41,20 @@ namespace NuGet.SolutionRestoreManager
 
             switch (keyName)
             {
-                case StandardTableColumnDefinitions.Text:
+                case StandardTableKeyNames.Text:
                     content = Message.Message;
                     return true;
-                case StandardTableColumnDefinitions.ErrorSeverity:
+                case StandardTableKeyNames.ErrorSeverity:
                     content = GetErrorCategory(Message.Level);
                     return true;
-                case StandardTableColumnDefinitions.Priority:
+                case StandardTableKeyNames.Priority:
                     content = "high";
                     return true;
-                case StandardTableColumnDefinitions.ErrorSource:
+                case StandardTableKeyNames.ErrorSource:
                     content = ErrorSouce;
                     return true;
-                case StandardTableColumnDefinitions.ErrorCode:
+                case StandardTableKeyNames.HelpKeyword:
+                case StandardTableKeyNames.ErrorCode:
                     var result = false;
 
                     if (Message.Code > NuGetLogCode.Undefined)
@@ -61,7 +64,18 @@ namespace NuGet.SolutionRestoreManager
                     }
 
                     return result;
-                case StandardTableColumnDefinitions.Line:
+                case StandardTableKeyNames.HelpLink:
+                case StandardTableKeyNames.ErrorCodeToolTip:
+                    result = false;
+
+                    if (Message.Code > NuGetLogCode.Undefined)
+                    {
+                        result = Message.Code.TryGetName(out var codeString);
+                        content = string.Format(HelpLink, CultureInfo.CurrentCulture, codeString);
+                    }
+
+                    return result;
+                case StandardTableKeyNames.Line:
 
                     if (Message is RestoreLogMessage)
                     {
@@ -70,7 +84,7 @@ namespace NuGet.SolutionRestoreManager
                     }
 
                     return false;
-                case StandardTableColumnDefinitions.Column:
+                case StandardTableKeyNames.Column:
 
                     if (Message is RestoreLogMessage)
                     {
@@ -79,8 +93,7 @@ namespace NuGet.SolutionRestoreManager
                     }
 
                     return false;
-                case StandardTableColumnDefinitions.DocumentName:
-
+                case StandardTableKeyNames.DocumentName:
                     var documentName = GetProjectFile(Message);
 
                     if (!string.IsNullOrEmpty(documentName))
@@ -91,7 +104,6 @@ namespace NuGet.SolutionRestoreManager
 
                     return false;
                 case StandardTableColumnDefinitions.ProjectName:
-
                     var projectName = GetProjectFile(Message);
 
                     if (!string.IsNullOrEmpty(projectName))

--- a/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
+++ b/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
@@ -2,7 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.legacy.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.common.props')" />
-  <Import Project="$(VSSDKRoot)\build\Microsoft.VSSDK.BuildTools.props" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' "/> <!-- No bootstrapping on XPLAT, this project is not expect to work correctly-->
+  <Import Project="$(VSSDKRoot)\build\Microsoft.VSSDK.BuildTools.props" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' " />
+  <!-- No bootstrapping on XPLAT, this project is not expect to work correctly-->
   <PropertyGroup>
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>
@@ -105,6 +106,10 @@
       <Project>{538adefd-2170-40a9-a2c5-ec8369cfe490}</Project>
       <Name>NuGet.PackageManagement.UI</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.SolutionRestoreManager\NuGet.SolutionRestoreManager.csproj">
+      <Project>{06662133-1292-4918-90F3-36C930C0B16F}</Project>
+      <Name>NuGet.SolutionRestoreManager</Name>
+    </ProjectReference>
     <ProjectReference Include="..\NuGet.VisualStudio.Common\NuGet.VisualStudio.Common.csproj">
       <Project>{eea49a74-6efc-410e-9745-bad367ac151d}</Project>
       <Name>NuGet.VisualStudio.Common</Name>
@@ -140,6 +145,6 @@
   </ItemGroup>
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' "/>
-  <Import Project="$(VSSDKRoot)\build\Microsoft.VSSDK.BuildTools.targets" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' "/>
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' " />
+  <Import Project="$(VSSDKRoot)\build\Microsoft.VSSDK.BuildTools.targets" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' " />
 </Project>

--- a/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
+++ b/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
@@ -2,8 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.legacy.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.common.props')" />
-  <Import Project="$(VSSDKRoot)\build\Microsoft.VSSDK.BuildTools.props" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' " />
   <!-- No bootstrapping on XPLAT, this project is not expect to work correctly-->
+  <Import Project="$(VSSDKRoot)\build\Microsoft.VSSDK.BuildTools.props" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' " />
   <PropertyGroup>
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>

--- a/src/NuGet.Clients/NuGet.Tools/OutputConsoleLogger.cs
+++ b/src/NuGet.Clients/NuGet.Tools/OutputConsoleLogger.cs
@@ -10,7 +10,6 @@ using NuGet.PackageManagement.VisualStudio;
 using NuGet.ProjectManagement;
 using NuGet.SolutionRestoreManager;
 using NuGet.VisualStudio;
-using NuGetConsole;
 
 namespace NuGetVSExtension
 {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/UserInterfaceService/INuGetUILogger.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/UserInterfaceService/INuGetUILogger.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using NuGet.Common;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -10,6 +11,8 @@ namespace NuGet.PackageManagement.VisualStudio
         void Log(ProjectManagement.MessageLevel level, string message, params object[] args);
 
         void ReportError(string message);
+
+        void ReportError(ILogMessage message);
 
         void Start();
 

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2914,7 +2914,7 @@ namespace NuGet.PackageManagement
                 // Read additional errors from the lock file if one exists
                 var logMessages = restoreResult.LockFile?
                     .LogMessages
-                    .Where(e => e.Level == LogLevel.Error)
+                    .Where(e => e.Level == LogLevel.Error || e.Level == LogLevel.Warning)
                     .Select(e => e.AsRestoreLogMessage())
                   ?? Enumerable.Empty<ILogMessage>();
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
@@ -46,6 +46,7 @@ namespace NuGet.Packaging.Signing
             Results = results;
             PackageIdentity = package;
             results.SelectMany(r => r.Issues).ForEach(l => l.LibraryId = package.ToString());
+            results.SelectMany(r => r.Issues).ForEach(l => l.Message = $"{package.ToString()}: {l.Message}");
         }
 
         public SignatureException(NuGetLogCode code, string message, PackageIdentity package)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
@@ -46,7 +46,6 @@ namespace NuGet.Packaging.Signing
             Results = results;
             PackageIdentity = package;
             results.SelectMany(r => r.Issues).ForEach(l => l.LibraryId = package.ToString());
-            results.SelectMany(r => r.Issues).ForEach(l => l.Message = $"{package.ToString()}: {l.Message}");
         }
 
         public SignatureException(NuGetLogCode code, string message, PackageIdentity package)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureLog.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureLog.cs
@@ -18,7 +18,7 @@ namespace NuGet.Packaging.Signing
 
         public NuGetLogCode Code { get; set; }
 
-        public WarningLevel WarningLevel { get; set; }
+        public WarningLevel WarningLevel { get; set; } = WarningLevel.Severe; //setting default to Severe as 0 implies show no warnings
 
         public string ProjectPath { get; set; }
 

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ErrorListTableEntryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ErrorListTableEntryTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using FluentAssertions;
-using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableManager;
 using NuGet.Common;
 using Xunit;
 
@@ -12,6 +12,8 @@ namespace NuGet.SolutionRestoreManager.Test
     {
         private const string _testMessage = "test log message";
         private const NuGetLogCode _testCode = NuGetLogCode.NU1000;
+        private const string _testCodeString = "NU1000";
+        private const string _testHelpLink = "https://msdn.microsoft.com/query/dev15.query?appId=Dev15IDEF1&l=en-US&k=k(NU1000)&rd=true";        
         private const string _testProjectPath = @"unit\test\project.csproj";
         private const string _testProjectName = "project";
         private const int _testLineNumber = 100;
@@ -47,15 +49,18 @@ namespace NuGet.SolutionRestoreManager.Test
 
         [Theory]
         [InlineData("")]
-        [InlineData(StandardTableColumnDefinitions.Text)]
-        [InlineData(StandardTableColumnDefinitions.ErrorSeverity)]
-        [InlineData(StandardTableColumnDefinitions.DocumentName)]
-        [InlineData(StandardTableColumnDefinitions.ErrorCode)]
-        [InlineData(StandardTableColumnDefinitions.ProjectName)]
-        [InlineData(StandardTableColumnDefinitions.Line)]
-        [InlineData(StandardTableColumnDefinitions.Column)]
-        [InlineData(StandardTableColumnDefinitions.Priority)]
-        [InlineData(StandardTableColumnDefinitions.ErrorSource)]
+        [InlineData(StandardTableKeyNames.Text)]
+        [InlineData(StandardTableKeyNames.ErrorSeverity)]
+        [InlineData(StandardTableKeyNames.DocumentName)]
+        [InlineData(StandardTableKeyNames.ErrorCode)]
+        [InlineData(StandardTableKeyNames.ProjectName)]
+        [InlineData(StandardTableKeyNames.Line)]
+        [InlineData(StandardTableKeyNames.Column)]
+        [InlineData(StandardTableKeyNames.Priority)]
+        [InlineData(StandardTableKeyNames.ErrorSource)]
+        [InlineData(StandardTableKeyNames.ErrorCodeToolTip)]
+        [InlineData(StandardTableKeyNames.HelpKeyword)]
+        [InlineData(StandardTableKeyNames.HelpLink)]
         public void CanSetValue_AlwaysReturnsFalse(string key)
         {
             // Arrange & Act
@@ -67,11 +72,15 @@ namespace NuGet.SolutionRestoreManager.Test
         }
 
         [Theory]
-        [InlineData(StandardTableColumnDefinitions.Text, _testMessage)]
-        [InlineData(StandardTableColumnDefinitions.DocumentName, _testProjectPath)]
-        [InlineData(StandardTableColumnDefinitions.ProjectName, _testProjectName)]
-        [InlineData(StandardTableColumnDefinitions.Priority, "high")]
-        [InlineData(StandardTableColumnDefinitions.ErrorSource, "NuGet")]
+        [InlineData(StandardTableKeyNames.Text, _testMessage)]
+        [InlineData(StandardTableKeyNames.DocumentName, _testProjectPath)]
+        [InlineData(StandardTableKeyNames.ProjectName, _testProjectName)]
+        [InlineData(StandardTableKeyNames.Priority, "high")]
+        [InlineData(StandardTableKeyNames.ErrorSource, "NuGet")]
+        [InlineData(StandardTableKeyNames.ErrorCodeToolTip, _testHelpLink)]
+        [InlineData(StandardTableKeyNames.HelpLink, _testHelpLink)]
+        [InlineData(StandardTableKeyNames.ErrorCode, _testCodeString)]
+        [InlineData(StandardTableKeyNames.HelpKeyword, _testCodeString)]
         public void TryGetValue_StringContent_ReturnsValues(string key, string content)
         {
             // Arrange
@@ -91,8 +100,8 @@ namespace NuGet.SolutionRestoreManager.Test
         }
 
         [Theory]
-        [InlineData(StandardTableColumnDefinitions.DocumentName)]
-        [InlineData(StandardTableColumnDefinitions.ProjectName)]
+        [InlineData(StandardTableKeyNames.DocumentName)]
+        [InlineData(StandardTableKeyNames.ProjectName)]
         public void TryGetValue_StringContentNotAvailable_ReturnsNull(string key)
         {
             // Arrange
@@ -108,8 +117,8 @@ namespace NuGet.SolutionRestoreManager.Test
         }
 
         [Theory]
-        [InlineData(StandardTableColumnDefinitions.DocumentName, _testProjectPath)]
-        [InlineData(StandardTableColumnDefinitions.ProjectName, _testProjectName)]
+        [InlineData(StandardTableKeyNames.DocumentName, _testProjectPath)]
+        [InlineData(StandardTableKeyNames.ProjectName, _testProjectName)]
         public void TryGetValue_ProjectPathNull_ReturnsFilePath(string key, string content)
         {
             // Arrange
@@ -129,8 +138,8 @@ namespace NuGet.SolutionRestoreManager.Test
         }
 
         [Theory]
-        [InlineData(StandardTableColumnDefinitions.Line, _testLineNumber)]
-        [InlineData(StandardTableColumnDefinitions.Column, _testColumnNumber)]
+        [InlineData(StandardTableKeyNames.Line, _testLineNumber)]
+        [InlineData(StandardTableKeyNames.Column, _testColumnNumber)]
         public void TryGetValue_IntContent_ReturnsValues(string key, int content)
         {
             // Arrange
@@ -151,8 +160,8 @@ namespace NuGet.SolutionRestoreManager.Test
         }
 
         [Theory]
-        [InlineData(StandardTableColumnDefinitions.Line)]
-        [InlineData(StandardTableColumnDefinitions.Column)]
+        [InlineData(StandardTableKeyNames.Line)]
+        [InlineData(StandardTableKeyNames.Column)]
         public void TryGetValue_IntContentNotAvailable_ReturnsZero(string key)
         {
             // Arrange


### PR DESCRIPTION
## Bug
Fixes: Half of https://github.com/NuGet/Home/issues/6944
Regression: No

## Fix
This PR fixes the following - 
1. During install, errors logged in the error list did not contain error code. Fixing this by adding a `ErrorListTableDataSource` in `OutputConsoleLogger` to have eeror code logs into the error list like the `SolutionRestoreJob`.
2. During install, warnings were not logged into the error list.
3. We were using wrong keys in `ErrorListTableEntry`. `StandardTableColumnDefinitions` keys are to be used for creating a table and `StandardTableKeyNames` keys are to be used for fetching values from an entry, as described [here](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.tablecontrol.standardtablecolumndefinitions?view=visualstudiosdk-2017).
4. For non-CPS projects, the error codes displayed in the error list did not have a hyperlink. Fixing that by adding support for `StandardTableKeyNames.ErrorCodeToolTip` and `StandardTableKeyNames.HelpLink`.


## Testing/Validation
Tests Added: Yes
Validation done:  Manual Validation.

## Images - 

### CPS Install failure with errors and warnings- 
![image](https://user-images.githubusercontent.com/10507120/41690400-35c59192-74aa-11e8-9602-6e2bb4ef2e20.png)

### CPS Install success with warnings- 
![image](https://user-images.githubusercontent.com/10507120/41690430-58c39b44-74aa-11e8-85dd-3236b8c1c5c0.png)

### Legacy csproj restore with errors and warnings - 
![image](https://user-images.githubusercontent.com/10507120/41690847-4fda0656-74ac-11e8-83bb-1379af9a031d.png)
