### PR TITLE
Fix a VS Credential Provider Importer UI Delay by avoiding unnecessary UI thread switches.

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
@@ -52,7 +52,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     var importer = new VsCredentialProviderImporter(
                         dte,
-                        VisualStudioAccountProvider.FactoryMethod,
                         (exception, failureMessage) => LogCredentialProviderError(exception, failureMessage));
 
                     return importer.GetProviders();

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
@@ -42,7 +42,6 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             // Initialize the credential providers.
             var credentialProviders = new List<ICredentialProvider>();
-            var dte = await _asyncServiceProvider.GetDTEAsync();
             var webProxy = await _asyncServiceProvider.GetServiceAsync<SVsWebProxy, IVsWebProxy>();
 
             TryAddCredentialProviders(
@@ -51,7 +50,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 () =>
                 {
                     var importer = new VsCredentialProviderImporter(
-                        dte,
                         (exception, failureMessage) => LogCredentialProviderError(exception, failureMessage));
 
                     return importer.GetProviders();

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VisualStudioAccountProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VisualStudioAccountProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -228,7 +228,5 @@ namespace NuGet.PackageManagement.VisualStudio
 
             return response;
         }
-
-        public static Func<ICredentialProvider> FactoryMethod = () => new VisualStudioAccountProvider();
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VsCredentialProviderImporter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VsCredentialProviderImporter.cs
@@ -113,6 +113,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private void Initialize()
         {
             var componentModel = ServiceLocator.GetGlobalService<SComponentModel, IComponentModel>();
+            
             // ensure we satisfy our imports
             componentModel?.DefaultCompositionService.SatisfyImportsOnce(this);
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VsCredentialProviderImporter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VsCredentialProviderImporter.cs
@@ -18,7 +18,6 @@ namespace NuGet.PackageManagement.VisualStudio
     /// </summary>
     public class VsCredentialProviderImporter
     {
-        private readonly DTE _dte;
         private readonly Action<Exception, string> _errorDelegate;
         private readonly Action _initializer;
 
@@ -28,9 +27,8 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <param name="dte">DTE instance, used to determine the Visual Studio version.</param>
         /// <param name="errorDelegate">Used to write error messages to the user.</param>
         public VsCredentialProviderImporter(
-            DTE dte,
             Action<Exception, string> errorDelegate)
-            : this(dte, errorDelegate, initializer: null)
+            : this(errorDelegate, initializer: null)
         {
         }
 
@@ -42,22 +40,10 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <param name="initializer">Init method used to supply MEF imports. Should only
         /// be supplied by tests.</param>
         public VsCredentialProviderImporter(
-            DTE dte,
             Action<Exception, string> errorDelegate,
             Action initializer)
         {
-            if (dte == null)
-            {
-                throw new ArgumentNullException(nameof(dte));
-            }
-
-            if (errorDelegate == null)
-            {
-                throw new ArgumentNullException(nameof(errorDelegate));
-            }
-
-            _dte = dte;
-            _errorDelegate = errorDelegate;
+            _errorDelegate = errorDelegate ?? throw new ArgumentNullException(nameof(errorDelegate));
             _initializer = initializer ?? Initialize;
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VsCredentialProviderImporterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VsCredentialProviderImporterTests.cs
@@ -78,7 +78,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
         
         [Fact]
-        public void WhenMultipleProvidersMatchingVstsContractFound_ThenInsertAllAndDoNotInsertBuiltInProvider()
+        public void WhenMultipleProvidersMatchingVstsContractFound_ThenInsertAll()
         {
             // Arrange
             // This simulates the fact that a third-party credential provider could export using the same 
@@ -97,7 +97,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             // Assert
             // We expect 2 providers:
-            // The non-failing provider, and the built-in provider on dev14
             Assert.Equal(2, results.Count);
             Assert.DoesNotContain(_visualStudioAccountProvider, results);
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VsCredentialProviderImporterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VsCredentialProviderImporterTests.cs
@@ -80,20 +80,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public void WhenVstsImportNotFound_WhenDev14_ThenInsertBuiltInProvider()
-        {
-            // Arrange
-            _mockDte.Setup(x => x.Version).Returns("14.0.247200.00");
-            var importer = GetTestableImporter();
-
-            // Act
-            var results = importer.GetProviders();
-
-            // Assert
-            Assert.Contains(_visualStudioAccountProvider, results);
-        }
-
-        [Fact]
         public void WhenVstsImportNotFound_WhenNotDev14_ThenDoNotInsertBuiltInProvider()
         {
             // Arrange
@@ -202,30 +188,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Act & Assert
             var actual = Assert.Throws<ArgumentException>(() => importer.GetProviders());
             Assert.Same(exception, actual);
-        }
-
-        [Fact]
-        public void WhenImportedProviderFailsOnDev14_ThenOtherProvidersAreStillImportedIncludingBuiltInProvider()
-        {
-            // Arrange
-            _mockDte.Setup(x => x.Version).Returns("14.0.247200.00");
-            var importer = GetTestableImporter();
-            var nonFailingProviderFactory = new Lazy<IVsCredentialProvider>(() => new NonFailingCredentialProvider());
-            var failingProviderFactory = new Lazy<IVsCredentialProvider>(() => new FailingCredentialProvider());
-            importer.ImportedProviders = new List<Lazy<IVsCredentialProvider>>
-            {
-                nonFailingProviderFactory,
-                failingProviderFactory
-            };
-
-            // Act
-            var results = importer.GetProviders();
-
-            // Assert
-            // We expect 2 providers:
-            // The non-failing provider, and the built-in provider on dev14
-            Assert.Equal(2, results.Count);
-            Assert.Contains(_visualStudioAccountProvider, results);
         }
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VsCredentialProviderImporterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VsCredentialProviderImporterTests.cs
@@ -56,7 +56,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         private readonly StringBuilder _testErrorOutput = new StringBuilder();
         private static readonly VisualStudioAccountProvider _visualStudioAccountProvider = new VisualStudioAccountProvider(null, null);
         private readonly Mock<DTE> _mockDte = new Mock<DTE>();
-        private readonly Func<Credentials.ICredentialProvider> _fallbackProviderFactory = () => _visualStudioAccountProvider;
         private readonly List<string> _errorMessages = new List<string>();
         private readonly Action<Exception, string> _errorDelegate;
 
@@ -74,11 +73,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             var importer = new VsCredentialProviderImporter(
                 _mockDte.Object,
-                _fallbackProviderFactory,
                 _errorDelegate,
                 initializer: () => { });
-
-            importer.Version = _mockDte.Object.Version;
 
             return importer;
         }
@@ -200,10 +196,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             _mockDte.Setup(x => x.Version).Returns("14.0.247200.00");
             var importer = new VsCredentialProviderImporter(
                 _mockDte.Object,
-                _fallbackProviderFactory,
                 _errorDelegate,
                 () => { throw exception; });
-            importer.Version = _mockDte.Object.Version;
 
             // Act & Assert
             var actual = Assert.Throws<ArgumentException>(() => importer.GetProviders());


### PR DESCRIPTION
## Bug
Fixes: https://devdiv.visualstudio.com/DevDiv/NuGet/_workitems/edit/654411
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details:  

The code in question is: 
https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VsCredentialProviderImporter.cs#L164-L171.
The root cause of the delay is MEF composition, satisfying the imports. 

There's no need to do this on the UI thread. 
Additionally we can remove the UI thread switch altogether because it's redundant. 
Cleaned up the unnecessary objects being passed and APIs. 

Perfview stack trace

Name | Inc | IncAvg | Inc Ct
-- | -- | -- | --
nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.VisualStudio.VsCredentialProviderImporter+<>c__DisplayClass_0+<<Initialize>b__>d.MoveNext | 1,065 | 1,065 | 1
microsoft.visualstudio.composition.dll!Microsoft.VisualStudio.Composition.NetFxAdapters+CompositionService.SatisfyImportsOnce | 1,065 | 1,065 | 1
system.componentmodel.composition.dll!System.ComponentModel.Composition.Hosting.CompositionContainer.SatisfyImportsOnce | 1,065 | 1,065 | 1
system.componentmodel.composition.dll!System.ComponentModel.Composition.Hosting.ImportEngine.SatisfyImportsOnce | 1,065 | 1,065 | 1
system.componentmodel.composition.dll!System.ComponentModel.Composition.Hosting.CompositionLock.LockComposition | 1,065 | 1,065 | 1
clr.dll!AwareLock::Enter | 1,065 | 1,065 | 1
clr.dll!AwareLock::EnterEpilog | 1,065 | 1,065 | 1
clr.dll!AwareLock::EnterEpilogHelper | 1,065 | 1,065 | 1
clr.dll!CLREventBase::Wait | 1,065 | 1,065 | 1
clr.dll!CLREventBase::WaitEx | 1,065 | 1,065 | 1
clr.dll!Thread::DoAppropriateWait | 1,065 | 1,065 | 1
clr.dll!Thread::DoAppropriateWaitWorker | 1,065 | 1,065 | 1
clr.dll!MsgWaitHelper | 1,065 | 1,065 | 1
vslog.dll!VSResponsiveness::Detours::DetourCoWaitForMultipleHandles | 1,065 | 1,065 | 1
combase.dll!CoWaitForMultipleHandles | 1,065 | 1,065 | 1
combase.dll!ClassicSTAThreadWaitForHandles | 1,065 | 1,065 | 1
combase.dll!CCliModalLoop::BlockFn | 1,065 | 1,065 | 1
vslog.dll!VSResponsiveness::Detours::DetourMsgWaitForMultipleObjectsEx | 1,065 | 1,065 | 1
user32.dll!MsgWaitForMultipleObjectsEx | 1,065 | 1,065 | 1

//cc @rrelyea 

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  
Validation done:  manual
