### PR TITLE
Remove built-in plugins for .NET Core, change the directory for internal plugins to plugins instead of nuget plugins

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/EmbeddedSignatureVerifier.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/EmbeddedSignatureVerifier.cs
@@ -27,7 +27,7 @@ namespace NuGet.Protocol.Plugins
         /// <returns>An embedded signature verifier.</returns>
         public static EmbeddedSignatureVerifier Create()
         {
-            if (RuntimeEnvironmentHelper.IsWindows)
+            if (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsMono)
             {
                 return new WindowsEmbeddedSignatureVerifier();
             }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
@@ -124,13 +124,13 @@ namespace NuGet.Protocol.Plugins
                 {
                     if (File.Exists(filePath))
                     {
-                        var state = new Lazy<PluginFileState> (() => _verifier.IsValid(filePath) ? PluginFileState.Valid : PluginFileState.InvalidEmbeddedSignature);
+                        var state = new Lazy<PluginFileState>(() => _verifier.IsValid(filePath) ? PluginFileState.Valid : PluginFileState.InvalidEmbeddedSignature);
 
                         files.Add(new PluginFile(filePath, state));
                     }
                     else
                     {
-                        files.Add(new PluginFile(filePath, new Lazy<PluginFileState> ( () => PluginFileState.NotFound)));
+                        files.Add(new PluginFile(filePath, new Lazy<PluginFileState>(() => PluginFileState.NotFound)));
                     }
                 }
                 else
@@ -146,7 +146,11 @@ namespace NuGet.Protocol.Plugins
         {
             if (string.IsNullOrEmpty(_rawPluginPaths))
             {
+#if IS_DESKTOP
                 var directories = new List<string> { PluginDiscoveryUtility.GetNuGetHomePluginsPath(), PluginDiscoveryUtility.GetInternalPlugins() };
+#else
+                var directories = new List<string> { PluginDiscoveryUtility.GetNuGetHomePluginsPath() };
+#endif
                 return PluginDiscoveryUtility.GetConventionBasedPlugins(directories);
             }
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
@@ -146,10 +146,10 @@ namespace NuGet.Protocol.Plugins
         {
             if (string.IsNullOrEmpty(_rawPluginPaths))
             {
-#if IS_DESKTOP
-                var directories = new List<string> { PluginDiscoveryUtility.GetNuGetHomePluginsPath(), PluginDiscoveryUtility.GetInternalPlugins() };
-#else
                 var directories = new List<string> { PluginDiscoveryUtility.GetNuGetHomePluginsPath() };
+#if IS_DESKTOP
+                // Internal plugins are only supported for .NET Framework scenarios, namely msbuild.exe
+                directories.Add(PluginDiscoveryUtility.GetInternalPlugins());
 #endif
                 return PluginDiscoveryUtility.GetConventionBasedPlugins(directories);
             }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
@@ -1,3 +1,4 @@
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -11,20 +12,25 @@ namespace NuGet.Protocol.Plugins
     {
         public static Lazy<string> InternalPluginDiscoveryRoot { get; set; }
 
-        private static string NuGetPluginsDirectory = "NuGetPlugins";
+        private static string NuGetPluginsDirectory = "Plugins";
 
+#if IS_DESKTOP
+        /// <summary>
+        /// The internal plugins located next to the NuGet assemblies.
+        /// </summary>
+        /// <returns>Internal plugins</returns>
         public static string GetInternalPlugins()
         {
             return InternalPluginDiscoveryRoot?.Value ??
                 GetNuGetPluginsDirectoryRelativeToNuGetAssembly(typeof(PluginDiscoveryUtility).GetTypeInfo().Assembly.Location); // NuGet.*.dll
         }
-#if IS_DESKTOP
+
         /// <summary>
-        /// Given Visual Studio 2017 MSBuild.exe path, return the NuGet plugins directory which is in CommonExtensions\NuGet\NuGetPlugins
+        /// Given Visual Studio 2017 MSBuild.exe path, return the NuGet plugins directory which is in CommonExtensions\NuGet\Plugins
         /// </summary>
         /// <param name="msbuildExePath">The MsBuildExe path. Needs to be a valid path. file:// not supported.</param>
         /// <returns>The NuGet plugins directory, null if <paramref name="msbuildExePath"/> is null</returns>
-        /// <remarks>The MSBuild.exe is in MSBuild\15.0\Bin\MsBuild.exe, the NuGetPlugins directory is in Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGetPlugins</remarks>
+        /// <remarks>The MSBuild.exe is in MSBuild\15.0\Bin\MsBuild.exe, the Plugins directory is in Common7\IDE\CommonExtensions\Microsoft\NuGet\Plugins</remarks>
         public static string GetInternalPluginRelativeToMSBuildExe(string msbuildExePath)
         {
             var parentDirectory = "..";
@@ -41,7 +47,7 @@ namespace NuGet.Protocol.Plugins
         /// Given a NuGet assembly path, returns the NuGet plugins directory
         /// </summary>
         /// <param name="nugetAssemblyPath">The path to a NuGet assembly in CommonExtensions\NuGet, needs to be a valid path. file:// not supported</param>
-        /// <returns>The NuGet plugins directory in CommonExtensions\NuGet\NuGetPlugins, null if the <paramref name="nugetAssemblyPath"/> is null</returns>
+        /// <returns>The NuGet plugins directory in CommonExtensions\NuGet\Plugins, null if the <paramref name="nugetAssemblyPath"/> is null</returns>
         public static string GetNuGetPluginsDirectoryRelativeToNuGetAssembly(string nugetAssemblyPath)
         {
             return !string.IsNullOrEmpty(nugetAssemblyPath) ?

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
@@ -55,19 +55,9 @@ namespace NuGet.Protocol.Plugins.Tests
                 ), result);
         }
 
-        [PlatformTheory(Platform.Linux, Platform.Darwin)]
-        [InlineData(@"/opt/coolpath/dotnet/sdk/2.0.0/NuGet.Protocol.dll",
-            @"/opt/coolpath/dotnet/sdk/2.0.0/NuGetPlugins")]
-        [InlineData(null, null)]
-        public void PluginDiscoveryUtility_GetsNuGetPluginPathGivenNuGetAssembliesInXPLATSDK(string given, string expected)
-        {
-            var result = PluginDiscoveryUtility.GetNuGetPluginsDirectoryRelativeToNuGetAssembly(given);
-            Assert.Equal(expected, result);
-        }
-
         [PlatformTheory(Platform.Windows)]
         [InlineData(@"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.Protocol.dll",
-    @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGetPlugins")]
+    @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\Plugins")]
         [InlineData(null, null)]
         public void PluginDiscoveryUtility_GetsNuGetPluginPathGivenNuGetAssemblies(string given, string expected)
         {
@@ -78,7 +68,7 @@ namespace NuGet.Protocol.Plugins.Tests
 #if IS_DESKTOP
         [Theory]
         [InlineData(@"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe",
-            @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGetPlugins")]
+            @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\Plugins")]
         [InlineData(null, null)]
         public void PluginDiscoveryUtility_GetsNuGetPluginPathGivenMSBuildExeLocation(string given, string expected)
         {


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7078
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
Per a discussion we had with the .NET Core folks we decided to remove built plugins for .net core. 
With this we're also going to change the internal plugins directory from:
NuGet\NuGetPlugins to NuGet\Plugins //cc @aldoms we need to coordinate this change with the insertion of the MSCred in VS. 

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  Updated existing ones
Validation done: Manual  
