### PR TITLE
fix the interactivity flag for the credential service

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -293,7 +293,7 @@ namespace NuGet.CommandLine.XPlat
                 var restoreRequests = await RestoreRunner.GetRequests(restoreContext);
 
                 //Setup the Credential Service
-                DefaultCredentialServiceUtility.SetupDefaultCredentialService(restoreContext.Log, packageReferenceArgs.Interactive);
+                DefaultCredentialServiceUtility.SetupDefaultCredentialService(restoreContext.Log, !packageReferenceArgs.Interactive);
 
                 // Run restore without commit. This will always return 1 Result pair since we are restoring for 1 request.
                 var restoreResult = await RestoreRunner.RunWithoutCommit(restoreRequests, restoreContext);

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -120,8 +120,9 @@ namespace NuGet.XPlat.FuncTest
             p.NoRestore == !string.IsNullOrEmpty(noRestoreSwitch) &&
             (string.IsNullOrEmpty(frameworkOption) || !string.IsNullOrEmpty(frameworkOption) && p.Frameworks.SequenceEqual(frameworks)) &&
             (string.IsNullOrEmpty(sourceOption) || !string.IsNullOrEmpty(sourceOption) && p.Sources.SequenceEqual(MSBuildStringUtility.Split(sourceString))) &&
-            (string.IsNullOrEmpty(packageDirectoryOption) || !string.IsNullOrEmpty(packageDirectoryOption) && p.PackageDirectory == packageDirectory)),
+            (string.IsNullOrEmpty(packageDirectoryOption) || !string.IsNullOrEmpty(packageDirectoryOption) && p.PackageDirectory == packageDirectory) && p.Interactive == !string.IsNullOrEmpty(interactiveSwitch)) ,
             It.IsAny<MSBuildAPIUtility>()));
+
 
             Assert.Equal(0, result);
         }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7046
Regression: 
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
The interactivity switch was flipped for the add package command credential service setup.   
Unfortunately it's difficult to add a good unit test for this specific behavior without changing the API for the CredentialService. 

## Testing/Validation
Tests Added: Yes 
Reason for not adding tests:  
Validation done:  yes, manual + test
