### PR TITLE
Updating dotnet restore property name to reevaluate lock file

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -120,7 +120,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       RestoreForce="$(RestoreForce)"
       HideWarningsAndErrors="$(HideWarningsAndErrors)"
       Interactive="$(NuGetInteractive)"
-      ReevaluateRestoreGraph="$(ReevaluateRestoreGraph)"/>
+      RestoreForceEvaluate="$(RestoreForceEvaluate)"/>
   </Target>
 
   <!--

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -77,7 +77,7 @@ namespace NuGet.Build.Tasks
         /// <summary>
         /// Reevaluate resotre graph even with a lock file, skip no op as well.
         /// </summary>
-        public bool ReevaluateRestoreGraph { get; set; }
+        public bool RestoreForceEvaluate { get; set; }
 
         public override bool Execute()
         {
@@ -91,7 +91,7 @@ namespace NuGet.Build.Tasks
             log.LogDebug($"(in) RestoreRecursive '{RestoreRecursive}'");
             log.LogDebug($"(in) RestoreForce '{RestoreForce}'");
             log.LogDebug($"(in) HideWarningsAndErrors '{HideWarningsAndErrors}'");
-            log.LogDebug($"(in) Reevaluate '{ReevaluateRestoreGraph}'");
+            log.LogDebug($"(in) RestoreForceEvaluate '{RestoreForceEvaluate}'");
 
             try
             {
@@ -166,7 +166,7 @@ namespace NuGet.Build.Tasks
                     CachingSourceProvider = sourceProvider,
                     AllowNoOp = !RestoreForce,
                     HideWarningsAndErrors = HideWarningsAndErrors,
-                    ReevaluateRestoreGraph = ReevaluateRestoreGraph
+                    RestoreForceEvaluate = RestoreForceEvaluate
                 };
 
                 if (restoreContext.DisableParallel)

--- a/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
@@ -49,7 +49,7 @@ namespace NuGet.Commands
                     {
                         Id = library.Name,
                         ResolvedVersion = library.Version,
-                        Sha512 = libraryLookup[identity].Sha512,
+                        ContentHash = libraryLookup[identity].Sha512,
                         Dependencies = library.Dependencies
                     };
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -64,7 +64,7 @@ namespace NuGet.Commands
 
         public bool IsRestoreOriginalAction { get; set; } = true;
 
-        public bool ReevaluateRestoreGraph { get; set; }
+        public bool RestoreForceEvaluate { get; set; }
 
         // Cache directory -> ISettings
         private ConcurrentDictionary<string, ISettings> _settingsCache
@@ -233,7 +233,7 @@ namespace NuGet.Commands
             request.HideWarningsAndErrors = HideWarningsAndErrors;
             request.ParentId = ParentId;
             request.IsRestoreOriginalAction = IsRestoreOriginalAction;
-            request.ReevaluateRestoreGraph = ReevaluateRestoreGraph;
+            request.RestoreForceEvaluate = RestoreForceEvaluate;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -405,7 +405,7 @@ namespace NuGet.Commands
             var librariesLookUp = lockFile.Targets
                 .SelectMany(t => t.Dependencies.Where(dep => dep.Type != PackageDependencyType.Project))
                 .Distinct(new LockFileDependencyIdVersionComparer())
-                .ToDictionary(dep => new PackageIdentity(dep.Id, dep.ResolvedVersion), val => val.Sha512);
+                .ToDictionary(dep => new PackageIdentity(dep.Id, dep.ResolvedVersion), val => val.ContentHash);
 
             foreach (var library in assetsFile.Libraries.Where(lib => lib.Type == LibraryType.Package))
             {
@@ -457,8 +457,8 @@ namespace NuGet.Commands
                 return Tuple.Create(success, Tuple.Create(isLockFileValid, packagesLockFile));
             }
 
-            // read packages.lock.json file if exists and ReevaluateRestoreGraph flag is not set to true
-            if (!_request.ReevaluateRestoreGraph && File.Exists(packagesLockFilePath))
+            // read packages.lock.json file if exists and RestoreForceEvaluate flag is not set to true
+            if (!_request.RestoreForceEvaluate && File.Exists(packagesLockFilePath))
             {
                 lockFileTelemetry.StartIntervalMeasure();
                 packagesLockFile = PackagesLockFileFormat.Read(packagesLockFilePath, _logger);
@@ -511,10 +511,10 @@ namespace NuGet.Commands
                 NoOpRestoreUtilities.UpdateRequestBestMatchingToolPathsIfAvailable(_request);
             }
 
-            // if --reevaluate flag is passed then restore noop check will also be skipped.
+            // if --force-evaluate flag is passed then restore noop check will also be skipped.
             // this will also help us to get rid of -force flag in near future.
             if (_request.AllowNoOp &&
-                !_request.ReevaluateRestoreGraph &&
+                !_request.RestoreForceEvaluate &&
                 File.Exists(_request.Project.RestoreMetadata.CacheFilePath))
             {
                 cacheFile = FileUtility.SafeRead(_request.Project.RestoreMetadata.CacheFilePath, (stream, path) => CacheFileFormat.Read(stream, _logger, path));

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
@@ -166,6 +166,6 @@ namespace NuGet.Commands
 
         public bool IsRestoreOriginalAction { get; set; } = true;
 
-        public bool ReevaluateRestoreGraph { get; set; }
+        public bool RestoreForceEvaluate { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -314,7 +314,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The packages lock file is inconsistent with the project dependencies so restore can&apos;t be run in locked mode. Please disable RestoreLockedMode MSBuild property or pass explicit --reevaluate flag to run restore to update the lock file..
+        ///   Looks up a localized string similar to The packages lock file is inconsistent with the project dependencies so restore can&apos;t be run in locked mode. Please disable RestoreLockedMode MSBuild property or pass explicit --force-evaluate flag to run restore to update the lock file..
         /// </summary>
         internal static string Error_RestoreInLockedMode {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -705,7 +705,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <comment>Do not localize snupkg and symbols.nupkg</comment>
   </data>
   <data name="Error_RestoreInLockedMode" xml:space="preserve">
-    <value>The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode. Please disable RestoreLockedMode MSBuild property or pass explicit --reevaluate flag to run restore to update the lock file.</value>
+    <value>The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode. Please disable RestoreLockedMode MSBuild property or pass explicit --force-evaluate flag to run restore to update the lock file.</value>
   </data>
   <data name="Error_PackageValidationFailed" xml:space="preserve">
     <value>The package {0} sha512 validation failed. The package is different than the last restore.</value>

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -42,7 +42,7 @@ namespace NuGet.PackageManagement
             CancellationToken token)
         {
             // TODO: This will flow from UI once we enable UI option to trigger reevaluation
-            var reevaluateRestoreGraph = false;
+            var restoreForceEvaluate = false;
 
             // Check if there are actual projects to restore before running.
             if (dgSpec.Restore.Count > 0)
@@ -61,7 +61,7 @@ namespace NuGet.PackageManagement
                         parentId,
                         forceRestore,
                         isRestoreOriginalAction,
-                        reevaluateRestoreGraph);
+                        restoreForceEvaluate);
 
                     var restoreSummaries = await RestoreRunner.RunAsync(restoreContext, token);
 
@@ -139,7 +139,7 @@ namespace NuGet.PackageManagement
                     parentId,
                     forceRestore: true,
                     isRestoreOriginalAction: false,
-                    reevaluateRestoreGraph: true);
+                    restoreForceEvaluate: true);
 
                 var requests = await RestoreRunner.GetRequests(restoreContext);
                 var results = await RestoreRunner.RunWithoutCommit(requests, restoreContext);
