### PR TITLE
Read revocation mode from settings and consuming it in verification

### DIFF
--- a/src/NuGet.Core/NuGet.Common/RevocationMode.cs
+++ b/src/NuGet.Core/NuGet.Common/RevocationMode.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Common
+{
+    public enum RevocationMode
+    {
+        /// <summary>
+        /// If needed go online to check for revocation.
+        /// This translates to X509RevocationMode.Online
+        /// </summary>
+        Online,
+
+        /// <summary>
+        /// Only use the machine cache to check for revocation.
+        /// This translates to X509RevocationMode.Offline
+        /// </summary>
+        Offline
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -21,7 +21,7 @@ namespace NuGet.Configuration
         private const string RepositoryPathKey = "repositoryPath";
         private const string MaxHttpRequestsPerSource = "maxHttpRequestsPerSource";
         public static readonly string DefaultGlobalPackagesFolderPath = "packages" + Path.DirectorySeparatorChar;
-        private const string RevocationModeKey = "certificateRevocationMode";
+        private const string RevocationModeEnvironmentKey = "NUGET_CERT_REVOCATION_MODE";
 
         public static string GetRepositoryPath(ISettings settings)
         {
@@ -320,7 +320,7 @@ namespace NuGet.Configuration
 
         public static RevocationMode GetRevocationMode()
         {
-            var revocationModeSetting = Environment.GetEnvironmentVariable(RevocationModeKey);
+            var revocationModeSetting = Environment.GetEnvironmentVariable(RevocationModeEnvironmentKey);
             if (!string.IsNullOrEmpty(revocationModeSetting) && Enum.TryParse(revocationModeSetting, ignoreCase: true, result: out RevocationMode revocationMode))
             {
                 return revocationMode;

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -21,6 +21,7 @@ namespace NuGet.Configuration
         private const string RepositoryPathKey = "repositoryPath";
         private const string MaxHttpRequestsPerSource = "maxHttpRequestsPerSource";
         public static readonly string DefaultGlobalPackagesFolderPath = "packages" + Path.DirectorySeparatorChar;
+        private const string RevocationModeKey = "certificateRevocationMode";
 
         public static string GetRepositoryPath(ISettings settings)
         {
@@ -315,6 +316,17 @@ namespace NuGet.Configuration
             {
                 return new List<string>();
             }
+        }
+
+        public static RevocationMode GetRevocationMode()
+        {
+            var revocationModeSetting = Environment.GetEnvironmentVariable(RevocationModeKey);
+            if (!string.IsNullOrEmpty(revocationModeSetting) && Enum.TryParse(revocationModeSetting, ignoreCase: true, result: out RevocationMode revocationMode))
+            {
+                return revocationMode;
+            }
+
+            return RevocationMode.Online;
         }
 
         private static string GetPathFromEnvOrConfig(string envVarName, string configKey, ISettings settings)

--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\NuGet.Configuration\NuGet.Configuration.csproj" />
     <ProjectReference Include="..\NuGet.Packaging.Core\NuGet.Packaging.Core.csproj" />
   </ItemGroup>
 
@@ -83,6 +84,6 @@
     </EmbeddedResource>
   </ItemGroup>
   
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/SignatureVerifySettings.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/SignatureVerifySettings.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using NuGet.Common;
+
 namespace NuGet.Packaging.Signing
 {
     /// <summary>
@@ -29,16 +31,23 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         public bool ReportUnknownRevocation { get; }
 
+        /// <summary>
+        /// Gets how the revocation verification should be performed.
+        /// </summary>
+        public RevocationMode RevocationMode { get; }
+
         public SignatureVerifySettings(
             bool allowIllegal,
             bool allowUntrusted,
             bool allowUnknownRevocation,
-            bool reportUnknownRevocation)
+            bool reportUnknownRevocation,
+            RevocationMode revocationMode)
         {
             AllowIllegal = allowIllegal;
             AllowUntrusted = allowUntrusted;
             AllowUnknownRevocation = allowUnknownRevocation;
             ReportUnknownRevocation = reportUnknownRevocation;
+            RevocationMode = revocationMode;
         }
 
         /// <summary>
@@ -48,6 +57,7 @@ namespace NuGet.Packaging.Signing
             allowIllegal: false,
             allowUntrusted: true,
             allowUnknownRevocation: true,
-            reportUnknownRevocation: true);
+            reportUnknownRevocation: true,
+            revocationMode: RevocationMode.Online);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateChainUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateChainUtility.cs
@@ -63,6 +63,8 @@ namespace NuGet.Packaging.Signing
                     DateTime.Now,
                     certificateType);
 
+                chain.ChainPolicy.RevocationMode = X509RevocationMode.Online;
+
                 if (chain.Build(certificate))
                 {
                     return GetCertificateChain(chain);
@@ -168,7 +170,6 @@ namespace NuGet.Packaging.Signing
             policy.ExtraStore.AddRange(additionalCertificates);
 
             policy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
-            policy.RevocationMode = X509RevocationMode.Online;
 
             if (certificateType != CertificateType.Timestamp)
             {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/RepositorySignatureInfoUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/RepositorySignatureInfoUtility.cs
@@ -56,6 +56,7 @@ namespace NuGet.Packaging.Signing
                     fallbackSettings.VerificationTarget,
                     fallbackSettings.SignaturePlacement,
                     fallbackSettings.RepositoryCountersignatureVerificationBehavior,
+                    fallbackSettings.RevocationMode,
                     repositoryAllowList?.AsReadOnly(),
                     fallbackSettings.ClientCertificateList);
             }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
@@ -67,7 +67,8 @@ namespace NuGet.Packaging.Signing
                 allowIllegal: settings.AllowIllegal,
                 allowUntrusted: settings.AllowUntrusted,
                 allowUnknownRevocation: settings.AllowUnknownRevocation,
-                reportUnknownRevocation: settings.ReportUnknownRevocation);
+                reportUnknownRevocation: settings.ReportUnknownRevocation,
+                revocationMode: settings.RevocationMode);
 
             SignatureVerificationSummary primarySummary = null;
 
@@ -133,7 +134,8 @@ namespace NuGet.Packaging.Signing
                         allowIllegal: settings.AllowIllegal,
                         allowUntrusted: settings.AllowUntrusted,
                         allowUnknownRevocation: settings.AllowUnknownRevocation,
