### PR TITLE
Let OperationCanceledException bubble up

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/DependencyInfo/RegistrationUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DependencyInfo/RegistrationUtility.cs
@@ -52,7 +52,7 @@ namespace NuGet.Protocol
                 },
                 async httpSourceResult =>
                 {
-                    return await httpSourceResult.Stream.AsJObjectAsync();
+                    return await httpSourceResult.Stream.AsJObjectAsync(token);
                 },
                 log,
                 token);
@@ -87,7 +87,7 @@ namespace NuGet.Protocol
                             },
                             async httpSourceResult =>
                             {
-                                return await httpSourceResult.Stream.AsJObjectAsync();
+                                return await httpSourceResult.Stream.AsJObjectAsync(token);
                             },
                             log,
                             token));

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
@@ -268,7 +268,7 @@ namespace NuGet.Protocol
                         return Task.FromResult<JObject>(null);
                     }
 
-                    return stream.AsJObjectAsync();
+                    return stream.AsJObjectAsync(token);
                 },
                 log: log,
                 token: token);

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/AutoCompleteResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/AutoCompleteResourceV2Feed.cs
@@ -81,7 +81,7 @@ namespace NuGet.Protocol
                    new HttpSourceRequest(apiEndpointUri, logger),
                    async stream =>
                    {
-                       using (var reader = new StreamReader(await stream.AsSeekableStreamAsync()))
+                       using (var reader = new StreamReader(await stream.AsSeekableStreamAsync(token)))
                        using (var jsonReader = new JsonTextReader(reader))
                        {
                            var serializer = JsonSerializer.Create();

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedParser.cs
@@ -437,7 +437,7 @@ namespace NuGet.Protocol
             var uri = string.Format("{0}{1}", _baseAddress, relativeUri);
             uris.Add(uri);
 
-            // page 
+            // page
             var page = 1;
 
             // http cache key
@@ -467,7 +467,7 @@ namespace NuGet.Protocol
                 docRequest = null;
                 if (max < 0 || results.Count < max)
                 {
-                    
+
                     // Request the next url in parallel to parsing the current page
                     if (!string.IsNullOrEmpty(nextUri))
                     {
@@ -549,7 +549,7 @@ namespace NuGet.Protocol
                             }
                             else
                             {
-                                return await LoadXmlAsync(response.Stream);
+                                return await LoadXmlAsync(response.Stream, token);
                             }
                         },
                         log,
@@ -583,7 +583,7 @@ namespace NuGet.Protocol
                     if (response.StatusCode == HttpStatusCode.OK)
                     {
                         var networkStream = await response.Content.ReadAsStreamAsync();
-                        return await LoadXmlAsync(networkStream);
+                        return await LoadXmlAsync(networkStream, token);
                     }
                     else if (ignoreNotFounds && response.StatusCode == HttpStatusCode.NotFound)
                     {
@@ -623,9 +623,9 @@ namespace NuGet.Protocol
                     select nextLink.Value).FirstOrDefault();
         }
 
-        internal static async Task<XDocument> LoadXmlAsync(Stream stream)
+        internal static async Task<XDocument> LoadXmlAsync(Stream stream, CancellationToken token)
         {
-            using (var memStream = await stream.AsSeekableStreamAsync())
+            using (var memStream = await stream.AsSeekableStreamAsync(token))
             {
                 var xmlReader = XmlReader.Create(memStream, new XmlReaderSettings()
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
@@ -70,7 +70,7 @@ namespace NuGet.Protocol
                             },
                             async httpSourceResult =>
                             {
-                                var json = await httpSourceResult.Stream.AsJObjectAsync();
+                                var json = await httpSourceResult.Stream.AsJObjectAsync(token);
 
                                 return new RepositorySignatureResource(json, source);
                             },

--- a/src/NuGet.Core/NuGet.Protocol/Providers/ServiceIndexResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/ServiceIndexResourceV3Provider.cs
@@ -131,7 +131,7 @@ namespace NuGet.Protocol
                             },
                             async httpSourceResult =>
                             {
-                                var result = await ConsumeServiceIndexStreamAsync(httpSourceResult.Stream, utcNow);
+                                var result = await ConsumeServiceIndexStreamAsync(httpSourceResult.Stream, utcNow, token);
 
                                 return result;
                             },
@@ -157,10 +157,10 @@ namespace NuGet.Protocol
             return null;
         }
 
-        private async Task<ServiceIndexResourceV3> ConsumeServiceIndexStreamAsync(Stream stream, DateTime utcNow)
+        private async Task<ServiceIndexResourceV3> ConsumeServiceIndexStreamAsync(Stream stream, DateTime utcNow, CancellationToken token)
         {
             // Parse the JSON
-            JObject json = await stream.AsJObjectAsync();
+            JObject json = await stream.AsJObjectAsync(token);
 
             // Use SemVer instead of NuGetVersion, the service index should always be
             // in strict SemVer format

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
@@ -367,7 +367,7 @@ namespace NuGet.Protocol
                             {
                                 try
                                 {
-                                    result = await ConsumeFlatContainerIndexAsync(httpSourceResult.Stream, id, baseUri);
+                                    result = await ConsumeFlatContainerIndexAsync(httpSourceResult.Stream, id, baseUri, cancellationToken);
                                 }
                                 catch
                                 {
@@ -378,7 +378,7 @@ namespace NuGet.Protocol
                             }
                             else if (httpSourceResult.Status == HttpSourceResultStatus.OpenedFromNetwork)
                             {
-                                result = await ConsumeFlatContainerIndexAsync(httpSourceResult.Stream, id, baseUri);
+                                result = await ConsumeFlatContainerIndexAsync(httpSourceResult.Stream, id, baseUri, cancellationToken);
                             }
 
                             return result;
@@ -408,9 +408,9 @@ namespace NuGet.Protocol
             return null;
         }
 
-        private async Task<SortedDictionary<NuGetVersion, PackageInfo>> ConsumeFlatContainerIndexAsync(Stream stream, string id, string baseUri)
+        private async Task<SortedDictionary<NuGetVersion, PackageInfo>> ConsumeFlatContainerIndexAsync(Stream stream, string id, string baseUri, CancellationToken token)
         {
-            var doc = await stream.AsJObjectAsync();
+            var doc = await stream.AsJObjectAsync(token);
 
             var streamResults = new SortedDictionary<NuGetVersion, PackageInfo>();
 

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -387,7 +387,7 @@ namespace NuGet.Protocol
                                     return false;
                                 }
 
-                                var doc = await V2FeedParser.LoadXmlAsync(httpSourceResult.Stream);
+                                var doc = await V2FeedParser.LoadXmlAsync(httpSourceResult.Stream, cancellationToken);
 
                                 var result = doc.Root
                                     .Elements(_xnameEntry)

--- a/src/NuGet.Core/NuGet.Protocol/Utility/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/StreamExtensions.cs
@@ -18,14 +18,14 @@ namespace NuGet.Protocol
             await stream.CopyToAsync(destination, BufferSize, token);
         }
 
-        internal static async Task<JObject> AsJObjectAsync(this Stream stream)
+        internal static async Task<JObject> AsJObjectAsync(this Stream stream, CancellationToken token)
         {
             if (stream == null)
             {
                 return null;
             }
 
-            using (var reader = new StreamReader(await stream.AsSeekableStreamAsync()))
+            using (var reader = new StreamReader(await stream.AsSeekableStreamAsync(token)))
             {
                 return JsonUtility.LoadJson(reader);
             }
@@ -35,12 +35,12 @@ namespace NuGet.Protocol
         /// Read a stream into a memory stream if CanSeek is false.
         /// This method is used to ensure that network streams
         /// can be read by non-async reads without hanging.
-        /// 
+        ///
         /// Closes the original stream by default.
         /// </summary>
-        internal static Task<Stream> AsSeekableStreamAsync(this Stream stream)
+        internal static Task<Stream> AsSeekableStreamAsync(this Stream stream, CancellationToken token)
         {
-            return AsSeekableStreamAsync(stream, leaveStreamOpen: false);
+            return AsSeekableStreamAsync(stream, leaveStreamOpen: false, token: token);
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace NuGet.Protocol
         /// This method is used to ensure that network streams
         /// can be read by non-async reads without hanging.
         /// </summary>
-        internal static async Task<Stream> AsSeekableStreamAsync(this Stream stream, bool leaveStreamOpen)
+        internal static async Task<Stream> AsSeekableStreamAsync(this Stream stream, bool leaveStreamOpen, CancellationToken token)
         {
             if (stream == null)
             {
@@ -69,7 +69,7 @@ namespace NuGet.Protocol
             {
                 // Copy the the current stream to a memory stream.
                 // This avoids the sync .Read call.
-                await stream.CopyToAsync(memStream);
+                await stream.CopyToAsync(memStream, token);
                 memStream.Position = 0;
             }
             finally


### PR DESCRIPTION
* resolves NuGet/Home#7240

## Bug
Fixes: https://github.com/NuGet/Home/issues/7240
Regression: No

## Fix
Details: Instead of suppressing **all** exceptions, let `OperationCanceledException` bubble.

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  Lacks infrastructure. I can't easily mock `HttpSource` to have it throw as it's not abstract nor the method call is virtual. If agreed I could work on it but I'd rather get a green lightfirst before putting the effort.