@@ -253,7 +253,7 @@ namespace NuGet.PackageManagement
             Guid parentId,
             bool forceRestore,
             bool isRestoreOriginalAction,
-            bool reevaluateRestoreGraph)
+            bool restoreForceEvaluate)
         {
             var caching = new CachingSourceProvider(new PackageSourceProvider(context.Settings));
             foreach( var source in sources)
@@ -272,7 +272,7 @@ namespace NuGet.PackageManagement
                 CachingSourceProvider = caching,
                 ParentId = parentId,
                 IsRestoreOriginalAction = isRestoreOriginalAction,
-                ReevaluateRestoreGraph = reevaluateRestoreGraph
+                RestoreForceEvaluate = restoreForceEvaluate
             };
 
             return restoreContext;

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependency.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependency.cs
@@ -19,7 +19,7 @@ namespace NuGet.ProjectModel
 
         public VersionRange RequestedVersion { get; set; }
 
-        public string Sha512 { get; set; }
+        public string ContentHash { get; set; }
 
         public PackageDependencyType Type { get; set; }
 
@@ -41,7 +41,7 @@ namespace NuGet.ProjectModel
                 EqualityUtility.EqualsWithNullCheck(ResolvedVersion, other.ResolvedVersion) &&
                 EqualityUtility.EqualsWithNullCheck(RequestedVersion, other.RequestedVersion) &&
                 EqualityUtility.SequenceEqualWithNullCheck(Dependencies, other.Dependencies) &&