-                        reportUnknownRevocation: settings.ReportUnknownRevocation);
+                        reportUnknownRevocation: settings.ReportUnknownRevocation,
+                        revocationMode: settings.RevocationMode);
 
                     var countersignatureSummary = VerifyValidityAndTrust(countersignature, settings, verifySettings, certificateExtraStore);
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifierSettings.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifierSettings.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using NuGet.Common;
+using NuGet.Configuration;
 
 namespace NuGet.Packaging.Signing
 {
@@ -78,6 +80,11 @@ namespace NuGet.Packaging.Signing
         public SignatureVerificationBehavior RepositoryCountersignatureVerificationBehavior { get; }
 
         /// <summary>
+        /// Gets how the revocation verification should be performed.
+        /// </summary>
+        public RevocationMode RevocationMode { get; }
+
+        /// <summary>
         /// Allowlist of repository certificates hashes.
         /// </summary>
         public IReadOnlyList<VerificationAllowListEntry> RepositoryCertificateList { get; }
@@ -100,7 +107,8 @@ namespace NuGet.Packaging.Signing
             bool allowNoClientCertificateList,
             VerificationTarget verificationTarget,
             SignaturePlacement signaturePlacement,
-            SignatureVerificationBehavior repositoryCountersignatureVerificationBehavior)
+            SignatureVerificationBehavior repositoryCountersignatureVerificationBehavior,
+            RevocationMode revocationMode)
             : this(
                   allowUnsigned,
                   allowIllegal,
@@ -115,6 +123,7 @@ namespace NuGet.Packaging.Signing
                   verificationTarget,
                   signaturePlacement,
                   repositoryCountersignatureVerificationBehavior,
+                  revocationMode,
                   repoAllowListEntries: null,
                   clientAllowListEntries: null)
         {
@@ -134,6 +143,7 @@ namespace NuGet.Packaging.Signing
             VerificationTarget verificationTarget,
             SignaturePlacement signaturePlacement,
             SignatureVerificationBehavior repositoryCountersignatureVerificationBehavior,
+            RevocationMode revocationMode,
             IReadOnlyList<VerificationAllowListEntry> repoAllowListEntries,
             IReadOnlyList<VerificationAllowListEntry> clientAllowListEntries)
         {
@@ -206,6 +216,7 @@ namespace NuGet.Packaging.Signing
             VerificationTarget = verificationTarget;
             SignaturePlacement = signaturePlacement;
             RepositoryCountersignatureVerificationBehavior = repositoryCountersignatureVerificationBehavior;
+            RevocationMode = revocationMode;
             RepositoryCertificateList = repoAllowListEntries;
             ClientCertificateList = clientAllowListEntries;
         }
@@ -231,12 +242,13 @@ namespace NuGet.Packaging.Signing
                 verificationTarget: VerificationTarget.All,
                 signaturePlacement: SignaturePlacement.Any,
                 repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary,
+                revocationMode: SettingsUtility.GetRevocationMode(),
                 repoAllowListEntries: repoAllowListEntries,
                 clientAllowListEntries: clientAllowListEntries);
         }
 
         /// <summary>
-        /// The aceept mode policy.
+        /// The accept mode policy.
         /// </summary>
         public static SignedPackageVerifierSettings GetAcceptModeDefaultPolicy(
             IReadOnlyList<VerificationAllowListEntry> repoAllowListEntries = null,
@@ -256,6 +268,7 @@ namespace NuGet.Packaging.Signing
                 verificationTarget: VerificationTarget.All,
                 signaturePlacement: SignaturePlacement.Any,
                 repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary,
+                revocationMode: SettingsUtility.GetRevocationMode(),
                 repoAllowListEntries: repoAllowListEntries,
                 clientAllowListEntries: clientAllowListEntries);
         }
@@ -281,6 +294,7 @@ namespace NuGet.Packaging.Signing
                 verificationTarget: VerificationTarget.All,
                 signaturePlacement: SignaturePlacement.Any,
                 repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary,
+                revocationMode: SettingsUtility.GetRevocationMode(),
                 repoAllowListEntries: repoAllowListEntries,
                 clientAllowListEntries: clientAllowListEntries);
         }
@@ -306,6 +320,7 @@ namespace NuGet.Packaging.Signing
                 verificationTarget: VerificationTarget.All,
                 signaturePlacement: SignaturePlacement.Any,
                 repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
+                revocationMode: SettingsUtility.GetRevocationMode(),
                 repoAllowListEntries: repoAllowListEntries,
                 clientAllowListEntries: clientAllowListEntries);
         }

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -1403,7 +1403,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The revocation function was unable to check revocation because the certificate is not available in the cached certificate revocation list and certificateRevocationMode has been set to offline. For more information, visit https://aka.ms/certificateRevocationMode..
+        ///   Looks up a localized string similar to The revocation function was unable to check revocation because the certificate is not available in the cached certificate revocation list and NUGET_CERT_REVOCATION_MODE environment variable has been set to offline. For more information, visit https://aka.ms/certificateRevocationMode..
         /// </summary>
         internal static string VerifyCertTrustOfflineWhileRevocationModeOffline {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -1403,6 +1403,24 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The revocation function was unable to check revocation because the certificate is not available in the cached certificate revocation list and certificateRevocationMode has been set to offline. For more information, visit https://aka.ms/certificateRevocationMode..
+        /// </summary>
+        internal static string VerifyCertTrustOfflineWhileRevocationModeOffline {
+            get {
+                return ResourceManager.GetString("VerifyCertTrustOfflineWhileRevocationModeOffline", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The revocation function was unable to check revocation because the revocation server could not be reached. For more information, visit https://aka.ms/certificateRevocationMode..
+        /// </summary>
+        internal static string VerifyCertTrustOfflineWhileRevocationModeOnline {
+            get {
+                return ResourceManager.GetString("VerifyCertTrustOfflineWhileRevocationModeOnline", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The {0} found a chain building issue: {1}.
         /// </summary>
         internal static string VerifyChainBuildingIssue {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -709,7 +709,7 @@ Valid from:</comment>
 3 - Log Message</comment>
   </data>
   <data name="VerifyCertTrustOfflineWhileRevocationModeOffline" xml:space="preserve">
-    <value>The revocation function was unable to check revocation because the certificate is not available in the cached certificate revocation list and certificateRevocationMode has been set to offline. For more information, visit https://aka.ms/certificateRevocationMode.</value>
+    <value>The revocation function was unable to check revocation because the certificate is not available in the cached certificate revocation list and NUGET_CERT_REVOCATION_MODE environment variable has been set to offline. For more information, visit https://aka.ms/certificateRevocationMode.</value>
   </data>
   <data name="VerifyCertTrustOfflineWhileRevocationModeOnline" xml:space="preserve">
     <value>The revocation function was unable to check revocation because the revocation server could not be reached. For more information, visit https://aka.ms/certificateRevocationMode.</value>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -708,4 +708,11 @@ Valid from:</comment>
 2 - package source url
 3 - Log Message</comment>
   </data>
+  <data name="VerifyCertTrustOfflineWhileRevocationModeOffline" xml:space="preserve">
+    <value>The revocation function was unable to check revocation because the certificate is not available in the cached certificate revocation list and certificateRevocationMode has been set to offline. For more information, visit https://aka.ms/certificateRevocationMode.</value>
+  </data>
+  <data name="VerifyCertTrustOfflineWhileRevocationModeOnline" xml:space="preserve">
+    <value>The revocation function was unable to check revocation because the revocation server could not be reached. For more information, visit https://aka.ms/certificateRevocationMode.</value>
+    <comment>0 - Signature friendly name</comment>
+  </data>
 </root>

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
@@ -1178,6 +1178,7 @@ namespace NuGet.Packaging.FuncTest
                 verificationTarget: VerificationTarget.All,
                 signaturePlacement: SignaturePlacement.Any,
                 repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary,
+                revocationMode: RevocationMode.Online,
                 repoAllowListEntries: repoAllowList,
                 clientAllowListEntries: clientAllowList);
         }

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
@@ -40,7 +40,8 @@ namespace NuGet.Packaging.FuncTest
                 allowIllegal: false,
                 allowUntrusted: false,
                 allowUnknownRevocation: false,
-                reportUnknownRevocation: true);
+                reportUnknownRevocation: true,
+                revocationMode: RevocationMode.Online);
 
             using (var test = await VerifyTest.CreateAsync(settings, _untrustedTestCertificate.Cert))
             {
@@ -64,7 +65,8 @@ namespace NuGet.Packaging.FuncTest
                 allowIllegal: false,
                 allowUntrusted: true,
                 allowUnknownRevocation: false,
-                reportUnknownRevocation: true);
+                reportUnknownRevocation: true,
+                revocationMode: RevocationMode.Online);
 
             using (var test = await VerifyTest.CreateAsync(settings, _untrustedTestCertificate.Cert))
             {

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -259,7 +259,8 @@ namespace NuGet.Packaging.FuncTest
                 allowNoRepositoryCertificateList: true,
                 verificationTarget: VerificationTarget.All,
                 signaturePlacement: SignaturePlacement.Any,
-                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary);
+                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary,
+                revocationMode: RevocationMode.Online);
 
             using (var directory = TestDirectory.Create())
             using (var certificate = new X509Certificate2(_trustedTestCert.Source.Cert))
@@ -311,7 +312,8 @@ namespace NuGet.Packaging.FuncTest
                 signaturePlacement: SignaturePlacement.Any,
                 repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary,
                 allowNoClientCertificateList: true,
-                allowNoRepositoryCertificateList: true);
+                allowNoRepositoryCertificateList: true,
+                revocationMode: RevocationMode.Online);
 
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
@@ -353,7 +355,8 @@ namespace NuGet.Packaging.FuncTest
                 signaturePlacement: SignaturePlacement.Any,
                 repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary,
                 allowNoClientCertificateList: true,
