### PR TITLE
PackageExtractionContext should be created with access to ISettings

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/AddCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/AddCommand.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Packaging;
@@ -38,14 +41,10 @@ namespace NuGet.CommandLine
             // If the Source Feed Folder does not exist, it will be created.
             OfflineFeedUtility.ThrowIfInvalid(Source);
 
-            var packageSaveMode = Expand
-                ? PackageSaveMode.Defaultv3
-                : PackageSaveMode.Nuspec | PackageSaveMode.Nupkg;
-
             var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
 
             var packageExtractionContext = new PackageExtractionContext(
-                packageSaveMode,
+                Expand ? PackageSaveMode.Defaultv3 : PackageSaveMode.Nuspec | PackageSaveMode.Nupkg,
                 PackageExtractionBehavior.XmlDocFileSaveMode,
                 Console,
                 signedPackageVerifier,
@@ -58,7 +57,6 @@ namespace NuGet.CommandLine
                 throwIfSourcePackageIsInvalid: true,
                 throwIfPackageExistsAndInvalid: true,
                 throwIfPackageExists: false,
-                expand: Expand,
                 extractionContext: packageExtractionContext);
 
             await OfflineFeedUtility.AddPackageToSource(offlineFeedAddContext, CancellationToken.None);

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InitCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InitCommand.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -39,14 +42,10 @@ namespace NuGet.CommandLine
 
             if (packagePaths.Count > 0)
             {
-                var packageSaveMode = Expand
-                    ? PackageSaveMode.Defaultv3
-                    : PackageSaveMode.Nuspec | PackageSaveMode.Nupkg;
-
                 var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
 
                 var packageExtractionContext = new PackageExtractionContext(
-                    packageSaveMode,
+                    Expand ? PackageSaveMode.Defaultv3 : PackageSaveMode.Nuspec | PackageSaveMode.Nupkg,
                     PackageExtractionBehavior.XmlDocFileSaveMode,
                     Console,
                     signedPackageVerifier,
@@ -61,7 +60,6 @@ namespace NuGet.CommandLine
                         throwIfSourcePackageIsInvalid: false,
                         throwIfPackageExistsAndInvalid: false,
                         throwIfPackageExists: false,
-                        expand: Expand,
                         extractionContext: packageExtractionContext);
 
                     await OfflineFeedUtility.AddPackageToSource(offlineFeedAddContext, CancellationToken.None);

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -200,10 +200,21 @@ namespace NuGet.CommandLine
                 cacheContext.DirectDownload = DirectDownload;
 
                 var downloadContext = new PackageDownloadContext(cacheContext, installPath, DirectDownload);
+                var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
+                var projectContext = new ConsoleProjectContext(Console)
+                {
+                    PackageExtractionContext = new PackageExtractionContext(
+                        Packaging.PackageSaveMode.Defaultv2,
+                        PackageExtractionBehavior.XmlDocFileSaveMode,
+                        Console,
+                        signedPackageVerifier,
+                        SignedPackageVerifierSettings.GetDefault())
+                };
 
                 var result = await PackageRestoreManager.RestoreMissingPackagesAsync(
                     packageRestoreContext,
-                    new ConsoleProjectContext(Console),
+                    projectContext,
                     downloadContext);
 
                 if (downloadContext.DirectDownload)

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -330,6 +330,7 @@ namespace NuGet.CommandLine
             CheckRequireConsent();
 
             var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+            var signingVerificationSettings = SignedPackageVerifierSettings.GetDefault();
             var projectContext = new ConsoleProjectContext(collectorLogger)
             {
                 PackageExtractionContext = new PackageExtractionContext(
@@ -337,7 +338,7 @@ namespace NuGet.CommandLine
                     PackageExtractionBehavior.XmlDocFileSaveMode,
                     collectorLogger,
                     signedPackageVerifier,
-                    SignedPackageVerifierSettings.GetDefault())
+                    signingVerificationSettings)
             };
 
             if (EffectivePackageSaveMode != Packaging.PackageSaveMode.None)
@@ -350,7 +351,16 @@ namespace NuGet.CommandLine
                 cacheContext.NoCache = NoCache;
                 cacheContext.DirectDownload = DirectDownload;
 
-                var downloadContext = new PackageDownloadContext(cacheContext, packagesFolderPath, DirectDownload);
+                var downloadContext = new PackageDownloadContext(cacheContext, packagesFolderPath, DirectDownload)
+                {
+                    ExtractionContext = new PackageExtractionContext(
+                         Packaging.PackageSaveMode.Defaultv3,
+                         PackageExtractionBehavior.XmlDocFileSaveMode,
+                         collectorLogger,
+                         signedPackageVerifier,
+                         signingVerificationSettings)
+                };
+
 
                 var result = await PackageRestoreManager.RestoreMissingPackagesAsync(
                     packageRestoreContext,

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -361,7 +361,6 @@ namespace NuGet.CommandLine
                          signingVerificationSettings)
                 };
 
