### PR TITLE
Fixed UI delay for TryCreateContext() for packages.config projects

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,6 +18,7 @@ using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
+using NuGet.ProjectManagement.Projects;
 using NuGet.ProjectModel;
 using NuGet.VisualStudio.Implementation.Resources;
 
@@ -30,13 +30,12 @@ namespace NuGet.VisualStudio
     [PartCreationPolicy(CreationPolicy.Shared)]
     public sealed class VsPathContextProvider : IVsPathContextProvider2
     {
-        private const string ProjectAssetsFile = "ProjectAssetsFile";
         private readonly IAsyncServiceProvider _asyncServiceprovider;
         private readonly Lazy<ISettings> _settings;
         private readonly Lazy<IVsSolutionManager> _solutionManager;
         private readonly Lazy<NuGet.Common.ILogger> _logger;
-        private readonly Lazy<IVsProjectAdapterProvider> _vsProjectAdapterProvider;
-        private readonly Func<string, LockFile> _getLockFileOrNull;
+        private readonly Func<BuildIntegratedNuGetProject, Task<LockFile>> _getLockFileOrNullAsync;
+
         private readonly Lazy<INuGetProjectContext> _projectContext = new Lazy<INuGetProjectContext>(() => new VSAPIProjectContext());
         
 
@@ -45,28 +44,24 @@ namespace NuGet.VisualStudio
             Lazy<ISettings> settings,
             Lazy<IVsSolutionManager> solutionManager,
             [Import("VisualStudioActivityLogger")]
-            Lazy<NuGet.Common.ILogger> logger,
-            Lazy<IVsProjectAdapterProvider> vsProjectAdapterProvider)
+            Lazy<NuGet.Common.ILogger> logger)
             : this(AsyncServiceProvider.GlobalProvider,
                   settings,
                   solutionManager,
-                  logger,
-                  vsProjectAdapterProvider)
+                  logger)
         { }
 
         public VsPathContextProvider(
             IAsyncServiceProvider asyncServiceProvider,
             Lazy<ISettings> settings,
             Lazy<IVsSolutionManager> solutionManager,
-            Lazy<NuGet.Common.ILogger> logger,
-            Lazy<IVsProjectAdapterProvider> vsProjectAdapterProvider)
+            Lazy<NuGet.Common.ILogger> logger)
         {
             _asyncServiceprovider = asyncServiceProvider ?? throw new ArgumentNullException(nameof(asyncServiceProvider));
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
             _solutionManager = solutionManager ?? throw new ArgumentNullException(nameof(solutionManager));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _vsProjectAdapterProvider = vsProjectAdapterProvider ?? throw new ArgumentNullException(nameof(vsProjectAdapterProvider));
-            _getLockFileOrNull = BuildIntegratedProjectUtility.GetLockFileOrNull;
+            _getLockFileOrNullAsync = BuildIntegratedProjectUtility.GetLockFileOrNull;
         }
 
         /// <summary>
@@ -76,8 +71,7 @@ namespace NuGet.VisualStudio
             ISettings settings,
             IVsSolutionManager solutionManager,
             NuGet.Common.ILogger logger,
-            IVsProjectAdapterProvider vsProjectAdapterProvider,
-            Func<string, LockFile> getLockFileOrNull)
+            Func<BuildIntegratedNuGetProject, Task<LockFile>> getLockFileOrNullAsync)
         {
             if (settings == null)
             {
@@ -94,16 +88,10 @@ namespace NuGet.VisualStudio
                 throw new ArgumentNullException(nameof(logger));
             }
 
-            if (vsProjectAdapterProvider == null)
-            {
-                throw new ArgumentNullException(nameof(vsProjectAdapterProvider));
-            }
-
             _settings = new Lazy<ISettings>(() => settings);
             _solutionManager = new Lazy<IVsSolutionManager>(() => solutionManager);
             _logger = new Lazy<NuGet.Common.ILogger>(() => logger);
-            _vsProjectAdapterProvider = new Lazy<IVsProjectAdapterProvider>(() => vsProjectAdapterProvider);
-            _getLockFileOrNull = getLockFileOrNull ?? BuildIntegratedProjectUtility.GetLockFileOrNull;
+            _getLockFileOrNullAsync = getLockFileOrNullAsync ?? BuildIntegratedProjectUtility.GetLockFileOrNull;
         }
 
         public bool TryCreateContext(string projectUniqueName, out IVsPathContext outputPathContext)
