### PR TITLE
Adding warning for P2P reference with ATF in GetReferenceNearestTargetFrameworkTask

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
@@ -67,11 +67,10 @@ namespace NuGet.Build.Tasks
             }
 
             var fallbackNuGetFrameworks = new List<NuGetFramework>();
-            NuGetFramework projectNuGetFramework;
 
             // validate current project framework
             var errorMessage = string.Format(Strings.UnsupportedTargetFramework, CurrentProjectTargetFramework);
-            if (!TryParseFramework(CurrentProjectTargetFramework, errorMessage, logger, out projectNuGetFramework))
+            if (!TryParseFramework(CurrentProjectTargetFramework, errorMessage, logger, out var projectNuGetFramework))
             {
                 return false;
             }

--- a/src/NuGet.Core/NuGet.Build.Tasks/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Strings.Designer.cs
@@ -62,7 +62,7 @@ namespace NuGet.Build.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Project &apos;{0}&apos; was restored using &apos;{1}&apos; instead of the project target framework &apos;{2}&apos;. This project may not be fully compatible with your project..
+        ///   Looks up a localized string similar to ProjectReference &apos;{0}&apos; was resolved using &apos;{1}&apos; instead of the project target framework &apos;{2}&apos;. This project may not be fully compatible with your project..
         /// </summary>
         internal static string ImportsFallbackWarning {
             get {

--- a/src/NuGet.Core/NuGet.Build.Tasks/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Strings.Designer.cs
@@ -62,6 +62,15 @@ namespace NuGet.Build.Tasks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Project &apos;{0}&apos; was restored using &apos;{1}&apos; instead of the project target framework &apos;{2}&apos;. This project may not be fully compatible with your project..
+        /// </summary>
+        internal static string ImportsFallbackWarning {
+            get {
+                return ResourceManager.GetString("ImportsFallbackWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Project &apos;{0}&apos; targets &apos;{2}&apos;. It cannot be referenced by a project that targets &apos;{1}&apos;..
         /// </summary>
         internal static string NoCompatibleTargetFramework {

--- a/src/NuGet.Core/NuGet.Build.Tasks/Strings.resx
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Strings.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ImportsFallbackWarning" xml:space="preserve">
+    <value>Project '{0}' was restored using '{1}' instead of the project target framework '{2}'. This project may not be fully compatible with your project.</value>
+    <comment>0 - referenced project path
+1 - resolved tfm
+2 - project tfm</comment>
+  </data>
   <data name="NoCompatibleTargetFramework" xml:space="preserve">
     <value>Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Build.Tasks/Strings.resx
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Strings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ImportsFallbackWarning" xml:space="preserve">
-    <value>Project '{0}' was restored using '{1}' instead of the project target framework '{2}'. This project may not be fully compatible with your project.</value>
+    <value>ProjectReference '{0}' was resolved using '{1}' instead of the project target framework '{2}'. This project may not be fully compatible with your project.</value>
     <comment>0 - referenced project path
 1 - resolved tfm
 2 - project tfm</comment>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -205,9 +205,14 @@ namespace NuGet.Common
         NU1608 = 1608,
 
         /// <summary>
-        /// Fallback framework used.
+        /// Fallback framework used for a package reference.
         /// </summary>
         NU1701 = 1701,
+
+        /// <summary>
+        /// Fallback framework used for a project reference.
+        /// </summary>
+        NU1702 = 1702,
 
         /// <summary>
         /// Feed error converted to a warning when ignoreFailedSources is true.

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetReferenceNearestTargetFrameworkTaskTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetReferenceNearestTargetFrameworkTaskTest.cs
@@ -13,6 +13,7 @@ namespace NuGet.Build.Tasks.Test
     {
         private const int DEBUG_MESSAGE_COUNT_INPUT = 3;
         private const int DEBUG_MESSAGE_COUNT_INPUT_OUTPUT = DEBUG_MESSAGE_COUNT_INPUT + 1;
+        //"Project '' was restored using '.NETFramework,Version=v4.6' instead of the project target framework '.NETCoreApp,Version=v2.0'. This project may not be fully compatible with your project."
 
         [Fact]
         public void GetReferenceNearestTargetFrameworkTask_NoReferences()
@@ -272,9 +273,9 @@ namespace NuGet.Build.Tasks.Test
         }
 
         [Theory]
-        [InlineData("netcoreapp2.0", "netcoreapp2.0")]
-        [InlineData("net46", "net46")]
-        public void GetReferenceNearestTargetFrameworkTask_WithSingleTfmAndSingleAtf(string referenceProjectFramework, string nearestMatchingFramework)
+        [InlineData("netcoreapp2.0", "netcoreapp2.0", false)]
+        [InlineData("net46", "net46", true)]
+        public void GetReferenceNearestTargetFrameworkTask_WithSingleTfmAndSingleAtf(string referenceProjectFramework, string nearestMatchingFramework, bool willGenerateWarning)
         {
             var buildEngine = new TestBuildEngine();
             var testLogger = buildEngine.TestLogger;
@@ -300,15 +301,15 @@ namespace NuGet.Build.Tasks.Test
             task.AssignedProjects.Should().HaveCount(1);
             task.AssignedProjects[0].GetMetadata("NearestTargetFramework").Should().Be(nearestMatchingFramework);
 
-            testLogger.Warnings.Should().Be(0);
+            testLogger.Warnings.Should().Be(willGenerateWarning ? 1 : 0);
             testLogger.Errors.Should().Be(0);
             testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT_OUTPUT);
         }
 
         [Theory]
-        [InlineData("netcoreapp2.0", "netcoreapp2.0")]
-        [InlineData("net46", "net46")]
-        public void GetReferenceNearestTargetFrameworkTask_WithSingleTfmAndMultipleAtf(string referenceProjectFramework, string nearestMatchingFramework)
+        [InlineData("netcoreapp2.0", "netcoreapp2.0", false)]
+        [InlineData("net46", "net46", true)]
+        public void GetReferenceNearestTargetFrameworkTask_WithSingleTfmAndMultipleAtf(string referenceProjectFramework, string nearestMatchingFramework, bool willGenerateWarning)
         {
             var buildEngine = new TestBuildEngine();
             var testLogger = buildEngine.TestLogger;
@@ -334,15 +335,15 @@ namespace NuGet.Build.Tasks.Test
             task.AssignedProjects.Should().HaveCount(1);
             task.AssignedProjects[0].GetMetadata("NearestTargetFramework").Should().Be(nearestMatchingFramework);
 
-            testLogger.Warnings.Should().Be(0);
+            testLogger.Warnings.Should().Be(willGenerateWarning ? 1 : 0);
             testLogger.Errors.Should().Be(0);
             testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT_OUTPUT);
         }
 
         [Theory]
-        [InlineData("netcoreapp2.0; netcoreapp1.0", "netcoreapp2.0")]
-        [InlineData("net45; net46", "net46")]
-        public void GetReferenceNearestTargetFrameworkTask_WithMultipleTfmAndSingleAtf(string referenceProjectFramework, string nearestMatchingFramework)
+        [InlineData("netcoreapp2.0; netcoreapp1.0", "netcoreapp2.0", false)]
+        [InlineData("net45; net46", "net46", true)]
+        public void GetReferenceNearestTargetFrameworkTask_WithMultipleTfmAndSingleAtf(string referenceProjectFramework, string nearestMatchingFramework, bool willGenerateWarning)
         {
             var buildEngine = new TestBuildEngine();
             var testLogger = buildEngine.TestLogger;
@@ -367,15 +368,15 @@ namespace NuGet.Build.Tasks.Test
             task.AssignedProjects.Should().HaveCount(1);
             task.AssignedProjects[0].GetMetadata("NearestTargetFramework").Should().Be(nearestMatchingFramework);
 
-            testLogger.Warnings.Should().Be(0);
+            testLogger.Warnings.Should().Be(willGenerateWarning ? 1 : 0);
             testLogger.Errors.Should().Be(0);
             testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT_OUTPUT);
         }
 
         [Theory]
-        [InlineData("netcoreapp2.0; netcoreapp1.0", "netcoreapp2.0")]
-        [InlineData("net45; net46", "net46")]
-        public void GetReferenceNearestTargetFrameworkTask_WithMultipleTfmAndMultipleAtf(string referenceProjectFramework, string nearestMatchingFramework)
+        [InlineData("netcoreapp2.0; netcoreapp1.0", "netcoreapp2.0", false)]
+        [InlineData("net45; net46", "net46", true)]
+        public void GetReferenceNearestTargetFrameworkTask_WithMultipleTfmAndMultipleAtf(string referenceProjectFramework, string nearestMatchingFramework, bool willGenerateWarning)
         {
             var buildEngine = new TestBuildEngine();
             var testLogger = buildEngine.TestLogger;
@@ -400,7 +401,7 @@ namespace NuGet.Build.Tasks.Test
             task.AssignedProjects.Should().HaveCount(1);
             task.AssignedProjects[0].GetMetadata("NearestTargetFramework").Should().Be(nearestMatchingFramework);
 
-            testLogger.Warnings.Should().Be(0);
+            testLogger.Warnings.Should().Be(willGenerateWarning ? 1 : 0);
             testLogger.Errors.Should().Be(0);
             testLogger.DebugMessages.Count.Should().Be(DEBUG_MESSAGE_COUNT_INPUT_OUTPUT);
         }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetReferenceNearestTargetFrameworkTaskTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetReferenceNearestTargetFrameworkTaskTest.cs
@@ -13,7 +13,6 @@ namespace NuGet.Build.Tasks.Test
     {
         private const int DEBUG_MESSAGE_COUNT_INPUT = 3;
         private const int DEBUG_MESSAGE_COUNT_INPUT_OUTPUT = DEBUG_MESSAGE_COUNT_INPUT + 1;
-        //"Project '' was restored using '.NETFramework,Version=v4.6' instead of the project target framework '.NETCoreApp,Version=v2.0'. This project may not be fully compatible with your project."
 
         [Fact]
         public void GetReferenceNearestTargetFrameworkTask_NoReferences()


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7137  
Regression: No

## Fix
Details: As part of https://github.com/NuGet/NuGet.Client/pull/1983 we enabled msbuild to check fallback frameworks while checking compatibility between 2 projects. However,  `AssetTargetFallback`  based compatibility in packages logs warning. This PR adds a warning in `GetReferenceNearestTargetFrameworkTask` which is called on build time by msbuild. 

## Testing/Validation
Tests Added: Yes
Validation done:  manual commandline
