### PR TITLE
Display signing warnings on package install in VS

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/ConsoleProjectContext.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/ConsoleProjectContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.Xml.Linq;
+using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.ProjectManagement;
 
@@ -53,9 +54,19 @@ namespace NuGet.CommandLine
             }
         }
 
+        public void Log(ILogMessage message)
+        {
+            _logger.Log(message);
+        }
+
         public void ReportError(string message)
         {
             _logger.LogError(message);
+        }
+
+        public void ReportError(ILogMessage message)
+        {
+            _logger.Log(message);
         }
 
         public virtual ProjectManagement.FileConflictAction ResolveFileConflict(string message)

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
@@ -133,12 +133,12 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
                 if (!string.IsNullOrEmpty(ex.Message))
                 {
-                    Log(LogUtility.LogLevelToMessageLevel(LogLevel.Error), ex.AsLogMessage().FormatWithCode());
+                    Log(ex.AsLogMessage());
                 }
 
                 var logMessages = ex.Results.SelectMany(p => p.Issues).ToList();
 
-                logMessages.ForEach(p => Log(LogUtility.LogLevelToMessageLevel(p.Level), p.FormatWithCode()));
+                logMessages.ForEach(p => Log(ex.AsLogMessage()));
             }
             catch (Exception ex)
             {
@@ -191,12 +191,12 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
                 if (!string.IsNullOrEmpty(ex.Message))
                 {
-                    Log(LogUtility.LogLevelToMessageLevel(LogLevel.Error), ex.AsLogMessage().FormatWithCode());
+                    Log(ex.AsLogMessage());
                 }
 
                 var logMessages = ex.Results.SelectMany(p => p.Issues).ToList();
 
-                logMessages.ForEach(p => Log(LogUtility.LogLevelToMessageLevel(p.Level), p.FormatWithCode()));
+                logMessages.ForEach(p => Log(p));
             }
             catch (Exception ex)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
@@ -211,12 +211,12 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
                 if (!string.IsNullOrEmpty(ex.Message))
                 {
-                    Log(LogUtility.LogLevelToMessageLevel(LogLevel.Error), ex.AsLogMessage().FormatWithCode());
+                    Log(ex.AsLogMessage());
                 }
 
                 var logMessages = ex.Results.SelectMany(p => p.Issues).ToList();
 
-                logMessages.ForEach(p => Log(LogUtility.LogLevelToMessageLevel(p.Level), p.FormatWithCode()));
+                logMessages.ForEach(p => Log(ex.AsLogMessage()));
             }
             catch (Exception ex)
             {
@@ -258,12 +258,12 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
                 if (!string.IsNullOrEmpty(ex.Message))
                 {
-                    Log(LogUtility.LogLevelToMessageLevel(LogLevel.Error), ex.AsLogMessage().FormatWithCode());
+                    Log(ex.AsLogMessage());
                 }
 
                 var logMessages = ex.Results.SelectMany(p => p.Issues).ToList();
 
-                logMessages.ForEach(p => Log(LogUtility.LogLevelToMessageLevel(p.Level), p.FormatWithCode()));
+                logMessages.ForEach(p => Log(p));
             }
             catch (Exception ex)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -927,9 +927,6 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         /// <summary>
         /// Implement INuGetProjectContext.Log(). Called by worker thread.
         /// </summary>
-        /// <param name="level"></param>
-        /// <param name="message"></param>
-        /// <param name="args"></param>
         public void Log(MessageLevel level, string message, params object[] args)
         {
             if (args.Length > 0)
@@ -938,6 +935,14 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             }
 
             BlockingCollection.Add(new LogMessage(level, message));
+        }
+
+        /// <summary>
+        /// Implement INuGetProjectContext.Log(). Called by worker thread.
+        /// </summary>
+        public void Log(ILogMessage message)
+        {
+            BlockingCollection.Add(new LogMessage(LogUtility.LogLevelToMessageLevel(message.Level), message.FormatWithCode()));
         }
 
         /// <summary>
@@ -1093,6 +1098,11 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         public ExecutionContext ExecutionContext { get; protected set; }
 
         public void ReportError(string message)
