### PR TITLE
Fix crash in `process.ProcessName` due to race.

### DIFF
--- a/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
@@ -256,6 +256,16 @@ namespace NuGet.Credentials
                 throw PluginException.CreateNotStartedMessage(Path);
             }
 
+            string processName;
+            try
+            {
+                processName = process.ProcessName;
+            }
+            catch (InvalidOperationException)
+            {
+                processName = System.IO.Path.GetFileName(startInfo.FileName);
+            }
+
             process.OutputDataReceived += (object o, DataReceivedEventArgs e) => { outBuffer.AppendLine(e.Data); };
 
             // Trace and error information may be written to standard error by the provider.
@@ -264,11 +274,7 @@ namespace NuGet.Credentials
             {
                 if (!string.IsNullOrWhiteSpace(e?.Data))
                 {
-                    // This is a workaround for mono issue: https://github.com/NuGet/Home/issues/4004
-                    if (!process.HasExited)
-                    {
-                        _logger.LogInformation($"{process.ProcessName}: {e.Data}");
-                    }
+                    _logger.LogInformation($"{processName}: {e.Data}");
                 }
             };
 


### PR DESCRIPTION
Details:
The code in PluginCredentailProvider.Execute() suffers from a race condition between the call to Process.HasExited returning false and the following call to Process.ProcessName. The fix has been proposed by TheJayMann (https://github.com/TheJayMann) in his issue report: https://github.com/NuGet/Home/issues/6572.

## Bug
Fixes: https://github.com/NuGet/Home/issues/6572  
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: The code in PluginCredentailProvider.Execute() suffers from a race condition between the call to Process.HasExited returning false and the following call to Process.ProcessName. The fix has been proposed by TheJayMann (https://github.com/TheJayMann) in his issue report: https://github.com/NuGet/Home/issues/6572. 

## Testing/Validation
Tests Added: No  
Reason for not adding tests: Race condition
Validation done: Local validation. 
