### PR TITLE
Errors/Warrnings: Improve NU1605 downgrade warning message

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -446,7 +446,7 @@ namespace NuGet.Commands
         /// are not logged. This is to avoid flooding the log with long 
         /// dependency chains for every package.
         /// </summary>
-        private static async Task<bool> ValidateRestoreGraphsAsync(IEnumerable<RestoreTargetGraph> graphs, ILogger logger)
+        private async Task<bool> ValidateRestoreGraphsAsync(IEnumerable<RestoreTargetGraph> graphs, ILogger logger)
         {
             // Check for cycles
             var success = await ValidateCyclesAsync(graphs, logger);
@@ -487,7 +487,7 @@ namespace NuGet.Commands
         /// <summary>
         /// Logs an error and returns false if any conflicts exist.
         /// </summary>
-        private static async Task<bool> ValidateConflictsAsync(IEnumerable<RestoreTargetGraph> graphs, ILogger logger)
+        private async Task<bool> ValidateConflictsAsync(IEnumerable<RestoreTargetGraph> graphs, ILogger logger)
         {
             foreach (var graph in graphs)
             {
@@ -496,7 +496,9 @@ namespace NuGet.Commands
                     var message = string.Format(
                             CultureInfo.CurrentCulture,
                             Strings.Log_VersionConflict,
-                            versionConflict.Selected.Key.Name)
+                            versionConflict.Selected.Key.Name,
+                            versionConflict.Selected.GetIdAndVersionOrRange(),
+                            _request.Project.Name)
                         + $" {Environment.NewLine} {versionConflict.Selected.GetPathWithLastRange()} {Environment.NewLine} {versionConflict.Conflicting.GetPathWithLastRange()}.";
 
                     await logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1107, message, versionConflict.Selected.Key.Name, graph.TargetGraphName));
@@ -552,6 +554,7 @@ namespace NuGet.Commands
 
                             messages.Add(new PackageDowngradeWarningLogMessage(
                                 downgraded.Key.Name,
+                                fromVersion.ToString(),
                                 downgraded.GetDirectDependencyNode().Key.Name,
                                 downgradedBy.GetDirectDependencyNode().Key.Name,
                                 string.Format(CultureInfo.CurrentCulture, message, Strings.Log_DowngradeWarningSolution),

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -235,7 +235,7 @@ namespace NuGet.Commands
 
                     // Write the logs into the assets file
                     var logs = _logger.Errors
-                        .Select(l => AssetsLogMessage.Create(l))
+                        .Select(l => l.AsAssetLogMessage())
                         .ToList();
 
                     _success &= !logs.Any(l => l.Level == LogLevel.Error);
@@ -543,13 +543,20 @@ namespace NuGet.Commands
 
                             var message = string.Format(
                                     CultureInfo.CurrentCulture,
-                                    Strings.Log_DowngradeWarning,
+                                    Strings.Log_DowngradeWarningTitle,
                                     downgraded.Key.Name,
                                     fromVersion,
                                     toVersion)
+                                + "{0}"
                                 + $" {Environment.NewLine} {downgraded.GetPathWithLastRange()} {Environment.NewLine} {downgradedBy.GetPathWithLastRange()}";
 
-                            messages.Add(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1605, message, downgraded.Key.Name, graph.TargetGraphName));
+                            messages.Add(new PackageDowngradeWarningLogMessage(
+                                downgraded.Key.Name,
+                                downgraded.GetDirectDependencyNode().Key.Name,
+                                downgradedBy.GetDirectDependencyNode().Key.Name,
+                                string.Format(CultureInfo.CurrentCulture, message, Strings.Log_DowngradeWarningSolution),
+                                message,
+                                new List<string>() { graph.TargetGraphName }));
                         }
                     }
                 }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1143,7 +1143,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Version conflict detected for {0}. Reference the package directly from the project to resolve this issue..
