### PR TITLE
Repeatable build using Project lock file implementation

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -363,7 +363,11 @@ namespace NuGet.PackageManagement.VisualStudio
                     ProjectWideWarningProperties = WarningProperties.GetWarningProperties(
                         treatWarningsAsErrors: _vsProjectAdapter.TreatWarningsAsErrors, 
                         noWarn: _vsProjectAdapter.NoWarn,
-                        warningsAsErrors: _vsProjectAdapter.WarningsAsErrors)
+                        warningsAsErrors: _vsProjectAdapter.WarningsAsErrors),
+                    RestoreLockProperties = new RestoreLockProperties(
+                        await _vsProjectAdapter.GetRestorePackagesWithLockFileAsync(),
+                        await _vsProjectAdapter.GetNuGetLockFilePathAsync(),
+                        await _vsProjectAdapter.IsRestoreLockedAsync())
                 }
             };
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -363,6 +363,31 @@ namespace NuGet.PackageManagement.VisualStudio
             return NuGetFramework.UnsupportedFramework;
         }
 
+        public async Task<string> GetRestorePackagesWithLockFileAsync()
+        {
+            await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            var value = await BuildProperties.GetPropertyValueAsync(ProjectBuildProperties.RestorePackagesWithLockFile);
+
+            return value;
+        }
+
+        public async Task<string> GetNuGetLockFilePathAsync()
+        {
+            await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            return await BuildProperties.GetPropertyValueAsync(ProjectBuildProperties.NuGetLockFilePath);
+        }
+
+        public async Task<bool> IsRestoreLockedAsync()
+        {
+            await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            var value = await BuildProperties.GetPropertyValueAsync(ProjectBuildProperties.RestoreLockedMode);
+
+            return MSBuildStringUtility.IsTrue(value);
+        }
+
         private async Task<string> GetTargetFrameworkStringAsync()
         {
             await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -329,15 +329,17 @@ namespace NuGet.SolutionRestoreManager
                             var providerCache = new RestoreCommandProvidersCache();
                             Action<SourceCacheContext> cacheModifier = (cache) => { };
 
+                            var isRestoreOriginalAction = true;
                             var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
                                 _solutionManager,
+                                dgSpec,
                                 cacheContext,
                                 providerCache,
                                 cacheModifier,
                                 sources,
                                 _nuGetProjectContext.OperationId,
                                 forceRestore,
-                                dgSpec,
+                                isRestoreOriginalAction,
                                 l,
                                 t);
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -57,7 +57,9 @@ namespace NuGet.SolutionRestoreManager
         private const string TreatWarningsAsErrors = nameof(TreatWarningsAsErrors);
         private const string WarningsAsErrors = nameof(WarningsAsErrors);
         private const string NoWarn = nameof(NoWarn);
-
+        private const string RestorePackagesWithLockFile = nameof(RestorePackagesWithLockFile);
+        private const string NuGetLockFilePath = nameof(NuGetLockFilePath);
+        private const string RestoreLockedMode = nameof(RestoreLockedMode);
 
         private static readonly Version Version20 = new Version(2, 0, 0, 0);
 
@@ -286,7 +288,11 @@ namespace NuGet.SolutionRestoreManager
                         treatWarningsAsErrors: GetSingleOrDefaultPropertyValue(projectRestoreInfo.TargetFrameworks, TreatWarningsAsErrors, e => e),
                         warningsAsErrors: GetSingleOrDefaultNuGetLogCodes(projectRestoreInfo.TargetFrameworks, WarningsAsErrors, e => MSBuildStringUtility.GetNuGetLogCodes(e)),
                         noWarn: GetSingleOrDefaultNuGetLogCodes(projectRestoreInfo.TargetFrameworks, NoWarn, e => MSBuildStringUtility.GetNuGetLogCodes(e))),
-                    CacheFilePath = NoOpRestoreUtilities.GetProjectCacheFilePath(cacheRoot: outputPath, projectPath: projectFullPath)
+                    CacheFilePath = NoOpRestoreUtilities.GetProjectCacheFilePath(cacheRoot: outputPath, projectPath: projectFullPath),
+                    RestoreLockProperties = new RestoreLockProperties(
+                        GetRestorePackagesWithLockFile(projectRestoreInfo.TargetFrameworks),
+                        GetNuGetLockFilePath(projectRestoreInfo.TargetFrameworks),
+                        IsLockFileFreezeOnRestore(projectRestoreInfo.TargetFrameworks))
                 },
                 RuntimeGraph = GetRuntimeGraph(projectRestoreInfo),
                 RestoreSettings = new ProjectRestoreSettings() { HideWarningsAndErrors = true }
@@ -314,6 +320,21 @@ namespace NuGet.SolutionRestoreManager
         private static string GetRestoreProjectPath(IVsTargetFrameworks tfms)
         {
             return GetSingleNonEvaluatedPropertyOrNull(tfms, RestorePackagesPath, e => e);
+        }
+
+        private static string GetRestorePackagesWithLockFile(IVsTargetFrameworks tfms)
+        {
+            return GetSingleNonEvaluatedPropertyOrNull(tfms, RestorePackagesWithLockFile, v => v);
+        }
+
+        private static string GetNuGetLockFilePath(IVsTargetFrameworks tfms)
+        {
+            return GetSingleNonEvaluatedPropertyOrNull(tfms, NuGetLockFilePath, v => v);
+        }
+
+        private static bool IsLockFileFreezeOnRestore(IVsTargetFrameworks tfms)
+        {
+            return GetSingleNonEvaluatedPropertyOrNull(tfms, RestoreLockedMode, MSBuildStringUtility.IsTrue);
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
@@ -128,5 +128,23 @@ namespace NuGet.VisualStudio
         /// Project's target framework
         /// </summary>
         Task<NuGetFramework> GetTargetFrameworkAsync();
+
+        /// <summary>
+        /// RestorePackagesWithLockFile project property.
+        /// </summary>
+        /// <returns></returns>
+        Task<string> GetRestorePackagesWithLockFileAsync();
+
+        /// <summary>
+        /// NuGetLockFilePath project property.
+        /// </summary>
+        /// <returns></returns>
+        Task<string> GetNuGetLockFilePathAsync();
+
+        /// <summary>
+        /// RestoreLockedMode project property.
+        /// </summary>
+        /// <returns></returns>
+        Task<bool> IsRestoreLockedAsync();
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -119,7 +119,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       RestoreRecursive="$(RestoreRecursive)"
       RestoreForce="$(RestoreForce)"
       HideWarningsAndErrors="$(HideWarningsAndErrors)"
-      Interactive="$(NuGetInteractive)"/>
+      Interactive="$(NuGetInteractive)"
+      ReevaluateRestoreGraph="$(ReevaluateRestoreGraph)"/>
   </Target>
 
   <!--
@@ -657,6 +658,9 @@ Copyright (c) .NET Foundation. All rights reserved.
         <TreatWarningsAsErrors>$(TreatWarningsAsErrors)</TreatWarningsAsErrors>
         <WarningsAsErrors>$(WarningsAsErrors)</WarningsAsErrors>
         <NoWarn>$(NoWarn)</NoWarn>
+        <RestorePackagesWithLockFile>$(RestorePackagesWithLockFile)</RestorePackagesWithLockFile>
+        <NuGetLockFilePath>$(NuGetLockFilePath)</NuGetLockFilePath>
+        <RestoreLockedMode>$(RestoreLockedMode)</RestoreLockedMode>
       </_RestoreGraphEntry>
     </ItemGroup>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -74,6 +74,11 @@ namespace NuGet.Build.Tasks
         /// </summary>
         public bool Interactive { get; set; }
 
+        /// <summary>
+        /// Reevaluate resotre graph even with a lock file, skip no op as well.
+        /// </summary>
+        public bool ReevaluateRestoreGraph { get; set; }
+
         public override bool Execute()
         {
             var log = new MSBuildLogger(Log);
@@ -86,6 +91,7 @@ namespace NuGet.Build.Tasks
             log.LogDebug($"(in) RestoreRecursive '{RestoreRecursive}'");
             log.LogDebug($"(in) RestoreForce '{RestoreForce}'");
             log.LogDebug($"(in) HideWarningsAndErrors '{HideWarningsAndErrors}'");
+            log.LogDebug($"(in) Reevaluate '{ReevaluateRestoreGraph}'");
 
             try
             {
@@ -159,7 +165,8 @@ namespace NuGet.Build.Tasks
                     PreLoadedRequestProviders = providers,
                     CachingSourceProvider = sourceProvider,
                     AllowNoOp = !RestoreForce,
-                    HideWarningsAndErrors = HideWarningsAndErrors
+                    HideWarningsAndErrors = HideWarningsAndErrors,
+                    ReevaluateRestoreGraph = ReevaluateRestoreGraph
                 };
 
                 if (restoreContext.DisableParallel)

--- a/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
@@ -1,0 +1,93 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using NuGet.Common;
+using NuGet.LibraryModel;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.Shared;
+
+namespace NuGet.Commands
+{
+    public class PackagesLockFileBuilder
+    {
+        public PackagesLockFile CreateNuGetLockFile(LockFile assetsFile)
+        {
+            var lockFile = new PackagesLockFile();
+
+            var libraryLookup = assetsFile.Libraries.Where(e => e.Type == LibraryType.Package)
+                .ToDictionary(e => new PackageIdentity(e.Name, e.Version));
+
+            foreach (var target in assetsFile.Targets)
+            {
+                var nuGettarget = new PackagesLockFileTarget()
+                {
+                    TargetFramework = target.TargetFramework,
+                    RuntimeIdentifier = target.RuntimeIdentifier
+                };
+
+                var framework = assetsFile.PackageSpec.TargetFrameworks.FirstOrDefault(
+                    f => EqualityUtility.EqualsWithNullCheck(f.FrameworkName, target.TargetFramework));
+
+                var libraries = target.Libraries;
+
+                // check if this is RID-based graph then only add those libraries which differ from original TFM.
+                if (!string.IsNullOrEmpty(target.RuntimeIdentifier))
+                {
+                    var onlyTFM = assetsFile.Targets.First(t => EqualityUtility.EqualsWithNullCheck(t.TargetFramework, target.TargetFramework));
+
+                    libraries = target.Libraries.Where(lib => !onlyTFM.Libraries.Any(tfmLib => tfmLib.Equals(lib))).ToList();
+                }
+
+                foreach (var library in libraries.Where(e => e.Type == LibraryType.Package))
+                {
+                    var identity = new PackageIdentity(library.Name, library.Version);
+
+                    var dependency = new LockFileDependency()
+                    {
+                        Id = library.Name,
+                        ResolvedVersion = library.Version,
+                        Sha512 = libraryLookup[identity].Sha512,
+                        Dependencies = library.Dependencies
+                    };
+
+                    var framework_dep = framework?.Dependencies.FirstOrDefault(
+                        dep => StringComparer.OrdinalIgnoreCase.Equals(dep.Name, library.Name));
+
+                    if (framework_dep != null)
+                    {
+                        dependency.Type = PackageDependencyType.Direct;
+                        dependency.RequestedVersion = framework_dep.LibraryRange.VersionRange;
+                    }
+                    else
+                    {
+                        dependency.Type = PackageDependencyType.Transitive;
+                    }
+
+                    nuGettarget.Dependencies.Add(dependency);
+                }
+
+                foreach (var projectReference in libraries.Where(e => e.Type == LibraryType.Project || e.Type == LibraryType.ExternalProject))
+                {
+                    var dependency = new LockFileDependency()
+                    {
+                        Id = projectReference.Name,
+                        Dependencies = projectReference.Dependencies,
+                        Type = PackageDependencyType.Project
+                    };
+
+                    nuGettarget.Dependencies.Add(dependency);
+                }
+
+                nuGettarget.Dependencies = nuGettarget.Dependencies.OrderBy(d => d.Type).ToList();
+
+                lockFile.Targets.Add(nuGettarget);
+            }
+
+            return lockFile;
+        }
+
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -154,8 +154,7 @@ namespace NuGet.Commands
                 //  Project.json is special cased to put assets file and generated .props and targets in the project folder
                 RestoreOutputPath = project.PackageSpec.RestoreMetadata.ProjectStyle == ProjectStyle.ProjectJson ? rootPath : project.PackageSpec.RestoreMetadata.OutputPath,
                 DependencyGraphSpec = projectDgSpec,
-                MSBuildProjectExtensionsPath = projectPackageSpec.RestoreMetadata.OutputPath,
-                ParentId = restoreArgs.ParentId
+                MSBuildProjectExtensionsPath = projectPackageSpec.RestoreMetadata.OutputPath
             };
             
             var restoreLegacyPackagesDirectory = project.PackageSpec?.RestoreMetadata?.LegacyPackagesDirectory

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/NoOpRestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/NoOpRestoreResult.cs
@@ -18,7 +18,7 @@ namespace NuGet.Commands
         public NoOpRestoreResult(bool success, LockFile lockFile, LockFile previousLockFile, string lockFilePath, CacheFile cacheFile, string cacheFilePath, ProjectStyle projectStyle, TimeSpan elapsedTime) :
             base(success : success, restoreGraphs : null, compatibilityCheckResults : new List<CompatibilityCheckResult>() , 
                 msbuildFiles : null, lockFile : lockFile, previousLockFile : previousLockFile, lockFilePath: lockFilePath,
-                cacheFile: cacheFile, cacheFilePath: cacheFilePath, projectStyle: projectStyle, elapsedTime: elapsedTime)
+                cacheFile: cacheFile, cacheFilePath: cacheFilePath, packagesLockFilePath:null, packagesLockFile:null, projectStyle: projectStyle, elapsedTime: elapsedTime)
         {
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -62,6 +62,10 @@ namespace NuGet.Commands
 
         public Guid ParentId { get; set; }
 
+        public bool IsRestoreOriginalAction { get; set; } = true;
+
+        public bool ReevaluateRestoreGraph { get; set; }
+
         // Cache directory -> ISettings
         private ConcurrentDictionary<string, ISettings> _settingsCache
             = new ConcurrentDictionary<string, ISettings>(StringComparer.Ordinal);
@@ -227,6 +231,9 @@ namespace NuGet.Commands
 
             request.AllowNoOp = !request.CacheContext.NoCache && AllowNoOp;
             request.HideWarningsAndErrors = HideWarningsAndErrors;
+            request.ParentId = ParentId;
+            request.IsRestoreOriginalAction = IsRestoreOriginalAction;
+            request.ReevaluateRestoreGraph = ReevaluateRestoreGraph;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -14,9 +14,12 @@ using NuGet.Common;
 using NuGet.DependencyResolver;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Repositories;
 using NuGet.RuntimeModel;
+using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.Commands
@@ -48,6 +51,8 @@ namespace NuGet.Commands
         private const string ValidateRestoreGraphs = "ValidateRestoreGraphs";
         private const string CreateRestoreResult = "CreateRestoreResult";
         private const string RestoreNoOpInformation = "RestoreNoOpInformation";
+        private const string RestoreLockFileInformation = "RestoreLockFileInformation";
+        private const string ValidatePackagesSha = "ValidatePackagesSha";
 
         // names for intervals in RestoreNoOpInformation
         private const string CacheFileEvaluateDuration = "CacheFileEvaluateDuration";
@@ -58,6 +63,13 @@ namespace NuGet.Commands
         //names for child events for GenerateRestoreGraph
         private const string CreateRestoreTargetGraph = "CreateRestoreTargetGraph";
         private const string RestoreAdditionalCompatCheck = "RestoreAdditionalCompatCheck";
+
+        // names for intervals in RestoreLockFileInformation
+        private const string IsLockFileEnabled = "IsLockFileEnabled";
+        private const string ReadLockFileDuration = "ReadLockFileDuration";
+        private const string ValidateLockFileDuration = "ValidateLockFileDuration";
+        private const string IsLockFileValidForRestore = "IsLockFileValidForRestore";
+        private const string LockFileEvaluationResult = "LockFileEvaluationResult";
 
         public RestoreCommand(RestoreRequest request)
         {
@@ -104,6 +116,7 @@ namespace NuGet.Commands
                 var contextForProject = CreateRemoteWalkContext(_request, _logger);
 
                 CacheFile cacheFile = null;
+
                 using (var noOpTelemetry = TelemetryActivity.CreateTelemetryActivityWithNewOperationIdAndEvent(parentId: _operationId, eventName: RestoreNoOpInformation))
                 {
                     if (NoOpRestoreUtilities.IsNoOpSupported(_request))
@@ -146,6 +159,58 @@ namespace NuGet.Commands
                                     restoreTime.Elapsed);
                             }
                         }
+                    }
+                }
+
+                // evaluate packages.lock.json file
+                var packagesLockFilePath = PackagesLockFileUtilities.GetNuGetLockFilePath(_request.Project);
+                var isLockFileValid = false;
+                PackagesLockFile packagesLockFile = null;
+
+                using (var lockFileTelemetry = TelemetryActivity.CreateTelemetryActivityWithNewOperationIdAndEvent(parentId: _operationId, eventName: RestoreLockFileInformation))
+                {
+                    lockFileTelemetry.TelemetryEvent[IsLockFileEnabled] = PackagesLockFileUtilities.IsNuGetLockFileSupported(_request.Project);
+
+                    var packagesLockFileResult = await EvaluatePackagesLockFileAsync(packagesLockFilePath, contextForProject, lockFileTelemetry);
+
+                    // result of packages.lock.json file evaluation where
+                    // Item1 is the status of evaluating packages lock file if false, then bail restore
+                    // Item2 is also a tuple which has 2 parts -
+                    //      Item1 tells whether lock file is still valid to be consumed for this restore
+                    //      Item2 is the PackagesLockFile instance
+                    var result = packagesLockFileResult.Item1;
+                    isLockFileValid = packagesLockFileResult.Item2.Item1;
+                    packagesLockFile = packagesLockFileResult.Item2.Item2;
+
+                    lockFileTelemetry.TelemetryEvent[IsLockFileValidForRestore] = isLockFileValid;
+                    lockFileTelemetry.TelemetryEvent[LockFileEvaluationResult] = result;
+
+                    if (!result)
+                    {
+                        _success = result;
+
+                        // Replay Warnings and Errors from an existing lock file
+                        await MSBuildRestoreUtility.ReplayWarningsAndErrorsAsync(_request.ExistingLockFile, _logger);
+
+                        if (cacheFile != null)
+                        {
+                            cacheFile.Success = _success;
+                        }
+
+                        return new RestoreResult(
+                            success: _success,
+                            restoreGraphs: new List<RestoreTargetGraph>(),
+                            compatibilityCheckResults: new List<CompatibilityCheckResult>(),
+                            msbuildFiles: new List<MSBuildOutputFile>(),
+                            lockFile: _request.ExistingLockFile,
+                            previousLockFile: _request.ExistingLockFile,
+                            lockFilePath: _request.ExistingLockFile?.Path,
+                            cacheFile: cacheFile,
+                            cacheFilePath: _request.Project.RestoreMetadata.CacheFilePath,
+                            packagesLockFilePath: packagesLockFilePath,
+                            packagesLockFile: packagesLockFile,
+                            projectStyle: _request.ProjectStyle,
+                            elapsedTime: restoreTime.Elapsed);
                     }
                 }
 
