### PR TITLE
Origin can be null on RepositoryItem

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/RepositoryItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/RepositoryItem.cs
@@ -199,8 +199,12 @@ namespace NuGet.Configuration
                 {
                     XElementUtility.RemoveIndented(_owners.Node);
                     _owners = null;
-                    Origin.IsDirty = true;
                     Owners.Clear();
+
+                    if (Origin != null)
+                    {
+                        Origin.IsDirty = true;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
`RepositoryItem` was added as part of https://github.com/NuGet/NuGet.Client/pull/2426. While looking into the code I saw that I missed a null check in the `update` code path for this object. This should never be called in a real scenario in our code path, but since the API permits it we need to add this null check. This same thing is done for all other `SettingItems`.