### PR TITLE
fix broken e2e test

### DIFF
--- a/test/EndToEnd/Packages/InstallPackageThrowsIfMinClientVersionIsNotSatisfied/kitty.1.0.0.nuspec
+++ b/test/EndToEnd/Packages/InstallPackageThrowsIfMinClientVersionIsNotSatisfied/kitty.1.0.0.nuspec
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
-    <metadata minClientVersion="5.0.0.0">
+    <metadata minClientVersion="100.0.0.0">
         <id>kitty</id>
         <version>1.0.0</version>
         <title />

--- a/test/EndToEnd/Packages/UpdatePackageThrowsIfMinClientVersionIsNotSatisfied/kitty.2.0.0.nuspec
+++ b/test/EndToEnd/Packages/UpdatePackageThrowsIfMinClientVersionIsNotSatisfied/kitty.2.0.0.nuspec
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
-    <metadata minClientVersion="5.0.0.1">
+    <metadata minClientVersion="100.0.0.1">
         <id>kitty</id>
         <version>2.0.0</version>
         <title />

--- a/test/EndToEnd/tests/InstallPackageTest.ps1
+++ b/test/EndToEnd/tests/InstallPackageTest.ps1
@@ -2461,7 +2461,7 @@ function Test-InstallPackageThrowsIfMinClientVersionIsNotSatisfied
     $currentSemanticVersion = Get-HostSemanticVersion
 
     # Act & Assert
-    Assert-Throws { $p | Install-Package Kitty -Source $context.RepositoryPath } "The 'kitty 1.0.0' package requires NuGet client version '5.0.0' or above, but the current NuGet version is '$currentSemanticVersion'. To upgrade NuGet, please go to http://docs.nuget.org/consume/installing-nuget"
+    Assert-Throws { $p | Install-Package Kitty -Source $context.RepositoryPath } "The 'kitty 1.0.0' package requires NuGet client version '100.0.0' or above, but the current NuGet version is '$currentSemanticVersion'. To upgrade NuGet, please go to http://docs.nuget.org/consume/installing-nuget"
     Assert-NoPackage $p "Kitty"
 }
 

--- a/test/EndToEnd/tests/UpdatePackageTest.ps1
+++ b/test/EndToEnd/tests/UpdatePackageTest.ps1
@@ -1496,7 +1496,7 @@ function Test-UpdatePackageThrowsIfMinClientVersionIsNotSatisfied
     $currentVersion = Get-HostSemanticVersion
 
     # Act & Assert
-    Assert-Throws { $p | Update-Package Kitty -Source $context.RepositoryPath } "The 'kitty 2.0.0' package requires NuGet client version '5.0.0.1' or above, but the current NuGet version is '$currentVersion'. To upgrade NuGet, please go to http://docs.nuget.org/consume/installing-nuget"
+    Assert-Throws { $p | Update-Package Kitty -Source $context.RepositoryPath } "The 'kitty 2.0.0' package requires NuGet client version '100.0.0.1' or above, but the current NuGet version is '$currentVersion'. To upgrade NuGet, please go to http://docs.nuget.org/consume/installing-nuget"
 
     Assert-NoPackage $p "Kitty" -Version 2.0.0
     Assert-Package $p "Kitty" -Version 1.0.0


### PR DESCRIPTION
Some of our minClientVersion tests were written assuming 5.0.0 was a high enough version, but branding nuget to version 5.0.0 broke these tests.

CC: @PatoBeltran 