+        {
+            // no-op
+        }
+
+        public void ReportError(ILogMessage message)
         {
             // no-op
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -356,7 +356,7 @@ namespace NuGet.PackageManagement.UI
             if (!string.IsNullOrEmpty(ex.Message))
             {
                 UILogger.ReportError(ex.AsLogMessage());
-                ProjectContext.Log(MessageLevel.Error, ex.AsLogMessage().FormatWithCode());
+                ProjectContext.Log(ex.AsLogMessage());
             }
 
             foreach (var result in ex.Results)
@@ -365,9 +365,10 @@ namespace NuGet.PackageManagement.UI
                 var warningList = result.GetWarningIssues().ToList();
 
                 errorList.ForEach(p => UILogger.ReportError(p));
+                warningList.ForEach(p => UILogger.ReportError(p));
 
-                errorList.ForEach(p => ProjectContext.Log(MessageLevel.Error, p.FormatWithCode()));
-                warningList.ForEach(p => ProjectContext.Log(MessageLevel.Warning, p.FormatWithCode()));
+                errorList.ForEach(p => ProjectContext.Log(p));
+                warningList.ForEach(p => ProjectContext.Log(p));
             }            
         }
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUIProjectContext.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUIProjectContext.cs
@@ -2,10 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Windows.Threading;
 using System.Xml.Linq;
+using NuGet.Common;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.ProjectManagement;
@@ -96,6 +94,16 @@ namespace NuGet.PackageManagement.UI
         public XDocument OriginalPackagesConfig { get; set; }
 
         public void ReportError(string message)
+        {
+            _logger.ReportError(message);
+        }
+
+        public void Log(ILogMessage message)
+        {
+            _logger.Log(message);
+        }
+
+        public void ReportError(ILogMessage message)
         {
             _logger.ReportError(message);
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PRMigratorBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PRMigratorBar.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Xml.Linq;
 using Microsoft.VisualStudio.Shell;
+using NuGet.Common;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.ProjectManagement;
@@ -54,9 +55,19 @@ namespace NuGet.PackageManagement.UI
             ShowMessage(message);
         }
 
+        public void Log(ILogMessage message)
+        {
+            ShowMessage(message.FormatWithCode());
+        }
+
         public void ReportError(string message)
         {
             ShowMessage(message);
+        }
+
+        public void ReportError(ILogMessage message)
+        {
+            ShowMessage(message.FormatWithCode());
         }
 
         private void ShowMessage(string message)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
@@ -184,9 +184,19 @@ namespace NuGet.PackageManagement.UI
             ShowMessage(message);
         }
 
+        public void Log(ILogMessage message)
+        {
+            ShowMessage(message.FormatWithCode());
+        }
+
         public void ReportError(string message)
         {
             ShowMessage(message);
+        }
+
+        public void ReportError(ILogMessage message)
+        {
+            ShowMessage(message.FormatWithCode());
         }
 
         public FileConflictAction ResolveFileConflict(string message)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/RestartRequestBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/RestartRequestBar.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Controls;
 using System.Xml.Linq;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.ProjectManagement;
 using NuGet.VisualStudio;
@@ -119,9 +120,19 @@ namespace NuGet.PackageManagement.UI
             ShowMessage(message);
         }
 
+        public void Log(ILogMessage message)
+        {
+            ShowMessage(message.FormatWithCode());
+        }
+
         public void ReportError(string message)
         {
             ShowMessage(message);
+        }
+
+        public void ReportError(ILogMessage message)
+        {
+            ShowMessage(message.FormatWithCode());
         }
 
         public void CleanUp()

--- a/src/NuGet.Clients/NuGet.Tools/OutputConsoleLogger.cs
+++ b/src/NuGet.Clients/NuGet.Tools/OutputConsoleLogger.cs
@@ -98,6 +98,23 @@ namespace NuGetVSExtension
             }
         }
 
+        public void Log(ILogMessage message)
+        {
+            if (message.Level == LogLevel.Information
+                || message.Level == LogLevel.Error
+                || message.Level == LogLevel.Warning
+                || _verbosityLevel > DefaultVerbosityLevel)
+            {
+                RunTaskOnUI(() => OutputConsole.WriteLine(message.FormatWithCode()));
+
+                if (message.Level == LogLevel.Error ||
+                    message.Level == LogLevel.Warning)
+                {
+                    RunTaskOnUI(() => ReportError(message));
+                }                    
+            }
+        }
+
         private int GetMSBuildVerbosityLevel()
         {
             var properties = _dte.get_Properties(DTEEnvironmentCategory, DTEProjectPage);

--- a/src/NuGet.Clients/NuGet.Tools/OutputConsoleLogger.cs
+++ b/src/NuGet.Clients/NuGet.Tools/OutputConsoleLogger.cs
@@ -26,6 +26,11 @@ namespace NuGetVSExtension
         private int _verbosityLevel;
         private EnvDTE.DTE _dte;
 
+        // keeps a reference to BuildEvents so that our event handler
+        // won't get disconnected because of GC.
+        private EnvDTE.BuildEvents _buildEvents;
+        private EnvDTE.SolutionEvents _solutionEvents;
+
         public IOutputConsole OutputConsole { get; private set; }
 
         public Lazy<ErrorListTableDataSource> ErrorListTableDataSource { get; private set; }
@@ -54,6 +59,10 @@ namespace NuGetVSExtension
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 _dte = serviceProvider.GetDTE();
+                _buildEvents = _dte.Events.BuildEvents;
+                _buildEvents.OnBuildBegin += (_, __) => { ErrorListTableDataSource.Value.ClearNuGetEntries(); };
+                _solutionEvents = _dte.Events.SolutionEvents;
+                _solutionEvents.AfterClosing += () => { ErrorListTableDataSource.Value.ClearNuGetEntries(); };
 
                 OutputConsole = consoleProvider.CreatePackageManagerConsole();
             });

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/UserInterfaceService/INuGetUILogger.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/UserInterfaceService/INuGetUILogger.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
 using NuGet.Common;
 
 namespace NuGet.PackageManagement.VisualStudio
