### PR TITLE
Update logging verbosity in SDK resolver

### DIFF
--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkLogger.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkLogger.cs
@@ -50,13 +50,21 @@ namespace Microsoft.Build.NuGetSdkResolver
             switch (level)
             {
                 case LogLevel.Debug:
-                case LogLevel.Minimal:
                 case LogLevel.Verbose:
-                case LogLevel.Information:
-                    // ReSharper disable once RedundantArgumentDefaultValue
+                    // Detailed and Diagnostic verbosity in MSBuild shows high, normal, and low importance messages
                     _sdkLogger.LogMessage(data, MessageImportance.Low);
                     break;
+                    
+                case LogLevel.Information:
+                    // Normal verbosity in MSBuild shows only high and normal importance messages
+                    _sdkLogger.LogMessage(data, MessageImportance.Normal);
+                    break;
 
+                case LogLevel.Minimal:
+                    // Minimal verbosity in MSBuild shows only high importance messages
+                    _sdkLogger.LogMessage(data, MessageImportance.High);
+                    break;
+                    
                 case LogLevel.Warning:
                     _warnings.Add(data);
                     break;

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/NuGetSdkLogger_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/NuGetSdkLogger_Tests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         {
             const string expectedMessage = "67170559A4EC47FE88FCC3E8B68E3522";
 
-            VerifyLog(sdkLogger => sdkLogger.LogInformation(expectedMessage), expectedMessage, MessageImportance.Low, isWarning: false, isError: false);
+            VerifyLog(sdkLogger => sdkLogger.LogInformation(expectedMessage), expectedMessage, MessageImportance.Normal, isWarning: false, isError: false);
         }
 
         [Fact]
@@ -45,13 +45,13 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         {
             const string expectedMessage = "EA9F5D816A0342E38A4A87DB955ABC33";
 
-            VerifyLog(sdkLogger => sdkLogger.LogInformationSummary(expectedMessage), expectedMessage, MessageImportance.Low, isWarning: false, isError: false);
+            VerifyLog(sdkLogger => sdkLogger.LogInformationSummary(expectedMessage), expectedMessage, MessageImportance.Normal, isWarning: false, isError: false);
         }
 
         [Theory]
         [InlineData(LogLevel.Debug, MessageImportance.Low, false, false)]
-        [InlineData(LogLevel.Information, MessageImportance.Low, false, false)]
-        [InlineData(LogLevel.Minimal, MessageImportance.Low, false, false)]
+        [InlineData(LogLevel.Information, MessageImportance.Normal, false, false)]
+        [InlineData(LogLevel.Minimal, MessageImportance.High, false, false)]
         [InlineData(LogLevel.Verbose, MessageImportance.Low, false, false)]
         [InlineData(LogLevel.Error, null, false, true)]
         [InlineData(LogLevel.Warning, null, true, false)]
@@ -65,8 +65,8 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 
         [Theory]
         [InlineData(LogLevel.Debug, MessageImportance.Low, false, false)]
-        [InlineData(LogLevel.Information, MessageImportance.Low, false, false)]
-        [InlineData(LogLevel.Minimal, MessageImportance.Low, false, false)]
+        [InlineData(LogLevel.Information, MessageImportance.Normal, false, false)]
+        [InlineData(LogLevel.Minimal, MessageImportance.High, false, false)]
         [InlineData(LogLevel.Verbose, MessageImportance.Low, false, false)]
         [InlineData(LogLevel.Error, null, false, true)]
         [InlineData(LogLevel.Warning, null, true, false)]
@@ -80,8 +80,8 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 
         [Theory]
         [InlineData(LogLevel.Debug, MessageImportance.Low, false, false)]
-        [InlineData(LogLevel.Information, MessageImportance.Low, false, false)]
-        [InlineData(LogLevel.Minimal, MessageImportance.Low, false, false)]
+        [InlineData(LogLevel.Information, MessageImportance.Normal, false, false)]
+        [InlineData(LogLevel.Minimal, MessageImportance.High, false, false)]
         [InlineData(LogLevel.Verbose, MessageImportance.Low, false, false)]
         [InlineData(LogLevel.Error, null, false, true)]
         [InlineData(LogLevel.Warning, null, true, false)]
@@ -97,8 +97,8 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
 
         [Theory]
         [InlineData(LogLevel.Debug, MessageImportance.Low, false, false)]
-        [InlineData(LogLevel.Information, MessageImportance.Low, false, false)]
-        [InlineData(LogLevel.Minimal, MessageImportance.Low, false, false)]
+        [InlineData(LogLevel.Information, MessageImportance.Normal, false, false)]
+        [InlineData(LogLevel.Minimal, MessageImportance.High, false, false)]
         [InlineData(LogLevel.Verbose, MessageImportance.Low, false, false)]
         [InlineData(LogLevel.Error, null, false, true)]
         [InlineData(LogLevel.Warning, null, true, false)]
@@ -117,7 +117,7 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         {
             const string expectedMessage = "D6412F6087CE41C4803AD940E26E221B";
 
-            VerifyLog(sdkLogger => sdkLogger.LogMinimal(expectedMessage), expectedMessage, MessageImportance.Low, isWarning: false, isError: false);
+            VerifyLog(sdkLogger => sdkLogger.LogMinimal(expectedMessage), expectedMessage, MessageImportance.High, isWarning: false, isError: false);
         }
 
         [Fact]


### PR DESCRIPTION
MSBuild has different verbosities than NuGet.  I didn't fully understand that when writing the SDK resolver.  This fixes the mappings.

Minimal = High Importance
Information = Normal Importance
Verbose = Low Importance

## Bug
Fixes: https://github.com/NuGet/Home/issues/7275
Regression: No
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   