-                allowNoRepositoryCertificateList: true);
+                allowNoRepositoryCertificateList: true,
+                revocationMode: RevocationMode.Online);
 
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
@@ -400,7 +403,8 @@ namespace NuGet.Packaging.FuncTest
                 allowNoRepositoryCertificateList: true,
                 verificationTarget: VerificationTarget.All,
                 signaturePlacement: SignaturePlacement.Any,
-                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists);
+                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
+                revocationMode: RevocationMode.Online);
 
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
@@ -447,7 +451,8 @@ namespace NuGet.Packaging.FuncTest
                 allowNoRepositoryCertificateList: true,
                 verificationTarget: VerificationTarget.All,
                 signaturePlacement: SignaturePlacement.Any,
-                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary);
+                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary,
+                revocationMode: RevocationMode.Online);
 
             using (var dir = TestDirectory.Create())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
@@ -494,7 +499,8 @@ namespace NuGet.Packaging.FuncTest
                 allowNoRepositoryCertificateList: true,
                 verificationTarget: VerificationTarget.All,
                 signaturePlacement: SignaturePlacement.Any,
-                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary);
+                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary,
+                revocationMode: RevocationMode.Online);
 
             using (var dir = TestDirectory.Create())
             using (var trustedCertificate = _testFixture.TrustedTestCertificateWillExpireIn10Seconds)
@@ -542,7 +548,8 @@ namespace NuGet.Packaging.FuncTest
                 allowNoRepositoryCertificateList: true,
                 verificationTarget: VerificationTarget.All,
                 signaturePlacement: SignaturePlacement.Any,
-                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary);
+                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary,
+                revocationMode: RevocationMode.Online);
             var verifier = new PackageSignatureVerifier(_trustProviders);
 
             using (var testDirectory = TestDirectory.Create())
@@ -593,7 +600,8 @@ namespace NuGet.Packaging.FuncTest
                 allowNoRepositoryCertificateList: true,
                 verificationTarget: VerificationTarget.All,
                 signaturePlacement: SignaturePlacement.Any,
-                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists);
+                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
+                revocationMode: RevocationMode.Online);
 
             using (var dir = TestDirectory.Create())
             using (var trustedCertificate = _testFixture.TrustedTestCertificateWillExpireIn10Seconds)
@@ -678,7 +686,8 @@ namespace NuGet.Packaging.FuncTest
                 allowNoRepositoryCertificateList: true,
                 verificationTarget: VerificationTarget.All,
                 signaturePlacement: SignaturePlacement.Any,
-                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary);
+                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary,
+                revocationMode: RevocationMode.Online);
             var timestampProvider = new Rfc3161TimestampProvider(timestampService.Url);
             var verificationProvider = new SignatureTrustAndValidityVerificationProvider();
 
@@ -826,8 +835,8 @@ namespace NuGet.Packaging.FuncTest
 
             Assert.Equal(2, matchingIssues.Count);
 
-            AssertOfflineRevocation(matchingIssues, LogLevel.Warning);
-            AssertRevocationStatusUnknown(matchingIssues, LogLevel.Warning);
+            AssertOfflineRevocationOnlineMode(matchingIssues, LogLevel.Warning);
+            AssertRevocationStatusUnknown(matchingIssues, NuGetLogCode.NU3018, LogLevel.Warning);
         }
 
         [CIOnlyFact]
@@ -844,8 +853,8 @@ namespace NuGet.Packaging.FuncTest
 
             Assert.Equal(2, matchingIssues.Count);
 
-            AssertOfflineRevocation(matchingIssues, LogLevel.Warning);
-            AssertRevocationStatusUnknown(matchingIssues, LogLevel.Warning);
+            AssertOfflineRevocationOnlineMode(matchingIssues, LogLevel.Warning);
+            AssertRevocationStatusUnknown(matchingIssues, NuGetLogCode.NU3018, LogLevel.Warning);
         }
 
         [CIOnlyFact]
@@ -865,7 +874,8 @@ namespace NuGet.Packaging.FuncTest
                 allowNoRepositoryCertificateList: true,
                 verificationTarget: VerificationTarget.All,
                 signaturePlacement: SignaturePlacement.Any,
-                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary);
+                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary,
+                revocationMode: RevocationMode.Online);
 
             // Act & Assert
             var matchingIssues = await VerifyUnavailableRevocationInfoAsync(
@@ -877,7 +887,7 @@ namespace NuGet.Packaging.FuncTest
         }
 
         [CIOnlyFact]
-        public async Task GetTrustResultAsync_WithUnavailableRevocationInformationAndAllowUnknownRevocation_WarnsAsync()
+        public async Task GetTrustResultAsync_WithUnavailableRevocationInformationAndAllowUnknownRevocation_WithOnlineRevocationMode_WarnsAsync()
         {
             // Arrange
             var setting = new SignedPackageVerifierSettings(
@@ -893,7 +903,8 @@ namespace NuGet.Packaging.FuncTest
                 allowNoRepositoryCertificateList: true,
                 verificationTarget: VerificationTarget.All,
                 signaturePlacement: SignaturePlacement.Any,
-                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary);
+                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary,
+                revocationMode: RevocationMode.Online);
 
             // Act & Assert
             var matchingIssues = await VerifyUnavailableRevocationInfoAsync(
@@ -903,8 +914,38 @@ namespace NuGet.Packaging.FuncTest
 
             Assert.Equal(2, matchingIssues.Count);
 
-            AssertOfflineRevocation(matchingIssues, LogLevel.Warning);
-            AssertRevocationStatusUnknown(matchingIssues, LogLevel.Warning);
+            AssertOfflineRevocationOnlineMode(matchingIssues, LogLevel.Warning);
+            AssertRevocationStatusUnknown(matchingIssues, NuGetLogCode.NU3018, LogLevel.Warning);
+        }
+
+        [CIOnlyFact]
+        public async Task GetTrustResultAsync_WithUnavailableRevocationInformationAndAllowUnknownRevocation_WithOfflineRevocationMode_WarnsAsync()
+        {
+            // Arrange
+            var setting = new SignedPackageVerifierSettings(
+                allowUnsigned: false,
+                allowIllegal: false,
+                allowUntrusted: false,
+                allowIgnoreTimestamp: false,
+                allowMultipleTimestamps: false,
+                allowNoTimestamp: false,
+                allowUnknownRevocation: true,
+                reportUnknownRevocation: true,
+                allowNoClientCertificateList: true,
+                allowNoRepositoryCertificateList: true,
+                verificationTarget: VerificationTarget.All,
+                signaturePlacement: SignaturePlacement.Any,
+                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary,
+                revocationMode: RevocationMode.Offline);
+
+            // Act & Assert
+            var matchingIssues = await VerifyUnavailableRevocationInfoAsync(
+                SignatureVerificationStatus.Valid,
+                LogLevel.Information,
+                setting);
+
+            AssertOfflineRevocationOfflineMode(matchingIssues);
+            AssertRevocationStatusUnknown(matchingIssues, NuGetLogCode.Undefined, LogLevel.Information);
         }
 
         [CIOnlyFact]
