### PR TITLE
Adding package id and source prefix to signing logs

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -1032,7 +1032,6 @@ namespace NuGet.Packaging
             }
         }
 
-
         /// <summary>
         /// Adds a package ID and package source as a prefix to log messages and adds package ID to the message.LibraryId.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -1009,8 +1009,10 @@ namespace NuGet.Packaging
                 {
                     await LogPackageSignatureVerificationAsync(source, package, packageExtractionContext.Logger, verifyResult);
 
-                    // Add the package id to all results
-                    verifyResult.Results.SelectMany(r => r.Issues).ForEach(l => l.LibraryId = package.Id);
+                    // Update errors and warnings with package id and source
+                    verifyResult.Results
+                            .SelectMany(r => r.Issues)
+                            .ForEach(e => AddPackageIdentityToSignatureLog(source, package, e));
 
                     if (verifyResult.Valid)
                     {
@@ -1028,6 +1030,19 @@ namespace NuGet.Packaging
                     }
                 }
             }
+        }
+
+
+        /// <summary>
+        /// Adds a package ID and package source as a prefix to log messages and adds package ID to the message.LibraryId.
+        /// </summary>
+        /// <param name="source">package source.</param>
+        /// <param name="package">package identity.</param>
+        /// <param name="message">ILogMessage to be modified.</param>
+        private static void AddPackageIdentityToSignatureLog(string source, PackageIdentity package, SignatureLog message)
+        {
+            message.LibraryId = package.Id;
+            message.Message = string.Format(CultureInfo.CurrentCulture, Strings.ExtractionLog_InformationPrefix, package.Id, package.Version, source, message.Message);
         }
 
         private static async Task LogPackageSignatureVerificationAsync(

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -449,6 +449,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package &apos;{0} {1}&apos; from source &apos;{2}&apos;: {3}.
+        /// </summary>
+        internal static string ExtractionLog_InformationPrefix {
+            get {
+                return ResourceManager.GetString("ExtractionLog_InformationPrefix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to update file time for {0}: {1}.
         /// </summary>
         internal static string FailedFileTime {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -701,4 +701,11 @@ Valid from:</comment>
   <data name="NoRepositoryCountersignature" xml:space="preserve">
     <value>Verification settings require a repository countersignature, but the package does not have a repository countersignature.</value>
   </data>
+  <data name="ExtractionLog_InformationPrefix" xml:space="preserve">
+    <value>Package '{0} {1}' from source '{2}': {3}</value>
+    <comment>0 - package ID
+1 - package versions
+2 - package source url
+3 - Log Message</comment>
+  </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/InstallCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/InstallCommandTests.cs
@@ -23,10 +23,14 @@ namespace NuGet.CommandLine.FuncTest.Commands
     [Collection(SignCommandTestCollection.Name)]
     public class InstallCommandTests
     {
-        private const string _NU3008 = "NU3008: The package integrity check failed.";
-        private const string _NU3012 = "NU3012: The author primary signature found a chain building issue: The certificate is revoked.";
-        private const string _NU3018 = "NU3018: The author primary signature found a chain building issue: A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.";
-        private const string _NU3027 = "NU3027: The signature should be timestamped to enable long-term signature validity after the certificate has expired.";
+        private static readonly string _NU3008Message = "The package integrity check failed.";
+        private static readonly string _NU3008 = "NU3008: {0}";
+        private static readonly string _NU3027Message = "The signature should be timestamped to enable long-term signature validity after the certificate has expired.";
+        private static readonly string _NU3027 = "NU3027: {0}";
+        private static readonly string _NU3012Message = "The author primary signature found a chain building issue: The certificate is revoked.";
+        private static readonly string _NU3012 = "NU3012: {0}";
+        private static readonly string _NU3018Message = "The author primary signature found a chain building issue: A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.";
+        private static readonly string _NU3018 = "NU3018: {0}";
 
         private SignCommandTestFixture _testFixture;
         private TrustedTestCert<TestCertificate> _trustedTestCert;
@@ -68,10 +72,9 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(0);
-                result.AllOutput.Should().Contain($"WARNING: {_NU3027}");
+                result.AllOutput.Should().Contain($"WARNING: {string.Format(_NU3027, SigningTestUtility.AddSignatureLogPrefix(_NU3027Message, nupkg.Identity, context.WorkingDirectory))}");
             }
         }
-
 
         [CIOnlyFact]
         public async Task Install_RepoSignedPackage_SucceedsAsync()
@@ -102,7 +105,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(0);
-                result.AllOutput.Should().Contain($"WARNING: {_NU3027}");
+                result.AllOutput.Should().Contain($"WARNING: {string.Format(_NU3027, SigningTestUtility.AddSignatureLogPrefix(_NU3027Message, nupkg.Identity, context.WorkingDirectory))}");
             }
         }
 
@@ -135,8 +138,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(0);
-                result.AllOutput.Should().Contain($"WARNING: {_NU3018}");
-                result.AllOutput.Should().Contain($"WARNING: {_NU3027}");
+                result.AllOutput.Should().Contain($"WARNING: {string.Format(_NU3018, SigningTestUtility.AddSignatureLogPrefix(_NU3018Message, nupkg.Identity, context.WorkingDirectory))}");
+                result.AllOutput.Should().Contain($"WARNING: {string.Format(_NU3027, SigningTestUtility.AddSignatureLogPrefix(_NU3027Message, nupkg.Identity, context.WorkingDirectory))}");
             }
         }
 
