### PR TITLE
Build in parallel and use SkipNonexistent targets when the discovered msbuild version is higher than 15.5

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -78,19 +78,19 @@ namespace NuGet.CommandLine
 
         protected internal CoreV2.NuGet.IPackageRepositoryFactory RepositoryFactory { get; set; }
 
-        private Lazy<MsBuildToolset> MsBuildDirectory {
+        private Lazy<MsBuildToolset> MsBuildToolset {
             get
             {
-                if (_defaultMsBuildDirectory == null)
+                if (_defaultMsBuildToolset == null)
                 {
-                    _defaultMsBuildDirectory = MsBuildUtility.GetMsBuildDirectoryFromMsBuildPath(null, null, Console);
+                    _defaultMsBuildToolset = MsBuildUtility.GetMsBuildDirectoryFromMsBuildPath(null, null, Console);
 
                 }
-                return _defaultMsBuildDirectory;
+                return _defaultMsBuildToolset;
             }
         }
 
-        private Lazy<MsBuildToolset> _defaultMsBuildDirectory;
+        private Lazy<MsBuildToolset> _defaultMsBuildToolset;
 
         public CommandAttribute CommandAttribute
         {
@@ -181,7 +181,7 @@ namespace NuGet.CommandLine
 
         protected virtual void SetDefaultCredentialProvider()
         {
-            SetDefaultCredentialProvider(MsBuildDirectory);
+            SetDefaultCredentialProvider(MsBuildToolset);
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -78,7 +78,7 @@ namespace NuGet.CommandLine
 
         protected internal CoreV2.NuGet.IPackageRepositoryFactory RepositoryFactory { get; set; }
 
-        private Lazy<string> MsBuildDirectory {
+        private Lazy<MsBuildToolset> MsBuildDirectory {
             get
             {
                 if (_defaultMsBuildDirectory == null)
@@ -90,7 +90,7 @@ namespace NuGet.CommandLine
             }
         }
 
-        private Lazy<string> _defaultMsBuildDirectory;
+        private Lazy<MsBuildToolset> _defaultMsBuildDirectory;
 
         public CommandAttribute CommandAttribute
         {
@@ -188,9 +188,9 @@ namespace NuGet.CommandLine
         /// Set default credential provider for the HttpClient, which is used by V2 sources.
         /// Also set up authenticated proxy handling for V3 sources.
         /// </summary>
-        protected void SetDefaultCredentialProvider(Lazy<string> msbuildDirectory)
+        protected void SetDefaultCredentialProvider(Lazy<MsBuildToolset> msbuildDirectory)
         {
-            Protocol.Plugins.PluginDiscoveryUtility.InternalPluginDiscoveryRoot = new Lazy<string>(() => Protocol.Plugins.PluginDiscoveryUtility.GetInternalPluginRelativeToMSBuildExe(msbuildDirectory.Value));
+            Protocol.Plugins.PluginDiscoveryUtility.InternalPluginDiscoveryRoot = new Lazy<string>(() => Protocol.Plugins.PluginDiscoveryUtility.GetInternalPluginRelativeToMSBuildExe(msbuildDirectory.Value.Path));
             CredentialService = new CredentialService(new AsyncLazy<IEnumerable<ICredentialProvider>>(() => GetCredentialProvidersAsync()), NonInteractive, handlesDefaultCredentials: PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders);
 
             CoreV2.NuGet.HttpClient.DefaultCredentialProvider = new CredentialServiceAdapter(CredentialService);

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
@@ -96,7 +96,7 @@ namespace NuGet.CommandLine
             packArgs.Arguments = Arguments;
             packArgs.OutputDirectory = OutputDirectory;
             packArgs.BasePath = BasePath;
-            packArgs.MsBuildDirectory = MsBuildUtility.GetMsBuildDirectoryFromMsBuildPath(MSBuildPath, MSBuildVersion, Console);
+            packArgs.MsBuildDirectory = new Lazy<string>(() => MsBuildUtility.GetMsBuildDirectoryFromMsBuildPath(MSBuildPath, MSBuildVersion, Console).Value.Path);
 
             // Get the input file
             packArgs.Path = PackCommandRunner.GetInputFile(packArgs);

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -59,9 +59,9 @@ namespace NuGet.CommandLine
         }
 
         // The directory that contains msbuild
-        private Lazy<string> _msbuildDirectory;
+        private Lazy<MsBuildToolset> _msbuildDirectory;
 
-        private Lazy<string> MsBuildDirectory
+        private Lazy<MsBuildToolset> MsBuildDirectory
         {
             get
             {
@@ -839,7 +839,7 @@ namespace NuGet.CommandLine
                 restoreInputs.PackagesConfigFiles.Add(solutionLevelPackagesConfig);
             }
 
-            var projectFiles = MsBuildUtility.GetAllProjectFileNames(solutionFileFullPath, MsBuildDirectory.Value);
+            var projectFiles = MsBuildUtility.GetAllProjectFileNames(solutionFileFullPath, MsBuildDirectory.Value.Path);
 
             foreach (var projectFile in projectFiles)
             {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -56,7 +56,7 @@ namespace NuGet.CommandLine
         public string MSBuildPath { get; set; }
 
         // The directory that contains msbuild
-        private Lazy<string> _msbuildDirectory;
+        private string _msbuildDirectory;
 
         public override async Task ExecuteCommandAsync()
         {
@@ -75,7 +75,7 @@ namespace NuGet.CommandLine
                 throw new CommandLineException(NuGetResources.InvalidFile);
             }
 
-            _msbuildDirectory = MsBuildUtility.GetMsBuildDirectoryFromMsBuildPath(MSBuildPath, MSBuildVersion, Console);
+            _msbuildDirectory = MsBuildUtility.GetMsBuildDirectoryFromMsBuildPath(MSBuildPath, MSBuildVersion, Console).Value.Path;
             var context = new UpdateConsoleProjectContext(Console, FileConflictAction);
 
             string inputFileName = Path.GetFileName(inputFile);
@@ -95,7 +95,7 @@ namespace NuGet.CommandLine
                 }
 
                 var projectSystem = new MSBuildProjectSystem(
-                    _msbuildDirectory.Value,
+                    _msbuildDirectory,
                     inputFile,
                     context);
                 await UpdatePackagesAsync(projectSystem, GetRepositoryPath(projectSystem.ProjectFullPath));
@@ -417,7 +417,7 @@ namespace NuGet.CommandLine
                 throw new CommandLineException(LocalizedResourceManager.GetString("MultipleProjectFilesFound"), packageReferenceFilePath);
             }
 
-            return new MSBuildProjectSystem(_msbuildDirectory.Value, projectFiles[0], projectContext);
+            return new MSBuildProjectSystem(_msbuildDirectory, projectFiles[0], projectContext);
         }
 
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -2,7 +2,6 @@ extern alias CoreV2;
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -264,10 +264,10 @@ namespace NuGet.CommandLine
             AddPropertyIfHasValue(args, "SolutionDir", solutionDirectory);
             AddPropertyIfHasValue(args, "SolutionName", solutionName);
 
-            // If the MSBuild version used supports SkipNonextentTargets and BuildInParallel
+            // If the MSBuild version used does not support SkipNonextentTargets and BuildInParallel
             // use the performance optimization
             // When BuildInParallel is used with ContinueOnError it does not continue in some scenarios
-            if (toolset.ParsedVersion.CompareTo(new Version(15, 5)) >= 0)
+            if (toolset.ParsedVersion.CompareTo(new Version(15, 5)) < 0)
             {
                 AddProperty(args, "RestoreBuildInParallel", bool.FalseString);
                 AddProperty(args, "RestoreUseSkipNonexistentTargets", bool.FalseString);

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -466,7 +466,7 @@ namespace NuGet.CommandLine
         /// <param name="userVersion">version string as passed by user (so may be empty)</param>
         /// <param name="console">The console used to output messages.</param>
         /// <returns>The msbuild directory.</returns>
-        public static MsBuildToolset GetMsBuildDirectory(string userVersion, IConsole console)
+        public static MsBuildToolset GetMsBuildToolset(string userVersion, IConsole console)
         {
             var currentDirectoryCache = Directory.GetCurrentDirectory();
             var msBuildDirectory = string.Empty;
@@ -523,7 +523,7 @@ namespace NuGet.CommandLine
         }
 
         /// <summary>
-        /// This method is called by GetMsBuildDirectory(). This method is not intended to be called directly.
+        /// This method is called by GetMsBuildToolset(). This method is not intended to be called directly.
         /// It's marked public so that it can be called by unit tests.
         /// </summary>
         /// <param name="userVersion">version string as passed by user (so may be empty)</param>
@@ -810,7 +810,7 @@ namespace NuGet.CommandLine
             }
             else
             {
-                return new Lazy<MsBuildToolset>(() => GetMsBuildDirectory(msbuildVersion, console));
+                return new Lazy<MsBuildToolset>(() => GetMsBuildToolset(msbuildVersion, console));
             }
         }
 

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -266,7 +266,8 @@ namespace NuGet.CommandLine
 
             // If the MSBuild version used supports SkipNonextentTargets and BuildInParallel
             // use the performance optimization
-            if (toolset.ParsedVersion.CompareTo(new Version(15,5)) >= 0)
+            // When BuildInParallel is used with ContinueOnError it does not continue in some scenarios
+            if (toolset.ParsedVersion.CompareTo(new Version(15, 5)) >= 0)
             {
                 AddProperty(args, "RestoreBuildInParallel", bool.FalseString);
                 AddProperty(args, "RestoreUseSkipNonexistentTargets", bool.FalseString);

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -264,13 +264,9 @@ namespace NuGet.CommandLine
             AddPropertyIfHasValue(args, "SolutionDir", solutionDirectory);
             AddPropertyIfHasValue(args, "SolutionName", solutionName);
 
-            // Disable parallel and use ContinueOnError since this may run on an older
-            // version of MSBuild that do not support SkipNonexistentTargets.
-            // When BuildInParallel is used with ContinueOnError it does not continue in
-            // some scenarios.
-            // Allow opt in to msbuild 15.5 behavior with NUGET_RESTORE_MSBUILD_USESKIPNONEXISTENT
-            var nonExistFlag = Environment.GetEnvironmentVariable("NUGET_RESTORE_MSBUILD_USESKIPNONEXISTENT");
-            if (nonExistFlag == null ? toolset.ParsedVersion.Major >= 15 && toolset.ParsedVersion.Minor >= 5: !StringComparer.OrdinalIgnoreCase.Equals(nonExistFlag, bool.TrueString))
+            // If the MSBuild version used supports SkipNonextentTargets and BuildInParallel
+            // use the performance optimization
+            if (toolset.ParsedVersion.CompareTo(new Version(15,5)) >= 0)
             {
                 AddProperty(args, "RestoreBuildInParallel", bool.FalseString);
                 AddProperty(args, "RestoreUseSkipNonexistentTargets", bool.FalseString);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -25,7 +25,7 @@ namespace NuGet.CommandLine.Test
             public TestInfo(string projectFileContent, string projectName = "proj1")
             {
                 ProjectDirectory = TestDirectory.Create();
-                MSBuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null);
+                MSBuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
                 NuGetProjectContext = new TestNuGetProjectContext();
 
                 var projectFilePath = Path.Combine(ProjectDirectory, projectName + ".csproj");

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
@@ -25,7 +25,7 @@ namespace NuGet.CommandLine.Test
             public TestInfo(string projectFileContent, string projectName = "proj1")
             {
                 ProjectDirectory = TestDirectory.Create();
-                MSBuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
+                MSBuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
                 NuGetProjectContext = new TestNuGetProjectContext();
 
                 var projectFilePath = Path.Combine(ProjectDirectory, projectName + ".csproj");

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -21,7 +21,7 @@ namespace NuGet.CommandLine.Test
                 userVersion: null,
                 console: null,
                 installedToolsets: toolsets.OrderByDescending(t => t),
-                getMsBuildPathInPathVar: () => null);
+                getMsBuildPathInPathVar: () => null).Path;
 
             // Assert
             Assert.Equal(expectedPath, directory);
@@ -38,7 +38,7 @@ namespace NuGet.CommandLine.Test
                 userVersion: null,
                 console: null,
                 installedToolsets: toolsets.OrderByDescending(t => t),
-                getMsBuildPathInPathVar: () => expectedPath);
+                getMsBuildPathInPathVar: () => expectedPath).Path;
 
             // Assert
             Assert.Equal(expectedPath, directory);
@@ -55,7 +55,7 @@ namespace NuGet.CommandLine.Test
                 userVersion: null,
                 console: null,
                 installedToolsets: toolsets.OrderByDescending(t => t),
-                getMsBuildPathInPathVar: () => expectedPath);
+                getMsBuildPathInPathVar: () => expectedPath).Path;
 
             // Assert
             Assert.Equal(expectedPath, directory);
