### PR TITLE
Restore Fix: allow project reference to override package dependency

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -377,8 +377,10 @@ namespace NuGet.DependencyResolver
                     var acceptedType = LibraryDependencyTargetUtils.Parse(acceptedNode.Item.Key.Type);
                     var childType = childNode.Key.TypeConstraint;
 
+                    // Skip the check if a project reference override a package dependency
                     // Check the type constraints, if there is any overlap check for conflict
-                    if ((childType & acceptedType) != LibraryDependencyTarget.None)
+                    if ((acceptedType & (LibraryDependencyTarget.Project | LibraryDependencyTarget.ExternalProject)) == LibraryDependencyTarget.None
+                        && (childType & acceptedType) != LibraryDependencyTarget.None)
                     {
                         var versionRange = childNode.Key.VersionRange;
                         var checkVersion = acceptedNode.Item.Key.Version;


### PR DESCRIPTION
## Bug
Fixes:https://github.com/NuGet/Home/issues/6536
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
allow project reference override package reference

## Testing/Validation
Tests Added: Yes  
Reason for not adding tests:  
Validation done:  
