### PR TITLE
Added solution packages folder value in IVsPathContext api

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContext.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -11,13 +11,15 @@ namespace NuGet.VisualStudio
 {
     // Implementation of IVsPathContext without support of reference resolving.
     // Used when project is not managed by NuGet or given project doesn't have any packages installed.
-    internal class VsPathContext : IVsPathContext
+    internal class VsPathContext : IVsPathContext2
     {
         public string UserPackageFolder { get; }
 
         public IEnumerable FallbackPackageFolders { get; }
 
-        public VsPathContext(NuGetPathContext pathContext)
+        public string SolutionPackageFolder { get; }
+
+        public VsPathContext(NuGetPathContext pathContext, string solutionPackageFolder = null)
         {
             if (pathContext == null)
             {
@@ -26,6 +28,7 @@ namespace NuGet.VisualStudio
 
             UserPackageFolder = pathContext.UserPackageFolder;
             FallbackPackageFolders = pathContext.FallbackPackageFolders;
+            SolutionPackageFolder = solutionPackageFolder;
         }
 
         public VsPathContext(string userPackageFolder, IEnumerable<string> fallbackPackageFolders)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -132,13 +132,23 @@ namespace NuGet.VisualStudio
             return outputPathContext != null;
         }
 
-        public bool TryCreateSolutionContext(out IVsPathContext outputPathContext)
+        public bool TryCreateSolutionContext(out IVsPathContext2 outputPathContext)
         {
-            outputPathContext = GetSolutionPathContext();
+            var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(_solutionManager.Value, _settings.Value);
+
+            // if solution package folder exists, then set it in VSPathContext
+            if (!string.IsNullOrEmpty(packagesFolderPath) && Directory.Exists(packagesFolderPath))
+            {
+                outputPathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value), packagesFolderPath);
+            }
+
+            else
+            {
+                outputPathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value));
+            }
 
             return outputPathContext != null;
         }
-
 
         private static async Task<Dictionary<string, EnvDTE.Project>> GetPathToDTEProjectLookupAsync(EnvDTE.DTE dte)
         {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -136,15 +136,7 @@ namespace NuGet.VisualStudio
         {
             var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(_solutionManager.Value, _settings.Value);
 
-            // if solution package folder exists, then set it in VSPathContext
-            if (!string.IsNullOrEmpty(packagesFolderPath) && Directory.Exists(packagesFolderPath))
-            {
-                outputPathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value), packagesFolderPath);
-            }
-            else
-            {
-                outputPathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value));
-            }
+            outputPathContext = GetSolutionPathContext(packagesFolderPath);
 
             return outputPathContext != null;
         }
@@ -158,17 +150,26 @@ namespace NuGet.VisualStudio
 
             var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(solutionDirectory, _settings.Value);
 
+            outputPathContext = GetSolutionPathContext(packagesFolderPath);
+
+            return outputPathContext != null;
+        }
+
+        private IVsPathContext2 GetSolutionPathContext(string packagesFolderPath)
+        {
+            VsPathContext pathContext = null;
+
             // if solution package folder exists, then set it in VSPathContext
             if (!string.IsNullOrEmpty(packagesFolderPath) && Directory.Exists(packagesFolderPath))
             {
-                outputPathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value), packagesFolderPath);
+                pathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value), packagesFolderPath);
             }
             else
             {
-                outputPathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value));
+                pathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value));
             }
 
-            return outputPathContext != null;
+            return pathContext;
         }
 
         private static async Task<Dictionary<string, EnvDTE.Project>> GetPathToDTEProjectLookupAsync(EnvDTE.DTE dte)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -141,7 +141,28 @@ namespace NuGet.VisualStudio
             {
                 outputPathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value), packagesFolderPath);
             }
+            else
+            {
+                outputPathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value));
+            }
 
