### PR TITLE
Adding logging to PC restore scenario in VS

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -179,7 +179,8 @@ namespace NuGet.CommandLine
                 packageRestoredEvent: null,
                 packageRestoreFailedEvent: (sender, args) => { failedEvents.Enqueue(args); },
                 sourceRepositories: packageSources.Select(sourceRepositoryProvider.CreateRepository),
-                maxNumberOfParallelTasks: DisableParallelProcessing ? 1 : PackageManagementConstants.DefaultMaxDegreeOfParallelism);
+                maxNumberOfParallelTasks: DisableParallelProcessing ? 1 : PackageManagementConstants.DefaultMaxDegreeOfParallelism,
+                logger: Console);
 
             var missingPackageReferences = installedPackageReferences.Where(reference =>
                 !nuGetPackageManager.PackageExistsInPackagesFolder(reference.PackageIdentity)).Any();
@@ -203,8 +204,7 @@ namespace NuGet.CommandLine
                 var result = await PackageRestoreManager.RestoreMissingPackagesAsync(
                     packageRestoreContext,
                     new ConsoleProjectContext(Console),
-                    downloadContext,
-                    Console);
+                    downloadContext);
 
                 if (downloadContext.DirectDownload)
                 {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -203,7 +203,8 @@ namespace NuGet.CommandLine
                 var result = await PackageRestoreManager.RestoreMissingPackagesAsync(
                     packageRestoreContext,
                     new ConsoleProjectContext(Console),
-                    downloadContext);
+                    downloadContext,
+                    Console);
 
                 if (downloadContext.DirectDownload)
                 {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -203,8 +203,8 @@ namespace NuGet.CommandLine
                 var result = await PackageRestoreManager.RestoreMissingPackagesAsync(
                     packageRestoreContext,
                     new ConsoleProjectContext(Console),
-                    downloadContext,
-                    Console);
+                    Console,
+                    downloadContext);
 
                 if (downloadContext.DirectDownload)
                 {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -203,8 +203,8 @@ namespace NuGet.CommandLine
                 var result = await PackageRestoreManager.RestoreMissingPackagesAsync(
                     packageRestoreContext,
                     new ConsoleProjectContext(Console),
-                    Console,
-                    downloadContext);
+                    downloadContext,
+                    Console);
 
                 if (downloadContext.DirectDownload)
                 {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -353,9 +353,9 @@ namespace NuGet.CommandLine
 
                 var result = await PackageRestoreManager.RestoreMissingPackagesAsync(
                     packageRestoreContext,
-                    projectContext,
-                    collectorLogger,
-                    downloadContext);
+                    projectContext,                    
+                    downloadContext,
+                    collectorLogger);
 
                 if (downloadContext.DirectDownload)
                 {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -354,7 +354,8 @@ namespace NuGet.CommandLine
                 var result = await PackageRestoreManager.RestoreMissingPackagesAsync(
                     packageRestoreContext,
                     projectContext,
-                    downloadContext);
+                    downloadContext,
+                    Console);
 
                 if (downloadContext.DirectDownload)
                 {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -354,8 +354,8 @@ namespace NuGet.CommandLine
                 var result = await PackageRestoreManager.RestoreMissingPackagesAsync(
                     packageRestoreContext,
                     projectContext,
-                    downloadContext,
-                    Console);
+                    collectorLogger,
+                    downloadContext);
 
                 if (downloadContext.DirectDownload)
                 {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -19,7 +19,6 @@ using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
-using NuGet.Shared;
 
 namespace NuGet.CommandLine
 {
@@ -76,6 +75,7 @@ namespace NuGet.CommandLine
 
         public override async Task ExecuteCommandAsync()
         {
+
             if (DisableParallelProcessing)
             {
                 HttpSourceResourceProvider.Throttle = SemaphoreSlimThrottle.CreateBinarySemaphore();
@@ -107,12 +107,6 @@ namespace NuGet.CommandLine
             {
                 var v2RestoreResult = await PerformNuGetV2RestoreAsync(restoreInputs);
                 restoreSummaries.Add(v2RestoreResult);
-
-                // log warnings
-                v2RestoreResult
-                    .Errors
-                    .Where(l => l.Level == LogLevel.Warning)
-                    .ForEach(l => Console.LogWarning(l.FormatWithCode()));
             }
 
             // project.json and PackageReference
@@ -326,17 +320,15 @@ namespace NuGet.CommandLine
             CheckRequireConsent();
 
             var collectorLogger = new RestoreCollectorLogger(Console);
-
             var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
-
             var projectContext = new ConsoleProjectContext(collectorLogger)
             {
                 PackageExtractionContext = new PackageExtractionContext(
-                        Packaging.PackageSaveMode.Defaultv2,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        collectorLogger,
-                        signedPackageVerifier,
-                        SignedPackageVerifierSettings.GetDefault())
+                Packaging.PackageSaveMode.Defaultv2,
+                PackageExtractionBehavior.XmlDocFileSaveMode,
+                collectorLogger,
+                signedPackageVerifier,
+                SignedPackageVerifierSettings.GetDefault())
             };
 
             if (EffectivePackageSaveMode != Packaging.PackageSaveMode.None)
@@ -353,7 +345,7 @@ namespace NuGet.CommandLine
 
                 var result = await PackageRestoreManager.RestoreMissingPackagesAsync(
                     packageRestoreContext,
-                    projectContext,                    
+                    projectContext,
                     downloadContext,
                     collectorLogger);
 
@@ -381,7 +373,7 @@ namespace NuGet.CommandLine
         {
             var result = new List<RestoreLogMessage>();
 
-            foreach(var failedEvent in failedEvents)
+            foreach (var failedEvent in failedEvents)
             {
                 if (failedEvent.Exception is SignatureException)
                 {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -334,11 +334,11 @@ namespace NuGet.CommandLine
             var projectContext = new ConsoleProjectContext(collectorLogger)
             {
                 PackageExtractionContext = new PackageExtractionContext(
-                Packaging.PackageSaveMode.Defaultv2,
-                PackageExtractionBehavior.XmlDocFileSaveMode,
-                collectorLogger,
-                signedPackageVerifier,
-                SignedPackageVerifierSettings.GetDefault())
+                    Packaging.PackageSaveMode.Defaultv2,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
+                    collectorLogger,
+                    signedPackageVerifier,
+                    SignedPackageVerifierSettings.GetDefault())
             };
 
             if (EffectivePackageSaveMode != Packaging.PackageSaveMode.None)

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -19,6 +19,7 @@ using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
+using NuGet.Shared;
 
 namespace NuGet.CommandLine
 {
@@ -107,6 +108,15 @@ namespace NuGet.CommandLine
             {
                 var v2RestoreResult = await PerformNuGetV2RestoreAsync(restoreInputs);
                 restoreSummaries.Add(v2RestoreResult);
+
+                // log warnings for a failure since the package extractor throws an exception without logging warnings
+                if (!v2RestoreResult.Success)
+                {
+                    v2RestoreResult
+                        .Errors
+                        .Where(l => l.Level == LogLevel.Warning)
+                        .ForEach(l => Console.LogWarning(l.FormatWithCode()));
+                }
             }
 
             // project.json and PackageReference

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -258,8 +258,9 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                             packages,
                             this,
                             downloadContext,
-                            Token,
-                            new LoggerAdapter(this));
+                            new LoggerAdapter(this),
+                            Token);
+
                         if (result.Restored)
                         {
                             await PackageRestoreManager.RaisePackagesMissingEventForSolutionAsync(solutionDirectory, CancellationToken.None);

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -258,7 +258,8 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                             packages,
                             this,
                             downloadContext,
-                            Token);
+                            Token,
+                            new LoggerAdapter(this));
                         if (result.Restored)
                         {
                             await PackageRestoreManager.RaisePackagesMissingEventForSolutionAsync(solutionDirectory, CancellationToken.None);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -122,7 +122,11 @@ namespace NuGet.PackageManagement.UI
             // Restore the project before proceeding
             var solutionDirectory = context.SolutionManager.SolutionDirectory;
 
-            await context.PackageRestoreManager.RestoreMissingPackagesInSolutionAsync(solutionDirectory, uiService.ProjectContext, new NullLogger(), CancellationToken.None);
+            await context.PackageRestoreManager.RestoreMissingPackagesInSolutionAsync(
+                solutionDirectory,
+                uiService.ProjectContext,
+                new LoggerAdapter(uiService.ProjectContext),
+                CancellationToken.None);
 
             var packagesDependencyInfo = await context.PackageManager.GetInstalledPackagesDependencyInfo(nuGetProject, CancellationToken.None, includeUnresolved: true);
             var upgradeInformationWindowModel = new NuGetProjectUpgradeWindowModel(nuGetProject, packagesDependencyInfo.ToList());

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -122,7 +122,7 @@ namespace NuGet.PackageManagement.UI
             // Restore the project before proceeding
             var solutionDirectory = context.SolutionManager.SolutionDirectory;
 
-            await context.PackageRestoreManager.RestoreMissingPackagesInSolutionAsync(solutionDirectory, uiService.ProjectContext, CancellationToken.None);
+            await context.PackageRestoreManager.RestoreMissingPackagesInSolutionAsync(solutionDirectory, uiService.ProjectContext, CancellationToken.None, new NullLogger());
 
             var packagesDependencyInfo = await context.PackageManager.GetInstalledPackagesDependencyInfo(nuGetProject, CancellationToken.None, includeUnresolved: true);
             var upgradeInformationWindowModel = new NuGetProjectUpgradeWindowModel(nuGetProject, packagesDependencyInfo.ToList());

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -122,7 +122,7 @@ namespace NuGet.PackageManagement.UI
             // Restore the project before proceeding
             var solutionDirectory = context.SolutionManager.SolutionDirectory;
 
-            await context.PackageRestoreManager.RestoreMissingPackagesInSolutionAsync(solutionDirectory, uiService.ProjectContext, CancellationToken.None, new NullLogger());
+            await context.PackageRestoreManager.RestoreMissingPackagesInSolutionAsync(solutionDirectory, uiService.ProjectContext, new NullLogger(), CancellationToken.None);
 
             var packagesDependencyInfo = await context.PackageManager.GetInstalledPackagesDependencyInfo(nuGetProject, CancellationToken.None, includeUnresolved: true);
             var upgradeInformationWindowModel = new NuGetProjectUpgradeWindowModel(nuGetProject, packagesDependencyInfo.ToList());

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
@@ -146,8 +146,8 @@ namespace NuGet.PackageManagement.UI
                 var solutionDirectory = SolutionManager.SolutionDirectory;
                 await PackageRestoreManager.RestoreMissingPackagesInSolutionAsync(solutionDirectory,
                     this,
-                    token,
-                    new LoggerAdapter(this));
+                    new LoggerAdapter(this),
+                    token);
 
                 if (RestoreException == null)
                 {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
@@ -146,7 +146,8 @@ namespace NuGet.PackageManagement.UI
                 var solutionDirectory = SolutionManager.SolutionDirectory;
                 await PackageRestoreManager.RestoreMissingPackagesInSolutionAsync(solutionDirectory,
                     this,
-                    token);
+                    token,
+                    new LoggerAdapter(this));
 
                 if (RestoreException == null)
                 {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -490,7 +490,7 @@ namespace NuGet.SolutionRestoreManager
                             // Display the restore opt out message if it has not been shown yet
                             await l.WriteHeaderAsync();
 
-                            await RestoreMissingPackagesInSolutionAsync(solutionDirectory, packages, t, l);
+                            await RestoreMissingPackagesInSolutionAsync(solutionDirectory, packages, l, t);
                         },
                         token);
 
@@ -536,8 +536,8 @@ namespace NuGet.SolutionRestoreManager
         private async Task RestoreMissingPackagesInSolutionAsync(
             string solutionDirectory,
             IEnumerable<PackageRestoreData> packages,
-            CancellationToken token,
-            ILogger logger)
+            ILogger logger,
+            CancellationToken token)
         {
             await TaskScheduler.Default;
 
@@ -553,8 +553,8 @@ namespace NuGet.SolutionRestoreManager
                     packages,
                     _nuGetProjectContext,
                     downloadContext,
-                    token,
-                    logger);
+                    logger,
+                    token);
             }
         }
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -490,7 +490,7 @@ namespace NuGet.SolutionRestoreManager
                             // Display the restore opt out message if it has not been shown yet
                             await l.WriteHeaderAsync();
 
