### PR TITLE
Fixed failing E2E test InstallingPackagesWorksInTurkishLocaleWhenPackageIdContainsLetterI

### DIFF
--- a/test/EndToEnd/tests/InstallPackageTest.ps1
+++ b/test/EndToEnd/tests/InstallPackageTest.ps1
@@ -2338,7 +2338,7 @@ function Test-InstallFailCleansUpSatellitePackageFiles
     Assert-NoSolutionPackage A.fr -Version 1.0.0
 }
 
-function Test-FileTransformWorksOnDependentFile
+function FileTransformWorksOnDependentFile
 {
     param($context)
 

--- a/test/EndToEnd/tests/InstallPackageTest.ps1
+++ b/test/EndToEnd/tests/InstallPackageTest.ps1
@@ -1800,7 +1800,7 @@ function Test-InstallPackageInstallsHighestPackageIfItIsReleaseWhenPreReleaseFla
 function Test-InstallingPackagesWorksInTurkishLocaleWhenPackageIdContainsLetterI
 {
     # Arrange
-    $p = New-ClassLibrary
+    $p = New-ClassLibraryNet46
 
     $currentCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
 


### PR DESCRIPTION
Not sure why this test was not failing before but we're trying to install a package which is 4.5.2 onto a project which is 4.5 hence it fails. I've fixed the test to be compatible.

cc @rrelyea 