### PR TITLE
Fixing binding redirects for facade assemblies

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/FrameworkAssemblyResolver.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/FrameworkAssemblyResolver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -87,9 +87,8 @@ namespace NuGet.PackageManagement.VisualStudio
             // Find a frameworkAssembly with the same name as assemblyName.
             // If one exists, see if its version is greater than that of the available version.
             return frameworkAssembliesDictionary[dotNetFrameworkVersion].Any(p =>
-                !p.IsFacade
-                    && string.Equals(p.AssemblyName.Name, simpleAssemblyName, StringComparison.OrdinalIgnoreCase)
-                    && p.AssemblyName.Version > availableVersion);
+                string.Equals(p.AssemblyName.Name, simpleAssemblyName, StringComparison.OrdinalIgnoreCase)
+                && p.AssemblyName.Version >= availableVersion);
         }
 
         /// <summary>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/FrameworkAssemblyResolverTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/FrameworkAssemblyResolverTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -259,7 +259,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         [Theory]
         [InlineData("System.Collections")]
         [InlineData("System.Runtime")]
-        public void FrameworkAssemblyResolver_IsHigherAssemblyVersionInFramework_DoesNotSupportFacadeAssemblies(string simpleAssemblyName)
+        public void FrameworkAssemblyResolver_IsHigherAssemblyVersionInFramework_SupportFacadeAssemblies(string simpleAssemblyName)
         {
             var actualResult = FrameworkAssemblyResolver.IsHigherAssemblyVersionInFramework(
                 simpleAssemblyName,
@@ -268,7 +268,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 frameworkName => new List<string>() { _fixture.Path },
                 _dictionary);
 
-            Assert.False(actualResult);
+            Assert.True(actualResult);
             Assert.Equal(1, _dictionary.Count);
         }
     }


### PR DESCRIPTION
This PR reverts a earlier PR# https://github.com/NuGet/NuGet.Client/pull/946 to allow binding redirects to work with facade assemblies as well instead of skipping those. And also make sure, version check is `>=` so that it also skip adding binding redirects for same versions being pulled from framework.

Fixes - https://devdiv.visualstudio.com/DevDiv/_workitems/edit/666788 

