### PR TITLE
Avoid null reference exception in UIFactory constructor

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetUIFactory.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetUIFactory.cs
@@ -61,7 +61,8 @@ namespace NuGetVSExtension
         public NuGetUIFactory(
             ICommonOperations commonOperations,
             INuGetUILogger logger,
-            ISourceControlManagerProvider sourceControlManagerProvider)
+            ISourceControlManagerProvider sourceControlManagerProvider,
+            ISettings settings)
         {
             ProjectContext = new NuGetUIProjectContext(
                 commonOperations,
@@ -72,7 +73,7 @@ namespace NuGetVSExtension
             ProjectContext.PackageExtractionContext = new PackageExtractionContext(
                     PackageSaveMode.Defaultv2,
                     PackageExtractionBehavior.XmlDocFileSaveMode,
-                    ClientPolicyContext.GetClientPolicy(Settings.Value, adapterLogger),
+                    ClientPolicyContext.GetClientPolicy(settings, adapterLogger),
                     adapterLogger);
         }
 

--- a/src/NuGet.Clients/NuGet.Tools/NuGetUIFactory.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetUIFactory.cs
@@ -61,20 +61,12 @@ namespace NuGetVSExtension
         public NuGetUIFactory(
             ICommonOperations commonOperations,
             INuGetUILogger logger,
-            ISourceControlManagerProvider sourceControlManagerProvider,
-            ISettings settings)
+            ISourceControlManagerProvider sourceControlManagerProvider)
         {
             ProjectContext = new NuGetUIProjectContext(
                 commonOperations,
                 logger,
                 sourceControlManagerProvider);
-
-            var adapterLogger = new LoggerAdapter(ProjectContext);
-            ProjectContext.PackageExtractionContext = new PackageExtractionContext(
-                    PackageSaveMode.Defaultv2,
-                    PackageExtractionBehavior.XmlDocFileSaveMode,
-                    ClientPolicyContext.GetClientPolicy(settings, adapterLogger),
-                    adapterLogger);
         }
 
         /// <summary>
@@ -83,6 +75,14 @@ namespace NuGetVSExtension
         public INuGetUI Create(params NuGetProject[] projects)
         {
             var uiContext = CreateUIContext(projects);
+
+            var adapterLogger = new LoggerAdapter(ProjectContext);
+            ProjectContext.PackageExtractionContext = new PackageExtractionContext(
+                    PackageSaveMode.Defaultv2,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
+                    ClientPolicyContext.GetClientPolicy(Settings.Value, adapterLogger),
+                    adapterLogger);
+
             return new NuGetUI(CommonOperations, ProjectContext, uiContext, OutputConsoleLogger);
         }
 


### PR DESCRIPTION
## Bug
Fixes: Internal [701495](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/701495)
Regression: Yes

## Fix
Details: As part of https://github.com/NuGet/NuGet.Client/pull/2452, some code that used the `ISettings` property in `UIFactory`'s constructor was added. For some reason it seems that now the initialization for this properties happens after the constructor, therefore this gives a null reference exception. Since `VSSettings` export `ISettings` to MEF, we can easily add them to the importing constructor and use that instead.
