### PR TITLE
Use comparer depend on the users OS

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -743,7 +743,7 @@ namespace NuGet.Build.Tasks.Pack
                     library => Path.GetFullPath(Path.Combine(
                         Path.GetDirectoryName(assetsFile.PackageSpec.RestoreMetadata.ProjectPath),
                         PathUtility.GetPathWithDirectorySeparator(library.MSBuildProject))),
-                    library => new PackageIdentity(library.Name, library.Version));
+                    library => new PackageIdentity(library.Name, library.Version), PathUtility.GetStringComparerBasedOnOS());
 
             // Consider all of the project references, grouped by target framework.
             foreach (var framework in assetsFile.PackageSpec.RestoreMetadata.TargetFrameworks)

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -743,7 +743,8 @@ namespace NuGet.Build.Tasks.Pack
                     library => Path.GetFullPath(Path.Combine(
                         Path.GetDirectoryName(assetsFile.PackageSpec.RestoreMetadata.ProjectPath),
                         PathUtility.GetPathWithDirectorySeparator(library.MSBuildProject))),
-                    library => new PackageIdentity(library.Name, library.Version), PathUtility.GetStringComparerBasedOnOS());
+                    library => new PackageIdentity(library.Name, library.Version),
+                    PathUtility.GetStringComparerBasedOnOS());
 
             // Consider all of the project references, grouped by target framework.
             foreach (var framework in assetsFile.PackageSpec.RestoreMetadata.TargetFrameworks)

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -131,13 +131,19 @@ namespace Dotnet.Integration.Test
         }
 
         internal void RestoreProject(string workingDirectory, string projectName, string args)
+            => RestoreProjectOrSolution(workingDirectory, $"{projectName}.csproj", args);
+
+        internal void RestoreSolution(string workingDirectory, string solutionName, string args)
+            => RestoreProjectOrSolution(workingDirectory, $"{solutionName}.sln", args);
+
+        private void RestoreProjectOrSolution(string workingDirectory, string fileName, string args)
         {
             var envVar = new Dictionary<string, string>();
             envVar.Add("MSBuildSDKsPath", MsBuildSdksPath);
 
             var result = CommandRunner.Run(TestDotnetCli,
                 workingDirectory,
-                $"restore {projectName}.csproj {args}",
+                $"restore {fileName} {args}",
                 waitForExit: true,
                 environmentVariables: _processEnvVars);
             Assert.True(result.Item1 == 0, $"Restore failed with following log information :\n {result.AllOutput}");
@@ -165,10 +171,16 @@ namespace Dotnet.Integration.Test
         }
 
         internal CommandRunnerResult PackProject(string workingDirectory, string projectName, string args, string nuspecOutputPath = "obj", bool validateSuccess = true)
+            => PackProjectOrSolution(workingDirectory, $"{projectName}.csproj", args, nuspecOutputPath, validateSuccess);
+
+        internal CommandRunnerResult PackSolution(string workingDirectory, string solutionName, string args, string nuspecOutputPath = "obj", bool validateSuccess = true)
+            => PackProjectOrSolution(workingDirectory, $"{solutionName}.sln", args, nuspecOutputPath, validateSuccess);
+
+        private CommandRunnerResult PackProjectOrSolution(string workingDirectory, string file, string args, string nuspecOutputPath, bool validateSuccess)
         {
             var result = CommandRunner.Run(TestDotnetCli,
                 workingDirectory,
-                $"pack {projectName}.csproj {args} /p:NuspecOutputPath={nuspecOutputPath}",
+                $"pack {file} {args} /p:NuspecOutputPath={nuspecOutputPath}",
                 waitForExit: true,
                 environmentVariables: _processEnvVars);
             if (validateSuccess)


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7329
Regression: Yes/No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: Use platform dependent comparer to avoid path with different cases missed in the nuget packaging process.

## Testing/Validation
Tests Added: Yes.  
Reason for not adding tests:  N/A
Validation done:  Yes, with unit and manual testing.
