### PR TITLE
Writing packages.lock.json file independent of writing project.assets.json

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -155,6 +155,11 @@ namespace NuGet.Commands
             await CommitCacheFileAsync(
                 log: log,
                 toolCommit : isTool);
+
+            // Commit the lock file to disk
+            await CommitLockFileAsync(
+                log: log,
+                toolCommit: isTool);
         }
 
         private async Task CommitAssetsFileAsync(
@@ -202,17 +207,6 @@ namespace NuGet.Commands
                     FileUtility.Replace(
                         (outputPath) => lockFileFormat.Write(outputPath, result.LockFile),
                         result.LockFilePath);
-
-                    if (NewPackagesLockFile != null && !string.IsNullOrEmpty(NewPackagesLockFilePath))
-                    {
-                        log.LogInformation(string.Format(CultureInfo.CurrentCulture,
-                        Strings.Log_WritingPackagesLockFile,
-                        NewPackagesLockFilePath));
-
-                        FileUtility.Replace(
-                            (outputPath) => PackagesLockFileFormat.Write(outputPath, NewPackagesLockFile),
-                            NewPackagesLockFilePath);
-                    }
                 }
             }
             else
@@ -251,6 +245,21 @@ namespace NuGet.Commands
                 await FileUtility.ReplaceWithLock(
                    outPath => CacheFileFormat.Write(outPath, CacheFile),
                             CacheFilePath);
+            }
+        }
+
+        private async Task CommitLockFileAsync(ILogger log, bool toolCommit)
+        {
+            // write packages lock file if it's not tool commit
+            if (!toolCommit && NewPackagesLockFile != null && !string.IsNullOrEmpty(NewPackagesLockFilePath))
+            {
+                log.LogInformation(string.Format(CultureInfo.CurrentCulture,
+                Strings.Log_WritingPackagesLockFile,
+                NewPackagesLockFilePath));
+
+                await FileUtility.ReplaceWithLock(
+                    (outputPath) => PackagesLockFileFormat.Write(outputPath, NewPackagesLockFile),
+                    NewPackagesLockFilePath);
             }
         }
     }


### PR DESCRIPTION
Writing packages.lock.json file should be independent of writing project.assets.json file since we could have a updated assets file but no lock file and a force restore should only generates a lock file.