-                Sha512 == other.Sha512 &&
+                ContentHash == other.ContentHash &&
                 Type == other.Type;
         }
 
@@ -58,7 +58,7 @@ namespace NuGet.ProjectModel
             combiner.AddObject(ResolvedVersion);
             combiner.AddObject(RequestedVersion);
             combiner.AddSequence(Dependencies);
-            combiner.AddObject(Sha512);
+            combiner.AddObject(ContentHash);
             combiner.AddObject(Type);
 
             return combiner.CombinedHash;

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileFormat.cs
@@ -22,7 +22,7 @@ namespace NuGet.ProjectModel
         private const string VersionProperty = "version";
         private const string ResolvedProperty = "resolved";
         private const string RequestedProperty = "requested";
-        private const string Sha512Property = "sha512";
+        private const string ContentHashProperty = "contentHash";
         private const string DependenciesProperty = "dependencies";
         private const string TypeProperty = "type";
 
@@ -196,7 +196,7 @@ namespace NuGet.ProjectModel
                 dependency.RequestedVersion = VersionRange.Parse(requestedString);
             }
 
-            dependency.Sha512 = JsonUtility.ReadProperty<string>(jObject, Sha512Property);
+            dependency.ContentHash = JsonUtility.ReadProperty<string>(jObject, ContentHashProperty);
 
             return dependency;
         }
@@ -227,9 +227,9 @@ namespace NuGet.ProjectModel
                 json[ResolvedProperty] = dependency.ResolvedVersion.ToNormalizedString();
             }
 
-            if (dependency.Sha512 != null)
+            if (dependency.ContentHash != null)
             {
-                json[Sha512Property] = dependency.Sha512;
+                json[ContentHashProperty] = dependency.ContentHash;
             }
 
             if (dependency.Dependencies?.Count > 0)

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileFormatTests.cs
@@ -20,7 +20,7 @@ namespace NuGet.ProjectModel.Test
                             ""type"": ""Direct"",
                             ""requested"": ""[1.*, )"",
                             ""resolved"": ""1.0.0"",
-                            ""sha512"": ""sbWWhjA2/cXJHBBKAVo3m2U0KxzNuW5dQANDwx8L96V+L6SML96cM/Myvmp6fiBqIDibvF6+Ss9YC+qqclrXnw=="",
+                            ""contentHash"": ""sbWWhjA2/cXJHBBKAVo3m2U0KxzNuW5dQANDwx8L96V+L6SML96cM/Myvmp6fiBqIDibvF6+Ss9YC+qqclrXnw=="",
                             ""dependencies"": {
                                  ""PackageB"": ""1.0.0""
                             }
@@ -28,7 +28,7 @@ namespace NuGet.ProjectModel.Test
                         ""PackageB"": {
                             ""type"": ""Transitive"",
                             ""resolved"": ""1.0.0"",
-                            ""sha512"": ""Fjiywrwerewr4dgbdgbfgjkoiuiorwrwn24+8hjnnuerwrwsfsHYWD3HJYUI7NJHssxDFSFSFEWEW34DFDFCVsxv=="",
+                            ""contentHash"": ""Fjiywrwerewr4dgbdgbfgjkoiuiorwrwn24+8hjnnuerwrwsfsHYWD3HJYUI7NJHssxDFSFSFEWEW34DFDFCVsxv=="",
                         }
                     }
                 }
@@ -46,7 +46,7 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(PackageDependencyType.Direct, target.Dependencies[0].Type);
             Assert.Equal("[1.*, )", target.Dependencies[0].RequestedVersion.ToNormalizedString());
             Assert.Equal("1.0.0", target.Dependencies[0].ResolvedVersion.ToNormalizedString());
