### PR TITLE
Setup the credential providers for xplat push

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.CommandLineUtils;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.Credentials;
 
 namespace NuGet.CommandLine.XPlat
 {
@@ -70,6 +71,11 @@ namespace NuGet.CommandLine.XPlat
                     Strings.NoServiceEndpoint_Description,
                     CommandOptionType.NoValue);
 
+                var interactive = push.Option(
+                    "--interactive",
+                    Strings.PushCommand_Interactive,
+                    CommandOptionType.SingleValue);
+
                 push.OnExecute(async () =>
                 {
                     if (arguments.Values.Count < 1)
@@ -92,10 +98,12 @@ namespace NuGet.CommandLine.XPlat
                         throw new ArgumentException(Strings.Push_InvalidTimeout);
                     }
 
-                    PackageSourceProvider sourceProvider = new PackageSourceProvider(XPlatUtility.CreateDefaultSettings());
+                    var sourceProvider = new PackageSourceProvider(XPlatUtility.CreateDefaultSettings());
 
                     try
                     {
+                        DefaultCredentialServiceUtility.SetupDefaultCredentialService(getLogger(), !interactive.HasValue());
+
                         await PushRunner.Run(
                             sourceProvider.Settings,
                             sourceProvider,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -790,6 +790,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allow the command to block and require manual action for operations like authentication..
+        /// </summary>
+        internal static string PushCommand_Interactive {
+            get {
+                return ResourceManager.GetString("PushCommand_Interactive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Removes a package reference from a project..
         /// </summary>
         internal static string RemovePkg_Description {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -474,4 +474,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="AddPkg_InteractiveDescription" xml:space="preserve">
     <value>Allow the command to block and require manual action for operations like authentication.</value>
   </data>
+  <data name="PushCommand_Interactive" xml:space="preserve">
+    <value>Allow the command to block and require manual action for operations like authentication.</value>
+  </data>
 </root>


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7233
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
Adding in the credential providers for dotnet nuget push. 

## Testing/Validation
Tests Added: No  
Reason for not adding tests: No test infrastructure for dealing with authenticated feeds.  
Validation done:  Manual

//cc @rrelyea 