@@ -72,7 +72,7 @@ namespace NuGet.CommandLine.Test
                 userVersion: null,
                 console: null,
                 installedToolsets: toolsets.OrderByDescending(t => t),
-                getMsBuildPathInPathVar: () => @"c:\foo");
+                getMsBuildPathInPathVar: () => @"c:\foo").Path;
 
             // Assert
             Assert.Equal(expectedPath, directory);
@@ -93,7 +93,7 @@ namespace NuGet.CommandLine.Test
                 userVersion: userVersion,
                 console: null,
                 installedToolsets: toolsets.OrderByDescending(t => t),
-                getMsBuildPathInPathVar: () => null);
+                getMsBuildPathInPathVar: () => null).Path;
 
             // Assert
             Assert.Equal(expectedPath, directory);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -85,7 +85,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null);
+                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
 
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
@@ -178,7 +178,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null);
+                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -281,7 +281,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null);
+                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
                 var projectSystem1 = new MSBuildProjectSystem(msbuildDirectory, projectFile1, testNuGetProjectContext);
                 var projectSystem2 = new MSBuildProjectSystem(msbuildDirectory, projectFile2, testNuGetProjectContext);
                 var msBuildProject1 = new MSBuildNuGetProject(projectSystem1, packagesDirectory, projectDirectory1);
