### PR TITLE
Ensure Root is absolute

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -74,7 +74,7 @@ namespace NuGet.CommandLine
 
             CalculateEffectivePackageSaveMode();
             CalculateEffectiveSettings();
-            var installPath = ResolveInstallPath();
+            var installPath = Path.GetFullPath(ResolveInstallPath());
 
             var configFilePath = Path.GetFullPath(Arguments.Count == 0 ? Constants.PackageReferenceFile : Arguments[0]);
             var configFileName = Path.GetFileName(configFilePath);

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -259,7 +259,7 @@ namespace NuGet.CommandLine
         private async Task<IReadOnlyList<RestoreSummary>> PerformNuGetV2RestoreAsync(PackageRestoreInputs packageRestoreInputs)
         {
             ReadSettings(packageRestoreInputs);
-            var packagesFolderPath = GetPackagesFolder(packageRestoreInputs);
+            var packagesFolderPath = Path.GetFullPath(GetPackagesFolder(packageRestoreInputs));
 
             var sourceRepositoryProvider = new CommandLineSourceRepositoryProvider(SourceProvider);
             var nuGetPackageManager = new NuGetPackageManager(sourceRepositoryProvider, Settings, packagesFolderPath);

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/Utils/InstalledPackageEnumerator.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/Utils/InstalledPackageEnumerator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -229,7 +230,7 @@ namespace NuGetConsole.Host.PowerShell
 
             // Get the path to the Packages folder.
             var packagesFolderPath = packageManager.PackagesFolderSourceRepository.PackageSource.Source;
-            var packagePathResolver = new PackagePathResolver(packagesFolderPath);
+            var packagePathResolver = new PackagePathResolver(Path.GetFullPath(packagesFolderPath));
 
             var packagesToSort = new HashSet<ResolverPackage>();
             var resolvedPackages = new HashSet<PackageIdentity>();

--- a/src/NuGet.Core/NuGet.Packaging/PackagePathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackagePathResolver.cs
@@ -17,6 +17,12 @@ namespace NuGet.Packaging
 
         public bool UseSideBySidePaths { get; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PackagePathResolver"/> class.
+        /// </summary>
+        /// <param name="rootDirectory">The root directory.</param>
+        /// <param name="useSideBySidePaths">A value indicating whether to use side-by-side paths.</param>
+        /// <exception cref="System.ArgumentException">If rootDirectory is null, empty or does not contain an absolute path. </exception>
         public PackagePathResolver(string rootDirectory, bool useSideBySidePaths = true)
         {
             if (string.IsNullOrEmpty(rootDirectory))
@@ -28,7 +34,7 @@ namespace NuGet.Packaging
             if (!Path.IsPathRooted(rootDirectory))
             {
                 throw new ArgumentException(
-                    string.Format(Strings.MustContainAbsolutePath, nameof(rootDirectory), string.Empty),
+                    string.Format(Strings.MustContainAbsolutePath, nameof(rootDirectory), rootDirectory),
                     nameof(rootDirectory));
             }
 

--- a/src/NuGet.Core/NuGet.Packaging/PackagePathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackagePathResolver.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Text;
-using NuGet.Common;
 using NuGet.Packaging.Core;
 
 namespace NuGet.Packaging
@@ -14,8 +13,9 @@ namespace NuGet.Packaging
     /// </summary>
     public class PackagePathResolver
     {
+        private readonly string _rootDirectory;
+
         public bool UseSideBySidePaths { get; }
-        protected internal string Root { get; }
 
         public PackagePathResolver(string rootDirectory, bool useSideBySidePaths = true)
         {
@@ -25,11 +25,20 @@ namespace NuGet.Packaging
                     string.Format(Strings.StringCannotBeNullOrEmpty, nameof(rootDirectory)),
                     nameof(rootDirectory));
             }
+            if (!Path.IsPathRooted(rootDirectory))
+            {
+                throw new ArgumentException(
+                    string.Format(Strings.MustContainAbsolutePath, nameof(rootDirectory), string.Empty),
+                    nameof(rootDirectory));
+            }
 
-            Root = Path.IsPathRooted(rootDirectory) ?
-                rootDirectory :
-                PathUtility.GetAbsolutePath(Directory.GetCurrentDirectory(), rootDirectory);
+            _rootDirectory = rootDirectory;
             UseSideBySidePaths = useSideBySidePaths;
+        }
+
+        protected internal string Root
+        {
+            get { return _rootDirectory; }
         }
 
         public virtual string GetPackageDirectoryName(PackageIdentity packageIdentity)
@@ -65,7 +74,7 @@ namespace NuGet.Packaging
 
         public virtual string GetInstallPath(PackageIdentity packageIdentity)
         {
-            return Path.Combine(Root, GetPackageDirectoryName(packageIdentity));
+            return Path.Combine(_rootDirectory, GetPackageDirectoryName(packageIdentity));
         }
 
         public virtual string GetInstalledPath(PackageIdentity packageIdentity)

--- a/src/NuGet.Core/NuGet.Packaging/PackagePathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackagePathResolver.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.IO;
 using System.Text;
+using NuGet.Common;
 using NuGet.Packaging.Core;
 
 namespace NuGet.Packaging
@@ -13,9 +14,8 @@ namespace NuGet.Packaging
     /// </summary>
     public class PackagePathResolver
     {
-        private readonly string _rootDirectory;
-
         public bool UseSideBySidePaths { get; }
+        protected internal string Root { get; }
 
         public PackagePathResolver(string rootDirectory, bool useSideBySidePaths = true)
         {
@@ -25,13 +25,11 @@ namespace NuGet.Packaging
                     string.Format(Strings.StringCannotBeNullOrEmpty, nameof(rootDirectory)),
                     nameof(rootDirectory));
             }
-            _rootDirectory = rootDirectory;
-            UseSideBySidePaths = useSideBySidePaths;
-        }
 
-        protected internal string Root
-        {
-            get { return _rootDirectory; }
+            Root = Path.IsPathRooted(rootDirectory) ?
+                rootDirectory :
+                PathUtility.GetAbsolutePath(Directory.GetCurrentDirectory(), rootDirectory);
+            UseSideBySidePaths = useSideBySidePaths;
         }
 
         public virtual string GetPackageDirectoryName(PackageIdentity packageIdentity)
@@ -67,7 +65,7 @@ namespace NuGet.Packaging
 
         public virtual string GetInstallPath(PackageIdentity packageIdentity)
         {
-            return Path.Combine(_rootDirectory, GetPackageDirectoryName(packageIdentity));
+            return Path.Combine(Root, GetPackageDirectoryName(packageIdentity));
         }
 
         public virtual string GetInstalledPath(PackageIdentity packageIdentity)

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -540,7 +540,7 @@ namespace NuGet.Protocol.Core.Types
 
             if (IsV2LocalRepository(root))
             {
-                var pathResolver = new PackagePathResolver(root, useSideBySidePaths: true);
+                var pathResolver = new PackagePathResolver(sourceUri.AbsolutePath, useSideBySidePaths: true);
                 var packageFileName = pathResolver.GetPackageFileName(packageIdentity);
 
                 var fullPath = Path.Combine(root, packageFileName);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/FolderNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/FolderNuGetProjectTests.cs
@@ -22,6 +22,8 @@ namespace NuGet.ProjectManagement.Test
 {
     public class FolderNuGetProjectTests
     {
+        private static readonly string Root = Path.GetFullPath("a");
+
         [Fact]
         public void Constructor_String_ThrowsForNullRoot()
         {
@@ -33,9 +35,9 @@ namespace NuGet.ProjectManagement.Test
         [Fact]
         public void Constructor_String_InitializesRootProperty()
         {
-            var project = new FolderNuGetProject(root: "a");
+            var project = new FolderNuGetProject(Root);
 
-            Assert.Equal("a", project.Root);
+            Assert.Equal(Root, project.Root);
         }
 
         [Fact]
@@ -44,7 +46,7 @@ namespace NuGet.ProjectManagement.Test
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new FolderNuGetProject(
                     root: null,
-                    packagePathResolver: new PackagePathResolver(rootDirectory: "a")));
+                    packagePathResolver: new PackagePathResolver(rootDirectory: Root)));
 
             Assert.Equal("root", exception.ParamName);
         }
@@ -53,7 +55,7 @@ namespace NuGet.ProjectManagement.Test
         public void Constructor_StringPackagePathResolver_ThrowsForNullPackagePathResolver()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new FolderNuGetProject(root: "a", packagePathResolver: null));
