### PR TITLE
Trim quotes when specified in msbuild lockFilePath property

### DIFF
--- a/src/NuGet.Core/NuGet.Common/MsBuildStringUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/MsBuildStringUtility.cs
@@ -19,6 +19,21 @@ namespace NuGet.Common
         }
 
         /// <summary>
+        /// Trim double quotes from the msbuild proprty value.
+        /// </summary>
+        /// <param name="s"></param>
+        /// <returns></returns>
+        public static string TrimQuotes(string s)
+        {
+            if (s == null)
+            {
+                return null;
+            }
+
+            return s.Trim('"');
+        }
+
+        /// <summary>
         /// Split on ; and trim. Null or empty inputs will return an
         /// empty array.
         /// </summary>

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -27,7 +27,7 @@ namespace NuGet.ProjectModel
                 return null;
             }
 
-            var path = project.RestoreMetadata.RestoreLockProperties.NuGetLockFilePath;
+            var path = MSBuildStringUtility.TrimQuotes(project.RestoreMetadata.RestoreLockProperties.NuGetLockFilePath);
 
             if (!string.IsNullOrEmpty(path))
             {


### PR DESCRIPTION
This will trim double quotes when specified while setting `NuGetLockFilePath` msbuild property.

Fixes https://github.com/NuGet/Home/issues/7243