### PR TITLE
Fix casing in csproj and resx files

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -152,7 +152,7 @@
     <Compile Include="IDE\VSProductUpdateService.cs" />
     <Compile Include="Projects\VsProjectJsonNuGetProject.cs" />
     <Compile Include="SourceControl\DefaultTFSSourceControlManager.cs" />
-    <Compile Include="SourceControl\VsSourceControlManagerProvider.cs" />
+    <Compile Include="SourceControl\VSSourceControlManagerProvider.cs" />
     <Compile Include="OptionsPageActivator.cs" />
     <Compile Include="ProjectSystems\CpsProjectSystem.cs" />
     <Compile Include="ProjectSystems\FSharpProjectSystem.cs" />

--- a/src/NuGet.Clients/NuGet.Tools/VSPackage.resx
+++ b/src/NuGet.Clients/NuGet.Tools/VSPackage.resx
@@ -149,7 +149,7 @@
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="301" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>resources\toolbar.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>Resources\Toolbar.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="4" xml:space="preserve">
     <value>plk</value>

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.legacy.props" />
   <PropertyGroup>
@@ -34,7 +34,7 @@
     <Compile Include="Command.cs" />
     <Compile Include="CommandParser.cs" />
     <Compile Include="Common\CommonResources.cs" />
-    <Compile Include="Common\CommonResources.designer.cs">
+    <Compile Include="Common\CommonResources.Designer.cs">
       <DependentUpon>CommonResources.cs</DependentUpon>
     </Compile>
     <Compile Include="Common\GlobalSuppressions.cs" />

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/Resources.resx
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/Resources.resx
@@ -119,7 +119,7 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Add_WrapperMembers" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>scripts\add-wrappermembers.ps1;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>Scripts\Add-WrapperMembers.ps1;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
   <data name="AggregateSourceName" xml:space="preserve">
     <value>All</value>


### PR DESCRIPTION
The Windows 10 April 2018  update added opt-in case sensitivity on a per-folder basis. Windows Subsystem for Linux uses it by default, so cloning the repo using linux's git binaries causes all folders to be case-sensitive. These changes fix the build when case sensitive directories are used.