@@ -233,6 +298,26 @@ namespace NuGet.Commands
                     // Revert to the original case if needed
                     await FixCaseForLegacyReaders(graphs, assetsFile, token);
 
+                    // if lock file was still valid then validate package's sha512 hash or else write
+                    // the file if enabled.
+                    if (isLockFileValid)
+                    {
+                        using (TelemetryActivity.CreateTelemetryActivityWithNewOperationIdAndEvent(parentId: _operationId, eventName: ValidatePackagesSha))
+                        {
+                            // validate package's SHA512
+                            _success &= ValidatePackagesSha512(packagesLockFile, assetsFile);
+                        }
+
+                        // clear out the existing lock file so that we don't over-write the same file
+                        packagesLockFile = null;
+                    }
+                    else if (PackagesLockFileUtilities.IsNuGetLockFileSupported(_request.Project))
+                    {
+                        // generate packages.lock.json file if enabled
+                        packagesLockFile = new PackagesLockFileBuilder()
+                            .CreateNuGetLockFile(assetsFile);
+                    }
+
                     // Write the logs into the assets file
                     var logs = _logger.Errors
                         .Select(l => AssetsLogMessage.Create(l))
@@ -276,6 +361,8 @@ namespace NuGet.Commands
                     assetsFilePath,
                     cacheFile,
                     cacheFilePath,
+                    packagesLockFilePath,
+                    packagesLockFile,
                     _request.ProjectStyle,
                     restoreTime.Elapsed);
             }
@@ -313,6 +400,104 @@ namespace NuGet.Commands
             return (_request.ExistingLockFile != null && pathComparer.Equals( _request.ExistingLockFile.PackageSpec.FilePath , _request.Project.FilePath));
         }
 
+        private bool ValidatePackagesSha512(PackagesLockFile lockFile, LockFile assetsFile)
+        {
+            var librariesLookUp = lockFile.Targets
+                .SelectMany(t => t.Dependencies.Where(dep => dep.Type != PackageDependencyType.Project))
+                .Distinct(new LockFileDependencyIdVersionComparer())
+                .ToDictionary(dep => new PackageIdentity(dep.Id, dep.ResolvedVersion), val => val.Sha512);
+
+            foreach (var library in assetsFile.Libraries.Where(lib => lib.Type == LibraryType.Package))
+            {
+                var package = new PackageIdentity(library.Name, library.Version);
+
+                if (!librariesLookUp.TryGetValue(package, out var sha512) || sha512 != library.Sha512)
+                {
+                    // raise validation error
+                    var message = string.Format(CultureInfo.CurrentCulture, Strings.Error_PackageValidationFailed, package.ToString());
+                    _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1403, message));
+
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Evaluate packages.lock.json file if available and accordingly return result.
+        /// </summary>
+        /// <param name="packagesLockFilePath"></param>
+        /// <param name="contextForProject"></param>
+        /// <returns>result of packages.lock.json file evaluation where
+        /// Item1 is the status of evaluating packages lock file if false, then bail restore
+        /// Item2 is also a tuple which has 2 parts -
+        ///     Item1 tells whether lock file is still valid to be consumed for this restore
+        ///     Item2 is the PackagesLockFile instance
+        /// </returns>
+        private async Task<Tuple<bool, Tuple<bool, PackagesLockFile>>> EvaluatePackagesLockFileAsync(
+            string packagesLockFilePath,
+            RemoteWalkContext contextForProject,
+            TelemetryActivity lockFileTelemetry)
+        {
+            PackagesLockFile packagesLockFile = null;
+            var isLockFileValid = false;
+            var success = true;
+
+            var restorePackagesWithLockFile = _request.Project.RestoreMetadata?.RestoreLockProperties.RestorePackagesWithLockFile;
+
+            if (!MSBuildStringUtility.IsTrueOrEmpty(restorePackagesWithLockFile) && File.Exists(packagesLockFilePath))
+            {
+                success = false;
+
+                // invalid input since packages.lock.json file exists along with RestorePackagesWithLockFile is set to false.
+                var message = string.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidLockFileInput, packagesLockFilePath);
+                await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1005, message));
+
+                return Tuple.Create(success, Tuple.Create(isLockFileValid, packagesLockFile));
+            }
+
+            // read packages.lock.json file if exists and ReevaluateRestoreGraph flag is not set to true
+            if (!_request.ReevaluateRestoreGraph && File.Exists(packagesLockFilePath))
+            {
+                lockFileTelemetry.StartIntervalMeasure();
+                packagesLockFile = PackagesLockFileFormat.Read(packagesLockFilePath, _logger);
+                lockFileTelemetry.EndIntervalMeasure(ReadLockFileDuration);
+
+                if (_request.DependencyGraphSpec != null && packagesLockFile.Targets.Count > 0)
+                {
+                    // check if lock file is out of sync with project data
+                    lockFileTelemetry.StartIntervalMeasure();
+                    isLockFileValid = PackagesLockFileUtilities.IsLockFileStillValid(_request.DependencyGraphSpec, packagesLockFile);
+                    lockFileTelemetry.EndIntervalMeasure(ValidateLockFileDuration);
+
+                    if (isLockFileValid)
+                    {
+                        // pass lock file details down to generate restore graph
+                        foreach (var target in packagesLockFile.Targets)
+                        {
+                            var libraries = target.Dependencies
+                                .Where(dep => dep.Type != PackageDependencyType.Project)
+                                .Select(dep => new LibraryIdentity(dep.Id, dep.ResolvedVersion, LibraryType.Package))
+                                .ToList();
+
+                            // add lock file libraries into RemoteWalkContext so that it can be used during restore graph generation
+                            contextForProject.LockFileLibraries.Add(new LockFileCacheKey(target.TargetFramework, target.RuntimeIdentifier), libraries);
+                        }
+                    }
+                    else if (_request.IsRestoreOriginalAction && _request.Project.RestoreMetadata.RestoreLockProperties.RestoreLockedMode)
+                    {
+                        success = false;
+
+                        // bail restore since it's the locked mode but required to update the lock file.
+                        await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1004, Strings.Error_RestoreInLockedMode));
+                    }
+                }
+            }
+
+            return Tuple.Create(success, Tuple.Create(isLockFileValid, packagesLockFile));
+        }
+
         private KeyValuePair<CacheFile, bool> EvaluateCacheFile()
         {
             CacheFile cacheFile;
@@ -326,7 +511,11 @@ namespace NuGet.Commands
                 NoOpRestoreUtilities.UpdateRequestBestMatchingToolPathsIfAvailable(_request);
             }
 
-            if (_request.AllowNoOp && File.Exists(_request.Project.RestoreMetadata.CacheFilePath))
+            // if --reevaluate flag is passed then restore noop check will also be skipped.
+            // this will also help us to get rid of -force flag in near future.
+            if (_request.AllowNoOp &&
+                !_request.ReevaluateRestoreGraph &&
+                File.Exists(_request.Project.RestoreMetadata.CacheFilePath))
             {
                 cacheFile = FileUtility.SafeRead(_request.Project.RestoreMetadata.CacheFilePath, (stream, path) => CacheFileFormat.Read(stream, _logger, path));
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
@@ -163,5 +163,9 @@ namespace NuGet.Commands
         public SignedPackageVerifierSettings SignedPackageVerifierSettings { get; set; } = SignedPackageVerifierSettings.GetDefault();
 
         public Guid ParentId { get; set;}
+
+        public bool IsRestoreOriginalAction { get; set; } = true;
+
+        public bool ReevaluateRestoreGraph { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -293,7 +293,8 @@ namespace NuGet.Commands
             }
 
             // Remote the summary messages from the assets file. This will be removed later.
-            var messages = restoreResult.Result.LockFile.LogMessages.Select(e => new RestoreLogMessage(e.Level, e.Code, e.Message));
+            var messages = restoreResult.Result.LockFile?.LogMessages
+                .Select(e => new RestoreLogMessage(e.Level, e.Code, e.Message)) ?? Enumerable.Empty<RestoreLogMessage>();
 
             // Build the summary
             return new RestoreSummary(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -266,6 +266,9 @@ namespace NuGet.Commands
 
                     // Warning properties
                     result.RestoreMetadata.ProjectWideWarningProperties = GetWarningProperties(specItem);
+
+                    // Packages lock file properties
+                    result.RestoreMetadata.RestoreLockProperties = GetRestoreLockProperites(specItem);
                 }
 
                 if (restoreType == ProjectStyle.ProjectJson)
@@ -825,6 +828,14 @@ namespace NuGet.Commands
                 treatWarningsAsErrors: specItem.GetProperty("TreatWarningsAsErrors"),
                 warningsAsErrors: specItem.GetProperty("WarningsAsErrors"),
                 noWarn: specItem.GetProperty("NoWarn"));
