### PR TITLE
support for package debugging

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
@@ -74,6 +74,9 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "PackageCommandMinClientVersion")]
         public string MinClientVersion { get; set; }
 
+        [Option(typeof(NuGetCommand), "PackageCommandSymbolPackageFormat")]
+        public string SymbolPackageFormat { get; set; }
+
         [Option(typeof(NuGetCommand), "CommandMSBuildVersion")]
         public string MSBuildVersion { get; set; }
 
@@ -91,7 +94,7 @@ namespace NuGet.CommandLine
 
         public override void ExecuteCommand()
         {
-            PackArgs packArgs = new PackArgs();
+            var packArgs = new PackArgs();
             packArgs.Logger = Console;
             packArgs.Arguments = Arguments;
             packArgs.OutputDirectory = OutputDirectory;
@@ -106,13 +109,19 @@ namespace NuGet.CommandLine
 
             Console.WriteLine(LocalizedResourceManager.GetString("PackageCommandAttemptingToBuildPackage"), Path.GetFileName(packArgs.Path));
 
-            if (!String.IsNullOrEmpty(MinClientVersion))
+            if (!string.IsNullOrEmpty(MinClientVersion))
             {
                 if (!System.Version.TryParse(MinClientVersion, out _minClientVersionValue))
                 {
                     throw new CommandLineException(LocalizedResourceManager.GetString("PackageCommandInvalidMinClientVersion"));
                 }
             }
+
+            if(!string.IsNullOrEmpty(SymbolPackageFormat))
+            {
+                packArgs.SymbolPackageFormat = PackArgs.GetSymbolPackageFormat(SymbolPackageFormat);
+            }
+
 
             packArgs.Build = Build;
             packArgs.Exclude = Exclude;
@@ -154,12 +163,12 @@ namespace NuGet.CommandLine
                 NuGetVersion version;
                 if (!NuGetVersion.TryParse(Version, out version))
                 {
-                    throw new PackagingException(NuGetLogCode.NU5010, String.Format(CultureInfo.CurrentCulture, NuGetResources.InstallCommandPackageReferenceInvalidVersion, Version));
+                    throw new PackagingException(NuGetLogCode.NU5010, string.Format(CultureInfo.CurrentCulture, NuGetResources.InstallCommandPackageReferenceInvalidVersion, Version));
                 }
                 packArgs.Version = version.ToFullString();
             }
 
-            PackCommandRunner packCommandRunner = new PackCommandRunner(packArgs, ProjectFactory.ProjectCreator);
+            var packCommandRunner = new PackCommandRunner(packArgs, ProjectFactory.ProjectCreator);
             packCommandRunner.BuildPackage();
         }
    }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
@@ -122,7 +122,6 @@ namespace NuGet.CommandLine
                 packArgs.SymbolPackageFormat = PackArgs.GetSymbolPackageFormat(SymbolPackageFormat);
             }
 
-
             packArgs.Build = Build;
             packArgs.Exclude = Exclude;
             packArgs.ExcludeEmptyDirectories = ExcludeEmptyDirectories;

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -819,11 +819,14 @@ namespace NuGet.CommandLine
                 if(SymbolPackageFormat == SymbolPackageFormat.Snupkg)
                 {
                     outputFileNames.Clear();
+                    outputFileNames.Add($"{targetFileName}.pdb");
                 }
-
-                outputFileNames.Add($"{targetFileName}.pdb");
-                outputFileNames.Add($"{targetFileName}.dll.mdb");
-                outputFileNames.Add($"{targetFileName}.exe.mdb");
+                else
+                {
+                    outputFileNames.Add($"{targetFileName}.pdb");
+                    outputFileNames.Add($"{targetFileName}.dll.mdb");
+                    outputFileNames.Add($"{targetFileName}.exe.mdb");
+                }
             }
 
             foreach (var file in GetFiles(projectOutputDirectory, outputFileNames, SearchOption.AllDirectories))