-
                 var result = await PackageRestoreManager.RestoreMissingPackagesAsync(
                     packageRestoreContext,
                     projectContext,

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 extern alias CoreV2;
 
 using System;

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -14,6 +14,9 @@ using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
+using NuGet.Packaging.Signing;
+using NuGet.Packaging;
+using NuGet.Packaging.PackageExtraction;
 
 namespace NuGet.CommandLine
 {
@@ -76,6 +79,17 @@ namespace NuGet.CommandLine
 
             _msbuildDirectory = MsBuildUtility.GetMsBuildDirectoryFromMsBuildPath(MSBuildPath, MSBuildVersion, Console).Value.Path;
             var context = new UpdateConsoleProjectContext(Console, FileConflictAction);
+
+            var signedPackageVerifier = new PackageSignatureVerifier(
+                SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+            var signedPackageVerifierSettings = SignedPackageVerifierSettings.GetDefault();
+
+            context.PackageExtractionContext = new PackageExtractionContext(
+                PackageSaveMode.Defaultv2,
+                PackageExtractionBehavior.XmlDocFileSaveMode,
+                new LoggerAdapter(context),
+                signedPackageVerifier,
+                signedPackageVerifierSettings);
 
             string inputFileName = Path.GetFileName(inputFile);
             // update with packages.config as parameter

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -78,11 +78,11 @@ namespace NuGet.CommandLine
             }
 
             _msbuildDirectory = MsBuildUtility.GetMsBuildDirectoryFromMsBuildPath(MSBuildPath, MSBuildVersion, Console).Value.Path;
-            var context = new UpdateConsoleProjectContext(Console, FileConflictAction);
 
-            var signedPackageVerifier = new PackageSignatureVerifier(
-                SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
             var signedPackageVerifierSettings = SignedPackageVerifierSettings.GetDefault();
+
+            var context = new UpdateConsoleProjectContext(Console, FileConflictAction);
 
             context.PackageExtractionContext = new PackageExtractionContext(
                 PackageSaveMode.Defaultv2,

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -254,17 +254,15 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
                         var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
 
-                        var packageExtractionContext = new PackageExtractionContext(
-                            PackageSaveMode.Defaultv3,
-                            PackageExtractionBehavior.XmlDocFileSaveMode,
-                            logger,
-                            signedPackageVerifier,
-                            SignedPackageVerifierSettings.GetDefault());
-
                         var downloadContext = new PackageDownloadContext(cacheContext)
                         {
                             ParentId = OperationId,
-                            ExtractionContext = packageExtractionContext
+                            ExtractionContext = new PackageExtractionContext(
+                                PackageSaveMode.Defaultv3,
+                                PackageExtractionBehavior.XmlDocFileSaveMode,
+                                logger,
+                                signedPackageVerifier,
+                                SignedPackageVerifierSettings.GetDefault())
                         };
 
                         var result = await PackageRestoreManager.RestoreMissingPackagesAsync(

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -76,6 +76,15 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             PackageRestoreManager = ServiceLocator.GetInstance<IPackageRestoreManager>();
             _deleteOnRestartManager = ServiceLocator.GetInstance<IDeleteOnRestartManager>();
 
+            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
+            PackageExtractionContext = new PackageExtractionContext(
+                PackageSaveMode.Defaultv2,
+                PackageExtractionBehavior.XmlDocFileSaveMode,
+                new LoggerAdapter(this),
+                signedPackageVerifier,
+                SignedPackageVerifierSettings.GetDefault());
+
             if (_commonOperations != null)
             {
                 ExecutionContext = new IDEExecutionContext(_commonOperations);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -547,7 +547,8 @@ namespace NuGet.SolutionRestoreManager
             {
                 var downloadContext = new PackageDownloadContext(cacheContext)
                 {
-                    ParentId = _nuGetProjectContext.OperationId
+                    ParentId = _nuGetProjectContext.OperationId,
+                    ExtractionContext = _nuGetProjectContext.PackageExtractionContext
                 };
 
                 await _packageRestoreManager.RestoreMissingPackagesAsync(

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -18,6 +18,8 @@ using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.PackageManagement;
 using NuGet.PackageManagement.VisualStudio;
+using NuGet.Packaging;
+using NuGet.Packaging.PackageExtraction;
 using NuGet.Packaging.Signing;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
@@ -542,13 +544,20 @@ namespace NuGet.SolutionRestoreManager
             CancellationToken token)
         {
             await TaskScheduler.Default;
-
+            
             using (var cacheContext = new SourceCacheContext())
             {
+                var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
                 var downloadContext = new PackageDownloadContext(cacheContext)
                 {
                     ParentId = _nuGetProjectContext.OperationId,
-                    ExtractionContext = _nuGetProjectContext.PackageExtractionContext
+                    ExtractionContext = new PackageExtractionContext(
+                        PackageSaveMode.Defaultv3,
+                        PackageExtractionBehavior.XmlDocFileSaveMode,
+                        logger,
+                        signedPackageVerifier,
+                        SignedPackageVerifierSettings.GetDefault())
                 };
 
                 await _packageRestoreManager.RestoreMissingPackagesAsync(

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
@@ -15,7 +15,10 @@ using Microsoft.VisualStudio.Threading;
 using NuGet.Common;
 using NuGet.PackageManagement;
 using NuGet.PackageManagement.VisualStudio;
+using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.Packaging.PackageExtraction;
+using NuGet.Packaging.Signing;
 using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
 using NuGet.Resolver;
@@ -59,7 +62,19 @@ namespace NuGet.VisualStudio
             _deleteOnRestartManager = deleteOnRestartManager;
             _isCPSJTFLoaded = false;
 
-            _projectContext = new Lazy<INuGetProjectContext>(() => new VSAPIProjectContext());
+            _projectContext = new Lazy<INuGetProjectContext>(() => {
+                var projectContext = new VSAPIProjectContext();
+                var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
+                projectContext.PackageExtractionContext = new PackageExtractionContext(
+                    PackageSaveMode.Defaultv2,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
+                    new LoggerAdapter(projectContext),
+                    signedPackageVerifier,
+                    SignedPackageVerifierSettings.GetDefault());
+
+                return projectContext;
+            });
 
             PumpingJTF = new PumpingJTF(NuGetUIThreadHelper.JoinableTaskFactory);
         }
@@ -164,6 +179,15 @@ namespace NuGet.VisualStudio
 
             var projectContext = new VSAPIProjectContext();
 
+            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
+            projectContext.PackageExtractionContext = new PackageExtractionContext(
+                PackageSaveMode.Defaultv2,
+                PackageExtractionBehavior.XmlDocFileSaveMode,
+                new LoggerAdapter(projectContext),
+                signedPackageVerifier,
+                SignedPackageVerifierSettings.GetDefault());
+
             return InstallInternalAsync(project, toInstall, GetSources(sources), projectContext, includePrerelease, ignoreDependencies, CancellationToken.None);
         }
 
@@ -217,6 +241,14 @@ namespace NuGet.VisualStudio
                     var disableBindingRedirects = skipAssemblyReferences;
 
                     var projectContext = new VSAPIProjectContext(skipAssemblyReferences, disableBindingRedirects);
+                    var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
+                    projectContext.PackageExtractionContext = new PackageExtractionContext(
+                        PackageSaveMode.Defaultv2,
+                        PackageExtractionBehavior.XmlDocFileSaveMode,
+                        new LoggerAdapter(projectContext),
+                        signedPackageVerifier,
+                        SignedPackageVerifierSettings.GetDefault());
 
                     await InstallInternalAsync(
                         project,
@@ -268,6 +300,14 @@ namespace NuGet.VisualStudio
                     var disableBindingRedirects = skipAssemblyReferences;
 
                     var projectContext = new VSAPIProjectContext(skipAssemblyReferences, disableBindingRedirects);
+                    var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
+                    projectContext.PackageExtractionContext = new PackageExtractionContext(
+                        PackageSaveMode.Defaultv2,
+                        PackageExtractionBehavior.XmlDocFileSaveMode,
+                        new LoggerAdapter(projectContext),
+                        signedPackageVerifier,
+                        SignedPackageVerifierSettings.GetDefault());
 
                     return InstallInternalAsync(
                         project,
@@ -438,6 +478,14 @@ namespace NuGet.VisualStudio
             var disableBindingRedirects = skipAssemblyReferences;
 
             var projectContext = new VSAPIProjectContext(skipAssemblyReferences, disableBindingRedirects);
+            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
+            projectContext.PackageExtractionContext = new PackageExtractionContext(
+                PackageSaveMode.Defaultv2,
+                PackageExtractionBehavior.XmlDocFileSaveMode,
+                new LoggerAdapter(projectContext),
+                signedPackageVerifier,
+                SignedPackageVerifierSettings.GetDefault());
 
             await InstallInternalAsync(
                 project,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
@@ -14,6 +14,8 @@ using NuGet.Configuration;
 using NuGet.PackageManagement;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
+using NuGet.Packaging.PackageExtraction;
+using NuGet.Packaging.Signing;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.ProjectModel;
@@ -135,9 +137,19 @@ namespace NuGet.VisualStudio
             {
                 InitializePackageManagerAndPackageFolderPath();
 
+                var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+                var projectContext = new VSAPIProjectContext();
+
+                projectContext.PackageExtractionContext = new PackageExtractionContext(
+                    PackageSaveMode.Defaultv2,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
+                    new LoggerAdapter(projectContext),
+                    signedPackageVerifier,
+                    SignedPackageVerifierSettings.GetDefault());
+
                 var nuGetProject = await _solutionManager.GetOrCreateProjectAsync(
                                     project,
-                                    new VSAPIProjectContext());
+                                    projectContext);
 
                 var installedPackages = await nuGetProject.GetInstalledPackagesAsync(CancellationToken.None);
                 packages.AddRange(installedPackages);
@@ -162,9 +174,19 @@ namespace NuGet.VisualStudio
                     {
                         InitializePackageManagerAndPackageFolderPath();
 
+                        var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
+                        var projectContext = new VSAPIProjectContext();
+                        projectContext.PackageExtractionContext = new PackageExtractionContext(
+                            PackageSaveMode.Defaultv2,
+                            PackageExtractionBehavior.XmlDocFileSaveMode,
+                            new LoggerAdapter(projectContext),
+                            signedPackageVerifier,
+                            SignedPackageVerifierSettings.GetDefault());
+
                         var nuGetProject = await _solutionManager.GetOrCreateProjectAsync(
                                             project,
-                                            new VSAPIProjectContext());
+                                            projectContext);
 
                         if (nuGetProject != null)
                         {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageUninstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageUninstaller.cs
@@ -9,6 +9,9 @@ using EnvDTE;
 using Microsoft.VisualStudio.Threading;
 using NuGet.PackageManagement;
 using NuGet.PackageManagement.VisualStudio;
+using NuGet.Packaging;
+using NuGet.Packaging.PackageExtraction;
+using NuGet.Packaging.Signing;
 using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
 
@@ -62,6 +65,15 @@ namespace NuGet.VisualStudio
 
                     UninstallationContext uninstallContext = new UninstallationContext(removeDependencies, false);
                     VSAPIProjectContext projectContext = new VSAPIProjectContext();
+
+                    var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
+                    projectContext.PackageExtractionContext = new PackageExtractionContext(
+                        PackageSaveMode.Defaultv2,
+                        PackageExtractionBehavior.XmlDocFileSaveMode,
+                        new LoggerAdapter(projectContext),
+                        signedPackageVerifier,
+                        SignedPackageVerifierSettings.GetDefault());
 
                     // find the project
                     NuGetProject nuGetProject = await _solutionManager.GetOrCreateProjectAsync(project, projectContext);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPathContextProvider.cs
@@ -17,6 +17,8 @@ using NuGet.PackageManagement;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.Packaging.PackageExtraction;
+using NuGet.Packaging.Signing;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.ProjectModel;
@@ -36,7 +38,20 @@ namespace NuGet.VisualStudio
         private readonly Lazy<NuGet.Common.ILogger> _logger;
         private readonly Func<BuildIntegratedNuGetProject, Task<LockFile>> _getLockFileOrNullAsync;
 
-        private readonly Lazy<INuGetProjectContext> _projectContext = new Lazy<INuGetProjectContext>(() => new VSAPIProjectContext());
+        private readonly Lazy<INuGetProjectContext> _projectContext = new Lazy<INuGetProjectContext>(() => {
+            var projectContext = new VSAPIProjectContext();
+
+            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
+            projectContext.PackageExtractionContext = new PackageExtractionContext(
+                PackageSaveMode.Defaultv2,
+                PackageExtractionBehavior.XmlDocFileSaveMode,
+                new LoggerAdapter(projectContext),
+                signedPackageVerifier,
+                SignedPackageVerifierSettings.GetDefault());
+
+            return projectContext;
+        });
         
 
         [ImportingConstructor]

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/PreinstalledPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/PreinstalledPackageInstaller.cs
@@ -39,6 +39,7 @@ namespace NuGet.VisualStudio
         private readonly ISourceRepositoryProvider _sourceProvider;
         private readonly VsPackageInstaller _installer;
         private readonly IVsProjectAdapterProvider _vsProjectAdapterProvider;
+        private readonly Configuration.ISettings _settings;
 
         public Action<string> InfoHandler { get; set; }
 
@@ -55,6 +56,7 @@ namespace NuGet.VisualStudio
             _sourceProvider = sourceProvider;
             _vsProjectAdapterProvider = vsProjectAdapterProvider;
             _installer = installer;
+            _settings = settings;
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/PreinstalledPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/PreinstalledPackageInstaller.cs
@@ -17,6 +17,8 @@ using NuGet.PackageManagement;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.Packaging.PackageExtraction;
+using NuGet.Packaging.Signing;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.Protocol;
@@ -174,6 +176,15 @@ namespace NuGet.VisualStudio
 
             // find the project
             var defaultProjectContext = new VSAPIProjectContext();
+            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
+            defaultProjectContext.PackageExtractionContext = new PackageExtractionContext(
+                PackageSaveMode.Defaultv2,
+                PackageExtractionBehavior.XmlDocFileSaveMode,
+                new LoggerAdapter(defaultProjectContext),
+                signedPackageVerifier,
+                SignedPackageVerifierSettings.GetDefault());
+
             var nuGetProject = await _solutionManager.GetOrCreateProjectAsync(project, defaultProjectContext);
             if (preferPackageReferenceFormat && await NuGetProjectUpgradeUtility.IsNuGetProjectUpgradeableAsync(nuGetProject, project, needsAPackagesConfig: false))
             {
@@ -228,6 +239,13 @@ namespace NuGet.VisualStudio
                             var disableBindingRedirects = package.SkipAssemblyReferences;
 
                             var projectContext = new VSAPIProjectContext(package.SkipAssemblyReferences, disableBindingRedirects);
+
+                            projectContext.PackageExtractionContext = new PackageExtractionContext(
+                                PackageSaveMode.Defaultv2,
+                                PackageExtractionBehavior.XmlDocFileSaveMode,
+                                new LoggerAdapter(projectContext),
+                                signedPackageVerifier,
+                                SignedPackageVerifierSettings.GetDefault());
 
                             // This runs from the UI thread
                             await _installer.InstallInternalCoreAsync(
@@ -326,6 +344,15 @@ namespace NuGet.VisualStudio
             }
 
             VSAPIProjectContext context = new VSAPIProjectContext(skipAssemblyReferences: true, bindingRedirectsDisabled: true);
+            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
+            context.PackageExtractionContext = new PackageExtractionContext(
+                PackageSaveMode.Defaultv2,
+                PackageExtractionBehavior.XmlDocFileSaveMode,
+                new LoggerAdapter(context),
+                signedPackageVerifier,
+                SignedPackageVerifierSettings.GetDefault());
+
             WebSiteProjectSystem projectSystem = new WebSiteProjectSystem(_vsProjectAdapterProvider.CreateAdapterForFullyLoadedProject(project), context);
 
             foreach (var packageName in packageNames)
@@ -370,6 +397,14 @@ namespace NuGet.VisualStudio
         private void CopyNativeBinariesToBin(EnvDTE.Project project, string repositoryPath, IEnumerable<PreinstalledPackageInfo> packageInfos)
         {
             var context = new VSAPIProjectContext();
+            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
+            context.PackageExtractionContext = new PackageExtractionContext(
+                PackageSaveMode.Defaultv2,
+                PackageExtractionBehavior.XmlDocFileSaveMode,
+                new LoggerAdapter(context),
+                signedPackageVerifier,
+                SignedPackageVerifierSettings.GetDefault());
             var projectSystem = new VsMSBuildProjectSystem(_vsProjectAdapterProvider.CreateAdapterForFullyLoadedProject(project), context);
 
             foreach (var packageInfo in packageInfos)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VSAPIProjectContext.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VSAPIProjectContext.cs
@@ -23,15 +23,6 @@ namespace NuGet.VisualStudio
 
         public VSAPIProjectContext(bool skipAssemblyReferences, bool bindingRedirectsDisabled)
         {
-            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
-
-            PackageExtractionContext = new PackageExtractionContext(
-                PackageSaveMode.Defaultv2,
-                PackageExtractionBehavior.XmlDocFileSaveMode,
-                new LoggerAdapter(this),
-                signedPackageVerifier,
-                SignedPackageVerifierSettings.GetDefault());
-
             SourceControlManagerProvider = ServiceLocator.GetInstanceSafe<ISourceControlManagerProvider>();
             SkipAssemblyReferences = skipAssemblyReferences;
             BindingRedirectsDisabled = bindingRedirectsDisabled;

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PushRunner.cs
@@ -37,6 +37,7 @@ namespace NuGet.Commands
             }
 
             var packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, source);
+            packageUpdateResource.Settings = settings;
             SymbolPackageUpdateResourceV3 symbolPackageUpdateResource = null;
 
             // figure out from index.json if pushing snupkg is supported

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/OriginalCaseGlobalPackageFolder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/OriginalCaseGlobalPackageFolder.cs
@@ -61,7 +61,6 @@ namespace NuGet.Commands
             // Keep track of the packages we've already converted to original case.
             var converted = new HashSet<PackageIdentity>();
 
-            var originalCaseContext = _request.PackageExtractionContext;
             var versionFolderPathResolver = new VersionFolderPathResolver(_request.PackagesDirectory, _request.IsLowercasePackagesDirectory);
 
             // Iterate over every package node.
@@ -112,7 +111,7 @@ namespace NuGet.Commands
                             identity,
                             packageDependency,
                             versionFolderPathResolver,
-                            originalCaseContext,
+                            _request.PackageExtractionContext,
                             token,
                             ParentId);
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/OriginalCaseGlobalPackageFolder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/OriginalCaseGlobalPackageFolder.cs
@@ -61,7 +61,7 @@ namespace NuGet.Commands
             // Keep track of the packages we've already converted to original case.
             var converted = new HashSet<PackageIdentity>();
 
-            var originalCaseContext = GetPathContext();
+            var originalCaseContext = _request.PackageExtractionContext;
             var versionFolderPathResolver = new VersionFolderPathResolver(_request.PackagesDirectory, _request.IsLowercasePackagesDirectory);
 
             // Iterate over every package node.
@@ -139,18 +139,6 @@ namespace NuGet.Commands
                 var path = _pathResolver.GetPackageDirectory(library.Name, library.Version);
                 library.Path = PathUtility.GetPathWithForwardSlashes(path);
             }
-        }
-
-        private PackageExtractionContext GetPathContext()
-        {
-            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
-
-            return new PackageExtractionContext(
-                _request.PackageSaveMode,
-                _request.XmlDocFileSaveMode,
-                _request.Log,
-                signedPackageVerifier,
-                SignedPackageVerifierSettings.GetDefault());
         }
 
         private static PackageIdentity GetPackageIdentity(RemoteMatch remoteMatch)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreRequest.cs
@@ -21,15 +21,8 @@ namespace NuGet.Commands
             PackagesDirectory = request.PackagesDirectory;
             ExistingLockFile = existingLockFile;
             MaxDegreeOfConcurrency = request.MaxDegreeOfConcurrency;
-            PackageSaveMode = request.PackageSaveMode;
             Project = packageSpec;
-            XmlDocFileSaveMode = request.XmlDocFileSaveMode;
-            PackageExtractionContext = new PackageExtractionContext(
-                request.PackageSaveMode,
-                request.XmlDocFileSaveMode,
-                log,
-                request.PackageSignatureVerifier,
-                request.SignedPackageVerifierSettings);
+            PackageExtractionContext = request.PackageExtractionContext;
         }
 
         public SourceCacheContext CacheContext { get; }
@@ -38,8 +31,6 @@ namespace NuGet.Commands
         public int MaxDegreeOfConcurrency { get; }
         public LockFile ExistingLockFile { get; }
         public PackageSpec Project { get; }
-        public PackageSaveMode PackageSaveMode { get; }
-        public XmlDocFileSaveMode XmlDocFileSaveMode { get; }
         public PackageExtractionContext PackageExtractionContext { get; }
         public Guid ParentId { get; set; }
     }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -3,15 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Configuration;
-using NuGet.Packaging;
-using NuGet.Packaging.PackageExtraction;
-using NuGet.Packaging.Signing;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using NuGet.Shared;
@@ -135,6 +131,7 @@ namespace NuGet.Commands
             var globalPath = GetPackagesPath(restoreArgs, projectPackageSpec);
             var settings = Settings.LoadSettingsGivenConfigPaths(projectPackageSpec.RestoreMetadata.ConfigFilePaths);
             var sources = restoreArgs.GetEffectiveSources(settings, projectPackageSpec.RestoreMetadata.Sources);
+            var extractionContext = restoreArgs.GetPackageExtractionContext(settings);
 
             var sharedCache = _providerCache.GetOrCreate(
                 globalPath,
@@ -144,14 +141,6 @@ namespace NuGet.Commands
                 restoreArgs.Log);
             
             var rootPath = Path.GetDirectoryName(project.PackageSpec.FilePath);
-            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
-
-            var extractionContext = new PackageExtractionContext(
-                restoreArgs.PackageSaveMode,
-                PackageExtractionBehavior.XmlDocFileSaveMode,
-                restoreArgs.Log,
-                signedPackageVerifier,
-                SignedPackageVerifierSettings.GetDefault());
 
             // Create request
             var request = new RestoreRequest(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -9,6 +9,9 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Configuration;
+using NuGet.Packaging;
+using NuGet.Packaging.PackageExtraction;
+using NuGet.Packaging.Signing;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using NuGet.Shared;
@@ -141,12 +144,21 @@ namespace NuGet.Commands
                 restoreArgs.Log);
             
             var rootPath = Path.GetDirectoryName(project.PackageSpec.FilePath);
+            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
+            var extractionContext = new PackageExtractionContext(
+                restoreArgs.PackageSaveMode,
+                PackageExtractionBehavior.XmlDocFileSaveMode,
+                restoreArgs.Log,
+                signedPackageVerifier,
+                SignedPackageVerifierSettings.GetDefault());
 
             // Create request
             var request = new RestoreRequest(
                 project.PackageSpec,
                 sharedCache,
                 restoreArgs.CacheContext,
+                extractionContext,
                 restoreArgs.Log)
             {
                 // Set properties from the restore metadata

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -9,6 +9,8 @@ using System.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Packaging;
+using NuGet.Packaging.PackageExtraction;
+using NuGet.Packaging.Signing;
 using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -174,6 +176,18 @@ namespace NuGet.Commands
             }
 
             return sourceObjects.Select(entry => CachingSourceProvider.CreateRepository(entry.Value)).ToList();
+        }
+
+        internal PackageExtractionContext GetPackageExtractionContext(ISettings settings)
+        {
+            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
+            return new PackageExtractionContext(
+                PackageSaveMode,
+                PackageExtractionBehavior.XmlDocFileSaveMode,
+                Log,
+                signedPackageVerifier,
+                SignedPackageVerifierSettings.GetDefault());
         }
 
         public void ApplyStandardProperties(RestoreRequest request)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -178,8 +178,6 @@ namespace NuGet.Commands
 
         public void ApplyStandardProperties(RestoreRequest request)
         {
-            request.PackageSaveMode = PackageSaveMode;
-
             if (request.ProjectStyle == ProjectStyle.PackageReference
                 || request.ProjectStyle == ProjectStyle.DotnetToolReference
                 || request.ProjectStyle == ProjectStyle.Standalone)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
@@ -7,8 +7,6 @@ using System.IO;
 using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging;
-using NuGet.Packaging.PackageExtraction;
-using NuGet.Packaging.Signing;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 
@@ -17,11 +15,12 @@ namespace NuGet.Commands
     public class RestoreRequest
     {
         public static readonly int DefaultDegreeOfConcurrency = 16;
-        
+
         public RestoreRequest(
             PackageSpec project,
             RestoreCommandProviders dependencyProviders,
             SourceCacheContext cacheContext,
+            PackageExtractionContext extractionContext,
             ILogger log)
         {
 
@@ -29,6 +28,7 @@ namespace NuGet.Commands
             Log = log ?? throw new ArgumentNullException(nameof(log));
             Project = project ?? throw new ArgumentNullException(nameof(project));
             DependencyProviders = dependencyProviders ?? throw new ArgumentNullException(nameof(dependencyProviders));
+            PackageExtractionContext = extractionContext ?? throw new ArgumentNullException(nameof(extractionContext));
 
             ExternalProjects = new List<ExternalProjectReference>();
             CompatibilityProfiles = new HashSet<FrameworkRuntimePair>();
@@ -107,18 +107,11 @@ namespace NuGet.Commands
         public ISet<string> RequestedRuntimes { get; } = new SortedSet<string>(StringComparer.Ordinal);
 
         /// <summary>
-        /// Gets or sets the <see cref="Packaging.PackageSaveMode"/>.
-        /// </summary>
-        public PackageSaveMode PackageSaveMode { get; set; } = PackageSaveMode.Defaultv3;
-
-        /// <summary>
         /// These Runtime Ids will be used if <see cref="RequestedRuntimes"/> and the project runtimes
         /// are both empty.
         /// </summary>
         /// <remarks>RIDs are case sensitive.</remarks>
         public ISet<string> FallbackRuntimes { get; } = new SortedSet<string>(StringComparer.Ordinal);
-
-        public XmlDocFileSaveMode XmlDocFileSaveMode { get; set; } = PackageExtractionBehavior.XmlDocFileSaveMode;
 
         /// <summary>
         /// This contains resources that are shared between project restores.
@@ -141,7 +134,7 @@ namespace NuGet.Commands
         /// </summary>
         public string MSBuildProjectExtensionsPath { get; set; }
 
-        
+
         /// <summary>
         /// Compatibility options
         /// </summary>
@@ -152,15 +145,7 @@ namespace NuGet.Commands
         /// </summary>
         public bool HideWarningsAndErrors { get; set; } = false;
 
-        /// <summary>
-        /// Package Signature verifier
-        /// </summary>
-        public IPackageSignatureVerifier PackageSignatureVerifier { get; set; } = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
-
-        /// <summary>
-        /// SignedPackageVerifierSettings to be used when verifying signed packages.
-        /// </summary>
-        public SignedPackageVerifierSettings SignedPackageVerifierSettings { get; set; } = SignedPackageVerifierSettings.GetDefault();
+        public PackageExtractionContext PackageExtractionContext { get; set; }
 
         public Guid ParentId { get; set;}
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
@@ -134,7 +134,6 @@ namespace NuGet.Commands
         /// </summary>
         public string MSBuildProjectExtensionsPath { get; set; }
 
-
         /// <summary>
         /// Compatibility options
         /// </summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
@@ -192,10 +192,17 @@ namespace NuGet.PackageManagement
 
             using (var cacheContext = new SourceCacheContext())
             {
+                var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
                 var downloadContext = new PackageDownloadContext(cacheContext)
                 {
                     ParentId = nuGetProjectContext.OperationId,
-                    ExtractionContext = nuGetProjectContext.PackageExtractionContext
+                    ExtractionContext = new PackageExtractionContext(
+                        PackageSaveMode.Defaultv3,
+                        PackageExtractionBehavior.XmlDocFileSaveMode,
+                        new LoggerAdapter(nuGetProjectContext),
+                        signedPackageVerifier,
+                        SignedPackageVerifierSettings.GetDefault())
                 };
 
                 return await RestoreMissingPackagesAsync(
@@ -229,10 +236,17 @@ namespace NuGet.PackageManagement
 
             using (var cacheContext = new SourceCacheContext())
             {
+                var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
                 var downloadContext = new PackageDownloadContext(cacheContext)
                 {
                     ParentId = nuGetProjectContext.OperationId,
-                    ExtractionContext = nuGetProjectContext.PackageExtractionContext
+                    ExtractionContext = new PackageExtractionContext(
+                        PackageSaveMode.Defaultv3,
+                        PackageExtractionBehavior.XmlDocFileSaveMode,
+                        new LoggerAdapter(nuGetProjectContext),
+                        signedPackageVerifier,
+                        SignedPackageVerifierSettings.GetDefault())
                 };
 
                 return await RestoreMissingPackagesAsync(

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -16,6 +16,7 @@ using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.Packaging.PackageExtraction;
 using NuGet.Packaging.Signing;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
@@ -189,10 +190,17 @@ namespace NuGet.PackageManagement
             IEnumerable<SourceRepository> secondarySources,
             CancellationToken token)
         {
+            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
             var downloadContext = new PackageDownloadContext(resolutionContext.SourceCacheContext)
             {
                 ParentId = nuGetProjectContext.OperationId,
-                ExtractionContext = nuGetProjectContext.PackageExtractionContext
+                ExtractionContext = new PackageExtractionContext(
+                    PackageSaveMode.Defaultv3,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
+                    new LoggerAdapter(nuGetProjectContext),
+                    signedPackageVerifier,
+                    SignedPackageVerifierSettings.GetDefault())
             };
 
             return InstallPackageAsync(
@@ -241,10 +249,17 @@ namespace NuGet.PackageManagement
             INuGetProjectContext nuGetProjectContext, IEnumerable<SourceRepository> primarySources,
             IEnumerable<SourceRepository> secondarySources, CancellationToken token)
         {
+            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
             var downloadContext = new PackageDownloadContext(resolutionContext.SourceCacheContext)
             {
                 ParentId = nuGetProjectContext.OperationId,
-                ExtractionContext = nuGetProjectContext.PackageExtractionContext
+                ExtractionContext = new PackageExtractionContext(
+                    PackageSaveMode.Defaultv3,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
+                    new LoggerAdapter(nuGetProjectContext),
+                    signedPackageVerifier,
+                    SignedPackageVerifierSettings.GetDefault())
             };
 
             await InstallPackageAsync(
@@ -313,10 +328,17 @@ namespace NuGet.PackageManagement
             IEnumerable<SourceRepository> secondarySources,
             CancellationToken token)
         {
+            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
             var downloadContext = new PackageDownloadContext(resolutionContext.SourceCacheContext)
             {
                 ParentId = nuGetProjectContext.OperationId,
-                ExtractionContext = nuGetProjectContext.PackageExtractionContext
+                ExtractionContext = new PackageExtractionContext(
+                    PackageSaveMode.Defaultv3,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
+                    new LoggerAdapter(nuGetProjectContext),
+                    signedPackageVerifier,
+                    SignedPackageVerifierSettings.GetDefault())
             };
 
             return InstallPackageAsync(
@@ -368,10 +390,17 @@ namespace NuGet.PackageManagement
             IEnumerable<SourceRepository> secondarySources,
             CancellationToken token)
         {
+            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
             var downloadContext = new PackageDownloadContext(resolutionContext.SourceCacheContext)
             {
                 ParentId = nuGetProjectContext.OperationId,
-                ExtractionContext = nuGetProjectContext.PackageExtractionContext
+                ExtractionContext = new PackageExtractionContext(
+                    PackageSaveMode.Defaultv3,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
+                    new LoggerAdapter(nuGetProjectContext),
+                    signedPackageVerifier,
+                    SignedPackageVerifierSettings.GetDefault())
             };
 
             await InstallPackageAsync(
@@ -2120,10 +2149,17 @@ namespace NuGet.PackageManagement
             SourceCacheContext sourceCacheContext,
             CancellationToken token)
         {
+            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
+
             var downloadContext = new PackageDownloadContext(sourceCacheContext)
             {
                 ParentId = nuGetProjectContext.OperationId,
-                ExtractionContext = nuGetProjectContext.PackageExtractionContext
+                ExtractionContext = new PackageExtractionContext(
+                    PackageSaveMode.Defaultv3,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
+                    new LoggerAdapter(nuGetProjectContext),
+                    signedPackageVerifier,
+                    SignedPackageVerifierSettings.GetDefault())
             };
 
             await ExecuteNuGetProjectActionsAsync(nuGetProject,

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -191,7 +191,8 @@ namespace NuGet.PackageManagement
         {
             var downloadContext = new PackageDownloadContext(resolutionContext.SourceCacheContext)
             {
-                ParentId = nuGetProjectContext.OperationId
+                ParentId = nuGetProjectContext.OperationId,
+                ExtractionContext = nuGetProjectContext.PackageExtractionContext
             };
 
             return InstallPackageAsync(
@@ -242,7 +243,8 @@ namespace NuGet.PackageManagement
         {
             var downloadContext = new PackageDownloadContext(resolutionContext.SourceCacheContext)
             {
-                ParentId = nuGetProjectContext.OperationId
+                ParentId = nuGetProjectContext.OperationId,
+                ExtractionContext = nuGetProjectContext.PackageExtractionContext
             };
 
             await InstallPackageAsync(
@@ -313,7 +315,8 @@ namespace NuGet.PackageManagement
         {
             var downloadContext = new PackageDownloadContext(resolutionContext.SourceCacheContext)
             {
-                ParentId = nuGetProjectContext.OperationId
+                ParentId = nuGetProjectContext.OperationId,
+                ExtractionContext = nuGetProjectContext.PackageExtractionContext
             };
 
             return InstallPackageAsync(
@@ -367,7 +370,8 @@ namespace NuGet.PackageManagement
         {
             var downloadContext = new PackageDownloadContext(resolutionContext.SourceCacheContext)
             {
-                ParentId = nuGetProjectContext.OperationId
+                ParentId = nuGetProjectContext.OperationId,
+                ExtractionContext = nuGetProjectContext.PackageExtractionContext
             };
 
             await InstallPackageAsync(
@@ -2118,7 +2122,8 @@ namespace NuGet.PackageManagement
         {
             var downloadContext = new PackageDownloadContext(sourceCacheContext)
             {
-                ParentId = nuGetProjectContext.OperationId
+                ParentId = nuGetProjectContext.OperationId,
+                ExtractionContext = nuGetProjectContext.PackageExtractionContext
             };
 
             await ExecuteNuGetProjectActionsAsync(nuGetProject,

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/FolderNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/FolderNuGetProject.cs
@@ -143,24 +143,9 @@ namespace NuGet.ProjectManagement
                 packageDirectory,
                 action: async cancellationToken =>
                 {
-                    // 1. Set a default package extraction context, if necessary.
                     var packageExtractionContext = nuGetProjectContext.PackageExtractionContext;
 
-                    if (packageExtractionContext == null)
-                    {
-                        var signedPackageVerifier = !downloadResourceResult.SignatureVerified ? new PackageSignatureVerifier(
-                            SignatureVerificationProviderFactory.GetSignatureVerificationProviders()) : null;
-                        var signedPackageVerifierSettings = !downloadResourceResult.SignatureVerified ? SignedPackageVerifierSettings.GetDefault() : null;
-
-                        packageExtractionContext = new PackageExtractionContext(
-                            PackageSaveMode.Defaultv2,
-                            PackageExtractionBehavior.XmlDocFileSaveMode,
-                            new LoggerAdapter(nuGetProjectContext),
-                            signedPackageVerifier,
-                            signedPackageVerifierSettings);
-                    }
-
-                    // 2. Check if the Package already exists at root, if so, return false
+                    // 1. Check if the Package already exists at root, if so, return false
                     if (PackageExists(packageIdentity, packageExtractionContext.PackageSaveMode))
                     {
                         nuGetProjectContext.Log(MessageLevel.Info, Strings.PackageAlreadyExistsInFolder, packageIdentity, Root);
@@ -169,7 +154,7 @@ namespace NuGet.ProjectManagement
 
                     nuGetProjectContext.Log(MessageLevel.Info, Strings.AddingPackageToFolder, packageIdentity, Path.GetFullPath(Root));
 
-                    // 3. Call PackageExtractor to extract the package into the root directory of this FileSystemNuGetProject
+                    // 2. Call PackageExtractor to extract the package into the root directory of this FileSystemNuGetProject
                     if (downloadResourceResult.Status == DownloadResourceResultStatus.Available)
                     {
                         downloadResourceResult.PackageStream.Seek(0, SeekOrigin.Begin);
@@ -414,24 +399,11 @@ namespace NuGet.ProjectManagement
 
             token.ThrowIfCancellationRequested();
 
-            var packageExtractionContext = nuGetProjectContext.PackageExtractionContext;
-            if (packageExtractionContext == null)
-            {
-                var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
-
-                packageExtractionContext = new PackageExtractionContext(
-                    PackageSaveMode.Defaultv2,
-                    PackageExtractionBehavior.XmlDocFileSaveMode,
-                    new LoggerAdapter(nuGetProjectContext),
-                    signedPackageVerifier,
-                    SignedPackageVerifierSettings.GetDefault());
-            }
-
             var copiedSatelliteFiles = await PackageExtractor.CopySatelliteFilesAsync(
                 packageIdentity,
                 PackagePathResolver,
                 GetPackageSaveMode(nuGetProjectContext),
-                packageExtractionContext,
+                nuGetProjectContext.PackageExtractionContext,
                 token);
 
             FileSystemUtility.PendAddFiles(copiedSatelliteFiles, Root, nuGetProjectContext);

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
@@ -77,11 +77,15 @@ namespace NuGet.Packaging.Signing
                 throw new ArgumentNullException(nameof(issues));
             }
 
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
             verificationFlags = SignatureVerificationStatusFlags.NoErrors;
             validTimestamp = null;
 
             var timestamps = Timestamps;
-            settings = settings ?? SignedPackageVerifierSettings.GetDefault();
 
             if (timestamps.Count == 0)
             {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Timestamp.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Timestamp.cs
@@ -104,7 +104,11 @@ namespace NuGet.Packaging.Signing
             HashAlgorithmName fingerprintAlgorithm,
             List<SignatureLog> issues)
         {
-            settings = settings ?? SignedPackageVerifierSettings.GetDefault();
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
             var flags = SignatureVerificationStatusFlags.NoErrors;
 
             if (signature == null)

--- a/src/NuGet.Core/NuGet.Protocol/PackageDownloadContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/PackageDownloadContext.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using NuGet.Packaging;
 
 namespace NuGet.Protocol.Core.Types
 {
@@ -42,5 +43,7 @@ namespace NuGet.Protocol.Core.Types
         public string DirectDownloadDirectory { get; }
 
         public Guid ParentId { get; set; }
+
+        public PackageExtractionContext ExtractionContext {get;set;}
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/PackageDownloadContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/PackageDownloadContext.cs
@@ -44,6 +44,6 @@ namespace NuGet.Protocol.Core.Types
 
         public Guid ParentId { get; set; }
 
-        public PackageExtractionContext ExtractionContext {get;set;}
+        public PackageExtractionContext ExtractionContext { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -431,7 +431,6 @@ namespace NuGet.Protocol.Core.Types
                     throwIfSourcePackageIsInvalid: true,
                     throwIfPackageExistsAndInvalid: false,
                     throwIfPackageExists: false,
-                    expand: true,
                     extractionContext: packageExtractionContext);
                 
                 await OfflineFeedUtility.AddPackageToSource(context, token);

--- a/src/NuGet.Core/NuGet.Protocol/Utility/GetDownloadResultUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/GetDownloadResultUtility.cs
@@ -93,6 +93,7 @@ namespace NuGet.Protocol
                                     packageStream,
                                     globalPackagesFolder,
                                     downloadContext.ParentId,
+                                    downloadContext.ExtractionContext,
                                     logger,
                                     token);
                             }

--- a/src/NuGet.Core/NuGet.Protocol/Utility/GlobalPackagesFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/GlobalPackagesFolderUtility.cs
@@ -79,6 +79,7 @@ namespace NuGet.Protocol
             Stream packageStream,
             string globalPackagesFolder,
             Guid parentId,
+            PackageExtractionContext extractionContext,
             ILogger logger,
             CancellationToken token)
         {
@@ -97,18 +98,9 @@ namespace NuGet.Protocol
                 throw new ArgumentNullException(nameof(globalPackagesFolder));
             }
 
-            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
-
             // The following call adds it to the global packages folder.
             // Addition is performed using ConcurrentUtils, such that,
             // multiple processes may add at the same time
-
-            var packageExtractionContext = new PackageExtractionContext(
-                PackageSaveMode.Defaultv3,
-                PackageExtractionBehavior.XmlDocFileSaveMode,
-                logger,
-                signedPackageVerifier,
-                SignedPackageVerifierSettings.GetDefault());
 
             var versionFolderPathResolver = new VersionFolderPathResolver(globalPackagesFolder);
 
@@ -117,7 +109,7 @@ namespace NuGet.Protocol
                 packageIdentity,
                 stream => packageStream.CopyToAsync(stream, BufferSize, token),
                 versionFolderPathResolver,
-                packageExtractionContext,
+                extractionContext,
                 token,
                 parentId);
 

--- a/src/NuGet.Core/NuGet.Protocol/Utility/OfflineFeedAddContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/OfflineFeedAddContext.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Globalization;
-using NuGet.Protocol;
+using NuGet.Packaging;
 
 namespace NuGet.Protocol.Core.Types
 {
@@ -16,6 +16,7 @@ namespace NuGet.Protocol.Core.Types
         public bool ThrowIfPackageExistsAndInvalid { get; }
         public bool ThrowIfPackageExists { get; }
         public bool Expand { get; }
+        public PackageExtractionContext ExtractionContext {get;}
 
         public OfflineFeedAddContext(
             string packagePath,
@@ -24,7 +25,8 @@ namespace NuGet.Protocol.Core.Types
             bool throwIfSourcePackageIsInvalid,
             bool throwIfPackageExistsAndInvalid,
             bool throwIfPackageExists,
-            bool expand)
+            bool expand,
+            PackageExtractionContext extractionContext)
         {
             if (string.IsNullOrEmpty(packagePath))
             {
@@ -40,18 +42,14 @@ namespace NuGet.Protocol.Core.Types
                     nameof(source)));
             }
 
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
             PackagePath = packagePath;
             Source = source;
-            Logger = logger;
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             ThrowIfSourcePackageIsInvalid = throwIfSourcePackageIsInvalid;
             ThrowIfPackageExists = throwIfPackageExists;
             ThrowIfPackageExistsAndInvalid = throwIfPackageExistsAndInvalid;
             Expand = expand;
+            ExtractionContext = extractionContext ?? throw new ArgumentNullException(nameof(extractionContext));
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Utility/OfflineFeedAddContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/OfflineFeedAddContext.cs
@@ -15,8 +15,7 @@ namespace NuGet.Protocol.Core.Types
         public bool ThrowIfSourcePackageIsInvalid { get; }
         public bool ThrowIfPackageExistsAndInvalid { get; }
         public bool ThrowIfPackageExists { get; }
-        public bool Expand { get; }
-        public PackageExtractionContext ExtractionContext {get;}
+        public PackageExtractionContext ExtractionContext { get; }
 
         public OfflineFeedAddContext(
             string packagePath,
@@ -25,7 +24,6 @@ namespace NuGet.Protocol.Core.Types
             bool throwIfSourcePackageIsInvalid,
             bool throwIfPackageExistsAndInvalid,
             bool throwIfPackageExists,
-            bool expand,
             PackageExtractionContext extractionContext)
         {
             if (string.IsNullOrEmpty(packagePath))
@@ -48,7 +46,6 @@ namespace NuGet.Protocol.Core.Types
             ThrowIfSourcePackageIsInvalid = throwIfSourcePackageIsInvalid;
             ThrowIfPackageExists = throwIfPackageExists;
             ThrowIfPackageExistsAndInvalid = throwIfPackageExistsAndInvalid;
-            Expand = expand;
             ExtractionContext = extractionContext ?? throw new ArgumentNullException(nameof(extractionContext));
         }
     }

--- a/src/NuGet.Core/NuGet.Protocol/Utility/OfflineFeedUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/OfflineFeedUtility.cs
@@ -191,19 +191,6 @@ namespace NuGet.Protocol.Core.Types
                     }
                     else
                     {
-                        var packageSaveMode = offlineFeedAddContext.Expand
-                            ? PackageSaveMode.Defaultv3
-                            : PackageSaveMode.Nuspec | PackageSaveMode.Nupkg;
-
-                        var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
-
-                        var packageExtractionContext = new PackageExtractionContext(
-                            packageSaveMode,
-                            PackageExtractionBehavior.XmlDocFileSaveMode,
-                            logger,
-                            signedPackageVerifier,
-                            SignedPackageVerifierSettings.GetDefault());
-
                         var versionFolderPathResolver = new VersionFolderPathResolver(source);
 
                         using (var packageDownloader = new LocalPackageArchiveDownloader(
@@ -217,7 +204,7 @@ namespace NuGet.Protocol.Core.Types
                                 packageIdentity,
                                 packageDownloader,
                                 versionFolderPathResolver,
-                                packageExtractionContext,
+                                offlineFeedAddContext.ExtractionContext,
                                 token,
                                 parentId: Guid.Empty);
                         }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
@@ -4,10 +4,11 @@ using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using Castle.Core.Logging;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.Packaging.PackageExtraction;
 using NuGet.ProjectManagement;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -322,12 +323,12 @@ namespace NuGet.CommandLine.Test.Caching
                     globalPackagesFolder: GlobalPackagesPath,
                     parentId: Guid.Empty,
                     extractionContext: new PackageExtractionContext(
-                        packageSaveMode: PackageSaveMode.Nupkg,
-                        xmlDocFileSaveMode: XmlDocFileSaveMode.None,
-                        logger: Common.NullLogger.Instance,
+                        PackageSaveMode.Defaultv3,
+                        PackageExtractionBehavior.XmlDocFileSaveMode,
+                        NullLogger.Instance,
                         signedPackageVerifier: null,
                         signedPackageVerifierSettings: null),
-                    logger: Common.NullLogger.Instance,
+                    logger: NullLogger.Instance,
                     token: CancellationToken.None))
                 {
                 }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Castle.Core.Logging;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -320,6 +321,12 @@ namespace NuGet.CommandLine.Test.Caching
                     packageStream: fileStream,
                     globalPackagesFolder: GlobalPackagesPath,
                     parentId: Guid.Empty,
+                    extractionContext: new PackageExtractionContext(
+                        packageSaveMode: PackageSaveMode.Nupkg,
+                        xmlDocFileSaveMode: XmlDocFileSaveMode.None,
+                        logger: Common.NullLogger.Instance,
+                        signedPackageVerifier: null,
+                        signedPackageVerifierSettings: null),
                     logger: Common.NullLogger.Instance,
                     token: CancellationToken.None))
                 {

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -15,6 +15,7 @@ using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.Packaging.PackageExtraction;
 using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -451,7 +452,7 @@ namespace NuGet.Commands.FuncTest
                         new VersionFolderPathResolver(packagesDir),
                         new PackageExtractionContext(
                             PackageSaveMode.Defaultv3,
-                            XmlDocFileSaveMode.None,
+                            PackageExtractionBehavior.XmlDocFileSaveMode,
                             logger,
                             signedPackageVerifier: null,
                             signedPackageVerifierSettings: null),
@@ -2010,7 +2011,7 @@ namespace NuGet.Commands.FuncTest
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
                     var packageExtractionContext = new PackageExtractionContext(
                          PackageSaveMode.Defaultv3,
-                         XmlDocFileSaveMode.None,
+                         PackageExtractionBehavior.XmlDocFileSaveMode,
                          logger,
                          signedPackageVerifier: null,
                          signedPackageVerifierSettings: null);
@@ -2066,7 +2067,7 @@ namespace NuGet.Commands.FuncTest
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
                     var packageExtractionContext = new PackageExtractionContext(
                          PackageSaveMode.Defaultv3,
-                         XmlDocFileSaveMode.None,
+                         PackageExtractionBehavior.XmlDocFileSaveMode,
                          logger,
                          signedPackageVerifier: null,
                          signedPackageVerifierSettings: null);
@@ -2121,7 +2122,7 @@ namespace NuGet.Commands.FuncTest
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
                     var packageExtractionContext = new PackageExtractionContext(
                          PackageSaveMode.Defaultv3,
-                         XmlDocFileSaveMode.None,
+                         PackageExtractionBehavior.XmlDocFileSaveMode,
                          logger,
                          signedPackageVerifier: null,
                          signedPackageVerifierSettings: null);
@@ -2176,7 +2177,7 @@ namespace NuGet.Commands.FuncTest
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
                     var packageExtractionContext = new PackageExtractionContext(
                          PackageSaveMode.Defaultv3,
-                         XmlDocFileSaveMode.None,
+                         PackageExtractionBehavior.XmlDocFileSaveMode,
                          logger,
                          signedPackageVerifier: null,
                          signedPackageVerifierSettings: null);
@@ -2231,7 +2232,7 @@ namespace NuGet.Commands.FuncTest
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
                     var packageExtractionContext = new PackageExtractionContext(
                          PackageSaveMode.Defaultv3,
-                         XmlDocFileSaveMode.None,
+                         PackageExtractionBehavior.XmlDocFileSaveMode,
                          logger,
                          signedPackageVerifier: null,
                          signedPackageVerifierSettings: null);
@@ -2286,7 +2287,7 @@ namespace NuGet.Commands.FuncTest
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
                     var packageExtractionContext = new PackageExtractionContext(
                          PackageSaveMode.Defaultv3,
-                         XmlDocFileSaveMode.None,
+                         PackageExtractionBehavior.XmlDocFileSaveMode,
                          logger,
                          signedPackageVerifier: null,
                          signedPackageVerifierSettings: null);
@@ -2341,7 +2342,7 @@ namespace NuGet.Commands.FuncTest
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
                     var packageExtractionContext = new PackageExtractionContext(
                          PackageSaveMode.Defaultv3,
-                         XmlDocFileSaveMode.None,
+                         PackageExtractionBehavior.XmlDocFileSaveMode,
                          logger,
                          signedPackageVerifier: null,
                          signedPackageVerifierSettings: null);
@@ -2397,7 +2398,7 @@ namespace NuGet.Commands.FuncTest
 
                     var packageExtractionContext = new PackageExtractionContext(
                          PackageSaveMode.Defaultv3,
-                         XmlDocFileSaveMode.None,
+                         PackageExtractionBehavior.XmlDocFileSaveMode,
                          logger,
                          signedPackageVerifier: null,
                          signedPackageVerifierSettings: null);

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -2008,7 +2008,14 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
-                    var request = new RestoreRequest(spec, provider, context, logger)
+                    var packageExtractionContext = new PackageExtractionContext(
+                         PackageSaveMode.Defaultv3,
+                         XmlDocFileSaveMode.None,
+                         logger,
+                         signedPackageVerifier: null,
+                         signedPackageVerifierSettings: null);
+
+                    var request = new RestoreRequest(spec, provider, context, packageExtractionContext, logger)
                     {
                         LockFilePath = Path.Combine(projectDir, "project.lock.json")
                     };
@@ -2057,7 +2064,13 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
-                    var request = new RestoreRequest(spec, provider, context, logger)
+                    var packageExtractionContext = new PackageExtractionContext(
+                         PackageSaveMode.Defaultv3,
+                         XmlDocFileSaveMode.None,
+                         logger,
+                         signedPackageVerifier: null,
+                         signedPackageVerifierSettings: null);
+                    var request = new RestoreRequest(spec, provider, context, packageExtractionContext, logger)
                     {
                         LockFilePath = Path.Combine(projectDir, "project.lock.json")
                     };
@@ -2106,7 +2119,13 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
-                    var request = new RestoreRequest(spec, provider, context, logger)
+                    var packageExtractionContext = new PackageExtractionContext(
+                         PackageSaveMode.Defaultv3,
+                         XmlDocFileSaveMode.None,
+                         logger,
+                         signedPackageVerifier: null,
+                         signedPackageVerifierSettings: null);
+                    var request = new RestoreRequest(spec, provider, context, packageExtractionContext, logger)
                     {
                         LockFilePath = Path.Combine(projectDir, "project.lock.json")
                     };
@@ -2155,7 +2174,13 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
-                    var request = new RestoreRequest(spec, provider, context, logger)
+                    var packageExtractionContext = new PackageExtractionContext(
+                         PackageSaveMode.Defaultv3,
+                         XmlDocFileSaveMode.None,
+                         logger,
+                         signedPackageVerifier: null,
+                         signedPackageVerifierSettings: null);
+                    var request = new RestoreRequest(spec, provider, context, packageExtractionContext, logger)
                     {
                         LockFilePath = Path.Combine(projectDir, "project.lock.json")
                     };
@@ -2204,7 +2229,13 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
-                    var request = new RestoreRequest(spec, provider, context, logger)
+                    var packageExtractionContext = new PackageExtractionContext(
+                         PackageSaveMode.Defaultv3,
+                         XmlDocFileSaveMode.None,
+                         logger,
+                         signedPackageVerifier: null,
+                         signedPackageVerifierSettings: null);
+                    var request = new RestoreRequest(spec, provider, context, packageExtractionContext, logger)
                     {
                         LockFilePath = Path.Combine(projectDir, "project.lock.json")
                     };
@@ -2253,7 +2284,13 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
-                    var request = new RestoreRequest(spec, provider, context, logger)
+                    var packageExtractionContext = new PackageExtractionContext(
+                         PackageSaveMode.Defaultv3,
+                         XmlDocFileSaveMode.None,
+                         logger,
+                         signedPackageVerifier: null,
+                         signedPackageVerifierSettings: null);
+                    var request = new RestoreRequest(spec, provider, context, packageExtractionContext, logger)
                     {
                         LockFilePath = Path.Combine(projectDir, "project.lock.json")
                     };
@@ -2302,7 +2339,13 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
-                    var request = new RestoreRequest(spec, provider, context, logger)
+                    var packageExtractionContext = new PackageExtractionContext(
+                         PackageSaveMode.Defaultv3,
+                         XmlDocFileSaveMode.None,
+                         logger,
+                         signedPackageVerifier: null,
+                         signedPackageVerifierSettings: null);
+                    var request = new RestoreRequest(spec, provider, context, packageExtractionContext, logger)
                     {
                         LockFilePath = Path.Combine(projectDir, "project.lock.json")
                     };
@@ -2351,7 +2394,14 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
-                    var request = new RestoreRequest(spec, provider, context, logger)
+
+                    var packageExtractionContext = new PackageExtractionContext(
+                         PackageSaveMode.Defaultv3,
+                         XmlDocFileSaveMode.None,
+                         logger,
+                         signedPackageVerifier: null,
+                         signedPackageVerifierSettings: null);
+                    var request = new RestoreRequest(spec, provider, context, packageExtractionContext, logger)
                     {
                         LockFilePath = Path.Combine(projectDir, "project.lock.json")
                     };

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json.Linq;
 using NuGet.Commands.Test;
 using NuGet.Configuration;
 using NuGet.Packaging;
+using NuGet.Packaging.PackageExtraction;
 using NuGet.Packaging.Signing;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
@@ -152,7 +153,7 @@ namespace NuGet.Commands.FuncTest
                 var logger = new TestLogger();
                 var extractionContext = new PackageExtractionContext(
                     PackageSaveMode.Defaultv3,
-                    Packaging.XmlDocFileSaveMode.None,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
                     logger,
                     signedPackageVerifier,
                     SignedPackageVerifierSettings.GetDefault());

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -10,6 +10,8 @@ using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Commands.Test;
 using NuGet.Configuration;
+using NuGet.Packaging;
+using NuGet.Packaging.Signing;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
@@ -145,13 +147,19 @@ namespace NuGet.Commands.FuncTest
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
 
                 var logger = new TestLogger();
-                var request = new TestRestoreRequest(spec, sources, packagesDir, cacheContext, logger)
+                var extractionContext = new PackageExtractionContext(
+                    PackageSaveMode.Defaultv3,
+                    Packaging.XmlDocFileSaveMode.None,
+                    logger,
+                    signedPackageVerifier,
+                    SignedPackageVerifierSettings.GetDefault());
+                var request = new TestRestoreRequest(spec, sources, packagesDir, cacheContext, extractionContext, logger)
                 {
-                    XmlDocFileSaveMode = Packaging.XmlDocFileSaveMode.None
+                    LockFilePath = Path.Combine(projectDir, "project.lock.json")
                 };
-                request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var lockFileFormat = new LockFileFormat();
                 var command = new RestoreCommand(request);

--- a/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/V2FeedParserTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/V2FeedParserTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
+using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -30,18 +31,30 @@ namespace NuGet.Core.FuncTest
             // Act & Assert
             using (var packagesFolder = TestDirectory.Create())
             using (var cacheContext = new SourceCacheContext())
-            using (var downloadResult = await parser.DownloadFromUrl(
-                new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("6.2.0")),
-                new Uri("https://www.nuget.org/api/v2/package/WindowsAzure.Storage/6.2.0"),
-                new PackageDownloadContext(cacheContext),
-                packagesFolder,
-                NullLogger.Instance,
-                CancellationToken.None))
             {
-                var packageReader = downloadResult.PackageReader;
-                var files = packageReader.GetFiles();
+                var downloadContext = new PackageDownloadContext(cacheContext)
+                {
+                    ExtractionContext = new PackageExtractionContext(
+                    PackageSaveMode.Defaultv3,
+                    XmlDocFileSaveMode.None,
+                    NullLogger.Instance,
+                    signedPackageVerifier: null,
+                    signedPackageVerifierSettings: null)
+                };
 
-                Assert.Equal(11, files.Count());
+                using (var downloadResult = await parser.DownloadFromUrl(
+                    new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("6.2.0")),
+                    new Uri("https://www.nuget.org/api/v2/package/WindowsAzure.Storage/6.2.0"),
+                    downloadContext,
+                    packagesFolder,
+                    NullLogger.Instance,
+                    CancellationToken.None))
+                {
+                    var packageReader = downloadResult.PackageReader;
+                    var files = packageReader.GetFiles();
+
+                    Assert.Equal(11, files.Count());
+                }
             }
         }
     }

--- a/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/V2FeedParserTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/V2FeedParserTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.Packaging.PackageExtraction;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
@@ -36,7 +37,7 @@ namespace NuGet.Core.FuncTest
                 {
                     ExtractionContext = new PackageExtractionContext(
                     PackageSaveMode.Defaultv3,
-                    XmlDocFileSaveMode.None,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
                     NullLogger.Instance,
                     signedPackageVerifier: null,
                     signedPackageVerifierSettings: null)

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
@@ -14,6 +14,7 @@ using Xunit;
 using NuGet.Protocol;
 using NuGet.Test.Utility;
 using NuGet.Packaging;
+using NuGet.Packaging.PackageExtraction;
 
 namespace NuGet.Protocol.FuncTest
 {
@@ -37,7 +38,7 @@ namespace NuGet.Protocol.FuncTest
                 {
                     ExtractionContext = new PackageExtractionContext(
                         PackageSaveMode.Defaultv3,
-                        XmlDocFileSaveMode.None,
+                        PackageExtractionBehavior.XmlDocFileSaveMode,
                         NullLogger.Instance,
                         signedPackageVerifier: null,
                         signedPackageVerifierSettings: null)
@@ -76,7 +77,7 @@ namespace NuGet.Protocol.FuncTest
                 {
                     ExtractionContext = new PackageExtractionContext(
                     PackageSaveMode.Defaultv3,
-                    XmlDocFileSaveMode.None,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
                     NullLogger.Instance,
                     signedPackageVerifier: null,
                     signedPackageVerifierSettings: null)

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -13,6 +13,7 @@ using NuGet.Versioning;
 using Xunit;
 using NuGet.Protocol;
 using NuGet.Test.Utility;
+using NuGet.Packaging;
 
 namespace NuGet.Protocol.FuncTest
 {
@@ -31,17 +32,29 @@ namespace NuGet.Protocol.FuncTest
             // Act & Assert
             using (var packagesFolder = TestDirectory.Create())
             using (var cacheContext = new SourceCacheContext())
-            using (var downloadResult = await downloadResource.GetDownloadResourceResultAsync(
-                package,
-                new PackageDownloadContext(cacheContext),
-                packagesFolder,
-                NullLogger.Instance,
-                CancellationToken.None))
             {
-                var packageReader = downloadResult.PackageReader;
-                var files = packageReader.GetFiles();
+                var downloadContext = new PackageDownloadContext(cacheContext)
+                {
+                    ExtractionContext = new PackageExtractionContext(
+                        PackageSaveMode.Defaultv3,
+                        XmlDocFileSaveMode.None,
+                        NullLogger.Instance,
+                        signedPackageVerifier: null,
+                        signedPackageVerifierSettings: null)
+                };
 
-                Assert.Equal(11, files.Count());
+                using (var downloadResult = await downloadResource.GetDownloadResourceResultAsync(
+                    package,
+                    downloadContext,
+                    packagesFolder,
+                    NullLogger.Instance,
+                    CancellationToken.None))
+                {
+                    var packageReader = downloadResult.PackageReader;
+                    var files = packageReader.GetFiles();
+
+                    Assert.Equal(11, files.Count());
+                }
             }
         }
 
@@ -58,17 +71,29 @@ namespace NuGet.Protocol.FuncTest
             // Act & Assert
             using (var packagesFolder = TestDirectory.Create())
             using (var cacheContext = new SourceCacheContext())
-            using (var downloadResult = await downloadResource.GetDownloadResourceResultAsync(
-                package,
-                new PackageDownloadContext(cacheContext),
-                packagesFolder,
-                NullLogger.Instance,
-                CancellationToken.None))
             {
-                var packageReader = downloadResult.PackageReader;
-                var files = packageReader.GetFiles();
+                var downloadContext = new PackageDownloadContext(cacheContext)
+                {
+                    ExtractionContext = new PackageExtractionContext(
+                    PackageSaveMode.Defaultv3,
+                    XmlDocFileSaveMode.None,
+                    NullLogger.Instance,
+                    signedPackageVerifier: null,
+                    signedPackageVerifierSettings: null)
+                };
 
-                Assert.Equal(11, files.Count());
+                using (var downloadResult = await downloadResource.GetDownloadResourceResultAsync(
+                    package,
+                    downloadContext,
+                    packagesFolder,
+                    NullLogger.Instance,
+                    CancellationToken.None))
+                {
+                    var packageReader = downloadResult.PackageReader;
+                    var files = packageReader.GetFiles();
+
+                    Assert.Equal(11, files.Count());
+                }
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/V2FeedParserTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/V2FeedParserTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Moq;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
@@ -90,9 +91,19 @@ namespace NuGet.Protocol.FuncTest
             using (var packagesFolder = TestDirectory.Create())
             using (var cacheContext = new SourceCacheContext())
             {
+                var downloadContext = new PackageDownloadContext(cacheContext)
+                {
+                    ExtractionContext = new PackageExtractionContext(
+                    PackageSaveMode.Defaultv3,
+                    XmlDocFileSaveMode.None,
+                    NullLogger.Instance,
+                    signedPackageVerifier: null,
+                    signedPackageVerifierSettings: null)
+                };
+
                 using (var downloadResult = await parser.DownloadFromIdentity(
                     new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("6.2.0")),
-                    new PackageDownloadContext(cacheContext),
+                    downloadContext,
                     packagesFolder,
                     cacheContext,
                     NullLogger.Instance,

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/V2FeedParserTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/V2FeedParserTests.cs
@@ -10,6 +10,7 @@ using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.Packaging.PackageExtraction;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -95,7 +96,7 @@ namespace NuGet.Protocol.FuncTest
                 {
                     ExtractionContext = new PackageExtractionContext(
                     PackageSaveMode.Defaultv3,
-                    XmlDocFileSaveMode.None,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
                     NullLogger.Instance,
                     signedPackageVerifier: null,
                     signedPackageVerifierSettings: null)

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
@@ -12,6 +12,7 @@ using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.Packaging.PackageExtraction;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
@@ -309,21 +310,33 @@ namespace NuGet.PackageManagement
 
             // Act
             using (var cacheContext = new SourceCacheContext())
-            using (var packagesDirectory = TestDirectory.Create())
-            using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
-                v2sourceRepository,
-                packageIdentity,
-                new PackageDownloadContext(cacheContext),
-                packagesDirectory,
-                NullLogger.Instance,
-                CancellationToken.None))
             {
-                var targetPackageStream = downloadResult.PackageStream;
+                var downloadContext = new PackageDownloadContext(cacheContext)
+                {
+                    ExtractionContext = new PackageExtractionContext(
+                        PackageSaveMode.Defaultv3,
+                        PackageExtractionBehavior.XmlDocFileSaveMode,
+                        NullLogger.Instance,
+                        signedPackageVerifier: null,
+                        signedPackageVerifierSettings: null)
+                };
 
-                // Assert
-                // jQuery.1.8.2 is of size 185476 bytes. Make sure the download is successful
-                Assert.Equal(185476, targetPackageStream.Length);
-                Assert.True(targetPackageStream.CanSeek);
+                using (var packagesDirectory = TestDirectory.Create())
+                using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
+                    v2sourceRepository,
+                    packageIdentity,
+                    downloadContext,
+                    packagesDirectory,
+                    NullLogger.Instance,
+                    CancellationToken.None))
+                {
+                    var targetPackageStream = downloadResult.PackageStream;
+
+                    // Assert
+                    // jQuery.1.8.2 is of size 185476 bytes. Make sure the download is successful
+                    Assert.Equal(185476, targetPackageStream.Length);
+                    Assert.True(targetPackageStream.CanSeek);
+                }
             }
         }
 
@@ -337,21 +350,33 @@ namespace NuGet.PackageManagement
 
             // Act
             using (var cacheContext = new SourceCacheContext())
-            using (var packagesDirectory = TestDirectory.Create())
-            using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
-                v3sourceRepository,
-                packageIdentity,
-                new PackageDownloadContext(cacheContext),
-                packagesDirectory,
-                NullLogger.Instance,
-                CancellationToken.None))
             {
-                var targetPackageStream = downloadResult.PackageStream;
+                var downloadContext = new PackageDownloadContext(cacheContext)
+                {
+                    ExtractionContext = new PackageExtractionContext(
+                        PackageSaveMode.Defaultv3,
+                        PackageExtractionBehavior.XmlDocFileSaveMode,
+                        NullLogger.Instance,
+                        signedPackageVerifier: null,
+                        signedPackageVerifierSettings: null)
+                };
 
-                // Assert
-                // jQuery.1.8.2 is of size 185476 bytes. Make sure the download is successful
-                Assert.Equal(185476, targetPackageStream.Length);
-                Assert.True(targetPackageStream.CanSeek);
+                using (var packagesDirectory = TestDirectory.Create())
+                using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
+                    v3sourceRepository,
+                    packageIdentity,
+                    downloadContext,
+                    packagesDirectory,
+                    NullLogger.Instance,
+                    CancellationToken.None))
+                {
+                    var targetPackageStream = downloadResult.PackageStream;
+
+                    // Assert
+                    // jQuery.1.8.2 is of size 185476 bytes. Make sure the download is successful
+                    Assert.Equal(185476, targetPackageStream.Length);
+                    Assert.True(targetPackageStream.CanSeek);
+                }
             }
         }
 
@@ -390,19 +415,31 @@ namespace NuGet.PackageManagement
 
             // Act
             using (var cacheContext = new SourceCacheContext())
-            using (var packagesDirectory = TestDirectory.Create())
-            using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
-                sourceRepositoryProvider.GetRepositories(),
-                packageIdentity,
-                new PackageDownloadContext(cacheContext),
-                packagesDirectory,
-                NullLogger.Instance,
-                CancellationToken.None))
             {
-                var targetPackageStream = downloadResult.PackageStream;
+                var downloadContext = new PackageDownloadContext(cacheContext)
+                {
+                    ExtractionContext = new PackageExtractionContext(
+                        PackageSaveMode.Defaultv3,
+                        PackageExtractionBehavior.XmlDocFileSaveMode,
+                        NullLogger.Instance,
+                        signedPackageVerifier: null,
+                        signedPackageVerifierSettings: null)
+                };
 
-                // Assert
-                Assert.True(targetPackageStream.CanSeek);
+                using (var packagesDirectory = TestDirectory.Create())
+                using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
+                    sourceRepositoryProvider.GetRepositories(),
+                    packageIdentity,
+                    downloadContext,
+                    packagesDirectory,
+                    NullLogger.Instance,
+                    CancellationToken.None))
+                {
+                    var targetPackageStream = downloadResult.PackageStream;
+
+                    // Assert
+                    Assert.True(targetPackageStream.CanSeek);
+                }
             }
         }
 
@@ -449,19 +486,31 @@ namespace NuGet.PackageManagement
 
             // Act
             using (var cacheContext = new SourceCacheContext())
-            using (var packagesDirectory = TestDirectory.Create())
-            using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
-                sourceRepositoryProvider.GetRepositories(),
-                packageIdentity,
-                new PackageDownloadContext(cacheContext),
-                packagesDirectory,
-                NullLogger.Instance,
-                CancellationToken.None))
             {
-                var targetPackageStream = downloadResult.PackageStream;
+                var downloadContext = new PackageDownloadContext(cacheContext)
+                {
+                    ExtractionContext = new PackageExtractionContext(
+                        PackageSaveMode.Defaultv3,
+                        PackageExtractionBehavior.XmlDocFileSaveMode,
+                        NullLogger.Instance,
+                        signedPackageVerifier: null,
+                        signedPackageVerifierSettings: null)
+                };
 
-                // Assert
-                Assert.True(targetPackageStream.CanSeek);
+                using (var packagesDirectory = TestDirectory.Create())
+                using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
+                    sourceRepositoryProvider.GetRepositories(),
+                    packageIdentity,
+                    downloadContext,
+                    packagesDirectory,
+                    NullLogger.Instance,
+                    CancellationToken.None))
+                {
+                    var targetPackageStream = downloadResult.PackageStream;
+
+                    // Assert
+                    Assert.True(targetPackageStream.CanSeek);
+                }
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Utility/OfflineFeedUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Utility/OfflineFeedUtilityTests.cs
@@ -9,6 +9,7 @@ using System.Xml.Linq;
 using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.Packaging.PackageExtraction;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -88,9 +89,9 @@ namespace NuGet.Protocol.Tests
         public async Task AddPackageToSource_ThrowsIfCancelledAsync()
         {
             var extractionContext = new PackageExtractionContext(
-                packageSaveMode: PackageSaveMode.Defaultv3,
-                xmlDocFileSaveMode: XmlDocFileSaveMode.None,
-                logger: Common.NullLogger.Instance,
+                PackageSaveMode.Defaultv3,
+                PackageExtractionBehavior.XmlDocFileSaveMode,
+                NullLogger.Instance,
                 signedPackageVerifier: null,
                 signedPackageVerifierSettings: null);
 
@@ -103,7 +104,6 @@ namespace NuGet.Protocol.Tests
                         throwIfSourcePackageIsInvalid: false,
                         throwIfPackageExistsAndInvalid: false,
                         throwIfPackageExists: false,
-                        expand: true,
                         extractionContext: extractionContext),
                     new CancellationToken(canceled: true)));
         }
@@ -153,9 +153,9 @@ namespace NuGet.Protocol.Tests
                     packageIdentity.Version.ToNormalizedString());
 
                 var extractionContext = new PackageExtractionContext(
-                    packageSaveMode: PackageSaveMode.Defaultv3,
-                    xmlDocFileSaveMode: XmlDocFileSaveMode.None,
-                    logger: Common.NullLogger.Instance,
+                    PackageSaveMode.Defaultv3,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
+                    NullLogger.Instance,
                     signedPackageVerifier: null,
                     signedPackageVerifierSettings: null);
 
@@ -166,7 +166,6 @@ namespace NuGet.Protocol.Tests
                     throwIfSourcePackageIsInvalid: false,
                     throwIfPackageExistsAndInvalid: false,
                     throwIfPackageExists: false,
-                    expand: true,
                     extractionContext: extractionContext);
 
                 await OfflineFeedUtility.AddPackageToSource(context, CancellationToken.None);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Utility/OfflineFeedUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Utility/OfflineFeedUtilityTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using NuGet.Common;
+using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
@@ -86,6 +87,13 @@ namespace NuGet.Protocol.Tests
         [Fact]
         public async Task AddPackageToSource_ThrowsIfCancelledAsync()
         {
+            var extractionContext = new PackageExtractionContext(
+                packageSaveMode: PackageSaveMode.Defaultv3,
+                xmlDocFileSaveMode: XmlDocFileSaveMode.None,
+                logger: Common.NullLogger.Instance,
+                signedPackageVerifier: null,
+                signedPackageVerifierSettings: null);
+
             await Assert.ThrowsAsync<OperationCanceledException>(
                 () => OfflineFeedUtility.AddPackageToSource(
                     new OfflineFeedAddContext(
@@ -95,7 +103,8 @@ namespace NuGet.Protocol.Tests
                         throwIfSourcePackageIsInvalid: false,
                         throwIfPackageExistsAndInvalid: false,
                         throwIfPackageExists: false,
-                        expand: true),
+                        expand: true,
+                        extractionContext: extractionContext),
                     new CancellationToken(canceled: true)));
         }
 
@@ -143,6 +152,13 @@ namespace NuGet.Protocol.Tests
                     packageIdentity.Id,
                     packageIdentity.Version.ToNormalizedString());
 
+                var extractionContext = new PackageExtractionContext(
+                    packageSaveMode: PackageSaveMode.Defaultv3,
+                    xmlDocFileSaveMode: XmlDocFileSaveMode.None,
+                    logger: Common.NullLogger.Instance,
+                    signedPackageVerifier: null,
+                    signedPackageVerifierSettings: null);
+
                 var context = new OfflineFeedAddContext(
                     sourcePackageFilePath,
                     destinationDirectoryPath,
@@ -150,7 +166,8 @@ namespace NuGet.Protocol.Tests
                     throwIfSourcePackageIsInvalid: false,
                     throwIfPackageExistsAndInvalid: false,
                     throwIfPackageExists: false,
-                    expand: true);
+                    expand: true,
+                    extractionContext: extractionContext);
 
                 await OfflineFeedUtility.AddPackageToSource(context, CancellationToken.None);
 

--- a/test/TestUtilities/Test.Utility/Commands/TestRestoreRequest.cs
+++ b/test/TestUtilities/Test.Utility/Commands/TestRestoreRequest.cs
@@ -5,6 +5,9 @@ using System.Collections.Generic;
 using System.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.Packaging;
+using NuGet.Packaging.PackageExtraction;
+using NuGet.Packaging.Signing;
 using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -32,6 +35,23 @@ namespace NuGet.Commands.Test
             PackageSpec project,
             IEnumerable<PackageSource> sources,
             string packagesDirectory,
+            PackageExtractionContext extractionContext,
+            ILogger log)
+            : this(
+                  project,
+                  sources.Select(source => Repository.Factory.GetCoreV3(source.Source)),
+                  packagesDirectory,
+                  new List<string>(),
+                  new TestSourceCacheContext(),
+                  extractionContext,
+                  log)
+        {
+        }
+
+        public TestRestoreRequest(
+            PackageSpec project,
+            IEnumerable<PackageSource> sources,
+            string packagesDirectory,
             SourceCacheContext cacheContext,
             ILogger log)
             : this(
@@ -41,6 +61,27 @@ namespace NuGet.Commands.Test
                   new List<string>(),
                   cacheContext,
                   log)
+        {
+        }
+
+        public TestRestoreRequest(
+            PackageSpec project,
+            IEnumerable<PackageSource> sources,
+            string packagesDirectory,
+            SourceCacheContext cacheContext,
+            PackageExtractionContext extractionContext,
+            ILogger log) : base(
+                project,
+                RestoreCommandProviders.Create(
+                    packagesDirectory,
+                    fallbackPackageFolderPaths: new List<string>(),
+                    sources: sources.Select(source => Repository.Factory.GetCoreV3(source.Source)),
+                    cacheContext: cacheContext,
+                    packageFileCache: new LocalPackageFileCache(),
+                    log: log),
+                cacheContext,
+                extractionContext,
+                log)
         {
         }
 
@@ -73,6 +114,12 @@ namespace NuGet.Commands.Test
                   packagesDirectory,
                   fallbackPackageFolders,
                   cacheContext,
+                  new PackageExtractionContext(
+                    PackageSaveMode.Defaultv3,
+                     PackageExtractionBehavior.XmlDocFileSaveMode,
+                     log,
+                     new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders()),
+                     SignedPackageVerifierSettings.GetDefault()),
                   log)
         {
         }
