### PR TITLE
Adding submodule checkout to Apex test step in the yaml file

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -356,7 +356,6 @@ phases:
         Remove-Item -Path $(BuildOutputTargetPath) -Force -Recurse -ErrorAction SilentlyContinue
     condition: "eq(variables['Agent.JobStatus'], 'Failed')"
 
-
 - phase: Functional_Tests_On_Windows
   dependsOn: Initialize_Build
   variables:
@@ -637,7 +636,6 @@ phases:
         KillRunningInstancesOfVS
     condition: "always()"
 
-
 - phase: Apex_Tests_On_Windows
   dependsOn:
   - Build_and_UnitTest
@@ -651,6 +649,10 @@ phases:
     demands: DotNetFramework
 
   steps:
+  - checkout: self
+    clean: true
+    submodules: true
+    
   - task: PowerShell@1
     displayName: "Print Environment Variables"
     inputs:


### PR DESCRIPTION
Based on an email discussion with VSTS folks, it seems that VSTS has stopped checking out submodules by default. This PR fixes that by adding the following step to the Apex test step - 

```
- checkout: self
    clean: true
    submodules: true
```