@@ -117,12 +105,15 @@ namespace NuGet.VisualStudio
             outputPathContext = NuGetUIThreadHelper.JoinableTaskFactory.Run(
                 async () =>
                 {
-                    // result.item1 is IVsProjectAdapter instance
-                    // result.item2 is ProjectAssetsFile path if exists
-                    var result = await CreateProjectAdapterAsync(projectUniqueName);
+                    var nuGetProject = await CreateNuGetProjectAsync(projectUniqueName);
 
-                    return result == null ? null
-                        : await CreatePathContextAsync(result.Item1, result.Item2, projectUniqueName, CancellationToken.None);
+                    // It's possible the project isn't a NuGet-compatible project at all.
+                    if (nuGetProject == null)
+                    {
+                        return null;
+                    }
+
+                    return await CreatePathContextAsync(nuGetProject, CancellationToken.None);
                 });
 
             return outputPathContext != null;
@@ -151,7 +142,7 @@ namespace NuGet.VisualStudio
             return outputPathContext != null;
         }
 
-        private async Task<Tuple<IVsProjectAdapter, string>> CreateProjectAdapterAsync(string projectUniqueName)
+        private async Task<NuGetProject> CreateNuGetProjectAsync(string projectUniqueName)
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
@@ -165,47 +156,47 @@ namespace NuGet.VisualStudio
                 if (!string.IsNullOrEmpty(solutionProjectPath) &&
                     PathUtility.GetStringComparerBasedOnOS().Equals(solutionProjectPath, projectUniqueName))
                 {
-                    // get the VSProjectAdapter instance which will be used to retrieve MSBuild properties
-                    var projectApadter = await _vsProjectAdapterProvider.Value.CreateAdapterForFullyLoadedProjectAsync(solutionProject);
-
-                    // read ProjectAssetsFile property to get assets file full path
-                    var projectAssetsFile = await projectApadter.BuildProperties.GetPropertyValueAsync(ProjectAssetsFile);
-
-                    return Tuple.Create(projectApadter, projectAssetsFile);
+                    return await _solutionManager.Value.GetOrCreateProjectAsync(solutionProject, _projectContext.Value);
                 }
             }
 
             return null;
         }
 