+        }
+
+        private static RestoreLockProperties GetRestoreLockProperites(IMSBuildItem specItem)
+        {
+            return new RestoreLockProperties(
+                specItem.GetProperty("RestorePackagesWithLockFile"),
+                specItem.GetProperty("NuGetLockFilePath"),
+                IsPropertyTrue(specItem, "RestoreLockedMode"));
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -179,6 +179,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid restore input where RestorePackagesWithLockFile property is set to false and also exist a packages lock file at {0}..
+        /// </summary>
+        internal static string Error_InvalidLockFileInput {
+            get {
+                return ResourceManager.GetString("Error_InvalidLockFileInput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid project-package combination for {0} {1}. DotnetToolReference project style can only contain references of the DotnetTool type.
         /// </summary>
         internal static string Error_InvalidProjectPackageCombo {
@@ -260,6 +269,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package {0} sha512 validation failed. The package is different than the last restore..
+        /// </summary>
+        internal static string Error_PackageValidationFailed {
+            get {
+                return ResourceManager.GetString("Error_PackageValidationFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to build package. {0}.
         /// </summary>
         internal static string Error_PackFailed {
@@ -292,6 +310,15 @@ namespace NuGet.Commands {
         internal static string Error_ProjectWithIncorrectDependenciesCount {
             get {
                 return ResourceManager.GetString("Error_ProjectWithIncorrectDependenciesCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The packages lock file is inconsistent with the project dependencies so restore can&apos;t be run in locked mode. Please disable RestoreLockedMode MSBuild property or pass explicit --reevaluate flag to run restore to update the lock file..
+        /// </summary>
+        internal static string Error_RestoreInLockedMode {
+            get {
+                return ResourceManager.GetString("Error_RestoreInLockedMode", resourceCulture);
             }
         }
         
@@ -1166,6 +1193,15 @@ namespace NuGet.Commands {
         internal static string Log_WritingLockFile {
             get {
                 return ResourceManager.GetString("Log_WritingLockFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Writing packages lock file at disk. Path: {0}.
+        /// </summary>
+        internal static string Log_WritingPackagesLockFile {
+            get {
+                return ResourceManager.GetString("Log_WritingPackagesLockFile", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -704,4 +704,19 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>The provided SymbolPackageFormat value {0} is invalid. Allowed values : 'snupkg', 'symbols.nupkg'.</value>
     <comment>Do not localize snupkg and symbols.nupkg</comment>
   </data>
+  <data name="Error_RestoreInLockedMode" xml:space="preserve">
+    <value>The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode. Please disable RestoreLockedMode MSBuild property or pass explicit --reevaluate flag to run restore to update the lock file.</value>
+  </data>
+  <data name="Error_PackageValidationFailed" xml:space="preserve">
+    <value>The package {0} sha512 validation failed. The package is different than the last restore.</value>
+    <comment>{0} - package id and version</comment>
+  </data>
+  <data name="Error_InvalidLockFileInput" xml:space="preserve">
+    <value>Invalid restore input where RestorePackagesWithLockFile property is set to false and also exist a packages lock file at {0}.</value>
+    <comment>{0} - packages lock file path</comment>
+  </data>
+  <data name="Log_WritingPackagesLockFile" xml:space="preserve">
+    <value>Writing packages lock file at disk. Path: {0}</value>
+    <comment>{0} - Path to packages lock file</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -60,6 +60,16 @@ namespace NuGet.Common
         NU1003 = 1003,
 
         /// <summary>
+        /// Locked mode, but restore needs to update the lock file.
+        /// </summary>
+        NU1004 = 1004,
+
+        /// <summary>
+        /// Invalid combination of RestorePackagesWithLockFile and packages.lock.json file.
+        /// </summary>
+        NU1005 = 1005,
+
+        /// <summary>
         /// Unable to resolve package, generic message for unknown type constraints.
         /// </summary>
         NU1100 = 1100,
@@ -144,6 +154,11 @@ namespace NuGet.Common
         /// Package contains unsafe zip entry.
         /// </summary>
         NU1402 = 1402,
+
+        /// <summary>
+        /// Package sha512 validation failed.
+        /// </summary>
+        NU1403 = 1403,
 
         /// <summary>
         /// Package Signature is invalid

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/LockFileCacheKey.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/LockFileCacheKey.cs
@@ -1,0 +1,82 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Frameworks;
+using NuGet.Shared;
+
+namespace NuGet.DependencyResolver
+{
+    /// <summary>
+    /// Helper class to hold lock file libraries per TFM/RID combo.
+    /// </summary>
+    public class LockFileCacheKey : IEquatable<LockFileCacheKey>
+    {
+        /// <summary>
+        /// Target framework.
+        /// </summary>
+        public NuGetFramework TargetFramework { get; }
+
+        /// <summary>	
+        /// Null for RIDless graphs.	
+        /// </summary>	
+        public string RuntimeIdentifier { get; }
+
+        public LockFileCacheKey(NuGetFramework framework, string runtimeIdentifier)
+        {
+            TargetFramework = framework;
+            RuntimeIdentifier = runtimeIdentifier;
+        }
+
+        /// <summary>
+        /// Full framework name.
+        /// </summary>
+        public string Name => GetNameString(TargetFramework.DotNetFrameworkName, RuntimeIdentifier);
+
+        public bool Equals(LockFileCacheKey other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return StringComparer.Ordinal.Equals(RuntimeIdentifier, other.RuntimeIdentifier)
+                && NuGetFramework.Comparer.Equals(TargetFramework, other.TargetFramework);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as LockFileCacheKey);
+        }
+
+        public override int GetHashCode()
+        {
+            var combiner = new HashCodeCombiner();
+
+            combiner.AddObject(TargetFramework);
+            combiner.AddObject(RuntimeIdentifier);
+
+            return combiner.CombinedHash;
+        }
+
+        public override string ToString()
+        {
+            return Name;
+        }
+
+        private static string GetNameString(string framework, string runtime)
+        {
+            if (!string.IsNullOrEmpty(runtime))
+            {
+                return $"{framework}/{runtime}";
+            }
+
+            return framework;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -90,6 +90,7 @@ namespace NuGet.DependencyResolver
                     _context.FindLibraryEntryCache,
                     libraryRange,
                     framework,
+                    runtimeName,
                     outerEdge,
                     _context,
                     CancellationToken.None)

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteWalkContext.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteWalkContext.cs
@@ -6,6 +6,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 
@@ -33,6 +35,8 @@ namespace NuGet.DependencyResolver
             RemoteLibraryProviders = new List<IRemoteDependencyProvider>();
 
             FindLibraryEntryCache = new ConcurrentDictionary<LibraryRangeCacheKey, Task<GraphItem<RemoteResolveResult>>>();
+
+            LockFileLibraries = new Dictionary<LockFileCacheKey, IList<LibraryIdentity>>();
         }
 
         public SourceCacheContext CacheContext { get; }
@@ -41,6 +45,11 @@ namespace NuGet.DependencyResolver
         public IList<IDependencyProvider> ProjectLibraryProviders { get; }
         public IList<IRemoteDependencyProvider> LocalLibraryProviders { get; }
         public IList<IRemoteDependencyProvider> RemoteLibraryProviders { get; }
+
+        /// <summary>
+        /// Packages lock file libraries to be used while generating restore graph.
+        /// </summary>
+        public IDictionary<LockFileCacheKey, IList<LibraryIdentity>> LockFileLibraries { get; }
 
         /// <summary>
         /// Library entry cache.

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2892,15 +2892,17 @@ namespace NuGet.PackageManagement
                     // Restore and commit the lock file to disk regardless of the result
                     // This will restore all parents in a single restore 
                     await DependencyGraphRestoreUtility.RestoreAsync(
+                        SolutionManager,
                         dgSpecForParents,
                         referenceContext,
                         GetRestoreProviderCache(),
                         cacheContextModifier,
                         projectAction.Sources,
                         nuGetProjectContext.OperationId,
-                        false, // No need to force restore as the inputs would've changed here anyways
-                        logger,
-                        token);
+                        forceRestore: false, // No need to force restore as the inputs would've changed here anyways
+                        isRestoreOriginalAction: false, // not an explicit restore request instead being done as part of install or update
+                        log: logger,
+                        token: token);
                 }
             }
             else

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
@@ -34,5 +34,8 @@ namespace NuGet.ProjectManagement
         public const string WarningsAsErrors = nameof(WarningsAsErrors);
         public const string TreatWarningsAsErrors = nameof(TreatWarningsAsErrors);
         public const string DotnetCliToolTargetFramework = nameof(DotnetCliToolTargetFramework);
+        public const string RestorePackagesWithLockFile = nameof(RestorePackagesWithLockFile);
+        public const string NuGetLockFilePath = nameof(NuGetLockFilePath);
+        public const string RestoreLockedMode = nameof(RestoreLockedMode);
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -329,6 +329,17 @@ namespace NuGet.ProjectModel
                 msbuildMetadata.ProjectWideWarningProperties = new WarningProperties(warnAsError, noWarn, allWarningsAsErrors);
             }
 
+            // read NuGet lock file msbuild properties
+            var restoreLockProperties = rawMSBuildMetadata.GetValue<JObject>("restoreLockProperties");
+
+            if (restoreLockProperties != null)
+            {
+                msbuildMetadata.RestoreLockProperties = new RestoreLockProperties(
+                    restoreLockProperties.GetValue<string>("restorePackagesWithLockFile"),
+                    restoreLockProperties.GetValue<string>("nuGetLockFilePath"),
+                    GetBoolOrFalse(restoreLockProperties, "restoreLockedMode", packageSpec.FilePath));
+            }
+
             return msbuildMetadata;
         }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -156,6 +156,9 @@ namespace NuGet.ProjectModel
             WriteMetadataTargetFrameworks(writer, msbuildMetadata);
             SetWarningProperties(writer, msbuildMetadata);
 
+            // write NuGet lock file msbuild properties
+            WriteNuGetLockFileProperties(writer, msbuildMetadata);
+
             writer.WriteObjectEnd();
         }
 
@@ -165,6 +168,24 @@ namespace NuGet.ProjectModel
             SetValueIfTrue(writer, "legacyPackagesDirectory", msbuildMetadata.LegacyPackagesDirectory);
             SetValueIfTrue(writer, "validateRuntimeAssets", msbuildMetadata.ValidateRuntimeAssets);
             SetValueIfTrue(writer, "skipContentFileWrite", msbuildMetadata.SkipContentFileWrite);
+        }
+
+
+        private static void WriteNuGetLockFileProperties(IObjectWriter writer, ProjectRestoreMetadata msbuildMetadata)
+        {
+            if (msbuildMetadata.RestoreLockProperties != null &&
+                (!string.IsNullOrEmpty(msbuildMetadata.RestoreLockProperties.RestorePackagesWithLockFile) ||
+                 !string.IsNullOrEmpty(msbuildMetadata.RestoreLockProperties.NuGetLockFilePath) ||
+                 msbuildMetadata.RestoreLockProperties.RestoreLockedMode))
+            {
+                writer.WriteObjectStart("restoreLockProperties");
+
+                SetValue(writer, "restorePackagesWithLockFile", msbuildMetadata.RestoreLockProperties.RestorePackagesWithLockFile);
+                SetValue(writer, "nuGetLockFilePath", msbuildMetadata.RestoreLockProperties.NuGetLockFilePath);
+                SetValueIfTrue(writer, "restoreLockedMode", msbuildMetadata.RestoreLockProperties.RestoreLockedMode);
+
+                writer.WriteObjectEnd();
+            }
         }
 
         private static void WriteMetadataTargetFrameworks(IObjectWriter writer, ProjectRestoreMetadata msbuildMetadata)

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependency.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependency.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NuGet.Common;
+using NuGet.Packaging.Core;
+using NuGet.Shared;
+using NuGet.Versioning;
+
+namespace NuGet.ProjectModel
+{
+    public class LockFileDependency : IEquatable<LockFileDependency>
+    {
+        public string Id { get; set; }
+
+        public NuGetVersion ResolvedVersion { get; set; }
+
+        public VersionRange RequestedVersion { get; set; }
+
+        public string Sha512 { get; set; }
+
+        public PackageDependencyType Type { get; set; }
+
+        public IList<PackageDependency> Dependencies { get; set; } = new List<PackageDependency>();
+
+        public bool Equals(LockFileDependency other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return StringComparer.OrdinalIgnoreCase.Equals(Id, other.Id) &&
+                EqualityUtility.EqualsWithNullCheck(ResolvedVersion, other.ResolvedVersion) &&
+                EqualityUtility.EqualsWithNullCheck(RequestedVersion, other.RequestedVersion) &&
+                EqualityUtility.SequenceEqualWithNullCheck(Dependencies, other.Dependencies) &&
+                Sha512 == other.Sha512 &&
+                Type == other.Type;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as LockFileDependency);
+        }
+
+        public override int GetHashCode()
+        {
+            var combiner = new HashCodeCombiner();
+
+            combiner.AddObject(Id);
+            combiner.AddObject(ResolvedVersion);
+            combiner.AddObject(RequestedVersion);
+            combiner.AddSequence(Dependencies);
+            combiner.AddObject(Sha512);
+            combiner.AddObject(Type);
+
+            return combiner.CombinedHash;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependencyIdVersionComparer.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependencyIdVersionComparer.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NuGet.Common;
+using NuGet.Shared;
+
+namespace NuGet.ProjectModel
+{
+    public class LockFileDependencyIdVersionComparer : IEqualityComparer<LockFileDependency>
+    {
+        public bool Equals(LockFileDependency x, LockFileDependency y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (ReferenceEquals(x, null)
+                || ReferenceEquals(y, null))
+            {
+                return false;
+            }
+
+            return StringComparer.OrdinalIgnoreCase.Equals(x.Id, y.Id) &&
+                EqualityUtility.EqualsWithNullCheck(x.ResolvedVersion, y.ResolvedVersion);
+        }
+
+        public int GetHashCode(LockFileDependency obj)
+        {
+            var combiner = new HashCodeCombiner();
+
+            combiner.AddObject(obj.Id);
+            combiner.AddObject(obj.ResolvedVersion);
+
+            return combiner.CombinedHash;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackageDependencyType.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackageDependencyType.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.ProjectModel
+{
+    public enum PackageDependencyType
+    {
+        /// <summary>
+        /// Package is directly installed into the project.
+        /// </summary>
+        Direct = 0,
+
+        /// <summary>
+        /// Package is transitively available to the project instead of directly installed.
+        /// </summary>
+        Transitive = 1,
+
+        /// <summary>
+        /// 
+        /// </summary>
+        Project = 2
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFile.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFile.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NuGet.Common;
+using NuGet.Shared;
+
+namespace NuGet.ProjectModel
+{
+    public class PackagesLockFile : IEquatable<PackagesLockFile>
+    {
+        public int Version { get; set; } = PackagesLockFileFormat.Version;
+
+        public string Path { get; set; }
+
+        public IList<PackagesLockFileTarget> Targets { get; set; } = new List<PackagesLockFileTarget>();
+
+        public bool Equals(PackagesLockFile other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return Version == other.Version &&
+                EqualityUtility.SequenceEqualWithNullCheck(Targets, other.Targets);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as PackagesLockFile);
+        }
+
+        public override int GetHashCode()
+        {
+            var combiner = new HashCodeCombiner();
+
+            combiner.AddObject(Version);
+            combiner.AddSequence(Targets);
+
+            return combiner.CombinedHash;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileFormat.cs
@@ -1,0 +1,246 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.Versioning;
+
+namespace NuGet.ProjectModel
+{
+    public class PackagesLockFileFormat
+    {
+        public static readonly int Version = 1;
+
+        public static readonly string LockFileName = "packages.lock.json";
+
+        private const string VersionProperty = "version";
+        private const string ResolvedProperty = "resolved";
+        private const string RequestedProperty = "requested";
+        private const string Sha512Property = "sha512";
+        private const string DependenciesProperty = "dependencies";
+        private const string TypeProperty = "type";
+
+        public static PackagesLockFile Parse(string lockFileContent, string path)
+        {
+            return Parse(lockFileContent, NullLogger.Instance, path);
+        }
+
+        public static PackagesLockFile Parse(string lockFileContent, ILogger log, string path)
+        {
+            using (var reader = new StringReader(lockFileContent))
+            {
+                return Read(reader, log, path);
+            }
+        }
+
+        public static PackagesLockFile Read(string filePath)
+        {
+            return Read(filePath, NullLogger.Instance);
+        }
+
+        public static PackagesLockFile Read(string filePath, ILogger log)
+        {
+            using (var stream = File.OpenRead(filePath))
+            {
+                return Read(stream, log, filePath);
+            }
+        }
+
+        public static PackagesLockFile Read(Stream stream, ILogger log, string path)
+        {
+            using (var textReader = new StreamReader(stream))
+            {
+                return Read(textReader, log, path);
+            }
+        }
+
+        public static PackagesLockFile Read(TextReader reader, ILogger log, string path)
+        {
+            try
+            {
+                var json = JsonUtility.LoadJson(reader);
+                var lockFile = ReadLockFile(json);
+                lockFile.Path = path;
+                return lockFile;
+            }
+            catch (Exception ex)
+            {
+                log.LogWarning(string.Format(CultureInfo.CurrentCulture,
+                    Strings.Log_ErrorReadingLockFile,
+                    path, ex.Message));
+
+                // Ran into parsing errors, mark it as unlocked and out-of-date
+                return new PackagesLockFile
+                {
+                    Version = int.MinValue,
+                    Path = path
+                };
+            }
+        }
+
+        private static PackagesLockFile ReadLockFile(JObject cursor)
+        {
+            var lockFile = new PackagesLockFile()
+            {
+                Version = JsonUtility.ReadInt(cursor, VersionProperty, defaultValue: int.MinValue),
+                Targets = JsonUtility.ReadObject(cursor[DependenciesProperty] as JObject, ReadDependency),
+            };
+
+            return lockFile;
+        }
+
+        public static string Render(PackagesLockFile lockFile)
+        {
+            using (var writer = new StringWriter())
+            {
+                Write(writer, lockFile);
+                return writer.ToString();
+            }
+        }
+
+        public static void Write(string filePath, PackagesLockFile lockFile)
+        {
+            // Create the directory if it does not exist
+            var fileInfo = new FileInfo(filePath);
+            fileInfo.Directory.Create();
+
+            using (var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                Write(stream, lockFile);
+            }
+        }
+
+        public static void Write(Stream stream, PackagesLockFile lockFile)
+        {
+            using (var textWriter = new StreamWriter(stream))
+            {
+                Write(textWriter, lockFile);
+            }
+        }
+
+        public static void Write(TextWriter textWriter, PackagesLockFile lockFile)
+        {
+            using (var jsonWriter = new JsonTextWriter(textWriter))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+
+                var json = WriteLockFile(lockFile);
+                json.WriteTo(jsonWriter);
+            }
+        }
+
+        private static JObject WriteLockFile(PackagesLockFile lockFile)
+        {
+            var json = new JObject
+            {
+                [VersionProperty] = new JValue(lockFile.Version),
+                [DependenciesProperty] = JsonUtility.WriteObject(lockFile.Targets, WriteTarget),
+            };
+
+            return json;
+        }
+
+        private static PackagesLockFileTarget ReadDependency(string property, JToken json)
+        {
+            var parts = property.Split(JsonUtility.PathSplitChars, 2);
+
+            var target = new PackagesLockFileTarget
+            {
+                TargetFramework = NuGetFramework.Parse(parts[0]),
+                Dependencies = JsonUtility.ReadObject(json as JObject, ReadTargetDependency)
+            };
+
+            if (parts.Length == 2)
+            {
+                target.RuntimeIdentifier = parts[1];
+            }
+
+            return target;
+        }
+
+        private static LockFileDependency ReadTargetDependency(string property, JToken json)
+        {
+            var dependency = new LockFileDependency
+            {
+                Id = property,
+                Dependencies = JsonUtility.ReadObject(json[DependenciesProperty] as JObject, JsonUtility.ReadPackageDependency)
+            };
+
+            var jObject = json as JObject;
+
+            var typeString = JsonUtility.ReadProperty<string>(jObject, TypeProperty);
+
+            if (!string.IsNullOrEmpty(typeString)
+                && Enum.TryParse<PackageDependencyType>(typeString, ignoreCase: true, result: out var installationType))
+            {
+                dependency.Type = installationType;
+            }
+
+            var resolvedString = JsonUtility.ReadProperty<string>(jObject, ResolvedProperty);
+
+            if (!string.IsNullOrEmpty(resolvedString))
+            {
+                dependency.ResolvedVersion = NuGetVersion.Parse(resolvedString);
+            }
+
+            var requestedString = JsonUtility.ReadProperty<string>(jObject, RequestedProperty);
+
+            if (!string.IsNullOrEmpty(requestedString))
+            {
+                dependency.RequestedVersion = VersionRange.Parse(requestedString);
+            }
+
+            dependency.Sha512 = JsonUtility.ReadProperty<string>(jObject, Sha512Property);
+
+            return dependency;
+        }
+
+        private static JProperty WriteTarget(PackagesLockFileTarget target)
+        {
+            var json = JsonUtility.WriteObject(target.Dependencies, WriteTargetDependency);
+
+            var key = target.Name;
+
+            return new JProperty(key, json);
+        }
+
+        private static JProperty WriteTargetDependency(LockFileDependency dependency)
+        {
+            var json = new JObject
+            {
+                [TypeProperty] = dependency.Type.ToString()
+            };
+
+            if (dependency.RequestedVersion != null)
+            {
+                json[RequestedProperty] = dependency.RequestedVersion.ToNormalizedString();
+            }
+
+            if (dependency.ResolvedVersion != null)
+            {
+                json[ResolvedProperty] = dependency.ResolvedVersion.ToNormalizedString();
+            }
+
+            if (dependency.Sha512 != null)
+            {
+                json[Sha512Property] = dependency.Sha512;
+            }
+
+            if (dependency.Dependencies?.Count > 0)
+            {
+                var ordered = dependency.Dependencies.OrderBy(dep => dep.Id, StringComparer.Ordinal);
+
+                json[DependenciesProperty] = JsonUtility.WriteObject(ordered, JsonUtility.WritePackageDependency);
+            }
+
+            return new JProperty(dependency.Id, json);
+        }
+
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileTarget.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileTarget.cs
@@ -1,0 +1,79 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Frameworks;
+using NuGet.Shared;
+
+namespace NuGet.ProjectModel
+{
+    /// <summary>
+    /// FrameworkName/RuntimeIdentifier combination
+    /// </summary>
+    public class PackagesLockFileTarget : IEquatable<PackagesLockFileTarget>
+    {
+        /// <summary>
+        /// Target framework.
+        /// </summary>
+        public NuGetFramework TargetFramework { get; set; }
+
+        /// <summary>	
+        /// Null for RIDless graphs.	
+        /// </summary>	
+        public string RuntimeIdentifier { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public IList<LockFileDependency> Dependencies { get; set; } = new List<LockFileDependency>();
+
+        /// <summary>
+        /// Full framework name.
+        /// </summary>
+        public string Name => GetNameString(TargetFramework.DotNetFrameworkName, RuntimeIdentifier);
+
+        public bool Equals(PackagesLockFileTarget other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return StringComparer.Ordinal.Equals(RuntimeIdentifier, other.RuntimeIdentifier)
+                && NuGetFramework.Comparer.Equals(TargetFramework, other.TargetFramework)
+                && EqualityUtility.SequenceEqualWithNullCheck(Dependencies, other.Dependencies);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as PackagesLockFileTarget);
+        }
+
+        public override int GetHashCode()
+        {
+            var combiner = new HashCodeCombiner();
+
+            combiner.AddObject(TargetFramework);
+            combiner.AddObject(RuntimeIdentifier);
+            combiner.AddSequence(Dependencies);
+
+            return combiner.CombinedHash;
+        }
+
+        private static string GetNameString(string framework, string runtime)
+        {
+            if (!string.IsNullOrEmpty(runtime))
+            {
+                return $"{framework}/{runtime}";
+            }
+
+            return framework;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -1,0 +1,144 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.Common;
+using NuGet.LibraryModel;
+using NuGet.Shared;
+
+namespace NuGet.ProjectModel
+{
+    public static class PackagesLockFileUtilities
+    {
+        public static bool IsNuGetLockFileSupported(PackageSpec project)
+        {
+            var restorePackagesWithLockFile = project.RestoreMetadata?.RestoreLockProperties.RestorePackagesWithLockFile;
+            return MSBuildStringUtility.IsTrue(restorePackagesWithLockFile) || File.Exists(GetNuGetLockFilePath(project));
+        }
+
+        public static string GetNuGetLockFilePath(PackageSpec project)
+        {
+            if (project.RestoreMetadata == null || project.BaseDirectory == null)
+            {
+                // RestoreMetadata or project BaseDirectory is not set which means it's probably called through test.
+                return null;
+            }
+
+            var path = project.RestoreMetadata.RestoreLockProperties.NuGetLockFilePath;
+
+            if (!string.IsNullOrEmpty(path))
+            {
+                return Path.Combine(project.BaseDirectory, path);
+            }
+
+            var projectName = Path.GetFileNameWithoutExtension(project.RestoreMetadata.ProjectPath);
+            path = Path.Combine(project.BaseDirectory, "packages." + projectName.Replace(' ', '_') + ".lock.json");
+
+            if (!File.Exists(path))
+            {
+                path = Path.Combine(project.BaseDirectory, PackagesLockFileFormat.LockFileName);
+            }
+
+            return path;
+        }
+
+        public static bool IsLockFileStillValid(DependencyGraphSpec dgSpec, PackagesLockFile nuGetLockFile)
+        {
+            var uniqueName = dgSpec.Restore.First();
+            var project = dgSpec.GetProjectSpec(uniqueName);
+
+            // Validate all the direct dependencies
+            foreach (var framework in project.TargetFrameworks)
+            {
+                var target = nuGetLockFile.Targets.FirstOrDefault(
+                    t => EqualityUtility.EqualsWithNullCheck(t.TargetFramework, framework.FrameworkName));
+
+                if (target != null)
+                {
+                    var directDependencies = target.Dependencies.Where(dep => dep.Type == PackageDependencyType.Direct);
+
+                    if (HasProjectDependencyChanged(framework.Dependencies, directDependencies))
+                    {
+                        // lock file is out of sync
+                        return false;
+                    }
+                }
+            }
+
+            // Validate all P2P references
+            foreach (var p2p in dgSpec.Projects)
+            {
+                if (PathUtility.GetStringComparerBasedOnOS().Equals(p2p.RestoreMetadata.ProjectUniqueName, uniqueName))
+                {
+                    continue;
+                }
+
+                var projectName = Path.GetFileNameWithoutExtension(p2p.RestoreMetadata.ProjectPath);
+
+                foreach (var framework in p2p.TargetFrameworks)
+                {
+                    var target = nuGetLockFile.Targets.FirstOrDefault(
+                    t => EqualityUtility.EqualsWithNullCheck(t.TargetFramework, framework.FrameworkName));
+
+                    if (target != null)
+                    {
+                        var projectDependency = target.Dependencies.FirstOrDefault(
+                            dep => dep.Type == PackageDependencyType.Project &&
+                            PathUtility.GetStringComparerBasedOnOS().Equals(dep.Id, projectName));
+
+                        if (HasP2PDependencyChanged(framework.Dependencies, projectDependency))
+                        {
+                            // lock file is out of sync
+                            return false;
+                        }
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private static bool HasProjectDependencyChanged(IEnumerable<LibraryDependency> newDependencies, IEnumerable<LockFileDependency> lockFileDependencies)
+        {
+            foreach (var dependency in newDependencies.Where(dep => dep.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package))
+            {
+                var lockFileDependency = lockFileDependencies.FirstOrDefault(d => StringComparer.OrdinalIgnoreCase.Equals(d.Id, dependency.Name));
+
+                if (lockFileDependency == null || !EqualityUtility.EqualsWithNullCheck(lockFileDependency.RequestedVersion, dependency.LibraryRange.VersionRange))
+                {
+                    // dependency has changed and lock file is out of sync.
+                    return true;
+                }
+            }
+
+            // no dependency changed. Lock file is still valid.
+            return false;
+        }
+
+        private static bool HasP2PDependencyChanged(IEnumerable<LibraryDependency> newDependencies, LockFileDependency projectDependency)
+        {
+            if (projectDependency == null)
+            {
+                // project dependency doesn't exists in lock file so it's out of sync.
+                return true;
+            }
+
+            foreach (var dependency in newDependencies.Where(dep => dep.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package))
+            {
+                var matchedP2PLibrary = projectDependency.Dependencies.FirstOrDefault(dep => StringComparer.OrdinalIgnoreCase.Equals(dep.Id, dependency.Name));
+
+                if (matchedP2PLibrary == null || !EqualityUtility.EqualsWithNullCheck(matchedP2PLibrary.VersionRange, dependency.LibraryRange.VersionRange))
+                {
+                    // P2P dependency has changed and lock file is out of sync.
+                    return true;
+                }
+            }
+
+            // no dependency changed. Lock file is still valid.
+            return false;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -111,6 +111,8 @@ namespace NuGet.ProjectModel
         /// </summary>
         public WarningProperties ProjectWideWarningProperties { get; set; } = new WarningProperties();
 
+        public RestoreLockProperties RestoreLockProperties { get; set; } = new RestoreLockProperties();
+
         public override int GetHashCode()
         {
             var hashCode = new HashCodeCombiner();
@@ -133,6 +135,7 @@ namespace NuGet.ProjectModel
             hashCode.AddObject(ValidateRuntimeAssets);
             hashCode.AddObject(SkipContentFileWrite);
             hashCode.AddObject(ProjectWideWarningProperties);
+            hashCode.AddObject(RestoreLockProperties);
 
             return hashCode.CombinedHash;
         }
@@ -171,7 +174,8 @@ namespace NuGet.ProjectModel
                    ValidateRuntimeAssets == other.ValidateRuntimeAssets &&
                    SkipContentFileWrite == other.SkipContentFileWrite &&
                    EqualityUtility.SequenceEqualWithNullCheck(Files, other.Files) &&
-                   EqualityUtility.EqualsWithNullCheck(ProjectWideWarningProperties, other.ProjectWideWarningProperties);
+                   EqualityUtility.EqualsWithNullCheck(ProjectWideWarningProperties, other.ProjectWideWarningProperties) &&
+                   EqualityUtility.EqualsWithNullCheck(RestoreLockProperties, other.RestoreLockProperties);
         }
 
         public ProjectRestoreMetadata Clone()
@@ -196,7 +200,8 @@ namespace NuGet.ProjectModel
                 Sources = Sources?.Select(c => c.Clone()).ToList(),
                 TargetFrameworks = TargetFrameworks?.Select(c => c.Clone()).ToList(),
                 Files = Files?.Select(c => c.Clone()).ToList(),
-                ProjectWideWarningProperties = ProjectWideWarningProperties?.Clone()
+                ProjectWideWarningProperties = ProjectWideWarningProperties?.Clone(),
+                RestoreLockProperties = RestoreLockProperties?.Clone()
             };
         }
     }

--- a/src/NuGet.Core/NuGet.ProjectModel/RestoreLockProperties.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/RestoreLockProperties.cs
@@ -1,0 +1,79 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Common;
+using NuGet.Shared;
+
+namespace NuGet.ProjectModel
+{
+    public class RestoreLockProperties : IEquatable<RestoreLockProperties>
+    {
+        /// <summary>
+        /// Set when customer wants to opt into packages lock file
+        /// </summary>
+        public string RestorePackagesWithLockFile { get; }
+
+        /// <summary>
+        /// Packages.lock.json file path including file name if customer wants to override defualt file name.
+        /// </summary>
+        public string NuGetLockFilePath { get; }
+
+        /// <summary>
+        /// True, if updating lock file on restore is denied.
+        /// </summary>
+        public bool RestoreLockedMode { get; }
+
+        public RestoreLockProperties()
+        {
+        }
+
+        public RestoreLockProperties(
+            string restorePackagesWithLockFile,
+            string nuGetLockFilePath,
+            bool restoreLockedMode)
+        {
+            RestorePackagesWithLockFile = restorePackagesWithLockFile;
+            NuGetLockFilePath = nuGetLockFilePath;
+            RestoreLockedMode = restoreLockedMode;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = new HashCodeCombiner();
+
+            hashCode.AddObject(RestorePackagesWithLockFile);
+            hashCode.AddObject(NuGetLockFilePath);
+            hashCode.AddObject(RestoreLockedMode);
+
+            return hashCode.CombinedHash;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as RestoreLockProperties);
+        }
+
+        public bool Equals(RestoreLockProperties other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return StringComparer.OrdinalIgnoreCase.Equals(RestorePackagesWithLockFile, other.RestorePackagesWithLockFile) &&
+                PathUtility.GetStringComparerBasedOnOS().Equals(NuGetLockFilePath, other.NuGetLockFilePath) &&
+                RestoreLockedMode == other.RestoreLockedMode;
+        }
+
+        public RestoreLockProperties Clone()
+        {
+            return new RestoreLockProperties(RestorePackagesWithLockFile, NuGetLockFilePath, RestoreLockedMode);
+        }
+    }
+}

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
@@ -1,0 +1,216 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.Packaging.Signing;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using Test.Utility.Signing;
+using Xunit;
+
+namespace NuGet.CommandLine.FuncTest.Commands
+{
+    /// <summary>
+    /// Tests restore command
+    /// These tests require admin privilege as the certs need to be added to the root store location
+    /// </summary>
+    [Collection(SignCommandTestCollection.Name)]
+    public class RestoreCommandSignPackagesTests
+    {
+        private static readonly string _NU3008Message = "The package integrity check failed.";
+        private static readonly string _NU3008 = "NU3008: {0}";
+        private static readonly string _NU3027Message = "The signature should be timestamped to enable long-term signature validity after the certificate has expired.";
+        private static readonly string _NU3027 = "NU3027: {0}";
+
+        private SignCommandTestFixture _testFixture;
+        private TrustedTestCert<TestCertificate> _trustedTestCert;
+        private readonly string _nugetExePath;
+
+        public RestoreCommandSignPackagesTests(SignCommandTestFixture fixture)
+        {
+            _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+            _trustedTestCert = SigningTestUtility.GenerateTrustedTestCertificate();
+            _nugetExePath = _testFixture.NuGetExePath;
+        }
+
+        [CIOnlyFact]
+        public async Task Restore_TamperedPackageInPackagesConfig_FailsWithErrorAsync()
+        {
+            // Arrange
+            var packagesConfigContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                "<packages>" +
+                "  <package id=\"X\" version=\"9.0.0\" targetFramework=\"net461\" />" +
+                "</packages>";
+
+            using (var pathContext = new SimpleTestPathContext())
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = new SimpleTestProjectContext(
+                    "a",
+                    ProjectStyle.PackagesConfig,
+                    pathContext.SolutionRoot);
+
+                var packageX = new SimpleTestPackageContext("X", "9.0.0");
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, packageX, pathContext.PackageSource);
+                SignedArchiveTestUtility.TamperWithPackage(signedPackagePath);
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                var packagesConfigPath = Path.Combine(Directory.GetParent(projectA.ProjectPath).FullName, "packages.config");
+
+                File.WriteAllBytes(packagesConfigPath, Encoding.ASCII.GetBytes(packagesConfigContent));
+
+                var args = new string[]
+                {
+                    projectA.ProjectPath,
+                    "-Source",
+                    pathContext.PackageSource,
+                    "-PackagesDirectory",
+                    "./packages"
+                };
+
+                // Act
+                var result = RunRestore(_nugetExePath, pathContext, expectedExitCode: 1, additionalArgs: args);
+
+                // Assert
+                result.ExitCode.Should().Be(1);
+                result.Errors.Should().Contain(string.Format(_NU3008, SigningTestUtility.AddSignatureLogPrefix(_NU3008Message, packageX.Identity, pathContext.PackageSource)));
+                result.AllOutput.Should().Contain(string.Format(_NU3027, SigningTestUtility.AddSignatureLogPrefix(_NU3027Message, packageX.Identity, pathContext.PackageSource)));
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task Restore_TamperedPackage_FailsAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("NETStandard2.0"));
+
+                var packageX = new SimpleTestPackageContext("X", "9.0.0");
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, packageX, pathContext.PackageSource);
+                SignedArchiveTestUtility.TamperWithPackage(signedPackagePath);
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                var args = new string[]
+                {
+                    projectA.ProjectPath,
+                    "-Source",
+                    pathContext.PackageSource
+                };
+
+                // Act
+                var result = RunRestore(_nugetExePath, pathContext, expectedExitCode: 1, additionalArgs: args);
+                var reader = new LockFileFormat();
+                var lockFile = reader.Read(projectA.AssetsFileOutputPath);
+                var errors = lockFile.LogMessages.Where(m => m.Level == LogLevel.Error);
+                var warnings = lockFile.LogMessages.Where(m => m.Level == LogLevel.Warning);
+
+                // Assert
+                result.ExitCode.Should().Be(1);
+                result.Errors.Should().Contain(string.Format(_NU3008, SigningTestUtility.AddSignatureLogPrefix(_NU3008Message, packageX.Identity, pathContext.PackageSource)));
+                result.AllOutput.Should().Contain($"WARNING: {string.Format(_NU3027, SigningTestUtility.AddSignatureLogPrefix(_NU3027Message, packageX.Identity, pathContext.PackageSource))}");
+
+                errors.Count().Should().Be(1);
+                errors.First().Code.Should().Be(NuGetLogCode.NU3008);
+                errors.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(_NU3008Message, packageX.Identity, pathContext.PackageSource));
+                errors.First().LibraryId.Should().Be(packageX.Id);
+
+                warnings.Count().Should().Be(1);
+                warnings.First().Code.Should().Be(NuGetLogCode.NU3027);
+                warnings.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(_NU3027Message, packageX.Identity, pathContext.PackageSource));
+                warnings.First().LibraryId.Should().Be(packageX.Id);
+            }
+        }
+
+        [Fact]
+        public void GetCertificateChain_WithUntrustedRoot_Throws()
+        {
+            using (var chainHolder = new X509ChainHolder())
+            using (var rootCertificate = SigningTestUtility.GetCertificate("root.crt"))
+            using (var intermediateCertificate = SigningTestUtility.GetCertificate("intermediate.crt"))
+            using (var leafCertificate = SigningTestUtility.GetCertificate("leaf.crt"))
+            {
+                var chain = chainHolder.Chain;
+                var extraStore = new X509Certificate2Collection() { rootCertificate, intermediateCertificate };
+                var logger = new TestLogger();
+
+                var exception = Assert.Throws<SignatureException>(
+                    () => CertificateChainUtility.GetCertificateChain(
+                        leafCertificate,
+                        extraStore,
+                        logger,
+                        CertificateType.Signature));
+
+                Assert.Equal(NuGetLogCode.NU3018, exception.Code);
+                Assert.Equal("Certificate chain validation failed.", exception.Message);
+
+                Assert.Equal(1, logger.Errors);
+                Assert.Equal(RuntimeEnvironmentHelper.IsWindows ? 2 : 1, logger.Warnings);
+
+                SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Error);
+                SigningTestUtility.AssertOfflineRevocation(logger.LogMessages, LogLevel.Warning);
+
+                if (RuntimeEnvironmentHelper.IsWindows)
+                {
+                    SigningTestUtility.AssertRevocationStatusUnknown(logger.LogMessages, LogLevel.Warning);
+                }
+            }
+        }
+
+        public static CommandRunnerResult RunRestore(string nugetExe, SimpleTestPathContext pathContext, int expectedExitCode = 0, params string[] additionalArgs)
+        {
+            // Store the dg file for debugging
+            var envVars = new Dictionary<string, string>()
+            {
+                { "NUGET_HTTP_CACHE_PATH", pathContext.HttpCacheFolder }
+            };
+
+            var args = new string[]
+            {
+                "restore",
+                "-Verbosity",
+                "detailed"
+            };
+
+            args = args.Concat(additionalArgs).ToArray();
+
+            // Act
+            var r = CommandRunner.Run(
+                nugetExe,
+                pathContext.WorkingDirectory,
+                string.Join(" ", args),
+                waitForExit: true,
+                environmentVariables: envVars);
+
+            // Assert
+            Assert.True(expectedExitCode == r.ExitCode, r.AllOutput);
+
+            return r;
+        }
+    }
+}

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -1,189 +1,155 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Threading.Tasks;
-using FluentAssertions;
-using NuGet.Common;
+using NuGet.CommandLine.Test;
 using NuGet.Frameworks;
-using NuGet.Packaging.Signing;
+using NuGet.Packaging;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
-using Test.Utility.Signing;
 using Xunit;
 
 namespace NuGet.CommandLine.FuncTest.Commands
 {
-    /// <summary>
-    /// Tests restore command
-    /// These tests require admin privilege as the certs need to be added to the root store location
-    /// </summary>
-    [Collection(SignCommandTestCollection.Name)]
     public class RestoreCommandTests
     {
-        private static readonly string _NU3008Message = "The package integrity check failed.";
-        private static readonly string _NU3008 = "NU3008: {0}";
-        private static readonly string _NU3027Message = "The signature should be timestamped to enable long-term signature validity after the certificate has expired.";
-        private static readonly string _NU3027 = "NU3027: {0}";
-
-        private SignCommandTestFixture _testFixture;
-        private TrustedTestCert<TestCertificate> _trustedTestCert;
-        private readonly string _nugetExePath;
-
-        public RestoreCommandTests(SignCommandTestFixture fixture)
-        {
-            _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
-            _trustedTestCert = SigningTestUtility.GenerateTrustedTestCertificate();
-            _nugetExePath = _testFixture.NuGetExePath;
-        }
-
-        [CIOnlyFact]
-        public async Task Restore_TamperedPackageInPackagesConfig_FailsWithErrorAsync()
+        [Fact]
+        public async Task Restore_LegacyPackageReference_WithNuGetLockFile()
         {
             // Arrange
-            var packagesConfigContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
-                "<packages>" +
-                "  <package id=\"X\" version=\"9.0.0\" targetFramework=\"net461\" />" +
-                "</packages>";
-
             using (var pathContext = new SimpleTestPathContext())
-            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
                 // Set up solution, project, and packages
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
 
-                var projectA = new SimpleTestProjectContext(
-                    "a",
-                    ProjectStyle.PackagesConfig,
-                    pathContext.SolutionRoot);
+                var net461 = NuGetFramework.Parse("net461");
 
-                var packageX = new SimpleTestPackageContext("X", "9.0.0");
-                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, packageX, pathContext.PackageSource);
-                SignedArchiveTestUtility.TamperWithPackage(signedPackagePath);
-
-                projectA.AddPackageToAllFrameworks(packageX);
-                solution.Projects.Add(projectA);
-                solution.Create(pathContext.SolutionRoot);
-
-                var packagesConfigPath = Path.Combine(Directory.GetParent(projectA.ProjectPath).FullName, "packages.config");
-
-                File.WriteAllBytes(packagesConfigPath, Encoding.ASCII.GetBytes(packagesConfigContent));
-
-                var args = new string[]
-                {
-                    projectA.ProjectPath,
-                    "-Source",
-                    pathContext.PackageSource,
-                    "-PackagesDirectory",
-                    "./packages"
-                };
-
-                // Act
-                var result = RunRestore(_nugetExePath, pathContext, expectedExitCode: 1, additionalArgs: args);
-
-                // Assert
-                result.ExitCode.Should().Be(1);
-                result.Errors.Should().Contain(string.Format(_NU3008, SigningTestUtility.AddSignatureLogPrefix(_NU3008Message, packageX.Identity, pathContext.PackageSource)));
-                result.AllOutput.Should().Contain(string.Format(_NU3027, SigningTestUtility.AddSignatureLogPrefix(_NU3027Message, packageX.Identity, pathContext.PackageSource)));
-            }
-        }
-
-        [CIOnlyFact]
-        public async Task Restore_TamperedPackage_FailsAsync()
-        {
-            // Arrange
-            using (var pathContext = new SimpleTestPathContext())
-            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
-            {
-                // Set up solution, project, and packages
-                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-
-                var projectA = SimpleTestProjectContext.CreateNETCore(
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
                     "a",
                     pathContext.SolutionRoot,
-                    NuGetFramework.Parse("NETStandard2.0"));
+                    net461);
 
-                var packageX = new SimpleTestPackageContext("X", "9.0.0");
-                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(testCertificate, packageX, pathContext.PackageSource);
-                SignedArchiveTestUtility.TamperWithPackage(signedPackagePath);
+                projectA.Properties.Add("RestorePackagesWithLockFile", "true");
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
 
                 projectA.AddPackageToAllFrameworks(packageX);
                 solution.Projects.Add(projectA);
                 solution.Create(pathContext.SolutionRoot);
 
-                var args = new string[]
-                {
-                    projectA.ProjectPath,
-                    "-Source",
-                    pathContext.PackageSource
-                };
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
 
                 // Act
-                var result = RunRestore(_nugetExePath, pathContext, expectedExitCode: 1, additionalArgs: args);
-                var reader = new LockFileFormat();
-                var lockFile = reader.Read(projectA.AssetsFileOutputPath);
-                var errors = lockFile.LogMessages.Where(m => m.Level == LogLevel.Error);
-                var warnings = lockFile.LogMessages.Where(m => m.Level == LogLevel.Warning);
-            
+                var result = RunRestore(pathContext);
+
                 // Assert
-                result.ExitCode.Should().Be(1);
-                result.Errors.Should().Contain(string.Format(_NU3008, SigningTestUtility.AddSignatureLogPrefix(_NU3008Message, packageX.Identity, pathContext.PackageSource)));
-                result.AllOutput.Should().Contain($"WARNING: {string.Format(_NU3027, SigningTestUtility.AddSignatureLogPrefix(_NU3027Message, packageX.Identity, pathContext.PackageSource))}");
+                Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
 
-                errors.Count().Should().Be(1);
-                errors.First().Code.Should().Be(NuGetLogCode.NU3008);
-                errors.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(_NU3008Message, packageX.Identity, pathContext.PackageSource));
-                errors.First().LibraryId.Should().Be(packageX.Id);
+                var lockFile = PackagesLockFileFormat.Read(projectA.NuGetLockFileOutputPath);
+                Assert.Equal(4, lockFile.Targets.Count);
 
-                warnings.Count().Should().Be(1);
-                warnings.First().Code.Should().Be(NuGetLogCode.NU3027);
-                warnings.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(_NU3027Message, packageX.Identity, pathContext.PackageSource));
-                warnings.First().LibraryId.Should().Be(packageX.Id);
+                var targets = lockFile.Targets.Where(t => t.Dependencies.Count > 0).ToList();
+                Assert.Equal(1, targets.Count);
+                Assert.Equal(".NETFramework,Version=v4.6.1", targets[0].Name);
+                Assert.Equal(1, targets[0].Dependencies.Count);
+                Assert.Equal("x", targets[0].Dependencies[0].Id);
             }
         }
 
         [Fact]
-        public void GetCertificateChain_WithUntrustedRoot_Throws()
+        public async Task Restore_LegacyPackageReference_WithNuGetLockFilePath()
         {
-            using (var chainHolder = new X509ChainHolder())
-            using (var rootCertificate = SigningTestUtility.GetCertificate("root.crt"))
-            using (var intermediateCertificate = SigningTestUtility.GetCertificate("intermediate.crt"))
-            using (var leafCertificate = SigningTestUtility.GetCertificate("leaf.crt"))
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
             {
-                var chain = chainHolder.Chain;
-                var extraStore = new X509Certificate2Collection() { rootCertificate, intermediateCertificate };
-                var logger = new TestLogger();
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
 
-                var exception = Assert.Throws<SignatureException>(
-                    () => CertificateChainUtility.GetCertificateChain(
-                        leafCertificate,
-                        extraStore,
-                        logger,
-                        CertificateType.Signature));
+                var net461 = "net461";
 
-                Assert.Equal(NuGetLogCode.NU3018, exception.Code);
-                Assert.Equal("Certificate chain validation failed.", exception.Message);
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse(net461));
 
-                Assert.Equal(1, logger.Errors);
-                Assert.Equal(RuntimeEnvironmentHelper.IsWindows ? 2 : 1, logger.Warnings);
+                var projectB = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "b",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse(net461));
 
-                SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Error);
-                SigningTestUtility.AssertOfflineRevocation(logger.LogMessages, LogLevel.Warning);
-
-                if (RuntimeEnvironmentHelper.IsWindows)
+                // set up packages
+                var packageX = new SimpleTestPackageContext()
                 {
-                    SigningTestUtility.AssertRevocationStatusUnknown(logger.LogMessages, LogLevel.Warning);
-                }
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile($"lib/{0}/x.dll", net461);
+
+                var packageY = new SimpleTestPackageContext()
+                {
+                    Id = "y",
+                    Version = "1.0.0"
+                };
+                packageY.Files.Clear();
+                packageY.AddFile($"lib/{0}/y.dll", net461);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                   pathContext.PackageSource,
+                   PackageSaveMode.Defaultv3,
+                   packageX,
+                   packageY);
+
+                // set up projects and solution
+                projectB.AddPackageToAllFrameworks(packageY);
+                projectA.Properties.Add("RestorePackagesWithLockFile", "true");
+                var packagesLockFilePath = Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "packages.custom.lock.json");
+                projectA.Properties.Add("NuGetLockFilePath", packagesLockFilePath);
+                projectA.AddProjectToAllFrameworks(projectB);
+                projectA.AddPackageToAllFrameworks(packageX);
+                solution.Projects.Add(projectA);
+                solution.Projects.Add(projectB);
+                solution.Create(pathContext.SolutionRoot);
+
+                // Act
+                var result = RunRestore(pathContext);
+
+                // Assert
+                Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
+                Assert.Equal(packagesLockFilePath, projectA.NuGetLockFileOutputPath);
+
+                var lockFile = PackagesLockFileFormat.Read(projectA.NuGetLockFileOutputPath);
+                Assert.Equal(4, lockFile.Targets.Count);
+
+                var targets = lockFile.Targets.Where(t => t.Dependencies.Count > 0).ToList();
+                Assert.Equal(1, targets.Count);
+                Assert.Equal(".NETFramework,Version=v4.6.1", targets[0].Name);
+                Assert.Equal(3, targets[0].Dependencies.Count);
+                Assert.Equal("x", targets[0].Dependencies[0].Id);
+                Assert.Equal(PackageDependencyType.Direct, targets[0].Dependencies[0].Type);
+                Assert.Equal("y", targets[0].Dependencies[1].Id);
+                Assert.Equal(PackageDependencyType.Transitive, targets[0].Dependencies[1].Type);
+                Assert.Equal("b", targets[0].Dependencies[2].Id);
+                Assert.Equal(PackageDependencyType.Project, targets[0].Dependencies[2].Type);
             }
         }
 
-        public static CommandRunnerResult RunRestore(string nugetExe, SimpleTestPathContext pathContext, int expectedExitCode = 0, params string[] additionalArgs)
+        public static CommandRunnerResult RunRestore(SimpleTestPathContext pathContext, int expectedExitCode = 0)
         {
+            var nugetExe = Util.GetNuGetExePath();
+
             // Store the dg file for debugging
             var envVars = new Dictionary<string, string>()
             {
@@ -193,16 +159,15 @@ namespace NuGet.CommandLine.FuncTest.Commands
             var args = new string[]
             {
                 "restore",
+                pathContext.SolutionRoot,
                 "-Verbosity",
                 "detailed"
             };
 
-            args = args.Concat(additionalArgs).ToArray();
-
             // Act
             var r = CommandRunner.Run(
                 nugetExe,
-                pathContext.WorkingDirectory,
+                pathContext.WorkingDirectory.Path,
                 string.Join(" ", args),
                 waitForExit: true,
                 environmentVariables: envVars);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -29,8 +30,10 @@
     <Compile Include="Feeds\UpdatePackageFeedTests.cs" />
     <Compile Include="Feeds\InstalledPackageFeedTests.cs" />
     <Compile Include="FrameworkAssemblyResolverTests.cs" />
+    <Compile Include="ProjectSystems\LegacyPackageReferenceRestoreUtilityTests.cs" />
     <Compile Include="ProjectSystems\ProjectKNuGetProjectTests.cs" />
     <Compile Include="ProjectSystems\ProjectSystemCacheTests.cs" />
+    <Compile Include="ProjectSystems\TestVSProjectAdapter.cs" />
     <Compile Include="Services\NuGetLockServiceTests.cs" />
     <Compile Include="Telemetry\ActionsTelemetryServiceTests.cs" />
     <Compile Include="Telemetry\NuGetTelemetryServiceTests.cs" />
@@ -91,6 +94,6 @@
     <PackageReference Include="EnvDTE" Version="8.0.1" />
   </ItemGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
@@ -1,0 +1,918 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Microsoft;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using NuGet.VisualStudio;
+using Test.Utility;
+using Test.Utility.Threading;
+using Xunit;
+
+namespace NuGet.PackageManagement.VisualStudio.Test
+{
+    [Collection(DispatcherThreadCollection.CollectionName)]
+    public class LegacyPackageReferenceRestoreUtilityTests
+    {
+        private readonly IVsProjectThreadingService _threadingService;
+
+        public LegacyPackageReferenceRestoreUtilityTests(DispatcherThreadFixture fixture)
+        {
+            Assumes.Present(fixture);
+
+            _threadingService = new TestProjectThreadingService(fixture.JoinableTaskFactory);
+        }
+
+        [Fact]
+        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_Success()
+        {
+            using (var packageSource = TestDirectory.Create())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var randomProjectFolderPath = TestDirectory.Create())
+                {
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testNuGetProjectContext = new TestNuGetProjectContext();
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+
+                    var projectTargetFrameworkStr = "net45";
+                    var fullProjectPath = Path.Combine(randomProjectFolderPath, "project1.csproj");
+                    var projectNames = new ProjectNames(
+                        fullName: fullProjectPath,
+                        uniqueName: Path.GetFileName(fullProjectPath),
+                        shortName: Path.GetFileNameWithoutExtension(fullProjectPath),
+                        customUniqueName: Path.GetFileName(fullProjectPath));
+                    var vsProjectAdapter = new TestVSProjectAdapter(
+                        fullProjectPath,
+                        projectNames,
+                        projectTargetFrameworkStr);
+
+                    var projectServices = new TestProjectSystemServices();
+                    projectServices.SetupInstalledPackages(
+                        NuGetFramework.Parse(projectTargetFrameworkStr),
+                        new LibraryDependency
+                        {
+                            LibraryRange = new LibraryRange(
+                                "packageA",
+                                VersionRange.Parse("1.*"),
+                                LibraryDependencyTarget.Package)
+                        });
+
+                    var legacyPRProject = new LegacyPackageReferenceProject(
+                        vsProjectAdapter,
+                        Guid.NewGuid().ToString(),
+                        projectServices,
+                        _threadingService);
+                    testSolutionManager.NuGetProjects.Add(legacyPRProject);
+
+                    var testLogger = new TestLogger();
+                    var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
+                    var providersCache = new RestoreCommandProvidersCache();
+
+                    var packageContext = new SimpleTestPackageContext("packageA", "1.0.0");
+                    packageContext.AddFile("lib/net45/a.dll");
+                    SimpleTestPackageUtility.CreateOPCPackage(packageContext, packageSource);
+
+                    var dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(testSolutionManager, restoreContext);
+
+                    // Act
+                    var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                        testSolutionManager,
+                        dgSpec,
+                        restoreContext,
+                        providersCache,
+                        (c) => { },
+                        sourceRepositoryProvider.GetRepositories(),
+                        Guid.Empty,
+                        false,
+                        true,
+                        testLogger,
+                        CancellationToken.None);
+
+                    // Assert
+                    foreach (var restoreSummary in restoreSummaries)
+                    {
+                        Assert.True(restoreSummary.Success);
+                        Assert.False(restoreSummary.NoOpRestore);
+                        Assert.Equal(1, restoreSummary.InstallCount);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_GenerateLockFile()
+        {
+            using (var packageSource = TestDirectory.Create())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var randomProjectFolderPath = TestDirectory.Create())
+                {
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testNuGetProjectContext = new TestNuGetProjectContext();
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+
+                    // set up projects
+                    var projectTargetFrameworkStr = "net45";
+                    var fullProjectPathB = Path.Combine(randomProjectFolderPath, "ProjectB", "project2.csproj");
+                    var projectNamesB = new ProjectNames(
+                        fullName: fullProjectPathB,
+                        uniqueName: Path.GetFileName(fullProjectPathB),
+                        shortName: Path.GetFileNameWithoutExtension(fullProjectPathB),
+                        customUniqueName: Path.GetFileName(fullProjectPathB));
+                    var vsProjectAdapterB = new TestVSProjectAdapter(
+                        fullProjectPathB,
+                        projectNamesB,
+                        projectTargetFrameworkStr);
+
+                    var projectServicesB = new TestProjectSystemServices();
+                    projectServicesB.SetupInstalledPackages(
+                        NuGetFramework.Parse(projectTargetFrameworkStr),
+                        new LibraryDependency
+                        {
+                            LibraryRange = new LibraryRange(
+                                "packageB",
+                                VersionRange.Parse("1.*"),
+                                LibraryDependencyTarget.Package)
+                        });
+
+                    var legacyPRProjectB = new LegacyPackageReferenceProject(
+                        vsProjectAdapterB,
+                        Guid.NewGuid().ToString(),
+                        projectServicesB,
+                        _threadingService);
+
+                    var projectPathA = Path.Combine(randomProjectFolderPath, "ProjectA");
+                    var fullProjectPathA = Path.Combine(projectPathA, "project1.csproj");
+                    var projectNamesA = new ProjectNames(
+                        fullName: fullProjectPathA,
+                        uniqueName: Path.GetFileName(fullProjectPathA),
+                        shortName: Path.GetFileNameWithoutExtension(fullProjectPathA),
+                        customUniqueName: Path.GetFileName(fullProjectPathA));
+                    var vsProjectAdapterA = new TestVSProjectAdapter(
+                        fullProjectPathA,
+                        projectNamesA,
+                        projectTargetFrameworkStr,
+                        restorePackagesWithLockFile: "true");
+
+                    var projectServicesA = new TestProjectSystemServices();
+                    projectServicesA.SetupInstalledPackages(
+                        NuGetFramework.Parse(projectTargetFrameworkStr),
+                        new LibraryDependency
+                        {
+                            LibraryRange = new LibraryRange(
+                                "packageA",
+                                VersionRange.Parse("1.*"),
+                                LibraryDependencyTarget.Package)
+                        });
+                    projectServicesA.SetupProjectDependencies(
+                        new ProjectRestoreReference
+                        {
+                            ProjectUniqueName = fullProjectPathB,
+                            ProjectPath = fullProjectPathB
+                        });
+
+                    var legacyPRProjectA = new LegacyPackageReferenceProject(
+                        vsProjectAdapterA,
+                        Guid.NewGuid().ToString(),
+                        projectServicesA,
+                        _threadingService);
+                    testSolutionManager.NuGetProjects.Add(legacyPRProjectB);
+                    testSolutionManager.NuGetProjects.Add(legacyPRProjectA);
+
+                    var testLogger = new TestLogger();
+                    var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
+                    var providersCache = new RestoreCommandProvidersCache();
+
+                    var packageContextA = new SimpleTestPackageContext("packageA", "1.0.0");
+                    packageContextA.AddFile("lib/net45/a.dll");
+                    var packageContextB = new SimpleTestPackageContext("packageB", "1.0.0");
+                    packageContextB.AddFile("lib/net45/b.dll");
+                    var packages = new List<SimpleTestPackageContext>() { packageContextA, packageContextB };
+                    SimpleTestPackageUtility.CreateOPCPackages(packages, packageSource);
+
+                    var dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(testSolutionManager, restoreContext);
+
+                    // Act
+                    var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                        testSolutionManager,
+                        dgSpec,
+                        restoreContext,
+                        providersCache,
+                        (c) => { },
+                        sourceRepositoryProvider.GetRepositories(),
+                        Guid.Empty,
+                        false,
+                        true,
+                        testLogger,
+                        CancellationToken.None);
+
+                    // Assert
+                    foreach (var restoreSummary in restoreSummaries)
+                    {
+                        Assert.True(restoreSummary.Success);
+                        Assert.False(restoreSummary.NoOpRestore);
+                    }
+
+                    Assert.True(File.Exists(Path.Combine(projectPathA, "packages.lock.json")));
+                    var lockFile = PackagesLockFileFormat.Read(Path.Combine(projectPathA, "packages.lock.json"));
+                    Assert.Equal(1, lockFile.Targets.Count);
+
+                    Assert.Equal(".NETFramework,Version=v4.5", lockFile.Targets[0].Name);
+                    Assert.Equal(3, lockFile.Targets[0].Dependencies.Count);
+                    Assert.Equal("packageA", lockFile.Targets[0].Dependencies[0].Id);
+                    Assert.Equal(PackageDependencyType.Direct, lockFile.Targets[0].Dependencies[0].Type);
+                    Assert.Equal("packageB", lockFile.Targets[0].Dependencies[1].Id);
+                    Assert.Equal(PackageDependencyType.Transitive, lockFile.Targets[0].Dependencies[1].Type);
+                    Assert.Equal("project2", lockFile.Targets[0].Dependencies[2].Id);
+                    Assert.Equal(PackageDependencyType.Project, lockFile.Targets[0].Dependencies[2].Type);
+                }
+            }
+        }
+
+        [Fact]
+        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_ReadLockFile()
+        {
+            using (var packageSource = TestDirectory.Create())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var randomProjectFolderPath = TestDirectory.Create())
+                {
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testNuGetProjectContext = new TestNuGetProjectContext();
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+
+                    var projectTargetFrameworkStr = "net45";
+                    var fullProjectPath = Path.Combine(randomProjectFolderPath, "project1.csproj");
+                    var projectNames = new ProjectNames(
+                        fullName: fullProjectPath,
+                        uniqueName: Path.GetFileName(fullProjectPath),
+                        shortName: Path.GetFileNameWithoutExtension(fullProjectPath),
+                        customUniqueName: Path.GetFileName(fullProjectPath));
+                    var vsProjectAdapter = new TestVSProjectAdapter(
+                        fullProjectPath,
+                        projectNames,
+                        projectTargetFrameworkStr);
+
+                    var projectServices = new TestProjectSystemServices();
+                    projectServices.SetupInstalledPackages(
+                        NuGetFramework.Parse(projectTargetFrameworkStr),
+                        new LibraryDependency
+                        {
+                            LibraryRange = new LibraryRange(
+                                "packageA",
+                                VersionRange.Parse("1.*"),
+                                LibraryDependencyTarget.Package)
+                        });
+
+                    var legacyPRProject = new LegacyPackageReferenceProject(
+                        vsProjectAdapter,
+                        Guid.NewGuid().ToString(),
+                        projectServices,
+                        _threadingService);
+                    testSolutionManager.NuGetProjects.Add(legacyPRProject);
+
+                    var testLogger = new TestLogger();
+                    var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
+
+                    var packageContext = new SimpleTestPackageContext("packageA", "1.0.0");
+                    packageContext.AddFile("lib/net45/a.dll");
+                    SimpleTestPackageUtility.CreateOPCPackage(packageContext, packageSource);
+
+                    var dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(testSolutionManager, restoreContext);
+
+                    var projectLockFilePath = Path.Combine(randomProjectFolderPath, "packages.project1.lock.json");
+                    File.Create(projectLockFilePath).Close();
+
+                    var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                        testSolutionManager,
+                        dgSpec,
+                        restoreContext,
+                        new RestoreCommandProvidersCache(),
+                        (c) => { },
+                        sourceRepositoryProvider.GetRepositories(),
+                        Guid.Empty,
+                        false,
+                        true,
+                        testLogger,
+                        CancellationToken.None);
+
+                    foreach (var restoreSummary in restoreSummaries)
+                    {
+                        Assert.True(restoreSummary.Success);
+                        Assert.False(restoreSummary.NoOpRestore);
+                    }
+
+                    Assert.True(File.Exists(projectLockFilePath));
+
+                    // delete existing restore output files
+                    File.Delete(Path.Combine(vsProjectAdapter.MSBuildProjectExtensionsPath, "project.assets.json"));
+                    File.Delete(Path.Combine(vsProjectAdapter.MSBuildProjectExtensionsPath, "project1.csproj.nuget.cache"));
+
+                    // add a new package
+                    var newPackageContext = new SimpleTestPackageContext("packageA", "1.0.1");
+                    newPackageContext.AddFile("lib/net45/a.dll");
+                    SimpleTestPackageUtility.CreateOPCPackage(newPackageContext, packageSource);
+
+                    // Act
+                    restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                        testSolutionManager,
+                        dgSpec,
+                        restoreContext,
+                        new RestoreCommandProvidersCache(),
+                        (c) => { },
+                        sourceRepositoryProvider.GetRepositories(),
+                        Guid.Empty,
+                        false,
+                        true,
+                        testLogger,
+                        CancellationToken.None);
+
+                    // Assert
+                    foreach (var restoreSummary in restoreSummaries)
+                    {
+                        Assert.True(restoreSummary.Success);
+                        Assert.False(restoreSummary.NoOpRestore);
+                    }
+
+                    var lockFilePath = Path.Combine(vsProjectAdapter.MSBuildProjectExtensionsPath, "project.assets.json");
+                    Assert.True(File.Exists(lockFilePath));
+
+                    var lockFile = new LockFileFormat().Read(lockFilePath);
+                    var resolvedVersion = lockFile.Targets.First().Libraries.First(library => library.Name.Equals("packageA", StringComparison.OrdinalIgnoreCase)).Version;
+                    Assert.Equal("1.0.0", resolvedVersion.ToNormalizedString());
+                }
+            }
+        }
+
+        [Fact]
+        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_UpdateLockFile()
+        {
+            using (var packageSource = TestDirectory.Create())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var randomProjectFolderPath = TestDirectory.Create())
+                {
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testNuGetProjectContext = new TestNuGetProjectContext();
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+
+                    var projectTargetFrameworkStr = "net45";
+                    var fullProjectPath = Path.Combine(randomProjectFolderPath, "project1.csproj");
+                    var projectLockFilePath = Path.Combine(randomProjectFolderPath, "packages.custom.lock.json");
+                    File.Create(projectLockFilePath).Close();
+
+                    var projectNames = new ProjectNames(
+                        fullName: fullProjectPath,
+                        uniqueName: Path.GetFileName(fullProjectPath),
+                        shortName: Path.GetFileNameWithoutExtension(fullProjectPath),
+                        customUniqueName: Path.GetFileName(fullProjectPath));
+                    var vsProjectAdapter = new TestVSProjectAdapter(
+                        fullProjectPath,
+                        projectNames,
+                        projectTargetFrameworkStr,
+                        restorePackagesWithLockFile: null,
+                        nuGetLockFilePath: projectLockFilePath);
+
+                    var projectServices = new TestProjectSystemServices();
+                    projectServices.SetupInstalledPackages(
+                        NuGetFramework.Parse(projectTargetFrameworkStr),
+                        new LibraryDependency
+                        {
+                            LibraryRange = new LibraryRange(
+                                "packageA",
+                                VersionRange.Parse("1.*"),
+                                LibraryDependencyTarget.Package)
+                        });
+
+                    var legacyPRProject = new LegacyPackageReferenceProject(
+                        vsProjectAdapter,
+                        Guid.NewGuid().ToString(),
+                        projectServices,
+                        _threadingService);
+                    testSolutionManager.NuGetProjects.Add(legacyPRProject);
+
+                    var testLogger = new TestLogger();
+                    var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
+
+                    var packageContextA = new SimpleTestPackageContext("packageA", "1.0.0");
+                    packageContextA.AddFile("lib/net45/a.dll");
+                    SimpleTestPackageUtility.CreateOPCPackage(packageContextA, packageSource);
+                    var packageContextB = new SimpleTestPackageContext("packageB", "1.0.0");
+                    packageContextB.AddFile("lib/net45/b.dll");
+                    SimpleTestPackageUtility.CreateOPCPackage(packageContextB, packageSource);
+
+                    var dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(testSolutionManager, restoreContext);
+
+                    var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                        testSolutionManager,
+                        dgSpec,
+                        restoreContext,
+                        new RestoreCommandProvidersCache(),
+                        (c) => { },
+                        sourceRepositoryProvider.GetRepositories(),
+                        Guid.Empty,
+                        false,
+                        true,
+                        testLogger,
+                        CancellationToken.None);
+
+                    foreach (var restoreSummary in restoreSummaries)
+                    {
+                        Assert.True(restoreSummary.Success);
+                        Assert.False(restoreSummary.NoOpRestore);
+                    }
+
+                    Assert.True(File.Exists(projectLockFilePath));
+                    Assert.True(File.Exists(Path.Combine(vsProjectAdapter.MSBuildProjectExtensionsPath, "project.assets.json")));
+
+                    // delete existing restore output files
+                    File.Delete(Path.Combine(vsProjectAdapter.MSBuildProjectExtensionsPath, "project.assets.json"));
+
+                    // install a new package
+                    projectServices.SetupInstalledPackages(
+                        NuGetFramework.Parse(projectTargetFrameworkStr),
+                        new LibraryDependency
+                        {
+                            LibraryRange = new LibraryRange(
+                                "packageA",
+                                VersionRange.Parse("1.*"),
+                                LibraryDependencyTarget.Package)
+                        },
+                        new LibraryDependency
+                        {
+                            LibraryRange = new LibraryRange(
+                                "packageB",
+                                VersionRange.Parse("1.0.0"),
+                                LibraryDependencyTarget.Package)
+                        });
+
+                    // update the proeject with new ProjectService instance
+                    restoreContext.PackageSpecCache.Clear();
+                    dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(testSolutionManager, restoreContext);
+
+                    // Act
+                    restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                        testSolutionManager,
+                        dgSpec,
+                        restoreContext,
+                        new RestoreCommandProvidersCache(),
+                        (c) => { },
+                        sourceRepositoryProvider.GetRepositories(),
+                        Guid.Empty,
+                        false,
+                        true,
+                        testLogger,
+                        CancellationToken.None);
+
+                    // Assert
+                    foreach (var restoreSummary in restoreSummaries)
+                    {
+                        Assert.True(restoreSummary.Success);
+                        Assert.False(restoreSummary.NoOpRestore);
+                    }
+
+                    Assert.True(File.Exists(projectLockFilePath));
+
+                    var lockFile = PackagesLockFileFormat.Read(projectLockFilePath);
+                    Assert.Equal(2, lockFile.Targets.First().Dependencies.Count);
+                }
+            }
+        }
+
+        [Fact]
+        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_RestorePackagesWithLockFile_False()
+        {
+            using (var packageSource = TestDirectory.Create())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var randomProjectFolderPath = TestDirectory.Create())
+                {
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testNuGetProjectContext = new TestNuGetProjectContext();
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+
+                    var projectTargetFrameworkStr = "net45";
+                    var fullProjectPath = Path.Combine(randomProjectFolderPath, "project1.csproj");
+                    var projectLockFilePath = Path.Combine(randomProjectFolderPath, "packages.lock.json");
+                    File.Create(projectLockFilePath).Close();
+
+                    var projectNames = new ProjectNames(
+                        fullName: fullProjectPath,
+                        uniqueName: Path.GetFileName(fullProjectPath),
+                        shortName: Path.GetFileNameWithoutExtension(fullProjectPath),
+                        customUniqueName: Path.GetFileName(fullProjectPath));
+                    var vsProjectAdapter = new TestVSProjectAdapter(
+                        fullProjectPath,
+                        projectNames,
+                        projectTargetFrameworkStr,
+                        restorePackagesWithLockFile: "false");
+
+                    var projectServices = new TestProjectSystemServices();
+                    projectServices.SetupInstalledPackages(
+                        NuGetFramework.Parse(projectTargetFrameworkStr),
+                        new LibraryDependency
+                        {
+                            LibraryRange = new LibraryRange(
+                                "packageA",
+                                VersionRange.Parse("1.*"),
+                                LibraryDependencyTarget.Package)
+                        });
+
+                    var legacyPRProject = new LegacyPackageReferenceProject(
+                        vsProjectAdapter,
+                        Guid.NewGuid().ToString(),
+                        projectServices,
+                        _threadingService);
+                    testSolutionManager.NuGetProjects.Add(legacyPRProject);
+
+                    var testLogger = new TestLogger();
+                    var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
+                    var providersCache = new RestoreCommandProvidersCache();
+
+                    var packageContext = new SimpleTestPackageContext("packageA", "1.0.0");
+                    packageContext.AddFile("lib/net45/a.dll");
+                    SimpleTestPackageUtility.CreateOPCPackage(packageContext, packageSource);
+
+                    var dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(testSolutionManager, restoreContext);
+
+                    // Act
+                    var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                        testSolutionManager,
+                        dgSpec,
+                        restoreContext,
+                        providersCache,
+                        (c) => { },
+                        sourceRepositoryProvider.GetRepositories(),
+                        Guid.Empty,
+                        false,
+                        true,
+                        testLogger,
+                        CancellationToken.None);
+
+                    // Assert
+                    foreach (var restoreSummary in restoreSummaries)
+                    {
+                        Assert.False(restoreSummary.Success);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_LockedMode()
+        {
+            using (var packageSource = TestDirectory.Create())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var randomProjectFolderPath = TestDirectory.Create())
+                {
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testNuGetProjectContext = new TestNuGetProjectContext();
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+
+                    var projectTargetFrameworkStr = "net45";
+                    var fullProjectPath = Path.Combine(randomProjectFolderPath, "project1.csproj");
+
+                    var projectNames = new ProjectNames(
+                        fullName: fullProjectPath,
+                        uniqueName: Path.GetFileName(fullProjectPath),
+                        shortName: Path.GetFileNameWithoutExtension(fullProjectPath),
+                        customUniqueName: Path.GetFileName(fullProjectPath));
+                    var vsProjectAdapter = new TestVSProjectAdapter(
+                        fullProjectPath,
+                        projectNames,
+                        projectTargetFrameworkStr,
+                        restorePackagesWithLockFile: "true",
+                        restoreLockedMode: true);
+
+                    var projectServices = new TestProjectSystemServices();
+                    projectServices.SetupInstalledPackages(
+                        NuGetFramework.Parse(projectTargetFrameworkStr),
+                        new LibraryDependency
+                        {
+                            LibraryRange = new LibraryRange(
+                                "packageA",
+                                VersionRange.Parse("1.*"),
+                                LibraryDependencyTarget.Package)
+                        });
+
+                    var legacyPRProject = new LegacyPackageReferenceProject(
+                        vsProjectAdapter,
+                        Guid.NewGuid().ToString(),
+                        projectServices,
+                        _threadingService);
+                    testSolutionManager.NuGetProjects.Add(legacyPRProject);
+
+                    var testLogger = new TestLogger();
+                    var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
+
+                    var packageContextA = new SimpleTestPackageContext("packageA", "1.0.0");
+                    packageContextA.AddFile("lib/net45/a.dll");
+                    SimpleTestPackageUtility.CreateOPCPackage(packageContextA, packageSource);
+                    var packageContextB = new SimpleTestPackageContext("packageB", "1.0.0");
+                    packageContextB.AddFile("lib/net45/b.dll");
+                    SimpleTestPackageUtility.CreateOPCPackage(packageContextB, packageSource);
+
+                    var dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(testSolutionManager, restoreContext);
+
+                    var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                        testSolutionManager,
+                        dgSpec,
+                        restoreContext,
+                        new RestoreCommandProvidersCache(),
+                        (c) => { },
+                        sourceRepositoryProvider.GetRepositories(),
+                        Guid.Empty,
+                        false,
+                        true,
+                        testLogger,
+                        CancellationToken.None);
+
+                    foreach (var restoreSummary in restoreSummaries)
+                    {
+                        Assert.True(restoreSummary.Success);
+                        Assert.False(restoreSummary.NoOpRestore);
+                    }
+
+                    Assert.True(File.Exists(Path.Combine(randomProjectFolderPath, "packages.lock.json")));
+
+                    // install a new package
+                    projectServices.SetupInstalledPackages(
+                        NuGetFramework.Parse(projectTargetFrameworkStr),
+                        new LibraryDependency
+                        {
+                            LibraryRange = new LibraryRange(
+                                "packageA",
+                                VersionRange.Parse("1.*"),
+                                LibraryDependencyTarget.Package)
+                        },
+                        new LibraryDependency
+                        {
+                            LibraryRange = new LibraryRange(
+                                "packageB",
+                                VersionRange.Parse("1.0.0"),
+                                LibraryDependencyTarget.Package)
+                        });
+
+                    // update the proeject with new ProjectService instance
+                    restoreContext.PackageSpecCache.Clear();
+                    dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(testSolutionManager, restoreContext);
+
+                    // Act
+                    restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                        testSolutionManager,
+                        dgSpec,
+                        restoreContext,
+                        new RestoreCommandProvidersCache(),
+                        (c) => { },
+                        sourceRepositoryProvider.GetRepositories(),
+                        Guid.Empty,
+                        false,
+                        true,
+                        testLogger,
+                        CancellationToken.None);
+
+                    // Assert
+                    foreach (var restoreSummary in restoreSummaries)
+                    {
+                        Assert.False(restoreSummary.Success);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_PackageShaValidationFailed()
+        {
+            using (var packageSource = TestDirectory.Create())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var randomProjectFolderPath = TestDirectory.Create())
+                {
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testNuGetProjectContext = new TestNuGetProjectContext();
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+
+                    var projectTargetFrameworkStr = "net45";
+                    var fullProjectPath = Path.Combine(randomProjectFolderPath, "project1.csproj");
+                    var projectNames = new ProjectNames(
+                        fullName: fullProjectPath,
+                        uniqueName: Path.GetFileName(fullProjectPath),
+                        shortName: Path.GetFileNameWithoutExtension(fullProjectPath),
+                        customUniqueName: Path.GetFileName(fullProjectPath));
+                    var vsProjectAdapter = new TestVSProjectAdapter(
+                        fullProjectPath,
+                        projectNames,
+                        projectTargetFrameworkStr);
+
+                    var projectServices = new TestProjectSystemServices();
+                    projectServices.SetupInstalledPackages(
+                        NuGetFramework.Parse(projectTargetFrameworkStr),
+                        new LibraryDependency
+                        {
+                            LibraryRange = new LibraryRange(
+                                "packageA",
+                                VersionRange.Parse("1.*"),
+                                LibraryDependencyTarget.Package)
+                        });
+
+                    var legacyPRProject = new LegacyPackageReferenceProject(
+                        vsProjectAdapter,
+                        Guid.NewGuid().ToString(),
+                        projectServices,
+                        _threadingService);
+                    testSolutionManager.NuGetProjects.Add(legacyPRProject);
+
+                    var testLogger = new TestLogger();
+                    var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
+
+                    var packageContext = new SimpleTestPackageContext("packageA", "1.0.0");
+                    packageContext.AddFile("lib/net45/a.dll");
+                    SimpleTestPackageUtility.CreateOPCPackage(packageContext, packageSource);
+
+                    var dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(testSolutionManager, restoreContext);
+
+                    var projectLockFilePath = Path.Combine(randomProjectFolderPath, "packages.project1.lock.json");
+                    File.Create(projectLockFilePath).Close();
+
+                    var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                        testSolutionManager,
+                        dgSpec,
+                        restoreContext,
+                        new RestoreCommandProvidersCache(),
+                        (c) => { },
+                        sourceRepositoryProvider.GetRepositories(),
+                        Guid.Empty,
+                        false,
+                        true,
+                        testLogger,
+                        CancellationToken.None);
+
+                    foreach (var restoreSummary in restoreSummaries)
+                    {
+                        Assert.True(restoreSummary.Success);
+                        Assert.False(restoreSummary.NoOpRestore);
+                    }
+
+                    Assert.True(File.Exists(projectLockFilePath));
+
+                    // delete existing restore output files
+                    File.Delete(Path.Combine(vsProjectAdapter.MSBuildProjectExtensionsPath, "project.assets.json"));
+                    File.Delete(Path.Combine(vsProjectAdapter.MSBuildProjectExtensionsPath, "project1.csproj.nuget.cache"));
+
+                    // clean packages folder
+                    var packagesFolder = Path.Combine(randomProjectFolderPath, "packages");
+                    Directory.Delete(packagesFolder, true);
+                    Directory.CreateDirectory(packagesFolder);
+
+                    // add a new package
+                    var newPackageContext = new SimpleTestPackageContext("packageA", "1.0.0");
+                    newPackageContext.AddFile("lib/net45/a1.dll");
+                    SimpleTestPackageUtility.CreateOPCPackage(newPackageContext, packageSource);
+
+                    // Act
+                    restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                        testSolutionManager,
+                        dgSpec,
+                        restoreContext,
+                        new RestoreCommandProvidersCache(),
+                        (c) => { },
+                        sourceRepositoryProvider.GetRepositories(),
+                        Guid.Empty,
+                        false,
+                        true,
+                        testLogger,
+                        CancellationToken.None);
+
+                    // Assert
+                    foreach (var restoreSummary in restoreSummaries)
+                    {
+                        Assert.False(restoreSummary.Success);
+                        Assert.True(restoreSummary.Errors.Count > 0);
+                        Assert.NotNull(restoreSummary.Errors.FirstOrDefault(message => (message as RestoreLogMessage).Code == NuGetLogCode.NU1403));
+                    }
+                }
+            }
+        }
+
+        private ISettings PopulateSettingsWithSources(SourceRepositoryProvider sourceRepositoryProvider, TestDirectory settingsDirectory)
+        {
+            var Settings = new Settings(settingsDirectory);
+            Settings.DeleteSection(ConfigurationConstants.PackageSources);
+            foreach (var source in sourceRepositoryProvider.GetRepositories())
+                Settings.SetValue(ConfigurationConstants.PackageSources, ConfigurationConstants.PackageSources, source.PackageSource.Source);
+
+            return Settings;
+        }
+
+        private SourceRepositoryProvider CreateSource(List<SourcePackageDependencyInfo> packages)
+        {
+            var resourceProviders = new List<Lazy<INuGetResourceProvider>>();
+            resourceProviders.Add(new Lazy<INuGetResourceProvider>(() => new TestDependencyInfoProvider(packages)));
+            resourceProviders.Add(new Lazy<INuGetResourceProvider>(() => new TestMetadataProvider(packages)));
+
+            var packageSource = new Configuration.PackageSource("http://temp");
+            var packageSourceProvider = new TestPackageSourceProvider(new[] { packageSource });
+
+            return new SourceRepositoryProvider(packageSourceProvider, resourceProviders);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
@@ -1,0 +1,219 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+using EnvDTE;
+using Microsoft.VisualStudio.Shell.Interop;
+using Moq;
+using NuGet.Frameworks;
+using NuGet.ProjectManagement;
+using NuGet.RuntimeModel;
+using NuGet.VisualStudio;
+
+namespace NuGet.PackageManagement.VisualStudio.Test
+{
+    internal class TestVSProjectAdapter : IVsProjectAdapter
+    {
+        private readonly string _targetFrameworkString;
+        private readonly string _restorePackagesWithLockFile;
+        private readonly string _nuGetLockFilePath;
+        private readonly bool _restoreLockedMode;
+
+        public TestVSProjectAdapter(
+            string fullProjectPath,
+            ProjectNames projectNames,
+            string targetFrameworkString,
+            string restorePackagesWithLockFile = null,
+            string nuGetLockFilePath = null,
+            bool restoreLockedMode = false)
+        {
+            FullProjectPath = fullProjectPath;
+            ProjectNames = projectNames;
+            _targetFrameworkString = targetFrameworkString;
+            _restorePackagesWithLockFile = restorePackagesWithLockFile;
+            _nuGetLockFilePath = nuGetLockFilePath;
+            _restoreLockedMode = restoreLockedMode;
+        }
+
+        public string AssetTargetFallback
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public string MSBuildProjectExtensionsPath
+        {
+            get
+            {
+                return Path.Combine(ProjectDirectory, "obj");
+            }
+        }
+
+        public IProjectBuildProperties BuildProperties { get; } = Mock.Of<IProjectBuildProperties>();
+
+        public string CustomUniqueName => ProjectNames.CustomUniqueName;
+
+        public string FullName => ProjectNames.FullName;
+
+        public string FullProjectPath { get; private set; }
+
+        public bool IsDeferred => false;
+
+        public bool IsSupported => true;
+
+        public string NoWarn
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public string PackageTargetFallback
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public Project Project { get; } = Mock.Of<Project>();
+
+        public string ProjectId
+        {
+            get
+            {
+                return Guid.Empty.ToString();
+            }
+        }
+
+        public string ProjectDirectory
+        {
+            get
+            {
+                return Path.GetDirectoryName(FullProjectPath);
+            }
+        }
+
+        public string ProjectName => ProjectNames.ShortName;
+
+        public ProjectNames ProjectNames { get; private set; }
+
+        public string RestoreAdditionalProjectFallbackFolders
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public string RestoreAdditionalProjectSources
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public string RestoreFallbackFolders
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public string RestorePackagesPath
+        {
+            get
+            {
+                return Path.Combine(ProjectDirectory, "packages");
+            }
+        }
+
+        public string RestoreSources
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public string TreatWarningsAsErrors
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public string UniqueName => ProjectNames.UniqueName;
+
+        public string Version
+        {
+            get
+            {
+                return "1.0.0";
+            }
+        }
+
+        public IVsHierarchy VsHierarchy { get; } = Mock.Of<IVsHierarchy>();
+
+        public string WarningsAsErrors
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public Task<FrameworkName> GetDotNetFrameworkNameAsync()
+        {
+            return Task.FromResult(new FrameworkName(_targetFrameworkString));
+        }
+
+        public Task<string> GetNuGetLockFilePathAsync() => Task.FromResult<string>(_nuGetLockFilePath);
+
+        public Task<string[]> GetProjectTypeGuidsAsync()
+        {
+            return Task.FromResult(Array.Empty<string>());
+        }
+
+        public Task<IEnumerable<string>> GetReferencedProjectsAsync()
+        {
+            return Task.FromResult(Enumerable.Empty<string>());
+        }
+
+        public Task<string> GetRestorePackagesWithLockFileAsync()
+        {
+            return Task.FromResult<string>(_restorePackagesWithLockFile);
+        }
+
+        public Task<IEnumerable<RuntimeDescription>> GetRuntimeIdentifiersAsync()
+        {
+            return Task.FromResult(Enumerable.Empty<RuntimeDescription>());
+        }
+
+        public Task<IEnumerable<CompatibilityProfile>> GetRuntimeSupportsAsync()
+        {
+            return Task.FromResult(Enumerable.Empty<CompatibilityProfile>());
+        }
+
+        public Task<NuGetFramework> GetTargetFrameworkAsync()
+        {
+            return Task.FromResult(NuGetFramework.Parse(_targetFrameworkString));
+        }
+
+        public Task<bool> IsRestoreLockedAsync()
+        {
+            return Task.FromResult(_restoreLockedMode);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -2485,6 +2485,52 @@ namespace NuGet.Commands.Test
             MSBuildRestoreUtility.FixSourcePath(input).Should().Be("file:///tmp/test/");
         }
 
+        [Theory]
+        [InlineData("true", "c:\\temp\\nuget.lock.json", "true")]
+        [InlineData(null, "c:\\temp\\nuget.lock.json", "false")]
+        [InlineData("false", null, null)]
+        public void MSBuildRestoreUtility_GetPackageSpec_NuGetLockFileProperties(
+            string RestoreWithLockFile,
+            string NuGetLockFilePath,
+            string LockedMode)
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var project1Root = Path.Combine(workingDir, "a");
+                var project1Path = Path.Combine(project1Root, "a.csproj");
+
+                var items = new List<IDictionary<string, string>>();
+
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "Version", "2.0.0-rc.2+a.b.c" },
+                    { "ProjectName", "a" },
+                    { "ProjectStyle", "PackageReference" },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectPath", project1Path },
+                    { "TargetFrameworks", "net46" },
+                    { "RestorePackagesWithLockFile", RestoreWithLockFile },
+                    { "NuGetLockFilePath", NuGetLockFilePath },
+                    { "RestoreLockedMode", LockedMode }
+                });
+
+                var wrappedItems = items.Select(CreateItems).ToList();
+
+                // Act
+                var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+                var project1Spec = dgSpec.Projects.Single();
+                var lockedModeBool = string.IsNullOrEmpty(LockedMode) ? false : bool.Parse(LockedMode);
+
+                // Assert
+                project1Spec.RestoreMetadata.RestoreLockProperties.RestorePackagesWithLockFile.Should().Be(RestoreWithLockFile);
+                project1Spec.RestoreMetadata.RestoreLockProperties.NuGetLockFilePath.Should().Be(NuGetLockFilePath);
+                project1Spec.RestoreMetadata.RestoreLockProperties.RestoreLockedMode.Should().Be(lockedModeBool);
+            }
+        }
+
         private static IDictionary<string, string> CreateProject(string root, string uniqueName)
         {
             var project1Path = Path.Combine(root, "a.csproj");

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
@@ -33,6 +33,8 @@ namespace NuGet.Commands.Test
                     msbuildFiles: Enumerable.Empty<MSBuildOutputFile>(),
                     cacheFile: null,
                     cacheFilePath: null,
+                    packagesLockFilePath: null,
+                    packagesLockFile: null,
                     projectStyle: ProjectStyle.Unknown,
                     elapsedTime: TimeSpan.MinValue);
 
@@ -66,6 +68,8 @@ namespace NuGet.Commands.Test
                     msbuildFiles: Enumerable.Empty<MSBuildOutputFile>(),
                     cacheFile: null,
                     cacheFilePath: null,
+                    packagesLockFilePath: null,
+                    packagesLockFile: null,
                     projectStyle: ProjectStyle.Unknown,
                     elapsedTime: TimeSpan.MinValue);
 
@@ -100,6 +104,8 @@ namespace NuGet.Commands.Test
                     msbuildFiles: Enumerable.Empty<MSBuildOutputFile>(),
                     cacheFile: new CacheFile("NotSoRandomString"),
                     cacheFilePath: cachePath,
+                    packagesLockFilePath: null,
+                    packagesLockFile: null,
                     projectStyle: ProjectStyle.Unknown,
                     elapsedTime: TimeSpan.MinValue);
 

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/FindPackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/FindPackageTests.cs
@@ -64,7 +64,7 @@ namespace NuGet.DependencyResolver.Core.Tests
             context.RemoteLibraryProviders.Add(remoteProvider2.Object);
 
             // Act
