### PR TITLE
Restore:  fix performance regression on .NET Core 2.1+

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpCacheUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpCacheUtility.cs
@@ -67,21 +67,43 @@ namespace NuGet.Protocol
             // The update of a cached file is divided into two steps:
             // 1) Delete the old file.
             // 2) Create a new file with the same name.
+
+            // Some FileStream operations on Windows are synchronous even though it may not seem so.
+            // The HTTP stack rewrite in .NET Core 2.1 introduced circumstances whereby these
+            // synchronous FileStream calls will keep an IO completion thread busy and block other
+            // HTTP requests from completing.  The immediate solution is to perform write and read
+            // operations on separate streams, but only on .NET Core where the problem exists.
+            // See https://github.com/dotnet/corefx/issues/31914 for details.
+            const int writeBufferSize =
+#if IS_CORECLR
+                1;  // This disables write buffering.
+#else
+                BufferSize;
+#endif
+
             using (var fileStream = new FileStream(
                 result.NewFile,
                 FileMode.Create,
-                FileAccess.ReadWrite,
+                FileAccess.Write,
                 FileShare.None,
-                BufferSize,
+                writeBufferSize,
                 useAsync: true))
             {
                 using (var networkStream = await response.Content.ReadAsStreamAsync())
                 {
                     await networkStream.CopyToAsync(fileStream, BufferSize, cancellationToken);
                 }
+            }
 
+            using (var fileStream = new FileStream(
+                result.NewFile,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.None,
+                BufferSize,
+                useAsync: true))
+            {
                 // Validate the content before putting it into the cache.
-                fileStream.Seek(0, SeekOrigin.Begin);
                 ensureValidContents?.Invoke(fileStream);
             }
 


### PR DESCRIPTION
Resolve https://github.com/NuGet/Home/issues/7314.

The core problem with the original code is that it forces a buffer to be flushed synchronously rather than asynchronously (and, actually worse than that, as a sync-over-async operation, meaning it’s performing an asynchronous operation and then blocking waiting for it to complete).  That would occur as part of the Seek, or if the validation wasn’t there, as part of Dispose’ing the FileStream, both synchronous operations.

The right fix would be to add an “await FileStream.FlushAsync();” before doing the seeking/validation/closing.  That flush would ensure that the buffer is empty when Seek/Dispose/etc. are closed, so there’s nothing more to flush.  However, there’s a bug in FlushAsync that’s causing it to also do the key part of the flush synchronously as well.

So, the workaround is to avoid buffering, such that nothing needs to be flushed as part of Seek/Dispose.  That’s what bufferSize=1 does.

However, the concern expressed was that disabling that buffering would avoid this problem for the writing but would slow down the reading/validation.  So, the fix splits it into two streams: one used for writing with buffering disabled, and then one used for reading that has buffering enabled still.

CC @rrelyea