-        public async Task<IVsPathContext> CreatePathContextAsync(
-            IVsProjectAdapter vsProjectAdapter,
-            string projectAssetsFile,
-            string projectUniqueName,
-            CancellationToken token)
+        public async Task<IVsPathContext> CreatePathContextAsync(NuGetProject nuGetProject, CancellationToken token)
         {
-            IVsPathContext context = null;
+            IVsPathContext context;
 
             try
             {
-                // First check for project.assets.json file and generate VsPathContext from there.
-                if (!string.IsNullOrEmpty(projectAssetsFile))
+                var buildIntegratedProject = nuGetProject as BuildIntegratedNuGetProject;
+
+                if (buildIntegratedProject != null)
                 {
-                    context = GetPathContextFromProjectLockFile(projectAssetsFile);
+                    // if project is build integrated, then read it from assets file.
+                    context = await GetPathContextFromAssetsFileAsync(
+                        buildIntegratedProject, token);
                 }
-
-                // if no project.assets.json file, then check for project.lock.json file.
-                context = context ?? GetPathContextForProjectJson(vsProjectAdapter);
-
-                // if no project.lock.json file, then look for packages.config file.
-                context = context ?? await GetPathContextForPackagesConfigAsync(vsProjectAdapter, token);
-
-                // Fallback to reading the path context from the solution's settings. Note that project level settings in
-                // VS are not currently supported.
-                context = context ?? GetSolutionPathContext();
+                else
+                {
+                    var msbuildNuGetProject = nuGetProject as MSBuildNuGetProject;
+                    if (msbuildNuGetProject != null)
+                    {
+                        // when a msbuild project, then read it from packages.config file.
+                        context = await GetPathContextFromPackagesConfigAsync(
+                            msbuildNuGetProject, token);
+                    }
+                    else
+                    {
+                        // Fallback to reading the path context from the solution's settings. Note that project level settings in
+                        // VS are not currently supported.
+                        context = GetSolutionPathContext();
+                    }
+                }
             }
             catch (Exception e) when (e is KeyNotFoundException || e is InvalidOperationException)
             {
+                var projectUniqueName = NuGetProject.GetUniqueNameOrName(nuGetProject);
                 var errorMessage = string.Format(CultureInfo.CurrentCulture, VsResources.PathContext_CreateContextError, projectUniqueName, e.Message);
                 _logger.Value.LogError(errorMessage);
                 throw new InvalidOperationException(errorMessage, e);
@@ -214,44 +205,16 @@ namespace NuGet.VisualStudio
             return context;
         }
 
-        private IVsPathContext GetPathContextForProjectJson(
-            IVsProjectAdapter vsProjectAdapter)
+        public IVsPathContext GetSolutionPathContext()
         {
-            // generate project.lock.json file path from project file
-            var projectFilePath = vsProjectAdapter.FullProjectPath;
-
-            if (!string.IsNullOrEmpty(projectFilePath))
-            {
-                var msbuildProjectFile = new FileInfo(projectFilePath);
-                var projectNameFromMSBuildPath = Path.GetFileNameWithoutExtension(msbuildProjectFile.Name);
-
-                string projectJsonPath = null;
-                if (string.IsNullOrEmpty(projectNameFromMSBuildPath))
-                {
-                    projectJsonPath = Path.Combine(msbuildProjectFile.DirectoryName,
-                        ProjectJsonPathUtilities.ProjectConfigFileName);
-                }
-                else
-                {
-                    projectJsonPath = ProjectJsonPathUtilities.GetProjectConfigPath(
-                        msbuildProjectFile.DirectoryName,
-                        projectNameFromMSBuildPath);
-                }
-
-                if (File.Exists(projectJsonPath))
-                {
-                    var lockFilePath = ProjectJsonPathUtilities.GetLockFilePath(projectJsonPath);
-                    return GetPathContextFromProjectLockFile(lockFilePath);
-                }
-            }
-
-            return null;
+            return new VsPathContext(NuGetPathContext.Create(_settings.Value));
         }
 
-        private IVsPathContext GetPathContextFromProjectLockFile(
-            string lockFilePath)
+        private async Task<IVsPathContext> GetPathContextFromAssetsFileAsync(
+            BuildIntegratedNuGetProject buildIntegratedProject, CancellationToken token)
         {
-            var lockFile = _getLockFileOrNull(lockFilePath);
+            var lockFile = await _getLockFileOrNullAsync(buildIntegratedProject);
+
             if ((lockFile?.PackageFolders?.Count ?? 0) == 0)
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, VsResources.PathContext_LockFileError));
@@ -297,30 +260,19 @@ namespace NuGet.VisualStudio
                 trie);
         }
 