@@ -969,7 +1010,7 @@ namespace NuGet.Packaging.FuncTest
             }
 
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_WithRepositorySignedPackage_ReturnsUnknown()
+            public async Task GetTrustResultAsync_WithRepositorySignedPackage_ReturnsUnknownAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
                     allowUnsigned: false,
@@ -984,7 +1025,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Author,
                     signaturePlacement: SignaturePlacement.PrimarySignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never,
+                    revocationMode: RevocationMode.Online);
 
                 using (var test = await Test.CreateRepositoryPrimarySignedPackageAsync(_fixture.TrustedTestCertificate.Source.Cert))
                 using (var packageReader = new PackageArchiveReader(test.PackageFile.FullName))
@@ -998,7 +1040,7 @@ namespace NuGet.Packaging.FuncTest
             }
 
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_WithValidSignature_ReturnsValid()
+            public async Task GetTrustResultAsync_WithValidSignature_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
                     allowUnsigned: false,
@@ -1013,7 +1055,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Author,
                     signaturePlacement: SignaturePlacement.PrimarySignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never,
+                    revocationMode: RevocationMode.Online);
                 var timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
 
                 using (var test = await Test.CreateAuthorSignedPackageAsync(
@@ -1032,7 +1075,7 @@ namespace NuGet.Packaging.FuncTest
             [CIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
-            public async Task GetTrustResultAsync_WithValidSignatureButNoTimestamp_ReturnsStatus(
+            public async Task GetTrustResultAsync_WithValidSignatureButNoTimestamp_ReturnsStatusAsync(
                 bool allowNoTimestamp,
                 SignatureVerificationStatus expectedStatus)
             {
@@ -1049,7 +1092,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Author,
                     signaturePlacement: SignaturePlacement.PrimarySignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never,
+                    revocationMode: RevocationMode.Online);
 
                 using (var test = await Test.CreateAuthorSignedPackageAsync(_fixture.TrustedTestCertificate.Source.Cert))
                 using (var packageReader = new PackageArchiveReader(test.PackageFile.FullName))
@@ -1065,7 +1109,7 @@ namespace NuGet.Packaging.FuncTest
             [CIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
-            public async Task GetTrustResultAsync_WithUntrustedSignature_ReturnsStatus(
+            public async Task GetTrustResultAsync_WithUntrustedSignature_ReturnsStatusAsync(
                 bool allowUntrusted,
                 SignatureVerificationStatus expectedStatus)
             {
@@ -1082,7 +1126,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Author,
                     signaturePlacement: SignaturePlacement.PrimarySignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never,
+                    revocationMode: RevocationMode.Online);
                 var timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
 
                 using (var test = await Test.CreateAuthorSignedPackageAsync(
@@ -1101,7 +1146,7 @@ namespace NuGet.Packaging.FuncTest
             [CIOnlyTheory]
             [InlineData(true)]
             [InlineData(false)]
-            public async Task GetTrustResultAsync_WithRevokedPrimaryCertificate_ReturnsSuspect(bool allowEverything)
+            public async Task GetTrustResultAsync_WithRevokedPrimaryCertificate_ReturnsSuspectAsync(bool allowEverything)
             {
                 var settings = new SignedPackageVerifierSettings(
                     allowUnsigned: allowEverything,
@@ -1116,7 +1161,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Author,
                     signaturePlacement: SignaturePlacement.PrimarySignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never,
+                    revocationMode: RevocationMode.Online);
                 var testServer = await _fixture.GetSigningTestServerAsync();
                 var certificateAuthority = await _fixture.GetDefaultTrustedCertificateAuthorityAsync();
                 var issueCertificateOptions = IssueCertificateOptions.CreateDefaultForEndCertificate();
@@ -1151,7 +1197,7 @@ namespace NuGet.Packaging.FuncTest
             [CIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
-            public async Task GetTrustResultAsync_WithRevokedTimestampCertificate_ReturnsStatus(
+            public async Task GetTrustResultAsync_WithRevokedTimestampCertificate_ReturnsStatusAsync(
                 bool allowIgnoreTimestamp,
                 SignatureVerificationStatus expectedStatus)
             {
@@ -1168,7 +1214,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Author,
                     signaturePlacement: SignaturePlacement.PrimarySignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never,
+                    revocationMode: RevocationMode.Online);
                 var testServer = await _fixture.GetSigningTestServerAsync();
                 var certificateAuthority = await _fixture.GetDefaultTrustedCertificateAuthorityAsync();
                 var timestampService = TimestampService.Create(certificateAuthority);
@@ -1195,7 +1242,7 @@ namespace NuGet.Packaging.FuncTest
             }
 
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_WithTamperedRepositoryPrimarySignedPackage_ReturnsValid()
+            public async Task GetTrustResultAsync_WithTamperedRepositoryPrimarySignedPackage_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
                     allowUnsigned: false,
@@ -1210,7 +1257,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Author,
                     signaturePlacement: SignaturePlacement.PrimarySignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never,
+                    revocationMode: RevocationMode.Online);
                 var timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
 
                 using (var test = await Test.CreateAuthorSignedPackageAsync(
@@ -1254,7 +1302,7 @@ namespace NuGet.Packaging.FuncTest
             }
 
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_WithAuthorSignedPackage_ReturnsUnknown()
+            public async Task GetTrustResultAsync_WithAuthorSignedPackage_ReturnsUnknownAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
                     allowUnsigned: false,
@@ -1269,7 +1317,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Repository,
                     signaturePlacement: SignaturePlacement.PrimarySignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never,
+                    revocationMode: RevocationMode.Online);
 
                 using (var test = await Test.CreateAuthorSignedPackageAsync(_fixture.TrustedTestCertificate.Source.Cert))
                 using (var packageReader = new PackageArchiveReader(test.PackageFile.FullName))
@@ -1283,7 +1332,7 @@ namespace NuGet.Packaging.FuncTest
             }
 
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_WithValidSignature_ReturnsValid()
+            public async Task GetTrustResultAsync_WithValidSignature_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
                     allowUnsigned: false,
@@ -1298,7 +1347,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Repository,
                     signaturePlacement: SignaturePlacement.PrimarySignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never,
+                    revocationMode: RevocationMode.Online);
                 var timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
 
                 using (var test = await Test.CreateRepositoryPrimarySignedPackageAsync(
@@ -1317,7 +1367,7 @@ namespace NuGet.Packaging.FuncTest
             [CIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
-            public async Task GetTrustResultAsync_WithValidSignatureButNoTimestamp_ReturnsStatus(
+            public async Task GetTrustResultAsync_WithValidSignatureButNoTimestamp_ReturnsStatusAsync(
                 bool allowNoTimestamp,
                 SignatureVerificationStatus expectedStatus)
             {
@@ -1334,7 +1384,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Repository,
                     signaturePlacement: SignaturePlacement.PrimarySignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never,
+                    revocationMode: RevocationMode.Online);
 
                 using (var test = await Test.CreateRepositoryPrimarySignedPackageAsync(
                     _fixture.TrustedRepositoryCertificate.Source.Cert))
@@ -1351,7 +1402,7 @@ namespace NuGet.Packaging.FuncTest
             [CIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
-            public async Task GetTrustResultAsync_WithUntrustedSignature_ReturnsStatus(
+            public async Task GetTrustResultAsync_WithUntrustedSignature_ReturnsStatusAsync(
                 bool allowUntrusted,
                 SignatureVerificationStatus expectedStatus)
             {
@@ -1368,7 +1419,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Repository,
                     signaturePlacement: SignaturePlacement.PrimarySignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never,
+                    revocationMode: RevocationMode.Online);
                 var timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
 
                 using (var test = await Test.CreateRepositoryPrimarySignedPackageAsync(
@@ -1387,7 +1439,7 @@ namespace NuGet.Packaging.FuncTest
             [CIOnlyTheory]
             [InlineData(true)]
             [InlineData(false)]
-            public async Task GetTrustResultAsync_WithRevokedPrimaryCertificate_ReturnsSuspect(bool allowEverything)
+            public async Task GetTrustResultAsync_WithRevokedPrimaryCertificate_ReturnsSuspectAsync(bool allowEverything)
             {
                 var settings = new SignedPackageVerifierSettings(
                     allowUnsigned: allowEverything,
@@ -1402,7 +1454,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Repository,
                     signaturePlacement: SignaturePlacement.PrimarySignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never,
+                    revocationMode: RevocationMode.Online);
                 var testServer = await _fixture.GetSigningTestServerAsync();
                 var certificateAuthority = await _fixture.GetDefaultTrustedCertificateAuthorityAsync();
                 var issueCertificateOptions = IssueCertificateOptions.CreateDefaultForEndCertificate();
@@ -1437,7 +1490,7 @@ namespace NuGet.Packaging.FuncTest
             [CIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
-            public async Task GetTrustResultAsync_WithRevokedTimestampCertificate_ReturnsStatus(
+            public async Task GetTrustResultAsync_WithRevokedTimestampCertificate_ReturnsStatusAsync(
                 bool allowIgnoreTimestamp,
                 SignatureVerificationStatus expectedStatus)
             {
@@ -1454,7 +1507,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Repository,
                     signaturePlacement: SignaturePlacement.PrimarySignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never,
+                    revocationMode: RevocationMode.Online);
                 var testServer = await _fixture.GetSigningTestServerAsync();
                 var certificateAuthority = await _fixture.GetDefaultTrustedCertificateAuthorityAsync();
                 var timestampService = TimestampService.Create(certificateAuthority);
@@ -1481,7 +1535,7 @@ namespace NuGet.Packaging.FuncTest
             }
 
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_WithTamperedRepositoryPrimarySignedPackage_ReturnsValid()
+            public async Task GetTrustResultAsync_WithTamperedRepositoryPrimarySignedPackage_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
                     allowUnsigned: false,
@@ -1496,7 +1550,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Repository,
                     signaturePlacement: SignaturePlacement.PrimarySignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never,
+                    revocationMode: RevocationMode.Online);
                 var timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
 
                 using (var test = await Test.CreateRepositoryPrimarySignedPackageAsync(
@@ -1522,7 +1577,7 @@ namespace NuGet.Packaging.FuncTest
             }
 
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_WithAlwaysVerifyCountersignatureBehavior_ReturnsDisallowed()
+            public async Task GetTrustResultAsync_WithAlwaysVerifyCountersignatureBehavior_ReturnsDisallowedAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
                     allowUnsigned: false,
@@ -1537,7 +1592,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Repository,
                     signaturePlacement: SignaturePlacement.Any,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Always);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Always,
+                    revocationMode: RevocationMode.Online);
                 var testServer = await _fixture.GetSigningTestServerAsync();
                 var certificateAuthority = await _fixture.GetDefaultTrustedCertificateAuthorityAsync();
                 var timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
@@ -1583,7 +1639,7 @@ namespace NuGet.Packaging.FuncTest
             }
 
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_WithAuthorSignedPackage_ReturnsUnknown()
+            public async Task GetTrustResultAsync_WithAuthorSignedPackage_ReturnsUnknownAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
                     allowUnsigned: false,
@@ -1598,7 +1654,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Repository,
                     signaturePlacement: SignaturePlacement.Countersignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
+                    revocationMode: RevocationMode.Online);
 
                 using (var test = await Test.CreateAuthorSignedPackageAsync(_fixture.TrustedTestCertificate.Source.Cert))
                 using (var packageReader = new PackageArchiveReader(test.PackageFile.FullName))
@@ -1612,7 +1669,7 @@ namespace NuGet.Packaging.FuncTest
             }
 
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_WithValidCountersignature_ReturnsValid()
+            public async Task GetTrustResultAsync_WithValidCountersignature_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
                     allowUnsigned: false,
@@ -1627,7 +1684,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Repository,
                     signaturePlacement: SignaturePlacement.Countersignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
+                    revocationMode: RevocationMode.Online);
                 var timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
 
                 using (var test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1646,7 +1704,7 @@ namespace NuGet.Packaging.FuncTest
             }
 
             [CIOnlyFact]
-            public async Task GetTrustResultAsync_WithValidCountersignatureAndUntrustedPrimarySignature_ReturnsValid()
+            public async Task GetTrustResultAsync_WithValidCountersignatureAndUntrustedPrimarySignature_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
                     allowUnsigned: false,
@@ -1661,7 +1719,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Repository,
                     signaturePlacement: SignaturePlacement.Countersignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
+                    revocationMode: RevocationMode.Online);
                 var timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
 
                 using (var test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1682,7 +1741,7 @@ namespace NuGet.Packaging.FuncTest
             [CIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
-            public async Task GetTrustResultAsync_WithValidCountersignatureButNoTimestamp_ReturnsStatus(
+            public async Task GetTrustResultAsync_WithValidCountersignatureButNoTimestamp_ReturnsStatusAsync(
                 bool allowNoTimestamp,
                 SignatureVerificationStatus expectedStatus)
             {
@@ -1699,7 +1758,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Repository,
                     signaturePlacement: SignaturePlacement.Countersignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
+                    revocationMode: RevocationMode.Online);
                 var timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
 
                 using (var test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1719,7 +1779,7 @@ namespace NuGet.Packaging.FuncTest
             [CIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
-            public async Task VerifyAsync_WithUntrustedCountersignature_ReturnsStatus(
+            public async Task VerifyAsync_WithUntrustedCountersignature_ReturnsStatusAsync(
                 bool allowUntrusted,
                 SignatureVerificationStatus expectedStatus)
             {
@@ -1736,7 +1796,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Repository,
                     signaturePlacement: SignaturePlacement.Countersignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
+                    revocationMode: RevocationMode.Online);
                 var timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
 
                 using (var test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1757,7 +1818,7 @@ namespace NuGet.Packaging.FuncTest
             [CIOnlyTheory]
             [InlineData(true)]
             [InlineData(false)]
-            public async Task VerifyAsync_WithRevokedCountersignatureCertificate_ReturnsSuspect(bool allowEverything)
+            public async Task VerifyAsync_WithRevokedCountersignatureCertificate_ReturnsSuspectAsync(bool allowEverything)
             {
                 var settings = new SignedPackageVerifierSettings(
                     allowUnsigned: allowEverything,
@@ -1772,7 +1833,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Repository,
                     signaturePlacement: SignaturePlacement.Countersignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
+                    revocationMode: RevocationMode.Online);
                 var testServer = await _fixture.GetSigningTestServerAsync();
                 var certificateAuthority = await _fixture.GetDefaultTrustedCertificateAuthorityAsync();
                 var issueCertificateOptions = IssueCertificateOptions.CreateDefaultForEndCertificate();
@@ -1809,7 +1871,7 @@ namespace NuGet.Packaging.FuncTest
             [CIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
-            public async Task VerifyAsync_WithRevokedTimestampCertificate_ReturnsStatus(
+            public async Task VerifyAsync_WithRevokedTimestampCertificate_ReturnsStatusAsync(
                 bool allowIgnoreTimestamp,
                 SignatureVerificationStatus expectedStatus)
             {
@@ -1826,7 +1888,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Repository,
                     signaturePlacement: SignaturePlacement.Countersignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
+                    revocationMode: RevocationMode.Online);
                 var testServer = await _fixture.GetSigningTestServerAsync();
                 var certificateAuthority = await _fixture.GetDefaultTrustedCertificateAuthorityAsync();
                 var timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
@@ -1856,7 +1919,7 @@ namespace NuGet.Packaging.FuncTest
             }
 
             [CIOnlyFact]
-            public async Task VerifyAsync_WithTamperedRepositoryCountersignedPackage_ReturnsValid()
+            public async Task VerifyAsync_WithTamperedRepositoryCountersignedPackage_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
                     allowUnsigned: false,
@@ -1871,7 +1934,8 @@ namespace NuGet.Packaging.FuncTest
                     allowNoClientCertificateList: true,
                     verificationTarget: VerificationTarget.Repository,
                     signaturePlacement: SignaturePlacement.Countersignature,
-                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists);
+                    repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
+                    revocationMode: RevocationMode.Online);
                 var timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
 
                 using (var test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -2016,18 +2080,26 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        private static void AssertOfflineRevocation(IEnumerable<SignatureLog> issues, LogLevel logLevel)
+        private static void AssertOfflineRevocationOnlineMode(IEnumerable<SignatureLog> issues, LogLevel logLevel)
         {
             Assert.Contains(issues, issue =>
                 issue.Code == NuGetLogCode.NU3018 &&
                 issue.Level == logLevel &&
-                issue.Message.Contains("The revocation function was unable to check revocation because the revocation server was offline."));
+                issue.Message.Contains("The revocation function was unable to check revocation because the revocation server could not be reached. For more information, visit https://aka.ms/certificateRevocationMode."));
         }
 
-        private static void AssertRevocationStatusUnknown(IEnumerable<SignatureLog> issues, LogLevel logLevel)
+        private static void AssertOfflineRevocationOfflineMode(IEnumerable<SignatureLog> issues)
         {
             Assert.Contains(issues, issue =>
-                issue.Code == NuGetLogCode.NU3018 &&
+                issue.Code == NuGetLogCode.Undefined &&
+                issue.Level == LogLevel.Information &&
+                issue.Message.Contains("The revocation function was unable to check revocation because the certificate is not available in the cached certificate revocation list and certificateRevocationMode has been set to offline. For more information, visit https://aka.ms/certificateRevocationMode."));
+        }
+
+        private static void AssertRevocationStatusUnknown(IEnumerable<SignatureLog> issues, NuGetLogCode code, LogLevel logLevel)
+        {
+            Assert.Contains(issues, issue =>
+                issue.Code == code &&
                 issue.Level == logLevel &&
                 issue.Message.Contains("The revocation function was unable to check revocation for the certificate."));
         }

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -2093,7 +2093,7 @@ namespace NuGet.Packaging.FuncTest
             Assert.Contains(issues, issue =>
                 issue.Code == NuGetLogCode.Undefined &&
                 issue.Level == LogLevel.Information &&
-                issue.Message.Contains("The revocation function was unable to check revocation because the certificate is not available in the cached certificate revocation list and certificateRevocationMode has been set to offline. For more information, visit https://aka.ms/certificateRevocationMode."));
+                issue.Message.Contains("The revocation function was unable to check revocation because the certificate is not available in the cached certificate revocation list and NUGET_CERT_REVOCATION_MODE environment variable has been set to offline. For more information, visit https://aka.ms/certificateRevocationMode."));
         }
 
         private static void AssertRevocationStatusUnknown(IEnumerable<SignatureLog> issues, NuGetLogCode code, LogLevel logLevel)

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Packaging.FuncTest
 
         private SigningTestFixture _testFixture;
         private TrustedTestCert<TestCertificate> _trustedTestCert;
-        private IList<ISignatureVerificationProvider> _trustProviders;
+        private readonly IList<ISignatureVerificationProvider> _trustProviders;
 
         private readonly SignedPackageVerifierSettings _settings;
 
@@ -57,7 +57,8 @@ namespace NuGet.Packaging.FuncTest
                 allowNoRepositoryCertificateList: true,
                 verificationTarget: VerificationTarget.All,
                 signaturePlacement: SignaturePlacement.Any,
-                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary);
+                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExistsAndIsNecessary,
+                revocationMode: RevocationMode.Online);
         }
 
         [CIOnlyFact]

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -2699,6 +2699,7 @@ namespace NuGet.Packaging.Test
                     verificationTarget: signedPackageVerifierSettings.VerificationTarget,
                     signaturePlacement: signedPackageVerifierSettings.SignaturePlacement,
                     repositoryCountersignatureVerificationBehavior: signedPackageVerifierSettings.RepositoryCountersignatureVerificationBehavior,
+                    revocationMode: signedPackageVerifierSettings.RevocationMode,
                     repoAllowListEntries: expectedAllowList,
                     clientAllowListEntries: signedPackageVerifierSettings.ClientCertificateList);
 
@@ -2772,6 +2773,7 @@ namespace NuGet.Packaging.Test
                     verificationTarget: signedPackageVerifierSettings.VerificationTarget,
                     signaturePlacement: signedPackageVerifierSettings.SignaturePlacement,
                     repositoryCountersignatureVerificationBehavior: signedPackageVerifierSettings.RepositoryCountersignatureVerificationBehavior,
+                    revocationMode: signedPackageVerifierSettings.RevocationMode,
                     repoAllowListEntries: expectedAllowList,
                     clientAllowListEntries: signedPackageVerifierSettings.ClientCertificateList);
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/RepositorySignatureInfoUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/RepositorySignatureInfoUtilityTests.cs
@@ -286,6 +286,7 @@ namespace NuGet.Packaging.Test
                 verificationTarget: VerificationTarget.All,
                 signaturePlacement: SignaturePlacement.Any,
                 repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
+                revocationMode: RevocationMode.Online,
                 repoAllowListEntries: null,
                 clientAllowListEntries: expectedClientAllowList);
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageVerifierSettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageVerifierSettingsTests.cs
@@ -12,7 +12,7 @@ namespace NuGet.Packaging.Test
 {
     public class SignedPackageVerifierSettingsTests
     {
-        const string RevocationModeEnvVar = "certificateRevocationMode";
+        const string RevocationModeEnvVar = "NUGET_CERT_REVOCATION_MODE";
 
         [Fact]
         public void ConstructorWithoutLists_WhenVerificationTargetIsUnrecognized_Throws()

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageVerifierSettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageVerifierSettingsTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using FluentAssertions;
+using NuGet.Common;
 using NuGet.Packaging.Signing;
 using Xunit;
 
@@ -11,6 +12,8 @@ namespace NuGet.Packaging.Test
 {
     public class SignedPackageVerifierSettingsTests
     {
+        const string RevocationModeEnvVar = "certificateRevocationMode";
+
         [Fact]
         public void ConstructorWithoutLists_WhenVerificationTargetIsUnrecognized_Throws()
         {
@@ -28,7 +31,8 @@ namespace NuGet.Packaging.Test
                 signaturePlacement: SignaturePlacement.Any,
                 repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
                 allowNoRepositoryCertificateList: false,
-                allowNoClientCertificateList: false));
+                allowNoClientCertificateList: false,
+                revocationMode: RevocationMode.Online));
 
             Assert.Equal("verificationTarget", exception.ParamName);
             Assert.StartsWith($"The enum value '{verificationTarget}' is unrecognized.", exception.Message);
@@ -51,7 +55,8 @@ namespace NuGet.Packaging.Test
                 signaturePlacement: signaturePlacement,
                 repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
                 allowNoRepositoryCertificateList: false,
-                allowNoClientCertificateList: false));
+                allowNoClientCertificateList: false,
+                revocationMode: RevocationMode.Online));
 
             Assert.Equal("signaturePlacement", exception.ParamName);
             Assert.StartsWith($"The enum value '{signaturePlacement}' is unrecognized.", exception.Message);
@@ -74,7 +79,8 @@ namespace NuGet.Packaging.Test
                 signaturePlacement: SignaturePlacement.Any,
                 repositoryCountersignatureVerificationBehavior: repositoryCountersignatureVerificationBehavior,
                 allowNoRepositoryCertificateList: false,
-                allowNoClientCertificateList: false));
+                allowNoClientCertificateList: false,
+                revocationMode: RevocationMode.Online));
 
             Assert.Equal("repositoryCountersignatureVerificationBehavior", exception.ParamName);
             Assert.StartsWith($"The enum value '{repositoryCountersignatureVerificationBehavior}' is unrecognized.", exception.Message);
@@ -125,20 +131,22 @@ namespace NuGet.Packaging.Test
                 signaturePlacement: signaturePlacement,
                 repositoryCountersignatureVerificationBehavior: repositoryCountersignatureVerificationBehavior,
                 allowNoRepositoryCertificateList: false,
-                allowNoClientCertificateList: false));
+                allowNoClientCertificateList: false,
+                revocationMode: RevocationMode.Online));
 
             Assert.Equal(parameterName2, exception.ParamName);
             Assert.StartsWith($"Invalid combination of arguments {parameterName1} and {parameterName2}.", exception.Message);
         }
 
         [Theory]