-                            await RestoreMissingPackagesInSolutionAsync(solutionDirectory, packages, t);
+                            await RestoreMissingPackagesInSolutionAsync(solutionDirectory, packages, t, l);
                         },
                         token);
 
@@ -536,7 +536,8 @@ namespace NuGet.SolutionRestoreManager
         private async Task RestoreMissingPackagesInSolutionAsync(
             string solutionDirectory,
             IEnumerable<PackageRestoreData> packages,
-            CancellationToken token)
+            CancellationToken token,
+            ILogger logger)
         {
             await TaskScheduler.Default;
 
@@ -552,7 +553,8 @@ namespace NuGet.SolutionRestoreManager
                     packages,
                     _nuGetProjectContext,
                     downloadContext,
-                    token);
+                    token,
+                    logger);
             }
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageRestorer.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageRestorer.cs
@@ -48,7 +48,7 @@ namespace NuGet.VisualStudio
                 NuGetUIThreadHelper.JoinableTaskFactory.Run(() =>
                     _restoreManager.RestoreMissingPackagesInSolutionAsync(solutionDirectory,
                     nuGetProjectContext,
-                    new NullLogger(),
+                    NullLogger.Instance,
                     CancellationToken.None));
             }
             catch (Exception ex)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageRestorer.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageRestorer.cs
