### PR TITLE
Moved from SemaphoreSlim to ReentrantSemaphore to fix UI hang

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollListBox.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollListBox.cs
@@ -1,12 +1,14 @@
 using System.Threading;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
+using Microsoft.VisualStudio.Threading;
+using NuGet.VisualStudio;
 
 namespace NuGet.PackageManagement.UI
 { 
     internal class InfiniteScrollListBox : ListBox
     {
-        public readonly SemaphoreSlim ItemsLock = new SemaphoreSlim(1, 1);
+        public ReentrantSemaphore ItemsLock { get; set; }
 
         protected override AutomationPeer OnCreateAutomationPeer()
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -647,7 +647,7 @@ namespace NuGet.PackageManagement.UI
             // start SearchAsync task for initial loading of packages
             var searchResultTask = loader.SearchAsync(continuationToken: null, cancellationToken: _loadCts.Token);
             // this will wait for searchResultTask to complete instead of creating a new task
-            _packageList.LoadItems(loader, loadingMessage, _uiLogger, searchResultTask, _loadCts.Token);
+            await _packageList.LoadItemsAsync(loader, loadingMessage, _uiLogger, searchResultTask, _loadCts.Token);
 
             if (pSearchCallback != null && searchTask != null)
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
@@ -65,7 +65,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Text.Logic" Version="15.0.26606" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="15.0.26606" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="15.0.26606" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.3.23" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.8.132" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.0.240" />
     <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
     <PackageReference Include="VSLangProj" Version="7.0.3300" />
@@ -99,6 +99,6 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>


### PR DESCRIPTION
Moved from wait() to waitAsync() so that we don't block UI thread while waiting for semaphore inside InfiniteScrollListBoxAutomationPeer. Although it will still block the UI thread since it's using `JTF.Run` but it will still be able to allow other thread sharing similar JTF context to proceed so that there is no deadlock.

Fixes - NuGet Package Manager hangs in InfiniteScrollListBoxAutomationPeer.GetChildrenCore [7089](https://github.com/NuGet/Home/issues/7089)

@rrelyea @AArnott @lifengl