### PR TITLE
Adding path for packaging project to bypass ResolveNearestFramework if not matching.

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
@@ -35,7 +35,6 @@ namespace NuGet.Build.Tasks
 
         /// <summary>
         /// The project references for property lookup.
-        /// The project references for property lookup.
         /// </summary>
         public ITaskItem[] AnnotatedProjectReferences { get; set; }
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
@@ -35,6 +35,7 @@ namespace NuGet.Build.Tasks
 
         /// <summary>
         /// The project references for property lookup.
+        /// The project references for property lookup.
         /// </summary>
         public ITaskItem[] AnnotatedProjectReferences { get; set; }
 
@@ -44,9 +45,13 @@ namespace NuGet.Build.Tasks
         [Output]
         public ITaskItem[] AssignedProjects { get; set; }
 
+        /// <summary>
+        /// Dont resolve the reference framework against the parent framework.
+        /// </summary>
+        public bool IgnoreParentFramework { get; set; }
+
         public override bool Execute()
         {
-
             var logger = new MSBuildLogger(Log);
 
             BuildTasksUtility.LogInputParam(logger, nameof(CurrentProjectTargetFramework), CurrentProjectTargetFramework);
@@ -116,14 +121,37 @@ namespace NuGet.Build.Tasks
 
             if (string.IsNullOrEmpty(referencedProjectFrameworkString))
             {
-                // No target frameworks set, nothing to do.
+                if(IgnoreParentFramework)
+                {
+                    // cant resolve against self, fail.
+                    var message = string.Format(CultureInfo.CurrentCulture,
+                    Strings.IgnoreParentFrameworkMissingSelfFramework,
+                    CurrentProjectName,
+                    referencedProjectFile);
+
+                    var error = RestoreLogMessage.CreateError(NuGetLogCode.NU1702, message);
+                    error.FilePath = referencedProjectFile;
+                    error.ProjectPath = CurrentProjectName;
+                    logger.Log(error);
+                }
+
                 return itemWithProperties;
             }
 
             var referencedProjectFrameworks = MSBuildStringUtility.Split(referencedProjectFrameworkString);
 
+            string nearestNuGetFramework = null;
+
+            if (IgnoreParentFramework)
+            {
+                nearestNuGetFramework = NuGetFramework.ParseFrameworkName(referencedProjectFrameworks[0], DefaultFrameworkNameProvider.Instance).GetDotNetFrameworkName(DefaultFrameworkNameProvider.Instance);
+            }
+            else
+            {
+                nearestNuGetFramework = NuGetFrameworkUtility.GetNearest(referencedProjectFrameworks, projectNuGetFramework, NuGetFramework.Parse);
+            }
+
             // try project framework
-            var nearestNuGetFramework = NuGetFrameworkUtility.GetNearest(referencedProjectFrameworks, projectNuGetFramework, NuGetFramework.Parse);
             if (nearestNuGetFramework != null)
             {
                 itemWithProperties.SetMetadata(NEAREST_TARGET_FRAMEWORK, nearestNuGetFramework);

--- a/src/NuGet.Core/NuGet.Build.Tasks/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Strings.Designer.cs
@@ -62,6 +62,15 @@ namespace NuGet.Build.Tasks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Project {0} has no framework, cannot ignore parent framework when resolving nearest framework dependency as a referenced project in {1}..
+        /// </summary>
+        internal static string IgnoreParentFrameworkMissingSelfFramework {
+            get {
+                return ResourceManager.GetString("IgnoreParentFrameworkMissingSelfFramework", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ProjectReference &apos;{0}&apos; was resolved using &apos;{1}&apos; instead of the project target framework &apos;{2}&apos;. This project may not be fully compatible with your project..
         /// </summary>
         internal static string ImportsFallbackWarning {

--- a/src/NuGet.Core/NuGet.Build.Tasks/Strings.resx
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Strings.resx
@@ -117,6 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="IgnoreParentFrameworkMissingSelfFramework" xml:space="preserve">
+    <value>Project {0} has no framework, cannot ignore parent framework when resolving nearest framework dependency as a referenced project in {1}.</value>
+    <comment>0 - Reference project path, 1 - parent project path.</comment>
+  </data>
   <data name="ImportsFallbackWarning" xml:space="preserve">
     <value>ProjectReference '{0}' was resolved using '{1}' instead of the project target framework '{2}'. This project may not be fully compatible with your project.</value>
     <comment>0 - referenced project path

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -703,7 +703,12 @@ namespace NuGet.Common
         /// <summary>
         /// Undefined package warning
         /// </summary>
-        NU5500 = 5500
+        NU5500 = 5500,
+
+        /// <summary>
+        /// Errro_Fallback Framework DNE.
+        /// </summary>
+        NU5501 = 5501
 
     }
 }


### PR DESCRIPTION
## Bug
Fixes: Adding a project targeting DNC3 from WapProj
Regression: No
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: Allows a package with a framework of NetFramework V5 to p2p to DotNetCore 3.0 by giving it the property to resolve the p2p reference framework against itself, instead of the parent project.

## Testing/Validation
Tests Added: Yes
Validation done:  Manual Validation and Test Suite Passover