@@ -48,8 +48,8 @@ namespace NuGet.VisualStudio
                 NuGetUIThreadHelper.JoinableTaskFactory.Run(() =>
                     _restoreManager.RestoreMissingPackagesInSolutionAsync(solutionDirectory,
                     nuGetProjectContext,
-                    CancellationToken.None,
-                    new NullLogger()));
+                    new NullLogger(),
+                    CancellationToken.None));
             }
             catch (Exception ex)
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageRestorer.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageRestorer.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.ComponentModel.Composition;
 using System.Threading;
 using EnvDTE;
+using NuGet.Common;
 using NuGet.PackageManagement;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.ProjectManagement;
@@ -47,7 +48,8 @@ namespace NuGet.VisualStudio
                 NuGetUIThreadHelper.JoinableTaskFactory.Run(() =>
                     _restoreManager.RestoreMissingPackagesInSolutionAsync(solutionDirectory,
                     nuGetProjectContext,
-                    CancellationToken.None));
+                    CancellationToken.None,
+                    new NullLogger()));
             }
             catch (Exception ex)
             {

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/IPackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/IPackageRestoreManager.cs
@@ -83,6 +83,18 @@ namespace NuGet.PackageManagement
             CancellationToken token);
 
         /// <summary>
+        /// Restores the missing packages for the current solution.
+        /// </summary>
+        /// <remarks>
+        /// Best use case is the restore button that shows up in the UI or powershell when certain packages
+        /// are missing
+        /// </remarks>
+        /// <returns>Returns true if atleast one package was restored.</returns>
+        Task<PackageRestoreResult> RestoreMissingPackagesInSolutionAsync(string solutionDirectory,
+            INuGetProjectContext nuGetProjectContext,
+            CancellationToken token);
+
+        /// <summary>
         /// Restores the package references if they are missing
         /// </summary>
         /// <param name="packages">