-        [InlineData(true, VerificationTarget.Author, SignaturePlacement.PrimarySignature, SignatureVerificationBehavior.Never)]
-        [InlineData(false, VerificationTarget.All, SignaturePlacement.Any, SignatureVerificationBehavior.IfExistsAndIsNecessary)]
+        [InlineData(true, VerificationTarget.Author, SignaturePlacement.PrimarySignature, SignatureVerificationBehavior.Never, RevocationMode.Online)]
+        [InlineData(false, VerificationTarget.All, SignaturePlacement.Any, SignatureVerificationBehavior.IfExistsAndIsNecessary, RevocationMode.Offline)]
         public void ConstructorWithoutLists_InitializesProperties(
             bool boolValue,
             VerificationTarget verificationTarget,
             SignaturePlacement signaturePlacement,
-            SignatureVerificationBehavior signatureVerificationBehavior)
+            SignatureVerificationBehavior signatureVerificationBehavior,
+            RevocationMode revocationMode)
         {
             // Arrange & Act
             var settings = new SignedPackageVerifierSettings(
@@ -154,7 +162,8 @@ namespace NuGet.Packaging.Test
                 signaturePlacement: signaturePlacement,
                 repositoryCountersignatureVerificationBehavior: signatureVerificationBehavior,
                 allowNoRepositoryCertificateList: boolValue,
-                allowNoClientCertificateList: boolValue);
+                allowNoClientCertificateList: boolValue,
+                revocationMode: revocationMode);
 
             // Assert
             settings.AllowUnsigned.Should().Be(boolValue);
