### PR TITLE
[WIP][Test] Adding lock on telemetryEvents in Packagemanager test

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NuGetVSActionTelemetryService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NuGetVSActionTelemetryService.cs
@@ -24,7 +24,7 @@ namespace NuGet.VisualStudio
         {
         }
 
-        public void EmitTelemetryEvent(TelemetryEvent telemetryData)
+        public virtual void EmitTelemetryEvent(TelemetryEvent telemetryData)
         {
             if (telemetryData == null)
             {

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -6336,7 +6336,7 @@ namespace NuGet.Test
                 .Callback<TelemetryEvent>(x => telemetryEvents.Add(x));
 
             var nugetProjectContext = new TestNuGetProjectContext();
-            var telemetryService = new NuGetVSTelemetryService(telemetrySession.Object);
+            var telemetryService = new TestNuGetVSTelemetryService(telemetrySession.Object, _logger);
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
@@ -6362,6 +6362,13 @@ namespace NuGet.Test
                 // Act
                 var target = new PackageIdentity("NuGet.Versioning", new NuGetVersion("4.6.9"));
 
+                lock (_logger)
+                {
+                    // telemetry count has been flaky, these xunit logs should help track the extra source of events on CI
+                    // for issue https://github.com/NuGet/Home/issues/7105
+                    _logger.LogInformation("Begin PreviewInstallPackageAsync");
+                }
+
                 await nuGetPackageManager.PreviewInstallPackageAsync(
                     buildIntegratedProject,
                     target,
@@ -6371,18 +6378,9 @@ namespace NuGet.Test
                     sourceRepositoryProvider.GetRepositories(),
                     CancellationToken.None);
 
-                // Adding lock since a leftover task in PreviewInstallPackageAsync can cause enumeration failures if it modifies telemetryEvents
-                lock (telemetryEvents)
+                lock (_logger)
                 {
-                    // telemetry count has been flaky, these xunit logs should help track the extra source of events on CI
-                    // for issue https://github.com/NuGet/Home/issues/7105
-                    foreach (var telemetryEvent in telemetryEvents)
-                    {
-                        _logger.LogInformation("--------------------------");
-                        _logger.LogInformation($"Name: {telemetryEvent.Name}");
-                        _logger.LogInformation($"Json: {telemetryEvent.ToJson()}");
-                        _logger.LogInformation("--------------------------");
-                    }
+                    _logger.LogInformation("End PreviewInstallPackageAsync");
                 }
 
                 // Assert
@@ -6915,6 +6913,37 @@ namespace NuGet.Test
             public int GetHashCode(Tuple<TestNuGetProject, PackageIdentity> obj)
             {
                 return obj.GetHashCode();
+            }
+        }
+
+        private class TestNuGetVSTelemetryService : NuGetVSTelemetryService
+        {
+            private ITelemetrySession _telemetrySession;
+            private XunitLogger _logger;
+
+            public TestNuGetVSTelemetryService(ITelemetrySession telemetrySession, XunitLogger logger)
+            {
+                _telemetrySession = telemetrySession ?? throw new ArgumentNullException(nameof(telemetrySession));
+                _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            }
+
+            public override void EmitTelemetryEvent(TelemetryEvent telemetryData)
+            {
+                if (telemetryData == null)
+                {
+                    throw new ArgumentNullException(nameof(telemetryData));
+                }
+
+                lock (_logger)
+                {
+                    _logger.LogInformation("--------------------------");
+                    _logger.LogInformation($"Name: {telemetryData.Name}");
+                    _logger.LogInformation($"Json: {telemetryData.ToJson()}");
+                    _logger.LogInformation($"Stack: {Environment.StackTrace}");
+                    _logger.LogInformation("--------------------------");
+                }
+
+                _telemetrySession.PostEvent(telemetryData);
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -6371,14 +6371,18 @@ namespace NuGet.Test
                     sourceRepositoryProvider.GetRepositories(),
                     CancellationToken.None);
 
-                // telemetry count has been flaky, these xunit logs should help track the extra source of events on CI
-                // for issue https://github.com/NuGet/Home/issues/7105
-                foreach (var telemetryEvent in telemetryEvents)
+                // Adding lock since a leftover task in PreviewInstallPackageAsync can cause enumeration failures if it modifies telemetryEvents
+                lock (telemetryEvents)
                 {
-                    _logger.LogInformation("--------------------------");
-                    _logger.LogInformation($"Name: {telemetryEvent.Name}");
-                    _logger.LogInformation($"Json: {telemetryEvent.ToJson()}");
-                    _logger.LogInformation("--------------------------");
+                    // telemetry count has been flaky, these xunit logs should help track the extra source of events on CI
+                    // for issue https://github.com/NuGet/Home/issues/7105
+                    foreach (var telemetryEvent in telemetryEvents)
+                    {
+                        _logger.LogInformation("--------------------------");
+                        _logger.LogInformation($"Name: {telemetryEvent.Name}");
+                        _logger.LogInformation($"Json: {telemetryEvent.ToJson()}");
+                        _logger.LogInformation("--------------------------");
+                    }
                 }
 
                 // Assert


### PR DESCRIPTION
Followup to https://github.com/NuGet/NuGet.Client/pull/2333

Seems that `NuGetPackageManager.PreviewInstallPackageAsync` leaves tasks running in case of a failure which is still adding events to `telemetryEvents`. To prevent that, this PR adds a test telemetry service `TestNuGetVSTelemetryService` which locks on the logger to make the logging serial.