### PR TITLE
Avoid doing disk I/O on UI thread as part of IVsPathContextProvider TryCreateContext api

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
@@ -171,7 +171,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                     });
 
                 // Act
-                var actual = await target.CreatePathContextAsync(project.Object, projectUniqueName, CancellationToken.None);
+                var actual = await target.CreatePathContextAsync(vsProjectAdapter.Object, "project.aseets.json", projectUniqueName, CancellationToken.None);
 
                 // Assert
                 Assert.NotNull(actual);
@@ -259,7 +259,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                     getLockFileOrNull: null);
 
                 // Act
-                var actual = await target.CreatePathContextAsync(project.Object, projectUniqueName, CancellationToken.None);
+                var actual = await target.CreatePathContextAsync(vsProjectAdapter.Object, string.Empty, projectUniqueName, CancellationToken.None);
 
                 // Assert
                 Assert.NotNull(actual);
@@ -300,7 +300,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
 
             // Act
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => target.CreatePathContextAsync(project.Object, projectUniqueName, CancellationToken.None));
+                () => target.CreatePathContextAsync(vsProjectAdapter.Object, "project.aseets.json", projectUniqueName, CancellationToken.None));
 
             // Assert
             Assert.Contains(projectUniqueName, exception.Message);
@@ -368,7 +368,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
 
                 // Act
                 var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => target.CreatePathContextAsync(project.Object, projectUniqueName, CancellationToken.None));
+                    () => target.CreatePathContextAsync(vsProjectAdapter.Object, string.Empty, projectUniqueName, CancellationToken.None));
 
                 // Assert
                 Assert.Contains(projectUniqueName, exception.Message);


### PR DESCRIPTION
Currently there are two issues with `TryCreateContext` api impl:
1. There are multiple UI vs BG thread context switching which add delay to multiple scenarios like rebuild or create project for WinForm projects.
2. As part of this api, we read the project's assets file libraries section and populate a trie to keep track of installed packages path which helps resolve any package asset file path and returns the corresponding package root folder path. But the whole disk read operation is being done on UI thread which add delays for `FileOperation_UIThread` RPS counter.

This PR resolves both of these issues by making sure that all disk I/O happens on BG thread and there is only one switch needed to go to UI thread.

![image](https://user-images.githubusercontent.com/18219758/42177635-48e3589a-7de2-11e8-8100-6ca947ae11c0.png)

@rrelyea 