### PR TITLE
pass normalized path for validation during extraction

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -571,7 +571,7 @@ namespace NuGet.Packaging
             packageFiles.ForEach(p =>
             {
                 var normalizedPath = Uri.UnescapeDataString(p.Replace('/', Path.DirectorySeparatorChar));
-                ValidatePackageEntry(normalizedDestination, p, packageIdentity);
+                ValidatePackageEntry(normalizedDestination, normalizedPath, packageIdentity);
             });
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -1661,6 +1661,33 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
+        public async Task ValidatePackageEntriesAsync_PackageFilesWithSpecialCharacters_DoesNotThrow()
+        {
+            // Arrange
+            using (var root = TestDirectory.Create())
+            {
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
+                var packageFileInfo = await TestPackagesCore.GeneratePackageAsync(
+                   root,
+                   identity.Id,
+                   identity.Version.ToString(),
+                   DateTimeOffset.UtcNow.LocalDateTime,
+                   "C++.dll",
+                   "content/net40/B&#A.txt",
+                   "content/net40/B.nuspec");
+
+                using (var packageStream = File.OpenRead(packageFileInfo.FullName))
+                using (var packageReader = new PackageArchiveReader(packageStream))
+                {
+                    // Act & Assert
+                    // This shouldn't throw
+                    await packageReader.ValidatePackageEntriesAsync(CancellationToken.None);
+                }
+            }
+        }
+
+        [Fact]
         public async Task ValidatePackageEntriesAsync_ValidPackageFiles_Succeeds()
         {
             // Arrange


### PR DESCRIPTION
follow up to fix a bug in  #2296 and #2302 