### PR TITLE
Fixing InvalidFrameworkFolderRule in Pack to warn for unsupported frameworks

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Rules/InvalidFrameworkFolderRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/InvalidFrameworkFolderRule.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 using NuGet.Common;
+using NuGet.Frameworks;
 
 namespace NuGet.Packaging.Rules
 {
@@ -51,7 +52,8 @@ namespace NuGet.Packaging.Rules
                 fx = null;
             }
 
-            return fx != null;
+            // return false if the framework is Null or Unsupported
+            return fx != null && fx.Identifier != NuGetFramework.UnsupportedFramework.Framework;
         }
 
         private static bool IsValidCultureName(PackageArchiveReader builder, string name)

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/InvalidFrameworkFolderRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/InvalidFrameworkFolderRuleTests.cs
@@ -1,0 +1,142 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Packaging.Rules;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class InvalidFrameworkFolderRuleTests
+    {
+        [Fact]
+        public void Validate_AssemblyWithInvalidTFMInPath_GeneratesWarning()
+        {
+            // Arrange
+            var nuspecContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+"<package xmlns=\"http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd\">" +
+"   <metadata>" +
+"        <id>test</id>" +
+"        <version>1.0.0</version>" +
+"        <authors>Unit Test</authors>" +
+"        <description>Sample Description</description>" +
+"        <language>en-US</language>" +
+"    <dependencies>" +
+"      <dependency id=\"System.Collections.Immutable\" version=\"4.3.0\" />" +
+"    </dependencies>" +
+"    </metadata>" +
+"</package>";
+
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var nuspecPath = Path.Combine(testDirectory, "test.nuspec");
+                File.AppendAllText(nuspecPath, nuspecContent);
+
+                // create a random_tfm directory in a lib directory
+                Directory.CreateDirectory(Path.Combine(testDirectory, "lib", "random_tfm"));
+
+                // place a dll inside the folder
+                var stream = File.Create(Path.Combine(testDirectory, "lib", "random_tfm", "test.dll"));
+                stream.Dispose();
+
+                var builder = new PackageBuilder();
+                var runner = new PackCommandRunner(
+                    new PackArgs
+                    {
+                        CurrentDirectory = testDirectory,
+                        OutputDirectory = testDirectory,
+                        Path = nuspecPath,
+                        Exclude = Array.Empty<string>(),
+                        Symbols = true,
+                        Logger = NullLogger.Instance
+                    },
+                    MSBuildProjectFactory.ProjectCreator,
+                    builder);
+
+                runner.BuildPackage();
+
+                var ruleSet = RuleSet.PackageCreationRuleSet;
+                var nupkgPath = Path.Combine(testDirectory, "test.1.0.0.nupkg");
+
+                using (var reader = new PackageArchiveReader(nupkgPath))
+                {
+                    var issues = new List<PackagingLogMessage>();
+                    foreach (var rule in ruleSet)
+                    {
+                        issues.AddRange(rule.Validate(reader).OrderBy(p => p.Code.ToString(), StringComparer.CurrentCulture));
+                    }
+
+                    Assert.True(issues.Any(p => p.Code == NuGetLogCode.NU5103 && p.Message.Contains("'lib' is not recognized as a valid framework name")));
+                }
+            }
+        }
+
+        [Fact]
+        public void Validate_AssemblyWithValidTFMInPath_NoWarning()
+        {
+            // Arrange
+            var nuspecContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+"<package xmlns=\"http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd\">" +
+"   <metadata>" +
+"        <id>test</id>" +
+"        <version>1.0.0</version>" +
+"        <authors>Unit Test</authors>" +
+"        <description>Sample Description</description>" +
+"        <language>en-US</language>" +
+"    <dependencies>" +
+"      <dependency id=\"System.Collections.Immutable\" version=\"4.3.0\" />" +
+"    </dependencies>" +
+"    </metadata>" +
+"</package>";
+
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var nuspecPath = Path.Combine(testDirectory, "test.nuspec");
+                File.AppendAllText(nuspecPath, nuspecContent);
+
+                // create a random_tfm directory in a lib directory
+                Directory.CreateDirectory(Path.Combine(testDirectory, "lib", "net46"));
+
+                // place a dll inside the folder
+                var stream = File.Create(Path.Combine(testDirectory, "lib", "net46", "test.dll"));
+                stream.Dispose();
+
+                var builder = new PackageBuilder();
+                var runner = new PackCommandRunner(
+                    new PackArgs
+                    {
+                        CurrentDirectory = testDirectory,
+                        OutputDirectory = testDirectory,
+                        Path = nuspecPath,
+                        Exclude = Array.Empty<string>(),
+                        Symbols = true,
+                        Logger = NullLogger.Instance
+                    },
+                    MSBuildProjectFactory.ProjectCreator,
+                    builder);
+
+                runner.BuildPackage();
+
+                var ruleSet = RuleSet.PackageCreationRuleSet;
+                var nupkgPath = Path.Combine(testDirectory, "test.1.0.0.nupkg");
+
+                using (var reader = new PackageArchiveReader(nupkgPath))
+                {
+                    var issues = new List<PackagingLogMessage>();
+                    foreach (var rule in ruleSet)
+                    {
+                        issues.AddRange(rule.Validate(reader).OrderBy(p => p.Code.ToString(), StringComparer.CurrentCulture));
+                    }
+
+                    Assert.False(issues.Any(p => p.Code == NuGetLogCode.NU5103 && p.Message.Contains("'lib' is not recognized as a valid framework name")));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bug
Currently the `InvalidFrameworkFolderRule` is only [checking](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Packaging/Rules/InvalidFrameworkFolderRule.cs#L54) if a framework parsing fails. This results in no warning if an assembly file is under a random tfm folder. 

### Sample nuspec - 
```
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
        <id>test</id>
        <version>1.2.3</version>
        <authors>Unit Test</authors>
        <description>package description</description>
        <language>en-US</language>
        <projectUrl>http://PROJECT_URL_HERE_OR_DELETE_THIS_LINE</projectUrl>
        <dependencies>
            <dependency id="System.Collections.Immutable" version="4.3.0" />
        </dependencies>
    </metadata>
</package>
```
Place an assembly at `./lib/random_tfm/test.dll`.

### Before - 
```
F:\validation\test\nuspec\test\test> nuget pack .\test.nuspec
Attempting to build package from 'test.nuspec'.
Successfully created package 'F:\validation\test\nuspec\test\test\test.1.2.3.nupkg'.
```

### After -
```
F:\validation\test\nuspec\test\test> E:\NuGet.Client\artifacts\NuGet.CommandLine\15.0\bin\Debug\net46\NuGet.exe pack .\test.nuspec
Attempting to build package from 'test.nuspec'.
Successfully created package 'F:\validation\test\nuspec\test\test\test.1.2.3.nupkg'.
WARNING: NU5103: The folder 'lib\random_tfm\temp.dll' under 'lib' is not recognized as a valid framework name or a supported culture identifier. Rename it to a valid framework name or culture identifier.
``` 

## Fix
Details: This PR fixes this by adding another check to see if the folder resolves to unsupported framework.

## Testing/Validation
Tests Added: Yes
Validation done:  Manual validation
