### PR TITLE
Removing NU5006 and falling back to NU5000

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -739,7 +739,7 @@ namespace NuGet.Commands
 
             if (mainPackageBuilder == null)
             {
-                throw new PackagingException(NuGetLogCode.NU5006, string.Format(CultureInfo.CurrentCulture, Strings.Error_PackFailed, path));
+                throw new PackagingException(string.Format(CultureInfo.CurrentCulture, Strings.Error_PackFailed, path));
             }
 
             InitCommonPackageBuilderProperties(mainPackageBuilder);

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -446,11 +446,6 @@ namespace NuGet.Common
         NU5005 = 5005,
 
         /// <summary>
-        /// Error_PackFailed
-        /// </summary>
-        NU5006 = 5006,
-
-        /// <summary>
         /// Error_UnableToLocateBuildOutput
         /// </summary>
         NU5007 = 5007,


### PR DESCRIPTION
After talking to @rohit21agrawal we realized there was no clear scenario that would hit this error. SO I have removed the dedicated error code for it. If the scenario is hit, we will report it as `NU5000`.
