### PR TITLE
Updating Loc validator to 2.0.1 to consume a repository signed package

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -20,7 +20,7 @@
   <package id="VSLangProj150" version="1.0.0" targetFramework="net46" />
   <package id="xunit.runner.console" version="2.3.1" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" />
-  <package id="NuGetValidator" version="2.0.0" targetFramework="net461" />
+  <package id="NuGetValidator" version="2.0.1" targetFramework="net461" />
   <package id="XunitXml.TestLogger" version="2.0.0" />
   <package id="Microsoft.DotNet.Build.Tasks.Feed" version="2.1.0-prerelease-02419-02" />   <!-- For the .NET Core orchestrated build.-->
 </packages>

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -182,7 +182,7 @@ Function Install-NuGet {
     if ($Force -or -not (Test-Path $NuGetExe)) {
         Trace-Log 'Downloading nuget.exe'
 
-        wget https://dist.nuget.org/win-x86-commandline/v4.4.1/nuget.exe -OutFile $NuGetExe
+        wget https://dist.nuget.org/win-x86-commandline/v4.7.0/nuget.exe -OutFile $NuGetExe
     }
 
     # Display nuget info

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -72,9 +72,9 @@ phases:
         gci env:* | sort-object name
 
   - task: NuGetToolInstaller@0
-    displayName: "Use NuGet 4.7.0"
+    displayName: "Use NuGet 4.6.2"
     inputs:
-      versionSpec: "4.7.0"
+      versionSpec: "4.6.2"
 
   - task: PowerShell@1
     inputs:

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -72,9 +72,9 @@ phases:
         gci env:* | sort-object name
 
   - task: NuGetToolInstaller@0
-    displayName: "Use NuGet 4.6.2"
+    displayName: "Use NuGet 4.7.0"
     inputs:
-      versionSpec: "4.6.2"
+      versionSpec: "4.7.0"
 
   - task: PowerShell@1
     inputs:

--- a/scripts/cibuild/BuildValidator.ps1
+++ b/scripts/cibuild/BuildValidator.ps1
@@ -27,7 +27,7 @@ if ($BuildRTM -eq 'false')
 {   
 
     $NuGetClientRoot = $env:BUILD_REPOSITORY_LOCALPATH
-    $NuGetValidator = [System.IO.Path]::Combine($NuGetClientRoot, 'packages', 'NuGetValidator.2.0.0', 'tools', 'NuGetValidator.exe')
+    $NuGetValidator = [System.IO.Path]::Combine($NuGetClientRoot, 'packages', 'NuGetValidator.2.0.1', 'tools', 'NuGetValidator.exe')
     $VsixLogOutputDir = [System.IO.Path]::Combine($BuildOutputTargetPath, 'LocalizationValidation', 'vsix' )
     $LocalizationRepository = [System.IO.Path]::Combine($NuGetClientRoot, 'submodules', 'NuGet.Build.Localization', 'localize', 'comments', '15')
     


### PR DESCRIPTION
This PR updates the localization validator version to `2.0.1` which is built from this [commit](https://github.com/NuGet/Entropy/commit/2d44f092c59f9b83dc9fb3c22f554cb8c10ce33d). The only changes are newer version to get a repository signed package from nuget.org - 

```
PS> nuget verify -signatures C:\Users\anmishr\Desktop\temp\NuGetValidator.2.0.1.nupkg

Verifying NuGetValidator.2.0.1
C:\Users\anmishr\Desktop\temp\NuGetValidator.2.0.1.nupkg

Signature Hash Algorithm: SHA256
Signature type: Repository
nuget-v3-service-index-url: https://api.nuget.org/v3/index.json
nuget-package-owners: mishra14
Verifying the repository primary signature with certificate:
  Subject Name: CN=NuGet.org Repository by Microsoft, O=NuGet.org Repository by Microsoft, L=Redmond, S=Washington, C=US
  SHA1 hash: 8FB6D7FCF7AD49EB774446EFE778B33365BB7BFB
  SHA256 hash: 0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D
  Issued by: CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US
  Valid from: 4/9/2018 5:00:00 PM to 4/14/2021 5:00:00 AM

Timestamp: 8/10/2018 11:28:11 AM

Verifying repository primary signature's timestamp with timestamping service certificate:
  Subject Name: CN=Symantec SHA256 TimeStamping Signer - G2, OU=Symantec Trust Network, O=Symantec Corporation, C=US
  SHA1 hash: 625AEC3AE4EDA1D169C4EE909E85B3BBC61076D3
  SHA256 hash: CF7AC17AD047ECD5FDC36822031B12D4EF078B6F2B4C5E6BA41F8FF2CF4BAD67
  Issued by: CN=Symantec SHA256 TimeStamping CA, OU=Symantec Trust Network, O=Symantec Corporation, C=US
  Valid from: 1/1/2017 4:00:00 PM to 4/1/2028 4:59:59 PM


Successfully verified package 'NuGetValidator.2.0.1'.
```

The results are in this [run](https://devdiv.visualstudio.com/DevDiv/DevDiv%20Team/_build?definitionId=8117&_a=summary), same as before.