### PR TITLE
Adding Log(ILogMessage) capability to LoggerAdapter

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Logging/LegacyLoggerAdapter.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/LegacyLoggerAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
@@ -17,56 +17,56 @@ namespace NuGet.Common
             switch (level)
             {
                 case LogLevel.Debug:
-                    {
-                        LogDebug(data);
-                        break;
-                    }
+                {
+                    LogDebug(data);
+                    break;
+                }
 
                 case LogLevel.Error:
-                    {
-                        LogError(data);
-                        break;
-                    }
+                {
+                    LogError(data);
+                    break;
+                }
 
                 case LogLevel.Information:
-                    {
-                        LogInformation(data);
-                        break;
-                    }
+                {
+                    LogInformation(data);
+                    break;
+                }
 
                 case LogLevel.Minimal:
-                    {
-                        LogMinimal(data);
-                        break;
-                    }
+                {
+                    LogMinimal(data);
+                    break;
+                }
 
                 case LogLevel.Verbose:
-                    {
-                        LogVerbose(data);
-                        break;
-                    }
+                {
+                    LogVerbose(data);
+                    break;
+                }
 
                 case LogLevel.Warning:
-                    {
-                        LogWarning(data);
-                        break;
-                    }
+                {
+                    LogWarning(data);
+                    break;
+                }
             }
         }
 
-        public Task LogAsync(LogLevel level, string data)
+        public virtual Task LogAsync(LogLevel level, string data)
         {
             Log(level, data);
 
             return Task.FromResult(0);
         }
 
-        public void Log(ILogMessage message)
+        public virtual void Log(ILogMessage message)
         {
             Log(message.Level, message.Message);
         }
 
-        public async Task LogAsync(ILogMessage message)
+        public virtual async Task LogAsync(ILogMessage message)
         {
             await LogAsync(message.Level, message.Message);
         }

--- a/src/NuGet.Core/NuGet.Common/Logging/LegacyLoggerAdapter.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/LegacyLoggerAdapter.cs
@@ -54,7 +54,7 @@ namespace NuGet.Common
             }
         }
 
-        public virtual Task LogAsync(LogLevel level, string data)
+        public Task LogAsync(LogLevel level, string data)
         {
             Log(level, data);
 

--- a/src/NuGet.Core/NuGet.PackageManagement/LoggerAdapter.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/LoggerAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -16,12 +16,7 @@ namespace NuGet.ProjectManagement
 
         public LoggerAdapter(INuGetProjectContext projectLogger)
         {
-            if (projectLogger == null)
-            {
-                throw new ArgumentNullException(nameof(projectLogger));
-            }
-
-            ProjectLogger = projectLogger;
+            ProjectLogger = projectLogger ?? throw new ArgumentNullException(nameof(projectLogger));
         }
 
         public override void LogDebug(string data)
@@ -57,6 +52,17 @@ namespace NuGet.ProjectManagement
         public override void LogInformationSummary(string data)
         {
             ProjectLogger.Log(MessageLevel.Debug, data);
+        }
+
+        public override void Log(ILogMessage message)
+        {
+            ProjectLogger.Log(message);
+        }
+
+        public override Task LogAsync(ILogMessage message)
+        {
+            ProjectLogger.Log(message);
+            return Task.FromResult(0);
         }
     }
 }


### PR DESCRIPTION
## Bug
Improves the install scenario for PC projects as part of https://github.com/NuGet/Home/issues/6318 for PC based projects

## Fix
Details: This follows the work done in https://github.com/NuGet/NuGet.Client/pull/2353 to improve PR based projects. This PR adds `Log(ILogMessage)` capability to `LoggerAdapter` to allow logging of warnings into VS output and Error List windows.

## Testing/Validation
Tests Added: No
Reason for not adding tests:  UI based change
Validation done:  Manual validation done.

### Before -
![image](https://user-images.githubusercontent.com/10507120/43554380-d0552834-95a8-11e8-8141-835bffc06255.png)

### After - 
![image](https://user-images.githubusercontent.com/10507120/43555599-00820b06-95b0-11e8-86ff-313ccc7353df.png)