-            var result = await ResolverUtility.FindLibraryEntryAsync(range, framework, edge, context, token);
+            var result = await ResolverUtility.FindLibraryEntryAsync(range, framework, null, edge, context, token);
 
             // Assert
             // Verify only one download happened
@@ -106,7 +106,7 @@ namespace NuGet.DependencyResolver.Core.Tests
             context.RemoteLibraryProviders.Add(remoteProvider.Object);
 
             // Act
-            var result = await ResolverUtility.FindLibraryEntryAsync(range, framework, edge, context, token);
+            var result = await ResolverUtility.FindLibraryEntryAsync(range, framework, null, edge, context, token);
 
             // Assert
             Assert.Equal(1, hitCount);
@@ -143,7 +143,7 @@ namespace NuGet.DependencyResolver.Core.Tests
             context.RemoteLibraryProviders.Add(remoteProvider.Object);
 
             // Act
-            await Assert.ThrowsAsync<FatalProtocolException>(async () => await ResolverUtility.FindLibraryEntryAsync(range, framework, edge, context, token));
+            await Assert.ThrowsAsync<FatalProtocolException>(async () => await ResolverUtility.FindLibraryEntryAsync(range, framework, null, edge, context, token));
 
             // Assert
             Assert.Equal(2, hitCount);