@@ -103,6 +115,28 @@ namespace NuGet.PackageManagement
             INuGetProjectContext nuGetProjectContext,
             PackageDownloadContext downloadContext,
             ILogger logger,
+            CancellationToken token);
+
+        /// <summary>
+        /// Restores the package references if they are missing
+        /// </summary>
+        /// <param name="packages">
+        /// This parameter is the list of package referneces mapped to the list of
+        /// project names a package is installed on. This is most likely obtained by calling
+        /// GetPackagesInSolutionAsync
+        /// </param>
+        /// <remarks>
+        /// Best use case is when GetPackagesInSolutionAsync was already called, the result can be used
+        /// in this method
+        /// </remarks>
+        /// <returns>
+        /// Returns true if at least one package is restored. Raised package restored failed event with the
+        /// list of project names.
+        /// </returns>
+        Task<PackageRestoreResult> RestoreMissingPackagesAsync(string solutionDirectory,
+            IEnumerable<PackageRestoreData> packages,
+            INuGetProjectContext nuGetProjectContext,
+            PackageDownloadContext downloadContext,
             CancellationToken token);
     }
 

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/IPackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/IPackageRestoreManager.cs
@@ -79,8 +79,8 @@ namespace NuGet.PackageManagement
         /// <returns>Returns true if atleast one package was restored.</returns>
         Task<PackageRestoreResult> RestoreMissingPackagesInSolutionAsync(string solutionDirectory,
             INuGetProjectContext nuGetProjectContext,
-            CancellationToken token,
-            ILogger logger);
+            ILogger logger,
+            CancellationToken token);
 
         /// <summary>
         /// Restores the package references if they are missing