@@ -88,6 +135,12 @@ namespace NuGet.Commands.Test
                 packagesDirectory,
                 fallbackPackageFolders,
                 new TestSourceCacheContext(),
+                new PackageExtractionContext(
+                    PackageSaveMode.Defaultv3,
+                     PackageExtractionBehavior.XmlDocFileSaveMode,
+                     log,
+                     new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders()),
+                     SignedPackageVerifierSettings.GetDefault()),
                 log)
         {
         }
@@ -98,6 +151,7 @@ namespace NuGet.Commands.Test
             string packagesDirectory,
             IEnumerable<string> fallbackPackageFolders,
             SourceCacheContext cacheContext,
+            PackageExtractionContext extractionContext,
             ILogger log) : base(
                 project,
                 RestoreCommandProviders.Create(
@@ -108,6 +162,7 @@ namespace NuGet.Commands.Test
                     packageFileCache: new LocalPackageFileCache(),
                     log: log),
                 cacheContext,
+                extractionContext,
                 log)
         {
         }


### PR DESCRIPTION
## Bug
Second part of https://github.com/NuGet/Home/issues/6961

## Fix
`PackageExtractionContext` is created with the necessary information for a package to be verified. The extraction context should be created when there is access to `ISettings` so that any setting needed for verification is passed through correctly.