### PR TITLE
Installing a development dependency should skip compile time assets

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -218,6 +218,21 @@ namespace NuGet.Commands
 
                         var package = packageInfo.Package;
 
+                        var developmentDependency = package.Nuspec.GetDevelopmentDependency();
+
+                        // check if package is development dependency and include flags are not overwritten
+                        if (developmentDependency && includeFlags == LibraryIncludeFlags.All)
+                        {
+                            var dependency = tfi.Dependencies.FirstOrDefault(dep => dep.Name.Equals(package.Id, StringComparison.OrdinalIgnoreCase));
+
+                            // make sure new resolved dependency still have default PrivateAssets as well as IncludeAssets
+                            if (dependency?.SuppressParent == LibraryIncludeFlagUtils.DefaultSuppressParent &&
+                                dependency?.IncludeType == LibraryIncludeFlags.All)
+                            {
+                                includeFlags = LibraryIncludeFlags.All & ~LibraryIncludeFlags.Compile;
+                            }
+                        }
+
                         var targetLibrary = LockFileUtils.CreateLockFileTargetLibrary(
                             libraries[Tuple.Create(library.Name, library.Version)],
                             package,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
@@ -993,6 +993,101 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             }
         }
 
+        [Fact]
+        public async void TestPacMan_InstallPackageAsync_LegacyPackageRefProjects_developmentDependency()
+        {
+            using (var packageSource = TestDirectory.Create())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var randomProjectFolderPath = TestDirectory.Create())
+                {
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testNuGetProjectContext = new TestNuGetProjectContext();
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+
+                    // set up projects
+                    var projectTargetFrameworkStr = "net45";
+                    var projectPathA = Path.Combine(randomProjectFolderPath, "ProjectA");
+                    var fullProjectPathA = Path.Combine(projectPathA, "project1.csproj");
+                    var projectNamesA = new ProjectNames(
+                        fullName: fullProjectPathA,
+                        uniqueName: Path.GetFileName(fullProjectPathA),
+                        shortName: Path.GetFileNameWithoutExtension(fullProjectPathA),
+                        customUniqueName: Path.GetFileName(fullProjectPathA));
+                    var vsProjectAdapterA = new TestVSProjectAdapter(
+                        fullProjectPathA,
+                        projectNamesA,
+                        projectTargetFrameworkStr);
+
+                    var projectServicesA = new TestProjectSystemServices();
+
+                    var legacyPRProjectA = new LegacyPackageReferenceProject(
+                        vsProjectAdapterA,
+                        Guid.NewGuid().ToString(),
+                        projectServicesA,
+                        _threadingService);
+                    testSolutionManager.NuGetProjects.Add(legacyPRProjectA);
+
+                    var testLogger = new TestLogger();
+                    var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
+                    var providersCache = new RestoreCommandProvidersCache();
+
+                    var packageContextA = new SimpleTestPackageContext("packageA", "1.0.0");
+                    packageContextA.AddFile("lib/net45/a.dll");
+                    var packages = new List<SimpleTestPackageContext>() { packageContextA };
+                    SimpleTestPackageUtility.CreateOPCPackages(packages, packageSource, developmentDependency: true);
+
+                    var dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(testSolutionManager, restoreContext);
+
+                    var packageIdentity = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+
+                    // Act
+                    await nuGetPackageManager.InstallPackageAsync(legacyPRProjectA, packageIdentity, new ResolutionContext(), new TestNuGetProjectContext(),
+                            sourceRepositoryProvider.GetRepositories(), sourceRepositoryProvider.GetRepositories(), CancellationToken.None);
+
+                    // Assert
+                    var assetsFilePath = Path.Combine(vsProjectAdapterA.MSBuildProjectExtensionsPath, "project.assets.json");
+                    Assert.True(File.Exists(assetsFilePath));
+
+                    var assetsFile = new LockFileFormat().Read(assetsFilePath);
+
+                    // asserts all the target libraries which define compile & runtime assets
+                    foreach (var target in assetsFile.Targets)
+                    {
+                        var dependency = target.Libraries.FirstOrDefault(lib => lib.Name.Equals("packageA", StringComparison.OrdinalIgnoreCase));
+
+                        Assert.NotNull(dependency);
+                        Assert.False(dependency.CompileTimeAssemblies.Any(item => item.Path.Equals("lib/net45/a.dll")));
+                        Assert.True(dependency.RuntimeAssemblies.Any(item => item.Path.Equals("lib/net45/a.dll")));
+                    }
+
+                    var expectedIncludeFlags = LibraryIncludeFlags.All & ~LibraryIncludeFlags.Compile;
+
+                    // asserts target dependencies under packageSpec which flows to pack
+                    foreach (var fwTarget in assetsFile.PackageSpec.TargetFrameworks)
+                    {
+                        var dependency = fwTarget.Dependencies.FirstOrDefault(lib => lib.Name.Equals("packageA", StringComparison.OrdinalIgnoreCase));
+
+                        Assert.NotNull(dependency);
+                        Assert.Equal(LibraryIncludeFlags.All, dependency.SuppressParent);
+                        Assert.Equal(expectedIncludeFlags, dependency.IncludeType);
+                    }
+                }
+            }
+        }
+
         private ISettings PopulateSettingsWithSources(SourceRepositoryProvider sourceRepositoryProvider, TestDirectory settingsDirectory)
         {
             var settings = new Settings(settingsDirectory);

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
@@ -544,7 +544,7 @@ namespace NuGet.Test.Utility
         /// <summary>
         /// Create packages with PackageBuilder, this includes OPC support.
         /// </summary>
-        public static void CreateOPCPackages(List<SimpleTestPackageContext> packages, string repositoryPath)
+        public static void CreateOPCPackages(List<SimpleTestPackageContext> packages, string repositoryPath, bool developmentDependency = false)
         {
             foreach (var package in packages)
             {
@@ -553,6 +553,7 @@ namespace NuGet.Test.Utility
                     Id = package.Id,
                     Version = NuGetVersion.Parse(package.Version),
                     Description = "Description.",
+                    DevelopmentDependency = developmentDependency
                 };
 
                 builder.Authors.Add("testAuthor");


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7084
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
As part of installing a new package with `developmentDependency` as `true`, current code was not skipping it from compile-time assets while building the `project.assets.json` file but it was still able to add the right metadata in `packageSpec` section or `PackageReference` metadata. So next restore will always result into correct assets file. This PR fixes the first installation as well and make sure it updates include flags if current dependency is `developmentDependency`.

## Testing/Validation
Tests Added: Yes
Reason for not adding tests:  
Validation done:  