@@ -385,7 +385,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null);
+                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
                 var projectSystem1 = new MSBuildProjectSystem(msbuildDirectory, projectFile1, testNuGetProjectContext);
                 var msBuildProject1 = new MSBuildNuGetProject(projectSystem1, packagesDirectory, projectDirectory);
 
@@ -482,7 +482,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null);
+                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -561,7 +561,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null);
+                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -646,7 +646,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null);
+                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -736,7 +736,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null);
+                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -827,7 +827,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null);
+                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a2Package))
@@ -911,7 +911,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null);
+                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -991,7 +991,7 @@ namespace NuGet.CommandLine.Test
                 var packagesConfigFile = Path.Combine(projectDirectory, "packages.config");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null);
+                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -1072,7 +1072,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null);
+                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -1189,7 +1189,7 @@ namespace NuGet.CommandLine.Test
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
 
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null);
+                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
 
                 var projectSystem1 = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject1 = new MSBuildNuGetProject(projectSystem1, packagesDirectory, projectDirectory);
@@ -1374,7 +1374,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null);
+                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
                 var projectSystem1 = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject1 = new MSBuildNuGetProject(projectSystem1, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -1491,7 +1491,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null);
+                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
                 var projectSystem1 = new MSBuildProjectSystem(msbuildDirectory, projectFile1, testNuGetProjectContext);
                 var projectSystem2 = new MSBuildProjectSystem(msbuildDirectory, projectFile2, testNuGetProjectContext);
                 var msBuildProject1 = new MSBuildNuGetProject(projectSystem1, packagesDirectory, projectDirectory1);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -85,7 +85,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
