### PR TITLE
Fix possible ArgumentOutOfRangeException from CombinationSolver.FindSolution when groupedItems empty

### DIFF
--- a/src/NuGet.Core/NuGet.Resolver/CombinationSolver.cs
+++ b/src/NuGet.Core/NuGet.Resolver/CombinationSolver.cs
@@ -144,9 +144,7 @@ namespace NuGet.Resolver
                         return null;
                     }
                 }
-
-                i = consistent ? MoveForward(i, ref consistent) : MoveBackward(i, ref consistent);
-
+                
                 if (diagnosticOutput != null && i > highest)
                 {
                     highest = i;
@@ -171,6 +169,8 @@ namespace NuGet.Resolver
                     // Impossible (no solution)
                     return null;
                 }
+
+                i = consistent ? MoveForward(i, ref consistent) : MoveBackward(i, ref consistent);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Resolver.Test/CombinationSolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Resolver.Test/CombinationSolverTests.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace NuGet.Resolver.Test
+{
+    /// <summary>
+    /// Tests for <see cref="CombinationSolver{T}"/>
+    /// </summary>
+    public class CombinationSolverTests
+    {
+        /// <summary>
+        /// Test that <see cref="CombinationSolver{T}.FindSolution(IEnumerable{IEnumerable{T}}, IComparer{T}, Func{T, T, bool}, Action{IEnumerable{T}})"/> solves constraint satisfaction problem in trivial case of empty collection.
+        /// </summary>
+        [Fact]
+        public void FindSolution_SolvesTrivialCase()
+        {
+            var groupedItems = Array.Empty<IEnumerable<int>>(); // empty list of groups
+            var itemSorter = Comparer<int>.Default;
+            Func<int, int, bool> shouldRejectPairFunc = (a, b) => true;
+
+            Assert.Empty(CombinationSolver<int>.FindSolution(groupedItems, itemSorter, shouldRejectPairFunc, null)); // empty set is unique solution
+        }
+    }
+}


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7130
Regression: No  

## Fix
Details: Moved MoveForward call below length check

## Testing/Validation
Tests Added: Yes, unit test
