### PR TITLE
Fixed ArgumentNullException by skipping floating version packages

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
@@ -179,6 +179,13 @@ namespace NuGet.VisualStudio
 
                             foreach (var package in installedPackages)
                             {
+                                if (!package.PackageIdentity.HasVersion)
+                                {
+                                    // Currently we are not supporting floating versions 
+                                    // because of that we will skip this package so that it doesn't throw ArgumentNullException
+                                    continue;
+                                }
+
                                 string installPath;
                                 if (buildIntegratedProject != null)
                                 {


### PR DESCRIPTION
GetInstalledPackage IVS api doesn't support floating versions yet so skip packages with floating version in order to avoid throwing ArgumentNullException.

Fixes - [Watson] clr20r3: CLR_EXCEPTION_System.ArgumentNullException_80004003_NuGet.Packaging.dll!NuGet.Packaging.FallbackPackagePathResolver.GetPackageInfo [656729](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/656729)

@rrelyea 