+                () => new FolderNuGetProject(Root, packagePathResolver: null));
 
             Assert.Equal("packagePathResolver", exception.ParamName);
         }
@@ -62,16 +64,16 @@ namespace NuGet.ProjectManagement.Test
         public void Constructor_StringPackagePathResolver_InitializesRootProperty()
         {
             var project = new FolderNuGetProject(
-                root: "a",
-                packagePathResolver: new PackagePathResolver(rootDirectory: "a"));
+                root: Root,
+                packagePathResolver: new PackagePathResolver(rootDirectory: Root));
 
-            Assert.Equal("a", project.Root);
+            Assert.Equal(Root, project.Root);
         }
 
         [Fact]
         public async Task GetInstalledPackagesAsync_DoesNotThrowIfCancelled()
         {
-            var project = new FolderNuGetProject(root: "a");
+            var project = new FolderNuGetProject(root: Root);
 
             await project.GetInstalledPackagesAsync(new CancellationToken(canceled: true));
         }
@@ -79,7 +81,7 @@ namespace NuGet.ProjectManagement.Test
         [Fact]
         public async Task GetInstalledPackagesAsync_ReturnsEmptyEnumerable()
         {
-            var project = new FolderNuGetProject(root: "a");
+            var project = new FolderNuGetProject(root: Root);
 
             var packages = await project.GetInstalledPackagesAsync(CancellationToken.None);
 
@@ -271,7 +273,7 @@ namespace NuGet.ProjectManagement.Test
         [Fact]
         public void PackageExists_PackageIdentity_ThrowsForNullPackageIdentity()
         {
-            var project = new FolderNuGetProject(root: "a");
+            var project = new FolderNuGetProject(root: Root);
 
             var exception = Assert.Throws<ArgumentNullException>(() => project.PackageExists(packageIdentity: null));
 
@@ -361,7 +363,7 @@ namespace NuGet.ProjectManagement.Test
         [Fact]
         public void PackageExists_PackageIdentityPackageSaveMode_ThrowsForNullPackageIdentity()
         {
-            var project = new FolderNuGetProject(root: "a");
+            var project = new FolderNuGetProject(root: Root);
 
             var exception = Assert.Throws<ArgumentNullException>(
                 () => project.PackageExists(packageIdentity: null, packageSaveMode: PackageSaveMode.Nupkg));
@@ -758,7 +760,7 @@ namespace NuGet.ProjectManagement.Test
         [Fact]
         public async Task UninstallPackageAsync_DoesNothing()
         {
-            var project = new FolderNuGetProject(root: "a");
+            var project = new FolderNuGetProject(root: Root);
 
             var wasUninstalled = await project.UninstallPackageAsync(
                 new PackageIdentity(id: "a", version: NuGetVersion.Parse("1.0.0")),

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -3596,7 +3596,7 @@ namespace NuGet.Packaging.Test
             var exception = await Assert.ThrowsAsync<ArgumentNullException>(
                 () => PackageExtractor.CopySatelliteFilesAsync(
                     packageIdentity: null,
-                    packagePathResolver: new PackagePathResolver(rootDirectory: "a"),
+                    packagePathResolver: new PackagePathResolver(rootDirectory: Path.GetFullPath("a")),
                     packageSaveMode: PackageSaveMode.Defaultv3,
                     packageExtractionContext: new PackageExtractionContext(
                         PackageSaveMode.Defaultv2,

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagePathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagePathResolverTests.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.IO;
+using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -109,7 +110,7 @@ namespace NuGet.Packaging.Test
             var target = new PackagePathResolver(
                 rootDirectory: InMemoryRootDirectory,
                 useSideBySidePaths: useSideBySidePaths);
-            expected = Path.Combine(InMemoryRootDirectory, expected);
+            expected = PathUtility.GetAbsolutePath(Directory.GetCurrentDirectory(), Path.Combine(InMemoryRootDirectory, expected));
 
             // Act
             var actual = target.GetInstallPath(PackageIdentity);
@@ -268,6 +269,22 @@ namespace NuGet.Packaging.Test
                 var actualFilePath = target.GetInstalledPackageFilePath(PackageIdentity);
 
                 Assert.Equal("", actualFilePath);
+            }
+        }
+
+        [Fact]
+        public void Root_ReturnsAbsolutePath()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var expectedPath = testDirectory.Path;
+                var relativePath = PathUtility.GetRelativePath(Directory.GetCurrentDirectory(), expectedPath);
+
+                var target = new PackagePathResolver(relativePath);
+
+                var actualPath = target.Root;
+
+                Assert.Equal(expectedPath, actualPath);
             }
         }
     }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7349
Regression: No  

## Fix
Details: Ensure Root is absolute for PackagePathResolver, as GetInstalledPath doesn't work with relative paths.  

## Testing/Validation
Tests Added: Yes
Validation done:  