-        private async Task<IVsPathContext> GetPathContextForPackagesConfigAsync(
-            IVsProjectAdapter vsProjectAdapter, CancellationToken token)
+        private async Task<IVsPathContext> GetPathContextFromPackagesConfigAsync(
+            MSBuildNuGetProject msbuildNuGetProject, CancellationToken token)
         {
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-            var props = new Dictionary<string, object>();
-            props.Add(NuGetProjectMetadataKeys.Name, Path.GetFileNameWithoutExtension(vsProjectAdapter.FullProjectPath));
-            props.Add(NuGetProjectMetadataKeys.TargetFramework, await vsProjectAdapter.GetTargetFrameworkAsync());
-
-            var packagesProject = new PackagesConfigNuGetProject(vsProjectAdapter.ProjectDirectory, props);
-
-            var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(_solutionManager.Value, _settings.Value);
-            var folderProject = new FolderNuGetProject(packagesFolderPath);
+            var packageReferences = await msbuildNuGetProject.GetInstalledPackagesAsync(token);
 
             // switch to a background thread to process packages data
             await TaskScheduler.Default;
-
-            var packageReferences = await packagesProject.GetInstalledPackagesAsync(token);
 
             var trie = new PathLookupTrie<string>();
 
             foreach (var pid in packageReferences.Select(pr => pr.PackageIdentity))
             {
-                var packageInstallPath = folderProject.GetInstalledPath(pid);
+                var packageInstallPath = msbuildNuGetProject.FolderNuGetProject.GetInstalledPath(pid);
                 if (string.IsNullOrEmpty(packageInstallPath))
                 {
                     throw new KeyNotFoundException(string.Format(CultureInfo.CurrentCulture, VsResources.PathContext_PackageDirectoryNotFound, pid));
@@ -335,11 +287,6 @@ namespace NuGet.VisualStudio
                 pathContext.UserPackageFolder,
                 pathContext.FallbackPackageFolders.Cast<string>(),
                 trie);
-        }
-
-        public IVsPathContext GetSolutionPathContext()
-        {
-            return new VsPathContext(NuGetPathContext.Create(_settings.Value));
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using Microsoft;
 using Microsoft.VisualStudio.Threading;
 using Moq;
@@ -56,8 +55,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 settings,
                 Mock.Of<IVsSolutionManager>(),
                 Mock.Of<ILogger>(),
-                Mock.Of<IVsProjectAdapterProvider>(),
-                getLockFileOrNull: null);
+                getLockFileOrNullAsync: null);
 
             // Act
             var actual = target.GetSolutionPathContext();
@@ -86,8 +84,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 settings.Object,
                 Mock.Of<IVsSolutionManager>(),
                 Mock.Of<ILogger>(),
-                Mock.Of<IVsProjectAdapterProvider>(),
-                getLockFileOrNull: null);
+                getLockFileOrNullAsync: null);
 
             // Act
             var actual = target.GetSolutionPathContext();
@@ -123,25 +120,11 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                     fallbackPackageFolder,
                     new PackageIdentity("Bar", NuGetVersion.Parse("1.0.2")));
 
-                var projectUniqueName = Guid.NewGuid().ToString();
-                var project = new Mock<EnvDTE.Project>();
-                var vsProjectAdapter = new Mock<IVsProjectAdapter>();
-                vsProjectAdapter
-                    .Setup(x => x.BuildProperties.GetPropertyValueAsync("ProjectAssetsFile"))
-                    .Returns(Task.FromResult("project.aseets.json"));
-
-
-                var vsProjectAdapterProvider = new Mock<IVsProjectAdapterProvider>();
-                vsProjectAdapterProvider
-                    .Setup(x => x.CreateAdapterForFullyLoadedProjectAsync(project.Object))
-                    .Returns(Task.FromResult(vsProjectAdapter.Object));
-
                 var target = new VsPathContextProvider(
                     Mock.Of<ISettings>(),
                     Mock.Of<IVsSolutionManager>(),
                     Mock.Of<ILogger>(),
-                    vsProjectAdapterProvider.Object,
-                    getLockFileOrNull: _ =>
+                    getLockFileOrNullAsync: _ =>
                     {
                         var lockFile = new LockFile
                         {
@@ -167,11 +150,13 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                             }
                         };
 
-                        return lockFile;
+                        return Task.FromResult(lockFile);
                     });
 
+                var project = Mock.Of<BuildIntegratedNuGetProject>();
+
                 // Act
-                var actual = await target.CreatePathContextAsync(vsProjectAdapter.Object, "project.aseets.json", projectUniqueName, CancellationToken.None);
+                var actual = await target.CreatePathContextAsync(project, CancellationToken.None);
 
                 // Assert
                 Assert.NotNull(actual);