@@ -102,8 +102,8 @@ namespace NuGet.PackageManagement
             IEnumerable<PackageRestoreData> packages,
             INuGetProjectContext nuGetProjectContext,
             PackageDownloadContext downloadContext,
-            CancellationToken token,
-            ILogger logger);
+            ILogger logger,
+            CancellationToken token);
     }
 
     /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/IPackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/IPackageRestoreManager.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
@@ -78,7 +79,8 @@ namespace NuGet.PackageManagement
         /// <returns>Returns true if atleast one package was restored.</returns>
         Task<PackageRestoreResult> RestoreMissingPackagesInSolutionAsync(string solutionDirectory,
             INuGetProjectContext nuGetProjectContext,
-            CancellationToken token);
+            CancellationToken token,
+            ILogger logger);
 
         /// <summary>
         /// Restores the package references if they are missing
@@ -100,7 +102,8 @@ namespace NuGet.PackageManagement
             IEnumerable<PackageRestoreData> packages,
             INuGetProjectContext nuGetProjectContext,
             PackageDownloadContext downloadContext,
-            CancellationToken token);
+            CancellationToken token,
+            ILogger logger);
     }
 
     /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreContext.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreContext.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 
 namespace NuGet.PackageManagement
@@ -17,6 +18,7 @@ namespace NuGet.PackageManagement
         public EventHandler<PackageRestoreFailedEventArgs> PackageRestoreFailedEvent { get; }
         public IEnumerable<SourceRepository> SourceRepositories { get; }
         public int MaxNumberOfParallelTasks { get; }
+        public ILogger Logger { get; }
 
         public PackageRestoreContext(NuGetPackageManager nuGetPackageManager,
             IEnumerable<PackageRestoreData> packages,
@@ -24,7 +26,8 @@ namespace NuGet.PackageManagement
             EventHandler<PackageRestoredEventArgs> packageRestoredEvent,
             EventHandler<PackageRestoreFailedEventArgs> packageRestoreFailedEvent,
             IEnumerable<SourceRepository> sourceRepositories,
-            int maxNumberOfParallelTasks)
+            int maxNumberOfParallelTasks,
+            ILogger logger)
         {
             if (maxNumberOfParallelTasks <= 0)
             {
@@ -33,6 +36,7 @@ namespace NuGet.PackageManagement
 
             PackageManager = nuGetPackageManager ?? throw new ArgumentNullException(nameof(nuGetPackageManager));
             Packages = packages ?? throw new ArgumentNullException(nameof(packages));
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             Token = token;
             PackageRestoredEvent = packageRestoredEvent;
             PackageRestoreFailedEvent = packageRestoreFailedEvent;

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
@@ -179,7 +179,8 @@ namespace NuGet.PackageManagement
         public virtual async Task<PackageRestoreResult> RestoreMissingPackagesInSolutionAsync(
             string solutionDirectory,
             INuGetProjectContext nuGetProjectContext,
-            CancellationToken token)
+            CancellationToken token,
+            ILogger logger)
         {
             var packageReferencesDictionary = await GetPackagesReferencesDictionaryAsync(token);
 
@@ -202,7 +203,8 @@ namespace NuGet.PackageManagement
                     packages,
                     nuGetProjectContext,
                     downloadContext,
-                    token);
+                    token,
+                    logger);
             }
         }
 
