### PR TITLE
Added project name check in addition to cache when restoring

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -317,7 +317,8 @@ namespace NuGet.Commands
             {
                 cacheFile = FileUtility.SafeRead(_request.Project.RestoreMetadata.CacheFilePath, (stream, path) => CacheFileFormat.Read(stream, _logger, path));
 
-                if (cacheFile.IsValid && StringComparer.Ordinal.Equals(cacheFile.DgSpecHash, newDgSpecHash) && _request.ExistingLockFile.PackageSpec.FilePath.Equals(_request.Project.FilePath))
+                if (cacheFile.IsValid && StringComparer.Ordinal.Equals(cacheFile.DgSpecHash, newDgSpecHash) &&
+                    (_request.ExistingLockFile == null || _request.ExistingLockFile.PackageSpec.FilePath.Equals(_request.Project.FilePath)))
                 {
                     _logger.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_RestoreNoOpFinish, _request.Project.Name));
                     _success = true;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -303,7 +303,7 @@ namespace NuGet.Commands
         /// <summary>
         /// Accounts for using the restore commands on 2 projects living in the same path
         /// </summary>
-        private bool VerifyCacheMatchesAssetsFile()
+        private bool VerifyAssetsFileMatchesProject()
         {
             if (_request.Project.RestoreMetadata.ProjectStyle == ProjectStyle.DotnetCliTool)
             {
@@ -330,7 +330,7 @@ namespace NuGet.Commands
             {
                 cacheFile = FileUtility.SafeRead(_request.Project.RestoreMetadata.CacheFilePath, (stream, path) => CacheFileFormat.Read(stream, _logger, path));
 
-                if (cacheFile.IsValid && StringComparer.Ordinal.Equals(cacheFile.DgSpecHash, newDgSpecHash) && VerifyCacheMatchesAssetsFile())
+                if (cacheFile.IsValid && StringComparer.Ordinal.Equals(cacheFile.DgSpecHash, newDgSpecHash) && VerifyAssetsFileMatchesProject())
                 {
                     _logger.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_RestoreNoOpFinish, _request.Project.Name));
                     _success = true;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -317,7 +317,7 @@ namespace NuGet.Commands
             {
                 cacheFile = FileUtility.SafeRead(_request.Project.RestoreMetadata.CacheFilePath, (stream, path) => CacheFileFormat.Read(stream, _logger, path));
 
-                if (cacheFile.IsValid && StringComparer.Ordinal.Equals(cacheFile.DgSpecHash, newDgSpecHash))
+                if (cacheFile.IsValid && StringComparer.Ordinal.Equals(cacheFile.DgSpecHash, newDgSpecHash) && _request.ExistingLockFile.PackageSpec.FilePath.Equals(_request.Project.FilePath))
                 {
                     _logger.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_RestoreNoOpFinish, _request.Project.Name));
                     _success = true;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -300,6 +300,22 @@ namespace NuGet.Commands
             return result;
         }
 
+        private bool SameProject(RestoreRequest _request)
+        {
+            if (_request.Project.RestoreMetadata.ProjectStyle == ProjectStyle.DotnetCliTool)
+            {
+                return true;
+            }
+            else if (_request.ExistingLockFile != null && _request.ExistingLockFile.PackageSpec.FilePath.Equals(_request.Project.FilePath))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
         private KeyValuePair<CacheFile, bool> EvaluateCacheFile()
         {
             CacheFile cacheFile;
@@ -317,8 +333,7 @@ namespace NuGet.Commands
             {
                 cacheFile = FileUtility.SafeRead(_request.Project.RestoreMetadata.CacheFilePath, (stream, path) => CacheFileFormat.Read(stream, _logger, path));
 
-                if (cacheFile.IsValid && StringComparer.Ordinal.Equals(cacheFile.DgSpecHash, newDgSpecHash) &&
-                    _request.ExistingLockFile != null && _request.ExistingLockFile.PackageSpec.FilePath.Equals(_request.Project.FilePath))
+                if (cacheFile.IsValid && StringComparer.Ordinal.Equals(cacheFile.DgSpecHash, newDgSpecHash) && SameProject(_request))
                 {
                     _logger.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_RestoreNoOpFinish, _request.Project.Name));
                     _success = true;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -318,7 +318,7 @@ namespace NuGet.Commands
                 cacheFile = FileUtility.SafeRead(_request.Project.RestoreMetadata.CacheFilePath, (stream, path) => CacheFileFormat.Read(stream, _logger, path));
 
                 if (cacheFile.IsValid && StringComparer.Ordinal.Equals(cacheFile.DgSpecHash, newDgSpecHash) &&
-                    (_request.ExistingLockFile == null || _request.ExistingLockFile.PackageSpec.FilePath.Equals(_request.Project.FilePath)))
+                    _request.ExistingLockFile != null && _request.ExistingLockFile.PackageSpec.FilePath.Equals(_request.Project.FilePath))
                 {
                     _logger.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_RestoreNoOpFinish, _request.Project.Name));
                     _success = true;

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/DotnetCliToolTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/DotnetCliToolTests.cs
@@ -224,7 +224,7 @@ namespace NuGet.Commands.Test
                 var result2 = results2.Single();
 
                 Assert.True(result2.Success, "Failed: " + string.Join(Environment.NewLine, logger2.Messages));
-                Assert.True(result2.NoOpRestore, "Should no-op: " + string.Join(Environment.NewLine, logger2.Messages));
+                Assert.False(result2.NoOpRestore, "Should no-op: " + string.Join(Environment.NewLine, logger2.Messages));
                 Assert.True(File.Exists(path));
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/DotnetCliToolTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/DotnetCliToolTests.cs
@@ -224,7 +224,7 @@ namespace NuGet.Commands.Test
                 var result2 = results2.Single();
 
                 Assert.True(result2.Success, "Failed: " + string.Join(Environment.NewLine, logger2.Messages));
-                Assert.False(result2.NoOpRestore, "Should no-op: " + string.Join(Environment.NewLine, logger2.Messages));
+                Assert.True(result2.NoOpRestore, "Should no-op: " + string.Join(Environment.NewLine, logger2.Messages));
                 Assert.True(File.Exists(path));
             }
         }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6114
Regression: No
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: In addition to checking that hashes match, I've added a check to make sure that the project name in project specs is similar to the one we are attempting to restore before no-oping

## Testing/Validation
Tests Added: No
Reason for not adding tests:  Edge case. Tested Locally.
