### PR TITLE
Improving NU3008 message and adding suffix to signing errors/warnings

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -1009,6 +1009,11 @@ namespace NuGet.Packaging
                 {
                     await LogPackageSignatureVerificationAsync(source, package, packageExtractionContext.Logger, verifyResult);
 
+                    var errorsAndWarningLogs = verifyResult.Results
+                            .SelectMany(r => r.Issues.Where(i => i.Level == LogLevel.Error || i.Level == LogLevel.Warning));
+
+                    errorsAndWarningLogs.ForEach(e => AddPackageIdentityToLogMessages(source, package, e));
+
                     if (verifyResult.Valid)
                     {
                         // log any warnings
@@ -1020,11 +1025,7 @@ namespace NuGet.Packaging
                         }
                     }
                     else
-                    {
-                        var errorsAndWarningLogs = verifyResult.Results
-                            .SelectMany(r => r.Issues.Where(i => i.Level == LogLevel.Error || i.Level == LogLevel.Warning));
-
-                        errorsAndWarningLogs.ForEach(e => AddPackageIdentityToLogMessages(source, package, e));
+                    {                       
                         throw new SignatureException(verifyResult.Results, package);
                     }
                 }
@@ -1036,16 +1037,16 @@ namespace NuGet.Packaging
         /// </summary>
         /// <param name="source">package source.</param>
         /// <param name="package">package identity.</param>
-        /// <param name="message">ILogMessage to be modified with the siffix.</param>
+        /// <param name="message">ILogMessage to be modified with the suffix.</param>
         private static void AddPackageIdentityToLogMessages(string source, PackageIdentity package, ILogMessage message)
         {
             switch (message.Code)
             {
                 case NuGetLogCode.NU3008:
-                    message.Message = string.Format(CultureInfo.CurrentCulture, Strings.ExtractionError_PackageSignatureIntegrityFailure, package, source);
+                    message.Message = string.Format(CultureInfo.CurrentCulture, Strings.ExtractionError_PackageSignatureIntegrityFailure, package.Id, package.Version, source);
                     break;
                 default:
-                    message.Message = string.Format(CultureInfo.CurrentCulture, Strings.ExtractionLog_InformationSuffix, message.Message, package, source);
+                    message.Message = string.Format(CultureInfo.CurrentCulture, Strings.ExtractionLog_InformationSuffix, message.Message, package.Id, package.Version, source);
                     break;
             }
         }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
+using NuGet.Shared;
 
 namespace NuGet.Packaging
 {
@@ -1020,9 +1021,20 @@ namespace NuGet.Packaging
                     }
                     else
                     {
+                        verifyResult.Results.SelectMany(r => r.GetErrorIssues()).ForEach(e => AddPackageIdentityToLogMessages(source, package, e));
                         throw new SignatureException(verifyResult.Results, package);
                     }
                 }
