### PR TITLE
Fixing default comparison in pack validation rules

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Rules/DefaultManifestValuesRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/DefaultManifestValuesRule.cs
@@ -12,9 +12,9 @@ namespace NuGet.Packaging.Rules
 {
     public class DefaultManifestValuesRule : IPackageRule
     {
-        internal static readonly string SampleProjectUrl = "http://PROJECT_URL_HERE_OR_DELETE_THIS_LINE";
-        internal static readonly string SampleLicenseUrl = "http://LICENSE_URL_HERE_OR_DELETE_THIS_LINE";
-        internal static readonly string SampleIconUrl = "http://ICON_URL_HERE_OR_DELETE_THIS_LINE";
+        internal static readonly string SampleProjectUrl = "http://PROJECT_URL_HERE_OR_DELETE_THIS_LINE/";
+        internal static readonly string SampleLicenseUrl = "http://LICENSE_URL_HERE_OR_DELETE_THIS_LINE/";
+        internal static readonly string SampleIconUrl = "http://ICON_URL_HERE_OR_DELETE_THIS_LINE/";
         internal static readonly string SampleTags = "Tag1 Tag2";
         internal static readonly string SampleReleaseNotes = "Summary of changes made in this release of the package.";
         internal static readonly string SampleDescription = "Package description";
@@ -35,19 +35,19 @@ namespace NuGet.Packaging.Rules
                 throw new ArgumentNullException(nameof(builder));
             }
             var nuspecReader = builder.NuspecReader;
-            if (SampleProjectUrl.Equals(nuspecReader.GetProjectUrl(), StringComparison.Ordinal))
+            if (SampleProjectUrl.Equals(nuspecReader.GetProjectUrl(), StringComparison.OrdinalIgnoreCase))
             {
                 yield return CreateIssueFor("ProjectUrl", nuspecReader.GetProjectUrl());
             }
-            if (SampleLicenseUrl.Equals(nuspecReader.GetLicenseUrl(), StringComparison.Ordinal))
+            if (SampleLicenseUrl.Equals(nuspecReader.GetLicenseUrl(), StringComparison.OrdinalIgnoreCase))
             {
                 yield return CreateIssueFor("LicenseUrl", nuspecReader.GetLicenseUrl());
             }
-            if (SampleIconUrl.Equals(nuspecReader.GetIconUrl(), StringComparison.Ordinal))
+            if (SampleIconUrl.Equals(nuspecReader.GetIconUrl(), StringComparison.OrdinalIgnoreCase))
             {
                 yield return CreateIssueFor("IconUrl", nuspecReader.GetIconUrl());
             }
-            if (SampleTags.Equals(nuspecReader.GetTags()))
+            if (SampleTags.Equals(nuspecReader.GetTags(), StringComparison.Ordinal))
             {
                 yield return CreateIssueFor("Tags", SampleTags);
             }
@@ -62,9 +62,9 @@ namespace NuGet.Packaging.Rules
 
             var dependency = nuspecReader.GetDependencyGroups().SelectMany(d => d.Packages).FirstOrDefault();
             if (dependency != null &&
-                dependency.Id.Equals(SampleManifestDependencyId, StringComparison.Ordinal) &&
+                dependency.Id.Equals(SampleManifestDependencyId, StringComparison.OrdinalIgnoreCase) &&
                 dependency.VersionRange != null &&
-                dependency.VersionRange.ToString().Equals("[" + SampleManifestDependencyVersion + "]", StringComparison.Ordinal))
+                dependency.VersionRange.ToString().Equals("[" + SampleManifestDependencyVersion + "]", StringComparison.OrdinalIgnoreCase))
             {
                 yield return CreateIssueFor("Dependency", dependency.ToString());
             }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/DefaultManifestValuesRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/DefaultManifestValuesRule.cs
