### PR TITLE
Removing dead code from NuGet.Packaging.Rules

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Rules/MisplacedAssemblyUnderLibRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/MisplacedAssemblyUnderLibRule.cs
@@ -39,15 +39,8 @@ namespace NuGet.Packaging.Rules
         private PackagingLogMessage CreatePackageIssueForAssembliesUnderLib(string target)
         {
             return PackagingLogMessage.CreateWarning(
-                String.Format(CultureInfo.CurrentCulture, MessageFormat, target),
+                string.Format(CultureInfo.CurrentCulture, MessageFormat, target),
                 NuGetLogCode.NU5101);
-        }
-
-        private static PackagingLogMessage CreatePackageIssueForAssembliesOutsideLib(string target)
-        {
-            return PackagingLogMessage.CreateWarning(
-                String.Format(CultureInfo.CurrentCulture, AnalysisResources.AssemblyOutsideLibWarning, target),
-                NuGetLogCode.NU5100);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/Rules/UnspecifiedDependencyVersionRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/UnspecifiedDependencyVersionRule.cs
@@ -31,20 +31,13 @@ namespace NuGet.Packaging.Rules
 
             if (dependency != null && dependency.VersionRange == VersionRange.All)
             {
-                var issue = PackagingLogMessage.CreateWarning(String.Format(
+                var issue = PackagingLogMessage.CreateWarning(string.Format(
                     CultureInfo.CurrentCulture,
                     AnalysisResources.UnspecifiedDependencyVersionWarning,
                     dependency.Id),
                     NuGetLogCode.NU5112);
                 yield return issue;
             }
-        }
-
-        private PackagingLogMessage CreateIssueFor(string field, string value)
-        {
-            return PackagingLogMessage.CreateWarning(
-                String.Format(CultureInfo.CurrentCulture, MessageFormat, value, field),
-                NuGetLogCode.NU5102);
         }
     }
 }


### PR DESCRIPTION
While investigating the pack error codes and corresponding documentation, I found some dead code in `NuGet.Packaging.Rules`. This PR removes that.