+            }
+        }
+
+        private static void AddPackageIdentityToLogMessages(string source, PackageIdentity package, ILogMessage error)
+        {
+            switch (error.Code)
+            {
+                case NuGetLogCode.NU3008:
+                    error.Message = string.Format(CultureInfo.CurrentCulture, Strings.ExtractionError_SignaturePackageIntegrityFailure, package, source);
+                    break;
             }
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -1009,10 +1009,10 @@ namespace NuGet.Packaging
                 {
                     await LogPackageSignatureVerificationAsync(source, package, packageExtractionContext.Logger, verifyResult);
 
-                    var errorsAndWarningLogs = verifyResult.Results
-                            .SelectMany(r => r.Issues.Where(i => i.Level == LogLevel.Error || i.Level == LogLevel.Warning));
-
-                    errorsAndWarningLogs.ForEach(e => AddPackageIdentityToLogMessages(source, package, e));
+                    // Update errors and warnings with package id and source
+                    verifyResult.Results
+                            .SelectMany(r => r.Issues.Where(i => i.Level == LogLevel.Error || i.Level == LogLevel.Warning))
+                            .ForEach(e => AddPackageIdentityToLogMessages(source, package, e));
 
                     if (verifyResult.Valid)
                     {
@@ -1025,7 +1025,7 @@ namespace NuGet.Packaging
                         }
                     }
                     else
-                    {                       
+                    {
                         throw new SignatureException(verifyResult.Results, package);
                     }
                 }

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -451,9 +451,18 @@ namespace NuGet.Packaging {
         /// <summary>
         ///   Looks up a localized string similar to Package integrity check failed for package &apos;{0}&apos; from source &apos;{1}&apos;.
         /// </summary>
-        internal static string ExtractionError_SignaturePackageIntegrityFailure {
+        internal static string ExtractionError_PackageSignatureIntegrityFailure {
             get {
-                return ResourceManager.GetString("ExtractionError_SignaturePackageIntegrityFailure", resourceCulture);
+                return ResourceManager.GetString("ExtractionError_PackageSignatureIntegrityFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} [Package &apos;{1}&apos; from source &apos;{2}&apos;].
+        /// </summary>
+        internal static string ExtractionLog_InformationSuffix {
+            get {
+                return ResourceManager.GetString("ExtractionLog_InformationSuffix", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -449,7 +449,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package integrity check failed for package &apos;{0}&apos; version &apos;{1}&apos; from source &apos;{2}&apos;.
+        ///   Looks up a localized string similar to Package integrity check failed for package &apos;{0} {1}&apos; from source &apos;{2}&apos;.
         /// </summary>
         internal static string ExtractionError_PackageSignatureIntegrityFailure {
             get {
@@ -458,7 +458,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} [Package &apos;{1}&apos; version &apos;{2}&apos; from source &apos;{3}&apos;].
+        ///   Looks up a localized string similar to {0} [Package &apos;{1} {2}&apos; from source &apos;{3}&apos;].
         /// </summary>
         internal static string ExtractionLog_InformationSuffix {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -449,6 +449,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package integrity check failed for package &apos;{0}&apos; from source &apos;{1}&apos;.
+        /// </summary>
+        internal static string ExtractionError_SignaturePackageIntegrityFailure {
+            get {
+                return ResourceManager.GetString("ExtractionError_SignaturePackageIntegrityFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to update file time for {0}: {1}.
         /// </summary>
         internal static string FailedFileTime {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -449,7 +449,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package integrity check failed for package &apos;{0}&apos; from source &apos;{1}&apos;.
+        ///   Looks up a localized string similar to Package integrity check failed for package &apos;{0}&apos; version &apos;{1}&apos; from source &apos;{2}&apos;.
         /// </summary>
         internal static string ExtractionError_PackageSignatureIntegrityFailure {
             get {
@@ -458,7 +458,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} [Package &apos;{1}&apos; from source &apos;{2}&apos;].
+        ///   Looks up a localized string similar to {0} [Package &apos;{1}&apos; version &apos;{2}&apos; from source &apos;{3}&apos;].
         /// </summary>
         internal static string ExtractionLog_InformationSuffix {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -701,4 +701,9 @@ Valid from:</comment>
   <data name="NoRepositoryCountersignature" xml:space="preserve">
     <value>Verification settings require a repository countersignature, but the package does not have a repository countersignature.</value>
   </data>
+  <data name="ExtractionError_SignaturePackageIntegrityFailure" xml:space="preserve">
+    <value>Package integrity check failed for package '{0}' from source '{1}'</value>
+    <comment>0 - package identity
+1 - package source url</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -702,12 +702,12 @@ Valid from:</comment>
     <value>Verification settings require a repository countersignature, but the package does not have a repository countersignature.</value>
   </data>
   <data name="ExtractionError_PackageSignatureIntegrityFailure" xml:space="preserve">
-    <value>Package integrity check failed for package '{0}' from source '{1}'</value>
+    <value>Package integrity check failed for package '{0}' version '{1}' from source '{2}'</value>
     <comment>0 - package identity
 1 - package source url</comment>
   </data>
   <data name="ExtractionLog_InformationSuffix" xml:space="preserve">
-    <value>{0} [Package '{1}' from source '{2}']</value>
+    <value>{0} [Package '{1}' version '{2}' from source '{3}']</value>
     <comment>0 - Log Message
 1 - Package ID and version
 2 - Package source URL</comment>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -702,14 +702,16 @@ Valid from:</comment>
     <value>Verification settings require a repository countersignature, but the package does not have a repository countersignature.</value>
   </data>
   <data name="ExtractionError_PackageSignatureIntegrityFailure" xml:space="preserve">
-    <value>Package integrity check failed for package '{0}' version '{1}' from source '{2}'</value>
-    <comment>0 - package identity
-1 - package source url</comment>
+    <value>Package integrity check failed for package '{0} {1}' from source '{2}'</value>
+    <comment>0 - package ID
+1 - package versions
+2 - package source url</comment>
   </data>
   <data name="ExtractionLog_InformationSuffix" xml:space="preserve">
-    <value>{0} [Package '{1}' version '{2}' from source '{3}']</value>
+    <value>{0} [Package '{1} {2}' from source '{3}']</value>
     <comment>0 - Log Message
-1 - Package ID and version
-2 - Package source URL</comment>
+1 - package ID
+2 - package versions
+3 - package source url</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -701,9 +701,15 @@ Valid from:</comment>
   <data name="NoRepositoryCountersignature" xml:space="preserve">
     <value>Verification settings require a repository countersignature, but the package does not have a repository countersignature.</value>
   </data>
-  <data name="ExtractionError_SignaturePackageIntegrityFailure" xml:space="preserve">
+  <data name="ExtractionError_PackageSignatureIntegrityFailure" xml:space="preserve">
     <value>Package integrity check failed for package '{0}' from source '{1}'</value>
     <comment>0 - package identity
 1 - package source url</comment>
+  </data>
+  <data name="ExtractionLog_InformationSuffix" xml:space="preserve">
+    <value>{0} [Package '{1}' from source '{2}']</value>
+    <comment>0 - Log Message
+1 - Package ID and version
+2 - Package source URL</comment>
   </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/InstallCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/InstallCommandTests.cs
@@ -23,7 +23,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
     [Collection(SignCommandTestCollection.Name)]
     public class InstallCommandTests
     {
-        private const string _NU3008 = "NU3008: The package integrity check failed.";
+        private const string _NU3008 = "NU3008: Package integrity check failed for package '{0}' version '{1}' from source '{2}'";
         private const string _NU3012 = "NU3012: The author primary signature found a chain building issue: The certificate is revoked.";
         private const string _NU3018 = "NU3018: The author primary signature found a chain building issue: A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.";
         private const string _NU3027 = "NU3027: The signature should be timestamped to enable long-term signature validity after the certificate has expired.";
@@ -68,7 +68,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(0);
-                result.AllOutput.Should().Contain($"WARNING: {_NU3027}");
+                result.AllOutput.Should().Contain($"WARNING: {_NU3027} {SigningTestUtility.GetSignatureLogSuffix(nupkg.Identity, context.WorkingDirectory)}");
             }
         }
 
@@ -102,7 +102,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(0);
-                result.AllOutput.Should().Contain($"WARNING: {_NU3027}");
+                result.AllOutput.Should().Contain($"WARNING: {_NU3027} {SigningTestUtility.GetSignatureLogSuffix(nupkg.Identity, context.WorkingDirectory)}");
             }
         }
 
@@ -135,8 +135,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(0);
-                result.AllOutput.Should().Contain($"WARNING: {_NU3018}");
-                result.AllOutput.Should().Contain($"WARNING: {_NU3027}");
+                result.AllOutput.Should().Contain($"WARNING: {_NU3018} {SigningTestUtility.GetSignatureLogSuffix(nupkg.Identity, context.WorkingDirectory)}");
+                result.AllOutput.Should().Contain($"WARNING: {_NU3027} {SigningTestUtility.GetSignatureLogSuffix(nupkg.Identity, context.WorkingDirectory)}");
             }
         }
 
@@ -170,8 +170,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(1);
-                result.Errors.Should().Contain(_NU3008);
-                result.AllOutput.Should().Contain($"WARNING: {_NU3027}");
+                result.Errors.Should().Contain(string.Format(_NU3008, nupkg.Identity.Id, nupkg.Identity.Version, context.WorkingDirectory));
+                result.AllOutput.Should().Contain($"WARNING: {_NU3027} {SigningTestUtility.GetSignatureLogSuffix(nupkg.Identity, context.WorkingDirectory)}");
             }
         }
 
@@ -215,9 +215,9 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(1);
-                result.Errors.Should().Contain(_NU3008);
-                result.Errors.Should().Contain(_NU3012);
-                result.AllOutput.Should().Contain($"WARNING: {_NU3027}");
+                result.Errors.Should().Contain(string.Format(_NU3008, nupkg.Identity.Id, nupkg.Identity.Version, context.WorkingDirectory));
+                result.Errors.Should().Contain($"{_NU3012} {SigningTestUtility.GetSignatureLogSuffix(nupkg.Identity, context.WorkingDirectory)}");
+                result.AllOutput.Should().Contain($"WARNING: {_NU3027} {SigningTestUtility.GetSignatureLogSuffix(nupkg.Identity, context.WorkingDirectory)}");
             }
         }
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/InstallCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/InstallCommandTests.cs
@@ -23,7 +23,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
     [Collection(SignCommandTestCollection.Name)]
     public class InstallCommandTests
     {
-        private const string _NU3008 = "NU3008: Package integrity check failed for package '{0}' version '{1}' from source '{2}'";
+        private const string _NU3008 = "NU3008: Package integrity check failed for package '{0} {1}' from source '{2}'";
         private const string _NU3012 = "NU3012: The author primary signature found a chain building issue: The certificate is revoked.";
         private const string _NU3018 = "NU3018: The author primary signature found a chain building issue: A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.";
         private const string _NU3027 = "NU3027: The signature should be timestamped to enable long-term signature validity after the certificate has expired.";

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -27,7 +27,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
     [Collection(SignCommandTestCollection.Name)]
     public class RestoreCommandTests
     {
-        private static readonly string _NU3008Message = "The package integrity check failed.";
+        private static readonly string _NU3008Message = "Package integrity check failed for package '{0}' version '{1}' from source '{2}'";
         private static readonly string _NU3008 = $"NU3008: {_NU3008Message}";
         private static readonly string _NU3027Message = "The signature should be timestamped to enable long-term signature validity after the certificate has expired.";
         private static readonly string _NU3027 = $"NU3027: {_NU3027Message}";
@@ -47,7 +47,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public async Task Restore_TamperedPackageInPackagesConfig_FailsWithErrorAsync()
         {
             // Arrange
-            var nupkg = new SimpleTestPackageContext("A", "1.0.0");
             var packagesConfigContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
                 "<packages>" +
                 "  <package id=\"X\" version=\"9.0.0\" targetFramework=\"net461\" />" +
@@ -90,8 +89,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(1);
-                result.Errors.Should().Contain(_NU3008);
-                result.AllOutput.Should().Contain(_NU3027);
+                result.Errors.Should().Contain(string.Format(_NU3008, packageX.Identity.Id, packageX.Identity.Version, pathContext.PackageSource));
+                result.AllOutput.Should().Contain($"{_NU3027} {SigningTestUtility.GetSignatureLogSuffix(packageX.Identity, pathContext.PackageSource)}");
             }
         }
 
@@ -99,8 +98,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public async Task Restore_TamperedPackage_FailsAsync()
         {
             // Arrange
-            var nupkg = new SimpleTestPackageContext("A", "1.0.0");
-
             using (var pathContext = new SimpleTestPathContext())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
@@ -136,18 +133,18 @@ namespace NuGet.CommandLine.FuncTest.Commands
             
                 // Assert
                 result.ExitCode.Should().Be(1);
-                result.Errors.Should().Contain(_NU3008);
-                result.AllOutput.Should().Contain($"WARNING: {_NU3027}");
+                result.Errors.Should().Contain(string.Format(_NU3008, packageX.Identity.Id, packageX.Identity.Version, pathContext.PackageSource));
+                result.AllOutput.Should().Contain($"WARNING: {_NU3027} {SigningTestUtility.GetSignatureLogSuffix(packageX.Identity, pathContext.PackageSource)}");
 
                 errors.Count().Should().Be(1);
                 errors.First().Code.Should().Be(NuGetLogCode.NU3008);
-                errors.First().Message.Should().Be(_NU3008Message);
+                errors.First().Message.Should().Be(string.Format(_NU3008Message, packageX.Identity.Id, packageX.Identity.Version, pathContext.PackageSource));
                 errors.First().LibraryId.Should().Be(packageX.ToString());
 
                 warnings.Count().Should().Be(1);
                 warnings.First().Code.Should().Be(NuGetLogCode.NU3027);
-                warnings.First().Message.Should().Be(_NU3027Message);
-                warnings.First().LibraryId.Should().Be("X.9.0.0");
+                result.AllOutput.Should().Contain($"{_NU3027Message} {SigningTestUtility.GetSignatureLogSuffix(packageX.Identity, pathContext.PackageSource)}");
+                warnings.First().LibraryId.Should().Be(packageX.Identity.ToString());
             }
         }
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -27,7 +27,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
     [Collection(SignCommandTestCollection.Name)]
     public class RestoreCommandTests
     {
-        private static readonly string _NU3008Message = "Package integrity check failed for package '{0}' version '{1}' from source '{2}'";
+        private static readonly string _NU3008Message = "Package integrity check failed for package '{0} {1}' from source '{2}'";
         private static readonly string _NU3008 = $"NU3008: {_NU3008Message}";
         private static readonly string _NU3027Message = "The signature should be timestamped to enable long-term signature validity after the certificate has expired.";
         private static readonly string _NU3027 = $"NU3027: {_NU3027Message}";

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
@@ -1131,13 +1131,14 @@ namespace NuGet.Packaging.FuncTest
                     {
                         exception.Results.First().Issues.Count().Should().Be(1);
                         exception.Results.First().Issues.First().Code.Should().Be(NuGetLogCode.NU3034);
-                        exception.Results.First().Issues.First().Message.Should().Be(_noMatchInRepoAllowList);
+                        exception.Results.First().Issues.First().Message.Should().Be($"{_noMatchInRepoAllowList} {SigningTestUtility.GetSignatureLogSuffix(packageReader.GetIdentity(), dir)}");
                     }
                     else
                     {
                         exception.Results.First().Issues.Count().Should().Be(2);
                         exception.Results.First().Issues.All(e => e.Code == NuGetLogCode.NU3034).Should().BeTrue();
-                        exception.Results.First().Issues.All(e => e.Message.Equals(_noMatchInRepoAllowList) || e.Message.Equals(_noClientAllowList));
+                        exception.Results.First().Issues.All(e => e.Message.Equals($"{_noMatchInRepoAllowList} {SigningTestUtility.GetSignatureLogSuffix(packageReader.GetIdentity(), dir)}") ||
+                                                                  e.Message.Equals($"{_noMatchInClientAllowList} {SigningTestUtility.GetSignatureLogSuffix(packageReader.GetIdentity(), dir)}"));
                     }
                 }
             }

--- a/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
@@ -67,8 +67,8 @@ namespace NuGet.Console.TestContract
             {
                 var snapshotLine = snapshot.GetLineFromLineNumber(i);
                 var lineText = snapshotLine.GetText();
-
-                var foundMessage = lineText.Contains(message);
+                var foundMessage = lineText.IndexOf(message, StringComparison.OrdinalIgnoreCase) >= 0;
+                
                 if (foundMessage)
                 {
                     return true;

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/AuthorSignedPackageTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/AuthorSignedPackageTestCase.cs
@@ -313,7 +313,7 @@ namespace NuGet.Tests.Apex
                 var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version);
-                nugetConsole.IsMessageFoundInPMC("package integrity check failed").Should().BeTrue("Integrity failed message shown.");
+                nugetConsole.IsMessageFoundInPMC("Package integrity check failed for package").Should().BeTrue("Integrity failed message shown.");
                 testContext.Project.Build();
                 testContext.NuGetApexTestService.WaitForAutoRestore();
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/AuthorSignedPackageTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/AuthorSignedPackageTestCase.cs
@@ -313,7 +313,7 @@ namespace NuGet.Tests.Apex
                 var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version);
-                nugetConsole.IsMessageFoundInPMC("Package integrity check failed for package").Should().BeTrue("Integrity failed message shown.");
+                nugetConsole.IsMessageFoundInPMC("Package integrity check failed for package").Should().BeTrue();
                 testContext.Project.Build();
                 testContext.NuGetApexTestService.WaitForAutoRestore();
 
@@ -338,7 +338,7 @@ namespace NuGet.Tests.Apex
                 var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version);
-                nugetConsole.IsMessageFoundInPMC("package integrity check failed").Should().BeTrue("Integrity failed message shown.");
+                nugetConsole.IsMessageFoundInPMC("Package integrity check failed").Should().BeTrue();
 
                 CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, testContext.Project, signedPackage.Id, signedPackage.Version, XunitLogger);
             }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/RepositoryCountersignedPackageTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/RepositoryCountersignedPackageTestCase.cs
@@ -435,7 +435,7 @@ namespace NuGet.Tests.Apex
                 var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version);
-                nugetConsole.IsMessageFoundInPMC("package integrity check failed").Should().BeTrue("Integrity failed message shown.");
+                nugetConsole.IsMessageFoundInPMC("Package integrity check failed").Should().BeTrue();
                 testContext.Project.Build();
                 testContext.NuGetApexTestService.WaitForAutoRestore();
 
@@ -460,7 +460,7 @@ namespace NuGet.Tests.Apex
                 var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version);
-                nugetConsole.IsMessageFoundInPMC("package integrity check failed").Should().BeTrue("Integrity failed message shown.");
+                nugetConsole.IsMessageFoundInPMC("Package integrity check failed").Should().BeTrue();
 
                 CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, testContext.Project, signedPackage.Id, signedPackage.Version, XunitLogger);
             }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/RepositorySignedPackageTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetPackageSigningTests/RepositorySignedPackageTestCase.cs
