### PR TITLE
Always use device flow with MSBuild + NuGetSDKResolver auth

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -211,7 +211,7 @@ namespace NuGet.CommandLine
             var pluginProviders = new PluginCredentialProviderBuilder(extensionLocator, Settings, Console)
                 .BuildAll(Verbosity.ToString())
                 .ToList();
-            var securePluginProviders =  await (new SecureCredentialProviderBuilder(pluginManager: PluginManager.Instance, canPrompt: true, logger: Console)).BuildAll();
+            var securePluginProviders =  await (new SecurePluginCredentialProviderBuilder(pluginManager: PluginManager.Instance, canPrompt: true, logger: Console)).BuildAll();
 
             providers.Add(new CredentialProviderAdapter(new SettingsCredentialProvider(SourceProvider, Console)));
             providers.AddRange(securePluginProviders);

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -211,7 +211,7 @@ namespace NuGet.CommandLine
             var pluginProviders = new PluginCredentialProviderBuilder(extensionLocator, Settings, Console)
                 .BuildAll(Verbosity.ToString())
                 .ToList();
-            var securePluginProviders =  await (new SecureCredentialProviderBuilder(PluginManager.Instance, Console)).BuildAll();
+            var securePluginProviders =  await (new SecureCredentialProviderBuilder(pluginManager: PluginManager.Instance, canPrompt: true, logger: Console)).BuildAll();
 
             providers.Add(new CredentialProviderAdapter(new SettingsCredentialProvider(SourceProvider, Console)));
             providers.AddRange(securePluginProviders);

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -211,7 +211,7 @@ namespace NuGet.CommandLine
             var pluginProviders = new PluginCredentialProviderBuilder(extensionLocator, Settings, Console)
                 .BuildAll(Verbosity.ToString())
                 .ToList();
-            var securePluginProviders =  await (new SecurePluginCredentialProviderBuilder(pluginManager: PluginManager.Instance, canShowDialog: true, logger: Console)).BuildAll();
+            var securePluginProviders =  await (new SecurePluginCredentialProviderBuilder(pluginManager: PluginManager.Instance, canShowDialog: true, logger: Console)).BuildAllAsync();
 
             providers.Add(new CredentialProviderAdapter(new SettingsCredentialProvider(SourceProvider, Console)));
             providers.AddRange(securePluginProviders);

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -211,7 +211,7 @@ namespace NuGet.CommandLine
             var pluginProviders = new PluginCredentialProviderBuilder(extensionLocator, Settings, Console)
                 .BuildAll(Verbosity.ToString())
                 .ToList();
-            var securePluginProviders =  await (new SecurePluginCredentialProviderBuilder(pluginManager: PluginManager.Instance, canPrompt: true, logger: Console)).BuildAll();
+            var securePluginProviders =  await (new SecurePluginCredentialProviderBuilder(pluginManager: PluginManager.Instance, canShowDialog: true, logger: Console)).BuildAll();
 
             providers.Add(new CredentialProviderAdapter(new SettingsCredentialProvider(SourceProvider, Console)));
             providers.AddRange(securePluginProviders);