+                var msbuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
 
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
@@ -178,7 +178,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
+                var msbuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -281,7 +281,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
+                var msbuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
                 var projectSystem1 = new MSBuildProjectSystem(msbuildDirectory, projectFile1, testNuGetProjectContext);
                 var projectSystem2 = new MSBuildProjectSystem(msbuildDirectory, projectFile2, testNuGetProjectContext);
                 var msBuildProject1 = new MSBuildNuGetProject(projectSystem1, packagesDirectory, projectDirectory1);
@@ -385,7 +385,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
+                var msbuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
                 var projectSystem1 = new MSBuildProjectSystem(msbuildDirectory, projectFile1, testNuGetProjectContext);
                 var msBuildProject1 = new MSBuildNuGetProject(projectSystem1, packagesDirectory, projectDirectory);
 
@@ -482,7 +482,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
+                var msbuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -561,7 +561,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
+                var msbuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -646,7 +646,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
+                var msbuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -736,7 +736,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
+                var msbuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -827,7 +827,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
+                var msbuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a2Package))
@@ -911,7 +911,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
+                var msbuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -991,7 +991,7 @@ namespace NuGet.CommandLine.Test
                 var packagesConfigFile = Path.Combine(projectDirectory, "packages.config");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
+                var msbuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -1072,7 +1072,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
+                var msbuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
                 var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -1189,7 +1189,7 @@ namespace NuGet.CommandLine.Test
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
 
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
+                var msbuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
 
                 var projectSystem1 = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject1 = new MSBuildNuGetProject(projectSystem1, packagesDirectory, projectDirectory);