@@ -170,8 +173,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(1);
-                result.Errors.Should().Contain(_NU3008);
-                result.AllOutput.Should().Contain($"WARNING: {_NU3027}");
+                result.Errors.Should().Contain(string.Format(_NU3008, SigningTestUtility.AddSignatureLogPrefix(_NU3008Message, nupkg.Identity, context.WorkingDirectory)));
+                result.AllOutput.Should().Contain($"WARNING: {string.Format(_NU3027, SigningTestUtility.AddSignatureLogPrefix(_NU3027Message, nupkg.Identity, context.WorkingDirectory))}");
             }
         }
 
@@ -215,9 +218,9 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(1);
-                result.Errors.Should().Contain(_NU3008);
-                result.Errors.Should().Contain(_NU3012);
-                result.AllOutput.Should().Contain($"WARNING: {_NU3027}");
+                result.Errors.Should().Contain(string.Format(_NU3008, SigningTestUtility.AddSignatureLogPrefix(_NU3008Message, nupkg.Identity, context.WorkingDirectory)));
+                result.Errors.Should().Contain(string.Format(_NU3012, SigningTestUtility.AddSignatureLogPrefix(_NU3012Message, nupkg.Identity, context.WorkingDirectory)));
+                result.AllOutput.Should().Contain($"WARNING: {string.Format(_NU3027, SigningTestUtility.AddSignatureLogPrefix(_NU3027Message, nupkg.Identity, context.WorkingDirectory))}");
             }
         }
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
@@ -28,9 +27,9 @@ namespace NuGet.CommandLine.FuncTest.Commands
     public class RestoreCommandTests
     {
         private static readonly string _NU3008Message = "The package integrity check failed.";
-        private static readonly string _NU3008 = $"NU3008: {_NU3008Message}";
+        private static readonly string _NU3008 = "NU3008: {0}";
         private static readonly string _NU3027Message = "The signature should be timestamped to enable long-term signature validity after the certificate has expired.";
-        private static readonly string _NU3027 = $"NU3027: {_NU3027Message}";
+        private static readonly string _NU3027 = "NU3027: {0}";
 
         private SignCommandTestFixture _testFixture;
         private TrustedTestCert<TestCertificate> _trustedTestCert;
@@ -47,7 +46,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public async Task Restore_TamperedPackageInPackagesConfig_FailsWithErrorAsync()
         {
             // Arrange
-            var nupkg = new SimpleTestPackageContext("A", "1.0.0");
             var packagesConfigContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
                 "<packages>" +
                 "  <package id=\"X\" version=\"9.0.0\" targetFramework=\"net461\" />" +
@@ -90,8 +88,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(1);
-                result.Errors.Should().Contain(_NU3008);
-                result.AllOutput.Should().Contain(_NU3027);
+                result.Errors.Should().Contain(string.Format(_NU3008, SigningTestUtility.AddSignatureLogPrefix(_NU3008Message, packageX.Identity, pathContext.PackageSource)));
+                result.AllOutput.Should().Contain(string.Format(_NU3027, SigningTestUtility.AddSignatureLogPrefix(_NU3027Message, packageX.Identity, pathContext.PackageSource)));
             }
         }
 
@@ -99,8 +97,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
         public async Task Restore_TamperedPackage_FailsAsync()
         {
             // Arrange
-            var nupkg = new SimpleTestPackageContext("A", "1.0.0");
-
             using (var pathContext = new SimpleTestPathContext())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
@@ -136,17 +132,17 @@ namespace NuGet.CommandLine.FuncTest.Commands
             
                 // Assert
                 result.ExitCode.Should().Be(1);
-                result.Errors.Should().Contain(_NU3008);
-                result.AllOutput.Should().Contain($"WARNING: {_NU3027}");
+                result.Errors.Should().Contain(string.Format(_NU3008, SigningTestUtility.AddSignatureLogPrefix(_NU3008Message, packageX.Identity, pathContext.PackageSource)));
+                result.AllOutput.Should().Contain($"WARNING: {string.Format(_NU3027, SigningTestUtility.AddSignatureLogPrefix(_NU3027Message, packageX.Identity, pathContext.PackageSource))}");
 
                 errors.Count().Should().Be(1);
                 errors.First().Code.Should().Be(NuGetLogCode.NU3008);
-                errors.First().Message.Should().Be(_NU3008Message);
+                errors.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(_NU3008Message, packageX.Identity, pathContext.PackageSource));
                 errors.First().LibraryId.Should().Be(packageX.Id);
 
                 warnings.Count().Should().Be(1);
                 warnings.First().Code.Should().Be(NuGetLogCode.NU3027);
