### PR TITLE
Fix the no-service endpoint message

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -943,7 +943,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to --no-service-endpoint does not append &quot;api/v2/packages&quot; to the source URL..
+        ///   Looks up a localized string similar to Does not append &quot;api/v2/package&quot; to the source URL..
         /// </summary>
         internal static string NoServiceEndpoint_Description {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -469,7 +469,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
 {1} - Project path</comment>
   </data>
   <data name="NoServiceEndpoint_Description" xml:space="preserve">
-    <value>--no-service-endpoint does not append "api/v2/packages" to the source URL.</value>
+    <value>Does not append "api/v2/package" to the source URL.</value>
   </data>
   <data name="AddPkg_InteractiveDescription" xml:space="preserve">
     <value>Allow the command to block and require manual action for operations like authentication.</value>


### PR DESCRIPTION
## Bug
Fixes: None
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 

Follow up instead of https://github.com/NuGet/NuGet.Client/pull/2273 as we got no further interaction on that PR.   

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  String change.
Validation done:  