+            return outputPathContext != null;
+        }
+
+        public bool TryCreateSolutionContext(string solutionDirectory, out IVsPathContext2 outputPathContext)
+        {
+            if (solutionDirectory == null)
+            {
+                throw new ArgumentNullException(nameof(solutionDirectory));
+            }
+
+            var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(solutionDirectory, _settings.Value);
+
+            // if solution package folder exists, then set it in VSPathContext
+            if (!string.IsNullOrEmpty(packagesFolderPath) && Directory.Exists(packagesFolderPath))
+            {
+                outputPathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value), packagesFolderPath);
+            }
             else
             {
                 outputPathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value));

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContext2.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContext2.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace NuGet.VisualStudio
+{
+    /// <summary>
+    /// NuGet path information specific to the current context (e.g. project context) or solution context
+    /// Represents captured snapshot associated with current project/solution settings.
+    /// Should be discarded immediately after all queries are done.
+    /// </summary>
+    [ComImport]
+    [Guid("24A1A187-75EE-4296-A8B3-59F0E0707119")]
+    public interface IVsPathContext2 : IVsPathContext
+    {
+        /// <summary>
+        /// Solution packages folder directory for packages.config based projects.
+        /// The path returned is an absolute path.
+        /// </summary>
+        string SolutionPackageFolder { get; }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContextProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Runtime.InteropServices;
@@ -23,7 +23,10 @@ namespace NuGet.VisualStudio
         /// <code>True</code> if operation has succeeded and context was created.
         /// False, otherwise, e.g. when provided project is not managed by NuGet.
         /// </returns>
-        /// <throws></throws>
+        /// <throws>
+        /// <code>ArgumentNullException</code> if projectUniqueName is passed as null.
+        /// <code>InvalidOperationException</code> when it fails to create a context and return appropriate error message.
+        /// </throws>
         bool TryCreateContext(string projectUniqueName, out IVsPathContext context);
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContextProvider2.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContextProvider2.cs
@@ -22,5 +22,19 @@ namespace NuGet.VisualStudio
         /// </returns>
         /// <throws></throws>
         bool TryCreateSolutionContext(out IVsPathContext2 context);
+
+        /// <summary>
+        /// Attempts to create an instance of <see cref="IVsPathContext2"/> for the solution.
+        /// </summary>
+        /// <param name="solutionDirectory">
+        /// path to the solution directory. Must be an absolute path.
+        /// </param>
+        /// <param name="context">The path context associated with this solution.</param>
+        /// <returns>
+        /// <code>True</code> if operation has succeeded and context was created.
+        /// <code>False</code> otherwise.
+        /// </returns>
+        /// <throws></throws>
+        bool TryCreateSolutionContext(string solutionDirectory, out IVsPathContext2 context);
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContextProvider2.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContextProvider2.cs
@@ -6,14 +6,14 @@ using System.Runtime.InteropServices;
 namespace NuGet.VisualStudio
 {
     /// <summary>
-    /// A factory to initialize <see cref="IVsPathContext"/> instances.
+    /// A factory to initialize <see cref="IVsPathContext2"/> instances.
     /// </summary>
     [ComImport]
     [Guid("5BAC7095-F674-4778-8788-E15FFF77F96B")]
     public interface IVsPathContextProvider2 : IVsPathContextProvider
     {
         /// <summary>
-        /// Attempts to create an instance of <see cref="IVsPathContext"/> for the solution.
+        /// Attempts to create an instance of <see cref="IVsPathContext2"/> for the solution.
         /// </summary>
         /// <param name="context">The path context associated with this solution.</param>
         /// <returns>
@@ -21,6 +21,6 @@ namespace NuGet.VisualStudio
         /// <code>False</code> otherwise.
         /// </returns>
         /// <throws></throws>
-        bool TryCreateSolutionContext(out IVsPathContext context);
+        bool TryCreateSolutionContext(out IVsPathContext2 context);
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContextProvider2.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContextProvider2.cs
@@ -20,7 +20,9 @@ namespace NuGet.VisualStudio
         /// <code>True</code> if operation has succeeded and context was created.
         /// <code>False</code> otherwise.
         /// </returns>
-        /// <throws></throws>
+        /// <throws>
+        /// <code>InvalidOperationException</code> when it fails to create a context and return appropriate error message.
+        /// </throws>
         bool TryCreateSolutionContext(out IVsPathContext2 context);
 
         /// <summary>
@@ -28,13 +30,17 @@ namespace NuGet.VisualStudio
         /// </summary>
         /// <param name="solutionDirectory">
         /// path to the solution directory. Must be an absolute path.
+        /// It will be performant to pass the solution directory if it's available.
         /// </param>
         /// <param name="context">The path context associated with this solution.</param>
         /// <returns>
         /// <code>True</code> if operation has succeeded and context was created.
         /// <code>False</code> otherwise.
         /// </returns>
-        /// <throws></throws>
+        /// <throws>
+        /// <code>ArgumentNullException</code> if solutionDirectory is passed as null.
+        /// <code>InvalidOperationException</code> when it fails to create a context and return appropriate error message.
+        /// </throws>
         bool TryCreateSolutionContext(string solutionDirectory, out IVsPathContext2 context);
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
@@ -475,6 +475,32 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
             }
         }
 
+        [Fact]
+        public void CreateSolutionContext_WithSolutionDirectory()
+        {
+            // Arrange
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var solutionPackageFolder = Path.Combine(testDirectory.Path, "packages");
+                Directory.CreateDirectory(solutionPackageFolder);
+
+                var target = new VsPathContextProvider(
+                Mock.Of<ISettings>(),
+                Mock.Of<IVsSolutionManager>(),
+                Mock.Of<ILogger>(),
+                Mock.Of<IVsProjectAdapterProvider>(),
+                getLockFileOrNull: null);
+
+                // Act
+                var result = target.TryCreateSolutionContext(testDirectory.Path, out var actual);
+
+                // Assert
+                Assert.True(result);
+                Assert.NotNull(actual);
+                Assert.Equal(solutionPackageFolder, actual.SolutionPackageFolder);
+            }
+        }
+
         private class TestPackageReferenceProject : BuildIntegratedNuGetProject
         {
             private readonly string _projectName;

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
@@ -379,64 +379,80 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         public void CreateSolutionContext_WithConfiguredUserPackageFolder()
         {
             // Arrange
-            var currentDirectory = Directory.GetCurrentDirectory();
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var currentDirectory = Directory.GetCurrentDirectory();
 
-            var settings = Mock.Of<ISettings>();
-            Mock.Get(settings)
-                .Setup(x => x.GetValue("config", "globalPackagesFolder", true))
-                .Returns(() => "solution/packages");
+                var settings = Mock.Of<ISettings>();
+                Mock.Get(settings)
+                    .Setup(x => x.GetValue("config", "globalPackagesFolder", true))
+                    .Returns(() => "solution/packages");
 
-            var target = new VsPathContextProvider(
-                settings,
-                Mock.Of<IVsSolutionManager>(),
-                Mock.Of<ILogger>(),
-                Mock.Of<IVsProjectAdapterProvider>(),
-                getLockFileOrNull: null);
+                var solutionManager = new Mock<IVsSolutionManager>();
+                solutionManager
+                    .Setup(x => x.SolutionDirectory)
+                    .Returns(testDirectory.Path);
 
-            // Act
-            var result = target.TryCreateSolutionContext(out var actual);
+                var target = new VsPathContextProvider(
+                    settings,
+                    solutionManager.Object,
+                    Mock.Of<ILogger>(),
+                    Mock.Of<IVsProjectAdapterProvider>(),
+                    getLockFileOrNull: null);
 
-            // Assert
-            Assert.True(result);
-            Assert.NotNull(actual);
-            Assert.Equal(Path.Combine(currentDirectory, "solution", "packages"), actual.UserPackageFolder);
+                // Act
+                var result = target.TryCreateSolutionContext(out var actual);
+
+                // Assert
+                Assert.True(result);
+                Assert.NotNull(actual);
+                Assert.Equal(Path.Combine(currentDirectory, "solution", "packages"), actual.UserPackageFolder);
+            }
         }
 
         [Fact]
         public void CreateSolutionContext_WithConfiguredFallbackPackageFolders()
         {
             // Arrange
-            var currentDirectory = Directory.GetCurrentDirectory();
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var currentDirectory = Directory.GetCurrentDirectory();
 
-            var settings = new Mock<ISettings>();
-            settings
-                .Setup(x => x.GetSettingValues("fallbackPackageFolders", true))
-                .Returns(() => new List<SettingValue>
-                {
+                var settings = new Mock<ISettings>();
+                settings
+                    .Setup(x => x.GetSettingValues("fallbackPackageFolders", true))
+                    .Returns(() => new List<SettingValue>
+                    {
                     new SettingValue("a", "solution/packagesA", isMachineWide: false),
                     new SettingValue("b", "solution/packagesB", isMachineWide: false)
-                });
+                    });
 
-            var target = new VsPathContextProvider(
-                settings.Object,
-                Mock.Of<IVsSolutionManager>(),
-                Mock.Of<ILogger>(),
-                Mock.Of<IVsProjectAdapterProvider>(),
-                getLockFileOrNull: null);
+                var solutionManager = new Mock<IVsSolutionManager>();
+                solutionManager
+                    .Setup(x => x.SolutionDirectory)
+                    .Returns(testDirectory.Path);
 
-            // Act
-            var result = target.TryCreateSolutionContext(out var actual);
+                var target = new VsPathContextProvider(
+                    settings.Object,
+                    solutionManager.Object,
+                    Mock.Of<ILogger>(),
+                    Mock.Of<IVsProjectAdapterProvider>(),
+                    getLockFileOrNull: null);
 
-            // Assert
-            Assert.True(result);
-            Assert.NotNull(actual);
-            Assert.Equal(
-                new[]
-                {
+                // Act
+                var result = target.TryCreateSolutionContext(out var actual);
+
+                // Assert
+                Assert.True(result);
+                Assert.NotNull(actual);
+                Assert.Equal(
+                    new[]
+                    {
                     Path.Combine(currentDirectory, "solution", "packagesA"),
                     Path.Combine(currentDirectory, "solution", "packagesB")
-                },
-                actual.FallbackPackageFolders.Cast<string>().ToArray());
+                    },
+                    actual.FallbackPackageFolders.Cast<string>().ToArray());
+            }
         }
 
         [Fact]
@@ -460,7 +476,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
 
                 var target = new VsPathContextProvider(
                 settings,
-                Mock.Of<IVsSolutionManager>(),
+                solutionManager.Object,
                 Mock.Of<ILogger>(),
                 Mock.Of<IVsProjectAdapterProvider>(),
                 getLockFileOrNull: null);


### PR DESCRIPTION
Extending PR# https://github.com/NuGet/NuGet.Client/pull/2321 we've now added `SolutionPackageFolder` to be returned as part of `IVsPathContext2` from `TryCreateSolutionContext` api. This will be helpful to know the solution packages folder for a solution which contains packages.config based projects.

@rrelyea @mgoertz-msft