### PR TITLE
Fixing PackageManager telelmetry tests by adding a Config file to TestSolutionManager

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -6198,7 +6198,7 @@ namespace NuGet.Test
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
-                    NullSettings.Instance,
+                    Settings.LoadSpecificSettings(solutionManager.SolutionDirectory, "NuGet.Config"),
                     solutionManager,
                     new TestDeleteOnRestartManager());
 
@@ -6241,7 +6241,7 @@ namespace NuGet.Test
 
                 Assert.True((string)telemetryEvents
                     .Where(p => p.Name == "ProjectRestoreInformation").
-                    Last()["ErrorCodes"] == NuGetLogCode.NU1100.ToString());
+                    Last()["ErrorCodes"] == NuGetLogCode.NU1102.ToString());
             }
         }
 
@@ -6269,7 +6269,7 @@ namespace NuGet.Test
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
-                    NullSettings.Instance,
+                    Settings.LoadSpecificSettings(solutionManager.SolutionDirectory, "NuGet.Config"),
                     solutionManager,
                     new TestDeleteOnRestartManager());
 
@@ -6315,7 +6315,7 @@ namespace NuGet.Test
 
                 Assert.True((string)telemetryEvents
                     .Where(p => p.Name == "ProjectRestoreInformation").
-                    Last()["ErrorCodes"] == NuGetLogCode.NU1100.ToString());
+                    Last()["ErrorCodes"] == NuGetLogCode.NU1102.ToString());
             }
         }
 
@@ -6323,7 +6323,6 @@ namespace NuGet.Test
         [Fact]
         public async Task TestPacMan_PreviewInstallPackage_BuildIntegrated_RaiseTelemetryEventsWithWarningCode()
         {
-
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
 
@@ -6344,7 +6343,7 @@ namespace NuGet.Test
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
-                    NullSettings.Instance,
+                    Settings.LoadSpecificSettings(solutionManager.SolutionDirectory, "NuGet.Config"),
                     solutionManager,
                     new TestDeleteOnRestartManager());
 
@@ -6427,7 +6426,7 @@ namespace NuGet.Test
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
-                    NullSettings.Instance,
+                    Settings.LoadSpecificSettings(solutionManager.SolutionDirectory, "NuGet.Config"),
                     solutionManager,
                     new TestDeleteOnRestartManager());
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -6383,7 +6383,7 @@ namespace NuGet.Test
                 }
 
                 // Assert
-                Assert.Equal(15, telemetryEvents.Count);
+                Assert.Equal(17, telemetryEvents.Count);
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateRestoreGraph").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateAssetsFile").Count());
@@ -6418,7 +6418,7 @@ namespace NuGet.Test
                 .Callback<TelemetryEvent>(x => telemetryEvents.Add(x));
 
             var nugetProjectContext = new TestNuGetProjectContext();
-            var telemetryService = new NuGetVSTelemetryService(telemetrySession.Object);
+            var telemetryService = new TestNuGetVSTelemetryService(telemetrySession.Object, _logger);
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
@@ -6457,7 +6457,7 @@ namespace NuGet.Test
                     CancellationToken.None);
 
                 // Assert
-                Assert.Equal(15, telemetryEvents.Count);
+                Assert.Equal(19, telemetryEvents.Count);
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateRestoreGraph").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateAssetsFile").Count());

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -6521,7 +6521,7 @@ namespace NuGet.Test
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
-                    NullSettings.Instance,
+                    Settings.LoadSpecificSettings(solutionManager.SolutionDirectory, "NuGet.Config"),
                     solutionManager,
                     new TestDeleteOnRestartManager());
 
@@ -6566,7 +6566,7 @@ namespace NuGet.Test
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
-                    NullSettings.Instance,
+                    Settings.LoadSpecificSettings(solutionManager.SolutionDirectory, "NuGet.Config"),
                     solutionManager,
                     new TestDeleteOnRestartManager());
 
@@ -6589,9 +6589,9 @@ namespace NuGet.Test
                     CancellationToken.None);
 
                 // Assert
-                Assert.Equal(3, telemetryEvents.Count);
+                Assert.Equal(5, telemetryEvents.Count);
                 Assert.Equal(1, telemetryEvents.Where(p => p.Name == "PackagePreFetcherInformation").Count());
-                Assert.Equal(1, telemetryEvents.Where(p => p.Name == "PackageExtractionInformation").Count());
+                Assert.Equal(2, telemetryEvents.Where(p => p.Name == "PackageExtractionInformation").Count());
                 Assert.Equal(1, telemetryEvents.Where(p => p.Name == "NugetActionSteps").Count());
                 Assert.True(telemetryEvents.Where(p => p.Name == "NugetActionSteps").
                      Any(p => (string)p["SubStepName"] == TelemetryConstants.ExecuteActionStepName));
@@ -6619,17 +6619,17 @@ namespace NuGet.Test
             using (var settingsdir = TestDirectory.Create())
             using (var testSolutionManager = new TestSolutionManager(true))
             {
-                var Settings = new Settings(settingsdir);
+                var settings = Settings.LoadSpecificSettings(testSolutionManager.SolutionDirectory, "NuGet.Config");
                 foreach (var source in sourceRepositoryProvider.GetRepositories())
                 {
-                    Settings.SetValue(ConfigurationConstants.PackageSources, ConfigurationConstants.PackageSources, source.PackageSource.Source);
+                    settings.SetValue(ConfigurationConstants.PackageSources, ConfigurationConstants.PackageSources, source.PackageSource.Source);
                 }
 
                 var token = CancellationToken.None;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
-                    Settings,
+                    settings,
                     testSolutionManager,
                     deleteOnRestartManager);
 
