### PR TITLE
Fix showing Migrate option to not show up on non packages.config projects

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/Guids.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Guids.cs
@@ -18,7 +18,7 @@ namespace NuGetVSExtension
         // any project system that wants to load NuGet when its project opens needs to activate a UI context with this GUID
         public const string guidAutoLoadNuGetString = "65B1D035-27A5-4BBA-BAB9-5F61C1E2BC4A";
 
-        // GUID for UI Context rule that is active when a project that might be upgradeable (from packages.config to project.json)
+        // GUID for UI Context rule that is active when a project that might be upgradeable (from packages.config to PackageReference)
         // is loaded. This will autoload our package, so we can dynamically control the visibility of the appropriate menu items.
         public const string guidUpgradeableProjectLoadedString = "1837160D-723F-43CD-8185-97758295A859";
 

--- a/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
@@ -83,6 +83,7 @@
       <Button guid="guidDialogCmdSet" id="cmdidUpgradeNuGetProject" priority="0x0400" type="Button">
         <Parent guid="guidReferenceContext" id="cmdAddReferenceGroup" />
         <Icon guid="guidToolbarImages" id="bmpUpgradeNuGetProject" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <CommandName>cmdidUpgradeNuGetProject</CommandName>
@@ -93,6 +94,7 @@
       <Button guid="guidDialogCmdSet" id="cmdidUpgradePackagesConfig" priority="0x0410" type="Button">
         <Parent guid="guidReferenceContext" id="cmdAddReferenceGroup" />
         <Icon guid="guidToolbarImages" id="bmpUpgradeNuGetProject" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <CommandName>cmdidUpgradePackagesConfig</CommandName>
@@ -163,8 +165,8 @@
     <VisibilityItem guid="guidDialogCmdSet" id="cmdidAddPackages" context="UICONTEXT_SolutionExistsAndNotBuildingAndNotDebugging" />
     <VisibilityItem guid="guidDialogCmdSet" id="cmdidAddPackagesForSolution" context="UICONTEXT_SolutionExistsAndNotBuildingAndNotDebugging" />
     <VisibilityItem guid="guidDialogCmdSet" id="cmdidRestorePackages" context="UICONTEXT_SolutionExistsAndNotBuildingAndNotDebugging" />
-    <VisibilityItem guid="guidDialogCmdSet" id="cmdidUpgradePackagesConfig" context="UICONTEXT_SolutionExistsAndNotBuildingAndNotDebugging" />
-    <VisibilityItem guid="guidDialogCmdSet" id="cmdidUpgradeNuGetProject" context="UICONTEXT_SolutionExistsAndNotBuildingAndNotDebugging" />
+    <VisibilityItem guid="guidDialogCmdSet" id="cmdidUpgradePackagesConfig" context="UICONTEXT_UpgradeableProjectLoaded" />
+    <VisibilityItem guid="guidDialogCmdSet" id="cmdidUpgradeNuGetProject" context="UICONTEXT_UpgradeableProjectLoaded" />
   </VisibilityConstraints>
 
   <CommandPlacements>
@@ -213,6 +215,7 @@
   </CommandPlacements>
 
   <Symbols>
+    <GuidSymbol name="UICONTEXT_UpgradeableProjectLoaded" value="{1837160D-723F-43CD-8185-97758295A859}" /> 
     <GuidSymbol name="guidNuGetPackage" value="{5fcc8577-4feb-4d04-ad72-d6c629b083cc}" />
     <GuidSymbol name="guidRestoreManagerPackage" value="{2b52ac92-4551-426d-bd34-c6d7d9fdd1c5}" />
     <GuidSymbol name="guidPowerConsoleCmdSet" value="{1E8A55F6-C18D-407F-91C8-94B02AE1CED6}">


### PR DESCRIPTION
This PR does following things:

- By default Migrator option is invisible for all projects.
- Added a new UI context to load NuGetPackage when there is a project with `packages.config` file so that it can dynamically control Migrator option behavior and let it be visible for projects with packages.config based projects.
- Don't show this option for docker files or any other file except `packages.config`

Fixes [Docker Tools]'Migrate packages.config to PackageReference...' item displays in the context menu after right clicking on 'dockerfile' [685531](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/685531)