-            Assert.NotEmpty(target.Dependencies[0].Sha512);
+            Assert.NotEmpty(target.Dependencies[0].ContentHash);
             Assert.Equal(1, target.Dependencies[0].Dependencies.Count);
             Assert.Equal("PackageB", target.Dependencies[0].Dependencies[0].Id);
 
@@ -55,7 +55,7 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(PackageDependencyType.Transitive, target.Dependencies[1].Type);
             Assert.Null(target.Dependencies[1].RequestedVersion);
             Assert.Equal("1.0.0", target.Dependencies[0].ResolvedVersion.ToNormalizedString());
-            Assert.NotEmpty(target.Dependencies[1].Sha512);
+            Assert.NotEmpty(target.Dependencies[1].ContentHash);
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace NuGet.ProjectModel.Test
                             ""type"": ""Direct"",
                             ""requested"": ""[1.*, )"",
                             ""resolved"": ""1.0.0"",
-                            ""sha512"": ""sbWWhjA2/cXJHBBKAVo3m2U0KxzNuW5dQANDwx8L96V+L6SML96cM/Myvmp6fiBqIDibvF6+Ss9YC+qqclrXnw=="",
+                            ""contentHash"": ""sbWWhjA2/cXJHBBKAVo3m2U0KxzNuW5dQANDwx8L96V+L6SML96cM/Myvmp6fiBqIDibvF6+Ss9YC+qqclrXnw=="",
                             ""dependencies"": {
                                  ""PackageB"": ""1.0.0""
                             }
@@ -77,7 +77,7 @@ namespace NuGet.ProjectModel.Test
                         ""PackageB"": {
                             ""type"": ""Transitive"",
                             ""resolved"": ""1.0.0"",
-                            ""sha512"": ""Fjiywrwerewr4dgbdgbfgjkoiuiorwrwn24+8hjnnuerwrwsfsHYWD3HJYUI7NJHssxDFSFSFEWEW34DFDFCVsxv==""
+                            ""contentHash"": ""Fjiywrwerewr4dgbdgbfgjkoiuiorwrwn24+8hjnnuerwrwsfsHYWD3HJYUI7NJHssxDFSFSFEWEW34DFDFCVsxv==""
                         }
                     },
                     "".NETFramework,Version=v4.5/win10-arm"": {
@@ -85,7 +85,7 @@ namespace NuGet.ProjectModel.Test
                             ""type"": ""Direct"",
                             ""requested"": ""[1.*, )"",
                             ""resolved"": ""1.0.0"",
-                            ""sha512"": ""QuiokjhjA2/cXJHBBKAVo3m2U0KxzNuW5dQANDwx8L96V+L6SML96cM/Myvmp6fiBqIDibvF6+Ss9YC+qqcfwef=="",
+                            ""contentHash"": ""QuiokjhjA2/cXJHBBKAVo3m2U0KxzNuW5dQANDwx8L96V+L6SML96cM/Myvmp6fiBqIDibvF6+Ss9YC+qqcfwef=="",
                             ""dependencies"": {
                                  ""PackageB"": ""1.0.0"",
                                  ""runtime.win10-arm.PackageA"": ""1.0.0""
@@ -94,7 +94,7 @@ namespace NuGet.ProjectModel.Test
                         ""runtime.win10-arm.PackageA"": {
                             ""type"": ""Transitive"",
                             ""resolved"": ""1.0.0"",
-                            ""sha512"": ""dfgdgdfIY434jhjkhkRARFSZSGFSDG423452bgdnuerwrwsfsHYWD3HJYUI7NJHssxDFSFSFEWEW34DFjkyuerd=="",
+                            ""contentHash"": ""dfgdgdfIY434jhjkhkRARFSZSGFSDG423452bgdnuerwrwsfsHYWD3HJYUI7NJHssxDFSFSFEWEW34DFjkyuerd=="",
                         }
                     }
                 }
@@ -112,7 +112,7 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(PackageDependencyType.Direct, target.Dependencies[0].Type);
             Assert.Equal("[1.*, )", target.Dependencies[0].RequestedVersion.ToNormalizedString());
             Assert.Equal("1.0.0", target.Dependencies[0].ResolvedVersion.ToNormalizedString());
-            Assert.NotEmpty(target.Dependencies[0].Sha512);
+            Assert.NotEmpty(target.Dependencies[0].ContentHash);
             Assert.Equal(2, target.Dependencies[0].Dependencies.Count);
             Assert.Equal("PackageB", target.Dependencies[0].Dependencies[0].Id);
             Assert.Equal("runtime.win10-arm.PackageA", target.Dependencies[0].Dependencies[1].Id);