@@ -174,7 +174,7 @@ namespace NuGet.DependencyResolver.Core.Tests
             context.RemoteLibraryProviders.Add(remoteProvider.Object);
 
             // Act
-            var result = await ResolverUtility.FindLibraryEntryAsync(range, framework, edge, context, token);
+            var result = await ResolverUtility.FindLibraryEntryAsync(range, framework, null, edge, context, token);
 
             // Assert
             Assert.Equal(LibraryType.Package, result.Data.Match.Library.Type);
@@ -198,7 +198,7 @@ namespace NuGet.DependencyResolver.Core.Tests
             context.RemoteLibraryProviders.Add(remoteProvider.Object);
 
             // Act
-            var result = await ResolverUtility.FindLibraryEntryAsync(range, framework, edge, context, CancellationToken.None);
+            var result = await ResolverUtility.FindLibraryEntryAsync(range, framework, null, edge, context, CancellationToken.None);
 
             // Assert
             Assert.Equal(LibraryType.Unresolved, result.Data.Match.Library.Type);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -1814,13 +1814,14 @@ namespace NuGet.Test
 
                 await DependencyGraphRestoreUtility.RestoreAsync(
                     testSolutionManager,
+                    dgSpec1,
                     restoreContext,
                     providersCache,
                     (c) => { },
                     sourceRepositoryProvider.GetRepositories(),
                     Guid.Empty,
                     false,
-                    dgSpec1,
+                    true,
                     testLogger,
                     CancellationToken.None);
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
@@ -62,26 +62,28 @@ namespace NuGet.PackageManagement.Test
 
                 await DependencyGraphRestoreUtility.RestoreAsync(
                     solutionManager,
+                    dgSpec1,
                     restoreContext,
                     providersCache,
                     (c) => { },
                     sources,
                     Guid.Empty,
                     false,
-                    dgSpec1,
+                    true,
                     testLogger,
                     CancellationToken.None);
 
                 var dgSpec2 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
                 var noOpRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
                     solutionManager,