@@ -6656,7 +6656,7 @@ namespace NuGet.Test
                     token);
 
                 // Assert
-                Assert.Equal(16, telemetryEvents.Count);
+                Assert.Equal(36, telemetryEvents.Count);
 
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").Count());
                 Assert.Equal(2, telemetryEvents.Where(p => p.Name == "GenerateRestoreGraph").Count());

--- a/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
+++ b/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
@@ -17,12 +17,20 @@ namespace Test.Utility
 {
     public class TestSolutionManager : ISolutionManager, IDisposable
     {
+        private static readonly string GLOBAL_PACKAGES_ENV_KEY = "NUGET_PACKAGES";
+
         public List<NuGetProject> NuGetProjects { get; set; } = new List<NuGetProject>();
+
         public INuGetProjectContext NuGetProjectContext { get; set; } = new TestNuGetProjectContext();
+
+        public string NuGetConfigPath { get; set; }
+
+        public string GlobalPackagesFolder { get; set; }
+
+        public string PackagesFolder { get; set; }
 
         public string SolutionDirectory { get; }
 
-        private const string PackagesFolder = "packages";
 
         private TestDirectory _testDirectory;
 
@@ -31,15 +39,24 @@ namespace Test.Utility
   <packageSources>
     <add key='NuGet.org' value='https://api.nuget.org/v3/index.json' />
   </packageSources>
+  <config>
+     <add key='globalPackagesFolder' value='{0}' />
+  </config>
 </configuration>";
 
         public TestSolutionManager(bool foo)
         {
             _testDirectory = TestDirectory.Create();
             SolutionDirectory = _testDirectory;
+            NuGetConfigPath = Path.Combine(SolutionDirectory, "NuGet.Config");
+            PackagesFolder = Path.Combine(SolutionDirectory, "packages");
+            GlobalPackagesFolder = Path.Combine(SolutionDirectory, "globalpackages");
+
+            // set environment variable to isolate tests
+            Environment.SetEnvironmentVariable(GLOBAL_PACKAGES_ENV_KEY, GlobalPackagesFolder);
 
             // create nuget config in solution root
-            File.WriteAllText(Path.Combine(SolutionDirectory, "NuGet.Config"), _configContent);
+            File.WriteAllText(NuGetConfigPath, string.Format(_configContent, GlobalPackagesFolder));
         }
 
         public TestSolutionManager(string solutionDirectory)
@@ -61,7 +78,7 @@ namespace Test.Utility
                 throw new ArgumentException("Project with " + projectName + " already exists");
             }
 
-            var packagesFolder = Path.Combine(SolutionDirectory, PackagesFolder);
+            var packagesFolder = PackagesFolder;
             projectName = string.IsNullOrEmpty(projectName) ? Guid.NewGuid().ToString() : projectName;
             var projectFullPath = Path.Combine(SolutionDirectory, projectName);
             Directory.CreateDirectory(projectFullPath);
@@ -83,7 +100,6 @@ namespace Test.Utility
                 throw new ArgumentException("Project with " + projectName + " already exists");
             }
 
-            var packagesFolder = Path.Combine(SolutionDirectory, PackagesFolder);
             projectName = string.IsNullOrEmpty(projectName) ? Guid.NewGuid().ToString() : projectName;
             var projectFullPath = Path.Combine(SolutionDirectory, projectName);
             Directory.CreateDirectory(projectFullPath);
@@ -202,6 +218,9 @@ namespace Test.Utility
                 testDirectory.Dispose();
                 _testDirectory = null;
             }
+
+            // reset environment variable
+            Environment.SetEnvironmentVariable(GLOBAL_PACKAGES_ENV_KEY, null);
         }
 
 #pragma warning restore 0067

--- a/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
+++ b/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
@@ -26,10 +26,20 @@ namespace Test.Utility
 
         private TestDirectory _testDirectory;
 
+        private readonly string _configContent = @"<?xml version='1.0' encoding='utf-8'?>
+<configuration>
+  <packageSources>
+    <add key='NuGet.org' value='https://api.nuget.org/v3/index.json' />
+  </packageSources>
+</configuration>";
+
         public TestSolutionManager(bool foo)
         {
             _testDirectory = TestDirectory.Create();
             SolutionDirectory = _testDirectory;
+
+            // create nuget config in solution root
+            File.WriteAllText(Path.Combine(SolutionDirectory, "NuGet.Config"), _configContent);
         }
 
         public TestSolutionManager(string solutionDirectory)

--- a/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
+++ b/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
@@ -52,9 +52,6 @@ namespace Test.Utility
             PackagesFolder = Path.Combine(SolutionDirectory, "packages");
             GlobalPackagesFolder = Path.Combine(SolutionDirectory, "globalpackages");
 
-            // set environment variable to isolate tests
-            Environment.SetEnvironmentVariable(GLOBAL_PACKAGES_ENV_KEY, GlobalPackagesFolder);
-
             // create nuget config in solution root
             File.WriteAllText(NuGetConfigPath, string.Format(_configContent, GlobalPackagesFolder));
         }


### PR DESCRIPTION
Fixing flaky telemetry tests in `NuGetPackageManagerTests` by adding a config file in `TestSolutionManager` that adds a source to avoid relying on the global packages folder which may or may not have needed packages.
