### PR TITLE
Error/Warning: Improve NU1107 error message

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -446,7 +446,7 @@ namespace NuGet.Commands
         /// are not logged. This is to avoid flooding the log with long 
         /// dependency chains for every package.
         /// </summary>
-        private static async Task<bool> ValidateRestoreGraphsAsync(IEnumerable<RestoreTargetGraph> graphs, ILogger logger)
+        private async Task<bool> ValidateRestoreGraphsAsync(IEnumerable<RestoreTargetGraph> graphs, ILogger logger)
         {
             // Check for cycles
             var success = await ValidateCyclesAsync(graphs, logger);
@@ -487,17 +487,19 @@ namespace NuGet.Commands
         /// <summary>
         /// Logs an error and returns false if any conflicts exist.
         /// </summary>
-        private static async Task<bool> ValidateConflictsAsync(IEnumerable<RestoreTargetGraph> graphs, ILogger logger)
+        private async Task<bool> ValidateConflictsAsync(IEnumerable<RestoreTargetGraph> graphs, ILogger logger)
         {
             foreach (var graph in graphs)
             {
                 foreach (var versionConflict in graph.AnalyzeResult.VersionConflicts)
                 {
                     var message = string.Format(
-                            CultureInfo.CurrentCulture,
-                            Strings.Log_VersionConflict,
-                            versionConflict.Selected.Key.Name)
-                        + $" {Environment.NewLine} {versionConflict.Selected.GetPathWithLastRange()} {Environment.NewLine} {versionConflict.Conflicting.GetPathWithLastRange()}.";
+                           CultureInfo.CurrentCulture,
+                           Strings.Log_VersionConflict,
+                           versionConflict.Selected.Key.Name,
+                           versionConflict.Selected.GetIdAndVersionOrRange(),
+                           _request.Project.Name)
+                       + $" {Environment.NewLine} {versionConflict.Selected.GetPathWithLastRange()} {Environment.NewLine} {versionConflict.Conflicting.GetPathWithLastRange()}.";
 
                     await logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1107, message, versionConflict.Selected.Key.Name, graph.TargetGraphName));
                     return false;

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1134,7 +1134,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Version conflict detected for {0}. Reference the package directly from the project to resolve this issue..
+        ///   Looks up a localized string similar to Version conflict detected for {0}. Install/reference {1} directly to project {2} to resolve this issue..
         /// </summary>
         internal static string Log_VersionConflict {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -212,7 +212,7 @@
 {2}: resolved version</comment>
   </data>
   <data name="Log_VersionConflict" xml:space="preserve">
-    <value>Version conflict detected for {0}. Reference the package directly from the project to resolve this issue.</value>
+    <value>Version conflict detected for {0}. Install/reference {1} directly to project {2} to resolve this issue.</value>
   </data>
   <data name="Error_UnknownBuildAction" xml:space="preserve">
     <value>Package '{0}' specifies an invalid build action '{1}' for file '{2}'.</value>


### PR DESCRIPTION
Current message: 
NU1107:
Version conflict detected for 'PackageA'. Reference the package directly from the project to resolve this issue.
'PackageB' 3.5.0 -> 'PackageA' (= 3.5.0)
'PackageC' 4.0.0 -> 'PackageA' (= 4.0.0)

with the change:
NU1107:
Version conflict detected for 'PackageA'. Install/reference 'PackageA 4.0.0' directly to project 'Project' to resolve this issue.
Project -> 'PackageB' 3.5.0 -> 'PackageA' (= 3.5.0)
Project -> 'PackageC' 4.0.0 -> 'PackageA' (= 4.0.0)