### PR TITLE
Disable any package download plugin by default

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
@@ -30,6 +30,7 @@ namespace NuGet.Protocol.Core.Types
 
         private const string _idleTimeoutEnvironmentVariable = "NUGET_PLUGIN_IDLE_TIMEOUT_IN_SECONDS";
         private const string _pluginPathsEnvironmentVariable = "NUGET_PLUGIN_PATHS";
+        private const string _downloadPluginsEnabledEnvironmentVariable = "NUGET_DOWNLOAD_PLUGINS_ENABLED";
 
         private ConnectionOptions _connectionOptions;
         private Lazy<IPluginDiscoverer> _discoverer;
@@ -131,7 +132,7 @@ namespace NuGet.Protocol.Core.Types
             var pluginCreationResults = new List<PluginCreationResult>();
 
             // Fast path
-            if (source.PackageSource.IsHttp && IsPluginPossiblyAvailable())
+            if (source.PackageSource.IsHttp && IsPluginPossiblyAvailable() && AreDownloadPlugingsEnabled())
             {
                 var serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>(cancellationToken);
 
@@ -334,6 +335,18 @@ namespace NuGet.Protocol.Core.Types
             var verifier = EmbeddedSignatureVerifier.Create();
 
             return new PluginDiscoverer(_rawPluginPaths, verifier);
+        }
+
+        private bool AreDownloadPlugingsEnabled()
+        {
+            var variableValue = EnvironmentVariableReader.GetEnvironmentVariable(_downloadPluginsEnabledEnvironmentVariable);
+
+            if (bool.TryParse(variableValue, out var result))
+            {
+                return result;
+            }
+
+            return false;
         }
 
         private bool IsPluginPossiblyAvailable()

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/CredentialTestConstants.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/CredentialTestConstants.cs
@@ -9,5 +9,6 @@ namespace NuGet.Credentials.Test
         public static string PluginIdleTimeoutEnvironmentVariable = "NUGET_PLUGIN_IDLE_TIMEOUT_IN_SECONDS";
         public static string PluginPathsEnvironmentVariable = "NUGET_PLUGIN_PATHS";
         public static string PluginRequestTimeoutEnvironmentVariable = "NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS";
+        public static string DownloadPluginsEnabledEnvironmentVariable = "NUGET_DOWNLOAD_PLUGINS_ENABLED";
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/PluginManagerMock.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/PluginManagerMock.cs
@@ -210,6 +210,9 @@ namespace NuGet.Credentials.Test
             _reader.Setup(x => x.GetEnvironmentVariable(
                     It.Is<string>(value => value == CredentialTestConstants.PluginHandshakeTimeoutEnvironmentVariable)))
                         .Returns("HandshakeTimeout");
+            _reader.Setup(x => x.GetEnvironmentVariable(
+                    It.Is<string>(value => value == CredentialTestConstants.DownloadPluginsEnabledEnvironmentVariable)))
+                        .Returns("true");
         }
 
         private void EnsureDiscovererIsCalled(string pluginFilePath, PluginFileState pluginFileState)

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderBuilderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderBuilderTests.cs
@@ -116,6 +116,9 @@ namespace NuGet.Credentials.Test
                 reader.Setup(x => x.GetEnvironmentVariable(
                         It.Is<string>(value => value == CredentialTestConstants.PluginHandshakeTimeoutEnvironmentVariable)))
                     .Returns("d");
+                reader.Setup(x => x.GetEnvironmentVariable(
+                        It.Is<string>(value => value == CredentialTestConstants.DownloadPluginsEnabledEnvironmentVariable)))
+                    .Returns("true");
 
                 var pluginDiscoverer = new Mock<IPluginDiscoverer>(MockBehavior.Strict);
                 var pluginDiscoveryResults = GetPluginDiscoveryResults(plugins);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginResourceProviderTests.cs
@@ -23,6 +23,7 @@ namespace NuGet.Protocol.Plugins.Tests
         private const string _pluginIdleTimeoutEnvironmentVariable = "NUGET_PLUGIN_IDLE_TIMEOUT_IN_SECONDS";
         private const string _pluginPathsEnvironmentVariable = "NUGET_PLUGIN_PATHS";
         private const string _pluginRequestTimeoutEnvironmentVariable = "NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS";
+        private const string _downloadPluginsEnabledEnvironmentVariable = "NUGET_DOWNLOAD_PLUGINS_ENABLED";
         private const string _sourceUri = "https://unit.test";
 
         [Fact]
@@ -301,6 +302,9 @@ namespace NuGet.Protocol.Plugins.Tests
                 reader.Setup(x => x.GetEnvironmentVariable(
                         It.Is<string>(value => value == _pluginHandshakeTimeoutEnvironmentVariable)))
                     .Returns("d");
+                reader.Setup(x => x.GetEnvironmentVariable(
+                        It.Is<string>(value => value == _downloadPluginsEnabledEnvironmentVariable)))
+                    .Returns("true");
 
                 var pluginDiscoverer = new Mock<IPluginDiscoverer>(MockBehavior.Strict);
                 var pluginDiscoveryResults = GetPluginDiscoveryResults(pluginsPath);
@@ -371,6 +375,9 @@ namespace NuGet.Protocol.Plugins.Tests
                 _reader.Setup(x => x.GetEnvironmentVariable(
                         It.Is<string>(value => value == _pluginHandshakeTimeoutEnvironmentVariable)))
                     .Returns("HandshakeTimeout");
+                _reader.Setup(x => x.GetEnvironmentVariable(
+                        It.Is<string>(value => value == _downloadPluginsEnabledEnvironmentVariable)))
+                    .Returns("true");
 
                 _pluginDiscoverer = new Mock<IPluginDiscoverer>(MockBehavior.Strict);
 


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7377

## Fix
This PR disables by default any package download plugin and adds an environment variable to enable them.