### PR TITLE
add ability to override cli version from CI via env variable

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -194,6 +194,8 @@ Function Install-DotnetCLI {
     param(
         [switch]$Force
     )
+    $msbuildExe = 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\bin\msbuild.exe'
+    $CliTargetBranch = & $msbuildExe $NuGetClientRoot\build\config.props /v:m /nologo /t:GetCliTargetBranch
 
     $cli = @{
             Root = $CLIRoot
@@ -212,8 +214,8 @@ Function Install-DotnetCLI {
         $DotNetInstall = Join-Path $cli.Root 'dotnet-install.ps1'
 
         Invoke-WebRequest $cli.DotNetInstallUrl -OutFile $DotNetInstall
-
-        & $DotNetInstall -Channel release/2.1.4xx -i $cli.Root
+        $channel = $CliTargetBranch.Trim()
+        & $DotNetInstall -Channel $channel  -i $cli.Root
     }
 
     if (-not (Test-Path $cli.DotNetExe)) {

--- a/build/config.props
+++ b/build/config.props
@@ -9,8 +9,10 @@
     <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">$(MajorNuGetVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</SemanticVersion>
     <VsTargetBranch>lab/d16.$(MinorNuGetVersion)stg</VsTargetBranch>
     <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d16.$(MinorNuGetVersion)</VsTargetBranch>
-    <SdkTargetBranch>release/2.1.4xx</SdkTargetBranch>
-    <CliTargetBranch>release/2.1.4xx</CliTargetBranch>
+    <CliTargetBranch Condition="'$(OverrideCliTargetBranch)' != ''">$(OverrideCliTargetBranch)</CliTargetBranch>
+    <CliTargetBranch Condition="'$(OverrideCliTargetBranch)' == ''">release/2.1.4xx</CliTargetBranch>
+    <SdkTargetBranch Condition="'$(OverrideCliTargetBranch)' != ''">$(OverrideCliTargetBranch)</SdkTargetBranch>
+    <SdkTargetBranch Condition="'$(OverrideCliTargetBranch)' == ''">release/2.1.4xx</SdkTargetBranch>
     <!-- We need to update this netcoreassembly build number with every milestone to workaround any breaking api
     changes we might have made-->
     <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">1</NetCoreAssemblyBuildNumber>


### PR DESCRIPTION
You can override CLI Target branch (and SDK too) that would be downloaded for running tests (and send PRs to if one is created from the build) by setting ```OverrideCliTargetBranch``` while queuing a build in VSTS.

By default it is empty, but can be given a value like ```release/2.2.1xx```

![image](https://user-images.githubusercontent.com/1857490/46105577-3d6d7a80-c18b-11e8-9317-36795aae1797.png)
