### PR TITLE
 fix case for dotnet pack when there is a floating version provided i…

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -751,7 +751,21 @@ namespace NuGet.Build.Tasks.Pack
                                 string.Equals(library.Name, packageDependency.Name, StringComparison.OrdinalIgnoreCase));
                         if (package != null)
                         {
-                            packageDependency.LibraryRange.VersionRange = new VersionRange(package.Version);
+                            if(packageDependency.LibraryRange.VersionRange.HasUpperBound)
+                            {
+                                packageDependency.LibraryRange.VersionRange = new VersionRange(
+                                    minVersion: package.Version,
+                                    includeMinVersion: packageDependency.LibraryRange.VersionRange.IsMinInclusive,
+                                    maxVersion: packageDependency.LibraryRange.VersionRange.MaxVersion,
+                                    includeMaxVersion: packageDependency.LibraryRange.VersionRange.IsMaxInclusive);
+                            }
+                            else
+                            {
+                                packageDependency.LibraryRange.VersionRange = new VersionRange(
+                                    minVersion: package.Version,
+                                    includeMinVersion: packageDependency.LibraryRange.VersionRange.IsMinInclusive);
+                            }
+                            
                         }
                     }
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/7232

From the issue,

Steps to reproduce
Create a project and add a reference to a nuget package, floating on the patch, but within a range.
e.g. <PackageReference Include="microsoft.aspnetcore.app" Version="[2.1.*, 2.3.0)" />

Expected behavior
When running dotnet pack the latest patch version is restored and the range is honored in the nuspec.
E.g. if the latest patch is version 2.1.3, the nuspec would contain:
<dependency id="microsoft.aspnetcore.app" version="[2.1.3, 3.0.0)" exclude="Build,Analyzers" />

Actual behavior
The latest patch is restored, however the range in the nuspec is removed:
<dependency id="microsoft.aspnetcore.app" version="2.1.3" exclude="Build,Analyzers" />

The same issue is seen when floating on the pre-release, e.g. 2.1.3-*