@@ -210,7 +212,8 @@ namespace NuGet.PackageManagement
             IEnumerable<PackageRestoreData> packages,
             INuGetProjectContext nuGetProjectContext,
             PackageDownloadContext downloadContext,
-            CancellationToken token)
+            CancellationToken token,
+            ILogger logger)
         {
             if (packages == null)
             {
@@ -228,7 +231,7 @@ namespace NuGet.PackageManagement
                 sourceRepositories: null,
                 maxNumberOfParallelTasks: PackageManagementConstants.DefaultMaxDegreeOfParallelism);
 
-            return RestoreMissingPackagesAsync(packageRestoreContext, nuGetProjectContext, downloadContext);
+            return RestoreMissingPackagesAsync(packageRestoreContext, nuGetProjectContext, downloadContext, logger);
         }
 
         private NuGetPackageManager GetNuGetPackageManager(string solutionDirectory)
@@ -254,7 +257,8 @@ namespace NuGet.PackageManagement
         public static async Task<PackageRestoreResult> RestoreMissingPackagesAsync(
             PackageRestoreContext packageRestoreContext,
             INuGetProjectContext nuGetProjectContext,
-            PackageDownloadContext downloadContext)
+            PackageDownloadContext downloadContext,
+            ILogger logger)
         {
             if (packageRestoreContext == null)
             {
@@ -289,7 +293,7 @@ namespace NuGet.PackageManagement
                 nuGetProjectContext.PackageExtractionContext = new PackageExtractionContext(
                     PackageSaveMode.Defaultv2,
                     PackageExtractionBehavior.XmlDocFileSaveMode,
-                    new LoggerAdapter(nuGetProjectContext),
+                    logger,
                     signedPackageVerifier,
                     SignedPackageVerifierSettings.GetDefault());
             }

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
@@ -179,8 +179,8 @@ namespace NuGet.PackageManagement
         public virtual async Task<PackageRestoreResult> RestoreMissingPackagesInSolutionAsync(
             string solutionDirectory,
             INuGetProjectContext nuGetProjectContext,
-            CancellationToken token,
-            ILogger logger)
+            ILogger logger,
+            CancellationToken token)
         {
             var packageReferencesDictionary = await GetPackagesReferencesDictionaryAsync(token);
 
@@ -203,8 +203,8 @@ namespace NuGet.PackageManagement
                     packages,
                     nuGetProjectContext,
                     downloadContext,
-                    token,
-                    logger);
+                    logger,
+                    token);
             }
         }
 
@@ -212,8 +212,8 @@ namespace NuGet.PackageManagement
             IEnumerable<PackageRestoreData> packages,
             INuGetProjectContext nuGetProjectContext,
             PackageDownloadContext downloadContext,
-            CancellationToken token,
-            ILogger logger)
+            ILogger logger,
+            CancellationToken token)
         {
             if (packages == null)
             {

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
@@ -229,9 +229,10 @@ namespace NuGet.PackageManagement
                 PackageRestoredEvent,
                 PackageRestoreFailedEvent,
                 sourceRepositories: null,
-                maxNumberOfParallelTasks: PackageManagementConstants.DefaultMaxDegreeOfParallelism);
+                maxNumberOfParallelTasks: PackageManagementConstants.DefaultMaxDegreeOfParallelism,
+                logger: logger);
 
