### PR TITLE
fix: AllVersion ignored for list from local folder

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageSearchResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageSearchResource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -57,8 +57,10 @@ namespace NuGet.Protocol
                     query = query.Where(package => ContainsAnyTerm(terms, package));
                 }
 
-                // Collapse to the highest version per id
-                var collapsedQuery = CollapseToHighestVersion(query);
+                // Collapse to the highest version per id, if necessary
+                var collapsedQuery = filters?.Filter == SearchFilterType.IsLatestVersion ||
+                                     filters?.Filter == SearchFilterType.IsAbsoluteLatestVersion
+                    ? CollapseToHighestVersion(query) : query;
 
                 // execute the query
                 var packages = collapsedQuery


### PR DESCRIPTION


Fixes 

## Bug
Fixes: NuGet/Home#4537
Regression: Yes  
If Regression then when did it last work:  Never?

## Fix
NuGet.exe list from local packages folder does not work with the `AllVersion` flag.
For example, a local folder D:\packages contains four packages:

    D:\packages>dir /b
    foo.1.0.0.31.nupkg
    foo.1.0.0.41.nupkg
    foo.1.0.0.43.nupkg
    foo.2.0.0.10.nupkg

Running the following command with the officially released nuget.exe will return a single package:

    D:\packages>nuget.exe  list -source d:\packages foo -allversions
    foo 2.0.0.10

With the fix the results are as follows:

    D:\packages>nuget.exe  list -source d:\packages foo
    foo 2.0.0.10

    D:\packages>nuget.exe  list -source d:\packages foo -includedelisted
    foo 2.0.0.10

    D:\packages>nuget.exe  list -source d:\packages foo -prerelease
    foo 2.0.0.10

    D:\packages>nuget.exe  list -source d:\packages foo -prerelease -includedelisted
    foo 2.0.0.10

    D:\packages>nuget.exe  list -source d:\packages foo -prerelease -includedelisted -allversions
    foo 1.0.0.31
    foo 1.0.0.41
    foo 1.0.0.43
    foo 2.0.0.10

    D:\packages>nuget.exe  list -source d:\packages foo -allversions
    foo 1.0.0.31
    foo 1.0.0.41
    foo 1.0.0.43
    foo 2.0.0.10


## Testing/Validation
Tests Added: No  
Reason for not adding tests:  I'll add them, if this fix is deemed correct
Validation done:  manual
