### PR TITLE
Reliably find path to nuget.exe from NuGet.CommandLine package

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -75,6 +75,11 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <Target Name="CopyNugetCommandLineProps" AfterTargets="Build">
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)NuGet.CommandLine.props"
+          DestinationFolder="$(NuspecBasePath)" />
+  </Target>
+
   <Target Name="ILMergeNuGetExe" AfterTargets="Build" Condition="'$(BuildingInsideVisualStudio)' != 'true'">
     <ItemGroup>
       <BuildArtifacts Include="$(OutputPath)\*.dll" Exclude="@(MergeExclude)" />

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.nuspec
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.nuspec
@@ -15,5 +15,6 @@
   <files>
       <file src="NuGet.exe" target="tools" />
       <file src="NuGet.pdb" target="tools" />
+      <file src="NuGet.CommandLine.props" target="build" />
   </files>
 </package>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.props
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" >
+
+  <PropertyGroup>
+    <NuGetCommandLineToolPath>$(MSBuildThisFileDirectory)..\tools\nuget.exe</NuGetCommandLineToolPath>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
When installing the NuGet.CommandLine package into a project, the path to `nuget.exe` currently has to be guessed - something like `$(NuGetPackageRoot)NuGet.CommandLine\4.6.2\tools\nuget.exe`. 
This means that the path needs to be updated manually when the version of the referenced package changes and also assumes that all packages are restored to a single directory.

This PR adds a MSBuild props file to the NuGet.Commandline package that defines the property `NuGetCommandLineToolPath`  that points to the nuget.exe from the package.

This way, nuget.exe can be called using a property that will always point to the currently referenced version of the package

## Fix
Details: 

- Add NuGet.CommandLine.props which defines the `NuGetCommandLineToolPath` property using a relative path from the package's `build` directory to the package's `tools` directory
- Update NuGet.CommandLine.nuspec to include the `.props` file
- Add a target `CopyNugetCommandLineProps` to NuGet.CommandLine.csproj that copies the file to the output directory so it can be included when packing the package
## Testing/Validation
Tests Added: No  
Reason for not adding tests:  No code changed
Validation done:  yes