@@ -168,6 +177,7 @@ namespace NuGet.Packaging.Test
             settings.AllowNoRepositoryCertificateList.Should().Be(boolValue);
             settings.AllowNoClientCertificateList.Should().Be(boolValue);
             settings.RepositoryCountersignatureVerificationBehavior.Should().Be(signatureVerificationBehavior);
+            settings.RevocationMode.Should().Be(revocationMode);
         }
 
         [Fact]
@@ -188,6 +198,7 @@ namespace NuGet.Packaging.Test
                 repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
                 allowNoRepositoryCertificateList: false,
                 allowNoClientCertificateList: false,
+                revocationMode: RevocationMode.Online,
                 repoAllowListEntries: Array.Empty<VerificationAllowListEntry>(),
                 clientAllowListEntries: Array.Empty<VerificationAllowListEntry>()));
 
@@ -213,6 +224,7 @@ namespace NuGet.Packaging.Test
                 repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
                 allowNoRepositoryCertificateList: false,
                 allowNoClientCertificateList: false,
+                revocationMode: RevocationMode.Online,
                 repoAllowListEntries: Array.Empty<VerificationAllowListEntry>(),
                 clientAllowListEntries: Array.Empty<VerificationAllowListEntry>()));
 
@@ -238,6 +250,7 @@ namespace NuGet.Packaging.Test
                 repositoryCountersignatureVerificationBehavior: repositoryCountersignatureVerificationBehavior,
                 allowNoRepositoryCertificateList: false,
                 allowNoClientCertificateList: false,