+                    dgSpec2,
                     restoreContext,
                     providersCache,
                     (c) => { },
                     sources,
                     Guid.Empty,
                     false,
-                    dgSpec2,
+                    true,
                     testLogger,
                     CancellationToken.None);
 
@@ -97,13 +99,14 @@ namespace NuGet.PackageManagement.Test
 
                 var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
                     solutionManager,
+                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
                     restoreContext,
                     new RestoreCommandProvidersCache(),
                     (c) => { },
                     sources,
                     Guid.Empty,
                     false,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                    true,
                     testLogger,
                     CancellationToken.None);
 
@@ -166,13 +169,14 @@ namespace NuGet.PackageManagement.Test
 
                 var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
                     solutionManager,
+                    dgSpec,
                     restoreContext,
                     providersCache,
                     (c) => { },
                     sources,
                     Guid.Empty,
                     false,
-                    dgSpec,
+                    true,
                     testLogger,
                     CancellationToken.None);
 
@@ -228,25 +232,27 @@ namespace NuGet.PackageManagement.Test
 
                 await DependencyGraphRestoreUtility.RestoreAsync(
                     solutionManager,
+                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
                     restoreContext,
                     providersCache,
                     (c) => { },
                     sources,
                     Guid.Empty,
                     false,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                    true,
                     testLogger,
                     CancellationToken.None);
 
                 var noOpRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
                     solutionManager,
