### PR TITLE
Error/Warning: Improve NU1605 warning message

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -612,11 +612,20 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Detected package downgrade: {0} from {1} to {2}. Reference the package directly from the project to select a different version..
+        ///   Looks up a localized string similar to Detected package downgrade: {0} from {1} to {2}. Install/Reference the package {0} {1} directly from the project {3} to avoid this..
         /// </summary>
-        internal static string Log_DowngradeWarning {
+        internal static string Log_DowngradeWarningSuggestReference {
             get {
-                return ResourceManager.GetString("Log_DowngradeWarning", resourceCulture);
+                return ResourceManager.GetString("Log_DowngradeWarningSuggestReference", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Detected package downgrade: {0} from {1} to {2}. Do not need to install/reference {0} {2} directly from the project {3}, since {4} already contains {0} {1} as dependency package. If you have to reference package {0} from the project directly, please install/reference package {0} {1} from the project..
+        /// </summary>
+        internal static string Log_DowngradeWarningSuggestRemove {
+            get {
+                return ResourceManager.GetString("Log_DowngradeWarningSuggestRemove", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -205,11 +205,12 @@
   <data name="Log_CycleDetected" xml:space="preserve">
     <value>Cycle detected.</value>
   </data>
-  <data name="Log_DowngradeWarning" xml:space="preserve">
-    <value>Detected package downgrade: {0} from {1} to {2}. Reference the package directly from the project to select a different version.</value>
+  <data name="Log_DowngradeWarningSuggestReference" xml:space="preserve">
+    <value>Detected package downgrade: {0} from {1} to {2}. Install/Reference the package {0} {1} directly from the project {3} to avoid this.</value>
     <comment>{0}: package id
 {1}: requested version
-{2}: resolved version</comment>
+{2}: resolved version
+{3}: project name</comment>
   </data>
   <data name="Log_VersionConflict" xml:space="preserve">
     <value>Version conflict detected for {0}. Reference the package directly from the project to resolve this issue.</value>
@@ -702,5 +703,13 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="LocalsCommand_ClearingNuGetPluginsCache" xml:space="preserve">
     <value>Clearing NuGet plugins cache: {0}</value>
     <comment>{0}: Plugins cache path</comment>
+  </data>
+  <data name="Log_DowngradeWarningSuggestRemove" xml:space="preserve">
+    <value>Detected package downgrade: {0} from {1} to {2}. Do not need to install/reference {0} {2} directly from the project {3}, since {4} already contains {0} {1} as dependency package. If you have to reference package {0} from the project directly, please install/reference package {0} {1} from the project.</value>
+    <comment>{0}: package id
+{1}: requested version
+{2}: resolved version
+{3}: project name
+{4}: package id</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -313,6 +313,21 @@ namespace NuGet.DependencyResolver
             return node.Key.TypeConstraintAllowsAnyOf(LibraryDependencyTarget.Package);
         }
 
+        /// <summary>
+        /// Return root direct dependency node which is the node or the ancestor of the node.
+        /// </summary>
+        public static GraphNode<TItem> GetDirectDependencyNode<TItem>(this GraphNode<TItem> node)
+        {
+            var current = node;
+
+            while (current.OuterNode != null && current.OuterNode.OuterNode != null)
+            {
+                current = current.OuterNode;
+            }
+
+            return current;
+        }
+
         private static bool TryResolveConflicts<TItem>(this GraphNode<TItem> root, List<VersionConflictResult<TItem>> versionConflicts)
         {
             // now we walk the tree as often as it takes to determine 

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/GraphOperationsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/GraphOperationsTests.cs
@@ -176,7 +176,42 @@ namespace NuGet.DependencyResolver.Core.Tests
             var parent = GetProjectNode("a");
             node.OuterNode = parent;
 
-            node.GetPathWithLastRange().Should().Be("a -> b");
+            node.GetPathWithLastRange().ToLowerInvariant().Should().Be("a -> b");
+        }
+
+        // For single node, return itself.
+        [Fact]
+        public void GetDirectDependencyNode_NodeIsRoot()
+        {
+            var node = GetProjectNode("project");
+
+            node.GetDirectDependencyNode().Key.Name.ToLowerInvariant().Should().Be("project");
+        }
+
+        // For direct dependency: project -> package
+        [Fact]
+        public void GetDirectDependencyNode_NodeIsDirectDependency()
+        {
+            var parent = GetProjectNode("project");
+            var package = GetPackageNode("package", "1.0.0", "1.0.0");
+            package.OuterNode = parent;
+
+            package.GetDirectDependencyNode().Key.Name.ToLowerInvariant().Should().Be("package");
+        }
+
+        // For transitive dependency package : projce -> a -> b -> c
+        [Fact]
+        public void GetDirectDependencyNode_NodeIsTransitiveDependency()
+        {
+            var parent = GetProjectNode("project");
+            var packageA = GetPackageNode("a", "1.0.0", "1.0.0");
+            var packageB = GetPackageNode("b", "1.0.0", "1.0.0");
+            var packageC = GetPackageNode("c", "1.0.0", "1.0.0");
+            packageA.OuterNode = parent;
+            packageB.OuterNode = packageA;
+            packageC.OuterNode = packageB;
+
+            packageC.GetDirectDependencyNode().Key.Name.ToLowerInvariant().Should().Be("a");
         }
 
         public GraphNode<RemoteResolveResult> GetNode(string id, string range, LibraryDependencyTarget target, string version, LibraryType type)


### PR DESCRIPTION
NU1605 warning message change:

Case 1 : one bad package contains warning

Detected package downgrade: 'PackageB' from 4.0.0 to 3.5.0. Install/Reference the package PackageB 4.0.0 directly from the project Project to avoid this.
Project -> 'PackageA' 3.5.0 -> 'PackageB' 3.5.0
Project -> 'PackageA' 3.5.0 -> 'PackageD' 4.0.0 -> 'PackageB' 4.0.0

Case 2: one directly dependency package which is lower version downgraded the dependency package of another package.
Detected package downgrade: PackageB from 4.0.0 to 3.5.0. Do not need to install/reference PackageB 3.5.0 directly from the project Project, since PackageA already contains PackageB 4.0.0 as dependency package. If you have to reference package PackageB from the project directly, please install/reference package PackageB 4.0.0 from the project.
Project -> 'PackageB' 3.5.0
Project -> 'PackageA' 4.0.0 -> 'PackageD' 4.0.0 -> 'PackageB' 4.0.0
