### PR TITLE
Added new interface IVSPathContextProvider2 and api TryCreateSolutionContext()

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -26,8 +26,9 @@ namespace NuGet.VisualStudio
 {
     // Implementation of IVsPathContextProvider as a MEF-exported component.
     [Export(typeof(IVsPathContextProvider))]
+    [Export(typeof(IVsPathContextProvider2))]
     [PartCreationPolicy(CreationPolicy.Shared)]
-    public sealed class VsPathContextProvider : IVsPathContextProvider
+    public sealed class VsPathContextProvider : IVsPathContextProvider2
     {
         private const string ProjectAssetsFile = "ProjectAssetsFile";
         private readonly Lazy<ISettings> _settings;
@@ -130,6 +131,14 @@ namespace NuGet.VisualStudio
 
             return outputPathContext != null;
         }
+
+        public bool TryCreateSolutionContext(out IVsPathContext outputPathContext)
+        {
+            outputPathContext = GetSolutionPathContext();
+
+            return outputPathContext != null;
+        }
+
 
         private static async Task<Dictionary<string, EnvDTE.Project>> GetPathToDTEProjectLookupAsync(EnvDTE.DTE dte)
         {

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContextProvider2.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContextProvider2.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+
+namespace NuGet.VisualStudio
+{
+    /// <summary>
+    /// A factory to initialize <see cref="IVsPathContext"/> instances.
+    /// </summary>
+    [ComImport]
+    [Guid("5BAC7095-F674-4778-8788-E15FFF77F96B")]
+    public interface IVsPathContextProvider2 : IVsPathContextProvider
+    {
+        /// <summary>
+        /// Attempts to create an instance of <see cref="IVsPathContext"/> for the solution.
+        /// </summary>
+        /// <param name="context">The path context associated with this solution.</param>
+        /// <returns>
+        /// <code>True</code> if operation has succeeded and context was created.
+        /// <code>False</code> otherwise.
+        /// </returns>
+        /// <throws></throws>
+        bool TryCreateSolutionContext(out IVsPathContext context);
+    }
+}


### PR DESCRIPTION
XAML team is facing performance issues while consuming existing api `TryCreateContext()` from `IVSPathContextProvider` interface for their new feature work where they need to know if the given assembly is coming from a NuGet package or not. 

This PR adds a new interface extending from `IVSPathContextProvider` and add a new api `TryCreateSolutionContext` which will only populate user packages folder path and list of fallback folders, and be very performance optimized compare to existing api.
 
@rrelyea @mgoertz-msft