### PR TITLE
Update SelfUpdater.cs

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/SelfUpdater.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/SelfUpdater.cs
@@ -82,7 +82,7 @@ namespace NuGet.CommandLine
             Console.WriteLine(LocalizedResourceManager.GetString("UpdateCommandCurrentlyRunningNuGetExe"), version); // SemanticVersion is the problem
 
             // Check to see if an update is needed
-            if (package == null || version >= package.Version)
+            if (package == null)
             {
                 Console.WriteLine(LocalizedResourceManager.GetString("UpdateCommandNuGetUpToDate"));
             }


### PR DESCRIPTION
Support going back to previous versions of nuget from the latest version.
This is required when troubleshooting bugs with specific versions of msbuild/nuget.

More details here:

https://stackoverflow.com/questions/52287500/how-to-install-a-specific-version-of-nuget