@@ -12,9 +12,9 @@ namespace NuGet.Packaging.Rules
 {
     public class DefaultManifestValuesRule : IPackageRule
     {
-        internal static readonly string SampleProjectUrl = "http://PROJECT_URL_HERE_OR_DELETE_THIS_LINE/";
-        internal static readonly string SampleLicenseUrl = "http://LICENSE_URL_HERE_OR_DELETE_THIS_LINE/";
-        internal static readonly string SampleIconUrl = "http://ICON_URL_HERE_OR_DELETE_THIS_LINE/";
+        internal static readonly Uri SampleProjectUrl = new Uri("http://PROJECT_URL_HERE_OR_DELETE_THIS_LINE");
+        internal static readonly Uri SampleLicenseUrl = new Uri("http://LICENSE_URL_HERE_OR_DELETE_THIS_LINE");
+        internal static readonly Uri SampleIconUrl = new Uri("http://ICON_URL_HERE_OR_DELETE_THIS_LINE");
         internal static readonly string SampleTags = "Tag1 Tag2";
         internal static readonly string SampleReleaseNotes = "Summary of changes made in this release of the package.";
         internal static readonly string SampleDescription = "Package description";
@@ -35,26 +35,35 @@ namespace NuGet.Packaging.Rules
                 throw new ArgumentNullException(nameof(builder));
             }
             var nuspecReader = builder.NuspecReader;
-            if (SampleProjectUrl.Equals(nuspecReader.GetProjectUrl(), StringComparison.OrdinalIgnoreCase))
+
+            Uri.TryCreate(nuspecReader.GetProjectUrl(), UriKind.RelativeOrAbsolute, out var projectUrl);
+            if (projectUrl == SampleProjectUrl)
             {
                 yield return CreateIssueFor("projectUrl", nuspecReader.GetProjectUrl());
             }
-            if (SampleLicenseUrl.Equals(nuspecReader.GetLicenseUrl(), StringComparison.OrdinalIgnoreCase))
+
+            Uri.TryCreate(nuspecReader.GetLicenseUrl(), UriKind.RelativeOrAbsolute, out var licenseUrl);
+            if (licenseUrl == SampleLicenseUrl)
             {
                 yield return CreateIssueFor("licenseUrl", nuspecReader.GetLicenseUrl());
             }
-            if (SampleIconUrl.Equals(nuspecReader.GetIconUrl(), StringComparison.OrdinalIgnoreCase))
+
+            Uri.TryCreate(nuspecReader.GetIconUrl(), UriKind.RelativeOrAbsolute, out var iconUrl);
+            if (iconUrl == SampleIconUrl)
             {
                 yield return CreateIssueFor("iconUrl", nuspecReader.GetIconUrl());
             }
+
             if (SampleTags.Equals(nuspecReader.GetTags(), StringComparison.Ordinal))
             {
                 yield return CreateIssueFor("tags", SampleTags);
             }
+
             if (SampleReleaseNotes.Equals(nuspecReader.GetReleaseNotes(), StringComparison.Ordinal))
             {
                 yield return CreateIssueFor("releaseNotes", SampleReleaseNotes);
             }
+
             if (SampleDescription.Equals(nuspecReader.GetDescription(), StringComparison.Ordinal))
             {
                 yield return CreateIssueFor("description", SampleDescription);

--- a/src/NuGet.Core/NuGet.Packaging/Rules/DefaultManifestValuesRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/DefaultManifestValuesRule.cs
@@ -37,27 +37,27 @@ namespace NuGet.Packaging.Rules
             var nuspecReader = builder.NuspecReader;
             if (SampleProjectUrl.Equals(nuspecReader.GetProjectUrl(), StringComparison.OrdinalIgnoreCase))
             {
-                yield return CreateIssueFor("ProjectUrl", nuspecReader.GetProjectUrl());
+                yield return CreateIssueFor("projectUrl", nuspecReader.GetProjectUrl());
             }
             if (SampleLicenseUrl.Equals(nuspecReader.GetLicenseUrl(), StringComparison.OrdinalIgnoreCase))
             {
-                yield return CreateIssueFor("LicenseUrl", nuspecReader.GetLicenseUrl());
+                yield return CreateIssueFor("licenseUrl", nuspecReader.GetLicenseUrl());
             }
             if (SampleIconUrl.Equals(nuspecReader.GetIconUrl(), StringComparison.OrdinalIgnoreCase))
             {
-                yield return CreateIssueFor("IconUrl", nuspecReader.GetIconUrl());
+                yield return CreateIssueFor("iconUrl", nuspecReader.GetIconUrl());
             }
             if (SampleTags.Equals(nuspecReader.GetTags(), StringComparison.Ordinal))
             {
-                yield return CreateIssueFor("Tags", SampleTags);
+                yield return CreateIssueFor("tags", SampleTags);
             }
             if (SampleReleaseNotes.Equals(nuspecReader.GetReleaseNotes(), StringComparison.Ordinal))
             {
-                yield return CreateIssueFor("ReleaseNotes", SampleReleaseNotes);
+                yield return CreateIssueFor("releaseNotes", SampleReleaseNotes);
             }
             if (SampleDescription.Equals(nuspecReader.GetDescription(), StringComparison.Ordinal))
             {
-                yield return CreateIssueFor("Description", SampleDescription);
+                yield return CreateIssueFor("description", SampleDescription);
             }
 
             var dependency = nuspecReader.GetDependencyGroups().SelectMany(d => d.Packages).FirstOrDefault();
@@ -66,7 +66,7 @@ namespace NuGet.Packaging.Rules
                 dependency.VersionRange != null &&
                 dependency.VersionRange.ToString().Equals("[" + SampleManifestDependencyVersion + "]", StringComparison.OrdinalIgnoreCase))
             {
-                yield return CreateIssueFor("Dependency", dependency.ToString());
+                yield return CreateIssueFor("dependency", dependency.ToString());
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/DefaultManifestValuesRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/DefaultManifestValuesRuleTests.cs
@@ -15,8 +15,11 @@ namespace NuGet.Packaging.Test
 {
     public class DefaultManifestValuesRuleTests
     {
-        [Fact]
-        public void Validate_NuSpecFileWithDefaultProjectUrl_GeneratesWarning()
+        [Theory]
+        [InlineData("<projectUrl>http://PROJECT_URL_HERE_OR_DELETE_THIS_LINE</projectUrl>", "projectUrl")]
+        [InlineData("<licenseUrl>http://LICENSE_URL_HERE_OR_DELETE_THIS_LINE</licenseUrl>", "licenseUrl")]
+        [InlineData("<iconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</iconUrl>", "iconUrl")]
+        public void Validate_NuSpecFileWithDefaultProjectUrl_GeneratesWarning(string urlMetadata, string urlType)
         {
             // Arrange
             var nuspecContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
@@ -27,7 +30,7 @@ namespace NuGet.Packaging.Test
 "        <authors>Unit Test</authors>" +
 "        <description>Sample Description</description>" +
 "        <language>en-US</language>" +
-"        <projectUrl>http://PROJECT_URL_HERE_OR_DELETE_THIS_LINE</projectUrl>" +
+urlMetadata +
 "    <dependencies>" +
 "      <dependency id=\"System.Collections.Immutable\" version=\"4.3.0\" />" +
 "    </dependencies>" +
@@ -66,7 +69,7 @@ namespace NuGet.Packaging.Test
                         issues.AddRange(rule.Validate(reader).OrderBy(p => p.Code.ToString(), StringComparer.CurrentCulture));
                     }
 
-                    Assert.True(issues.Any(p => p.Code == NuGetLogCode.NU5102 && p.Message.Contains("projectUrl")));
+                    Assert.True(issues.Any(p => p.Code == NuGetLogCode.NU5102 && p.Message.Contains(urlType)));
                 }
             }
         }
@@ -84,6 +87,8 @@ namespace NuGet.Packaging.Test
 "        <description>Sample Description</description>" +
 "        <language>en-US</language>" +
 "        <projectUrl>http://unit.test</projectUrl>" +
+"        <licenseUrl>http://unit.test</licenseUrl>" +
+"        <iconUrl>http://unit.test</iconUrl>" +
 "    <dependencies>" +
 "      <dependency id=\"System.Collections.Immutable\" version=\"4.3.0\" />" +
 "    </dependencies>" +
@@ -122,7 +127,7 @@ namespace NuGet.Packaging.Test
                         issues.AddRange(rule.Validate(reader).OrderBy(p => p.Code.ToString(), StringComparer.CurrentCulture));
                     }
 