--- a/src/NuGet.Clients/NuGet.Credentials/DefaultCredentialServiceUtility.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/DefaultCredentialServiceUtility.cs
@@ -33,7 +33,7 @@ namespace NuGet.Credentials
         {
             var providers = new List<ICredentialProvider>();
 
-            var securePluginProviders = await new SecurePluginCredentialProviderBuilder(pluginManager: PluginManager.Instance, canPrompt: false, logger: logger).BuildAll();
+            var securePluginProviders = await new SecurePluginCredentialProviderBuilder(pluginManager: PluginManager.Instance, canShowDialog: false, logger: logger).BuildAll();
             providers.AddRange(securePluginProviders);
 
             if (providers.Any())

--- a/src/NuGet.Clients/NuGet.Credentials/DefaultCredentialServiceUtility.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/DefaultCredentialServiceUtility.cs
@@ -33,7 +33,7 @@ namespace NuGet.Credentials
         {
             var providers = new List<ICredentialProvider>();
 
-            var securePluginProviders = await new SecurePluginCredentialProviderBuilder(pluginManager: PluginManager.Instance, canShowDialog: false, logger: logger).BuildAll();
+            var securePluginProviders = await new SecurePluginCredentialProviderBuilder(pluginManager: PluginManager.Instance, canShowDialog: false, logger: logger).BuildAllAsync();
             providers.AddRange(securePluginProviders);
 
             if (providers.Any())

--- a/src/NuGet.Clients/NuGet.Credentials/DefaultCredentialServiceUtility.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/DefaultCredentialServiceUtility.cs
@@ -33,7 +33,7 @@ namespace NuGet.Credentials
         {
             var providers = new List<ICredentialProvider>();
 
-            var securePluginProviders = await new SecureCredentialProviderBuilder(pluginManager: PluginManager.Instance, canPrompt: false, logger: logger).BuildAll();
+            var securePluginProviders = await new SecurePluginCredentialProviderBuilder(pluginManager: PluginManager.Instance, canPrompt: false, logger: logger).BuildAll();
             providers.AddRange(securePluginProviders);
 
             if (providers.Any())

--- a/src/NuGet.Clients/NuGet.Credentials/DefaultCredentialServiceUtility.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/DefaultCredentialServiceUtility.cs
@@ -28,11 +28,12 @@ namespace NuGet.Credentials
         }
 
         // Add only the secure plugin. This will be done when there's nothing set
+        // By default the plugins cannot prompt. Currently this is only used to setup from MSBuild/dotnet.exe code paths
         private static async Task<IEnumerable<ICredentialProvider>> GetCredentialProvidersAsync(ILogger logger)
         {
             var providers = new List<ICredentialProvider>();
 
-            var securePluginProviders = await (new SecureCredentialProviderBuilder(PluginManager.Instance, logger)).BuildAll();
+            var securePluginProviders = await new SecureCredentialProviderBuilder(pluginManager: PluginManager.Instance, canPrompt: false, logger: logger).BuildAll();
             providers.AddRange(securePluginProviders);
 
             if (providers.Any())

--- a/src/NuGet.Clients/NuGet.Credentials/SecureCredentialProviderBuilder.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/SecureCredentialProviderBuilder.cs
@@ -15,19 +15,22 @@ namespace NuGet.Credentials
     /// </summary>
     public class SecureCredentialProviderBuilder
     {
-        private Common.ILogger _logger;
-        private IPluginManager _pluginManager;
+        private readonly Common.ILogger _logger;
+        private readonly IPluginManager _pluginManager;
+        private readonly bool _canPrompt;
 
         /// <summary>
         /// Create a credential provider builders
         /// </summary>
-        /// <param name="pluginManager"></param>
-        /// <param name="logger"></param>
+        /// <param name="pluginManager">pluginManager</param>
+        /// <param name="canPrompt">canPrompt - whether can pop up a dialog or it needs to use device flow</param>
+        /// <param name="logger">logger</param>
         /// <exception cref="ArgumentNullException">if <paramref name="logger"/> is null</exception>
         /// <exception cref="ArgumentNullException">if <paramref name="pluginManager"/> is null</exception>
-        public SecureCredentialProviderBuilder(IPluginManager pluginManager, Common.ILogger logger)
+        public SecureCredentialProviderBuilder(IPluginManager pluginManager, bool canPrompt, Common.ILogger logger)
         {
             _pluginManager = pluginManager ?? throw new ArgumentNullException(nameof(pluginManager));
+            _canPrompt = canPrompt;
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -43,7 +46,7 @@ namespace NuGet.Credentials
             foreach (var pluginDiscoveryResult in availablePlugins)
             {
                 _logger.LogDebug(string.Format(CultureInfo.CurrentCulture, Resources.SecurePluginNotice_UsingPluginAsProvider, pluginDiscoveryResult.PluginFile.Path));
-                plugins.Add(new SecurePluginCredentialProvider(_pluginManager, pluginDiscoveryResult, _logger));
+                plugins.Add(new SecurePluginCredentialProvider(_pluginManager, pluginDiscoveryResult, _canPrompt, _logger));
             }
 
             return plugins;

--- a/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
@@ -33,9 +33,9 @@ namespace NuGet.Credentials
         private readonly IPluginManager _pluginManager;
 
         /// <summary>
-        /// canPrompt, whether the plugin can prompt or it should use device flow. This is a host decision not a user one. 
+        /// canShowDialog, whether the plugin can prompt or it should use device flow. This is a host decision not a user one. 
         /// </summary>
-        private readonly bool _canPrompt;
+        private readonly bool _canShowDialog;
 
         // We use this to avoid needlessly instantiating plugins if they don't support authentication.
         private bool _isAnAuthenticationPlugin = true;
@@ -46,17 +46,17 @@ namespace NuGet.Credentials
         /// </summary>
         /// <param name="pluginManager"></param>
         /// <param name="pluginDiscoveryResult"></param>
-        /// <param name="canPrompt"></param>
+        /// <param name="canShowDialog"></param>
         /// <param name="logger"></param>
         /// <exception cref="ArgumentNullException">if <paramref name="pluginDiscoveryResult"/> is null</exception>
         /// <exception cref="ArgumentNullException">if <paramref name="logger"/> is null</exception>
         /// <exception cref="ArgumentNullException">if <paramref name="pluginManager"/> is null</exception>
         /// <exception cref="ArgumentException">if plugin file is not valid</exception>
-        public SecurePluginCredentialProvider(IPluginManager pluginManager, PluginDiscoveryResult pluginDiscoveryResult, bool canPrompt, ILogger logger)
+        public SecurePluginCredentialProvider(IPluginManager pluginManager, PluginDiscoveryResult pluginDiscoveryResult, bool canShowDialog, ILogger logger)
         {
             _pluginManager = pluginManager ?? throw new ArgumentNullException(nameof(pluginManager));
             _discoveredPlugin = pluginDiscoveryResult ?? throw new ArgumentNullException(nameof(pluginDiscoveryResult));
-            _canPrompt = canPrompt;
+            _canShowDialog = canShowDialog;
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             Id = $"{nameof(SecurePluginCredentialProvider)}_{pluginDiscoveryResult.PluginFile.Path}";
         }
@@ -114,7 +114,7 @@ namespace NuGet.Credentials
                         await SetProxyCredentialsToPlugin(uri, proxy, plugin, cancellationToken);
                     }
 
-                    var request = new GetAuthenticationCredentialsRequest(uri, isRetry, nonInteractive, _canPrompt);
+                    var request = new GetAuthenticationCredentialsRequest(uri, isRetry, nonInteractive, _canShowDialog);
                     var credentialResponse = await plugin.Plugin.Connection.SendRequestAndReceiveResponseAsync<GetAuthenticationCredentialsRequest, GetAuthenticationCredentialsResponse>(
                         MessageMethod.GetAuthenticationCredentials,
                         request,

--- a/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProvider.cs
@@ -25,30 +25,38 @@ namespace NuGet.Credentials
         /// <summary>
         /// logger
         /// </summary>
-        private readonly Common.ILogger _logger;
+        private readonly ILogger _logger;
 
         /// <summary>
         /// pluginManager
         /// </summary>
         private readonly IPluginManager _pluginManager;
 
+        /// <summary>
+        /// canPrompt, whether the plugin can prompt or it should use device flow. This is a host decision not a user one. 
+        /// </summary>
+        private readonly bool _canPrompt;
+
         // We use this to avoid needlessly instantiating plugins if they don't support authentication.
         private bool _isAnAuthenticationPlugin = true;
+
 
         /// <summary>
         /// Create a credential provider based on provided plugin
         /// </summary>
         /// <param name="pluginManager"></param>
         /// <param name="pluginDiscoveryResult"></param>
+        /// <param name="canPrompt"></param>
         /// <param name="logger"></param>
         /// <exception cref="ArgumentNullException">if <paramref name="pluginDiscoveryResult"/> is null</exception>
         /// <exception cref="ArgumentNullException">if <paramref name="logger"/> is null</exception>
         /// <exception cref="ArgumentNullException">if <paramref name="pluginManager"/> is null</exception>
         /// <exception cref="ArgumentException">if plugin file is not valid</exception>
-        public SecurePluginCredentialProvider(IPluginManager pluginManager, PluginDiscoveryResult pluginDiscoveryResult, ILogger logger)
+        public SecurePluginCredentialProvider(IPluginManager pluginManager, PluginDiscoveryResult pluginDiscoveryResult, bool canPrompt, ILogger logger)
         {
             _pluginManager = pluginManager ?? throw new ArgumentNullException(nameof(pluginManager));
             _discoveredPlugin = pluginDiscoveryResult ?? throw new ArgumentNullException(nameof(pluginDiscoveryResult));
+            _canPrompt = canPrompt;
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             Id = $"{nameof(SecurePluginCredentialProvider)}_{pluginDiscoveryResult.PluginFile.Path}";
         }
@@ -106,7 +114,7 @@ namespace NuGet.Credentials
                         await SetProxyCredentialsToPlugin(uri, proxy, plugin, cancellationToken);
                     }
 
-                    var request = new GetAuthenticationCredentialsRequest(uri, isRetry, nonInteractive);
+                    var request = new GetAuthenticationCredentialsRequest(uri, isRetry, nonInteractive, _canPrompt);
                     var credentialResponse = await plugin.Plugin.Connection.SendRequestAndReceiveResponseAsync<GetAuthenticationCredentialsRequest, GetAuthenticationCredentialsResponse>(
                         MessageMethod.GetAuthenticationCredentials,
                         request,

--- a/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProviderBuilder.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProviderBuilder.cs
@@ -38,7 +38,7 @@ namespace NuGet.Credentials
         /// Creates credential providers for each valid plugin (regardless if it supports authentication or not)
         /// </summary>
         /// <returns>credential providers</returns>
-        public async Task<IEnumerable<ICredentialProvider>> BuildAll()
+        public async Task<IEnumerable<ICredentialProvider>> BuildAllAsync()
         {
             var availablePlugins = await _pluginManager.FindAvailablePluginsAsync(CancellationToken.None);
 

--- a/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProviderBuilder.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProviderBuilder.cs
@@ -17,20 +17,20 @@ namespace NuGet.Credentials
     {
         private readonly Common.ILogger _logger;
         private readonly IPluginManager _pluginManager;
-        private readonly bool _canPrompt;
+        private readonly bool _canShowDialog;
 
         /// <summary>
         /// Create a credential provider builders
         /// </summary>
         /// <param name="pluginManager">pluginManager</param>
-        /// <param name="canPrompt">canPrompt - whether can pop up a dialog or it needs to use device flow</param>
+        /// <param name="canShowDialog">canShowDialog - whether can pop up a dialog or it needs to use device flow</param>
         /// <param name="logger">logger</param>
         /// <exception cref="ArgumentNullException">if <paramref name="logger"/> is null</exception>
         /// <exception cref="ArgumentNullException">if <paramref name="pluginManager"/> is null</exception>
-        public SecurePluginCredentialProviderBuilder(IPluginManager pluginManager, bool canPrompt, Common.ILogger logger)
+        public SecurePluginCredentialProviderBuilder(IPluginManager pluginManager, bool canShowDialog, Common.ILogger logger)
         {
             _pluginManager = pluginManager ?? throw new ArgumentNullException(nameof(pluginManager));
-            _canPrompt = canPrompt;
+            _canShowDialog = canShowDialog;
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -46,7 +46,7 @@ namespace NuGet.Credentials
             foreach (var pluginDiscoveryResult in availablePlugins)
             {
                 _logger.LogDebug(string.Format(CultureInfo.CurrentCulture, Resources.SecurePluginNotice_UsingPluginAsProvider, pluginDiscoveryResult.PluginFile.Path));
-                plugins.Add(new SecurePluginCredentialProvider(_pluginManager, pluginDiscoveryResult, _canPrompt, _logger));
+                plugins.Add(new SecurePluginCredentialProvider(_pluginManager, pluginDiscoveryResult, _canShowDialog, _logger));
             }
 
             return plugins;

--- a/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProviderBuilder.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/SecurePluginCredentialProviderBuilder.cs
@@ -13,7 +13,7 @@ namespace NuGet.Credentials
     /// <summary>
     /// Builder for credential providers that are based on the secure plugin model (Version 2.0.0)
     /// </summary>
-    public class SecureCredentialProviderBuilder
+    public class SecurePluginCredentialProviderBuilder
     {
         private readonly Common.ILogger _logger;
         private readonly IPluginManager _pluginManager;
@@ -27,7 +27,7 @@ namespace NuGet.Credentials
         /// <param name="logger">logger</param>
         /// <exception cref="ArgumentNullException">if <paramref name="logger"/> is null</exception>
         /// <exception cref="ArgumentNullException">if <paramref name="pluginManager"/> is null</exception>
-        public SecureCredentialProviderBuilder(IPluginManager pluginManager, bool canPrompt, Common.ILogger logger)
+        public SecurePluginCredentialProviderBuilder(IPluginManager pluginManager, bool canPrompt, Common.ILogger logger)
         {
             _pluginManager = pluginManager ?? throw new ArgumentNullException(nameof(pluginManager));
             _canPrompt = canPrompt;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
@@ -73,7 +73,7 @@ namespace NuGet.PackageManagement.VisualStudio
             await TryAddCredentialProvidersAsync(
                 credentialProviders,
                 Strings.CredentialProviderFailed_PluginCredentialProvider,
-                async () => await (new SecureCredentialProviderBuilder(PluginManager.Instance, NullLogger.Instance).BuildAll())
+                async () => await (new SecureCredentialProviderBuilder(PluginManager.Instance, true, NullLogger.Instance).BuildAll())
                 );
 
             if (PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
@@ -73,7 +73,7 @@ namespace NuGet.PackageManagement.VisualStudio
             await TryAddCredentialProvidersAsync(
                 credentialProviders,
                 Strings.CredentialProviderFailed_PluginCredentialProvider,
-                async () => await (new SecurePluginCredentialProviderBuilder(PluginManager.Instance, true, NullLogger.Instance).BuildAll())
+                async () => await (new SecurePluginCredentialProviderBuilder(PluginManager.Instance, canShowDialog: true, logger: NullLogger.Instance).BuildAllAsync())
                 );
 
             if (PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
@@ -73,7 +73,7 @@ namespace NuGet.PackageManagement.VisualStudio
             await TryAddCredentialProvidersAsync(
                 credentialProviders,
                 Strings.CredentialProviderFailed_PluginCredentialProvider,
-                async () => await (new SecureCredentialProviderBuilder(PluginManager.Instance, true, NullLogger.Instance).BuildAll())
+                async () => await (new SecurePluginCredentialProviderBuilder(PluginManager.Instance, true, NullLogger.Instance).BuildAll())
                 );
 
             if (PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders)

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
@@ -4,6 +4,7 @@
 using Microsoft.Build.Framework;
 using NuGet.Commands;
 using NuGet.Configuration;
+using NuGet.Credentials;
 using NuGet.Packaging;
 using NuGet.Versioning;
 using System;
@@ -125,13 +126,16 @@ namespace Microsoft.Build.NuGetSdkResolver
                 {
                     try
                     {
+                        var nugetSDKLogger = new NuGetSdkLogger(context.Logger, warnings, errors);
+                        DefaultCredentialServiceUtility.SetupDefaultCredentialService(nugetSDKLogger, nonInteractive: true);
+
                         // Asynchronously run the restore without a commit which find the package on configured feeds, download, and unzip it without generating any other files
                         var results = RestoreRunnerEx.RunWithoutCommit(
                                 context.ProjectFilePath,
                                 sdk.Name,
                                 parsedSdkVersion.ToFullString(),
                                 settings,
-                                new NuGetSdkLogger(context.Logger, warnings, errors))
+                                nugetSDKLogger)
                             .ConfigureAwait(continueOnCapturedContext: false)
                             .GetAwaiter()
                             .GetResult();

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetAuthenticationCredentialsRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetAuthenticationCredentialsRequest.cs
@@ -30,6 +30,12 @@ namespace NuGet.Protocol.Plugins
         public bool IsNonInteractive { get; }
 
         /// <summary>
+        /// CanPrompt
+        /// </summary>
+        [JsonRequired]
+        public bool CanPrompt { get; }
+
+        /// <summary>
         /// Create a GetAuthenticationCredentialsRequest
         /// </summary>
         /// <param name="uri"></param>
@@ -37,11 +43,12 @@ namespace NuGet.Protocol.Plugins
         /// <param name="isNonInteractive"></param>
         /// <exception cref="ArgumentNullException"> if <paramref name="uri"/> is null</exception>
         [JsonConstructor]
-        public GetAuthenticationCredentialsRequest(Uri uri, bool isRetry, bool isNonInteractive)
+        public GetAuthenticationCredentialsRequest(Uri uri, bool isRetry, bool isNonInteractive, bool canPrompt)
         {
             Uri = uri ?? throw new ArgumentNullException(nameof(uri));
             IsRetry = isRetry;
             IsNonInteractive = isNonInteractive;
+            CanPrompt = canPrompt;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetAuthenticationCredentialsRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetAuthenticationCredentialsRequest.cs
@@ -30,10 +30,10 @@ namespace NuGet.Protocol.Plugins
         public bool IsNonInteractive { get; }
 
         /// <summary>
-        /// CanPrompt
+        /// CanShowDialog
         /// </summary>
         [JsonRequired]
-        public bool CanPrompt { get; }
+        public bool CanShowDialog { get; }
 
         /// <summary>
         /// Create a GetAuthenticationCredentialsRequest
@@ -43,12 +43,12 @@ namespace NuGet.Protocol.Plugins
         /// <param name="isNonInteractive"></param>
         /// <exception cref="ArgumentNullException"> if <paramref name="uri"/> is null</exception>
         [JsonConstructor]
-        public GetAuthenticationCredentialsRequest(Uri uri, bool isRetry, bool isNonInteractive, bool canPrompt)
+        public GetAuthenticationCredentialsRequest(Uri uri, bool isRetry, bool isNonInteractive, bool canShowDialog)
         {
             Uri = uri ?? throw new ArgumentNullException(nameof(uri));
             IsRetry = isRetry;
             IsNonInteractive = isNonInteractive;
-            CanPrompt = canPrompt;
+            CanShowDialog = canShowDialog;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetAuthenticationCredentialsRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetAuthenticationCredentialsRequest.cs
@@ -24,13 +24,13 @@ namespace NuGet.Protocol.Plugins
         public bool IsRetry { get; }
 
         /// <summary>
-        /// IsNonInteractive
+        /// IsNonInteractive - tells the plugin whether it can block the operation to ask for user input. Be it a device flow request or a pop-up. 
         /// </summary>
         [JsonRequired]
         public bool IsNonInteractive { get; }
 
         /// <summary>
-        /// CanShowDialog
+        /// CanShowDialog - tells the plugin whether it can show a dialog if the plugin is run in interactive mode. This being false normally means that the auth method should be device flow.
         /// </summary>
         [JsonRequired]
         public bool CanShowDialog { get; }

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/PluginManagerMock.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/PluginManagerMock.cs
@@ -32,6 +32,7 @@ namespace NuGet.Credentials.Test
         public string ProxyUsername { get; }
         public string ProxyPassword { get; }
         public bool PluginLaunched { get; }
+        public bool CanPrompt { get; }
 
         internal TestExpectation(
             string serviceIndexJson,
@@ -45,7 +46,8 @@ namespace NuGet.Credentials.Test
             bool success,
             string proxyUsername = null,
             string proxyPassword = null,
-            bool pluginLaunched = true
+            bool pluginLaunched = true,
+            bool canPrompt = true
             )
         {
             var serviceIndex = string.IsNullOrEmpty(serviceIndexJson)
@@ -62,6 +64,7 @@ namespace NuGet.Credentials.Test
             ProxyPassword = proxyPassword;
             ProxyUsername = proxyUsername;
             PluginLaunched = pluginLaunched;
+            CanPrompt = canPrompt;
         }
     }
 
@@ -138,7 +141,7 @@ namespace NuGet.Credentials.Test
             {
                 _connection.Setup(x => x.SendRequestAndReceiveResponseAsync<GetAuthenticationCredentialsRequest, GetAuthenticationCredentialsResponse>(
                     It.Is<MessageMethod>(m => m == MessageMethod.GetAuthenticationCredentials),
-                    It.Is<GetAuthenticationCredentialsRequest>(e => e.Uri.Equals(expectations.Uri)),
+                    It.Is<GetAuthenticationCredentialsRequest>(e => e.Uri.Equals(expectations.Uri) && e.CanPrompt.Equals(expectations.CanPrompt)),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new GetAuthenticationCredentialsResponse(expectations.AuthenticationUsername, expectations.AuthenticationPassword, null, null, MessageResponseCode.Success));
             }

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/PluginManagerMock.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/PluginManagerMock.cs
@@ -32,7 +32,7 @@ namespace NuGet.Credentials.Test
         public string ProxyUsername { get; }
         public string ProxyPassword { get; }
         public bool PluginLaunched { get; }
-        public bool CanPrompt { get; }
+        public bool CanShowDialog { get; }
 
         internal TestExpectation(
             string serviceIndexJson,
@@ -47,7 +47,7 @@ namespace NuGet.Credentials.Test
             string proxyUsername = null,
             string proxyPassword = null,
             bool pluginLaunched = true,
-            bool canPrompt = true
+            bool canShowDialog = true
             )
         {
             var serviceIndex = string.IsNullOrEmpty(serviceIndexJson)
@@ -64,7 +64,7 @@ namespace NuGet.Credentials.Test
             ProxyPassword = proxyPassword;
             ProxyUsername = proxyUsername;
             PluginLaunched = pluginLaunched;
-            CanPrompt = canPrompt;
+            CanShowDialog = canShowDialog;
         }
     }
 
@@ -141,7 +141,7 @@ namespace NuGet.Credentials.Test
             {
                 _connection.Setup(x => x.SendRequestAndReceiveResponseAsync<GetAuthenticationCredentialsRequest, GetAuthenticationCredentialsResponse>(
                     It.Is<MessageMethod>(m => m == MessageMethod.GetAuthenticationCredentials),
-                    It.Is<GetAuthenticationCredentialsRequest>(e => e.Uri.Equals(expectations.Uri) && e.CanPrompt.Equals(expectations.CanPrompt)),
+                    It.Is<GetAuthenticationCredentialsRequest>(e => e.Uri.Equals(expectations.Uri) && e.CanShowDialog.Equals(expectations.CanShowDialog)),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new GetAuthenticationCredentialsResponse(expectations.AuthenticationUsername, expectations.AuthenticationPassword, null, null, MessageResponseCode.Success));
             }

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderBuilderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderBuilderTests.cs
@@ -40,7 +40,7 @@ namespace NuGet.Credentials.Test
             var pluginManager = new PluginManagerBuilderMock(plugins);
             var builder = new SecurePluginCredentialProviderBuilder(pluginManager.PluginManager, true, NullLogger.Instance);
 
-            var credentialProviders = await builder.BuildAll();
+            var credentialProviders = await builder.BuildAllAsync();
             Assert.Equal(0, credentialProviders.Count());
         }
 
@@ -55,7 +55,7 @@ namespace NuGet.Credentials.Test
             var pluginManager = new PluginManagerBuilderMock(plugins);
             var builder = new SecurePluginCredentialProviderBuilder(pluginManager.PluginManager, true, NullLogger.Instance);
 
-            var credentialProviders = (await builder.BuildAll()).ToArray();
+            var credentialProviders = (await builder.BuildAllAsync()).ToArray();
             Assert.Equal(3, credentialProviders.Count());
             Assert.StartsWith(nameof(SecurePluginCredentialProvider) + "_a", credentialProviders[0].Id);
             Assert.StartsWith(nameof(SecurePluginCredentialProvider) + "_b", credentialProviders[1].Id);
@@ -75,7 +75,7 @@ namespace NuGet.Credentials.Test
             var pluginManager = new PluginManagerBuilderMock(plugins);
             var builder = new SecurePluginCredentialProviderBuilder(pluginManager.PluginManager, true, NullLogger.Instance);
 
-            var credentialProviders = (await builder.BuildAll()).ToArray();
+            var credentialProviders = (await builder.BuildAllAsync()).ToArray();
             Assert.Equal(4, credentialProviders.Count());
         }
 
@@ -90,7 +90,7 @@ namespace NuGet.Credentials.Test
             var pluginManager = new PluginManagerBuilderMock(plugins);
             var builder = new SecurePluginCredentialProviderBuilder(pluginManager.PluginManager, canShowDialog, NullLogger.Instance);
 
-            var credentialProviders = (await builder.BuildAll()).ToArray();
+            var credentialProviders = (await builder.BuildAllAsync()).ToArray();
             Assert.Equal(1, credentialProviders.Count());
             var bla = typeof(SecurePluginCredentialProvider).GetTypeInfo().GetField("_canShowDialog", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
             Assert.Equal(canShowDialog, bla.GetValue(credentialProviders.Single()));

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderBuilderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderBuilderTests.cs
@@ -82,18 +82,18 @@ namespace NuGet.Credentials.Test
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task BuildAll_PassesCorrectCanPromptValue(bool canPrompt)
+        public async Task BuildAll_PassesCorrectCanShowDialogValue(bool canShowDialog)
         {
             var plugins = new List<KeyValuePair<string, PluginFileState>>();
             plugins.Add(new KeyValuePair<string, PluginFileState>("a", PluginFileState.Valid));
 
             var pluginManager = new PluginManagerBuilderMock(plugins);
-            var builder = new SecurePluginCredentialProviderBuilder(pluginManager.PluginManager, canPrompt, NullLogger.Instance);
+            var builder = new SecurePluginCredentialProviderBuilder(pluginManager.PluginManager, canShowDialog, NullLogger.Instance);
 
             var credentialProviders = (await builder.BuildAll()).ToArray();
             Assert.Equal(1, credentialProviders.Count());
-            var bla = typeof(SecurePluginCredentialProvider).GetTypeInfo().GetField("_canPrompt", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
-            Assert.Equal(canPrompt, bla.GetValue(credentialProviders.Single()));
+            var bla = typeof(SecurePluginCredentialProvider).GetTypeInfo().GetField("_canShowDialog", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
+            Assert.Equal(canShowDialog, bla.GetValue(credentialProviders.Single()));
         }
 
         private sealed class PluginManagerBuilderMock

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderBuilderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderBuilderTests.cs
@@ -11,7 +11,6 @@ using Moq;
 using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Plugins;
-using Test.Utility;
 using Xunit;
 
 namespace NuGet.Credentials.Test
@@ -22,7 +21,7 @@ namespace NuGet.Credentials.Test
         public void CredentialProviderBuilder_ThrowsExceptionForNullLogger()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new SecureCredentialProviderBuilder(CreateDefaultPluginManager(), true, null));
+                () => new SecurePluginCredentialProviderBuilder(CreateDefaultPluginManager(), true, null));
             Assert.Equal("logger", exception.ParamName);
         }
 
@@ -30,7 +29,7 @@ namespace NuGet.Credentials.Test
         public void CredentialProviderBuilder_ThrowsExceptionForNullPluginManager()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new SecureCredentialProviderBuilder(null, true, NullLogger.Instance));
+                () => new SecurePluginCredentialProviderBuilder(null, true, NullLogger.Instance));
             Assert.Equal("pluginManager", exception.ParamName);
         }
 
@@ -39,7 +38,7 @@ namespace NuGet.Credentials.Test
         {
             var plugins = new List<KeyValuePair<string, PluginFileState>>();
             var pluginManager = new PluginManagerBuilderMock(plugins);
-            var builder = new SecureCredentialProviderBuilder(pluginManager.PluginManager, true, NullLogger.Instance);
+            var builder = new SecurePluginCredentialProviderBuilder(pluginManager.PluginManager, true, NullLogger.Instance);
 
             var credentialProviders = await builder.BuildAll();
             Assert.Equal(0, credentialProviders.Count());
@@ -54,7 +53,7 @@ namespace NuGet.Credentials.Test
             plugins.Add(new KeyValuePair<string, PluginFileState>("c", PluginFileState.Valid));
 
             var pluginManager = new PluginManagerBuilderMock(plugins);
-            var builder = new SecureCredentialProviderBuilder(pluginManager.PluginManager, true, NullLogger.Instance);
+            var builder = new SecurePluginCredentialProviderBuilder(pluginManager.PluginManager, true, NullLogger.Instance);
 
             var credentialProviders = (await builder.BuildAll()).ToArray();
             Assert.Equal(3, credentialProviders.Count());
@@ -74,7 +73,7 @@ namespace NuGet.Credentials.Test
 
 
             var pluginManager = new PluginManagerBuilderMock(plugins);
-            var builder = new SecureCredentialProviderBuilder(pluginManager.PluginManager, true, NullLogger.Instance);
+            var builder = new SecurePluginCredentialProviderBuilder(pluginManager.PluginManager, true, NullLogger.Instance);
 
             var credentialProviders = (await builder.BuildAll()).ToArray();
             Assert.Equal(4, credentialProviders.Count());
@@ -89,7 +88,7 @@ namespace NuGet.Credentials.Test
             plugins.Add(new KeyValuePair<string, PluginFileState>("a", PluginFileState.Valid));
 
             var pluginManager = new PluginManagerBuilderMock(plugins);
-            var builder = new SecureCredentialProviderBuilder(pluginManager.PluginManager, canPrompt, NullLogger.Instance);
+            var builder = new SecurePluginCredentialProviderBuilder(pluginManager.PluginManager, canPrompt, NullLogger.Instance);
 
             var credentialProviders = (await builder.BuildAll()).ToArray();
             Assert.Equal(1, credentialProviders.Count());

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderTests.cs
@@ -305,12 +305,12 @@ namespace NuGet.Credentials.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public void GetCredentialsAsync_SendsCorrectCanPromptValue()
+        public void GetCredentialsAsync_SendsCorrectCanShowDialogValue()
         {
             var uri = new Uri("https://api.nuget.org/v3/index.json");
             var authUsername = "username";
             var authPassword = "password";
-            var canPrompt = false;
+            var canShowDialog = false;
             var expectation = new TestExpectation(
                 serviceIndexJson: null,
                 sourceUri: null,
@@ -324,7 +324,7 @@ namespace NuGet.Credentials.Test
                 proxyUsername: null,
                 proxyPassword: null,
                 pluginLaunched: true,
-                canPrompt: canPrompt
+                canShowDialog: canShowDialog
                 );
 
             using (var test = new PluginManagerMock(
@@ -333,7 +333,7 @@ namespace NuGet.Credentials.Test
                 expectations: expectation))
             {
                 var discoveryResult = new PluginDiscoveryResult(new PluginFile("a", new Lazy<PluginFileState>(() => PluginFileState.Valid)));
-                var provider = new SecurePluginCredentialProvider(test.PluginManager, discoveryResult, canPrompt, NullLogger.Instance);
+                var provider = new SecurePluginCredentialProvider(test.PluginManager, discoveryResult, canShowDialog, NullLogger.Instance);
 
                 IWebProxy proxy = null;
                 var credType = CredentialRequestType.Unauthorized;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetAuthenticationCredentialsRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetAuthenticationCredentialsRequestTests.cs
@@ -19,24 +19,30 @@ namespace NuGet.Protocol.Tests.Plugins
                 () => new GetAuthenticationCredentialsRequest(
                     uri: uri,
                     isRetry: false,
-                    isNonInteractive: false
+                    isNonInteractive: false,
+                    canPrompt: false
                     ));
             Assert.Equal("uri", exception.ParamName);
         }
 
         [Theory]
-        [InlineData(@"http://api.nuget.org/v3/index.json", false, false)]
-        [InlineData(@"http://api.nuget.org/v3/index.json", true, false)]
-        [InlineData(@"http://api.nuget.org/v3/index.json", false, true)]
-        [InlineData(@"http://api.nuget.org/v3/index.json", true, true)]
+        [InlineData(@"http://api.nuget.org/v3/index.json", false, false, false)]
+        [InlineData(@"http://api.nuget.org/v3/index.json", true, false, false)]
+        [InlineData(@"http://api.nuget.org/v3/index.json", false, false, true)]
+        [InlineData(@"http://api.nuget.org/v3/index.json", true, false, true)]
+        [InlineData(@"http://api.nuget.org/v3/index.json", false, true, false)]
+        [InlineData(@"http://api.nuget.org/v3/index.json", true, true, false)]
+        [InlineData(@"http://api.nuget.org/v3/index.json", false, true, true)]
+        [InlineData(@"http://api.nuget.org/v3/index.json", true, true, true)]
         public void AJsonSerialization_ReturnsCorrectJson(
             string uri,
             bool isRetry,
+            bool canPrompt,
             bool isNonInteractive)
         {
-            var expectedJson = "{\"Uri\":\"" + uri + "\",\"IsRetry\":" + isRetry.ToString().ToLowerInvariant() + ",\"IsNonInteractive\":" + isNonInteractive.ToString().ToLowerInvariant() + "}";
+            var expectedJson = "{\"Uri\":\"" + uri + "\",\"IsRetry\":" + isRetry.ToString().ToLowerInvariant() + ",\"IsNonInteractive\":" + isNonInteractive.ToString().ToLowerInvariant()  + ",\"CanPrompt\":" + canPrompt.ToString().ToLowerInvariant() + "}";
 
-            var request = new GetAuthenticationCredentialsRequest(new Uri(uri), isRetry, isNonInteractive);
+            var request = new GetAuthenticationCredentialsRequest(new Uri(uri), isRetry, isNonInteractive, canPrompt);
 
 
             var actualJson = TestUtilities.Serialize(request);
@@ -45,14 +51,19 @@ namespace NuGet.Protocol.Tests.Plugins
         }
 
         [Theory]
-        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":true,\"IsNonInteractive\":true}", "http://api.nuget.org/v3/index.json", true, true)]
-        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":true,\"IsNonInteractive\":false}", "http://api.nuget.org/v3/index.json", true, false)]
-        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":false,\"IsNonInteractive\":false}", "http://api.nuget.org/v3/index.json", false, false)]
-        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":false,\"IsNonInteractive\":true}", "http://api.nuget.org/v3/index.json", false, true)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":true,\"IsNonInteractive\":true,\"CanPrompt\":true}", "http://api.nuget.org/v3/index.json", true, true, true)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":true,\"IsNonInteractive\":false,\"CanPrompt\":true}", "http://api.nuget.org/v3/index.json", true, true, false)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":false,\"IsNonInteractive\":false,\"CanPrompt\":true}", "http://api.nuget.org/v3/index.json", false, true, false)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":false,\"IsNonInteractive\":true,\"CanPrompt\":true}", "http://api.nuget.org/v3/index.json", false, true, true)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":true,\"IsNonInteractive\":true,\"CanPrompt\":false}", "http://api.nuget.org/v3/index.json", true, false, true)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":true,\"IsNonInteractive\":false,\"CanPrompt\":false}", "http://api.nuget.org/v3/index.json", true, false, false)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":false,\"IsNonInteractive\":false,\"CanPrompt\":false}", "http://api.nuget.org/v3/index.json", false, false, false)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":false,\"IsNonInteractive\":true,\"CanPrompt\":false}", "http://api.nuget.org/v3/index.json", false, false, true)]
         public void AJsonDeserialization_ReturnsCorrectObject(
             string json,
             string packageSourceRepository,
             bool isRetry,
+            bool canPrompt,
             bool isNonInteractive)
         {
             var request = JsonSerializationUtilities.Deserialize<GetAuthenticationCredentialsRequest>(json);
@@ -60,6 +71,7 @@ namespace NuGet.Protocol.Tests.Plugins
             Assert.Equal(packageSourceRepository, request.Uri.ToString());
             Assert.Equal(isRetry, request.IsRetry);
             Assert.Equal(isNonInteractive, request.IsNonInteractive);
+            Assert.Equal(canPrompt, request.CanPrompt);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetAuthenticationCredentialsRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetAuthenticationCredentialsRequestTests.cs
@@ -20,7 +20,7 @@ namespace NuGet.Protocol.Tests.Plugins
                     uri: uri,
                     isRetry: false,
                     isNonInteractive: false,
-                    canPrompt: false
+                    canShowDialog: false
                     ));
             Assert.Equal("uri", exception.ParamName);
         }