@@ -123,7 +123,7 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(PackageDependencyType.Transitive, target.Dependencies[1].Type);
             Assert.Null(target.Dependencies[1].RequestedVersion);
             Assert.Equal("1.0.0", target.Dependencies[0].ResolvedVersion.ToNormalizedString());
-            Assert.NotEmpty(target.Dependencies[1].Sha512);
+            Assert.NotEmpty(target.Dependencies[1].ContentHash);
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace NuGet.ProjectModel.Test
                             ""type"": ""Direct"",
                             ""requested"": ""[1.*, )"",
                             ""resolved"": ""1.0.0"",
-                            ""sha512"": ""sbWWhjA2/cXJHBBKAVo3m2U0KxzNuW5dQANDwx8L96V+L6SML96cM/Myvmp6fiBqIDibvF6+Ss9YC+qqclrXnw=="",
+                            ""contentHash"": ""sbWWhjA2/cXJHBBKAVo3m2U0KxzNuW5dQANDwx8L96V+L6SML96cM/Myvmp6fiBqIDibvF6+Ss9YC+qqclrXnw=="",
                             ""dependencies"": {
                                  ""PackageB"": ""1.0.0""
                             }
@@ -145,7 +145,7 @@ namespace NuGet.ProjectModel.Test
                         ""PackageB"": {
                             ""type"": ""Transitive"",
                             ""resolved"": ""1.0.0"",
-                            ""sha512"": ""Fjiywrwerewr4dgbdgbfgjkoiuiorwrwn24+8hjnnuerwrwsfsHYWD3HJYUI7NJHssxDFSFSFEWEW34DFDFCVsxv=="",
+                            ""contentHash"": ""Fjiywrwerewr4dgbdgbfgjkoiuiorwrwn24+8hjnnuerwrwsfsHYWD3HJYUI7NJHssxDFSFSFEWEW34DFDFCVsxv=="",
                         }
                     }
                 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackagesLockFileTests.cs
@@ -35,7 +35,7 @@ namespace NuGet.ProjectModel.Test
                                     Type = PackageDependencyType.Direct,
                                     RequestedVersion = VersionRange.Parse("1.0.0"),
                                     ResolvedVersion = NuGetVersion.Parse("1.0.0"),
-                                    Sha512 = "sha1",
+                                    ContentHash = "sha1",
                                     Dependencies = new List<PackageDependency>()
                                     {
                                         new PackageDependency("PackageB", VersionRange.Parse("1.0.0"))
@@ -46,7 +46,7 @@ namespace NuGet.ProjectModel.Test
                                     Id = "PackageB",
                                     Type = PackageDependencyType.Transitive,
                                     ResolvedVersion = NuGetVersion.Parse("1.0.0"),
-                                    Sha512 = "sha2"
+                                    ContentHash = "sha2"
                                 }
                             }
                         },
@@ -64,7 +64,7 @@ namespace NuGet.ProjectModel.Test
                                     Type = PackageDependencyType.Direct,
                                     RequestedVersion = VersionRange.Parse("1.0.0"),
                                     ResolvedVersion = NuGetVersion.Parse("1.0.0"),
-                                    Sha512 = "sha3",
+                                    ContentHash = "sha3",
                                     Dependencies = new List<PackageDependency>()
                                     {
                                         new PackageDependency("runtime.win10-arm.PackageA", VersionRange.Parse("1.0.0"))
@@ -75,7 +75,7 @@ namespace NuGet.ProjectModel.Test
                                     Id = "runtime.win10-arm.PackageA",
                                     Type = PackageDependencyType.Transitive,
                                     ResolvedVersion = NuGetVersion.Parse("1.0.0"),
-                                    Sha512 = "sha4"
+                                    ContentHash = "sha4"
                                 }
                             }
                         }


### PR DESCRIPTION
As per discuss in dotnet CLI PR# https://github.com/dotnet/cli/pull/9868 changing `--reevaluate` flag to `--force-evaluate` and corresponding msbuild property to `RestoreForceEvaluate`.

I'll update the Spec as well - https://github.com/NuGet/Home/wiki/Enable-repeatable-package-restore-using-lock-file

