### PR TITLE
Obsolete Settings APIs should be able to create SourceItems

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
@@ -895,12 +895,25 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
         private ISettings PopulateSettingsWithSources(SourceRepositoryProvider sourceRepositoryProvider, TestDirectory settingsDirectory)
         {
-            var Settings = new Settings(settingsDirectory);
-            Settings.DeleteSection(ConfigurationConstants.PackageSources);
-            foreach (var source in sourceRepositoryProvider.GetRepositories())
-                Settings.SetValue(ConfigurationConstants.PackageSources, ConfigurationConstants.PackageSources, source.PackageSource.Source);
+            var settings = new Settings(settingsDirectory);
+            var section = settings.GetSection(ConfigurationConstants.PackageSources);
 
-            return Settings;
+            if (section != null && section.Items.Any())
+            {
+                foreach (var item in section.Items)
+                {
+                    settings.Remove(ConfigurationConstants.PackageSources, item);
+                }
+            }
+
+            foreach (var source in sourceRepositoryProvider.GetRepositories())
+            {
+                settings.AddOrUpdate(ConfigurationConstants.PackageSources, source.PackageSource.AsSourceItem());
+            }
+
+            settings.SaveToDisk();
+
+            return settings;
         }
 
         private SourceRepositoryProvider CreateSource(List<SourcePackageDependencyInfo> packages)


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7307

## Fix
Fixes the issue by creating a `sourceItem` instead of `addItem` when the section is `packageSources`. This change only affects obsolete APIs in Settings.