### PR TITLE
Fix dotnet add package command to commit restore

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Commands;
 using NuGet.Common;
@@ -182,6 +183,9 @@ namespace NuGet.CommandLine.XPlat
                     libraryDependency,
                     compatibleOriginalFrameworks);
             }
+
+            // 5. Commit restore result
+            await RestoreRunner.CommitAsync(restorePreviewResult, CancellationToken.None);
 
             return 0;
         }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -161,6 +161,7 @@ namespace NuGet.XPlat.FuncTest
                 Assert.Equal(0, result);
                 Assert.NotNull(itemGroup);
                 Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, userInputVersion));
+                Assert.True(XPlatTestUtils.ValidateAssetsFile(projectA, packageX.Id));
             }
         }
 
@@ -199,6 +200,7 @@ namespace NuGet.XPlat.FuncTest
                 Assert.Equal(0, result);
                 Assert.NotNull(itemGroup);
                 Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, userInputVersion));
+                Assert.True(XPlatTestUtils.ValidateAssetsFile(projectA, packageX.Id));
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -310,6 +310,16 @@ namespace NuGet.XPlat.FuncTest
             return true;
         }
 
+        public static bool ValidateAssetsFile(SimpleTestProjectContext project, string packageId)
+        {
+            if (!File.Exists(project.AssetsFileOutputPath))
+            {
+                return false;
+            }
+
+            return project.AssetsFile.Targets.Any(t => t.Libraries.Any(library => string.Equals(library.Name, packageId, StringComparison.OrdinalIgnoreCase)));
+        }
+
         public static bool ValidateNoReference(XElement root, string packageId, PackageType packageType = null)
         {
             var packageReferences = root

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
@@ -131,7 +131,7 @@ namespace NuGet.Test.Utility
                     zip.AddEntry("contentFiles/cs/net45/code.cs", new byte[] { 0 });
                     zip.AddEntry("lib/net45/a.dll", new byte[] { 0 });
                     zip.AddEntry("lib/netstandard1.0/a.dll", new byte[] { 0 });
-                    zip.AddEntry($"build/net45/{id}.targets", @"<targets />", Encoding.UTF8);
+                    zip.AddEntry($"build/net45/{id}.targets", @"<Project />", Encoding.UTF8);
                     zip.AddEntry("runtimes/any/native/a.dll", new byte[] { 0 });
                     zip.AddEntry("tools/a.exe", new byte[] { 0 });
                 }

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -227,7 +227,7 @@ namespace NuGet.Test.Utility
                 _packageSpec.RestoreMetadata.ProjectName = ProjectName;
                 _packageSpec.RestoreMetadata.ProjectPath = ProjectPath;
                 _packageSpec.RestoreMetadata.ProjectStyle = Type;
-                _packageSpec.RestoreMetadata.OutputPath = AssetsFileOutputPath;
+                _packageSpec.RestoreMetadata.OutputPath = OutputPath;
                 _packageSpec.RestoreMetadata.OriginalTargetFrameworks = OriginalFrameworkStrings;
                 _packageSpec.RestoreMetadata.TargetFrameworks = Frameworks
                     .Select(f => new ProjectRestoreMetadataFrameworkInfo(f.Framework))


### PR DESCRIPTION
Currently dotnet add package runs a preview restore, update project file, but doesn't commit the restore artifacts. So next time, a restore happens, it runs a full restore again and then commit.

This PR fixes it by commiting restore as part of add package command. This is even more essential to get before project file comes into picture.

Next: We should also fix `dotnet remove` command since that doesn't even run restore as of now, instead just update the project file. https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs#L13

Fixes - https://github.com/NuGet/Home/issues/6928

@rrelyea 