### PR TITLE
Always return SolutionPackagesFolder in IVsPathContext2 through TryCreateSolutionContext()

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -136,7 +136,7 @@ namespace NuGet.VisualStudio
         {
             var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(_solutionManager.Value, _settings.Value);
 
-            outputPathContext = GetSolutionPathContext(packagesFolderPath);
+            outputPathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value), packagesFolderPath);
 
             return outputPathContext != null;
         }
@@ -150,26 +150,9 @@ namespace NuGet.VisualStudio
 
             var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(solutionDirectory, _settings.Value);
 
-            outputPathContext = GetSolutionPathContext(packagesFolderPath);
+            outputPathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value), packagesFolderPath);
 
             return outputPathContext != null;
-        }
-
-        private IVsPathContext2 GetSolutionPathContext(string packagesFolderPath)
-        {
-            VsPathContext pathContext = null;
-
-            // if solution package folder exists, then set it in VSPathContext
-            if (!string.IsNullOrEmpty(packagesFolderPath) && Directory.Exists(packagesFolderPath))
-            {
-                pathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value), packagesFolderPath);
-            }
-            else
-            {
-                pathContext = new VsPathContext(NuGetPathContext.Create(_settings.Value));
-            }
-
-            return pathContext;
         }
 
         private static async Task<Dictionary<string, EnvDTE.Project>> GetPathToDTEProjectLookupAsync(EnvDTE.DTE dte)

--- a/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContext2.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContext2.cs
@@ -16,7 +16,7 @@ namespace NuGet.VisualStudio
     public interface IVsPathContext2 : IVsPathContext
     {
         /// <summary>
-        /// Solution packages folder directory for packages.config based projects.
+        /// Solution packages folder directory. This will always be set irrespective if folder actually exists or not.
         /// The path returned is an absolute path.
         /// </summary>
         string SolutionPackageFolder { get; }


### PR DESCRIPTION
As per XAML request, we'll always return SolutionPackagesFolder in IVsPathContext2 through TryCreateSolutionContext() api. 

It will resolve their create new project scenario where solution folder doesn't exists yet so NuGet doesn't return it hence they can't validate if references are being resolved from a NuGet package or not unless they keep refreshing NuGet path context by calling into NuGet.

@rrelyea @mgoertz-msft