### PR TITLE
ValidAuthenticationTypes should be set to null when removing

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
@@ -280,6 +280,12 @@ namespace NuGet.Configuration
                 else if (credentials.ValidAuthenticationTypes == null)
                 {
                     XElementUtility.RemoveIndented(_validAuthenticationTypes.Node);
+                    _validAuthenticationTypes = null;
+
+                    if (Origin != null)
+                    {
+                        Origin.IsDirty = true;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
While doing some exploratory testing I found a bug with the implementation of `CredentaislItem`.

When using `update` to remove `ValidAuthenticationTypes` we were not removing the object properly, therefore the object model would be in a weird state where it is accessible from the object and you see it in the file but it's not in the XDocument abstraction.