### PR TITLE
Extending PumpingJTF from DelegatingJoinableTaskFactory instead of JoinableTaskFactory to resolve CPS deadlock

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
@@ -61,7 +61,7 @@ namespace NuGet.VisualStudio
 
             _projectContext = new Lazy<INuGetProjectContext>(() => new VSAPIProjectContext());
 
-            PumpingJTF = new PumpingJTF(NuGetUIThreadHelper.JoinableTaskFactory.Context);
+            PumpingJTF = new PumpingJTF(NuGetUIThreadHelper.JoinableTaskFactory);
         }
 
         private void RunJTFWithCorrectContext(Project project, Func<Task> asyncTask)
@@ -79,7 +79,7 @@ namespace NuGet.VisualStudio
                         // Lazy load the CPS enabled JoinableTaskFactory for the UI.
                         NuGetUIThreadHelper.SetJoinableTaskFactoryFromService(ProjectServiceAccessor.Value as IProjectServiceAccessor);
 
-                        PumpingJTF = new PumpingJTF(NuGetUIThreadHelper.JoinableTaskFactory.Context);
+                        PumpingJTF = new PumpingJTF(NuGetUIThreadHelper.JoinableTaskFactory);
                         _isCPSJTFLoaded = true;
                     }
                 });

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageUninstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageUninstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -35,7 +35,7 @@ namespace NuGet.VisualStudio
             _settings = settings;
             _solutionManager = solutionManager;
 
-            PumpingJTF = new PumpingJTF(NuGetUIThreadHelper.JoinableTaskFactory.Context);
+            PumpingJTF = new PumpingJTF(NuGetUIThreadHelper.JoinableTaskFactory);
             _deleteOnRestartManager = deleteOnRestartManager;
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Utility/PumpingJTF.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Utility/PumpingJTF.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
@@ -17,10 +17,10 @@ namespace NuGet.VisualStudio
     /// This class is used to have a pumping JTF, in order, to not allow access to DTE objects from a background
     /// thread
     /// </summary>
-    internal class PumpingJTF : JoinableTaskFactory
+    internal class PumpingJTF : DelegatingJoinableTaskFactory
     {
-        public PumpingJTF(JoinableTaskContext joinableTaskContext)
-            : base(joinableTaskContext)
+        public PumpingJTF(JoinableTaskFactory joinableTaskFactory)
+            : base(joinableTaskFactory)
         {
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VsTemplateWizard.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VsTemplateWizard.cs
@@ -69,7 +69,7 @@ namespace NuGet.VisualStudio
 
             _preinstalledPackageInstaller = new PreinstalledPackageInstaller(_packageServices, _solutionManager, _settings, _sourceProvider, (VsPackageInstaller)_installer, _vsProjectAdapterProvider);
 
-            PumpingJTF = new PumpingJTF(NuGetUIThreadHelper.JoinableTaskFactory.Context);
+            PumpingJTF = new PumpingJTF(NuGetUIThreadHelper.JoinableTaskFactory);
         }
 
         private IEnumerable<PreinstalledPackageConfiguration> GetConfigurationsFromVsTemplateFile(string vsTemplatePath)


### PR DESCRIPTION
So the issue is NuGet through PumpingJTF is holding project lock and waiting for UI thread and another Project System call which is on UI thread, is waiting for project lock. Hence deadlock, if it was CPS JTF instead of PumpingJTF then it would have resolved itself but unfortunately, what CPS needs is the callback to OnTransitioningToMainThread which is on the JoinableTaskFactory (and a switch to main thread calls that only for the ambient jobs owner, which in this case is the PumpingJTF and not the CPS JTF). 

So the solution is to wrap and delegate to an inner JTF, which is why we've moved to DelegatingJoinableTaskFactory which allows passing a full JTF instead of just context.

Fixes - [Regression] Deadlock due to using PumpingJTF when calling into CPS [#7103](https://github.com/NuGet/Home/issues/7103) 

@rrelyea @AArnott @jviau @lifengl

