### PR TITLE
Add '-VerbatimVersion' command line option to 'nuget pack', et al.

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -38,6 +38,9 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "InstallCommandVersionDescription")]
         public string Version { get; set; }
 
+        [Option(typeof(NuGetCommand), "InstallCommandVerbatimVersionDescription")]
+        public bool VerbatimVersion { get; set; }
+
         [Option(typeof(NuGetCommand), "InstallCommandDependencyVersion")]
         public string DependencyVersion { get; set; }
 
@@ -101,7 +104,7 @@ namespace NuGet.CommandLine
             else
             {
                 var packageId = Arguments[0];
-                var version = Version != null ? new NuGetVersion(Version) : null;
+                var version = Version != null ? new NuGetVersion(Version, VerbatimVersion) : null;
                 return InstallPackageAsync(packageId, version, installPath);
             }
         }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
@@ -32,6 +32,9 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "PackageCommandVersionDescription")]
         public string Version { get; set; }
 
+        [Option(typeof(NuGetCommand), "PackageCommandVerbatimVersionDescription")]
+        public bool VerbatimVersion { get; set; }
+
         [Option(typeof(NuGetCommand), "PackageCommandSuffixDescription")]
         public string Suffix { get; set; }
 
@@ -148,11 +151,12 @@ namespace NuGet.CommandLine
             packArgs.Tool = Tool;
             packArgs.InstallPackageToOutputPath = InstallPackageToOutputPath;
             packArgs.OutputFileNamesWithoutVersion = OutputFileNamesWithoutVersion;
+            packArgs.VerbatimVersion = VerbatimVersion;
 
             if (!string.IsNullOrEmpty(Version))
             {
                 NuGetVersion version;
-                if (!NuGetVersion.TryParse(Version, out version))
+                if (!NuGetVersion.TryParse(Version, out version, VerbatimVersion))
                 {
                     throw new PackagingException(NuGetLogCode.NU5010, String.Format(CultureInfo.CurrentCulture, NuGetResources.InstallCommandPackageReferenceInvalidVersion, Version));
                 }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -270,7 +270,7 @@ namespace NuGet.CommandLine
             Packaging.Manifest manifest = null;
 
             // If there is a project.json file, load that and skip any nuspec that may exist
-            if (!PackCommandRunner.ProcessProjectJsonFile(builder, _project.DirectoryPath as string, builder.Id, version, suffix, GetPropertyValue))
+            if (!PackCommandRunner.ProcessProjectJsonFile(builder, _project.DirectoryPath as string, builder.Id, version, suffix, GetPropertyValue, false))
             {
                 // If the package contains a nuspec file then use it for metadata
                 manifest = ProcessNuspec(builder, basePath);
@@ -681,7 +681,7 @@ namespace NuGet.CommandLine
 
         private bool ProcessJsonFile(Packaging.PackageBuilder builder, string basePath, string id)
         {
-            return PackCommandRunner.ProcessProjectJsonFile(builder, basePath, id, null, null, GetPropertyValue);
+            return PackCommandRunner.ProcessProjectJsonFile(builder, basePath, id, null, null, GetPropertyValue, false);
         }
 
         // Creates a package dependency from the given project, which has a corresponding

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -30,6 +30,9 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "UpdateCommandVersionDescription")]
         public string Version { get; set; }
 
+        [Option(typeof(NuGetCommand), "UpdateCommandVerbatimVersionDescription")]
+        public bool VerbatimVersion { get; set; }
+
         [Option(typeof(NuGetCommand), "UpdateCommandRepositoryPathDescription")]
         public string RepositoryPath { get; set; }
 
@@ -286,7 +289,7 @@ namespace NuGet.CommandLine
                     var installed = await nugetProject.GetInstalledPackagesAsync(CancellationToken.None);
 
                     // If -Id has been specified and has exactly one package, use the explicit version requested
