### PR TITLE
Showing PR migrator option on all the projects but display error dialog for incompatible project

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
@@ -83,7 +83,6 @@
       <Button guid="guidDialogCmdSet" id="cmdidUpgradeNuGetProject" priority="0x0400" type="Button">
         <Parent guid="guidReferenceContext" id="cmdAddReferenceGroup" />
         <Icon guid="guidToolbarImages" id="bmpUpgradeNuGetProject" />
-        <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <CommandName>cmdidUpgradeNuGetProject</CommandName>
@@ -94,7 +93,6 @@
       <Button guid="guidDialogCmdSet" id="cmdidUpgradePackagesConfig" priority="0x0410" type="Button">
         <Parent guid="guidReferenceContext" id="cmdAddReferenceGroup" />
         <Icon guid="guidToolbarImages" id="bmpUpgradeNuGetProject" />
-        <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <CommandName>cmdidUpgradePackagesConfig</CommandName>
@@ -165,6 +163,8 @@
     <VisibilityItem guid="guidDialogCmdSet" id="cmdidAddPackages" context="UICONTEXT_SolutionExistsAndNotBuildingAndNotDebugging" />
     <VisibilityItem guid="guidDialogCmdSet" id="cmdidAddPackagesForSolution" context="UICONTEXT_SolutionExistsAndNotBuildingAndNotDebugging" />
     <VisibilityItem guid="guidDialogCmdSet" id="cmdidRestorePackages" context="UICONTEXT_SolutionExistsAndNotBuildingAndNotDebugging" />
+    <VisibilityItem guid="guidDialogCmdSet" id="cmdidUpgradePackagesConfig" context="UICONTEXT_SolutionExistsAndNotBuildingAndNotDebugging" />
+    <VisibilityItem guid="guidDialogCmdSet" id="cmdidUpgradeNuGetProject" context="UICONTEXT_SolutionExistsAndNotBuildingAndNotDebugging" />
   </VisibilityConstraints>
 
   <CommandPlacements>

--- a/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
@@ -268,6 +268,15 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Project is not eligible for migration. Either the project is not packages.config based or doesn&apos;t support PackageReference yet. Visit https://docs.microsoft.com/en-us/nuget/reference/migrate-packages-config-to-package-reference for more information..
+        /// </summary>
+        internal static string ProjectMigrateErrorMessage {
+            get {
+                return ResourceManager.GetString("ProjectMigrateErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Some NuGet packages were installed using a target framework different from the current target framework and may need to be reinstalled. Visit http://docs.nuget.org/docs/workflows/reinstalling-packages for more information.  Packages affected: {0}.
         /// </summary>
         internal static string ProjectUpgradeAndRetargetErrorMessage {

--- a/src/NuGet.Clients/NuGet.Tools/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.resx
@@ -198,4 +198,7 @@
   <data name="DTE_ProjectUnsupported" xml:space="preserve">
     <value>The project '{0}' is unsupported</value>
   </data>
+  <data name="ProjectMigrateErrorMessage" xml:space="preserve">
+    <value>Project is not eligible for migration. Either the project is not packages.config based or doesn't support PackageReference yet. Visit https://docs.microsoft.com/en-us/nuget/reference/migrate-packages-config-to-package-reference for more information.</value>
+  </data>
 </root>


### PR DESCRIPTION
With current behavior, lot of customers get confused as when do they see this migrator option or not, and often thinks that something is broken in NuGet which is why they are not seeing this option for some projects (which are either incompatible with PR or doesn't even have a packages.config file).

So we'll now show PR migrator option for all the projects which means it will be shown for a blank new library or c++ project or ASP.NET web app, etc... but after clicking the option, it will show a error dialog with will tell customer that this is a incompatible project and give NuGet doc link to get more information. 

Fixes - https://github.com/NuGet/Home/issues/6958

@rrelyea 