+                revocationMode: RevocationMode.Online,
                 repoAllowListEntries: Array.Empty<VerificationAllowListEntry>(),
                 clientAllowListEntries: Array.Empty<VerificationAllowListEntry>()));
 
@@ -297,6 +310,7 @@ namespace NuGet.Packaging.Test
                 repositoryCountersignatureVerificationBehavior: repositoryCountersignatureVerificationBehavior,
                 allowNoRepositoryCertificateList: false,
                 allowNoClientCertificateList: false,
+                revocationMode: RevocationMode.Online,
                 repoAllowListEntries: Array.Empty<VerificationAllowListEntry>(),
                 clientAllowListEntries: Array.Empty<VerificationAllowListEntry>()));
 
@@ -305,13 +319,14 @@ namespace NuGet.Packaging.Test
         }
 
         [Theory]
-        [InlineData(true, VerificationTarget.Unknown, SignaturePlacement.PrimarySignature, SignatureVerificationBehavior.Never)]
-        [InlineData(false, VerificationTarget.All, SignaturePlacement.Any, SignatureVerificationBehavior.IfExistsAndIsNecessary)]
+        [InlineData(true, VerificationTarget.Unknown, SignaturePlacement.PrimarySignature, SignatureVerificationBehavior.Never, RevocationMode.Online)]
+        [InlineData(false, VerificationTarget.All, SignaturePlacement.Any, SignatureVerificationBehavior.IfExistsAndIsNecessary, RevocationMode.Offline)]
         public void ConstructorWithLists_InitializesProperties(
             bool boolValue,
             VerificationTarget verificationTarget,
             SignaturePlacement signaturePlacement,
-            SignatureVerificationBehavior signatureVerificationBehavior)
+            SignatureVerificationBehavior signatureVerificationBehavior,
+            RevocationMode revocationMode)
         {
             // Arrange
             var repoList = new List<CertificateHashAllowListEntry>();
@@ -332,6 +347,7 @@ namespace NuGet.Packaging.Test
                 verificationTarget: verificationTarget,
                 signaturePlacement: signaturePlacement,
                 repositoryCountersignatureVerificationBehavior: signatureVerificationBehavior,
+                revocationMode: revocationMode,
                 repoAllowListEntries: repoList,
                 clientAllowListEntries: clientList);
 