+                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
                     restoreContext,
                     providersCache,
                     (c) => { },
                     sources,
                     Guid.Empty,
                     false,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                    true,
                     testLogger,
                     CancellationToken.None);
 
@@ -262,13 +268,14 @@ namespace NuGet.PackageManagement.Test
 
                 var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
                     solutionManager,
+                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
                     restoreContext,
                     new RestoreCommandProvidersCache(),
                     (c) => { },
                     sources,
                     Guid.Empty,
                     false,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                    true,
                     testLogger,
                     CancellationToken.None);
 
@@ -325,25 +332,27 @@ namespace NuGet.PackageManagement.Test
 
                 await DependencyGraphRestoreUtility.RestoreAsync(
                     solutionManager,
+                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
                     restoreContext,
                     providersCache,
                     (c) => { },
                     sources,
                     Guid.Empty,
                     false,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                    true,
                     testLogger,
                     CancellationToken.None);
 
                 var noOpRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
                     solutionManager,
+                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
                     restoreContext,
                     providersCache,
                     (c) => { },
                     sources,
                     Guid.Empty,
                     false,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                    true,
                     testLogger,
                     CancellationToken.None);
 
@@ -401,25 +410,27 @@ namespace NuGet.PackageManagement.Test
 
                 await DependencyGraphRestoreUtility.RestoreAsync(
                     solutionManager,
+                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
                     restoreContext,
                     providersCache,
                     (c) => { },
                     sources,
                     Guid.Empty,
                     false,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                    true,
                     testLogger,
                     CancellationToken.None);
 
                 var noOpRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
                     solutionManager,
+                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
                     restoreContext,
                     providersCache,
                     (c) => { },
                     sources,
                     Guid.Empty,
                     false,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                    true,
                     testLogger,
                     CancellationToken.None);
 
@@ -475,13 +486,14 @@ namespace NuGet.PackageManagement.Test
 
                 await DependencyGraphRestoreUtility.RestoreAsync(
                     solutionManager,
+                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
                     restoreContext,
                     new RestoreCommandProvidersCache(),
                     (c) => { },
                     sources,
                     Guid.Empty,
                     false,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                    true,
                     testLogger,
                     CancellationToken.None);
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedRestoreUtilityTests.cs
@@ -58,13 +58,14 @@ namespace NuGet.Test
                 // Act
                 await DependencyGraphRestoreUtility.RestoreAsync(
                     solutionManager,
+                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
                     restoreContext,
                     new RestoreCommandProvidersCache(),
                     (c) => { },
                     sources,
                     Guid.Empty,
                     false,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                    true,
                     testLogger,
                     CancellationToken.None);
 
@@ -110,13 +111,14 @@ namespace NuGet.Test
                 // Act
                 await DependencyGraphRestoreUtility.RestoreAsync(
                     solutionManager,
+                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
                     restoreContext,
                     new RestoreCommandProvidersCache(),
                     (c) => { },
                     sources,
                     Guid.Empty,
                     false,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                    true,
                     testLogger,
                     CancellationToken.None);
 
@@ -178,13 +180,14 @@ namespace NuGet.Test
                 // Act
                 await DependencyGraphRestoreUtility.RestoreAsync(
                     solutionManager,
+                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
                     restoreContext,
                     new RestoreCommandProvidersCache(),
                     (c) => { },
                     sources,
                     Guid.Empty,
                     false,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                    true,
                     testLogger,
                     CancellationToken.None);
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/DependencyGraphRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/DependencyGraphRestoreUtilityTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,7 +10,6 @@ using NuGet.Commands;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.ProjectManagement;
-using NuGet.ProjectManagement.Projects;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.VisualStudio;
 using NuGet.Test.Utility;
@@ -57,13 +55,14 @@ namespace NuGet.PackageManagement.Test
                 // Act
                 await DependencyGraphRestoreUtility.RestoreAsync(
                     solutionManager,
+                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
                     restoreContext,
                     new RestoreCommandProvidersCache(),
                     (c) => { },
                     sources,
                     Guid.Empty,
                     false,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                    true,
                     logger,
                     CancellationToken.None);
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/InstallationCompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/InstallationCompatibilityTests.cs
@@ -508,6 +508,8 @@ namespace NuGet.PackageManagement.Test
                     null,
                     null,
                     null,
+                    null,
+                    null,
                     ProjectStyle.Unknown,
                     TimeSpan.MinValue);
             }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -6159,7 +6159,7 @@ namespace NuGet.Test
                     CancellationToken.None);
 
                 // Assert
-                Assert.Equal(15, telemetryEvents.Count);
+                Assert.Equal(17, telemetryEvents.Count);
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateRestoreGraph").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateAssetsFile").Count());
@@ -6226,7 +6226,7 @@ namespace NuGet.Test
                     CancellationToken.None);
 
                 // Assert
-                Assert.Equal(15, telemetryEvents.Count);
+                Assert.Equal(17, telemetryEvents.Count);
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateRestoreGraph").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateAssetsFile").Count());
@@ -6300,7 +6300,7 @@ namespace NuGet.Test
                     CancellationToken.None);
 
                 // Assert
-                Assert.Equal(15, telemetryEvents.Count);
+                Assert.Equal(17, telemetryEvents.Count);
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateRestoreGraph").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateAssetsFile").Count());
@@ -6383,7 +6383,7 @@ namespace NuGet.Test
                 }
 
                 // Assert
-                Assert.Equal(17, telemetryEvents.Count);
+                Assert.Equal(19, telemetryEvents.Count);
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateRestoreGraph").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateAssetsFile").Count());
@@ -6457,7 +6457,7 @@ namespace NuGet.Test
                     CancellationToken.None);
 
                 // Assert
-                Assert.Equal(19, telemetryEvents.Count);
+                Assert.Equal(21, telemetryEvents.Count);
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateRestoreGraph").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateAssetsFile").Count());
@@ -6656,7 +6656,7 @@ namespace NuGet.Test
                     token);
 
                 // Assert
