### PR TITLE
change default of IsPackable to false for Exe

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -31,6 +31,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PackageDescription Condition="'$(PackageDescription)'==''">$(Description)</PackageDescription>
     <PackageDescription Condition="'$(PackageDescription)'==''">Package Description</PackageDescription>
     <IsPackable Condition="'$(IsPackable)'=='' AND '$(IsTestProject)'=='true'">false</IsPackable>
+    <IsPackable Condition="'$(IsPackable)'=='' AND '$(OutputType)'=='Exe'">false</IsPackable>
     <IsPackable Condition="'$(IsPackable)'==''">true</IsPackable>
     <IncludeBuildOutput Condition="'$(IncludeBuildOutput)'==''">true</IncludeBuildOutput>
     <BuildOutputTargetFolder Condition="'$(BuildOutputTargetFolder)' == '' AND '$(IsTool)' == 'true'">tools</BuildOutputTargetFolder>


### PR DESCRIPTION
Let `IsPackable` default to `false` for projects with `OutputType` == `Exe`.

This PR is just a suggestion to change the default behaviour to make generic build scripts and running msbuild on solution files produce more reasonable output.

This avoids simple console applications to be packaged (and maybe later pushed to some nuget server) -- even if e.g. `msbuild /t:pack` is called for a solution that contains such a console application project and a class library project.

One could argue that calling target `pack` should always create nupkg but this isn't the case for test projects, neither (see line above my change). There are valid reasons to produce packages for Exe projects but the same is true for test projects -- but defaults should prefer the most common case.

IMO this should improve output for mixed solutions (or situations with generic build scripts).
A solution consisting of a console application, a class library and a test project should produce at most a nupkg for the class library by default.