### PR TITLE
Make dotnet delete use the new credential provider plugins

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/DeleteCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/DeleteCommand.cs
@@ -53,7 +53,7 @@ namespace NuGet.CommandLine.XPlat
 
                 var interactive = delete.Option(
                     "--interactive",
-                    Strings.PushCommand_Interactive,
+                    Strings.PushDeleteCommand_Interactive,
                     CommandOptionType.SingleValue);
 
                 delete.OnExecute(async () =>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/DeleteCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/DeleteCommand.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.CommandLineUtils;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.Credentials;
 
 namespace NuGet.CommandLine.XPlat
 {
@@ -50,6 +51,11 @@ namespace NuGet.CommandLine.XPlat
                     Strings.NoServiceEndpoint_Description,
                     CommandOptionType.NoValue);
 
+                var interactive = delete.Option(
+                    "--interactive",
+                    Strings.PushCommand_Interactive,
+                    CommandOptionType.SingleValue);
+
                 delete.OnExecute(async () =>
                 {
                     if (arguments.Values.Count < 2)
@@ -63,6 +69,8 @@ namespace NuGet.CommandLine.XPlat
                     string apiKeyValue = apikey.Value();
                     bool nonInteractiveValue = nonInteractive.HasValue();
                     bool noServiceEndpoint = noServiceEndpointDescription.HasValue();
+
+                    DefaultCredentialServiceUtility.SetupDefaultCredentialService(getLogger(), !interactive.HasValue());
 
                     PackageSourceProvider sourceProvider = new PackageSourceProvider(XPlatUtility.CreateDefaultSettings());
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
@@ -73,7 +73,7 @@ namespace NuGet.CommandLine.XPlat
 
                 var interactive = push.Option(
                     "--interactive",
-                    Strings.PushCommand_Interactive,
+                    Strings.PushDeleteCommand_Interactive,
                     CommandOptionType.SingleValue);
 
                 push.OnExecute(async () =>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -1080,9 +1080,9 @@ namespace NuGet.CommandLine.XPlat {
         /// <summary>
         ///   Looks up a localized string similar to Allow the command to block and require manual action for operations like authentication..
         /// </summary>
-        internal static string PushCommand_Interactive {
+        internal static string PushDeleteCommand_Interactive {
             get {
-                return ResourceManager.GetString("PushCommand_Interactive", resourceCulture);
+                return ResourceManager.GetString("PushDeleteCommand_Interactive", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -555,7 +555,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="ListPkg_TransitiveHeader" xml:space="preserve">
     <value>Transitive Package</value>
   </data>
-  <data name="PushCommand_Interactive" xml:space="preserve">
+  <data name="PushDeleteCommand_Interactive" xml:space="preserve">
     <value>Allow the command to block and require manual action for operations like authentication.</value>
   </data>
   <data name="ListPkg_ErrorFileNotFound" xml:space="preserve">


### PR DESCRIPTION
## Bug
Fixes: Link_to_issue  
Regression: Yes/No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: Make dotnet delete use the new credential provider plugins 

## Testing/Validation
Tests Added: Yes/No  
Reason for not adding tests:  
Validation done:  