-            return RestoreMissingPackagesAsync(packageRestoreContext, nuGetProjectContext, downloadContext, logger);
+            return RestoreMissingPackagesAsync(packageRestoreContext, nuGetProjectContext, downloadContext);
         }
 
         private NuGetPackageManager GetNuGetPackageManager(string solutionDirectory)
@@ -257,8 +258,7 @@ namespace NuGet.PackageManagement
         public static async Task<PackageRestoreResult> RestoreMissingPackagesAsync(
             PackageRestoreContext packageRestoreContext,
             INuGetProjectContext nuGetProjectContext,
-            PackageDownloadContext downloadContext,
-            ILogger logger)
+            PackageDownloadContext downloadContext)
         {
             if (packageRestoreContext == null)
             {
@@ -293,7 +293,7 @@ namespace NuGet.PackageManagement
                 nuGetProjectContext.PackageExtractionContext = new PackageExtractionContext(
                     PackageSaveMode.Defaultv2,
                     PackageExtractionBehavior.XmlDocFileSaveMode,
-                    logger,
+                    packageRestoreContext.Logger,
                     signedPackageVerifier,
                     SignedPackageVerifierSettings.GetDefault());
             }
@@ -330,7 +330,8 @@ namespace NuGet.PackageManagement
         /// that dequeue from the ConcurrentQueue and perform package restore. So, this method should pre-populate the
         /// queue and must not enqueued to by other methods
         /// </summary>
-        private static async Task<IEnumerable<AttemptedPackage>> ThrottledPackageRestoreAsync(HashSet<PackageReference> packageReferences,
+        private static async Task<IEnumerable<AttemptedPackage>> ThrottledPackageRestoreAsync(
+            HashSet<PackageReference> packageReferences,
             PackageRestoreContext packageRestoreContext,
             INuGetProjectContext nuGetProjectContext,
             PackageDownloadContext downloadContext)

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
@@ -160,6 +160,7 @@ namespace NuGet.Test
                 // Act
                 await packageRestoreManager.RestoreMissingPackagesInSolutionAsync(testSolutionManager.SolutionDirectory,
                     testNuGetProjectContext,
+                    new TestLogger(),
                     CancellationToken.None);
 
                 Assert.Equal(1, restoredPackages.Count);
@@ -267,6 +268,7 @@ namespace NuGet.Test
                 // Act
                 await packageRestoreManager.RestoreMissingPackagesInSolutionAsync(testSolutionManager.SolutionDirectory,
                     testNuGetProjectContext,
+                    new TestLogger(),
                     CancellationToken.None);
 
                 Assert.True(nuGetPackageManager.PackageExistsInPackagesFolder((packageIdentity)));
@@ -358,6 +360,7 @@ namespace NuGet.Test
                 // Act
                 await packageRestoreManager.RestoreMissingPackagesInSolutionAsync(testSolutionManager.SolutionDirectory,
                     testNuGetProjectContext,
+                    new TestLogger(),
                     CancellationToken.None);
 
                 // Assert


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6318
Regression: No

## Fix
Details: This PR fixes the scenario where Packages.Config restore in VS would not display any warnings. The issue was that on restore `SolutionRestoreContext` is instantiated [here](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs#L238) which creates an `EmptyNuGetProjectContext` [here](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJobContext.cs#L13). This context is then used to populate the `PackageExtractionContext` [here](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs#L292), resulting in no logs being displayed.

This PR fixes this by passing an `ILogger` from `SolutionRestoreJob` (and other places) to `RestorePackageManager`.

## Testing/Validation
Tests Added: No
Reason for not adding tests:  UI changes
Validation done:  Manual Validation

### Before - 
![image](https://user-images.githubusercontent.com/10507120/43808263-215b0ba6-9a61-11e8-9d89-c9d39a542537.png)


### After - 
![image](https://user-images.githubusercontent.com/10507120/43808242-04f1e49e-9a61-11e8-9193-2403b9920c41.png)