@@ -207,59 +192,31 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                     userPackageFolder,
                     new PackageIdentity("Foo", NuGetVersion.Parse("1.0.1")));
 
-                var solutionManager = new Mock<IVsSolutionManager>();
-                solutionManager
-                    .Setup(x => x.SolutionDirectory)
-                    .Returns(testDirectory.Path);
-
                 var settings = Mock.Of<ISettings>();
                 Mock.Get(settings)
                     .Setup(x => x.GetValue("config", "globalPackagesFolder", true))
                     .Returns(() => userPackageFolder);
-                Mock.Get(settings)
-                    .Setup(x => x.GetValue("config", "repositoryPath", true))
-                    .Returns(() => userPackageFolder);
-
-                var pacakgesConfig = @"<?xml version=""1.0"" encoding=""utf-8""?>
-                                <packages>
-                                    <package id=""Foo"" version=""1.0.1"" targetFramework=""net45"" />
-                                </packages>";
-
-                var project1 = new DirectoryInfo(Path.Combine(testDirectory, "project1"));
-                project1.Create();
-                var projectFullPath = Path.Combine(project1.FullName, "project1.csproj");
-                File.WriteAllText(Path.Combine(project1.FullName, "packages.config"), pacakgesConfig);
-
-                var projectUniqueName = Guid.NewGuid().ToString();
-                var project = new Mock<EnvDTE.Project>();
-                var vsProjectAdapter = new Mock<IVsProjectAdapter>();
-                vsProjectAdapter
-                    .Setup(x => x.FullProjectPath)
-                    .Returns(projectFullPath);
-                vsProjectAdapter
-                    .Setup(x => x.ProjectDirectory)
-                    .Returns(project1.FullName);
-                vsProjectAdapter
-                    .Setup(x => x.BuildProperties.GetPropertyValueAsync("ProjectAssetsFile"))
-                    .Returns(Task.FromResult(string.Empty));
-                vsProjectAdapter
-                    .Setup(x => x.GetTargetFrameworkAsync())
-                    .Returns(Task.FromResult(NuGetFramework.AnyFramework));
-
-                var vsProjectAdapterProvider = new Mock<IVsProjectAdapterProvider>();
-                vsProjectAdapterProvider
-                    .Setup(x => x.CreateAdapterForFullyLoadedProjectAsync(project.Object))
-                    .Returns(Task.FromResult(vsProjectAdapter.Object));
 
                 var target = new VsPathContextProvider(
                     settings,
-                    solutionManager.Object,
+                    Mock.Of<IVsSolutionManager>(),
                     Mock.Of<ILogger>(),
-                    vsProjectAdapterProvider.Object,
-                    getLockFileOrNull: null);
+                    getLockFileOrNullAsync: null);
+
+                var project = new Mock<MSBuildNuGetProject>(
+                    Mock.Of<IMSBuildProjectSystem>(), userPackageFolder, testDirectory.Path);
+
+                project
+                    .Setup(x => x.GetInstalledPackagesAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new[]
+                    {
+                        new PackageReference(
+                            new PackageIdentity("Foo", NuGetVersion.Parse("1.0.1")),
+                            NuGetFramework.AnyFramework)
+                    });
 
                 // Act
-                var actual = await target.CreatePathContextAsync(vsProjectAdapter.Object, string.Empty, projectUniqueName, CancellationToken.None);
+                var actual = await target.CreatePathContextAsync(project.Object, CancellationToken.None);
 
                 // Assert
                 Assert.NotNull(actual);
@@ -275,100 +232,45 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         }
 
         [Fact]