-                Assert.Equal(36, telemetryEvents.Count);
+                Assert.Equal(38, telemetryEvents.Count);
 
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateRestoreGraph").Count());

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileFormatTests.cs
@@ -1,0 +1,163 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public class PackagesLockFileFormatTests
+    {
+        [Fact]
+        public void PackagesLockFileFormat_Read()
+        {
+            var nuGetLockFileContent = @"{
+                ""version"": 1,
+                ""dependencies"": {
+                    "".NETFramework,Version=v4.5"": {
+                        ""PackageA"": {
+                            ""type"": ""Direct"",
+                            ""requested"": ""[1.*, )"",
+                            ""resolved"": ""1.0.0"",
+                            ""sha512"": ""sbWWhjA2/cXJHBBKAVo3m2U0KxzNuW5dQANDwx8L96V+L6SML96cM/Myvmp6fiBqIDibvF6+Ss9YC+qqclrXnw=="",
+                            ""dependencies"": {
+                                 ""PackageB"": ""1.0.0""
+                            }
+                        },
+                        ""PackageB"": {
+                            ""type"": ""Transitive"",
+                            ""resolved"": ""1.0.0"",
+                            ""sha512"": ""Fjiywrwerewr4dgbdgbfgjkoiuiorwrwn24+8hjnnuerwrwsfsHYWD3HJYUI7NJHssxDFSFSFEWEW34DFDFCVsxv=="",
+                        }
+                    }
+                }
+            }";
+
+            var lockFile = PackagesLockFileFormat.Parse(nuGetLockFileContent, "In Memory");
+
+            Assert.Equal(1, lockFile.Targets.Count);
+
+            var target = lockFile.Targets.First();
+            Assert.Equal(".NETFramework,Version=v4.5", target.Name);
+            Assert.Equal(2, target.Dependencies.Count);
+
+            Assert.Equal("PackageA", target.Dependencies[0].Id);
+            Assert.Equal(PackageDependencyType.Direct, target.Dependencies[0].Type);
+            Assert.Equal("[1.*, )", target.Dependencies[0].RequestedVersion.ToNormalizedString());
+            Assert.Equal("1.0.0", target.Dependencies[0].ResolvedVersion.ToNormalizedString());
+            Assert.NotEmpty(target.Dependencies[0].Sha512);
+            Assert.Equal(1, target.Dependencies[0].Dependencies.Count);
+            Assert.Equal("PackageB", target.Dependencies[0].Dependencies[0].Id);
+
+
+            Assert.Equal("PackageB", target.Dependencies[1].Id);
+            Assert.Equal(PackageDependencyType.Transitive, target.Dependencies[1].Type);
+            Assert.Null(target.Dependencies[1].RequestedVersion);
+            Assert.Equal("1.0.0", target.Dependencies[0].ResolvedVersion.ToNormalizedString());
+            Assert.NotEmpty(target.Dependencies[1].Sha512);
+        }
+
+        [Fact]
+        public void PackagesLockFileFormat_ReadWithRuntimeGraph()
+        {
+            var nuGetLockFileContent = @"{
+                ""version"": 1,
+                ""dependencies"": {
+                    "".NETFramework,Version=v4.5"": {
+                        ""PackageA"": {
+                            ""type"": ""Direct"",
+                            ""requested"": ""[1.*, )"",
+                            ""resolved"": ""1.0.0"",
+                            ""sha512"": ""sbWWhjA2/cXJHBBKAVo3m2U0KxzNuW5dQANDwx8L96V+L6SML96cM/Myvmp6fiBqIDibvF6+Ss9YC+qqclrXnw=="",
+                            ""dependencies"": {
+                                 ""PackageB"": ""1.0.0""
+                            }
+                        },
+                        ""PackageB"": {
+                            ""type"": ""Transitive"",
+                            ""resolved"": ""1.0.0"",
+                            ""sha512"": ""Fjiywrwerewr4dgbdgbfgjkoiuiorwrwn24+8hjnnuerwrwsfsHYWD3HJYUI7NJHssxDFSFSFEWEW34DFDFCVsxv==""
+                        }
+                    },
+                    "".NETFramework,Version=v4.5/win10-arm"": {
+                        ""PackageA"": {
+                            ""type"": ""Direct"",
+                            ""requested"": ""[1.*, )"",
+                            ""resolved"": ""1.0.0"",
+                            ""sha512"": ""QuiokjhjA2/cXJHBBKAVo3m2U0KxzNuW5dQANDwx8L96V+L6SML96cM/Myvmp6fiBqIDibvF6+Ss9YC+qqcfwef=="",
+                            ""dependencies"": {
+                                 ""PackageB"": ""1.0.0"",
+                                 ""runtime.win10-arm.PackageA"": ""1.0.0""
+                            }
+                        },
+                        ""runtime.win10-arm.PackageA"": {
+                            ""type"": ""Transitive"",
+                            ""resolved"": ""1.0.0"",
+                            ""sha512"": ""dfgdgdfIY434jhjkhkRARFSZSGFSDG423452bgdnuerwrwsfsHYWD3HJYUI7NJHssxDFSFSFEWEW34DFjkyuerd=="",
+                        }
+                    }
+                }
+            }";
+
+            var lockFile = PackagesLockFileFormat.Parse(nuGetLockFileContent, "In Memory");
+
+            Assert.Equal(2, lockFile.Targets.Count);
+
+            var target = lockFile.Targets.First(t => !string.IsNullOrEmpty(t.RuntimeIdentifier));
+            Assert.Equal(".NETFramework,Version=v4.5/win10-arm", target.Name);
+            Assert.Equal(2, target.Dependencies.Count);
+
+            Assert.Equal("PackageA", target.Dependencies[0].Id);
+            Assert.Equal(PackageDependencyType.Direct, target.Dependencies[0].Type);
+            Assert.Equal("[1.*, )", target.Dependencies[0].RequestedVersion.ToNormalizedString());
+            Assert.Equal("1.0.0", target.Dependencies[0].ResolvedVersion.ToNormalizedString());
+            Assert.NotEmpty(target.Dependencies[0].Sha512);
+            Assert.Equal(2, target.Dependencies[0].Dependencies.Count);
+            Assert.Equal("PackageB", target.Dependencies[0].Dependencies[0].Id);
+            Assert.Equal("runtime.win10-arm.PackageA", target.Dependencies[0].Dependencies[1].Id);
+
+            // Runtime graph will only have additional transitive dependenies which are not part of
+            // original TFM graph
+            Assert.Equal("runtime.win10-arm.PackageA", target.Dependencies[1].Id);
+            Assert.Equal(PackageDependencyType.Transitive, target.Dependencies[1].Type);
+            Assert.Null(target.Dependencies[1].RequestedVersion);
+            Assert.Equal("1.0.0", target.Dependencies[0].ResolvedVersion.ToNormalizedString());
+            Assert.NotEmpty(target.Dependencies[1].Sha512);
+        }
+
+        [Fact]
+        public void PackagesLockFileFormat_Write()
+        {
+            var nuGetLockFileContent = @"{
+                ""version"": 1,
+                ""dependencies"": {
+                    "".NETFramework,Version=v4.5"": {
+                        ""PackageA"": {
+                            ""type"": ""Direct"",
+                            ""requested"": ""[1.*, )"",
+                            ""resolved"": ""1.0.0"",
+                            ""sha512"": ""sbWWhjA2/cXJHBBKAVo3m2U0KxzNuW5dQANDwx8L96V+L6SML96cM/Myvmp6fiBqIDibvF6+Ss9YC+qqclrXnw=="",
+                            ""dependencies"": {
+                                 ""PackageB"": ""1.0.0""
+                            }
+                        },
+                        ""PackageB"": {
+                            ""type"": ""Transitive"",
+                            ""resolved"": ""1.0.0"",
+                            ""sha512"": ""Fjiywrwerewr4dgbdgbfgjkoiuiorwrwn24+8hjnnuerwrwsfsHYWD3HJYUI7NJHssxDFSFSFEWEW34DFDFCVsxv=="",
+                        }
+                    }
+                }
+            }";
+
+            var lockFile = PackagesLockFileFormat.Parse(nuGetLockFileContent, "In Memory");
+
+            var output = JObject.Parse(PackagesLockFileFormat.Render(lockFile));
+            var expected = JObject.Parse(nuGetLockFileContent);
+
+            // Assert
+            Assert.Equal(expected.ToString(), output.ToString());
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Frameworks;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public class PackagesLockFileTests
+    {
+        [Fact]
+        public void PackagesLockFile_Equals()
+        {
+            Func<PackagesLockFile> getLockFile = () =>
+            {
+                var lockFile = new PackagesLockFile()
+                {
+                    Version = 1,
+
+                    Targets = new List<PackagesLockFileTarget>()
+                    {
+                        new PackagesLockFileTarget()
+                        {
+                            TargetFramework = FrameworkConstants.CommonFrameworks.Net45,
+
+                            Dependencies = new List<LockFileDependency>()
+                            {
+                                new LockFileDependency()
+                                {
+                                    Id = "PackageA",
+                                    Type = PackageDependencyType.Direct,
+                                    RequestedVersion = VersionRange.Parse("1.0.0"),
+                                    ResolvedVersion = NuGetVersion.Parse("1.0.0"),
+                                    Sha512 = "sha1",
+                                    Dependencies = new List<PackageDependency>()
+                                    {
+                                        new PackageDependency("PackageB", VersionRange.Parse("1.0.0"))
+                                    }
+                                },
+                                new LockFileDependency()
+                                {
+                                    Id = "PackageB",
+                                    Type = PackageDependencyType.Transitive,
+                                    ResolvedVersion = NuGetVersion.Parse("1.0.0"),
+                                    Sha512 = "sha2"
+                                }
+                            }
+                        },
+                        new PackagesLockFileTarget()
+                        {
+                            TargetFramework = FrameworkConstants.CommonFrameworks.Net45,
+
+                            RuntimeIdentifier = "win10-arm",
+
+                            Dependencies = new List<LockFileDependency>()
+                            {
+                                new LockFileDependency()
+                                {
+                                    Id = "PackageA",
+                                    Type = PackageDependencyType.Direct,
+                                    RequestedVersion = VersionRange.Parse("1.0.0"),
+                                    ResolvedVersion = NuGetVersion.Parse("1.0.0"),
+                                    Sha512 = "sha3",
+                                    Dependencies = new List<PackageDependency>()
+                                    {
+                                        new PackageDependency("runtime.win10-arm.PackageA", VersionRange.Parse("1.0.0"))
+                                    }
+                                },
+                                new LockFileDependency()
+                                {
+                                    Id = "runtime.win10-arm.PackageA",
+                                    Type = PackageDependencyType.Transitive,
+                                    ResolvedVersion = NuGetVersion.Parse("1.0.0"),
+                                    Sha512 = "sha4"
+                                }
+                            }
+                        }
+                    }
+                };
+
+                return lockFile;
+            };
+
+            var self = getLockFile();
+            var other = getLockFile();
+
+            Assert.NotSame(self, other);
+            Assert.Equal(self, other);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
@@ -94,6 +94,25 @@ namespace NuGet.ProjectModel.Test
             metadata1.Equals(metadata2).Should().BeFalse();
         }
 
+        [Fact]
+        public void Equals_WithDifferentRestoreLockProperties_ReturnsFalse()
+        {
+            // Arrange
+            var metadata1 = CreateProjectRestoreMetadata();
+            var metadata2 = metadata1.Clone();
+            var metadata3 = metadata1.Clone();
+            var metadata4 = metadata1.Clone();
+
+            metadata2.RestoreLockProperties = new RestoreLockProperties("false", null, false);
+            metadata3.RestoreLockProperties = new RestoreLockProperties("true", "tempPath", false);
+            metadata4.RestoreLockProperties = new RestoreLockProperties("true", null, true);
+
+            // Act & Assert
+            metadata1.Equals(metadata2).Should().BeFalse();
+            metadata1.Equals(metadata3).Should().BeFalse();
+            metadata1.Equals(metadata4).Should().BeFalse();
+        }
+
         private ProjectRestoreMetadata CreateProjectRestoreMetadata()
         {
             var projectReference = new ProjectRestoreReference
@@ -116,6 +135,7 @@ namespace NuGet.ProjectModel.Test
             var noWarn = new HashSet<NuGetLogCode>() { NuGetLogCode.NU1000, NuGetLogCode.NU1500 };
             var warningsAsErrors = new HashSet<NuGetLogCode>() { NuGetLogCode.NU1001, NuGetLogCode.NU1501 };
             var warningProperties = new WarningProperties(allWarningsAsErrors: allWarningsAsErrors, warningsAsErrors: warningsAsErrors, noWarn: noWarn);
+            var restoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile: "true", nuGetLockFilePath: null, restoreLockedMode: false);
             var originalProjectRestoreMetadata = new ProjectRestoreMetadata
             {
                 ProjectStyle = ProjectStyle.PackageReference,
@@ -136,7 +156,8 @@ namespace NuGet.ProjectModel.Test
                 ConfigFilePaths = new List<string>() { "config1" },
                 OriginalTargetFrameworks = new List<string>() { "net45" },
                 Files = new List<ProjectRestoreMetadataFile>() { new ProjectRestoreMetadataFile("packagePath", "absolutePath") },
-                ProjectWideWarningProperties = warningProperties
+                ProjectWideWarningProperties = warningProperties,
+                RestoreLockProperties = restoreLockProperties
             };
 
             return originalProjectRestoreMetadata;

--- a/test/TestUtilities/Test.Utility/PackageManagement/TestDependencyInfoProvider.cs
+++ b/test/TestUtilities/Test.Utility/PackageManagement/TestDependencyInfoProvider.cs
@@ -1,0 +1,77 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Frameworks;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+
+namespace Test.Utility
+{
+    public class TestDependencyInfoProvider : ResourceProvider
+    {
+        public List<SourcePackageDependencyInfo> Packages { get; set; }
+
+        public TestDependencyInfoProvider(List<SourcePackageDependencyInfo> packages)
+            : base(typeof(DependencyInfoResource))
+        {
+            Packages = packages;
+        }
+
+        public override Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        {
+            var nuGetResource = new TestDependencyInfo(source, Packages);
+            return Task.FromResult(new Tuple<bool, INuGetResource>(true, nuGetResource));
+        }
+    }
+
+    /// <summary>
+    /// Resolves against a local set of packages
+    /// </summary>
+    internal class TestDependencyInfo : DependencyInfoResource
+    {
+        public SourceRepository Source { get; set; }
+
+        public List<SourcePackageDependencyInfo> Packages { get; set; }
+
+        public TestDependencyInfo(SourceRepository source, List<SourcePackageDependencyInfo> packages)
+        {
+            Source = source;
+            Packages = packages;
+        }
+
+        public override Task<SourcePackageDependencyInfo> ResolvePackage(PackageIdentity package, NuGetFramework projectFramework, SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, CancellationToken token)
+        {
+            var matchingPackage = Packages.FirstOrDefault(e => PackageIdentity.Comparer.Equals(e, package));
+            return Task.FromResult<SourcePackageDependencyInfo>(ApplySource(matchingPackage));
+        }
+
+        public override Task<IEnumerable<SourcePackageDependencyInfo>> ResolvePackages(string packageId, NuGetFramework projectFramework, SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, CancellationToken token)
+        {
+            var results = new HashSet<SourcePackageDependencyInfo>(
+                Packages.Where(e => StringComparer.OrdinalIgnoreCase.Equals(packageId, e.Id)),
+                PackageIdentity.Comparer);
+
+            return Task.FromResult<IEnumerable<SourcePackageDependencyInfo>>(results.Select(p => ApplySource(p)));
+        }
+
+        SourcePackageDependencyInfo ApplySource(SourcePackageDependencyInfo original)
+        {
+            if (original == null)
+            {
+                return null;
+            }
+
+            return new SourcePackageDependencyInfo(
+                original.Id,
+                original.Version,
+                original.Dependencies,
+                original.Listed,
+                Source);
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/PackageManagement/TestMetadataProvider.cs
+++ b/test/TestUtilities/Test.Utility/PackageManagement/TestMetadataProvider.cs
@@ -1,0 +1,92 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+namespace Test.Utility
+{
+    public class TestMetadataProvider : ResourceProvider
+    {
+        public List<SourcePackageDependencyInfo> Packages { get; set; }
+
+        public TestMetadataProvider(List<SourcePackageDependencyInfo> packages)
+            : base(typeof(MetadataResource))
+        {
+            Packages = packages;
+        }
+
+        public override Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        {
+            var nuGetResource = new TestMetadataResource(Packages);
+            return Task.FromResult(new Tuple<bool, INuGetResource>(true, nuGetResource));
+        }
+    }
+
+    /// <summary>
+    /// Retrieve versions from a local set of packages
+    /// </summary>
+    internal class TestMetadataResource : MetadataResource
+    {
+        public List<SourcePackageDependencyInfo> Packages { get; set; }
+
+        public TestMetadataResource(List<SourcePackageDependencyInfo> packages)
+        {
+            Packages = packages;
+        }
+
+        public override Task<IEnumerable<NuGetVersion>> GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, CancellationToken token)
+        {
+            return Task.FromResult(Packages
+                .Where(p =>
+                    p.Id.Equals(packageId, StringComparison.InvariantCultureIgnoreCase)
+                    && (!p.Version.IsPrerelease || includePrerelease)
+                    && (p.Listed || includeUnlisted))
+                .Select(p => p.Version)
+            );
+        }
+
+        public override Task<bool> Exists(PackageIdentity identity, bool includeUnlisted, SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, CancellationToken token)
+        {
+            return Task.FromResult(Packages
+                .Exists(p =>
+                    ((PackageIdentity)p).Equals(identity)
+                    && (p.Listed || includeUnlisted))
+            );
+        }
+
+        public override Task<bool> Exists(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, CancellationToken token)
+        {
+            return Task.FromResult(Packages
+                .Exists((p) =>
+                    p.Id.Equals(packageId, StringComparison.InvariantCultureIgnoreCase)
+                    && (!p.Version.IsPrerelease || includePrerelease)
+                    && (p.Listed || includeUnlisted))
+            );
+        }
+
+        public async override Task<IEnumerable<KeyValuePair<string, NuGetVersion>>> GetLatestVersions(IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, CancellationToken token)
+        {
+            var results = new List<KeyValuePair<string, NuGetVersion>>();
+
+            foreach (var id in packageIds)
+            {
+                var versions = await GetVersions(id, sourceCacheContext, log, token);
+                var latest = versions.OrderByDescending(p => p, VersionComparer.VersionRelease).FirstOrDefault();
+
+                if (latest != null)
+                {
+                    results.Add(new KeyValuePair<string, NuGetVersion>(id, latest));
+                }
+            }
+
+            return results;
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -160,6 +160,24 @@ namespace NuGet.Test.Utility
             }
         }
 
+        public string NuGetLockFileOutputPath
+        {
+            get
+            {
+                switch (Type)
+                {
+                    case ProjectStyle.PackageReference:
+                        if (Properties.ContainsKey("NuGetLockFilePath"))
+                        {
+                            return Properties["NuGetLockFilePath"];
+                        }
+                        return Path.Combine(Path.GetDirectoryName(ProjectPath), "packages.lock.json");
+                    default:
+                        return null;
+                }
+            }
+        }
+
         public string TargetsOutput
         {
             get


### PR DESCRIPTION
This is Repeatable build using Project lock file implementation and contain following parts:
- generating/ updating project lock file
- consuming project lock file during restore
- Validation of package's sha512 and added error messages as appropriate
- Test infra for legacy PackageReference func tests
- Unit tests for lock file
- Basic workflow is completed

Spec - https://github.com/NuGet/Home/wiki/Enable-repeatable-package-restore-using-lock-file
Technical Spec - https://github.com/NuGet/Home/wiki/Repeatable-build-using-lock-file-implementation
