### PR TITLE
Fix package source order

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -57,7 +57,10 @@ namespace NuGet.Configuration
         private Dictionary<string, IndexedPackageSource> LoadPackageSourceLookup(bool byName)
         {
             var packageSourcesSection = Settings.GetSection(ConfigurationConstants.PackageSources);
-            var sources = packageSourcesSection?.Items.OfType<SourceItem>();
+            var sourcesItems = packageSourcesSection?.Items.OfType<SourceItem>();
+
+            // Order the list so that the closer to the user appear first
+            var sources = sourcesItems?.OrderByDescending(item => item.Origin?.Priority ?? 0);
 
             // get list of disabled packages
             var disabledSourcesSection = Settings.GetSection(ConfigurationConstants.DisabledPackageSources);

--- a/src/NuGet.Core/NuGet.Configuration/Settings/NuGetConfiguration.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NuGetConfiguration.cs
@@ -13,7 +13,7 @@ namespace NuGet.Configuration
     {
         public override string ElementName => ConfigurationConstants.Configuration;
 
-        internal IReadOnlyDictionary<string, SettingSection> Sections => ChildrenSet.Select(c => c.Value).ToDictionary(c => c.ElementName);
+        internal IReadOnlyDictionary<string, SettingSection> Sections => Children.ToDictionary(c => c.ElementName);
 
         protected override bool CanBeCleared => false;
 
@@ -36,7 +36,7 @@ namespace NuGet.Configuration
             foreach (var section in sections)
             {
                 section.Parent = this;
-                ChildrenSet.Add(section, section);
+                Children.Add(section);
             }
         }
 
@@ -54,7 +54,7 @@ namespace NuGet.Configuration
 
             defaultSection.SetNode(defaultSection.AsXNode());
 
-            ChildrenSet.Add(defaultSection, defaultSection);
+            Children.Add(defaultSection);
 
             SetNode(AsXNode());
             SetOrigin(origin);
@@ -161,6 +161,6 @@ namespace NuGet.Configuration
             return Sections.OrderedEquals(nugetConfiguration.Sections, s => s.Key, StringComparer.Ordinal);
         }
 
-        public override int GetHashCode() => ChildrenSet.GetHashCode();
+        public override int GetHashCode() => Children.GetHashCode();
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ParsedSettingSection.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ParsedSettingSection.cs
@@ -17,9 +17,9 @@ namespace NuGet.Configuration
         internal ParsedSettingSection(string name, params SettingItem[] children)
             : base(name, attributes: null, children: new HashSet<SettingItem>(children))
         {
-            foreach (var child in ChildrenSet)
+            foreach (var child in Children)
             {
-                child.Value.Parent = this;
+                child.Parent = this;
             }
         }
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingSection.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingSection.cs
@@ -11,7 +11,7 @@ namespace NuGet.Configuration
 {
     public abstract class SettingSection : SettingsGroup<SettingItem>
     {
-        public IReadOnlyCollection<SettingItem> Items => ChildrenSet.Values;
+        public IReadOnlyCollection<SettingItem> Items => Children.ToList();
 
         public T GetFirstItemWithAttribute<T>(string attributeName, string expectedAttributeValue) where T : SettingItem
         {
@@ -43,10 +43,8 @@ namespace NuGet.Configuration
                 return false;
             }
 
-            if (ChildrenSet.ContainsKey(item))
+            if (TryGetChild(item, out var currentChild))
             {
-                var currentChild = ChildrenSet[item];
-
                 if (currentChild.Origin != null && currentChild.Origin.IsMachineWide)
                 {
                     return false;

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1480,20 +1480,20 @@ namespace NuGet.Configuration.Test
                 // Assert - 1
                 Assert.Collection(sources,
                     source =>
-                        {
-                            Assert.Equal("NuGet.org", source.Name);
-                            Assert.Equal("https://NuGet.org", source.Source);
-                            Assert.True(source.IsEnabled);
-                        },
+                    {
+                        Assert.Equal("test.org", source.Name);
+                        Assert.Equal("https://test.org", source.Source);
+                        Assert.True(source.IsEnabled);
+                    },
                     source =>
-                        {
-                            Assert.Equal("test.org", source.Name);
-                            Assert.Equal("https://test.org", source.Source);
-                            Assert.True(source.IsEnabled);
-                        });
+                    {
+                        Assert.Equal("NuGet.org", source.Name);
+                        Assert.Equal("https://NuGet.org", source.Source);
+                        Assert.True(source.IsEnabled);
+                    });
 
                 // Act - 2
-                sources.First().IsEnabled = false;
+                sources.Last().IsEnabled = false;
                 packageSourceProvider.SavePackageSources(sources);
 
                 // Assert - 2
@@ -1551,20 +1551,21 @@ namespace NuGet.Configuration.Test
                 // Assert - 1
                 Assert.Collection(sources,
                     source =>
-                        {
-                            Assert.Equal("test.org", source.Name);
-                            Assert.Equal("https://test.org", source.Source);
-                            Assert.True(source.IsEnabled);
-                        },
+                    {
+                        Assert.Equal("NuGet.org", source.Name);
+                        Assert.Equal("https://NuGet.org", source.Source);
+                        Assert.True(source.IsEnabled);
+                    },
                     source =>
-                        {
-                            Assert.Equal("NuGet.org", source.Name);
-                            Assert.Equal("https://NuGet.org", source.Source);
-                            Assert.True(source.IsEnabled);
-                        });
+                    {
+                        Assert.Equal("test.org", source.Name);
+                        Assert.Equal("https://test.org", source.Source);
+                        Assert.True(source.IsEnabled);
+                    }
+                    );
 
                 // Act - 2
-                sources[0].IsEnabled = false;
+                sources[1].IsEnabled = false;
                 sources.Add(new PackageSource("http://newsource", "NewSourceName"));
 
                 packageSourceProvider.SavePackageSources(sources);
@@ -1691,16 +1692,16 @@ namespace NuGet.Configuration.Test
                 var sources = packageSourceProvider.LoadPackageSources().ToList();
 
                 // Act
-                sources[1].IsEnabled = false;
+                sources[2].IsEnabled = false;
                 packageSourceProvider.SavePackageSources(sources);
 
                 // Assert
                 var newSources = packageSourceProvider.LoadPackageSources().ToList();
-                Assert.True(newSources[0].IsEnabled);
-                Assert.Equal("Microsoft and .NET", newSources[0].Name);
+                Assert.True(newSources[1].IsEnabled);
+                Assert.Equal("Microsoft and .NET", newSources[1].Name);
 
-                Assert.False(newSources[1].IsEnabled);
-                Assert.Equal("test1", newSources[1].Name);
+                Assert.False(newSources[2].IsEnabled);
+                Assert.Equal("test1", newSources[2].Name);
             }
         }
 


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7303

## Fix
As part of https://github.com/NuGet/NuGet.Client/pull/2370 the ordering of how package sources are read was changed. This caused the issue of selecting incorrectly the first active source in the UI. 

This PR fixes the ordering to match the previously correct order and updates back some tests that where mistakenly updated to match the incorrect order.

The main problem had 2 parts:
- When package sources are read in the `PackageSourceProvider`, they should have been ordered top to bottom, so that sources closer to the user appear first.
- When merging a single setting item with another one, it was being merged in place (keeping the same spot on the list as the one that is overwritten) instead of being added to the end (this was the previous behavior of merging). Since a set/dictionary being converted to a list doesn't provide any deterministic order in the items, the solution was to use a list instead. This list keeps the order of reading, and whenever an item needs to be merged, the old one is deleted from the list and the new one is added back again, this ensures the order is as expected. 