### PR TITLE
Don't silently ignore exception from AssemblyMetadataExtractor.ExtractMetadata

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -750,8 +750,9 @@ namespace NuGet.CommandLine
                 {
                     AssemblyMetadataExtractor.ExtractMetadata(builder, TargetPath);
                 }
-                catch
+                catch (Exception ex)
                 {
+                    Logger.Log(PackagingLogMessage.CreateMessage(ex.Message, LogLevel.Verbose));
                     ExtractMetadataFromProject(builder);
                 }
             }


### PR DESCRIPTION
I just wasted many hours trying to figure out why replacement tokens were not working with my .csproj/.nuspec.

The comments in the source code explain the problem. I'm using UWP, which uses .NET core, so it appears that it is not expected that it should work in my case. However, this doesn't appear to be documented anywhere other than this one comment in the source code.

There also appears to be a related issue where a malformed version string in `AssemblyInformationalVersion` causes an exception which is also silently ignored in this catch statement.

Let's print a message here, at least when verbose logging is enabled, so that users can at least get some hint of what is going on without having to dig into the source code.

Related issues: #5548, #5807, #4234 (and a bunch of closed ones too).