-                    var targetVersion = Version != null && Id != null && Id.Count == 1 ? new NuGetVersion(Version) : null;
+                    var targetVersion = Version != null && Id != null && Id.Count == 1 ? new NuGetVersion(Version, VerbatimVersion) : null;
 
                     var targetIdentities = installed
                         .Select(pr => pr.PackageIdentity.Id)

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -4927,6 +4927,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Forces the version number to be used verbatim..
+        /// </summary>
+        internal static string InstallCommandVerbatimVersionDescription {
+            get {
+                return ResourceManager.GetString("InstallCommandVerbatimVersionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to List all versions of a package. By default, only the latest package version is displayed..
         /// </summary>
         internal static string ListCommandAllVersionsDescription {
@@ -8584,6 +8593,15 @@ namespace NuGet.CommandLine {
         internal static string PackageCommandVersionDescription_trk {
             get {
                 return ResourceManager.GetString("PackageCommandVersionDescription_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Forces the version number from the nuspec file to be used verbatim..
+        /// </summary>
+        internal static string PackageCommandVerbatimVersionDescription {
+            get {
+                return ResourceManager.GetString("PackageCommandVerbatimVersionDescription", resourceCulture);
             }
         }
         
@@ -14764,6 +14782,15 @@ namespace NuGet.CommandLine {
         internal static string UpdateCommandVersionDescription {
             get {
                 return ResourceManager.GetString("UpdateCommandVersionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Forces the version number to be used verbatim..
+        /// </summary>
+        internal static string UpdateCommandVerbatimVersionDescription {
+            get {
+                return ResourceManager.GetString("UpdateCommandVerbatimVersionDescription", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -302,6 +302,9 @@ nuget list -verbose -allversions</value>
   <data name="PackageCommandVersionDescription" xml:space="preserve">
     <value>Overrides the version number from the nuspec file.</value>
   </data>
+  <data name="PackageCommandVerbatimVersionDescription" xml:space="preserve">
+    <value>Forces the version number from the nuspec file to be used verbatim.</value>
+  </data>
   <data name="PackCommandUsageExamples" xml:space="preserve">
     <value>nuget pack
 
@@ -429,6 +432,9 @@ nuget spec -a MyAssembly.dll</value>
   </data>
   <data name="UpdateCommandVersionDescription" xml:space="preserve">
     <value>Updates the package in -Id to the version indicated.  Requires -Id to contain exactly one package id.</value>
+  </data>
+  <data name="UpdateCommandVerbatimVersionDescription" xml:space="preserve">
+    <value>Forces the version number to be used verbatim.</value>
   </data>
   <data name="UpdateCommandUsageExamples" xml:space="preserve">
     <value>nuget update
@@ -1721,6 +1727,9 @@ nuget install ninject -o c:\foo</value>
   </data>
   <data name="InstallCommandVersionDescription_cht" xml:space="preserve">
     <value>要安裝的封裝版本。</value>
+  </data>
+  <data name="InstallCommandVerbatimVersionDescription" xml:space="preserve">
+    <value>Forces the version number to be used verbatim.</value>
   </data>
   <data name="ListCommandAllVersionsDescription_csy" xml:space="preserve">
     <value>Zobrazí seznam všech verzí balíčku. Ve výchozím nastavení se zobrazí pouze nejnovější verze balíčku.</value>

--- a/src/NuGet.Core/NuGet.Commands/CommandArgs/PackArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandArgs/PackArgs.cs
@@ -37,6 +37,7 @@ namespace NuGet.Commands
         public bool Symbols { get; set; }
         public bool Tool { get; set; }
         public string Version { get; set; }
+        public bool VerbatimVersion { get; set; }
         public WarningProperties WarningProperties { get; set; }
         public MSBuildPackTargetArgs PackTargetArgs { get; set; }
         public Dictionary<string, string> Properties

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
@@ -96,12 +96,12 @@ namespace NuGet.Packaging
                                 file.Exclude != null ? new XAttribute("exclude", file.Exclude) : null))) : null)).Save(stream);
         }
 
-        public static Manifest ReadFrom(Stream stream, bool validateSchema)
+        public static Manifest ReadFrom(Stream stream, bool validateSchema, bool verbatimVersion = false)
         {
-            return ReadFrom(stream, null, validateSchema);
+            return ReadFrom(stream, null, validateSchema, verbatimVersion);
         }
 
-        public static Manifest ReadFrom(Stream stream, Func<string, string> propertyProvider, bool validateSchema)
+        public static Manifest ReadFrom(Stream stream, Func<string, string> propertyProvider, bool validateSchema, bool verbatimVersion = false)
         {
             XDocument document;
             if (propertyProvider == null)
@@ -131,7 +131,7 @@ namespace NuGet.Packaging
             }
 
             // Deserialize it
-            var manifest = ManifestReader.ReadManifest(document);
+            var manifest = ManifestReader.ReadManifest(document, verbatimVersion);
 
             // Validate before returning
             Validate(manifest);

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -89,7 +89,7 @@ namespace NuGet.ProjectModel
                 {
                     var versionString = version.Value<string>();
                     packageSpec.HasVersionSnapshot = PackageSpecUtility.IsSnapshotVersion(versionString);
-                    packageSpec.Version = PackageSpecUtility.SpecifySnapshot(versionString, snapshotValue);
+                    packageSpec.Version = PackageSpecUtility.SpecifySnapshot(versionString, snapshotValue, false);
                 }
                 catch (Exception ex)
                 {

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
@@ -11,7 +11,7 @@ namespace NuGet.ProjectModel
         /// <summary>
         /// Apply a snapshot value.
         /// </summary>
-        public static NuGetVersion SpecifySnapshot(string version, string snapshotValue)
+        public static NuGetVersion SpecifySnapshot(string version, string snapshotValue, bool verbatimVersion)
         {
             // Snapshots should be in the form 1.0.0-*, 1.0.0-beta-*, or 1.0.0-rc.*
             // Snapshots may not contain metadata such as 1.0.0+5.* or be stable versions such as 1.0.*
@@ -27,7 +27,7 @@ namespace NuGet.ProjectModel
                 }
             }
 
-            return NuGetVersion.Parse(version);
+            return NuGetVersion.Parse(version, verbatimVersion);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
+++ b/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
@@ -132,11 +132,11 @@ namespace NuGet.Versioning
         /// <summary>
         /// Parse a floating version into a FloatRange
         /// </summary>
-        public static FloatRange Parse(string versionString)
+        public static FloatRange Parse(string versionString, bool verbatimVersion = false)
         {
             FloatRange range = null;
 
-            TryParse(versionString, out range);
+            TryParse(versionString, out range, verbatimVersion);
 
             return range;
         }
@@ -144,7 +144,7 @@ namespace NuGet.Versioning
         /// <summary>
         /// Parse a floating version into a FloatRange
         /// </summary>
-        public static bool TryParse(string versionString, out FloatRange range)
+        public static bool TryParse(string versionString, out FloatRange range, bool verbatimVersion = false)
         {
             range = null;
 
@@ -158,7 +158,7 @@ namespace NuGet.Versioning
                 if (versionString.Length == 1
                     && starPos == 0)
                 {
-                    range = new FloatRange(NuGetVersionFloatBehavior.Major, new NuGetVersion(new Version(0, 0)));
+                    range = new FloatRange(NuGetVersionFloatBehavior.Major, new NuGetVersion(new Version(0, 0), releaseLabel: null, metadata: null, verbatim: verbatimVersion));
                 }
                 // * must appear as the last char in the string. 
                 // * cannot appear in the metadata section after the +
@@ -212,7 +212,7 @@ namespace NuGet.Versioning
                     }
 
                     NuGetVersion version = null;
-                    if (NuGetVersion.TryParse(actualVersion, out version))
+                    if (NuGetVersion.TryParse(actualVersion, out version, verbatimVersion))
                     {
                         // there is no float range for this version
                         range = new FloatRange(behavior, version, releasePrefix);
@@ -222,7 +222,7 @@ namespace NuGet.Versioning
                 {
                     // normal version parse
                     NuGetVersion version = null;
-                    if (NuGetVersion.TryParse(versionString, out version))
+                    if (NuGetVersion.TryParse(versionString, out version, verbatimVersion))
                     {
                         // there is no float range for this version
                         range = new FloatRange(NuGetVersionFloatBehavior.None, version);

--- a/src/NuGet.Core/NuGet.Versioning/NuGetVersion.cs
+++ b/src/NuGet.Core/NuGet.Versioning/NuGetVersion.cs
@@ -14,21 +14,23 @@ namespace NuGet.Versioning
     public partial class NuGetVersion : SemanticVersion
     {
         private readonly string _originalString;
+        private readonly bool _verbatim;
 
         /// <summary>
         /// Creates a NuGetVersion using NuGetVersion.Parse(string)
         /// </summary>
         /// <param name="version">Version string</param>
-        public NuGetVersion(string version)
-            : this(Parse(version))
+        /// <param name="verbatim">Preserve all System.Version components</param>
+        public NuGetVersion(string version, bool verbatim = false)
+            : this(Parse(version, verbatim))
         {
         }
 
         /// <summary>
         /// Creates a NuGetVersion from an existing NuGetVersion
         /// </summary>
-        public NuGetVersion(NuGetVersion version)
-            : this(version.Version, version.ReleaseLabels, version.Metadata, version.OriginalVersion)
+        public NuGetVersion(NuGetVersion version, bool verbatim = false)
+            : this(version.Version, version.ReleaseLabels, version.Metadata, version.OriginalVersion, verbatim || version.Verbatim)
         {
         }
 
@@ -38,7 +40,8 @@ namespace NuGet.Versioning
         /// <param name="version">Version numbers</param>
         /// <param name="releaseLabel">Prerelease label</param>
         /// <param name="metadata">Build metadata</param>
-        public NuGetVersion(Version version, string releaseLabel = null, string metadata = null)
+        /// <param name="verbatim">Preserve all System.Version components</param>
+        public NuGetVersion(Version version, string releaseLabel = null, string metadata = null, bool verbatim = false)
             : this(version, ParseReleaseLabels(releaseLabel), metadata, GetLegacyString(version, ParseReleaseLabels(releaseLabel), metadata))
         {
         }
@@ -113,8 +116,9 @@ namespace NuGet.Versioning
         /// <param name="revision">w.x.y.Z</param>
         /// <param name="releaseLabel">Prerelease label</param>
         /// <param name="metadata">Build metadata</param>
-        public NuGetVersion(int major, int minor, int patch, int revision, string releaseLabel, string metadata)
-            : this(major, minor, patch, revision, ParseReleaseLabels(releaseLabel), metadata)
+        /// <param name="verbatim">Preserve all System.Version components</param>
+        public NuGetVersion(int major, int minor, int patch, int revision, string releaseLabel, string metadata, bool verbatim = false)
+            : this(major, minor, patch, revision, ParseReleaseLabels(releaseLabel), metadata, verbatim)
         {
         }
 
@@ -127,8 +131,9 @@ namespace NuGet.Versioning
         /// <param name="revision">w.x.y.Z</param>
         /// <param name="releaseLabels">Prerelease labels</param>
         /// <param name="metadata">Build metadata</param>
-        public NuGetVersion(int major, int minor, int patch, int revision, IEnumerable<string> releaseLabels, string metadata)
-            : this(new Version(major, minor, patch, revision), releaseLabels, metadata, null)
+        /// <param name="verbatim">Preserve all System.Version components</param>
+        public NuGetVersion(int major, int minor, int patch, int revision, IEnumerable<string> releaseLabels, string metadata, bool verbatim = false)
+            : this(new Version(major, minor, patch, revision), releaseLabels, metadata, null, verbatim)
         {
         }
 
@@ -140,10 +145,12 @@ namespace NuGet.Versioning
         /// <param name="releaseLabels">prerelease labels</param>
         /// <param name="metadata">Build metadata</param>
         /// <param name="originalVersion">Non-normalized original version string</param>
-        public NuGetVersion(Version version, IEnumerable<string> releaseLabels, string metadata, string originalVersion)
+        /// <param name="verbatim">Preserve all System.Version components</param>
+        public NuGetVersion(Version version, IEnumerable<string> releaseLabels, string metadata, string originalVersion, bool verbatim = false)
             : base(version, releaseLabels, metadata)
         {
             _originalString = originalVersion;
+            _verbatim = verbatim;
         }
 
         /// <summary>
@@ -170,6 +177,14 @@ namespace NuGet.Versioning
         public Version Version
         {
             get { return _version; }
+        }
+
+        /// <summary>
+        /// True if the NuGetVersion must be preserved verbatim (i.e. without normalizing away the revision).
+        /// </summary>
+        public bool Verbatim
+        {
+            get { return _verbatim; }
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Versioning/NuGetVersionFactory.cs
+++ b/src/NuGet.Core/NuGet.Versioning/NuGetVersionFactory.cs
@@ -12,8 +12,9 @@ namespace NuGet.Versioning
     {
         /// <summary>
         /// Creates a NuGetVersion from a string representing the semantic version.
+        /// Optionally, the revision can be preserved (i.e. even if it is zero).
         /// </summary>
-        public new static NuGetVersion Parse(string value)
+        public new static NuGetVersion Parse(string value, bool verbatim = false)
         {
             if (String.IsNullOrEmpty(value))
             {
@@ -21,7 +22,7 @@ namespace NuGet.Versioning
             }
 
             NuGetVersion ver = null;
-            if (!TryParse(value, out ver))
+            if (!TryParse(value, out ver, verbatim))
             {
                 throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Resources.Invalidvalue, value), "value");
             }
@@ -31,9 +32,9 @@ namespace NuGet.Versioning
 
         /// <summary>
         /// Parses a version string using loose semantic versioning rules that allows 2-4 version components followed
-        /// by an optional special version.
+        /// by an optional special version.  Optionally, the revision can be preserved (i.e. even if it is zero).
         /// </summary>
-        public static bool TryParse(string value, out NuGetVersion version)
+        public static bool TryParse(string value, out NuGetVersion version, bool verbatim = false)
         {
             version = null;
 
@@ -86,10 +87,20 @@ namespace NuGet.Versioning
                             originalVersion = value.Replace(" ", string.Empty);
                         }
 
-                        version = new NuGetVersion(version: ver,
-                            releaseLabels: sections.Item2,
-                            metadata: sections.Item3 ?? string.Empty,
-                            originalVersion: originalVersion);
+                        if (verbatim)
+                        {
+                            version = new NuGetVersion(version: systemVersion,
+                                releaseLabels: sections.Item2,
+                                metadata: sections.Item3 ?? string.Empty,
+                                originalVersion: originalVersion, verbatim: true);
+                        }
+                        else
+                        {
+                            version = new NuGetVersion(version: ver,
+                                releaseLabels: sections.Item2,
+                                metadata: sections.Item3 ?? string.Empty,
+                                originalVersion: originalVersion);
+                        }
 
                         return true;
                     }

--- a/src/NuGet.Core/NuGet.Versioning/SemanticVersionFactory.cs
+++ b/src/NuGet.Core/NuGet.Versioning/SemanticVersionFactory.cs
@@ -12,12 +12,12 @@ namespace NuGet.Versioning
         internal static readonly string[] EmptyReleaseLabels = Array.Empty<string>();
 
         /// <summary>
-        /// Parses a SemVer string using strict SemVer rules.
+        /// Parses a SemVer string using strict SemVer rules, optionally preserving the exact value provided by the caller.
         /// </summary>
-        public static SemanticVersion Parse(string value)
+        public static SemanticVersion Parse(string value, bool verbatim = false)
         {
             SemanticVersion ver = null;
-            if (!TryParse(value, out ver))
+            if (!TryParse(value, out ver, verbatim))
             {
                 throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Resources.Invalidvalue, value), nameof(value));
             }
@@ -26,10 +26,10 @@ namespace NuGet.Versioning
         }
 
         /// <summary>
-        /// Parse a version string
+        /// Parse a version string, optionally preserving the exact value provided by the caller.
         /// </summary>
         /// <returns>false if the version is not a strict semver</returns>
-        public static bool TryParse(string value, out SemanticVersion version)
+        public static bool TryParse(string value, out SemanticVersion version, bool verbatim = false)
         {
             version = null;
 
@@ -80,11 +80,21 @@ namespace NuGet.Versioning
                         return false;
                     }
 
-                    var ver = NormalizeVersionValue(systemVersion);
+                    if (verbatim)
+                    {
+                        version = new NuGetVersion(version: systemVersion,
+                            releaseLabels: sections.Item2,
+                            metadata: sections.Item3 ?? string.Empty,
+                            originalVersion: null, verbatim: true);
+                    }
+                    else
+                    {
+                        var ver = NormalizeVersionValue(systemVersion);
 
-                    version = new SemanticVersion(version: ver,
-                        releaseLabels: sections.Item2,
-                        metadata: sections.Item3 ?? string.Empty);
+                        version = new SemanticVersion(version: ver,
+                            releaseLabels: sections.Item2,
+                            metadata: sections.Item3 ?? string.Empty);
+                    }
 
                     return true;
                 }

--- a/src/NuGet.Core/NuGet.Versioning/VersionFormatter.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionFormatter.cs
@@ -117,6 +117,14 @@ namespace NuGet.Versioning
             return fullString;
         }
 
+        /// <summary>
+        /// Returns non-zero if string formatting of the specified version should always include the revision number.
+        /// </summary>
+        private static bool ShouldIncludeRevision(NuGetVersion nuGetVersion)
+        {
+            return nuGetVersion != null && (nuGetVersion.Verbatim || nuGetVersion.IsLegacyVersion);
+        }
+
         private static string Format(char c, SemanticVersion version)
         {
             string s = null;
@@ -149,7 +157,7 @@ namespace NuGet.Versioning
                     break;
                 case 'r':
                     var nuGetVersion = version as NuGetVersion;
-                    s = string.Format(CultureInfo.InvariantCulture, "{0}", nuGetVersion != null && nuGetVersion.IsLegacyVersion ? nuGetVersion.Version.Revision : 0);
+                    s = string.Format(CultureInfo.InvariantCulture, "{0}", ShouldIncludeRevision(nuGetVersion) ? nuGetVersion.Version.Revision : 0);
                     break;
             }
 
@@ -159,10 +167,9 @@ namespace NuGet.Versioning
         private static string FormatVersion(SemanticVersion version)
         {
             var nuGetVersion = version as NuGetVersion;
-            var legacy = nuGetVersion != null && nuGetVersion.IsLegacyVersion;
 
             return string.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}{3}", version.Major, version.Minor, version.Patch,
-                legacy ? string.Format(CultureInfo.InvariantCulture, ".{0}", nuGetVersion.Version.Revision) : null);
+                ShouldIncludeRevision(nuGetVersion) ? string.Format(CultureInfo.InvariantCulture, ".{0}", nuGetVersion.Version.Revision) : null);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Versioning/VersionRange.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRange.cs
@@ -352,7 +352,8 @@ namespace NuGet.Versioning
                     version.Patch,
                     version.Revision,
                     fixedLabels,
-                    version.Metadata);
+                    version.Metadata,
+                    version.Verbatim);
             }
 
             return nonSnapshotVersion;

--- a/src/NuGet.Core/NuGet.Versioning/VersionRangeFactory.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRangeFactory.cs
@@ -57,7 +57,7 @@ namespace NuGet.Versioning
         /// <summary>
         /// Direct parse
         /// </summary>
-        public static VersionRange Parse(string value, bool allowFloating)
+        public static VersionRange Parse(string value, bool allowFloating, bool verbatimVersion = false)
         {
             if (value == null)
             {
@@ -65,7 +65,7 @@ namespace NuGet.Versioning
             }
 
             VersionRange versionInfo;
-            if (!TryParse(value, allowFloating, out versionInfo))
+            if (!TryParse(value, allowFloating, out versionInfo, verbatimVersion))
             {
                 throw new ArgumentException(
                     String.Format(CultureInfo.CurrentCulture,
@@ -78,15 +78,15 @@ namespace NuGet.Versioning
         /// <summary>
         /// Parses a VersionRange from its string representation.
         /// </summary>
-        public static bool TryParse(string value, out VersionRange versionRange)
+        public static bool TryParse(string value, out VersionRange versionRange, bool verbatimVersion = false)
         {
-            return TryParse(value, true, out versionRange);
+            return TryParse(value, true, out versionRange, verbatimVersion);
         }
 
         /// <summary>
         /// Parses a VersionRange from its string representation.
         /// </summary>
-        public static bool TryParse(string value, bool allowFloating, out VersionRange versionRange)
+        public static bool TryParse(string value, bool allowFloating, out VersionRange versionRange, bool verbatimVersion = false)
         {
             versionRange = null;
 
@@ -199,7 +199,7 @@ namespace NuGet.Versioning
                 if (allowFloating && minVersionString.Contains("*"))
                 {
                     // single floating version
-                    if (FloatRange.TryParse(minVersionString, out floatRange)
+                    if (FloatRange.TryParse(minVersionString, out floatRange, verbatimVersion)
                         && floatRange.HasMinVersion)
                     {
                         minVersion = floatRange.MinVersion;
@@ -213,7 +213,7 @@ namespace NuGet.Versioning
                 else
                 {
                     // single non-floating version
-                    if (!NuGetVersion.TryParse(minVersionString, out minVersion))
+                    if (!NuGetVersion.TryParse(minVersionString, out minVersion, verbatimVersion))
                     {
                         // invalid version
                         return false;
@@ -224,7 +224,7 @@ namespace NuGet.Versioning
             // parse the max version string, the max cannot float
             if (!String.IsNullOrWhiteSpace(maxVersionString))
             {
-                if (!NuGetVersion.TryParse(maxVersionString, out maxVersion))
+                if (!NuGetVersion.TryParse(maxVersionString, out maxVersion, verbatimVersion))
                 {
                     // invalid version
                     return false;


### PR DESCRIPTION
## Bug
Fixes: NuGet/Home#3050
Regression: Yes  
If Regression then when did it last work:   NuGet 2.8.x (possibly NuGet 3.3.x?)
If Regression then how are we preventing it in future:  N/A

## Fix
Details: Modify all code necessary to add the -VerbatimVersion command line option, primarily for use with the 'nuget pack' command. 

## Testing/Validation
Tests Added: No  
Reason for not adding tests: Trivially easy to manually verify.
Validation done:  Manually verified the linked issue is fixed.