@@ -37,12 +37,12 @@ namespace NuGet.Protocol.Tests.Plugins
         public void AJsonSerialization_ReturnsCorrectJson(
             string uri,
             bool isRetry,
-            bool canPrompt,
+            bool canShowDialog,
             bool isNonInteractive)
         {
-            var expectedJson = "{\"Uri\":\"" + uri + "\",\"IsRetry\":" + isRetry.ToString().ToLowerInvariant() + ",\"IsNonInteractive\":" + isNonInteractive.ToString().ToLowerInvariant()  + ",\"CanPrompt\":" + canPrompt.ToString().ToLowerInvariant() + "}";
+            var expectedJson = "{\"Uri\":\"" + uri + "\",\"IsRetry\":" + isRetry.ToString().ToLowerInvariant() + ",\"IsNonInteractive\":" + isNonInteractive.ToString().ToLowerInvariant()  + ",\"CanShowDialog\":" + canShowDialog.ToString().ToLowerInvariant() + "}";
 
-            var request = new GetAuthenticationCredentialsRequest(new Uri(uri), isRetry, isNonInteractive, canPrompt);
+            var request = new GetAuthenticationCredentialsRequest(new Uri(uri), isRetry, isNonInteractive, canShowDialog);
 
 
             var actualJson = TestUtilities.Serialize(request);
@@ -51,19 +51,19 @@ namespace NuGet.Protocol.Tests.Plugins
         }
 
         [Theory]
