### PR TITLE
Make sure reposign certificates content url and reposign resource are https

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
@@ -42,6 +42,12 @@ namespace NuGet.Protocol
             ILogger log,
             CancellationToken token)
         {
+            var validUri = Uri.TryCreate(repoSignUrl, UriKind.Absolute, out var repoSignValidUri);
+            if (!validUri || !string.Equals(repoSignValidUri.Scheme, "https", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new FatalProtocolException(string.Format(CultureInfo.CurrentCulture, Strings.RepositorySignaturesResourceMustBeHttps, source.PackageSource.Source));
+            }
+
             var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
             var client = httpSourceResource.HttpSource;
 

--- a/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
@@ -30,10 +30,13 @@ namespace NuGet.Protocol
             AllRepositorySigned = allRepositorySigned;
             RepositoryCertificateInfos = data.OfType<JObject>().Select(p => p.FromJToken<RepositoryCertificateInfo>());
 
-            var validUri = Uri.TryCreate(source.PackageSource.Source, UriKind.Absolute, out var v3ServiceIndexUrl);
-            if (!validUri || !string.Equals(v3ServiceIndexUrl.Scheme, "https", StringComparison.OrdinalIgnoreCase))
+            foreach (var repositoryCertificateInfo in RepositoryCertificateInfos)
             {
-                throw new FatalProtocolException(Strings.RepositoryContentUrlMustBeHttps);
+                var validUri = Uri.TryCreate(repositoryCertificateInfo.ContentUrl, UriKind.Absolute, out var repositoryContentUrl);
+                if (!validUri || !string.Equals(repositoryContentUrl.Scheme, "https", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new FatalProtocolException(Strings.RepositoryContentUrlMustBeHttps);
+                }
             }
 
             Source = source.PackageSource.Source;

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -962,6 +962,15 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Repository Signatures resouce must be served over HTTPS. Source: {0}.
+        /// </summary>
+        internal static string RepositorySignaturesResourceMustBeHttps {
+            get {
+                return ResourceManager.GetString("RepositorySignaturesResourceMustBeHttps", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The &apos;{0}&apos; installation feature was required by a package but is not supported on the current host..
         /// </summary>
         internal static string RequiredFeatureUnsupportedException_DefaultMessageWithFeature {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -490,4 +490,8 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
   <data name="RepositoryContentUrlMustBeHttps" xml:space="preserve">
     <value>Repository content URL for repository signatures must be HTTPS.</value>
   </data>
+  <data name="RepositorySignaturesResourceMustBeHttps" xml:space="preserve">
+    <value>Repository Signatures resouce must be served over HTTPS. Source: {0}</value>
+    <comment>{0} source service index</comment>
+  </data>
 </root>

--- a/test/TestUtilities/Test.Utility/JsonData.cs
+++ b/test/TestUtilities/Test.Utility/JsonData.cs
@@ -4391,6 +4391,203 @@ namespace Test.Utility
     ""comment"": ""http://www.w3.org/2000/01/rdf-schema#comment""
   }
 }";
+
+        public const string RepoSignIndexJsonDataResourceNotHTTPS = @"{
+  ""version"": ""3.0.0"",
+  ""resources"": [
+    {
+      ""@id"": ""https://nuget-dev-usnc-v2v3search.nugettest.org/"",
+      ""@type"": ""SearchGalleryQueryService/3.0.0-rc"",
+      ""comment"": ""Azure Website based Search Service used by Gallery (primary)""
+    },
+    {
+      ""@id"": ""https://nuget-dev-ussc-v2v3search.nugettest.org/"",
+      ""@type"": ""SearchGalleryQueryService/3.0.0-rc"",
+      ""comment"": ""Azure Website based Search Service used by Gallery (secondary)""
+    },
+    {
+      ""@id"": ""https://nuget-dev-usnc-v2v3search.nugettest.org/autocomplete"",
+      ""@type"": ""SearchAutocompleteService"",
+      ""comment"": ""Autocomplete endpoint of NuGet Search service (primary).""
+    },
+    {
+      ""@id"": ""https://nuget-dev-ussc-v2v3search.nugettest.org/autocomplete"",
+      ""@type"": ""SearchAutocompleteService"",
+      ""comment"": ""Autocomplete endpoint of NuGet Search service (secondary).""
+    },
+    {
+      ""@id"": ""https://nuget-dev-usnc-v2v3search.nugettest.org/autocomplete"",
+      ""@type"": ""SearchAutocompleteService/3.0.0-beta"",
+      ""comment"": ""Autocomplete endpoint of NuGet Search service (primary) used by beta clients""
+    },
+    {
+      ""@id"": ""https://nuget-dev-ussc-v2v3search.nugettest.org/autocomplete"",
+      ""@type"": ""SearchAutocompleteService/3.0.0-beta"",
+      ""comment"": ""Autocomplete endpoint of NuGet Search service (secondary) used by beta clients""
+    },
+    {
+      ""@id"": ""https://nuget-dev-usnc-v2v3search.nugettest.org/autocomplete"",
+      ""@type"": ""SearchAutocompleteService/3.0.0-rc"",
+      ""comment"": ""Autocomplete endpoint of NuGet Search service (primary) used by RC clients""
+    },
+    {
+      ""@id"": ""https://nuget-dev-ussc-v2v3search.nugettest.org/autocomplete"",
+      ""@type"": ""SearchAutocompleteService/3.0.0-rc"",
+      ""comment"": ""Autocomplete endpoint of NuGet Search service (secondary) used by RC clients""
+    },
+    {
+      ""@id"": ""https://nuget-dev-usnc-v2v3search.nugettest.org/query"",
+      ""@type"": ""SearchQueryService"",
+      ""comment"": ""Query endpoint of NuGet Search service (primary).""
+    },
+    {
+      ""@id"": ""https://nuget-dev-ussc-v2v3search.nugettest.org/query"",
+      ""@type"": ""SearchQueryService"",
+      ""comment"": ""Query endpoint of NuGet Search service (secondary).""
+    },
+    {
+      ""@id"": ""https://nuget-dev-usnc-v2v3search.nugettest.org/query"",
+      ""@type"": ""SearchQueryService/3.0.0-beta"",
+      ""comment"": ""Query endpoint of NuGet Search service (primary) used by beta clients""
+    },
+    {
+      ""@id"": ""https://nuget-dev-ussc-v2v3search.nugettest.org/query"",
+      ""@type"": ""SearchQueryService/3.0.0-beta"",
+      ""comment"": ""Query endpoint of NuGet Search service (secondary) used by beta clients""
+    },
+    {
+      ""@id"": ""https://nuget-dev-usnc-v2v3search.nugettest.org/query"",
+      ""@type"": ""SearchQueryService/3.0.0-rc"",
+      ""comment"": ""Query endpoint of NuGet Search service (primary) used by RC clients""
+    },
+    {
+      ""@id"": ""https://nuget-dev-ussc-v2v3search.nugettest.org/query"",
+      ""@type"": ""SearchQueryService/3.0.0-rc"",
+      ""comment"": ""Query endpoint of NuGet Search service (secondary) used by RC clients""
+    },
+    {
+      ""@id"": ""https://nuget-dev-usnc-v2v3search.nugettest.org/query"",
+      ""@type"": ""SearchQueryService/3.4.0"",
+      ""comment"": ""Query endpoint of NuGet Search service (primary).""
+    },
+    {
+      ""@id"": ""https://nuget-dev-ussc-v2v3search.nugettest.org/query"",
+      ""@type"": ""SearchQueryService/3.4.0"",
+      ""comment"": ""Query endpoint of NuGet Search service (secondary).""
+    },
+    {
+      ""@id"": ""https://dev.nugettest.org/packages/{id}/{version}/ReportAbuse"",
+      ""@type"": ""ReportAbuseUriTemplate"",
+      ""comment"": ""URI template used by NuGet Client to construct Report Abuse URL for packages.""
+    },
+    {
+      ""@id"": ""https://dev.nugettest.org/packages/{id}/{version}/ReportAbuse"",
+      ""@type"": ""ReportAbuseUriTemplate/3.0.0-beta"",
+      ""comment"": ""URI template used by NuGet Client to construct Report Abuse URL for packages.""
+    },
+    {
+      ""@id"": ""https://dev.nugettest.org/packages/{id}/{version}/ReportAbuse"",
+      ""@type"": ""ReportAbuseUriTemplate/3.0.0-rc"",
+      ""comment"": ""URI template used by NuGet Client to construct Report Abuse URL for packages.""
+    },
+    {
+      ""@id"": ""https://api.nuget.org/v3-registration3/"",
+      ""@type"": ""RegistrationsBaseUrl"",
+      ""comment"": ""Base URL of Azure storage where NuGet package registration info is stored. This base URL does not include SemVer 2.0.0 packages.""
+    },
+    {
+      ""@id"": ""https://api.nuget.org/v3-registration3/"",
+      ""@type"": ""RegistrationsBaseUrl/3.0.0-beta"",
+      ""comment"": ""Base URL of Azure storage where NuGet package registration info is stored. This base URL does not include SemVer 2.0.0 packages.""
+    },
+    {
+      ""@id"": ""https://api.nuget.org/v3-registration3/"",
+      ""@type"": ""RegistrationsBaseUrl/3.0.0-rc"",
+      ""comment"": ""Base URL of Azure storage where NuGet package registration info is stored. This base URL does not include SemVer 2.0.0 packages.""
+    },
+    {
+      ""@id"": ""https://api.nuget.org/v3-registration3/{id-lower}/index.json"",
+      ""@type"": ""PackageDisplayMetadataUriTemplate"",
+      ""comment"": ""URI template used by NuGet Client to construct display metadata for Packages using ID.""
+    },
+    {
+      ""@id"": ""https://api.nuget.org/v3-registration3/{id-lower}/index.json"",
+      ""@type"": ""PackageDisplayMetadataUriTemplate/3.0.0-beta"",
+      ""comment"": ""URI template used by NuGet Client to construct display metadata for Packages using ID.""
+    },
+    {
+      ""@id"": ""https://api.nuget.org/v3-registration3/{id-lower}/index.json"",
+      ""@type"": ""PackageDisplayMetadataUriTemplate/3.0.0-rc"",
+      ""comment"": ""URI template used by NuGet Client to construct display metadata for Packages using ID.""
+    },
+    {
+      ""@id"": ""https://api.nuget.org/v3-registration3/{id-lower}/{version-lower}.json"",
+      ""@type"": ""PackageVersionDisplayMetadataUriTemplate"",
+      ""comment"": ""URI template used by NuGet Client to construct display metadata for Packages using ID, Version.""
+    },
+    {
+      ""@id"": ""https://api.nuget.org/v3-registration3/{id-lower}/{version-lower}.json"",
+      ""@type"": ""PackageVersionDisplayMetadataUriTemplate/3.0.0-beta"",
+      ""comment"": ""URI template used by NuGet Client to construct display metadata for Packages using ID, Version.""
+    },
+    {
+      ""@id"": ""https://api.nuget.org/v3-registration3/{id-lower}/{version-lower}.json"",
+      ""@type"": ""PackageVersionDisplayMetadataUriTemplate/3.0.0-rc"",
+      ""comment"": ""URI template used by NuGet Client to construct display metadata for Packages using ID, Version.""
+    },
+    {
+      ""@id"": ""https://api.nuget.org/v3-flatcontainer/"",
+      ""@type"": ""PackageBaseAddress/3.0.0"",
+      ""comment"": ""Base URL of where NuGet packages are stored, in the format https://api.nuget.org/v3-flatcontainer/{id-lower}/{version-lower}/{id-lower}.{version-lower}.nupkg""
+    },
+    {
+      ""@id"": ""https://dev.nugettest.org/api/v2"",
+      ""@type"": ""LegacyGallery"",
+      ""comment"": ""Legacy gallery using the V2 protocol.""
+    },
+    {
+      ""@id"": ""https://dev.nugettest.org/api/v2"",
+      ""@type"": ""LegacyGallery/2.0.0"",
+      ""comment"": ""Legacy gallery using the V2 protocol.""
+    },
+    {
+      ""@id"": ""https://dev.nugettest.org/api/v2/package"",
+      ""@type"": ""PackagePublish/2.0.0"",
+      ""comment"": ""Legacy gallery publish endpoint using the V2 protocol.""
+    },
+    {
+      ""@id"": ""https://api.nuget.org/v3-registration3-gz/"",
+      ""@type"": ""RegistrationsBaseUrl/3.4.0"",
+      ""comment"": ""Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL does not include SemVer 2.0.0 packages.""
+    },
+    {
+      ""@id"": ""https://api.nuget.org/v3-registration3-gz-semver2/"",
+      ""@type"": ""RegistrationsBaseUrl/3.6.0"",
+      ""comment"": ""Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL includes SemVer 2.0.0 packages.""
+    },
+    {
+      ""@id"": ""https://api.nuget.org/v3-registration3-gz-semver2/"",
+      ""@type"": ""RegistrationsBaseUrl/Versioned"",
+      ""clientVersion"": ""4.3.0-alpha"",
+      ""comment"": ""Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL includes SemVer 2.0.0 packages.""
+    },
+    {
+      ""@id"": ""http://api.nuget.org/v3-index/repository-signatures/index.json"",
+      ""@type"": ""RepositorySignatures/4.7.0"",
+      ""comment"": ""The endpoint for discovering information about this package source's repository signatures.""
+    },
+    {
+      ""@id"": ""https://az635243.vo.msecnd.net/v3/catalog0/index.json"",
+      ""@type"": ""Catalog/3.0.0"",
+      ""comment"": ""Index of the NuGet package catalog.""
+    }
+  ],
+  ""@context"": {
+    ""@vocab"": ""http://schema.nuget.org/schema#"",
+    ""comment"": ""http://www.w3.org/2000/01/rdf-schema#comment""
+  }
+}";
+
         #endregion
 
         #region repoSignResponse
@@ -4409,6 +4606,23 @@ namespace Test.Utility
     }
   ]
 }";
+
+        public const string RepoSignDataNotHTTPS = @"{
+  ""allRepositorySigned"": false,
+  ""signingCertificates"": [
+    {
+      ""fingerprints"": {
+        ""2.16.840.1.101.3.4.2.1"": ""3f9001ea83c560d712c24cf213c3d312cb3bff51ee89435d3430bd06b5d0eece""
+      },
+      ""subject"": ""CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"",
+      ""issuer"": ""CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US"",
+      ""notBefore"": ""2018-02-26T00:00:00.0000000Z"",
+      ""notAfter"": ""2021-01-27T12:00:00.0000000Z"",
+      ""contentUrl"": ""http://api.nuget.org/v3-index/repository-signatures/certificates/3f9001ea83c560d712c24cf213c3d312cb3bff51ee89435d3430bd06b5d0eece.crt""
+    }
+  ]
+}";
+
         #endregion
 
         #region repoSignResponseWithoutAllRepositorySigned


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7174
Regression: Yes/No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Repository signature resource endpoint and certificates `ContentUrl` are required to be served over `HTTPS`, currently, in our code, we are doing this check incorrectly and we are checking that the package source is over https, which has nothing to do with either the resource endpoint or certificates `ContentUrl`. 

This error was introduced in 4.8 and can make any client running this code that has nuget.org as an HTTP source fail to install/restore/update any repo signed package from that source.

This PR fixes the current code to look at the `ContentURL` of each repository certificate announced and adds a check for the repository signatures resource to be over HTTPS.

cc. @dtivel 