@@ -1253,6 +1256,13 @@ namespace NuGet.CommandLine
             {
                 string fullPath = item.GetMetadataValue("FullPath");
                 if (_excludeFiles.Contains(Path.GetFileName(fullPath)))
+                {
+                    continue;
+                }
+
+                if (IncludeSymbols &&
+                    SymbolPackageFormat == SymbolPackageFormat.Snupkg &&
+                    !string.Equals(Path.GetExtension(fullPath), ".pdb", StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -305,11 +305,7 @@ namespace NuGet.CommandLine
             // Add sources if this is a symbol package
             if (IncludeSymbols)
             {
-                if (SymbolPackageFormat == SymbolPackageFormat.Snupkg)
-                {
-                    builder.PackageTypes.Add(PackageType.SymbolsPackage);
-                }
-                else
+                if (SymbolPackageFormat != SymbolPackageFormat.Snupkg)
                 {
                     ApplyAction(p => p.AddFiles(builder, SourcesItemType, SourcesFolder));
                 }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -305,7 +305,7 @@ namespace NuGet.CommandLine
             // Add sources if this is a symbol package
             if (IncludeSymbols)
             {
-                if (SymbolPackageFormat != SymbolPackageFormat.Snupkg)
+                if (SymbolPackageFormat == SymbolPackageFormat.SymbolsNupkg)
                 {
                     ApplyAction(p => p.AddFiles(builder, SourcesItemType, SourcesFolder));
                 }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -591,6 +591,7 @@ namespace NuGet.CommandLine
                     referencedProject.ProjectProperties = ProjectProperties;
                     referencedProject.TargetFramework = TargetFramework;
                     referencedProject.BuildProject();
+                    referencedProject.SymbolPackageFormat = SymbolPackageFormat;
                     referencedProject.RecursivelyApply(action, alreadyAppliedProjects);
                 }
             }
@@ -705,6 +706,7 @@ namespace NuGet.CommandLine
                 var projectFactory = new ProjectFactory(_msbuildDirectory, _msbuildAssembly, _frameworkAssembly, project);
                 projectFactory.Build = Build;
                 projectFactory.ProjectProperties = ProjectProperties;
+                projectFactory.SymbolPackageFormat = SymbolPackageFormat;
                 projectFactory.BuildProject();
                 var builder = new Packaging.PackageBuilder();
 

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -7832,6 +7832,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to If creating a symbols package, allows to choose between the &apos;snupkg&apos; and &apos;symbols.nupkg&apos; format..
+        /// </summary>
+        internal static string PackageCommandSymbolPackageFormat {
+            get {
+                return ResourceManager.GetString("PackageCommandSymbolPackageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Determines if a package containing sources and symbols should be created. When specified with a nuspec, creates a regular NuGet package file and the corresponding symbols package..
         /// </summary>
         internal static string PackageCommandSymbolsDescription {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -7832,7 +7832,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If creating a symbols package, allows to choose between the &apos;snupkg&apos; and &apos;symbols.nupkg&apos; format..
+        ///   Looks up a localized string similar to When creating a symbols package, allows to choose between the &apos;snupkg&apos; and &apos;symbols.nupkg&apos; format..
         /// </summary>
         internal static string PackageCommandSymbolPackageFormat {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5481,6 +5481,7 @@ This option should be used when specifying the certificate via -CertificateSubje
     <comment>Please don't localize "basic,negotiate"</comment>
   </data>
   <data name="PackageCommandSymbolPackageFormat" xml:space="preserve">
-    <value>If creating a symbols package, allows to choose between the 'snupkg' and 'symbols.nupkg' format.</value>
+    <value>When creating a symbols package, allows to choose between the 'snupkg' and 'symbols.nupkg' format.</value>
+    <comment>Do not localize snupkg and symbols.nupkg</comment>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5479,5 +5479,7 @@ This option should be used when specifying the certificate via -CertificateSubje
   <data name="SourcesCommandValidAuthenticationTypesDescription" xml:space="preserve">
     <value>Comma-separated list of valid authentication types for this source. By default, all authentication types are valid. Example: basic,negotiate</value>
     <comment>Please don't localize "basic,negotiate"</comment>
+  <data name="PackageCommandSymbolPackageFormat" xml:space="preserve">
+    <value>If creating a symbols package, allows to choose between the 'snupkg' and 'symbols.nupkg' format.</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5479,6 +5479,7 @@ This option should be used when specifying the certificate via -CertificateSubje
   <data name="SourcesCommandValidAuthenticationTypesDescription" xml:space="preserve">
     <value>Comma-separated list of valid authentication types for this source. By default, all authentication types are valid. Example: basic,negotiate</value>
     <comment>Please don't localize "basic,negotiate"</comment>
+  </data>
   <data name="PackageCommandSymbolPackageFormat" xml:space="preserve">
     <value>If creating a symbols package, allows to choose between the 'snupkg' and 'symbols.nupkg' format.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/GetPackOutputItemsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/GetPackOutputItemsTask.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NuGet.Commands;
+using NuGet.Common;
 using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
@@ -30,6 +31,8 @@ namespace NuGet.Build.Tasks.Pack
 
         public bool IncludeSource { get; set; }
 
+        public string SymbolPackageFormat { get; set; }
+
         /// <summary>
         /// Output items
         /// </summary>
@@ -47,8 +50,9 @@ namespace NuGet.Build.Tasks.Pack
                     PackageVersion));
             }
 
-            var nupkgFileName = PackCommandRunner.GetOutputFileName(PackageId, version, isNupkg: true, symbols: false);
-            var nuspecFileName = PackCommandRunner.GetOutputFileName(PackageId, version, isNupkg: false, symbols: false);
+            var symbolPackageFormat = PackArgs.GetSymbolPackageFormat(MSBuildStringUtility.TrimAndGetNullForEmpty(SymbolPackageFormat));
+            var nupkgFileName = PackCommandRunner.GetOutputFileName(PackageId, version, isNupkg: true, symbols: false, symbolPackageFormat: symbolPackageFormat);
+            var nuspecFileName = PackCommandRunner.GetOutputFileName(PackageId, version, isNupkg: false, symbols: false, symbolPackageFormat: symbolPackageFormat);
             
             var outputs = new List<ITaskItem>();
             outputs.Add(new TaskItem(Path.Combine(PackageOutputPath, nupkgFileName)));
@@ -56,8 +60,8 @@ namespace NuGet.Build.Tasks.Pack
 
             if(IncludeSource || IncludeSymbols)
             {
-                var nupkgSymbolsFileName = PackCommandRunner.GetOutputFileName(PackageId, version, isNupkg: true, symbols: true);
-                var nuspecSymbolsFileName = PackCommandRunner.GetOutputFileName(PackageId, version, isNupkg: false, symbols: true);
+                var nupkgSymbolsFileName = PackCommandRunner.GetOutputFileName(PackageId, version, isNupkg: true, symbols: true, symbolPackageFormat: symbolPackageFormat);
+                var nuspecSymbolsFileName = PackCommandRunner.GetOutputFileName(PackageId, version, isNupkg: false, symbols: true, symbolPackageFormat: symbolPackageFormat);
 
                 outputs.Add(new TaskItem(Path.Combine(PackageOutputPath, nupkgSymbolsFileName)));
                 outputs.Add(new TaskItem(Path.Combine(NuspecOutputPath, nuspecSymbolsFileName)));

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
@@ -63,6 +63,7 @@ namespace NuGet.Build.Tasks.Pack
         string RestoreOutputPath { get; }
         bool Serviceable { get; }
         TItem[] SourceFiles { get; }
+        string SymbolPackageFormat { get; }
         string[] Tags { get; }
         string[] TargetFrameworks { get; }
         TItem[] TargetPathsToSymbols { get; }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -39,6 +39,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PackDependsOn>$(BeforePack); _IntermediatePack; GenerateNuspec; $(PackDependsOn)</PackDependsOn>
     <IsInnerBuild Condition="'$(TargetFramework)' != '' AND '$(TargetFrameworks)' != ''">true</IsInnerBuild>
     <NoBuild Condition="'$(GeneratePackageOnBuild)' == 'true'">true</NoBuild>
+    <SymbolPackageFormat Condition="'$(SymbolPackageFormat)' == ''">snupkg</SymbolPackageFormat>
     <AddPriFileDependsOn Condition="'$(MicrosoftPortableCurrentVersionPropsHasBeenImported)' == 'true'">DeterminePortableBuildCapabilities</AddPriFileDependsOn>
     <NuspecOutputPath Condition="'$(NuspecOutputPath)' == ''">$(BaseIntermediateOutputPath)$(Configuration)\</NuspecOutputPath>
     <WarnOnPackingNonPackableProject Condition="'$(WarnOnPackingNonPackableProject)' == ''">false</WarnOnPackingNonPackableProject>
@@ -248,7 +249,8 @@ Copyright (c) .NET Foundation. All rights reserved.
               WarningsAsErrors="$(WarningsAsErrors)"
               TreatWarningsAsErrors="$(TreatWarningsAsErrors)"
               OutputFileNamesWithoutVersion="$(OutputFileNamesWithoutVersion)"
-              InstallPackageToOutputPath="$(InstallPackageToOutputPath)"/>
+              InstallPackageToOutputPath="$(InstallPackageToOutputPath)"
+              SymbolPackageFormat="$(SymbolPackageFormat)"/>
   </Target>
 
   <!--

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -46,6 +46,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ImportNuGetBuildTasksPackTargetsFromSdk Condition="'$(ImportNuGetBuildTasksPackTargetsFromSdk)' == ''">false</ImportNuGetBuildTasksPackTargetsFromSdk>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>.dll; .exe; .winmd; .json; .pri; .xml; $(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>.pdb; .mdb; $(AllowedOutputExtensionsInPackageBuildOutputFolder); $(AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder)</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
+    <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder Condition="'$(SymbolPackageFormat)' == 'snupkg'">.pdb; .mdb</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
     <SuppressDependenciesWhenPacking Condition="'$(SuppressDependenciesWhenPacking)' == ''">false</SuppressDependenciesWhenPacking>
   </PropertyGroup>
   <PropertyGroup Condition="'$(NoBuild)' == 'true' ">
@@ -83,7 +84,8 @@ Copyright (c) .NET Foundation. All rights reserved.
         PackageId="$(PackageId)"
         PackageVersion="$(PackageVersion)"
         IncludeSymbols="$(IncludeSymbols)"
-        IncludeSource="$(IncludeSource)">
+        IncludeSource="$(IncludeSource)"
+        SymbolPackageFormat="$(SymbolPackageFormat)">
 
       <Output
         TaskParameter="OutputPackItems"

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -39,7 +39,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PackDependsOn>$(BeforePack); _IntermediatePack; GenerateNuspec; $(PackDependsOn)</PackDependsOn>
     <IsInnerBuild Condition="'$(TargetFramework)' != '' AND '$(TargetFrameworks)' != ''">true</IsInnerBuild>
     <NoBuild Condition="'$(GeneratePackageOnBuild)' == 'true'">true</NoBuild>
-    <SymbolPackageFormat Condition="'$(SymbolPackageFormat)' == ''">snupkg</SymbolPackageFormat>
+    <SymbolPackageFormat Condition="'$(SymbolPackageFormat)' == ''">symbols.nupkg</SymbolPackageFormat>
     <AddPriFileDependsOn Condition="'$(MicrosoftPortableCurrentVersionPropsHasBeenImported)' == 'true'">DeterminePortableBuildCapabilities</AddPriFileDependsOn>
     <NuspecOutputPath Condition="'$(NuspecOutputPath)' == ''">$(BaseIntermediateOutputPath)$(Configuration)\</NuspecOutputPath>
     <WarnOnPackingNonPackableProject Condition="'$(WarnOnPackingNonPackableProject)' == ''">false</WarnOnPackingNonPackableProject>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -45,8 +45,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <WarnOnPackingNonPackableProject Condition="'$(WarnOnPackingNonPackableProject)' == ''">false</WarnOnPackingNonPackableProject>
     <ImportNuGetBuildTasksPackTargetsFromSdk Condition="'$(ImportNuGetBuildTasksPackTargetsFromSdk)' == ''">false</ImportNuGetBuildTasksPackTargetsFromSdk>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>.dll; .exe; .winmd; .json; .pri; .xml; $(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>.pdb; .mdb; $(AllowedOutputExtensionsInPackageBuildOutputFolder); $(AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder)</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
-    <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder Condition="'$(SymbolPackageFormat)' == 'snupkg'">.pdb; .mdb</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
+    <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder Condition="'$(SymbolPackageFormat)' != 'snupkg'">.pdb; .mdb; $(AllowedOutputExtensionsInPackageBuildOutputFolder); $(AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder)</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
+    <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder Condition="'$(SymbolPackageFormat)' == 'snupkg'">.pdb</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
     <SuppressDependenciesWhenPacking Condition="'$(SuppressDependenciesWhenPacking)' == ''">false</SuppressDependenciesWhenPacking>
   </PropertyGroup>
   <PropertyGroup Condition="'$(NoBuild)' == 'true' ">

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
@@ -52,6 +52,7 @@ namespace NuGet.Build.Tasks.Pack
         public ITaskItem[] SourceFiles { get; set; }
         public bool NoPackageAnalysis { get; set; }
         public string NuspecFile { get; set; }
+        public string SymbolPackageFormat { get; set; }
         public string MinClientVersion { get; set; }
         public bool Serviceable { get; set; }
         public ITaskItem[] FrameworkAssemblyReferences { get; set; }
@@ -197,6 +198,7 @@ namespace NuGet.Build.Tasks.Pack
                 RestoreOutputPath = MSBuildStringUtility.TrimAndGetNullForEmpty(RestoreOutputPath),
                 Serviceable = Serviceable,
                 SourceFiles = MSBuildUtility.WrapMSBuildItem(SourceFiles),
+                SymbolPackageFormat = MSBuildStringUtility.TrimAndGetNullForEmpty(SymbolPackageFormat),
                 Tags = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(Tags),
                 TargetFrameworks = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(TargetFrameworks),
                 TargetPathsToSymbols = MSBuildUtility.WrapMSBuildItem(TargetPathsToSymbols),

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -30,6 +30,7 @@ namespace NuGet.Build.Tasks.Pack
                 Serviceable = request.Serviceable,
                 Tool = request.IsTool,
                 Symbols = request.IncludeSymbols,
+                SymbolPackageFormat = PackArgs.GetSymbolPackageFormat(request.SymbolPackageFormat),
                 BasePath = request.NuspecBasePath,
                 NoPackageAnalysis = request.NoPackageAnalysis,
                 NoDefaultExcludes = request.NoDefaultExcludes,

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
@@ -63,5 +63,6 @@ namespace NuGet.Build.Tasks.Pack
         public string TreatWarningsAsErrors { get; set; }
         public string WarningsAsErrors { get; set; }
         public IMSBuildItem[] FrameworksWithSuppressedDependencies { get; set; }
+        public string SymbolPackageFormat { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/CommandArgs/PackArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandArgs/PackArgs.cs
@@ -7,6 +7,7 @@ using System.IO;
 using NuGet.Configuration;
 using NuGet.Common;
 using NuGet.ProjectModel;
+using NuGet.Packaging;
 
 namespace NuGet.Commands
 {
@@ -26,6 +27,7 @@ namespace NuGet.Commands
         public bool InstallPackageToOutputPath { get; set; }
         public IMachineWideSettings MachineWideSettings { get; set; }
         public Version MinClientVersion { get; set; }
+        public SymbolPackageFormat SymbolPackageFormat { get; set; } = SymbolPackageFormat.Snupkg;
         public Lazy<string> MsBuildDirectory { get; set; }
         public bool NoDefaultExcludes { get; set; }
         public bool NoPackageAnalysis { get; set; }
@@ -69,5 +71,27 @@ namespace NuGet.Commands
 
             return null;
         }
+
+        public static SymbolPackageFormat GetSymbolPackageFormat(string symbolPackageFormat)
+        {
+            if (string.Equals(symbolPackageFormat, PackagingConstants.SnupkgFormat, StringComparison.OrdinalIgnoreCase))
+            {
+                return SymbolPackageFormat.Snupkg;
+            }
+            else if (string.Equals(symbolPackageFormat, PackagingConstants.SymbolsNupkgFormat, StringComparison.OrdinalIgnoreCase))
+            {
+                return SymbolPackageFormat.SymbolsNupkg;
+            }
+            else
+            {
+                throw new ArgumentException(string.Format(Strings.Error_InvalidSymbolPackageFormat, symbolPackageFormat));
+            }
+        }
+    }
+
+    public enum SymbolPackageFormat
+    {
+        Snupkg,
+        SymbolsNupkg
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/CommandArgs/PackArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandArgs/PackArgs.cs
@@ -27,7 +27,7 @@ namespace NuGet.Commands
         public bool InstallPackageToOutputPath { get; set; }
         public IMachineWideSettings MachineWideSettings { get; set; }
         public Version MinClientVersion { get; set; }
-        public SymbolPackageFormat SymbolPackageFormat { get; set; } = SymbolPackageFormat.Snupkg;
+        public SymbolPackageFormat SymbolPackageFormat { get; set; } = SymbolPackageFormat.SymbolsNupkg;
         public Lazy<string> MsBuildDirectory { get; set; }
         public bool NoDefaultExcludes { get; set; }
         public bool NoPackageAnalysis { get; set; }

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -1021,8 +1021,11 @@ namespace NuGet.Commands
                 }
             }
 
-            var outputFile = GetOutputFileName(builder.Id, versionToUse, isNupkg: isNupkg,
-                symbols: symbols, symbolPackageFormat: packArgs.SymbolPackageFormat,
+            var outputFile = GetOutputFileName(builder.Id,
+                versionToUse,
+                isNupkg: isNupkg,
+                symbols: symbols,
+                symbolPackageFormat: packArgs.SymbolPackageFormat,
                 excludeVersion: packArgs.OutputFileNamesWithoutVersion);
 
             var finalOutputDirectory = packArgs.OutputDirectory ?? packArgs.CurrentDirectory;

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -677,7 +677,7 @@ namespace NuGet.Commands
         private PackageBuilder CreatePackageBuilderFromNuspec(string path)
         {
             // Set the version property if the flag is set
-            if (!String.IsNullOrEmpty(_packArgs.Version))
+            if (!string.IsNullOrEmpty(_packArgs.Version))
             {
                 _packArgs.Properties["version"] = _packArgs.Version;
             }
@@ -692,7 +692,7 @@ namespace NuGet.Commands
                 _packArgs.Logger = new PackCollectorLogger(_packArgs.Logger, _packArgs.WarningProperties);
             }            
 
-            if (String.IsNullOrEmpty(_packArgs.BasePath))
+            if (string.IsNullOrEmpty(_packArgs.BasePath))
             {
                 return new PackageBuilder(path, _packArgs.GetPropertyValue, !_packArgs.ExcludeEmptyDirectories);
             }
@@ -702,7 +702,7 @@ namespace NuGet.Commands
         private PackageArchiveReader BuildFromProjectFile(string path)
         {
             // PackTargetArgs is only set for dotnet.exe pack code path, hence the check.
-            if ((String.IsNullOrEmpty(_packArgs.MsBuildDirectory?.Value) || _createProjectFactory == null) && _packArgs.PackTargetArgs == null)
+            if ((string.IsNullOrEmpty(_packArgs.MsBuildDirectory?.Value) || _createProjectFactory == null) && _packArgs.PackTargetArgs == null)
             {
                 throw new PackagingException(NuGetLogCode.NU5009, string.Format(CultureInfo.CurrentCulture, Strings.Error_CannotFindMsbuild));
             }
@@ -722,7 +722,7 @@ namespace NuGet.Commands
                 if (factory.GetProjectProperties().ContainsKey(property.Key))
                 {
                     _packArgs.Logger.Log(PackagingLogMessage.CreateWarning(
-                        String.Format(CultureInfo.CurrentCulture, Strings.Warning_DuplicatePropertyKey, property.Key),
+                        string.Format(CultureInfo.CurrentCulture, Strings.Warning_DuplicatePropertyKey, property.Key),
                         NuGetLogCode.NU5114));
                 }
                 factory.GetProjectProperties()[property.Key] = property.Value;
@@ -735,7 +735,7 @@ namespace NuGet.Commands
             }
 
             // Create a builder for the main package as well as the sources/symbols package
-            PackageBuilder mainPackageBuilder = factory.CreateBuilder(_packArgs.BasePath, version, _packArgs.Suffix, buildIfNeeded: true, builder: this._packageBuilder);
+            var mainPackageBuilder = factory.CreateBuilder(_packArgs.BasePath, version, _packArgs.Suffix, buildIfNeeded: true, builder: this._packageBuilder);
 
             if (mainPackageBuilder == null)
             {
@@ -750,7 +750,7 @@ namespace NuGet.Commands
                 PackageArchiveReader packageArchiveReader = null;
                 if (_packArgs.InstallPackageToOutputPath)
                 {
-                    string outputPath = GetOutputPath(mainPackageBuilder, _packArgs);
+                    var outputPath = GetOutputPath(mainPackageBuilder, _packArgs);
                     packageArchiveReader = BuildPackage(mainPackageBuilder, outputPath: outputPath);
                 }
                 else
@@ -776,7 +776,7 @@ namespace NuGet.Commands
 
             if (_packArgs.Symbols)
             {
-                WriteLine(String.Empty);
+                WriteLine(string.Empty);
                 WriteLine(Strings.Log_PackageCommandAttemptingToBuildSymbolsPackage, Path.GetFileName(path));
                 NuGetVersion argsVersion = null;
                 if (_packArgs.Version != null)
@@ -785,18 +785,23 @@ namespace NuGet.Commands
                 }
 
                 factory.SetIncludeSymbols(true);
-                PackageBuilder symbolsBuilder = factory.CreateBuilder(_packArgs.BasePath, argsVersion, _packArgs.Suffix, buildIfNeeded: false, builder: mainPackageBuilder);
+                var symbolsBuilder = factory.CreateBuilder(_packArgs.BasePath, argsVersion, _packArgs.Suffix, buildIfNeeded: false, builder: mainPackageBuilder);
                 symbolsBuilder.Version = mainPackageBuilder.Version;
                 symbolsBuilder.HasSnapshotVersion = mainPackageBuilder.HasSnapshotVersion;
+                if(_packArgs.SymbolPackageFormat == SymbolPackageFormat.Snupkg)
+                {
+                    symbolsBuilder.PackageTypes.Add(PackageType.SymbolsPackage);
+                }
+
 
                 // Get the file name for the sources package and build it
-                string outputPath = GetOutputPath(symbolsBuilder, _packArgs, symbols: true);
+                var outputPath = GetOutputPath(symbolsBuilder, _packArgs, symbols: true);
 
                 InitCommonPackageBuilderProperties(symbolsBuilder);
 
                 if (GenerateNugetPackage)
                 {
-                    PackageArchiveReader symbolsPackage = BuildPackage(symbolsBuilder, outputPath);
+                    var symbolsPackage = BuildPackage(symbolsBuilder, outputPath);
                     return symbolsPackage;
                 }
             }
@@ -1014,14 +1019,16 @@ namespace NuGet.Commands
                 }
             }
 
-            var outputFile = GetOutputFileName(builder.Id, versionToUse, isNupkg: isNupkg, symbols: symbols, excludeVersion: packArgs.OutputFileNamesWithoutVersion);
+            var outputFile = GetOutputFileName(builder.Id, versionToUse, isNupkg: isNupkg,
+                symbols: symbols, symbolPackageFormat: packArgs.SymbolPackageFormat,
+                excludeVersion: packArgs.OutputFileNamesWithoutVersion);
 
             var finalOutputDirectory = packArgs.OutputDirectory ?? packArgs.CurrentDirectory;
             finalOutputDirectory = outputDirectory ?? finalOutputDirectory;
             return Path.Combine(finalOutputDirectory, outputFile);
         }
 
-        public static string GetOutputFileName(string packageId, NuGetVersion version, bool isNupkg, bool symbols, bool excludeVersion = false)
+        public static string GetOutputFileName(string packageId, NuGetVersion version, bool isNupkg, bool symbols, SymbolPackageFormat symbolPackageFormat, bool excludeVersion = false)
         {
             // Output file is {id}.{version}
             var normalizedVersion = version.ToNormalizedString();
@@ -1029,7 +1036,7 @@ namespace NuGet.Commands
 
             var extension = isNupkg ? NuGetConstants.PackageExtension : NuGetConstants.ManifestExtension;
             var symbolsExtension = isNupkg
-                ? NuGetConstants.SymbolsExtension
+                ? (symbolPackageFormat == SymbolPackageFormat.Snupkg ? NuGetConstants.SnupkgExtension : NuGetConstants.SymbolsExtension)
                 : NuGetConstants.ManifestSymbolsExtension;
 
             // If this is a source package then add .symbols.nupkg to the package file name
@@ -1047,7 +1054,7 @@ namespace NuGet.Commands
 
         public static void SetupCurrentDirectory(PackArgs packArgs)
         {
-            string directory = Path.GetDirectoryName(packArgs.Path);
+            var directory = Path.GetDirectoryName(packArgs.Path);
 
             if (!directory.Equals(packArgs.CurrentDirectory, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -46,7 +46,7 @@ namespace NuGet.Commands
                 && sourceUri.IsAbsoluteUri)
             {
                 symbolPackageUpdateResource = await CommandRunnerUtility.GetSymbolPackageUpdateResource(sourceProvider, source);
-                if(symbolPackageUpdateResource != null)
+                if (symbolPackageUpdateResource != null)
                 {
                     symbolSource = symbolPackageUpdateResource.SourceUri.AbsoluteUri;
                     symbolApiKey = apiKey;

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -38,6 +38,7 @@ namespace NuGet.Commands
 
             var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, source);
             SymbolPackageUpdateResourceV3 symbolPackageUpdateResource = null;
+
             // figure out from index.json if pushing snupkg is supported
             var sourceUri = packageUpdateResource.SourceUri;
             if (string.IsNullOrEmpty(symbolSource)

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Common;
+using NuGet.Protocol.Core.Types;
 
 namespace NuGet.Commands
 {
@@ -36,6 +37,21 @@ namespace NuGet.Commands
             }
 
             var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, source);
+            SymbolPackageUpdateResourceV3 symbolPackageUpdateResource = null;
+            // figure out from index.json if pushing snupkg is supported
+            var sourceUri = packageUpdateResource.SourceUri;
+            if (string.IsNullOrEmpty(symbolSource)
+                && !noSymbols
+                && !sourceUri.IsFile
+                && sourceUri.IsAbsoluteUri)
+            {
+                symbolPackageUpdateResource = await CommandRunnerUtility.GetSymbolPackageUpdateResource(sourceProvider, source);
+                if(symbolPackageUpdateResource != null)
+                {
+                    symbolSource = symbolPackageUpdateResource.SourceUri.AbsoluteUri;
+                    symbolApiKey = apiKey;
+                }
+            }
 
             await packageUpdateResource.Push(
                 packagePath,
@@ -45,6 +61,7 @@ namespace NuGet.Commands
                 endpoint => apiKey ?? CommandRunnerUtility.GetApiKey(settings, endpoint, source, defaultApiKey: null, isSymbolApiKey: false),
                 symbolsEndpoint => symbolApiKey ?? CommandRunnerUtility.GetApiKey(settings, symbolsEndpoint, symbolSource, apiKey, isSymbolApiKey: true),
                 noServiceEndpoint,
+                symbolPackageUpdateResource,
                 logger);
         }
     }

--- a/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
@@ -90,10 +90,8 @@ namespace NuGet.Commands
             {
                 AddSourceFiles();
             }
-            
-            
 
-            Manifest manifest = new Manifest(new ManifestMetadata(builder), Files);
+            var manifest = new Manifest(new ManifestMetadata(builder), Files);
             var manifestPath = PackCommandRunner.GetOutputPath(
                 builder,
                 PackArgs,

--- a/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
@@ -160,7 +160,7 @@ namespace NuGet.Commands
 
                 if(IncludeSymbols &&
                     PackArgs.SymbolPackageFormat == SymbolPackageFormat.Snupkg &&
-                    !string.Equals(fileExtension, ".pdb", PathUtility.GetStringComparisonBasedOnOS()))
+                    !string.Equals(fileExtension, ".pdb", StringComparison.OrdinalIgnoreCase))
                 {
                     return false;
                 }

--- a/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
@@ -78,6 +78,7 @@ namespace NuGet.Commands
         {
             // Add output files
             Files.Clear();
+            builder.Files.Clear();
 
             AddOutputFiles(builder);
 
@@ -156,13 +157,10 @@ namespace NuGet.Commands
             if (!Files.Any(p => packageFile.Target.Equals(p.Target, StringComparison.CurrentCultureIgnoreCase)))
             {
                 var fileExtension = Path.GetExtension(packageFile.Source);
-                var allowedExtensions = IncludeSymbols ?
-                    PackTargetArgs.AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder :
-                    PackTargetArgs.AllowedOutputExtensionsInPackageBuildOutputFolder;
 
                 if(IncludeSymbols &&
                     PackArgs.SymbolPackageFormat == SymbolPackageFormat.Snupkg &&
-                    !allowedExtensions.Contains(fileExtension, PathUtility.GetStringComparerBasedOnOS()))
+                    !string.Equals(fileExtension, ".pdb", PathUtility.GetStringComparisonBasedOnOS()))
                 {
                     return false;
                 }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -188,6 +188,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The provided SymbolPackageFormat value {0} is invalid. Possible allowed values are either &apos;snupkg&apos; or &apos;symbols.nupkg&apos;..
+        /// </summary>
+        internal static string Error_InvalidSymbolPackageFormat {
+            get {
+                return ResourceManager.GetString("Error_InvalidSymbolPackageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to build package because of an unsupported targetFramework value on &apos;{0}&apos;..
         /// </summary>
         internal static string Error_InvalidTargetFramework {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -188,7 +188,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The provided SymbolPackageFormat value {0} is invalid. Possible allowed values are either &apos;snupkg&apos; or &apos;symbols.nupkg&apos;..
+        ///   Looks up a localized string similar to The provided SymbolPackageFormat value {0} is invalid. Allowed values : &apos;snupkg&apos;, &apos;symbols.nupkg&apos;..
         /// </summary>
         internal static string Error_InvalidSymbolPackageFormat {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -701,6 +701,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <comment>{0}: Plugins cache path</comment>
   </data>
   <data name="Error_InvalidSymbolPackageFormat" xml:space="preserve">
-    <value>The provided SymbolPackageFormat value {0} is invalid. Possible allowed values are either 'snupkg' or 'symbols.nupkg'.</value>
+    <value>The provided SymbolPackageFormat value {0} is invalid. Allowed values : 'snupkg', 'symbols.nupkg'.</value>
+    <comment>Do not localize snupkg and symbols.nupkg</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -700,4 +700,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>Clearing NuGet plugins cache: {0}</value>
     <comment>{0}: Plugins cache path</comment>
   </data>
+  <data name="Error_InvalidSymbolPackageFormat" xml:space="preserve">
+    <value>The provided SymbolPackageFormat value {0} is invalid. Possible allowed values are either 'snupkg' or 'symbols.nupkg'.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -89,6 +89,30 @@ namespace NuGet.Commands
             var sourceRepository = sourceRepositoryProvider.CreateRepository(packageSource);
 
             return await sourceRepository.GetResourceAsync<PackageUpdateResource>();
+        }
+
+        public static async Task<SymbolPackageUpdateResourceV3> GetSymbolPackageUpdateResource(IPackageSourceProvider sourceProvider, string source)
+        {
+            // Use a loaded PackageSource if possible since it contains credential info
+            PackageSource packageSource = null;
+            foreach (var loadedPackageSource in sourceProvider.LoadPackageSources())
+            {
+                if (loadedPackageSource.IsEnabled && source == loadedPackageSource.Source)
+                {
+                    packageSource = loadedPackageSource;
+                    break;
+                }
+            }
+
+            if (packageSource == null)
+            {
+                packageSource = new PackageSource(source);
+            }
+
+            var sourceRepositoryProvider = new CachingSourceProvider(sourceProvider);
+            var sourceRepository = sourceRepositoryProvider.CreateRepository(packageSource);
+
+            return await sourceRepository.GetResourceAsync<SymbolPackageUpdateResourceV3>();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
@@ -94,15 +94,9 @@ namespace NuGet.Commands
         public static async Task<SymbolPackageUpdateResourceV3> GetSymbolPackageUpdateResource(IPackageSourceProvider sourceProvider, string source)
         {
             // Use a loaded PackageSource if possible since it contains credential info
-            PackageSource packageSource = null;
-            foreach (var loadedPackageSource in sourceProvider.LoadPackageSources())
-            {
-                if (loadedPackageSource.IsEnabled && source == loadedPackageSource.Source)
-                {
-                    packageSource = loadedPackageSource;
-                    break;
-                }
-            }
+            var packageSource = sourceProvider.LoadPackageSources()
+                .Where(e => e.IsEnabled && string.Equals(source, e.Source, StringComparison.OrdinalIgnoreCase))
+                .FirstOrDefault();
 
             if (packageSource == null)
             {

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
@@ -29,6 +29,20 @@ namespace NuGet.Common
         }
 
         /// <summary>
+        /// Returns OrdinalIgnoreCase windows and mac. Ordinal for linux.
+        /// </summary>
+        /// <returns></returns>
+        public static StringComparison GetStringComparisonBasedOnOS()
+        {
+            if (IsFileSystemCaseInsensitive)
+            {
+                return StringComparison.OrdinalIgnoreCase;
+            }
+
+            return StringComparison.Ordinal;
+        }
+
+        /// <summary>
         /// Returns distinct orderd paths based on the file system case sensitivity.
         /// </summary>
         public static IEnumerable<string> GetUniquePathsBasedOnOS(IEnumerable<string> paths)

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace NuGet.Configuration
@@ -30,6 +30,7 @@ namespace NuGet.Configuration
         public static readonly string NuGetSolutionSettingsFolder = ".nuget";
 
         public static readonly string PackageExtension = ".nupkg";
+        public static readonly string SnupkgExtension = ".snupkg";
         public static readonly string SymbolsExtension = ".symbols" + PackageExtension;
         public static readonly string ManifestExtension = ".nuspec";
         public static readonly string ManifestSymbolsExtension = ".symbols" + ManifestExtension;

--- a/src/NuGet.Core/NuGet.Packaging.Core/PackageType.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/PackageType.cs
@@ -16,6 +16,7 @@ namespace NuGet.Packaging.Core
         public static readonly PackageType DotnetCliTool = new PackageType("DotnetCliTool", version: EmptyVersion);
         public static readonly PackageType Dependency = new PackageType("Dependency", version: EmptyVersion);
         public static readonly PackageType DotnetTool = new PackageType("DotnetTool", version: EmptyVersion);
+        public static readonly PackageType SymbolsPackage = new PackageType("SymbolsPackage", version: EmptyVersion);
 
         public PackageType(string name, Version version)
         {

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -300,7 +300,7 @@ namespace NuGet.Packaging
                 yield return String.Format(CultureInfo.CurrentCulture, NuGetResources.Manifest_RequiredMetadataMissing, "Version");
             }
 
-            if (Authors == null || !Authors.Any(author => !String.IsNullOrEmpty(author)))
+            if ((Authors == null || !Authors.Any(author => !String.IsNullOrEmpty(author))) && !PackageTypes.Contains(PackageType.SymbolsPackage))
             {
                 yield return String.Format(CultureInfo.CurrentCulture, NuGetResources.Manifest_RequiredMetadataMissing, "Authors");
             }

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
@@ -51,6 +51,10 @@ namespace NuGet.Packaging
             // now check for required elements, which include <id>, <version>, <authors> and <description>
             foreach (var requiredElement in RequiredElements)
             {
+                if(requiredElement.Equals("authors") && manifestMetadata.PackageTypes.Contains(PackageType.SymbolsPackage))
+                {
+                    continue;
+                }
                 if (!allElements.Contains(requiredElement))
                 {
                     throw new InvalidDataException(

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
@@ -35,8 +35,12 @@ namespace NuGet.Packaging.Xml
             elem.Add(new XElement(ns + "id", metadata.Id));
             AddElementIfNotNull(elem, ns, "version", metadata.Version?.ToFullString());
             AddElementIfNotNull(elem, ns, "title", metadata.Title);
-            AddElementIfNotNull(elem, ns, "authors", metadata.Authors, authors => string.Join(",", authors));
-            AddElementIfNotNull(elem, ns, "owners", metadata.Owners, owners => string.Join(",", owners));
+            if(!metadata.PackageTypes.Contains(PackageType.SymbolsPackage))
+            {
+                AddElementIfNotNull(elem, ns, "authors", metadata.Authors, authors => string.Join(",", authors));
+                AddElementIfNotNull(elem, ns, "owners", metadata.Owners, owners => string.Join(",", owners));
+            }
+            
             elem.Add(new XElement(ns + "requireLicenseAcceptance", metadata.RequireLicenseAcceptance));
             if (metadata.DevelopmentDependency)
             {

--- a/src/NuGet.Core/NuGet.Packaging/PackagingConstants.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackagingConstants.cs
@@ -49,6 +49,11 @@ namespace NuGet.Packaging
         /// </summary>
         public static readonly string ManifestExtension = ".nuspec";
 
+        public static readonly string SnupkgFormat = "snupkg";
+
+        public static readonly string SymbolsNupkgFormat = "symbols.nupkg";
+
+
         // Starting from nuget 2.0, we use a file with the special name '_._' to represent an empty folder.
         internal const string PackageEmptyFileName = "_._";
     }

--- a/src/NuGet.Core/NuGet.Protocol/Constants.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Constants.cs
@@ -11,6 +11,7 @@ namespace NuGet.Protocol
         public static readonly string Version340 = "/3.4.0";
         public static readonly string Versioned = "/Versioned";
         public static readonly string Version470 = "/4.7.0";
+        public static readonly string Version100 = "/1.0.0";
 
         public static readonly string[] SearchQueryService = { "SearchQueryService" + Versioned, "SearchQueryService" + Version340, "SearchQueryService" + Version300beta };
         public static readonly string[] RegistrationsBaseUrl = { "RegistrationsBaseUrl" + Versioned, "RegistrationsBaseUrl" + Version340, "RegistrationsBaseUrl" + Version300beta };
@@ -20,5 +21,6 @@ namespace NuGet.Protocol
         public static readonly string[] PackagePublish = { "PackagePublish" + Versioned, "PackagePublish" + Version200 };
         public static readonly string[] PackageBaseAddress = { "PackageBaseAddress" + Versioned, "PackageBaseAddress" + Version300 };
         public static readonly string[] RepositorySignatures = { "RepositorySignatures" + Version470 };
+        public static readonly string[] SymbolPackagePublish = { "SymbolPackagePublish" + Version100 };
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Constants.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Constants.cs
@@ -11,7 +11,7 @@ namespace NuGet.Protocol
         public static readonly string Version340 = "/3.4.0";
         public static readonly string Versioned = "/Versioned";
         public static readonly string Version470 = "/4.7.0";
-        public static readonly string Version100 = "/1.0.0";
+        public static readonly string Version490 = "/4.9.0";
 
         public static readonly string[] SearchQueryService = { "SearchQueryService" + Versioned, "SearchQueryService" + Version340, "SearchQueryService" + Version300beta };
         public static readonly string[] RegistrationsBaseUrl = { "RegistrationsBaseUrl" + Versioned, "RegistrationsBaseUrl" + Version340, "RegistrationsBaseUrl" + Version300beta };
@@ -21,6 +21,6 @@ namespace NuGet.Protocol
         public static readonly string[] PackagePublish = { "PackagePublish" + Versioned, "PackagePublish" + Version200 };
         public static readonly string[] PackageBaseAddress = { "PackageBaseAddress" + Versioned, "PackageBaseAddress" + Version300 };
         public static readonly string[] RepositorySignatures = { "RepositorySignatures" + Version470 };
-        public static readonly string[] SymbolPackagePublish = { "SymbolPackagePublish" + Version100 };
+        public static readonly string[] SymbolPackagePublish = { "SymbolPackagePublish" + Version490 };
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/FactoryExtensionsV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/FactoryExtensionsV3.cs
@@ -35,6 +35,7 @@ namespace NuGet.Protocol
             yield return new Lazy<INuGetResourceProvider>(() => new MetadataResourceV3Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new RawSearchResourceV3Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new RegistrationResourceV3Provider());
+            yield return new Lazy<INuGetResourceProvider>(() => new SymbolPackageUpdateResourceV3Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new ReportAbuseResourceV3Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new ServiceIndexResourceV3Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new ODataServiceDocumentResourceV2Provider());

--- a/src/NuGet.Core/NuGet.Protocol/Providers/SymbolPackageUpdateResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/SymbolPackageUpdateResourceV3Provider.cs
@@ -40,12 +40,6 @@ namespace NuGet.Protocol
                     }
                     symbolPackageUpdateResource = new SymbolPackageUpdateResourceV3(sourceUri, httpSource);
                 }
-                else
-                {
-                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
-                        Strings.PackageServerEndpoint_NotSupported,
-                        source));
-                }
             }
 
             var result = new Tuple<bool, INuGetResource>(symbolPackageUpdateResource != null, symbolPackageUpdateResource);

--- a/src/NuGet.Core/NuGet.Protocol/Providers/SymbolPackageUpdateResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/SymbolPackageUpdateResourceV3Provider.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.Protocol
+{
+    public class SymbolPackageUpdateResourceV3Provider : ResourceProvider
+    {
+        public SymbolPackageUpdateResourceV3Provider()
+            : base(typeof(SymbolPackageUpdateResourceV3),
+                  nameof(SymbolPackageUpdateResourceV3),
+                  NuGetResourceProviderPositions.Last)
+        {
+        }
+
+        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        {
+            SymbolPackageUpdateResourceV3 symbolPackageUpdateResource = null;
+
+            var serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
+
+            if (serviceIndex != null)
+            {
+                var baseUrl = serviceIndex.GetServiceEntryUri(ServiceTypes.SymbolPackagePublish);
+
+                HttpSource httpSource = null;
+                var sourceUri = baseUrl?.AbsoluteUri;
+                if (!string.IsNullOrEmpty(sourceUri))
+                {
+                    if (!(new Uri(sourceUri)).IsFile)
+                    {
+                        var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
+                        httpSource = httpSourceResource.HttpSource;
+                    }
+                    symbolPackageUpdateResource = new SymbolPackageUpdateResourceV3(sourceUri, httpSource);
+                }
+                else
+                {
+                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
+                        Strings.PackageServerEndpoint_NotSupported,
+                        source));
+                }
+            }
+
+            var result = new Tuple<bool, INuGetResource>(symbolPackageUpdateResource != null, symbolPackageUpdateResource);
+            return result;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -80,6 +80,13 @@ namespace NuGet.Protocol.Core.Types
                 // - The endpoint for main package supports pushing snupkgs
                 if (!string.IsNullOrEmpty(symbolSource))
                 {
+                    // This is the scenario where user pushes *.nupkg on a source which supports pushing snupkg. Since the wildcard doesn't match
+                    // snupkg, we should not push snupkgs unintentionally.
+                    if(symbolPackageUpdateResource != null && packagePath.EndsWith(NuGetConstants.PackageExtension, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return;
+                    }
+
                     var symbolApiKey = getSymbolApiKey(symbolSource);
 
                     await PushSymbols(packagePath, symbolSource, symbolApiKey,

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -107,8 +107,8 @@ namespace NuGet.Protocol.Core.Types
                 getApiKey,
                 getSymbolApiKey,
                 noServiceEndpoint,
-                null,
-                log);
+                symbolPackageUpdateResource: null,
+                log: log);
         }
 
         public async Task Delete(string packageId,

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -80,13 +80,6 @@ namespace NuGet.Protocol.Core.Types
                 // - The endpoint for main package supports pushing snupkgs
                 if (!string.IsNullOrEmpty(symbolSource))
                 {
-                    // This is the scenario where user pushes *.nupkg on a source which supports pushing snupkg. Since the wildcard doesn't match
-                    // snupkg, we should not push snupkgs unintentionally.
-                    if(symbolPackageUpdateResource != null && packagePath.EndsWith(NuGetConstants.PackageExtension, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return;
-                    }
-
                     var symbolApiKey = getSymbolApiKey(symbolSource);
 
                     await PushSymbols(packagePath, symbolSource, symbolApiKey,

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -69,7 +69,11 @@ namespace NuGet.Protocol.Core.Types
                 tokenSource.CancelAfter(requestTimeout);
                 var apiKey = getApiKey(_source);
 
-                await PushPackage(packagePath, _source, apiKey, noServiceEndpoint, requestTimeout, log, tokenSource.Token, isSnupkgPush: false);
+                // if only a snupkg is being pushed, then don't try looking for nupkgs.
+                if(!packagePath.EndsWith(NuGetConstants.SnupkgExtension, StringComparison.OrdinalIgnoreCase))
+                {
+                    await PushPackage(packagePath, _source, apiKey, noServiceEndpoint, requestTimeout, log, tokenSource.Token, isSnupkgPush: false);
+                }
 
                 // symbolSource is only set when:
                 // - The user specified it on the command line
@@ -157,7 +161,7 @@ namespace NuGet.Protocol.Core.Types
             var symbolPackagePath = GetSymbolsPath(packagePath, isSymbolEndpointSnupkgCapable);
 
             // Push the symbols package if it exists
-            if (File.Exists(symbolPackagePath))
+            if (File.Exists(symbolPackagePath) || symbolPackagePath.IndexOf('*') != -1)
             {
                 var sourceUri = UriUtility.CreateSourceUri(source);
 

--- a/src/NuGet.Core/NuGet.Protocol/Resources/SymbolPackageUpdateResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/SymbolPackageUpdateResourceV3.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Common;
+
+namespace NuGet.Protocol.Core.Types
+{
+    /// <summary>
+    /// Contains logics to push or delete packages in Http server or file system
+    /// </summary>
+    public class SymbolPackageUpdateResourceV3 : INuGetResource
+    {
+
+        private HttpSource _httpSource;
+        private string _source;
+
+        public SymbolPackageUpdateResourceV3(string source,
+            HttpSource httpSource)
+        {
+            _source = source;
+            _httpSource = httpSource;
+        }
+
+        public Uri SourceUri
+        {
+            get { return UriUtility.CreateSourceUri(_source); }
+        }
+
+        
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Resources/SymbolPackageUpdateResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/SymbolPackageUpdateResourceV3.cs
@@ -7,7 +7,7 @@ using NuGet.Common;
 namespace NuGet.Protocol.Core.Types
 {
     /// <summary>
-    /// Contains logics to push or delete packages in Http server or file system
+    /// Contains logics to push symbol packages in Http server or file system
     /// </summary>
     public class SymbolPackageUpdateResourceV3 : INuGetResource
     {

--- a/src/NuGet.Core/NuGet.Protocol/Utility/LocalFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/LocalFolderUtility.cs
@@ -955,14 +955,14 @@ namespace NuGet.Protocol
         /// </summary>
         /// <param name="packagePath">Package path</param>
         /// <returns>A list of package paths that match the input path.</returns>
-        public static IEnumerable<string> ResolvePackageFromPath(string packagePath)
+        public static IEnumerable<string> ResolvePackageFromPath(string packagePath, bool isSnupkg = false)
         {
             // Ensure packagePath ends with *.nupkg
-            packagePath = EnsurePackageExtension(packagePath);
+            packagePath = EnsurePackageExtension(packagePath, isSnupkg);
             return PathResolver.PerformWildcardSearch(Directory.GetCurrentDirectory(), packagePath);
         }
 
-        private static string EnsurePackageExtension(string packagePath)
+        private static string EnsurePackageExtension(string packagePath, bool isSnupkg)
         {
             if (packagePath.IndexOf('*') == -1)
             {
@@ -970,7 +970,8 @@ namespace NuGet.Protocol
                 return packagePath;
             }
             // If the path does not contain wildcards, we need to add *.nupkg to it.
-            if (!packagePath.EndsWith(NuGetConstants.PackageExtension, StringComparison.OrdinalIgnoreCase))
+            if (!packagePath.EndsWith(NuGetConstants.PackageExtension, StringComparison.OrdinalIgnoreCase)
+                && !packagePath.EndsWith(NuGetConstants.SnupkgExtension, StringComparison.OrdinalIgnoreCase))
             {
                 if (packagePath.EndsWith("**", StringComparison.OrdinalIgnoreCase))
                 {
@@ -980,7 +981,7 @@ namespace NuGet.Protocol
                 {
                     packagePath = packagePath + '*';
                 }
-                packagePath = packagePath + NuGetConstants.PackageExtension;
+                packagePath = packagePath + (isSnupkg? NuGetConstants.SnupkgExtension : NuGetConstants.PackageExtension);
             }
             return packagePath;
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -843,15 +843,10 @@ namespace Proj2
                 // Assert
                 var package = new PackageArchiveReader(Path.Combine(proj2Directory, $"proj2.0.0.0.{extension}"));
                 var files = package.GetFiles()
-                    .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package"))
-                    .Select(t => t.Replace("/", "\\"))
+                    .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package"))                    
                     .ToArray();
                 Array.Sort(files);
-
-                if(symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg)
-                {
-                    Assert.Equal(
-                    new string[]
+                var actual = symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg ? new string[]
                     {
                         Path.Combine("content", "proj1_file2.txt"),
                         Path.Combine("lib", "net40", "proj1.dll"),
@@ -861,20 +856,15 @@ namespace Proj2
                         "proj2.nuspec",
                         Path.Combine("src", "proj1", "proj1_file1.cs"),
                         Path.Combine("src", "proj2", "proj2_file1.cs"),
-                    },
-                    files);
-                }
-                else
-                {
-                    Assert.Equal(
-                    new string[]
+                    }
+                    : new string[]
                     {
                         Path.Combine("lib", "net40", "proj1.pdb"),
                         Path.Combine("lib", "net40", "proj2.pdb"),
                         "proj2.nuspec"
-                    },
-                    files);
-                }
+                    };
+                actual = actual.Select(t => NuGet.Common.PathUtility.GetPathWithForwardSlashes(t)).ToArray();
+                Assert.Equal(actual, files);
                 
             }
         }
@@ -929,30 +919,20 @@ namespace Proj2
                     .Select(t => t.Replace("/", "\\"))
                     .ToArray();
                 Array.Sort(files);
-
-                if(symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg)
-                {
-                    Assert.Equal(
-                    new string[]
+                var actual = symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg ?  new string[]
                     {
                         "A.nuspec",
                         Path.Combine("lib", "net40", "A.dll"),
                         Path.Combine("lib", "net40", "A.pdb"),
                         Path.Combine("src", "B.cs")
-                    },
-                    files);
-                }
-                else
-                {
-                    Assert.Equal(
-                    new string[]
+                    }
+                    : new string[]
                     {
                         "A.nuspec",
                         Path.Combine("lib", "net40", "A.pdb")
-                    },
-                    files);
-                }
-                
+                    };
+                actual = actual.Select(t => NuGet.Common.PathUtility.GetPathWithForwardSlashes(t)).ToArray();
+                Assert.Equal(actual, files);
             }
         }
 
@@ -1008,29 +988,19 @@ public class B
                     .Select(t => t.Replace("/", "\\"))
                     .ToArray();
                 Array.Sort(files);
-
-                if(symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg)
-                {
-                    Assert.Equal(
-                    new string[]
+                var actual = symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg ? new string[]
                     {
                         "A.nuspec",
                         Path.Combine("lib", "net40", "A.exe"),
                         Path.Combine("lib", "net40", "A.pdb"),
                         Path.Combine("src", "B.cs"),
-                    },
-                    files);
-                }
-                else
-                {
-                    Assert.Equal(
-                    new string[]
+                    }
+                    : new string[]
                     {
                         "A.nuspec",
                         Path.Combine("lib", "net40", "A.pdb"),
-                    },
-                    files);
-                }
+                    };
+                Assert.Equal(actual, files);
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -400,6 +400,89 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        public void PackCommand_SymbolPackageWithNuspecFile()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var workingDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "lib", "uap10.0"),
+                    "packageA.dll",
+                    string.Empty);
+
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "lib", "uap10.0"),
+                    "packageA.pdb",
+                    string.Empty);
+
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "contentFiles", "any", "any"),
+                    "image.jpg",
+                    "");
+
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "contentFiles", "cs", "net45"),
+                    "code.cs",
+                    "");
+
+                Util.CreateFile(
+                    workingDirectory,
+                    "packageA.nuspec",
+@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
+  <metadata>
+    <id>packageA</id>
+    <version>1.0.0</version>
+    <title>packageA</title>
+    <authors>test</authors>
+    <owners>test</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Description</description>
+    <copyright>Copyright ©  2013</copyright>
+  </metadata>
+</package>");
+
+                // Act
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingDirectory,
+                    "pack packageA.nuspec -symbols -SymbolPackageFormat snupkg",
+                    waitForExit: true);
+                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+
+                // Assert
+                var path = Path.Combine(workingDirectory, "packageA.1.0.0.nupkg");
+                var symbolPath = Path.Combine(workingDirectory, "packageA.1.0.0.snupkg");
+                var package = new PackageArchiveReader(path);
+                var symbolPackage = new PackageArchiveReader(symbolPath);
+                var files = package.GetFiles()
+                    .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package") && !t.EndsWith("nuspec"))
+                    .ToArray();
+                var symbolFiles = symbolPackage.GetFiles()
+                    .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package") && !t.EndsWith("nuspec"))
+                    .ToArray();
+                Array.Sort(files);
+                Array.Sort(symbolFiles);
+
+                Assert.Equal(
+                    new string[]
+                    {
+                        "contentFiles/any/any/image.jpg",
+                        "contentFiles/cs/net45/code.cs",
+                        Path.Combine("lib", "uap10.0", "packageA.dll").Replace('\\', '/'),
+                    },
+                    files);
+                Assert.Equal(
+                    new string[]
+                    {
+                        Path.Combine("lib", "uap10.0", "packageA.pdb").Replace('\\','/'),
+                    },
+                    symbolFiles);
+            }
+        }
+
+        [Fact]
         public void PackCommand_ContentV2PackageFromNuspec()
         {
             var nugetexe = Util.GetNuGetExePath();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -1067,7 +1067,6 @@ public class B
                 var package = new PackageArchiveReader(Path.Combine(projDirectory, $"A.0.0.0.{extension}"));
                 var files = package.GetFiles()
                     .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package"))
-                    .Select(t => t.Replace("/", "\\"))
                     .ToArray();
                 Array.Sort(files);
                 var actual = symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg ? new string[]

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -999,20 +999,19 @@ namespace Proj2
                 var package = new PackageArchiveReader(Path.Combine(projDirectory, $"A.0.0.0.{extension}"));
                 var files = package.GetFiles()
                     .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package"))
-                    .Select(t => t.Replace("/", "\\"))
                     .ToArray();
                 Array.Sort(files);
                 var actual = symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg ?  new string[]
                     {
                         "A.nuspec",
-                        Path.Combine("lib", "net40", "A.dll"),
-                        Path.Combine("lib", "net40", "A.pdb"),
-                        Path.Combine("src", "B.cs")
+                        "lib/net40/A.dll",
+                        "lib/net40/A.pdb",
+                        "src/B.cs"
                     }
                     : new string[]
                     {
                         "A.nuspec",
-                        Path.Combine("lib", "net40", "A.pdb")
+                        "lib/net40/A.pdb"
                     };
                 actual = actual.Select(t => NuGet.Common.PathUtility.GetPathWithForwardSlashes(t)).ToArray();
                 Assert.Equal(actual, files);
@@ -1074,14 +1073,14 @@ public class B
                 var actual = symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg ? new string[]
                     {
                         "A.nuspec",
-                        Path.Combine("lib", "net40", "A.exe"),
-                        Path.Combine("lib", "net40", "A.pdb"),
-                        Path.Combine("src", "B.cs"),
+                        "lib/net40/A.exe",
+                        "lib/net40/A.pdb",
+                        "src/B.cs"
                     }
                     : new string[]
                     {
                         "A.nuspec",
-                        Path.Combine("lib", "net40", "A.pdb"),
+                        "lib/net40/A.pdb"
                     };
                 Assert.Equal(actual, files);
             }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -94,20 +94,6 @@ namespace Dotnet.Integration.Test
                 {
                     var nuspecReader = nupkgReader.NuspecReader;
 
-                    // Validate the output .nuspec.
-                    Assert.Equal("ClassLibrary1", nuspecReader.GetId());
-                    Assert.Equal("1.0.0", nuspecReader.GetVersion().ToFullString());
-                    Assert.Equal("ClassLibrary1", nuspecReader.GetAuthors());
-                    Assert.Equal("ClassLibrary1", nuspecReader.GetOwners());
-                    Assert.Equal("Package Description", nuspecReader.GetDescription());
-                    Assert.False(nuspecReader.GetRequireLicenseAcceptance());
-
-                    var dependencyGroups = nuspecReader.GetDependencyGroups().ToList();
-                    Assert.Equal(1, dependencyGroups.Count);
-                    Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard20, dependencyGroups[0].TargetFramework);
-                    var packages = dependencyGroups[0].Packages.ToList();
-                    Assert.Equal(0, packages.Count);
-
                     // Validate the assets.
                     var libItems = nupkgReader.GetLibItems().ToList();
                     var libSymItems = symbolReader.GetLibItems().ToList();
@@ -115,7 +101,7 @@ namespace Dotnet.Integration.Test
                     Assert.Equal(1, libSymItems.Count);
                     Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard20, libItems[0].TargetFramework);
                     Assert.Equal(new[] { "lib/netstandard2.0/ClassLibrary1.dll" }, libItems[0].Items);
-                    Assert.Equal(new[] { "lib/netstandard2.0/ClassLibrary1.pdb" }, libItems[0].Items);
+                    Assert.Equal(new[] { "lib/netstandard2.0/ClassLibrary1.pdb" }, libSymItems[0].Items);
                 }
 
             }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
@@ -629,6 +629,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                         {"TargetFramework", "net45" }
                     })},
                     Logger = new TestLogger(),
+                    SymbolPackageFormat = "symbols.nupkg",
                     FrameworkAssemblyReferences = new MSBuildItem[]{}
                 };
             }


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/6878

Adds support in Pack for creating the new symbols package (snupkg) and support in push to be able to push the same by discovering whether the endpoint supports the capability.

Spec for the same can be found at: https://github.com/NuGet/Home/wiki/NuGet-Client-Package-Debugging
and https://github.com/NuGet/Home/wiki/NuGet-Package-Debugging-&-Symbols-Improvements