@@ -346,20 +362,31 @@ namespace NuGet.Packaging.Test
             settings.AllowNoRepositoryCertificateList.Should().Be(boolValue);
             settings.AllowNoClientCertificateList.Should().Be(boolValue);
             settings.RepositoryCountersignatureVerificationBehavior.Should().Be(signatureVerificationBehavior);
+            settings.RevocationMode.Should().Be(revocationMode);
             settings.RepositoryCertificateList.Should().BeSameAs(repoList);
             settings.ClientCertificateList.Should().BeSameAs(clientList);
         }
 
-        [Fact]
-        public void GetDefault_InitializesProperties()
+        [Theory]
+        [InlineData(null, RevocationMode.Online)]
+        [InlineData("", RevocationMode.Online)]
+        [InlineData("online", RevocationMode.Online)]
+        [InlineData("offline", RevocationMode.Offline)]
+        [InlineData("Offline", RevocationMode.Offline)]
+        public void GetDefault_InitializesProperties(string revocationModeEnvVar, RevocationMode expectedRevocationMode)
         {
             // Arrange
             var repoList = new List<CertificateHashAllowListEntry>();
             var clientList = new List<CertificateHashAllowListEntry>();
             var defaultValue = true;
 
+            if (revocationModeEnvVar != null)
+            {
+                Environment.SetEnvironmentVariable(RevocationModeEnvVar, revocationModeEnvVar);
+            }
+
             // Act
-            var settings = SignedPackageVerifierSettings.GetDefault(repoList, clientList);
+            var settings = SignedPackageVerifierSettings.GetDefault( repoList, clientList);
 
             // Assert
             settings.AllowUnsigned.Should().Be(defaultValue);
@@ -375,17 +402,30 @@ namespace NuGet.Packaging.Test
             settings.VerificationTarget.Should().Be(VerificationTarget.All);
             settings.SignaturePlacement.Should().Be(SignaturePlacement.Any);
             settings.RepositoryCountersignatureVerificationBehavior.Should().Be(SignatureVerificationBehavior.IfExistsAndIsNecessary);
+            settings.RevocationMode.Should().Be(expectedRevocationMode);
             settings.RepositoryCertificateList.Should().BeSameAs(repoList);
             settings.ClientCertificateList.Should().BeSameAs(clientList);
+
+            Environment.SetEnvironmentVariable(RevocationModeEnvVar, string.Empty);
         }
 
-        [Fact]
-        public void GetAcceptModeDefaultPolicy_InitializesProperties()
+        [Theory]
+        [InlineData(null, RevocationMode.Online)]
+        [InlineData("", RevocationMode.Online)]
+        [InlineData("online", RevocationMode.Online)]
+        [InlineData("offline", RevocationMode.Offline)]
+        [InlineData("Offline", RevocationMode.Offline)]
+        public void GetAcceptModeDefaultPolicy_InitializesProperties(string revocationModeEnvVar, RevocationMode expectedRevocationMode)
         {
             // Arrange
             var repoList = new List<CertificateHashAllowListEntry>();
             var clientList = new List<CertificateHashAllowListEntry>();
             var defaultValue = true;
+
+            if (revocationModeEnvVar != null)
+            {
+                Environment.SetEnvironmentVariable(RevocationModeEnvVar, revocationModeEnvVar);
+            }
 
             // Act
             var settings = SignedPackageVerifierSettings.GetAcceptModeDefaultPolicy(repoList, clientList);
@@ -404,16 +444,29 @@ namespace NuGet.Packaging.Test
             settings.VerificationTarget.Should().Be(VerificationTarget.All);
             settings.SignaturePlacement.Should().Be(SignaturePlacement.Any);
             settings.RepositoryCountersignatureVerificationBehavior.Should().Be(SignatureVerificationBehavior.IfExistsAndIsNecessary);
+            settings.RevocationMode.Should().Be(expectedRevocationMode);
             settings.RepositoryCertificateList.Should().BeSameAs(repoList);
             settings.ClientCertificateList.Should().BeSameAs(clientList);
+
+            Environment.SetEnvironmentVariable(RevocationModeEnvVar, string.Empty);
         }
 
-        [Fact]
-        public void GetRequireModeDefaultPolicy_InitializesProperties()
+        [Theory]
+        [InlineData(null, RevocationMode.Online)]
+        [InlineData("", RevocationMode.Online)]
+        [InlineData("online", RevocationMode.Online)]
+        [InlineData("offline", RevocationMode.Offline)]
+        [InlineData("Offline", RevocationMode.Offline)]
+        public void GetRequireModeDefaultPolicy_InitializesProperties(string revocationModeEnvVar, RevocationMode expectedRevocationMode)
         {
             // Arrange
             var repoList = new List<CertificateHashAllowListEntry>();
             var clientList = new List<CertificateHashAllowListEntry>();
+
+            if (revocationModeEnvVar != null)
+            {
+                Environment.SetEnvironmentVariable(RevocationModeEnvVar, revocationModeEnvVar);
+            }
 
             // Act
             var settings = SignedPackageVerifierSettings.GetRequireModeDefaultPolicy(repoList, clientList);
@@ -432,16 +485,29 @@ namespace NuGet.Packaging.Test
             settings.VerificationTarget.Should().Be(VerificationTarget.All);
             settings.SignaturePlacement.Should().Be(SignaturePlacement.Any);
             settings.RepositoryCountersignatureVerificationBehavior.Should().Be(SignatureVerificationBehavior.IfExistsAndIsNecessary);
+            settings.RevocationMode.Should().Be(expectedRevocationMode);
             settings.RepositoryCertificateList.Should().BeSameAs(repoList);
             settings.ClientCertificateList.Should().BeSameAs(clientList);
+
+            Environment.SetEnvironmentVariable(RevocationModeEnvVar, string.Empty);
         }
 
-        [Fact]
-        public void GetVerifyCommandDefaultPolicy_InitializesProperties()
+        [Theory]
+        [InlineData(null, RevocationMode.Online)]
+        [InlineData("", RevocationMode.Online)]
+        [InlineData("online", RevocationMode.Online)]
+        [InlineData("offline", RevocationMode.Offline)]
+        [InlineData("Offline", RevocationMode.Offline)]
+        public void GetVerifyCommandDefaultPolicy_InitializesProperties(string revocationModeEnvVar, RevocationMode expectedRevocationMode)
         {
             // Arrange
             var repoList = new List<CertificateHashAllowListEntry>();
             var clientList = new List<CertificateHashAllowListEntry>();
+
+            if (revocationModeEnvVar != null)
+            {
+                Environment.SetEnvironmentVariable(RevocationModeEnvVar, revocationModeEnvVar);
+            }
 
             // Act
             var settings = SignedPackageVerifierSettings.GetVerifyCommandDefaultPolicy(repoList, clientList);
@@ -460,8 +526,11 @@ namespace NuGet.Packaging.Test
             settings.VerificationTarget.Should().Be(VerificationTarget.All);
             settings.SignaturePlacement.Should().Be(SignaturePlacement.Any);
             settings.RepositoryCountersignatureVerificationBehavior.Should().Be(SignatureVerificationBehavior.IfExists);
+            settings.RevocationMode.Should().Be(expectedRevocationMode);
             settings.RepositoryCertificateList.Should().BeSameAs(repoList);
             settings.ClientCertificateList.Should().BeSameAs(clientList);
+
+            Environment.SetEnvironmentVariable(RevocationModeEnvVar, string.Empty);
         }
     }
 }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7173

## Fix
Currently, the revocation mode when building chain defaults to online. In some offline cases, this gives some problems where a package install can experience a hang of approximately 4 minutes per package (in the average scenario). This PR adds an option to the settings that let the user override the revocation mode to be done offline if needed.

