### PR TITLE
Fix plugin startup with invariant culture

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
@@ -349,13 +349,31 @@ namespace NuGet.Protocol.Core.Types
             }
         }
 
+        /// <summary>
+        /// Gets the current culture.
+        /// An invariant culture's name will be "". Since InitializeRequest has a null or empty check, this can be a problem.
+        /// Because the InitializeRequest message is part of a protocol, and the reason why we set the culture is allow the plugins to localize their messages,
+        /// we can safely default to en. 
+        /// </summary>
+        /// <returns>CurrentCulture or an en default if the current culture is invariant</returns>
+        private static string GetCurrentCultureName()
+        {
+            var currentCultureName = CultureInfo.CurrentCulture.Name;
+            if (string.IsNullOrEmpty(currentCultureName))
+            {
+                currentCultureName = "en";
+            }
+            return currentCultureName;
+        }
+
         private static async Task InitializePluginAsync(
             IPlugin plugin,
             TimeSpan requestTimeout,
             CancellationToken cancellationToken)
         {
             var clientVersion = MinClientVersionUtility.GetNuGetClientVersion().ToNormalizedString();
-            var culture = CultureInfo.CurrentCulture.Name;
+            var culture = GetCurrentCultureName();
+
             var payload = new InitializeRequest(
                 clientVersion,
                 culture,


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7223  
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details:
An invariant culture's Name is "". 
To alleviate this we default to "en" when appropriate. 

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  Don't really have tests for different cultures. 
Validation done:  Manual