-        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":true,\"IsNonInteractive\":true,\"CanPrompt\":true}", "http://api.nuget.org/v3/index.json", true, true, true)]
-        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":true,\"IsNonInteractive\":false,\"CanPrompt\":true}", "http://api.nuget.org/v3/index.json", true, true, false)]
-        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":false,\"IsNonInteractive\":false,\"CanPrompt\":true}", "http://api.nuget.org/v3/index.json", false, true, false)]
-        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":false,\"IsNonInteractive\":true,\"CanPrompt\":true}", "http://api.nuget.org/v3/index.json", false, true, true)]
-        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":true,\"IsNonInteractive\":true,\"CanPrompt\":false}", "http://api.nuget.org/v3/index.json", true, false, true)]
-        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":true,\"IsNonInteractive\":false,\"CanPrompt\":false}", "http://api.nuget.org/v3/index.json", true, false, false)]
-        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":false,\"IsNonInteractive\":false,\"CanPrompt\":false}", "http://api.nuget.org/v3/index.json", false, false, false)]
-        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":false,\"IsNonInteractive\":true,\"CanPrompt\":false}", "http://api.nuget.org/v3/index.json", false, false, true)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":true,\"IsNonInteractive\":true,\"CanShowDialog\":true}", "http://api.nuget.org/v3/index.json", true, true, true)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":true,\"IsNonInteractive\":false,\"CanShowDialog\":true}", "http://api.nuget.org/v3/index.json", true, true, false)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":false,\"IsNonInteractive\":false,\"CanShowDialog\":true}", "http://api.nuget.org/v3/index.json", false, true, false)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":false,\"IsNonInteractive\":true,\"CanShowDialog\":true}", "http://api.nuget.org/v3/index.json", false, true, true)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":true,\"IsNonInteractive\":true,\"CanShowDialog\":false}", "http://api.nuget.org/v3/index.json", true, false, true)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":true,\"IsNonInteractive\":false,\"CanShowDialog\":false}", "http://api.nuget.org/v3/index.json", true, false, false)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":false,\"IsNonInteractive\":false,\"CanShowDialog\":false}", "http://api.nuget.org/v3/index.json", false, false, false)]
+        [InlineData("{\"Uri\":\"http://api.nuget.org/v3/index.json\",\"IsRetry\":false,\"IsNonInteractive\":true,\"CanShowDialog\":false}", "http://api.nuget.org/v3/index.json", false, false, true)]
         public void AJsonDeserialization_ReturnsCorrectObject(
             string json,
             string packageSourceRepository,
             bool isRetry,
-            bool canPrompt,
+            bool canShowDialog,
             bool isNonInteractive)
         {
             var request = JsonSerializationUtilities.Deserialize<GetAuthenticationCredentialsRequest>(json);
@@ -71,7 +71,7 @@ namespace NuGet.Protocol.Tests.Plugins
             Assert.Equal(packageSourceRepository, request.Uri.ToString());
             Assert.Equal(isRetry, request.IsRetry);
             Assert.Equal(isNonInteractive, request.IsNonInteractive);
-            Assert.Equal(canPrompt, request.CanPrompt);
+            Assert.Equal(canShowDialog, request.CanShowDialog);
         }
     }
 }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7076
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
There are 3 commits here. 
It's probably easier to review commit by commit:


1. MSBuild and dotnet.exe should always use device flow by default. Added an extra parameter in the getauthcred message to relay this to the plugin. 
1. Rename SecureCredentialProviderBuilder to Secure**Plugin**CredentialProviderBuilder to make it consistent with the rest of the code.
1. Added the necessary setup for the CredentialService in the MSBuild SDK resolver. This should allow the SDK resolver to work with private feeds. //cc @jeffkl FYI

## Testing/Validation
Tests Added: Yes  
Reason for not adding tests:  
Validation done:  Manual + automation. 