@@ -1374,7 +1374,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
+                var msbuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
                 var projectSystem1 = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
                 var msBuildProject1 = new MSBuildNuGetProject(projectSystem1, packagesDirectory, projectDirectory);
                 using (var stream = File.OpenRead(a1Package))
@@ -1491,7 +1491,7 @@ namespace NuGet.CommandLine.Test
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
 
                 var testNuGetProjectContext = new TestNuGetProjectContext();
-                var msbuildDirectory = MsBuildUtility.GetMsBuildDirectory(null, null).Path;
+                var msbuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
                 var projectSystem1 = new MSBuildProjectSystem(msbuildDirectory, projectFile1, testNuGetProjectContext);
                 var projectSystem2 = new MSBuildProjectSystem(msbuildDirectory, projectFile2, testNuGetProjectContext);
                 var msBuildProject1 = new MSBuildNuGetProject(projectSystem1, packagesDirectory, projectDirectory1);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
@@ -407,7 +407,7 @@ namespace NuGet.CommandLine
                 Authors = new[] { "Outercurve Foundation" },
             };
             var projectMock = new Mock<MockProject>();
-            var msbuildDirectory = NuGet.CommandLine.MsBuildUtility.GetMsBuildDirectory(null, null);
+            var msbuildDirectory = NuGet.CommandLine.MsBuildUtility.GetMsBuildDirectory(null, null).Path;
             var factory = new ProjectFactory(msbuildDirectory, projectMock.Object);
 
             // act

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
@@ -407,7 +407,7 @@ namespace NuGet.CommandLine
                 Authors = new[] { "Outercurve Foundation" },
             };
             var projectMock = new Mock<MockProject>();
-            var msbuildDirectory = NuGet.CommandLine.MsBuildUtility.GetMsBuildDirectory(null, null).Path;
+            var msbuildDirectory = NuGet.CommandLine.MsBuildUtility.GetMsBuildToolset(null, null).Path;
             var factory = new ProjectFactory(msbuildDirectory, projectMock.Object);
 
             // act


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6898
Regression: Ye  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
Whenever possible we should call MSBuild with SkipNonexistentTargets and BuildInParallel. 

This is a nuget.exe only change so it should be safe to go in 4.8. 

//cc @rrelyea 

## Testing/Validation
Tests Added: No
Reason for not adding tests:  
Validation done:  