+        ///   Looks up a localized string similar to Version conflict detected for {0}. Install/reference {1} directly to project {2} to resolve this issue..
         /// </summary>
         internal static string Log_VersionConflict {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -612,11 +612,20 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Detected package downgrade: {0} from {1} to {2}. Reference the package directly from the project to select a different version..
+        ///   Looks up a localized string similar to Reference the package directly from the project to select a different version..
         /// </summary>
-        internal static string Log_DowngradeWarning {
+        internal static string Log_DowngradeWarningSolution {
             get {
-                return ResourceManager.GetString("Log_DowngradeWarning", resourceCulture);
+                return ResourceManager.GetString("Log_DowngradeWarningSolution", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Detected package downgrade: {0} from {1} to {2}. .
+        /// </summary>
+        internal static string Log_DowngradeWarningTitle {
+            get {
+                return ResourceManager.GetString("Log_DowngradeWarningTitle", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -212,7 +212,7 @@
 {2}: resolved version</comment>
   </data>
   <data name="Log_VersionConflict" xml:space="preserve">
-    <value>Version conflict detected for {0}. Reference the package directly from the project to resolve this issue.</value>
+    <value>Version conflict detected for {0}. Install/reference {1} directly to project {2} to resolve this issue.</value>
   </data>
   <data name="Error_UnknownBuildAction" xml:space="preserve">
     <value>Package '{0}' specifies an invalid build action '{1}' for file '{2}'.</value>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -205,8 +205,8 @@
   <data name="Log_CycleDetected" xml:space="preserve">
     <value>Cycle detected.</value>
   </data>
-  <data name="Log_DowngradeWarning" xml:space="preserve">
-    <value>Detected package downgrade: {0} from {1} to {2}. Reference the package directly from the project to select a different version.</value>
+  <data name="Log_DowngradeWarningTitle" xml:space="preserve">
+    <value>Detected package downgrade: {0} from {1} to {2}. </value>
     <comment>{0}: package id
 {1}: requested version
 {2}: resolved version</comment>
@@ -702,5 +702,8 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="LocalsCommand_ClearingNuGetPluginsCache" xml:space="preserve">
     <value>Clearing NuGet plugins cache: {0}</value>
     <comment>{0}: Plugins cache path</comment>
+  </data>
+  <data name="Log_DowngradeWarningSolution" xml:space="preserve">
+    <value>Reference the package directly from the project to select a different version.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Utility/Extensions.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/Extensions.cs
@@ -53,29 +53,15 @@ namespace NuGet.Commands
                 await logger.LogAsync(message);
             }
         }
-
-        /// <summary>
-        /// Converts an IAssetsLogMessage into a RestoreLogMessage.
-        /// This is needed when an IAssetsLogMessage needs to be logged and loggers do not have visibility to IAssetsLogMessage.
-        /// </summary>
-        /// <param name="logMessage">IAssetsLogMessage to be converted.</param>
-        /// <returns>RestoreLogMessage equivalent to the IAssetsLogMessage.</returns>
-        public static RestoreLogMessage AsRestoreLogMessage(this IAssetsLogMessage logMessage)
+        public static IAssetsLogMessage AsAssetLogMessage(this IRestoreLogMessage logMessage)
         {
-            return new RestoreLogMessage(logMessage.Level, logMessage.Code, logMessage.Message)
+            if (logMessage is PackageDowngradeWarningLogMessage)
             {
-                ProjectPath = logMessage.ProjectPath,
-                WarningLevel = logMessage.WarningLevel,
-                FilePath = logMessage.FilePath,
-                LibraryId = logMessage.LibraryId,
-                TargetGraphs = logMessage.TargetGraphs,
-                StartLineNumber = logMessage.StartLineNumber,
-                StartColumnNumber = logMessage.StartColumnNumber,
-                EndLineNumber = logMessage.EndLineNumber,
-                EndColumnNumber = logMessage.EndColumnNumber
-            };
-        }
+                return new PackageDowngradeAssetsLogMessage(logMessage as PackageDowngradeWarningLogMessage);
+            }
 
+            return AssetsLogMessage.Create(logMessage);
+        }
         /// <summary>
         /// Converts an LogMessage into a RestoreLogMessage.
         /// This is needed when an LogMessage needs to be logged and loggers do not have visibility to LogMessage.

--- a/src/NuGet.Core/NuGet.Common/Errors/PackageDowngradeWarningLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/PackageDowngradeWarningLogMessage.cs
@@ -11,10 +11,13 @@ namespace NuGet.Common
 
         public string DowngradeFromDirectPackageRef { get; }
 
+        public string LibaryIdHigherVersion { get; }
+
         public string MessageWithSolution { get; }
 
         public PackageDowngradeWarningLogMessage(
             string libraryId,
+            string libraryIdHigherVersion,
             string downgradeFrom,
             string downgradeTo,
             string message,
@@ -23,6 +26,7 @@ namespace NuGet.Common
             base(LogLevel.Warning, NuGetLogCode.NU1605, message)
         {
             LibraryId = libraryId;
+            LibaryIdHigherVersion = libraryIdHigherVersion;
             TargetGraphs = targetGraphs;
             DowngradeToDirectPackageRef = downgradeTo;
             DowngradeFromDirectPackageRef = downgradeFrom;

--- a/src/NuGet.Core/NuGet.Common/Errors/PackageDowngradeWarningLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/PackageDowngradeWarningLogMessage.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGet.Common
+{
+    public class PackageDowngradeWarningLogMessage : RestoreLogMessage
+    {
+        public string DowngradeToDirectPackageRef { get; }
+
+        public string DowngradeFromDirectPackageRef { get; }
+
+        public string MessageWithSolution { get; }
+
+        public PackageDowngradeWarningLogMessage(
+            string libraryId,
+            string downgradeFrom,
+            string downgradeTo,
+            string message,
+            string messageWithSolution,
+            IReadOnlyList<string> targetGraphs) :
+            base(LogLevel.Warning, NuGetLogCode.NU1605, message)
+        {
+            LibraryId = libraryId;
+            TargetGraphs = targetGraphs;
+            DowngradeToDirectPackageRef = downgradeTo;
+            DowngradeFromDirectPackageRef = downgradeFrom;
+            MessageWithSolution = messageWithSolution;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -313,6 +313,21 @@ namespace NuGet.DependencyResolver
             return node.Key.TypeConstraintAllowsAnyOf(LibraryDependencyTarget.Package);
         }
 
+        /// <summary>
+        /// Return root direct dependency node which is the node or the ancestor of the node.
+        /// </summary>
+        public static GraphNode<TItem> GetDirectDependencyNode<TItem>(this GraphNode<TItem> node)
+        {
+            var current = node;
+
+            while (current.OuterNode != null && current.OuterNode.OuterNode != null)
+            {
+                current = current.OuterNode;
+            }
+
+            return current;
+        }
+
         private static bool TryResolveConflicts<TItem>(this GraphNode<TItem> root, List<VersionConflictResult<TItem>> versionConflicts)
         {
             // now we walk the tree as often as it takes to determine 

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -349,7 +349,7 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package {0} requires higher version of {1}, please uninstall package {2} or upgrade package {2} to higher version..
+        ///   Looks up a localized string similar to The package &apos;{0}&apos; requires version &apos;{1}&apos; of &apos;{2}&apos;, please uninstall package &apos;{3}&apos; or upgrade package &apos;{3}&apos; to version &apos;{1}&apos;..
         /// </summary>
         internal static string DowngradeWarning_InstallHigherVersion {
             get {
@@ -358,7 +358,7 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The higher version of package {0} is already installed through transitive dependency of package {1}, no need to install package {0}..
+        ///   Looks up a localized string similar to The version &apos;{0}&apos; of package &apos;{1}&apos; is already installed through transitive dependency of package &apos;{2}&apos;, no need to install package &apos;{1}&apos;..
         /// </summary>
         internal static string DowngradeWarning_InstallLowerVersion {
             get {
@@ -367,7 +367,7 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package {0} cause Package {1} downgrade, Reference the higher version of package {2} directly from the project to fix it..
+        ///   Looks up a localized string similar to Package &apos;{0}&apos; causes Package &apos;{1}&apos; downgrade, Install/Reference the  version &apos;{2}&apos; of package &apos;{3}&apos; to the project &apos;{4}&apos; to fix it..
         /// </summary>
         internal static string DowngradeWarning_InstallTwoConflictPackage {
             get {
@@ -376,7 +376,7 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package {0} contains package version conflict which cause downgrade, please contact package author to fix it..
+        ///   Looks up a localized string similar to Dependency graph of Package &apos;{0}&apos; contains package &apos;{1}&apos; version conflict which causes downgrade, please contact package author to fix it..
         /// </summary>
         internal static string DowngradeWarning_InvalidPackage {
             get {

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -349,6 +349,42 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package {0} requires higher version of {1}, please uninstall package {2} or upgrade package {2} to higher version..
+        /// </summary>
+        internal static string DowngradeWarning_InstallHigherVersion {
+            get {
+                return ResourceManager.GetString("DowngradeWarning_InstallHigherVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The higher version of package {0} is already installed through transitive dependency of package {1}, no need to install package {0}..
+        /// </summary>
+        internal static string DowngradeWarning_InstallLowerVersion {
+            get {
+                return ResourceManager.GetString("DowngradeWarning_InstallLowerVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package {0} cause Package {1} downgrade, Reference the higher version of package {2} directly from the project to fix it..
+        /// </summary>
+        internal static string DowngradeWarning_InstallTwoConflictPackage {
+            get {
+                return ResourceManager.GetString("DowngradeWarning_InstallTwoConflictPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package {0} contains package version conflict which cause downgrade, please contact package author to fix it..
+        /// </summary>
+        internal static string DowngradeWarning_InvalidPackage {
+            get {
+                return ResourceManager.GetString("DowngradeWarning_InvalidPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot download packages from &apos;{0}&apos;..
         /// </summary>
         internal static string DownloadResourceNotFound {

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -367,7 +367,7 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package &apos;{0}&apos; causes Package &apos;{1}&apos; downgrade, Install/Reference the  version &apos;{2}&apos; of package &apos;{3}&apos; to the project &apos;{4}&apos; to fix it..
+        ///   Looks up a localized string similar to Package &apos;{0}&apos; causes dependency package of the package &apos;{1}&apos; downgrade, Install/Reference the  version &apos;{2}&apos; of package &apos;{3}&apos; to the project &apos;{4}&apos; to fix it..
         /// </summary>
         internal static string DowngradeWarning_InstallTwoConflictPackage {
             get {

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -491,4 +491,16 @@
     <value>Signed package validation failed with multiple errors:{0}</value>
     <comment>0 - new line separated list of errors</comment>
   </data>
+  <data name="DowngradeWarning_InstallHigherVersion" xml:space="preserve">
+    <value>The package {0} requires higher version of {1}, please uninstall package {2} or upgrade package {2} to higher version.</value>
+  </data>
+  <data name="DowngradeWarning_InstallLowerVersion" xml:space="preserve">
+    <value>The higher version of package {0} is already installed through transitive dependency of package {1}, no need to install package {0}.</value>
+  </data>
+  <data name="DowngradeWarning_InstallTwoConflictPackage" xml:space="preserve">
+    <value>Package {0} cause Package {1} downgrade, Reference the higher version of package {2} directly from the project to fix it.</value>
+  </data>
+  <data name="DowngradeWarning_InvalidPackage" xml:space="preserve">
+    <value>Package {0} contains package version conflict which cause downgrade, please contact package author to fix it.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -492,15 +492,29 @@
     <comment>0 - new line separated list of errors</comment>
   </data>
   <data name="DowngradeWarning_InstallHigherVersion" xml:space="preserve">
-    <value>The package {0} requires higher version of {1}, please uninstall package {2} or upgrade package {2} to higher version.</value>
+    <value>The package '{0}' requires version '{1}' of '{2}', please uninstall package '{3}' or upgrade package '{3}' to version '{1}'.</value>
+    <comment>{0} - package id 
+{1} - package version 
+{2} - package id 
+{3} - package id</comment>
   </data>
   <data name="DowngradeWarning_InstallLowerVersion" xml:space="preserve">
-    <value>The higher version of package {0} is already installed through transitive dependency of package {1}, no need to install package {0}.</value>
+    <value>The version '{0}' of package '{1}' is already installed through transitive dependency of package '{2}', no need to install package '{1}'.</value>
+    <comment>{0} - package version
+{1} - package id 
+{2} - package id </comment>
   </data>
   <data name="DowngradeWarning_InstallTwoConflictPackage" xml:space="preserve">
-    <value>Package {0} cause Package {1} downgrade, Reference the higher version of package {2} directly from the project to fix it.</value>
+    <value>Package '{0}' causes Package '{1}' downgrade, Install/Reference the  version '{2}' of package '{3}' to the project '{4}' to fix it.</value>
+    <comment>{0} - package id 
+{1} - package id 
+{2} - package version 
+{3} - package id
+{4} - project name</comment>
   </data>
   <data name="DowngradeWarning_InvalidPackage" xml:space="preserve">
-    <value>Package {0} contains package version conflict which cause downgrade, please contact package author to fix it.</value>
+    <value>Dependency graph of Package '{0}' contains package '{1}' version conflict which causes downgrade, please contact package author to fix it.</value>
+    <comment>{0} - package id
+{1} - package id</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -505,7 +505,7 @@
 {2} - package id </comment>
   </data>
   <data name="DowngradeWarning_InstallTwoConflictPackage" xml:space="preserve">
-    <value>Package '{0}' causes Package '{1}' downgrade, Install/Reference the  version '{2}' of package '{3}' to the project '{4}' to fix it.</value>
+    <value>Package '{0}' causes dependency package of the package '{1}' downgrade, Install/Reference the  version '{2}' of package '{3}' to the project '{4}' to fix it.</value>
     <comment>{0} - package id 
 {1} - package id 
 {2} - package version 

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/AssetsLogMessage.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/AssetsLogMessage.cs
@@ -107,5 +107,21 @@ namespace NuGet.ProjectModel
 
             return combiner.CombinedHash;
         }
+
+        public virtual RestoreLogMessage AsRestoreLogMessage()
+        {
+            return new RestoreLogMessage(Level, Code, Message)
+            {
+                ProjectPath = ProjectPath,
+                WarningLevel = WarningLevel,
+                FilePath = FilePath,
+                LibraryId = LibraryId,
+                TargetGraphs = TargetGraphs,
+                StartLineNumber = StartLineNumber,
+                StartColumnNumber = StartColumnNumber,
+                EndLineNumber = EndLineNumber,
+                EndColumnNumber = EndColumnNumber
+            };
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/IAssetsLogMessage.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/IAssetsLogMessage.cs
@@ -68,5 +68,7 @@ namespace NuGet.ProjectModel
         /// List of TargetGraphs
         /// </summary>
         IReadOnlyList<string> TargetGraphs { get; }
+
+        RestoreLogMessage AsRestoreLogMessage();
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/PackageDowngradeAssetsLogMessage.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/PackageDowngradeAssetsLogMessage.cs
@@ -13,6 +13,8 @@ namespace NuGet.ProjectModel
 
         public string MessageWithSolution { get; }
 
+        public string LibaryIdHigherVersion { get; }
+
         public PackageDowngradeAssetsLogMessage(PackageDowngradeWarningLogMessage logMessage)
             : base(logMessage.Level, logMessage.Code, logMessage.Message)
         {
@@ -28,11 +30,12 @@ namespace NuGet.ProjectModel
             DowngradeFromDirectPackageRef = logMessage.DowngradeFromDirectPackageRef;
             DowngradeToDirectPackageRef = logMessage.DowngradeToDirectPackageRef;
             MessageWithSolution = logMessage.MessageWithSolution;
+            LibaryIdHigherVersion = logMessage.LibaryIdHigherVersion;
         }
 
         public override RestoreLogMessage AsRestoreLogMessage()
         {
-            return new PackageDowngradeWarningLogMessage(LibraryId, DowngradeFromDirectPackageRef, DowngradeToDirectPackageRef, Message, MessageWithSolution, TargetGraphs)
+            return new PackageDowngradeWarningLogMessage(LibraryId, LibaryIdHigherVersion, DowngradeFromDirectPackageRef, DowngradeToDirectPackageRef, Message, MessageWithSolution, TargetGraphs)
             {
                 ProjectPath = ProjectPath,
                 WarningLevel = WarningLevel,

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/PackageDowngradeAssetsLogMessage.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/PackageDowngradeAssetsLogMessage.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Common;
+
+namespace NuGet.ProjectModel
+{
+    public class PackageDowngradeAssetsLogMessage : AssetsLogMessage
+    {
+        public string DowngradeToDirectPackageRef { get; }
+
+        public string DowngradeFromDirectPackageRef { get; }
+
+        public string MessageWithSolution { get; }
+
+        public PackageDowngradeAssetsLogMessage(PackageDowngradeWarningLogMessage logMessage)
+            : base(logMessage.Level, logMessage.Code, logMessage.Message)
+        {
+            ProjectPath = logMessage.ProjectPath;
+            WarningLevel = logMessage.WarningLevel;
+            FilePath = logMessage.FilePath;
+            LibraryId = logMessage.LibraryId;
+            TargetGraphs = logMessage.TargetGraphs;
+            StartLineNumber = logMessage.StartLineNumber;
+            StartColumnNumber = logMessage.StartColumnNumber;
+            EndLineNumber = logMessage.EndLineNumber;
+            EndColumnNumber = logMessage.EndColumnNumber;
+            DowngradeFromDirectPackageRef = logMessage.DowngradeFromDirectPackageRef;
+            DowngradeToDirectPackageRef = logMessage.DowngradeToDirectPackageRef;
+            MessageWithSolution = logMessage.MessageWithSolution;
+        }
+
+        public override RestoreLogMessage AsRestoreLogMessage()
+        {
+            return new PackageDowngradeWarningLogMessage(LibraryId, DowngradeFromDirectPackageRef, DowngradeToDirectPackageRef, Message, MessageWithSolution, TargetGraphs)
+            {
+                ProjectPath = ProjectPath,
+                WarningLevel = WarningLevel,
+                FilePath = FilePath,
+                StartLineNumber = StartLineNumber,
+                StartColumnNumber = StartColumnNumber,
+                EndLineNumber = EndLineNumber,
+                EndColumnNumber = EndColumnNumber
+            };
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/GraphOperationsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/GraphOperationsTests.cs
@@ -176,7 +176,42 @@ namespace NuGet.DependencyResolver.Core.Tests
             var parent = GetProjectNode("a");
             node.OuterNode = parent;
 
-            node.GetPathWithLastRange().Should().Be("a -> b");
+            node.GetPathWithLastRange().ToLowerInvariant().Should().Be("a -> b");
+        }
+
+        // For single node, return itself.
+        [Fact]
+        public void GetDirectDependencyNode_NodeIsRoot()
+        {
+            var node = GetProjectNode("project");
+
+            node.GetDirectDependencyNode().Key.Name.ToLowerInvariant().Should().Be("project");
+        }
+
+        // For direct dependency: project -> package
+        [Fact]
+        public void GetDirectDependencyNode_NodeIsDirectDependency()
+        {
+            var parent = GetProjectNode("project");
+            var package = GetPackageNode("package", "1.0.0", "1.0.0");
+            package.OuterNode = parent;
+
+            package.GetDirectDependencyNode().Key.Name.ToLowerInvariant().Should().Be("package");
+        }
+
+        // For transitive dependency package : projce -> a -> b -> c
+        [Fact]
+        public void GetDirectDependencyNode_NodeIsTransitiveDependency()
+        {
+            var parent = GetProjectNode("project");
+            var packageA = GetPackageNode("a", "1.0.0", "1.0.0");
+            var packageB = GetPackageNode("b", "1.0.0", "1.0.0");
+            var packageC = GetPackageNode("c", "1.0.0", "1.0.0");
+            packageA.OuterNode = parent;
+            packageB.OuterNode = packageA;
+            packageC.OuterNode = packageB;
+
+            packageC.GetDirectDependencyNode().Key.Name.ToLowerInvariant().Should().Be("a");
         }
 
         public GraphNode<RemoteResolveResult> GetNode(string id, string range, LibraryDependencyTarget target, string version, LibraryType type)


### PR DESCRIPTION
provide better solution message to user based on user's action

Current error message for NU1605 and NU1107:
NU1605:
Detected package downgrade: 'PackageB' from 4.0.0 to 3.5.0. Reference the package directly from the project to select a different version.
  Project -> 'PackageA' 3.5.0 -> 'PackageB' 3.5.0
  Project -> 'PackageC' 4.0.0 -> 'PackageD' 4.0.0 -> 'PackageB' 4.0.0

NU1107: 

Version conflict detected for 'PackageA'. Reference the package directly from the project to resolve this issue.
  'PackageB' 3.5.0 -> 'PackageA' (= 3.5.0)
  'PackageC' 4.0.0 -> 'PackageA' (= 4.0.0)

With this change:

NU1605: 
Restore is the same.
Install/Update : 

Case 1: the project has a bad package which causes downgrade.

Detected package downgrade: 'PackageB' from 4.0.0 to 3.5.0. Dependency graph of Package 'PackageA' contains package 'PackageB' version conflict which causes downgrade, please contact package author to fix it.

 Project -> 'PackageA' 3.5.0 -> 'PackageB' 3.5.0
 Project -> 'PackageA' 3.5.0 -> 'PackageD' 4.0.0 -> 'PackageB' 4.0.0


Case 2: user try to install one packageA which require higher version of packageB, and lower version of package B is already installed from project.
Detected package downgrade: 'PackageB' from 4.0.0 to 3.5.0. The package 'PackageA' requires version '4.0.0' of 'PackageB', please uninstall package 'PackageB' or upgrade package 'PackageB' to version '4.0.0'.

Project -> 'PackageB' 3.5.0 
Project -> 'PackageA' 4.0.0 -> 'PackageD' 4.0.0 -> 'PackageB' 4.0.0

Case 3: user try to install a lower version of packageB, but one installed packageA require higher version.

Detected package downgrade: 'PackageB' from 4.0.0 to 3.5.0. The version '4.0.0' of package 'PackageB' is already installed through transitive dependency of package 'PackageA', no need to install package 'PackageB'.
Project -> 'PackageB' 3.5.0 
Project -> 'PackageA' 4.0.0 -> 'PackageD' 4.0.0 -> 'PackageB' 4.0.0

Case 4: user do update all, all pacakges are updating, two package conflict with each other.
Detected package downgrade: 'PackageB' from 4.0.0 to 3.5.0. Package 'B' causes dependency package of the Package 'A' downgrade, Install/Reference the  version '4.0.0' of package 'B' to the project 'project' to fix it.
Project -> 'PackageB' 3.5.0 
Project -> 'PackageA' 4.0.0 -> 'PackageD' 4.0.0 -> 'PackageB' 4.0.0

 
NU1107:
Version conflict detected for 'PackageA'. Install/reference 'PackageA 4.0.0' directly to project 'Project' to resolve this issue. 
Project -> 'PackageB' 3.5.0 -> 'PackageA' (= 3.5.0)
Project -> 'PackageC' 4.0.0 -> 'PackageA' (= 4.0.0)


