### PR TITLE
Fixing InvalidPlaceholderFileRule in pack

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
@@ -107,6 +107,15 @@ namespace NuGet.Packaging.Rules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The file at &apos;{0}&apos; uses the symbol for empty directory &apos;_._&apos;, but it is present in a directory that contains other files. Please remove this file from directories that contain other files..
+        /// </summary>
+        public static string InvalidPlaceholderFileWarning {
+            get {
+                return ResourceManager.GetString("InvalidPlaceholderFileWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency &quot;{0}&quot; or update the version field in the nuspec..
         /// </summary>
         public static string InvalidPrereleaseDependencyWarning {

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
@@ -132,6 +132,10 @@
   <data name="InvalidFrameworkWarning" xml:space="preserve">
     <value>The folder '{0}' under 'lib' is not recognized as a valid framework name or a supported culture identifier. Rename it to a valid framework name or culture identifier.</value>
   </data>
+  <data name="InvalidPlaceholderFileWarning" xml:space="preserve">
+    <value>The file at '{0}' uses the symbol for empty directory '_._', but it is present in a directory that contains other files. Please remove this file from directories that contain other files.</value>
+    <comment>0 - file path ending in _._</comment>
+  </data>
   <data name="InvalidPrereleaseDependencyWarning" xml:space="preserve">
     <value>A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency "{0}" or update the version field in the nuspec.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Packaging/Rules/RuleSet.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/RuleSet.cs
@@ -19,7 +19,7 @@ namespace NuGet.Packaging.Rules
                 new InitScriptNotUnderToolsRule(AnalysisResources.MisplacedInitScriptWarning),
                 new WinRTNameIsObsoleteRule( AnalysisResources.WinRTObsoleteWarning),
                 new DefaultManifestValuesRule(AnalysisResources.DefaultSpecValueWarning),
-                new InvalidPlaceholderFileRule(AnalysisResources.InvalidFrameworkWarning),
+                new InvalidPlaceholderFileRule(AnalysisResources.InvalidPlaceholderFileWarning),
                 new LegacyVersionRule(AnalysisResources.LegacyVersionWarning),
                 new InvalidPrereleaseDependencyRule(AnalysisResources.InvalidPrereleaseDependencyWarning),
                 new UnspecifiedDependencyVersionRule(AnalysisResources.UnspecifiedDependencyVersionWarning),

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/InvalidPlaceholderFileRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/InvalidPlaceholderFileRuleTests.cs
@@ -1,0 +1,141 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Packaging.Rules;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class InvalidPlaceholderFileRuleTests
+    {
+        [Fact]
+        public void Validate_FileWithEmptyDirectorySymbolWithOtherFiles_GeneratesWarning()
+        {
+            // Arrange
+            var nuspecContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+"<package xmlns=\"http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd\">" +
+"   <metadata>" +
+"        <id>test</id>" +
+"        <version>1.0.0</version>" +
+"        <authors>Unit Test</authors>" +
+"        <description>Sample Description</description>" +
+"        <language>en-US</language>" +
+"    </metadata>" +
+"</package>";
+
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var nuspecPath = Path.Combine(testDirectory, "test.nuspec");
+                File.AppendAllText(nuspecPath, nuspecContent);
+
+                // create a directory that contains a _._ file and another file
+                var toolsPath = Path.Combine(testDirectory, "tools");
+                Directory.CreateDirectory(toolsPath);
+
+                var emptyDirFilePath = Path.Combine(toolsPath, "_._");
+                var otherFilePath = Path.Combine(toolsPath, "sample.txt");
+                var stream = File.CreateText(emptyDirFilePath);
+                stream.Dispose();
+                stream = File.CreateText(otherFilePath);
+                stream.Dispose();
+
+                var builder = new PackageBuilder();
+                var runner = new PackCommandRunner(
+                    new PackArgs
+                    {
+                        CurrentDirectory = testDirectory,
+                        OutputDirectory = testDirectory,
+                        Path = nuspecPath,
+                        Exclude = Array.Empty<string>(),
+                        Symbols = false,
+                        Logger = NullLogger.Instance
+                    },
+                    MSBuildProjectFactory.ProjectCreator,
+                    builder);
+
+                runner.BuildPackage();
+
+                var ruleSet = RuleSet.PackageCreationRuleSet;
+                var nupkgPath = Path.Combine(testDirectory, "test.1.0.0.nupkg");
+
+                using (var reader = new PackageArchiveReader(nupkgPath))
+                {
+                    var issues = new List<PackagingLogMessage>();
+                    foreach (var rule in ruleSet)
+                    {
+                        issues.AddRange(rule.Validate(reader).OrderBy(p => p.Code.ToString(), StringComparer.CurrentCulture));
+                    }
+
+                    Assert.True(issues.Any(p => p.Code == NuGetLogCode.NU5109 && p.Message.Contains(@"The file at 'tools/_._' uses the symbol for empty directory '_._'")));
+                }
+            }
+        }
+
+        [Fact]
+        public void Validate_FileWithEmptyDirectorySymbolWithNoOtherFiles_NoWarning()
+        {
+            // Arrange
+            var nuspecContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+"<package xmlns=\"http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd\">" +
+"   <metadata>" +
+"        <id>test</id>" +
+"        <version>1.0.0</version>" +
+"        <authors>Unit Test</authors>" +
+"        <description>Sample Description</description>" +
+"        <language>en-US</language>" +
+"    </metadata>" +
+"</package>";
+
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var nuspecPath = Path.Combine(testDirectory, "test.nuspec");
+                File.AppendAllText(nuspecPath, nuspecContent);
+
+                // create a directory that contains a _._ file but no other file
+                var toolsPath = Path.Combine(testDirectory, "tools");
+                Directory.CreateDirectory(toolsPath);
+
+                var emptyDirFilePath = Path.Combine(toolsPath, "_._");
+                var stream = File.CreateText(emptyDirFilePath);
+                stream.Dispose();
+
+                var builder = new PackageBuilder();
+                var runner = new PackCommandRunner(
+                    new PackArgs
+                    {
+                        CurrentDirectory = testDirectory,
+                        OutputDirectory = testDirectory,
+                        Path = nuspecPath,
+                        Exclude = Array.Empty<string>(),
+                        Symbols = false,
+                        Logger = NullLogger.Instance
+                    },
+                    MSBuildProjectFactory.ProjectCreator,
+                    builder);
+
+                runner.BuildPackage();
+
+                var ruleSet = RuleSet.PackageCreationRuleSet;
+                var nupkgPath = Path.Combine(testDirectory, "test.1.0.0.nupkg");
+
+                using (var reader = new PackageArchiveReader(nupkgPath))
+                {
+                    var issues = new List<PackagingLogMessage>();
+                    foreach (var rule in ruleSet)
+                    {
+                        issues.AddRange(rule.Validate(reader).OrderBy(p => p.Code.ToString(), StringComparer.CurrentCulture));
+                    }
+
+                    Assert.False(issues.Any(p => p.Code == NuGetLogCode.NU5109 && p.Message.Contains(@"The file at 'tools/_._' uses the symbol for empty directory '_._'")));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bug
Currently the `InvalidPlaceHolderRule` is [using](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Packaging/Rules/RuleSet.cs#L22) a wrong string.

### Sample nuspec - 
```
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
        <id>test</id>
        <version>1.2.3</version>
        <authors>Unit Test</authors>
        <description>package description</description>
        <language>en-US</language>
    </metadata>
</package>
```
Place a file at `./tools/_._`.
Place another file at `./tools/sample.txt`.

### Before - 
```
F:\validation\test\nuspec\test\test> nuget pack .\test.nuspec
Attempting to build package from 'test.nuspec'.
Successfully created package 'F:\validation\test\nuspec\test\test\test.1.2.0.nupkg'.
WARNING: NU5109: The folder 'tools/_._' under 'lib' is not recognized as a valid framework name or a supported culture identifier. Rename it to a valid framework name or culture identifier.
```

### After -
```
F:\validation\test\nuspec\test\test> E:\NuGet.Client\artifacts\NuGet.CommandLine\15.0\bin\Debug\net46\NuGet.exe pack .\test.nuspec
Attempting to build package from 'test.nuspec'.
Successfully created package 'F:\validation\test\nuspec\test\test\test.1.2.0.nupkg'.
WARNING: NU5109: The file at 'tools/_._' uses the symbol for empty directory '_._', but it is present in a directory that contains other files. Please remove this file from directories that contain other files.
``` 

## Fix
Details: This PR fixes the string and adds some tests.

Old string - `NU5109: The folder 'tools/_._' under 'lib' is not recognized as a valid framework name or a supported culture identifier. Rename it to a valid framework name or culture identifier.`

New string - `NU5109: The file at 'tools/_._' uses the symbol for empty directory '_._', but it is present in a directory that contains other files. Please remove this file from directories that contain other files.`

## Testing/Validation
Tests Added: Yes
Validation done:  Manual validation