-                    Assert.False(issues.Any(p => p.Code == NuGetLogCode.NU5102 && p.Message.Contains("projectUrl")));
+                    Assert.False(issues.Any(p => p.Code == NuGetLogCode.NU5102));
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/DefaultManifestValuesRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/DefaultManifestValuesRuleTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Packaging.Rules;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class DefaultManifestValuesRuleTests
+    {
+        [Fact]
+        public void Validate_NuSpecFileWithDefaultProjectUrl_GeneratesWarning()
+        {
+            // Arrange
+            var nuspecContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+"<package xmlns=\"http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd\">" +
+"   <metadata>" +
+"        <id>test</id>" +
+"        <version>1.0.0</version>" +
+"        <authors>Unit Test</authors>" +
+"        <description>Sample Description</description>" +
+"        <language>en-US</language>" +
+"        <projectUrl>http://PROJECT_URL_HERE_OR_DELETE_THIS_LINE</projectUrl>" +
+"    <dependencies>" +
+"      <dependency id=\"System.Collections.Immutable\" version=\"4.3.0\" />" +
+"    </dependencies>" +
+"    </metadata>" +
+"</package>";
+
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var nuspecPath = Path.Combine(testDirectory, "test.nuspec");
+                File.AppendAllText(nuspecPath, nuspecContent);
+
+                var builder = new PackageBuilder();
+                var runner = new PackCommandRunner(
+                    new PackArgs
+                    {
+                        CurrentDirectory = testDirectory,
+                        OutputDirectory = testDirectory,
+                        Path = nuspecPath,
+                        Exclude = Array.Empty<string>(),
+                        Symbols = true,
+                        Logger = NullLogger.Instance
+                    },
+                    MSBuildProjectFactory.ProjectCreator,
+                    builder);
+
+                runner.BuildPackage();
+
+                var ruleSet = RuleSet.PackageCreationRuleSet;
+                var nupkgPath = Path.Combine(testDirectory, "test.1.0.0.nupkg");
+
+                using (var reader = new PackageArchiveReader(nupkgPath))
+                {
+                    var issues = new List<PackagingLogMessage>();
+                    foreach (var rule in ruleSet)
+                    {
+                        issues.AddRange(rule.Validate(reader).OrderBy(p => p.Code.ToString(), StringComparer.CurrentCulture));
+                    }
+
+                    Assert.True(issues.Any(p => p.Code == NuGetLogCode.NU5102 && p.Message.Contains("projectUrl")));
+                }
+            }
+        }
+
+        [Fact]
+        public void Validate_NuSpecFileWithNonDefaultProjectUrl_NoWarning()
+        {
+            // Arrange
+            var nuspecContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+"<package xmlns=\"http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd\">" +
+"   <metadata>" +
+"        <id>test</id>" +
+"        <version>1.0.0</version>" +
+"        <authors>Unit Test</authors>" +
+"        <description>Sample Description</description>" +
+"        <language>en-US</language>" +
+"        <projectUrl>http://unit.test</projectUrl>" +
+"    <dependencies>" +
+"      <dependency id=\"System.Collections.Immutable\" version=\"4.3.0\" />" +
+"    </dependencies>" +
+"    </metadata>" +
+"</package>";
+
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var nuspecPath = Path.Combine(testDirectory, "test.nuspec");
+                File.AppendAllText(nuspecPath, nuspecContent);
+
+                var builder = new PackageBuilder();
+                var runner = new PackCommandRunner(
+                    new PackArgs
+                    {
+                        CurrentDirectory = testDirectory,
+                        OutputDirectory = testDirectory,
+                        Path = nuspecPath,
+                        Exclude = Array.Empty<string>(),
+                        Symbols = true,
+                        Logger = NullLogger.Instance
+                    },
+                    MSBuildProjectFactory.ProjectCreator,
+                    builder);
+
+                runner.BuildPackage();
+
+                var ruleSet = RuleSet.PackageCreationRuleSet;
+                var nupkgPath = Path.Combine(testDirectory, "test.1.0.0.nupkg");
+
+                using (var reader = new PackageArchiveReader(nupkgPath))
+                {
+                    var issues = new List<PackagingLogMessage>();
+                    foreach (var rule in ruleSet)
+                    {
+                        issues.AddRange(rule.Validate(reader).OrderBy(p => p.Code.ToString(), StringComparer.CurrentCulture));
+                    }
+
+                    Assert.False(issues.Any(p => p.Code == NuGetLogCode.NU5102 && p.Message.Contains("projectUrl")));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bug
Currently the `XmlReader` used [here](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Packaging.Core/NuspecCoreReaderBase.cs#L222) is converting urls to lowercase and adding a `/` at the end. This is breaking the validation rules [here](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Packaging/Rules/DefaultManifestValuesRule.cs#L38).

### Sample nuspec - 
```
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
        <id>test</id>
        <version>1.2.3</version>
        <authors>Unit Test</authors>
        <description>package description</description>
        <language>en-US</language>
        <projectUrl>http://PROJECT_URL_HERE_OR_DELETE_THIS_LINE</projectUrl>
        <dependencies>
            <dependency id="System.Collections.Immutable" version="4.3.0" />
        </dependencies>
    </metadata>
</package>
```


### Before - 
```
F:\validation\test\nuspec\test\test> nuget pack .\test.nuspec
Attempting to build package from 'test.nuspec'.
Successfully created package 'F:\validation\test\nuspec\test\test\test.1.2.3.nupkg'.
```

### After -
```
F:\validation\test\nuspec\test\test> E:\NuGet.Client\artifacts\NuGet.CommandLine\15.0\bin\Debug\net46\NuGet.exe pack .\test.nuspec
Attempting to build package from 'test.nuspec'.
Successfully created package 'F:\validation\test\nuspec\test\test\test.1.2.3.nupkg'.
WARNING: NU5102: The value "http://project_url_here_or_delete_this_line/" for projectUrl is a sample value and should be removed. Replace it with an appropriate value or remove it and rebuild your package.
``` 

## Fix
Details: This PR fixes this by making the comparisons through `Uri.Equality`  overload type which normalizes the strings before comparison.

## Testing/Validation
Tests Added: Yes
Validation done:  Manual validation
