### PR TITLE
Allow delisted packages in Update-Package -Reinstall

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
@@ -178,7 +178,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                     var resolutionContext = new ResolutionContext(
                         GetDependencyBehavior(),
                         _allowPrerelease,
-                        false,
+                        ShouldAllowDelistedPackages(),
                         DetermineVersionConstraints(),
                         new GatherCache(),
                         sourceCacheContext);
@@ -289,7 +289,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                 var resolutionContext = new ResolutionContext(
                     GetDependencyBehavior(),
                     _allowPrerelease,
-                    false,
+                    ShouldAllowDelistedPackages(),
                     DetermineVersionConstraints(),
                     new GatherCache(),
                     sourceCacheContext);
@@ -453,6 +453,20 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             {
                 return VersionConstraints.None;
             }
+        }
+
+        /// <summary>
+        /// Determine if the update action should allow use of delisted packages
+        /// </summary>        
+        private bool ShouldAllowDelistedPackages()
+        {
+            // If a delisted package is already installed, it should be reinstallable too.
+            if (Reinstall.IsPresent)
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/test/EndToEnd/tests/UpdatePackageTest.ps1
+++ b/test/EndToEnd/tests/UpdatePackageTest.ps1
@@ -158,7 +158,7 @@ function Test-UpdatingPackageWithSharedDependencySimple {
     Assert-Package $p D 1.0
     Assert-Package $p B 1.0
     Assert-SolutionPackage D 1.0
-    Assert-Sol utionPackage B 1.0
+    Assert-SolutionPackage B 1.0
     
     Update-Package D -Source $context.RepositoryPath
     # Make sure the new package is installed

--- a/test/EndToEnd/tests/UpdatePackageTest.ps1
+++ b/test/EndToEnd/tests/UpdatePackageTest.ps1
@@ -158,7 +158,7 @@ function Test-UpdatingPackageWithSharedDependencySimple {
     Assert-Package $p D 1.0
     Assert-Package $p B 1.0
     Assert-SolutionPackage D 1.0
-    Assert-SolutionPackage B 1.0
+    Assert-Sol utionPackage B 1.0
     
     Update-Package D -Source $context.RepositoryPath
     # Make sure the new package is installed
@@ -1760,4 +1760,20 @@ function Test-UpdatingBindingRedirectAfterUpdate {
     # Assert
     Assert-Package $p B 3.0
     Assert-BindingRedirect $p web.config B '0.0.0.0-3.0.0.0' '3.0.0.0'
+}
+
+function Test-CanReinstallDelistedPackage
+{
+    # Arrange
+    # using a delisted package
+    $nugetsource = "https://www.nuget.org/api/v2/"
+    $p = New-ClassLibrary
+    $p | Install-Package Rx-Core -Version 2.2.5 -Source $nugetsource
+    
+    # Act
+    Update-Package Rx-Core -Reinstall -ProjectName $p.Name -Source $nugetsource
+
+    # Assert
+    # we get here as act errored prior to fix
+    Assert-Package $p Rx-Core 2.2.5
 }


### PR DESCRIPTION
## 7268
Fixes: https://github.com/NuGet/Home/issues/7268
Regression: No  

## Fix
* If Update-Package action is reinstall, set resolution context to allow delisted packages

## Testing/Validation
Tests Added: Yes
