### PR TITLE
Adding logging to PC restore scenario in VS

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -18,6 +18,8 @@ using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.PackageManagement;
 using NuGet.PackageManagement.VisualStudio;
+using NuGet.Packaging;
+using NuGet.Packaging.PackageExtraction;
 using NuGet.Packaging.Signing;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
@@ -475,6 +477,14 @@ namespace NuGet.SolutionRestoreManager
                         {
                             // Display the restore opt out message if it has not been shown yet
                             await l.WriteHeaderAsync();
+
+                            // initialize PackageExtractionContext to allow logging inside the restore call
+                            _nuGetProjectContext.PackageExtractionContext = new PackageExtractionContext(
+                                PackageSaveMode.Defaultv2,
+                                PackageExtractionBehavior.XmlDocFileSaveMode,
+                                _logger,
+                                new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders()),
+                                SignedPackageVerifierSettings.GetDefault());
 
                             await RestoreMissingPackagesInSolutionAsync(solutionDirectory, packages, t);
                         },

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
@@ -282,18 +282,6 @@ namespace NuGet.PackageManagement
             // Before starting to restore package, set the nuGetProjectContext such that satellite files are not copied yet
             // Satellite files will be copied as a post operation. This helps restore packages in parallel
             // and not have to determine if the package is a satellite package beforehand
-            if (nuGetProjectContext.PackageExtractionContext == null)
-            {
-                var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
-
-                nuGetProjectContext.PackageExtractionContext = new PackageExtractionContext(
-                    PackageSaveMode.Defaultv2,
-                    PackageExtractionBehavior.XmlDocFileSaveMode,
-                    new LoggerAdapter(nuGetProjectContext),
-                    signedPackageVerifier,
-                    SignedPackageVerifierSettings.GetDefault());
-            }
-
             nuGetProjectContext.PackageExtractionContext.CopySatelliteFiles = false;
 
             packageRestoreContext.Token.ThrowIfCancellationRequested();

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
@@ -282,6 +282,18 @@ namespace NuGet.PackageManagement
             // Before starting to restore package, set the nuGetProjectContext such that satellite files are not copied yet
             // Satellite files will be copied as a post operation. This helps restore packages in parallel
             // and not have to determine if the package is a satellite package beforehand
+            if (nuGetProjectContext.PackageExtractionContext == null)
+            {
+                var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
+                nuGetProjectContext.PackageExtractionContext = new PackageExtractionContext(
+                    PackageSaveMode.Defaultv2,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
+                    new LoggerAdapter(nuGetProjectContext),
+                    signedPackageVerifier,
+                    SignedPackageVerifierSettings.GetDefault());
+            }
+
             nuGetProjectContext.PackageExtractionContext.CopySatelliteFiles = false;
 
             packageRestoreContext.Token.ThrowIfCancellationRequested();


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6318
Regression: No

## Fix
Details: This PR fixes the scenario where Packages.Config restore in VS would not display any warnings. The issue was that on restore `SolutionRestoreContext` is instantiated [here](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs#L238) which creates an `EmptyNuGetProjectContext` [here](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJobContext.cs#L13). This context is then used to populate the `PackageExtractionContext` [here](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs#L292), resulting in no logs being displayed.

This PR fixes this by initializing `PackageExtractionContext` in `SolutionRestoreJob` and  using a `RestoreOperationLogger` as a logger.

## Testing/Validation
Tests Added: No
Reason for not adding tests:  UI changes
Validation done:  Manual Validation

### Before - 
![image](https://user-images.githubusercontent.com/10507120/43808263-215b0ba6-9a61-11e8-9d89-c9d39a542537.png)


### After - 
![image](https://user-images.githubusercontent.com/10507120/43808242-04f1e49e-9a61-11e8-9193-2403b9920c41.png)
