### PR TITLE
Fix installing a package through the UI

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetUIFactory.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetUIFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -9,6 +9,9 @@ using NuGet.Configuration;
 using NuGet.PackageManagement;
 using NuGet.PackageManagement.UI;
 using NuGet.PackageManagement.VisualStudio;
+using NuGet.Packaging;
+using NuGet.Packaging.PackageExtraction;
+using NuGet.Packaging.Signing;
 using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
 using NuGet.VisualStudio;
@@ -60,10 +63,18 @@ namespace NuGetVSExtension
             INuGetUILogger logger,
             ISourceControlManagerProvider sourceControlManagerProvider)
         {
+            var signedPackageVerifier = new PackageSignatureVerifier(SignatureVerificationProviderFactory.GetSignatureVerificationProviders());
             ProjectContext = new NuGetUIProjectContext(
                 commonOperations,
                 logger,
                 sourceControlManagerProvider);
+
+            ProjectContext.PackageExtractionContext = new PackageExtractionContext(
+                    PackageSaveMode.Defaultv2,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
+                    new LoggerAdapter(ProjectContext),
+                    signedPackageVerifier,
+                    SignedPackageVerifierSettings.GetDefault());
         }
 
         /// <summary>


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7357

## Fix
When installing a package using the UI, the project context created for the UIAction did not create an `ExtractionContext`. This ended up in a null pointer exception when trying to install the package. This PR fixes it by creating an extraction context when the project context is created. Since this is a UI scenario the tests that should have caught this are manual tests and Apex, which we might have skipped since they are not as reliable.

I manually tested this scenario with PC, legacy PR, and PR and it works.