### PR TITLE
allow build actions to be set for all package files

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -62,9 +62,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BuildOutputInPackage>
       <TargetFramework>$(TargetFramework)</TargetFramework>
     </BuildOutputInPackage>
-    <TfmSpecificPackageFile>
-      <BuildAction>None</BuildAction>
-    </TfmSpecificPackageFile>
   </ItemDefinitionGroup>
 
   <Target Name="_GetOutputItemsFromPack"
@@ -424,6 +421,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <TfmSpecificPackageFileWithRecursiveDir Include="@(TfmSpecificPackageFile)">
         <NuGetRecursiveDir>%(TfmSpecificPackageFile.RecursiveDir)</NuGetRecursiveDir>
+        <BuildAction>%(TfmSpecificPackageFile.BuildAction)</BuildAction>
       </TfmSpecificPackageFileWithRecursiveDir>
     </ItemGroup>
   </Target>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -475,7 +475,8 @@ namespace NuGet.Build.Tasks.Pack
                 }
             }
 
-            var buildAction = BuildAction.Parse(packageFile.GetProperty("BuildAction"));
+            var buildActionString = packageFile.GetProperty("BuildAction");
+            var buildAction = BuildAction.Parse(string.IsNullOrEmpty(buildActionString) ? "None" : buildActionString);
 
             // TODO: Do the work to get the right language of the project, tracked via https://github.com/NuGet/Home/issues/4100
             var language = buildAction.Equals(BuildAction.Compile) ? "cs" : "any";
@@ -557,7 +558,7 @@ namespace NuGet.Build.Tasks.Pack
 
             return totalSetOfTargetPaths.Select(target => new ContentMetadata()
             {
-                BuildAction = buildAction.IsKnown ? buildAction.Value : null,
+                BuildAction = buildAction.Value,
                 Source = sourcePath,
                 Target = target,
                 CopyToOutput = packageFile.GetProperty("PackageCopyToOutput"),

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -2303,6 +2303,8 @@ namespace ClassLibrary
         [InlineData("Content",                                      "Page",                                 "Page")]
         [InlineData("EmbeddedResource",                             "",                                     "EmbeddedResource")]
         [InlineData("EmbeddedResource",                             "ApplicationDefinition",                "ApplicationDefinition")]
+        [InlineData("Content",                                      "LinkDescription",                      "LinkDescription")]
+        [InlineData("Content",                                      "RandomBuildAction",                    "RandomBuildAction")]
         public void PackCommand_PackProject_OutputsBuildActionForContentFiles(string itemType, string buildAction, string expectedBuildAction )
         {
             // Arrange


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/7155 

This allows package authors to set any build action for their contentFiles in their package. Before this , we were validating for known build actions and changing to None if it was an unknown build action