-                warnings.First().Message.Should().Be(_NU3027Message);
+                warnings.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(_NU3027Message, packageX.Identity, pathContext.PackageSource));
                 warnings.First().LibraryId.Should().Be(packageX.Id);
             }
         }

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
@@ -1131,13 +1131,14 @@ namespace NuGet.Packaging.FuncTest
                     {
                         exception.Results.First().Issues.Count().Should().Be(1);
                         exception.Results.First().Issues.First().Code.Should().Be(NuGetLogCode.NU3034);
-                        exception.Results.First().Issues.First().Message.Should().Be(_noMatchInRepoAllowList);
+                        exception.Results.First().Issues.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(_noMatchInRepoAllowList, packageReader.GetIdentity(), dir));
                     }
                     else
                     {
                         exception.Results.First().Issues.Count().Should().Be(2);
                         exception.Results.First().Issues.All(e => e.Code == NuGetLogCode.NU3034).Should().BeTrue();
-                        exception.Results.First().Issues.All(e => e.Message.Equals(_noMatchInRepoAllowList) || e.Message.Equals(_noClientAllowList));
+                        exception.Results.First().Issues.All(e => e.Message.Equals(SigningTestUtility.AddSignatureLogPrefix(_noMatchInRepoAllowList, packageReader.GetIdentity(), dir)) ||
+                                                                  e.Message.Equals(SigningTestUtility.AddSignatureLogPrefix(_noClientAllowList, packageReader.GetIdentity(), dir)));
                     }
                 }
             }

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -11,6 +11,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
+using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
 using NuGet.Shared;
 using NuGet.Test.Utility;
@@ -31,6 +32,8 @@ namespace Test.Utility.Signing
 {
     public static class SigningTestUtility
     {
+        private static readonly string _signatureLogPrefix = "Package '{0} {1}' from source '{2}':";
+
         /// <summary>
         /// Modification generator that can be passed to TestCertificate.Generate().
         /// The generator will change the certificate EKU to ClientAuth.
@@ -714,6 +717,11 @@ namespace Test.Utility.Signing
                 issue.Code == NuGetLogCode.NU3018 &&
                 issue.Level == logLevel &&
                 issue.Message == untrustedRoot);
+        }
+
+        public static string AddSignatureLogPrefix(string log, PackageIdentity package, string source)
+        {
+            return $"{string.Format(_signatureLogPrefix, package.Id, package.Version, source)} {log}";
         }
     }
 }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6944
Regression: No

## Fix
Details: This PR fixes signing logs by adding a prefix indicating the package id, version and source for the error or warning.


## Result
before - 

![image](https://user-images.githubusercontent.com/10507120/42478235-cf54397a-8388-11e8-8a6f-483278a346e8.png)

```
WARNING: NU3018: The author primary signature found a chain building issue: A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
WARNING: NU3037: The author primary signature validity period has expired.
Committing restore...
Generating MSBuild file F:\validation\testsdk\obj\testsdk.csproj.nuget.g.props.
Writing lock file to disk. Path: F:\validation\testsdk\obj\project.assets.json
Restore failed in 884.94 ms for F:\validation\testsdk\testsdk.csproj.

Errors in F:\validation\testsdk\testsdk.csproj
    NU3008: The package integrity check failed.
```


after - 

![image](https://user-images.githubusercontent.com/10507120/42976632-8ce26bec-8b77-11e8-807d-d1eab08e7bde.png)

```
WARNING: NU3018: Package 'A 1.0.0' from source 'F:\validation\test-local-source': The author primary signature found a chain building issue: A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
WARNING: NU3037: Package 'A 1.0.0' from source 'F:\validation\test-local-source': The author primary signature validity period has expired.
Committing restore...
Generating MSBuild file C:\Users\anmishr\Source\Repos\ConsoleApp175\ConsoleApp175\obj\ConsoleApp175.csproj.nuget.g.props.
Writing lock file to disk. Path: C:\Users\anmishr\Source\Repos\ConsoleApp175\ConsoleApp175\obj\project.assets.json
Restore failed in 545.51 ms for C:\Users\anmishr\Source\Repos\ConsoleApp175\ConsoleApp175\ConsoleApp175.csproj.

Errors in C:\Users\anmishr\Source\Repos\ConsoleApp175\ConsoleApp175\ConsoleApp175.csproj
    NU3008: Package 'A 1.0.0' from source 'F:\validation\test-local-source': The package integrity check failed.
```

## Testing/Validation
Tests Added: Yes
Validation done:  Manual validation
