### PR TITLE
Add locals command for the plugins cache

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -6014,7 +6014,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;all | http-cache | global-packages | temp&gt; [-clear | -list].
+        ///   Looks up a localized string similar to &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [-clear | -list].
         /// </summary>
         internal static string LocalsCommandSummary {
             get {
@@ -12483,6 +12483,15 @@ namespace NuGet.CommandLine {
         internal static string SourcesCommandStorePasswordInClearTextDescription_trk {
             get {
                 return ResourceManager.GetString("SourcesCommandStorePasswordInClearTextDescription_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Make a source a trusted repository for repository signature verification..
+        /// </summary>
+        internal static string SourcesCommandTrustDescription {
+            get {
+                return ResourceManager.GetString("SourcesCommandTrustDescription", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -6014,7 +6014,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [-clear | -list].
+        ///   Looks up a localized string similar to &lt;all | http-cache | global-packages | temp | plugins-cache&gt; [-clear | -list].
         /// </summary>
         internal static string LocalsCommandSummary {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5305,7 +5305,7 @@ nuget locals global-packages -list</value>
     <comment>Please don't localize this string</comment>
   </data>
   <data name="LocalsCommandSummary" xml:space="preserve">
-    <value>&lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [-clear | -list]</value>
+    <value>&lt;all | http-cache | global-packages | temp | plugins-cache&gt; [-clear | -list]</value>
     <comment>Please don't localize this string</comment>
   </data>
   <data name="LocalsCommandClearDescription" xml:space="preserve">

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5305,7 +5305,7 @@ nuget locals global-packages -list</value>
     <comment>Please don't localize this string</comment>
   </data>
   <data name="LocalsCommandSummary" xml:space="preserve">
-    <value>&lt;all | http-cache | global-packages | temp&gt; [-clear | -list]</value>
+    <value>&lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [-clear | -list]</value>
     <comment>Please don't localize this string</comment>
   </data>
   <data name="LocalsCommandClearDescription" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -486,7 +486,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Clears or lists local NuGet resources such as http requests cache, packages cache or machine-wide global packages folder..
+        ///   Looks up a localized string similar to Clears or lists local NuGet resources such as http requests cache, packages folder, plugin operations cache  or machine-wide global packages folder..
         /// </summary>
         internal static string LocalsCommand_Description {
             get {
@@ -495,7 +495,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
+        ///   Looks up a localized string similar to usage: NuGet locals &lt;all | http-cache | global-packages | temp | plugins-cache&gt; [--clear | -c | --list | -l]
         ///For more information, visit http://docs.nuget.org/docs/reference/command-line-reference.
         /// </summary>
         internal static string LocalsCommand_Help {
@@ -515,7 +515,7 @@ namespace NuGet.CommandLine.XPlat {
         
         /// <summary>
         ///   Looks up a localized string similar to Both operations, --list and --clear, are not supported in the same command. Please specify only one operation.
-        ///usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
+        ///usage: NuGet locals &lt;all | http-cache | global-packages | temp | plugins-cache&gt; [--clear | -c | --list | -l]
         ///For more information, visit http://docs.nuget.org/docs/reference/command-line-reference.
         /// </summary>
         internal static string LocalsCommand_MultipleOperations {
@@ -526,7 +526,7 @@ namespace NuGet.CommandLine.XPlat {
         
         /// <summary>
         ///   Looks up a localized string similar to No Cache Type was specified.
-        ///usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
+        ///usage: NuGet locals &lt;all | http-cache | global-packages | temp | plugins-cache&gt; [--clear | -c | --list | -l]
         ///For more information, visit http://docs.nuget.org/docs/reference/command-line-reference.
         /// </summary>
         internal static string LocalsCommand_NoArguments {
@@ -537,7 +537,7 @@ namespace NuGet.CommandLine.XPlat {
         
         /// <summary>
         ///   Looks up a localized string similar to Please specify an operation i.e. --list or --clear.
-        ///usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
+        ///usage: NuGet locals &lt;all | http-cache | global-packages | temp | plugins-cache&gt; [--clear | -c | --list | -l]
         ///For more information, visit http://docs.nuget.org/docs/reference/command-line-reference.
         /// </summary>
         internal static string LocalsCommand_NoOperation {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -495,7 +495,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+        ///   Looks up a localized string similar to usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
         ///For more information, visit http://docs.nuget.org/docs/reference/command-line-reference.
         /// </summary>
         internal static string LocalsCommand_Help {
@@ -515,7 +515,7 @@ namespace NuGet.CommandLine.XPlat {
         
         /// <summary>
         ///   Looks up a localized string similar to Both operations, --list and --clear, are not supported in the same command. Please specify only one operation.
-        ///usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+        ///usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
         ///For more information, visit http://docs.nuget.org/docs/reference/command-line-reference.
         /// </summary>
         internal static string LocalsCommand_MultipleOperations {
@@ -526,7 +526,7 @@ namespace NuGet.CommandLine.XPlat {
         
         /// <summary>
         ///   Looks up a localized string similar to No Cache Type was specified.
-        ///usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+        ///usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
         ///For more information, visit http://docs.nuget.org/docs/reference/command-line-reference.
         /// </summary>
         internal static string LocalsCommand_NoArguments {
@@ -537,7 +537,7 @@ namespace NuGet.CommandLine.XPlat {
         
         /// <summary>
         ///   Looks up a localized string similar to Please specify an operation i.e. --list or --clear.
-        ///usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+        ///usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
         ///For more information, visit http://docs.nuget.org/docs/reference/command-line-reference.
         /// </summary>
         internal static string LocalsCommand_NoOperation {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -321,22 +321,22 @@
     <value>Clears or lists local NuGet resources such as http requests cache, packages cache or machine-wide global packages folder.</value>
   </data>
   <data name="LocalsCommand_Help" xml:space="preserve">
-    <value>usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+    <value>usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
 For more information, visit http://docs.nuget.org/docs/reference/command-line-reference</value>
   </data>
   <data name="LocalsCommand_MultipleOperations" xml:space="preserve">
     <value>Both operations, --list and --clear, are not supported in the same command. Please specify only one operation.
-usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
 For more information, visit http://docs.nuget.org/docs/reference/command-line-reference</value>
   </data>
   <data name="LocalsCommand_NoArguments" xml:space="preserve">
     <value>No Cache Type was specified.
-usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
 For more information, visit http://docs.nuget.org/docs/reference/command-line-reference</value>
   </data>
   <data name="LocalsCommand_NoOperation" xml:space="preserve">
     <value>Please specify an operation i.e. --list or --clear.
-usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
 For more information, visit http://docs.nuget.org/docs/reference/command-line-reference</value>
   </data>
   <data name="Error_MsBuildUnableToOpenProject" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -318,25 +318,25 @@
     <value>List the selected local resources or cache location(s).</value>
   </data>
   <data name="LocalsCommand_Description" xml:space="preserve">
-    <value>Clears or lists local NuGet resources such as http requests cache, packages cache or machine-wide global packages folder.</value>
+    <value>Clears or lists local NuGet resources such as http requests cache, packages folder, plugin operations cache  or machine-wide global packages folder.</value>
   </data>
   <data name="LocalsCommand_Help" xml:space="preserve">
-    <value>usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
+    <value>usage: NuGet locals &lt;all | http-cache | global-packages | temp | plugins-cache&gt; [--clear | -c | --list | -l]
 For more information, visit http://docs.nuget.org/docs/reference/command-line-reference</value>
   </data>
   <data name="LocalsCommand_MultipleOperations" xml:space="preserve">
     <value>Both operations, --list and --clear, are not supported in the same command. Please specify only one operation.
-usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
+usage: NuGet locals &lt;all | http-cache | global-packages | temp | plugins-cache&gt; [--clear | -c | --list | -l]
 For more information, visit http://docs.nuget.org/docs/reference/command-line-reference</value>
   </data>
   <data name="LocalsCommand_NoArguments" xml:space="preserve">
     <value>No Cache Type was specified.
-usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
+usage: NuGet locals &lt;all | http-cache | global-packages | temp | plugins-cache&gt; [--clear | -c | --list | -l]
 For more information, visit http://docs.nuget.org/docs/reference/command-line-reference</value>
   </data>
   <data name="LocalsCommand_NoOperation" xml:space="preserve">
     <value>Please specify an operation i.e. --list or --clear.
-usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
+usage: NuGet locals &lt;all | http-cache | global-packages | temp | plugins-cache&gt; [--clear | -c | --list | -l]
 For more information, visit http://docs.nuget.org/docs/reference/command-line-reference</value>
   </data>
   <data name="Error_MsBuildUnableToOpenProject" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/LocalsCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/LocalsCommandRunner.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -21,11 +21,13 @@ namespace NuGet.Commands
             HttpCache,
             GlobalPackagesFolder,
             Temp,
+            PluginsCache,
             All
         }
 
         private const string HttpCacheResourceName = "http-cache";
         private const string GlobalPackagesResourceName = "global-packages";
+        private const string PluginsCacheResourceName = "plugins-cache";
         private const string AllResourceName = "all";
         private const string TempResourceName = "temp";
 
@@ -80,10 +82,15 @@ namespace NuGet.Commands
                     PrintLocalResourcePath(TempResourceName, NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp), localsArgs);
                     break;
 
+                case LocalResourceName.PluginsCache:
+                    PrintLocalResourcePath(PluginsCacheResourceName, SettingsUtility.GetPluginsCache(), localsArgs);
+                    break;
+
                 case LocalResourceName.All:
                     PrintLocalResourcePath(HttpCacheResourceName, SettingsUtility.GetHttpCacheFolder(), localsArgs);
                     PrintLocalResourcePath(GlobalPackagesResourceName, SettingsUtility.GetGlobalPackagesFolder(localsArgs.Settings), localsArgs);
                     PrintLocalResourcePath(TempResourceName, NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp), localsArgs);
+                    PrintLocalResourcePath(PluginsCacheResourceName, SettingsUtility.GetPluginsCache(), localsArgs);
                     break;
 
                 default:
@@ -133,10 +140,15 @@ namespace NuGet.Commands
                     success &= ClearNuGetTempFolder(localsArgs);
                     break;
 
+                case LocalResourceName.PluginsCache:
+                    success &= ClearNuGetPluginsCache(localsArgs);
+                    break;
+
                 case LocalResourceName.All:
                     success &= ClearNuGetHttpCache(localsArgs);
                     success &= ClearNuGetGlobalPackagesFolder(localsArgs);
                     success &= ClearNuGetTempFolder(localsArgs);
+                    success &= ClearNuGetPluginsCache(localsArgs);
                     break;
 
                 default:
@@ -155,6 +167,22 @@ namespace NuGet.Commands
         }
 
         /// <summary>
+        /// Clears the NuGet plugins cache.
+        /// </summary>
+        /// <param name="localsArgs"></param>
+        /// <returns><code>True</code> if the operation was successful; otherwise <code>false</code>.</returns>
+        private bool ClearNuGetPluginsCache(LocalsArgs localsArgs)
+        {
+            var success = true;
+            var pluginsCacheFolder = SettingsUtility.GetPluginsCache();
+
+            localsArgs.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.LocalsCommand_ClearingNuGetPluginsCache, pluginsCacheFolder));
+
+            success &= ClearCacheDirectory(pluginsCacheFolder, localsArgs);
+            return success;
+        }
+
+        /// <summary>
         /// Clears the global NuGet packages cache.
         /// </summary>
         /// <returns><code>True</code> if the operation was successful; otherwise <code>false</code>.</returns>
@@ -163,7 +191,7 @@ namespace NuGet.Commands
             var success = true;
             var globalPackagesFolderPath = SettingsUtility.GetGlobalPackagesFolder(localsArgs.Settings);
 
-            localsArgs.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.LocalsCommand_ClearingNuGetGlobalPackagesCache, globalPackagesFolderPath));
+            localsArgs.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.LocalsCommand_ClearingNuGetGlobalPackagesFolder, globalPackagesFolderPath));
 
             success &= ClearCacheDirectory(globalPackagesFolderPath, localsArgs);
             return success;
@@ -229,6 +257,10 @@ namespace NuGet.Commands
             else if (string.Equals(localResourceName, TempResourceName, StringComparison.OrdinalIgnoreCase))
             {
                 return LocalResourceName.Temp;
+            }
+            else if (string.Equals(localResourceName, PluginsCacheResourceName, StringComparison.OrdinalIgnoreCase))
+            {
+                return LocalResourceName.PluginsCache;
             }
             else
             {

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/LocalsCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/LocalsCommandRunner.cs
@@ -83,14 +83,14 @@ namespace NuGet.Commands
                     break;
 
                 case LocalResourceName.PluginsCache:
-                    PrintLocalResourcePath(PluginsCacheResourceName, SettingsUtility.GetPluginsCache(), localsArgs);
+                    PrintLocalResourcePath(PluginsCacheResourceName, SettingsUtility.GetPluginsCacheFolder(), localsArgs);
                     break;
 
                 case LocalResourceName.All:
                     PrintLocalResourcePath(HttpCacheResourceName, SettingsUtility.GetHttpCacheFolder(), localsArgs);
                     PrintLocalResourcePath(GlobalPackagesResourceName, SettingsUtility.GetGlobalPackagesFolder(localsArgs.Settings), localsArgs);
                     PrintLocalResourcePath(TempResourceName, NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp), localsArgs);
-                    PrintLocalResourcePath(PluginsCacheResourceName, SettingsUtility.GetPluginsCache(), localsArgs);
+                    PrintLocalResourcePath(PluginsCacheResourceName, SettingsUtility.GetPluginsCacheFolder(), localsArgs);
                     break;
 
                 default:
@@ -174,7 +174,7 @@ namespace NuGet.Commands
         private bool ClearNuGetPluginsCache(LocalsArgs localsArgs)
         {
             var success = true;
-            var pluginsCacheFolder = SettingsUtility.GetPluginsCache();
+            var pluginsCacheFolder = SettingsUtility.GetPluginsCacheFolder();
 
             localsArgs.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.LocalsCommand_ClearingNuGetPluginsCache, pluginsCacheFolder));
 

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/LocalsCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/LocalsCommandRunner.cs
@@ -169,7 +169,6 @@ namespace NuGet.Commands
         /// <summary>
         /// Clears the NuGet plugins cache.
         /// </summary>
-        /// <param name="localsArgs"></param>
         /// <returns><code>True</code> if the operation was successful; otherwise <code>false</code>.</returns>
         private bool ClearNuGetPluginsCache(LocalsArgs localsArgs)
         {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -503,7 +503,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
+        ///   Looks up a localized string similar to usage: NuGet locals &lt;all | http-cache | global-packages | temp | plugins-cache&gt; [--clear | -c | --list | -l]
         ///For more information, visit http://docs.nuget.org/docs/reference/command-line-reference.
         /// </summary>
         internal static string LocalsCommand_Help {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -458,11 +458,11 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Clearing NuGet global packages cache: {0}.
+        ///   Looks up a localized string similar to Clearing NuGet global packages folder: {0}.
         /// </summary>
-        internal static string LocalsCommand_ClearingNuGetGlobalPackagesCache {
+        internal static string LocalsCommand_ClearingNuGetGlobalPackagesFolder {
             get {
-                return ResourceManager.GetString("LocalsCommand_ClearingNuGetGlobalPackagesCache", resourceCulture);
+                return ResourceManager.GetString("LocalsCommand_ClearingNuGetGlobalPackagesFolder", resourceCulture);
             }
         }
         
@@ -472,6 +472,15 @@ namespace NuGet.Commands {
         internal static string LocalsCommand_ClearingNuGetHttpCache {
             get {
                 return ResourceManager.GetString("LocalsCommand_ClearingNuGetHttpCache", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Clearing NuGet plugins cache: {0}.
+        /// </summary>
+        internal static string LocalsCommand_ClearingNuGetPluginsCache {
+            get {
+                return ResourceManager.GetString("LocalsCommand_ClearingNuGetPluginsCache", resourceCulture);
             }
         }
         
@@ -494,7 +503,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+        ///   Looks up a localized string similar to usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
         ///For more information, visit http://docs.nuget.org/docs/reference/command-line-reference.
         /// </summary>
         internal static string LocalsCommand_Help {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -428,8 +428,8 @@
     <value>Clearing NuGet cache: {0}</value>
     <comment>{0} : Cache path</comment>
   </data>
-  <data name="LocalsCommand_ClearingNuGetGlobalPackagesCache" xml:space="preserve">
-    <value>Clearing NuGet global packages cache: {0}</value>
+  <data name="LocalsCommand_ClearingNuGetGlobalPackagesFolder" xml:space="preserve">
+    <value>Clearing NuGet global packages folder: {0}</value>
     <comment>{0} : Global packages cache path</comment>
   </data>
   <data name="LocalsCommand_ClearingNuGetHttpCache" xml:space="preserve">
@@ -453,7 +453,7 @@
     <value>Reading project file {0}.</value>
   </data>
   <data name="LocalsCommand_Help" xml:space="preserve">
-    <value>usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+    <value>usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
 For more information, visit http://docs.nuget.org/docs/reference/command-line-reference</value>
   </data>
   <data name="InvalidRestoreInput" xml:space="preserve">
@@ -698,5 +698,9 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   </data>
   <data name="Warning_FileExcludedByDefault" xml:space="preserve">
     <value>File '{0}' was not added to the package. Files and folders starting with '.' or ending with '.nupkg' are excluded by default. To include this file, use -NoDefaultExcludes from the commandline</value>
+  </data>
+  <data name="LocalsCommand_ClearingNuGetPluginsCache" xml:space="preserve">
+    <value>Clearing NuGet plugins cache: {0}</value>
+    <comment>{0}: Plugins cache path</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -453,7 +453,7 @@
     <value>Reading project file {0}.</value>
   </data>
   <data name="LocalsCommand_Help" xml:space="preserve">
-    <value>usage: NuGet locals &lt;all | http-cache | global-packages | temp | nuget-plugins&gt; [--clear | -c | --list | -l]
+    <value>usage: NuGet locals &lt;all | http-cache | global-packages | temp | plugins-cache&gt; [--clear | -c | --list | -l]
 For more information, visit http://docs.nuget.org/docs/reference/command-line-reference</value>
   </data>
   <data name="InvalidRestoreInput" xml:space="preserve">

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetLocalsCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetLocalsCommandTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetLocalsCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetLocalsCommandTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
@@ -14,7 +14,7 @@ namespace NuGet.CommandLine.Test
     public class NuGetLocalsCommandTest
     {
         private const string LocalsHelpStringFragment =
-            "usage: NuGet locals <all | http-cache | global-packages | temp> [-clear | -list]";
+            "usage: NuGet locals <all | http-cache | global-packages | temp | plugins-cache> [-clear | -list]";
 
         [Theory]
         [InlineData("locals")]

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetLocalsCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetLocalsCommandTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -32,6 +32,10 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("locals global-packages -l")]
         [InlineData("locals --list global-packages")]
         [InlineData("locals -l global-packages")]
+        [InlineData("locals plugins-cache --list")]
+        [InlineData("locals plugins-cache -l")]
+        [InlineData("locals --list plugins-cache")]
+        [InlineData("locals -l plugins-cache")]
         public static void Locals_List_Succeeds(string args)
         {
             Assert.NotNull(DotnetCli);
@@ -43,10 +47,12 @@ namespace NuGet.XPlat.FuncTest
                 var mockGlobalPackagesDirectory = Directory.CreateDirectory(Path.Combine(mockBaseDirectory.Path, @"global-packages"));
                 var mockHttpCacheDirectory = Directory.CreateDirectory(Path.Combine(mockBaseDirectory.Path, @"http-cache"));
                 var mockTmpCacheDirectory = Directory.CreateDirectory(Path.Combine(mockBaseDirectory.Path, @"temp"));
+                var mockPluginsCacheDirectory = Directory.CreateDirectory(Path.Combine(mockBaseDirectory.Path, @"plugins-cache"));
 
                 DotnetCliUtil.CreateTestFiles(mockGlobalPackagesDirectory.FullName);
                 DotnetCliUtil.CreateTestFiles(mockHttpCacheDirectory.FullName);
                 DotnetCliUtil.CreateTestFiles(mockTmpCacheDirectory.FullName);
+                DotnetCliUtil.CreateTestFiles(mockPluginsCacheDirectory.FullName);
 
                 // Act
                 var result = CommandRunner.Run(
@@ -58,6 +64,7 @@ namespace NuGet.XPlat.FuncTest
                     {
                         { "NUGET_PACKAGES", mockGlobalPackagesDirectory.FullName },
                         { "NUGET_HTTP_CACHE_PATH", mockHttpCacheDirectory.FullName },
+                        { "NUGET_PLUGINS_CACHE_PATH", mockPluginsCacheDirectory.FullName },
                         { RuntimeEnvironmentHelper.IsWindows ? "TMP" : "TMPDIR", mockTmpCacheDirectory.FullName }
                     });
                 // Unix uses TMPDIR as environment variable as opposed to TMP on windows
@@ -82,6 +89,10 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("locals global-packages -c")]
         [InlineData("locals --clear global-packages")]
         [InlineData("locals -c global-packages")]
+        [InlineData("locals -c plugins-cache")]
+        [InlineData("locals --clear plugins-cache")]
+        [InlineData("locals plugins-cache --clear")]
+        [InlineData("locals plugins-cache -c")]
         public static void Locals_Clear_Succeeds(string args)
         {
             Assert.NotNull(DotnetCli);
@@ -93,11 +104,13 @@ namespace NuGet.XPlat.FuncTest
                 var mockGlobalPackagesDirectory = Directory.CreateDirectory(Path.Combine(mockBaseDirectory.Path, @"global-packages"));
                 var mockHttpCacheDirectory = Directory.CreateDirectory(Path.Combine(mockBaseDirectory.Path, @"http-cache"));
                 var mockTmpDirectory = Directory.CreateDirectory(Path.Combine(mockBaseDirectory.Path, @"temp"));
+                var mockPluginsCacheDirectory = Directory.CreateDirectory(Path.Combine(mockBaseDirectory.Path, @"plugins-cache"));
                 var mockTmpCacheDirectory = Directory.CreateDirectory(Path.Combine(mockTmpDirectory.FullName, @"NuGetScratch"));
 
                 DotnetCliUtil.CreateTestFiles(mockGlobalPackagesDirectory.FullName);
                 DotnetCliUtil.CreateTestFiles(mockHttpCacheDirectory.FullName);
                 DotnetCliUtil.CreateTestFiles(mockTmpCacheDirectory.FullName);
+                DotnetCliUtil.CreateTestFiles(mockPluginsCacheDirectory.FullName);
 
                 var cacheType = args.Split(null)[1].StartsWith("-") ? args.Split(null)[2] : args.Split(null)[1];
 
@@ -111,7 +124,8 @@ namespace NuGet.XPlat.FuncTest
                     {
                         { "NUGET_PACKAGES", mockGlobalPackagesDirectory.FullName },
                         { "NUGET_HTTP_CACHE_PATH", mockHttpCacheDirectory.FullName },
-                        { RuntimeEnvironmentHelper.IsWindows ? "TMP" : "TMPDIR", mockTmpDirectory.FullName }
+                        { RuntimeEnvironmentHelper.IsWindows ? "TMP" : "TMPDIR", mockTmpDirectory.FullName },
+                        { "NUGET_PLUGINS_CACHE_PATH", mockPluginsCacheDirectory.FullName }
                     });
                 // Unix uses TMPDIR as environment variable as opposed to TMP on windows
 
@@ -121,11 +135,13 @@ namespace NuGet.XPlat.FuncTest
                     DotnetCliUtil.VerifyClearSuccess(mockGlobalPackagesDirectory.FullName);
                     DotnetCliUtil.VerifyClearSuccess(mockHttpCacheDirectory.FullName);
                     DotnetCliUtil.VerifyClearSuccess(mockTmpCacheDirectory.FullName);
+                    DotnetCliUtil.VerifyClearSuccess(mockPluginsCacheDirectory.FullName);
 
                     // Assert clear message
-                    DotnetCliUtil.VerifyResultSuccess(result, "Clearing NuGet global packages cache:");
+                    DotnetCliUtil.VerifyResultSuccess(result, "Clearing NuGet global packages folder:");
                     DotnetCliUtil.VerifyResultSuccess(result, "Clearing NuGet HTTP cache:");
                     DotnetCliUtil.VerifyResultSuccess(result, "Clearing NuGet Temp cache:");
+                    DotnetCliUtil.VerifyResultSuccess(result, "Clearing NuGet plugins cache:");
                     DotnetCliUtil.VerifyResultSuccess(result, "Local resources cleared.");
                 }
                 else if (cacheType == "global-packages")
@@ -136,9 +152,10 @@ namespace NuGet.XPlat.FuncTest
                     // Http cache and Temp cahce should be untouched
                     DotnetCliUtil.VerifyNoClear(mockHttpCacheDirectory.FullName);
                     DotnetCliUtil.VerifyNoClear(mockTmpCacheDirectory.FullName);
+                    DotnetCliUtil.VerifyNoClear(mockPluginsCacheDirectory.FullName);                    
 
                     // Assert clear message
-                    DotnetCliUtil.VerifyResultSuccess(result, "Clearing NuGet global packages cache:");
+                    DotnetCliUtil.VerifyResultSuccess(result, "Clearing NuGet global packages folder:");
                     DotnetCliUtil.VerifyResultSuccess(result, "Local resources cleared.");
                 }
                 else if (cacheType == "http-cache")
@@ -149,6 +166,7 @@ namespace NuGet.XPlat.FuncTest
                     // Global packages cache and temp cache should be untouched
                     DotnetCliUtil.VerifyNoClear(mockGlobalPackagesDirectory.FullName);
                     DotnetCliUtil.VerifyNoClear(mockTmpCacheDirectory.FullName);
+                    DotnetCliUtil.VerifyNoClear(mockPluginsCacheDirectory.FullName);
 
                     // Assert clear message
                     DotnetCliUtil.VerifyResultSuccess(result, "Clearing NuGet HTTP cache:");
@@ -162,9 +180,23 @@ namespace NuGet.XPlat.FuncTest
                     // Global packages cache and Http cache should be un touched
                     DotnetCliUtil.VerifyNoClear(mockGlobalPackagesDirectory.FullName);
                     DotnetCliUtil.VerifyNoClear(mockHttpCacheDirectory.FullName);
+                    DotnetCliUtil.VerifyNoClear(mockPluginsCacheDirectory.FullName);
 
                     // Assert clear message
                     DotnetCliUtil.VerifyResultSuccess(result, "Clearing NuGet Temp cache:");
+                    DotnetCliUtil.VerifyResultSuccess(result, "Local resources cleared.");
+                }
+                else if (cacheType == "plugins-cache")
+                {
+                    DotnetCliUtil.VerifyClearSuccess(mockPluginsCacheDirectory.FullName);
+
+                    // Global packages cache and Http cache should be un touched
+                    DotnetCliUtil.VerifyNoClear(mockGlobalPackagesDirectory.FullName);
+                    DotnetCliUtil.VerifyNoClear(mockHttpCacheDirectory.FullName);
+                    DotnetCliUtil.VerifyNoClear(mockTmpCacheDirectory.FullName);
+
+                    // Assert clear message
+                    DotnetCliUtil.VerifyResultSuccess(result, "Clearing NuGet plugins cache:");
                     DotnetCliUtil.VerifyResultSuccess(result, "Local resources cleared.");
                 }
             }
@@ -183,7 +215,7 @@ namespace NuGet.XPlat.FuncTest
             // Arrange
             var expectedResult = string.Concat("error: No Cache Type was specified.",
                                                Environment.NewLine,
-                                               "error: usage: NuGet locals <all | http-cache | global-packages | temp> [--clear | -c | --list | -l]",
+                                               "error: usage: NuGet locals <all | http-cache | global-packages | temp | plugins-cache> [--clear | -c | --list | -l]",
                                                Environment.NewLine,
                                                "error: For more information, visit http://docs.nuget.org/docs/reference/command-line-reference");
 
@@ -253,6 +285,7 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("locals http-cache")]
         [InlineData("locals global-packages")]
         [InlineData("locals temp")]
+        [InlineData("locals plugins-cache")]
         public static void Locals_Success_NoFlags_HelpMessage(string args)
         {
             Assert.NotNull(DotnetCli);
@@ -261,7 +294,7 @@ namespace NuGet.XPlat.FuncTest
             // Arrange
             var expectedResult = string.Concat("error: Please specify an operation i.e. --list or --clear.",
                                                Environment.NewLine,
-                                               "error: usage: NuGet locals <all | http-cache | global-packages | temp> [--clear | -c | --list | -l]",
+                                               "error: usage: NuGet locals <all | http-cache | global-packages | temp | plugins-cache> [--clear | -c | --list | -l]",
                                                Environment.NewLine,
                                                "error: For more information, visit http://docs.nuget.org/docs/reference/command-line-reference");
 
@@ -281,10 +314,13 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("locals -c -l global-packages")]
         [InlineData("locals -c -l http-cache")]
         [InlineData("locals -c -l temp")]
+        [InlineData("locals -c -l plugins-cache")]
         [InlineData("locals --clear --list all")]
         [InlineData("locals --clear --list global-packages")]
         [InlineData("locals --clear --list http-cache")]
         [InlineData("locals --clear --list temp")]
+        [InlineData("locals --clear --list plugins-cache")]
+
         public static void Locals_Success_BothFlags_HelpMessage(string args)
         {
             Assert.NotNull(DotnetCli);
@@ -293,7 +329,7 @@ namespace NuGet.XPlat.FuncTest
             // Arrange
             var expectedResult = string.Concat("error: Both operations, --list and --clear, are not supported in the same command. Please specify only one operation.",
                                                Environment.NewLine,
-                                               "error: usage: NuGet locals <all | http-cache | global-packages | temp> [--clear | -c | --list | -l]",
+                                               "error: usage: NuGet locals <all | http-cache | global-packages | temp | plugins-cache> [--clear | -c | --list | -l]",
                                                Environment.NewLine,
                                                "error: For more information, visit http://docs.nuget.org/docs/reference/command-line-reference");
 


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7075
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details:
Follow up to https://github.com/NuGet/NuGet.Client/pull/2299. 
Adding the ability to clean the operation claims plugins cache. 

I will amend the docs as well  

## Testing/Validation
Tests Added: Yes  
Reason for not adding tests:  
Validation done:  Manual, tests 
