### PR TITLE
Added Equals method for VersionRange to compare floating ranges

### DIFF
--- a/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
+++ b/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -277,6 +277,16 @@ namespace NuGet.Versioning
         {
             return FloatBehavior == other.FloatBehavior
                    && VersionComparer.Default.Equals(MinVersion, other.MinVersion);
+        }
+
+        /// <summary>
+        /// Override Object.Equals
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as FloatRange);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Versioning/VersionRange.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRange.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NuGet.Shared;
 
 namespace NuGet.Versioning
 {
@@ -205,8 +206,8 @@ namespace NuGet.Versioning
             }
 
             // If the range contains only stable versions disallow prerelease versions
-            if (!HasPrereleaseBounds 
-                && considering.IsPrerelease 
+            if (!HasPrereleaseBounds
+                && considering.IsPrerelease
                 && _floatRange?.FloatBehavior != NuGetVersionFloatBehavior.Prerelease
                 && _floatRange?.FloatBehavior != NuGetVersionFloatBehavior.AbsoluteLatest)
             {
@@ -364,6 +365,42 @@ namespace NuGet.Versioning
         public virtual string ToShortString()
         {
             return ToString("A", new VersionRangeFormatter());
+        }
+
+        /// <summary>
+        /// Equals implementation for VersionRange.
+        /// </summary>
+        public bool Equals(VersionRange other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return base.Equals(other) &&
+                IsFloating == other.IsFloating &&
+                EqualityUtility.EqualsWithNullCheck(Float, other.Float);
+        }
+
+        /// <summary>
+        /// Compare the obj as VersionRange.
+        /// </summary>
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as VersionRange);
+        }
+
+        /// <summary>
+        /// Returns the VersionRangeBase hashcode
+        /// </summary>
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -2093,15 +2093,14 @@ namespace NuGet.CommandLine.Test
 
                 // Act
                 var r2 = Util.RestoreSolution(pathContext);
+
                 // Assert
                 Assert.True(File.Exists(assetsPath));
                 Assert.True(File.Exists(cachePath));
-                // This is a more complex scenario, since when we dedup 2.0.0 and 2.0.* we only look for 2.0.*...if 2.0.0 package exists, the 2.0.* would resolve to 2.0.0 so both cases would be covered
-                // The issue is ofc when you have 2.5 package in your local, and a package with 2.0.0 was added remotely. Then we won't redownload
-                Assert.False(File.Exists(assetsPath20));
-                Assert.False(File.Exists(cachePath20));
-                Assert.Contains($"The restore inputs for 'z-netcoreapp1.0-[2.0.*, )' have not changed. No further actions are required to complete the restore.", r2.Item2);
-                r = Util.RestoreSolution(pathContext);
+
+                Assert.True(File.Exists(assetsPath20));
+                Assert.True(File.Exists(cachePath20));
+
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
@@ -725,5 +725,17 @@ namespace NuGet.Versioning.Test
             Assert.Equal(versionRange.MinVersion, actual.MinVersion);
             Assert.Equal(versionRange.MaxVersion, actual.MaxVersion);
         }
+
+        [Theory]
+        [InlineData("1.0.0", "1.0.*", false)]
+        [InlineData("[1.0.0,)", "[1.0.*, )", false)]
+        [InlineData("1.1.*", "1.0.*", false)]
+        public void VersionRange_Equals(string versionString1, string versionString2, bool isEquals)
+        {
+            var range1 = VersionRange.Parse(versionString1);
+            var range2 = VersionRange.Parse(versionString2);
+
+            Assert.Equal(isEquals, range1.Equals(range2));
+        }
     }
 }


### PR DESCRIPTION
This is to add Equals method for VersionRange to handle floating versions.

Fixes - https://github.com/NuGet/Home/issues/7324