@@ -251,7 +251,7 @@ namespace NuGet.Tests.Apex
                 var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version);
-                nugetConsole.IsMessageFoundInPMC("package integrity check failed").Should().BeTrue("Integrity failed message shown.");
+                nugetConsole.IsMessageFoundInPMC("Package integrity check failed").Should().BeTrue();
                 testContext.Project.Build();
                 testContext.NuGetApexTestService.WaitForAutoRestore();
 
@@ -276,7 +276,7 @@ namespace NuGet.Tests.Apex
                 var nugetConsole = GetConsole(testContext.Project);
 
                 nugetConsole.InstallPackageFromPMC(signedPackage.Id, signedPackage.Version);
-                nugetConsole.IsMessageFoundInPMC("package integrity check failed").Should().BeTrue("Integrity failed message shown.");
+                nugetConsole.IsMessageFoundInPMC("Package integrity check failed").Should().BeTrue();
 
                 CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, testContext.Project, signedPackage.Id, signedPackage.Version, XunitLogger);
             }

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -11,6 +11,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
+using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
 using NuGet.Shared;
 using NuGet.Test.Utility;
@@ -31,6 +32,8 @@ namespace Test.Utility.Signing
 {
     public static class SigningTestUtility
     {
+        private static readonly string _signatureLogSuffix = "[Package '{0}' version '{1}' from source '{2}']";
+
         /// <summary>
         /// Modification generator that can be passed to TestCertificate.Generate().
         /// The generator will change the certificate EKU to ClientAuth.
@@ -714,6 +717,11 @@ namespace Test.Utility.Signing
                 issue.Code == NuGetLogCode.NU3018 &&
                 issue.Level == logLevel &&
                 issue.Message == untrustedRoot);
+        }
+
+        public static string GetSignatureLogSuffix(PackageIdentity package, string source)
+        {
+            return string.Format(_signatureLogSuffix, package.Id, package.Version, source);
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -32,7 +32,7 @@ namespace Test.Utility.Signing
 {
     public static class SigningTestUtility
     {
-        private static readonly string _signatureLogSuffix = "[Package '{0}' version '{1}' from source '{2}']";
+        private static readonly string _signatureLogSuffix = "[Package '{0} {1}' from source '{2}']";
 
         /// <summary>
         /// Modification generator that can be passed to TestCertificate.Generate().


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6944
Regression: No

## Fix
Details: This PR fixes signing error messages in the following 2 ways - 
1. `NU3008` - The error message for `NU3008` is improved by adding the package id, version and source.

2. Rest of the signing errors and warnings are improved by adding a suffix indicating the package id, version and source for the error or warning, similar to the way msbuild appends project path to all logs.


## Result
before - 

![image](https://user-images.githubusercontent.com/10507120/42478235-cf54397a-8388-11e8-8a6f-483278a346e8.png)

```
WARNING: NU3018: The author primary signature found a chain building issue: A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
WARNING: NU3037: The author primary signature validity period has expired.
Committing restore...
Generating MSBuild file F:\validation\testsdk\obj\testsdk.csproj.nuget.g.props.
Writing lock file to disk. Path: F:\validation\testsdk\obj\project.assets.json
Restore failed in 884.94 ms for F:\validation\testsdk\testsdk.csproj.

Errors in F:\validation\testsdk\testsdk.csproj
    NU3008: The package integrity check failed.
```


after - 

![image](https://user-images.githubusercontent.com/10507120/42477143-ed4baea8-8384-11e8-8086-a39c721b9df6.png)

```
WARNING: NU3018: The author primary signature found a chain building issue: A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider. [Package 'A 1.0.0' from source 'F:\validation\test-local-source']
WARNING: NU3037: The author primary signature validity period has expired. [Package 'A 1.0.0' from source 'F:\validation\test-local-source']
Committing restore...
Generating MSBuild file F:\validation\testsdk\obj\testsdk.csproj.nuget.g.props.
Writing lock file to disk. Path: F:\validation\testsdk\obj\project.assets.json
Restore failed in 679.97 ms for F:\validation\testsdk\testsdk.csproj.

Errors in F:\validation\testsdk\testsdk.csproj
    NU3008: Package integrity check failed for package 'A 1.0.0' from source 'F:\validation\test-local-source'
```

## Testing/Validation
Tests Added: Yes
Validation done:  Manual validation