-        public async Task CreatePathContextAsync_WithUnrestoredPackageReference_Throws()
-        {
-            var projectUniqueName = Guid.NewGuid().ToString();
-            var project = new Mock<EnvDTE.Project>();
-
-            var vsProjectAdapter = new Mock<IVsProjectAdapter>();
-            vsProjectAdapter
-                .Setup(x => x.BuildProperties.GetPropertyValueAsync("ProjectAssetsFile"))
-                .Returns(Task.FromResult("project.aseets.json"));
-
-
-            var vsProjectAdapterProvider = new Mock<IVsProjectAdapterProvider>();
-            vsProjectAdapterProvider
-                .Setup(x => x.CreateAdapterForFullyLoadedProjectAsync(project.Object))
-                .Returns(Task.FromResult(vsProjectAdapter.Object));
-
-            var target = new VsPathContextProvider(
-                Mock.Of<ISettings>(),
-                Mock.Of<IVsSolutionManager>(),
-                Mock.Of<ILogger>(),
-                vsProjectAdapterProvider.Object,
-                getLockFileOrNull: null);
-
-            // Act
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => target.CreatePathContextAsync(vsProjectAdapter.Object, "project.aseets.json", projectUniqueName, CancellationToken.None));
-
-            // Assert
-            Assert.Contains(projectUniqueName, exception.Message);
-        }
-
-        [Fact]
         public async Task CreatePathContextAsync_WithUnrestoredPackagesConfig_Throws()
         {
             // Arrange
             using (var testDirectory = TestDirectory.Create())
             {
                 var userPackageFolder = Path.Combine(testDirectory.Path, "packagesA");
-                Directory.CreateDirectory(userPackageFolder);
-
-                var solutionManager = new Mock<IVsSolutionManager>();
-                solutionManager
-                    .Setup(x => x.SolutionDirectory)
-                    .Returns(testDirectory.Path);
 
                 var settings = Mock.Of<ISettings>();
                 Mock.Get(settings)
                     .Setup(x => x.GetValue("config", "globalPackagesFolder", true))
                     .Returns(() => userPackageFolder);
-                Mock.Get(settings)
-                    .Setup(x => x.GetValue("config", "repositoryPath", true))
-                    .Returns(() => userPackageFolder);
-
-                var pacakgesConfig = @"<?xml version=""1.0"" encoding=""utf-8""?>
-                                <packages>
-                                    <package id=""Foo"" version=""1.0.1"" targetFramework=""net45"" />
-                                </packages>";
-
-                var project1 = new DirectoryInfo(Path.Combine(testDirectory, "project1"));
-                project1.Create();
-                var projectFullPath = Path.Combine(project1.FullName, "project1.csproj");
-                File.WriteAllText(Path.Combine(project1.FullName, "packages.config"), pacakgesConfig);
-
-                var projectUniqueName = Guid.NewGuid().ToString();
-                var project = new Mock<EnvDTE.Project>();
-                var vsProjectAdapter = new Mock<IVsProjectAdapter>();
-                vsProjectAdapter
-                    .Setup(x => x.FullProjectPath)
-                    .Returns(projectFullPath);
-                vsProjectAdapter
-                    .Setup(x => x.ProjectDirectory)
-                    .Returns(project1.FullName);
-                vsProjectAdapter
-                    .Setup(x => x.BuildProperties.GetPropertyValueAsync("ProjectAssetsFile"))
-                    .Returns(Task.FromResult(string.Empty));
-                vsProjectAdapter
-                    .Setup(x => x.GetTargetFrameworkAsync())
-                    .Returns(Task.FromResult(NuGetFramework.AnyFramework));
-
-                var vsProjectAdapterProvider = new Mock<IVsProjectAdapterProvider>();
-                vsProjectAdapterProvider
-                    .Setup(x => x.CreateAdapterForFullyLoadedProjectAsync(project.Object))
-                    .Returns(Task.FromResult(vsProjectAdapter.Object));
 
                 var target = new VsPathContextProvider(
                     settings,
-                    solutionManager.Object,
+                    Mock.Of<IVsSolutionManager>(),
                     Mock.Of<ILogger>(),
-                    vsProjectAdapterProvider.Object,
-                    getLockFileOrNull: null);
+                    getLockFileOrNullAsync: null);
+
+                var projectUniqueName = Guid.NewGuid().ToString();
+
+                var projectSystem = Mock.Of<IMSBuildProjectSystem>();
+                Mock.Get(projectSystem)
+                    .SetupGet(x => x.ProjectUniqueName)
+                    .Returns(projectUniqueName);
+
+                var project = new Mock<MSBuildNuGetProject>(
+                    projectSystem, userPackageFolder, testDirectory.Path);
+
+                project
+                    .Setup(x => x.GetInstalledPackagesAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new[]
+                    {
+                        new PackageReference(
+                            new PackageIdentity("Foo", NuGetVersion.Parse("1.0.1")),
+                            NuGetFramework.AnyFramework)
+                    });
 
                 // Act
-                var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => target.CreatePathContextAsync(vsProjectAdapter.Object, string.Empty, projectUniqueName, CancellationToken.None));
+                var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => target.CreatePathContextAsync(project.Object, CancellationToken.None));
 
                 // Assert
                 Assert.Contains(projectUniqueName, exception.Message);
