### PR TITLE
Fix live lock 

### DIFF
--- a/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
+++ b/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
@@ -147,6 +147,10 @@ namespace NuGet.Common
                         Thread.Sleep(SleepDuration);
                         continue;
                     }
+                    catch (FileLoadException)
+                    {
+                        throw;
+                    }
                     catch (IOException)
                     {
                         Thread.Sleep(SleepDuration);


### PR DESCRIPTION
It fixes live lock when the assembly did not load System.Security.Cryptography.Algorithms.dll an example in case incorrect binding redirect.