### PR TITLE
Removing NU5113 since it can never be invoked

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -951,14 +951,6 @@ namespace NuGet.Commands
         {
             IEnumerable<IPackageRule> packageRules = Rules;
             IList<PackagingLogMessage> issues = new List<PackagingLogMessage>();
-            NuGetVersion version;
-
-            if (!NuGetVersion.TryParseStrict(package.GetIdentity().Version.ToString(), out version))
-            {
-                issues.Add(PackagingLogMessage.CreateWarning(
-                    String.Format(CultureInfo.CurrentCulture, Strings.Warning_SemanticVersion, package.GetIdentity().Version),
-                    NuGetLogCode.NU5113));
-            }
 
             foreach (var rule in packageRules)
             {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1647,15 +1647,6 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Version &quot;{0}&quot; does not follow semantic versioning guidelines. Update your nuspec file or use the AssemblyInformationalVersion assembly attribute to specify a semantic version as described at http://semver.org..
-        /// </summary>
-        internal static string Warning_SemanticVersion {
-            get {
-                return ResourceManager.GetString("Warning_SemanticVersion", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; was included in the project but the path could not be resolved. Skipping....
         /// </summary>
         internal static string Warning_UnresolvedFilePath {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -320,9 +320,6 @@
   <data name="Warning_DuplicatePropertyKey" xml:space="preserve">
     <value>'{0}' key already exists in Properties collection. Overriding value.</value>
   </data>
-  <data name="Warning_SemanticVersion" xml:space="preserve">
-    <value>Version "{0}" does not follow semantic versioning guidelines. Update your nuspec file or use the AssemblyInformationalVersion assembly attribute to specify a semantic version as described at http://semver.org.</value>
-  </data>
   <data name="MSBuildWarning_MultiTarget" xml:space="preserve">
     <value>Packages containing MSBuild targets and props files cannot be fully installed in projects targeting multiple frameworks. The MSBuild targets and props files have been ignored.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -631,11 +631,6 @@ namespace NuGet.Common
         NU5112 = 5112,
 
         /// <summary>
-        /// Warning_SemanticVersion
-        /// </summary>
-        NU5113 = 5113,
-
-        /// <summary>
         /// Warning_DuplicatePropertyKey
         /// </summary>
         NU5114 = 5114,


### PR DESCRIPTION
This PR removes `NU5113` since it cannot happen. The warning was thrown if a generated package was not SemVer compatible. However, since this is only called right after package generation, it will never run into the case where the package version is not SemVer compatible since we always create SemVer compatible versions.