@@ -397,8 +299,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                     settings,
                     solutionManager.Object,
                     Mock.Of<ILogger>(),
-                    Mock.Of<IVsProjectAdapterProvider>(),
-                    getLockFileOrNull: null);
+                    getLockFileOrNullAsync: null);
 
                 // Act
                 var result = target.TryCreateSolutionContext(out var actual);
@@ -436,8 +337,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                     settings.Object,
                     solutionManager.Object,
                     Mock.Of<ILogger>(),
-                    Mock.Of<IVsProjectAdapterProvider>(),
-                    getLockFileOrNull: null);
+                    getLockFileOrNullAsync: null);
 
                 // Act
                 var result = target.TryCreateSolutionContext(out var actual);
@@ -478,8 +378,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 settings,
                 solutionManager.Object,
                 Mock.Of<ILogger>(),
-                Mock.Of<IVsProjectAdapterProvider>(),
-                getLockFileOrNull: null);
+                getLockFileOrNullAsync: null);
 
                 // Act
                 var result = target.TryCreateSolutionContext(out var actual);
@@ -504,8 +403,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 Mock.Of<ISettings>(),
                 Mock.Of<IVsSolutionManager>(),
                 Mock.Of<ILogger>(),
-                Mock.Of<IVsProjectAdapterProvider>(),
-                getLockFileOrNull: null);
+                getLockFileOrNullAsync: null);
 
                 // Act
                 var result = target.TryCreateSolutionContext(testDirectory.Path, out var actual);
@@ -515,6 +413,26 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 Assert.NotNull(actual);
                 Assert.Equal(solutionPackageFolder, actual.SolutionPackageFolder);
             }
+
+        }
+
+        [Fact]
+        public async Task CreatePathContextAsync_WithUnrestoredPackageReference_Throws()
+        {
+            var target = new VsPathContextProvider(
+                Mock.Of<ISettings>(),
+                Mock.Of<IVsSolutionManager>(),
+                Mock.Of<ILogger>(),
+                getLockFileOrNullAsync: _ => Task.FromResult(null as LockFile));
+
+            var projectUniqueName = Guid.NewGuid().ToString();
+
+            var project = new TestPackageReferenceProject(projectUniqueName);
+
+            // Act
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => target.CreatePathContextAsync(project, CancellationToken.None));
+
+            Assert.Contains(projectUniqueName, exception.Message);
         }
 
         private class TestPackageReferenceProject : BuildIntegratedNuGetProject


### PR DESCRIPTION
Instead of loading MSBuild storage property instance for packages.config project to get list of installed packages, this PR will directly read it from packages.config file which skips these UI delays. This is being done by creating the NuGet project out of dte project. It doesn't impact anything for non packages.config projects since they still uses the same method of getting installed packages from lock file.

Fixes - [PerfWatson] UIDelay: nuget.visualstudio.implementation.dll!NuGet.VisualStudio.VsPathContextProvider+<CreatePathContextAsync>d__.MoveNext [654410](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/654410)

@rrelyea 