@@ -9,6 +8,8 @@ namespace NuGet.PackageManagement.VisualStudio
     public interface INuGetUILogger
     {
         void Log(ProjectManagement.MessageLevel level, string message, params object[] args);
+
+        void Log(ILogMessage message);
 
         void ReportError(string message);
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VSAPIProjectContext.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VSAPIProjectContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Xml.Linq;
 using NuGet.Common;
@@ -43,6 +42,11 @@ namespace NuGet.VisualStudio
             // No logging needed when using the API
         }
 
+        public void Log(ILogMessage message)
+        {
+            // No logging needed when using the API
+        }
+
         public FileConflictAction ResolveFileConflict(string message)
         {
             return FileConflictAction.IgnoreAll;
@@ -52,10 +56,7 @@ namespace NuGet.VisualStudio
 
         public ISourceControlManagerProvider SourceControlManagerProvider { get; }
 
-        public ExecutionContext ExecutionContext
-        {
-            get { return null; }
-        }
+        public ExecutionContext ExecutionContext => null;
 
         public bool SkipAssemblyReferences { get; }
 
@@ -69,6 +70,12 @@ namespace NuGet.VisualStudio
         {
             // no-op
             Debug.Fail(message);
+        }
+
+        public void ReportError(ILogMessage message)
+        {
+            // no-op
+            Debug.Fail(message.FormatWithCode());
         }
 
         public NuGetActionType ActionType { get; set; }

--- a/src/NuGet.Core/NuGet.PackageManagement/EmptyNuGetProjectContext.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/EmptyNuGetProjectContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Xml.Linq;
+using NuGet.Common;
 using NuGet.Packaging;
 
 namespace NuGet.ProjectManagement
@@ -22,20 +23,25 @@ namespace NuGet.ProjectManagement
 
         public PackageExtractionContext PackageExtractionContext { get; set; }
 
-        public ISourceControlManagerProvider SourceControlManagerProvider
-        {
-            get { return null; }
-        }
+        public ISourceControlManagerProvider SourceControlManagerProvider => null;
 
-        public ExecutionContext ExecutionContext
-        {
-            get { return null; }
-        }
+        public ExecutionContext ExecutionContext => null;
 
         public XDocument OriginalPackagesConfig { get; set; }
 
         public void ReportError(string message)
         {
+            // No-op
+        }
+
+        public void Log(ILogMessage message)
+        {
+            // No-op
+        }
+
+        public void ReportError(ILogMessage message)
+        {
+            // No-op
         }
 
         public NuGetActionType ActionType { get; set; }

--- a/src/NuGet.Core/NuGet.PackageManagement/INuGetProjectContext.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/INuGetProjectContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Xml.Linq;
+using NuGet.Common;
 using NuGet.Packaging;
 
 namespace NuGet.ProjectManagement
@@ -18,7 +19,20 @@ namespace NuGet.ProjectManagement
         /// </summary>
         void Log(MessageLevel level, string message, params object[] args);
 
+        /// <summary>
+        /// Logs a message for the given project context
+        /// </summary>
+        void Log(ILogMessage message);
+
+        /// <summary>
+        /// Logs an error for the given project context
+        /// </summary>
         void ReportError(string message);
+
+        /// <summary>
+        /// Logs an error or warning for the given project context
+        /// </summary>
+        void ReportError(ILogMessage message);
 
         /// <summary>
         /// Resolves a file conflict for the given project context

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2355,7 +2355,7 @@ namespace NuGet.PackageManagement
 
                     foreach (var warning in warnings)
                     {
-                        nuGetProjectContext.Log(MessageLevel.Warning, warning.FormatWithCode());
+                        nuGetProjectContext.Log(warning);
                     }
 
                     exceptionInfo = ExceptionDispatchInfo.Capture(unwrappedException);

--- a/src/NuGet.Core/NuGet.PackageManagement/ProjectContextLogger.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/ProjectContextLogger.cs
@@ -21,9 +21,7 @@ namespace NuGet.PackageManagement
         {
             if (DisplayMessage(message.Level))
             {
-                var messageLevel = LogUtility.LogLevelToMessageLevel(message.Level);
-
-                _projectContext.Log(messageLevel, message.FormatWithCode());
+                _projectContext.Log(message);
             }
         }
 
@@ -31,9 +29,7 @@ namespace NuGet.PackageManagement
         {
             if (DisplayMessage(message.Level))
             {
-                var messageLevel = LogUtility.LogLevelToMessageLevel(message.Level);
-
-                _projectContext.Log(messageLevel, message.FormatWithCode());
+                _projectContext.Log(message);
             }
 
             return Task.FromResult(0);

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
+using NuGet.Shared;
 
 namespace NuGet.Packaging
 {
@@ -1007,6 +1008,9 @@ namespace NuGet.Packaging
                 if (verifyResult.Signed)
                 {
                     await LogPackageSignatureVerificationAsync(source, package, packageExtractionContext.Logger, verifyResult);
+
+                    // Add the package id to all results
+                    verifyResult.Results.SelectMany(r => r.Issues).ForEach(l => l.LibraryId = package.Id);
 
                     if (verifyResult.Valid)
                     {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
@@ -45,7 +45,6 @@ namespace NuGet.Packaging.Signing
         {
             Results = results;
             PackageIdentity = package;
-            results.SelectMany(r => r.Issues).ForEach(l => l.LibraryId = package.ToString());
         }
 
         public SignatureException(NuGetLogCode code, string message, PackageIdentity package)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/PackageVerificationResult.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/PackageVerificationResult.cs
@@ -34,7 +34,7 @@ namespace NuGet.Packaging.Signing
 
         public IEnumerable<ILogMessage> GetWarningIssues()
         {
-            return Issues.Where(p => p.Level==LogLevel.Warning);
+            return Issues.Where(p => p.Level == LogLevel.Warning);
         }
 
         public IEnumerable<ILogMessage> GetErrorIssues()

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -142,12 +142,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 errors.Count().Should().Be(1);
                 errors.First().Code.Should().Be(NuGetLogCode.NU3008);
                 errors.First().Message.Should().Be(_NU3008Message);
-                errors.First().LibraryId.Should().Be(packageX.ToString());
+                errors.First().LibraryId.Should().Be(packageX.Id);
 
                 warnings.Count().Should().Be(1);
                 warnings.First().Code.Should().Be(NuGetLogCode.NU3027);
                 warnings.First().Message.Should().Be(_NU3027Message);
-                warnings.First().LibraryId.Should().Be("X.9.0.0");
+                warnings.First().LibraryId.Should().Be(packageX.Id);
             }
         }
 

--- a/test/TestUtilities/Test.Utility/ProjectManagement/TestNuGetProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/ProjectManagement/TestNuGetProjectContext.cs
@@ -24,6 +24,12 @@ namespace Test.Utility
             // Console.WriteLine(message, args);
         }
 
+        public void Log(ILogMessage message)
+        {
+            // Uncomment when you want to debug tests.
+            // Console.WriteLine(message.FormatWithCode());
+        }
+
         public FileConflictAction ResolveFileConflict(string message)
         {
             return FileConflictAction.IgnoreAll;
@@ -50,6 +56,10 @@ namespace Test.Utility
         public XDocument OriginalPackagesConfig { get; set; }
 
         public void ReportError(string message)
+        {
+        }
+
+        public void ReportError(ILogMessage message)
         {
         }
 


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6318  
Regression: No

## Fix
Details: This PR adds support, in `INuGetProjectContext` and all of its child types, to log/error using `ILogMessage`. This primarily improves package install scenarios into classic csproj, where warnings were logged into the output console but not displayed in the VS error list.

Before - 
![image](https://user-images.githubusercontent.com/10507120/42854648-b5a89a38-89f1-11e8-9bca-bb46ec3bd998.png)

After - 
![image](https://user-images.githubusercontent.com/10507120/42854774-607a6d88-89f2-11e8-9e51-9124682ee1e6.png)


Further, this fixes a regression caused by https://github.com/NuGet/NuGet.Client/commit/d0f97b53c1850d7209723afc7aa85986beabe3b8 where the error list would not clear on solution close and build.

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  UI change
Validation done:  manual validation
