### PR TITLE
Initialize MEF before migrating project

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -523,6 +523,11 @@ namespace NuGetVSExtension
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
+            if (ShouldMEFBeInitialized())
+            {
+                await InitializeMEFAsync();
+            }
+
             var project = EnvDTEProjectInfoUtility.GetActiveProject(VsMonitorSelection);
 
             if (!await NuGetProjectUpgradeUtility.IsNuGetProjectUpgradeableAsync(null, project))


### PR DESCRIPTION
NuGet package MEF were not initialized when migrating project was the first NuGet action after opening the VS. This fix makes sure MEF is initialized before starting to migrate.

Fixes - [Test Failure] Clicking “Migrate packages.config to PackageReference” makes VS crash in an exsisting solution with “packages.config” format package installed [692256](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/692256)

