### PR TITLE
Fix allSigned with unsigned package

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/VerifyCommand/VerifyCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/VerifyCommand/VerifyCommandRunner.cs
@@ -101,7 +101,7 @@ namespace NuGet.Commands
                     result = errors;
                 }
 
-                if (verificationResult.Valid)
+                if (verificationResult.IsValid)
                 {
                     logger.LogInformation(Environment.NewLine + string.Format(CultureInfo.CurrentCulture, Strings.VerifyCommand_Success, packageIdentity.ToString()));
                 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -1088,7 +1088,7 @@ namespace NuGet.Packaging
                        token,
                        parentId);
 
-                if (verifyResult.Signed)
+                if (verifyResult.Signed || !verifyResult.Valid)
                 {
                     await LogPackageSignatureVerificationAsync(source, package, packageExtractionContext.Logger, verifyResult);
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -1088,7 +1088,7 @@ namespace NuGet.Packaging
                        token,
                        parentId);
 
-                if (verifyResult.Signed || !verifyResult.Valid)
+                if (verifyResult.IsSigned || !verifyResult.IsValid)
                 {
                     await LogPackageSignatureVerificationAsync(source, package, packageExtractionContext.Logger, verifyResult);
 
@@ -1097,7 +1097,7 @@ namespace NuGet.Packaging
                             .SelectMany(r => r.Issues)
                             .ForEach(e => AddPackageIdentityToSignatureLog(source, package, e));
 
-                    if (verifyResult.Valid)
+                    if (verifyResult.IsValid)
                     {
                         // log any warnings
                         var warnings = verifyResult.Results.SelectMany(r => r.GetWarningIssues());
@@ -1135,7 +1135,7 @@ namespace NuGet.Packaging
         {
             await logger.LogAsync(
                 LogLevel.Verbose,
-                string.Format(CultureInfo.CurrentCulture, Strings.PackageSignatureVerificationLog, package, source, verifyResult.Valid));
+                string.Format(CultureInfo.CurrentCulture, Strings.PackageSignatureVerificationLog, package, source, verifyResult.IsValid));
         }
 
         private static RepositorySignatureInfo GetRepositorySignatureInfo(string source)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/VerifySignaturesResult.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/VerifySignaturesResult.cs
@@ -15,12 +15,12 @@ namespace NuGet.Packaging.Signing
         /// <summary>
         /// True if signature is valid.
         /// </summary>
-        public bool Valid { get; }
+        public bool IsValid { get; }
 
         /// <summary>
         /// True if the package is signed.
         /// </summary>
-        public bool Signed { get; }
+        public bool IsSigned { get; }
 
         /// <summary>
         /// Individual trust results.
@@ -32,10 +32,10 @@ namespace NuGet.Packaging.Signing
         {
         }
 
-        public VerifySignaturesResult(bool valid, bool signed, IEnumerable<PackageVerificationResult> results)
+        public VerifySignaturesResult(bool isValid, bool isSigned, IEnumerable<PackageVerificationResult> results)
         {
-            Valid = valid;
-            Signed = signed;
+            IsValid = isValid;
+            IsSigned = isSigned;
             Results = results?.ToList().AsReadOnly() ?? throw new ArgumentNullException(nameof(results));
         }
     }

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
@@ -73,7 +73,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     totalWarningIssues.Count().Should().Be(0);
                 }
             }
@@ -114,7 +114,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrors = resultsWithErrors.SelectMany(r => r.GetErrorIssues()).OrderByDescending(i => i.Message.Length).ToList();
 
                     // Assert
-                    result.Valid.Should().Be(valid);
+                    result.IsValid.Should().Be(valid);
                     resultsWithErrors.Count().Should().Be(resultsWithErrorsCount);
                     totalErrors.Count().Should().Be(totalErrorsCount);
 
@@ -162,7 +162,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                     resultsWithWarnings.Count().Should().Be(1);
                     totalErrorIssues.Count().Should().Be(0);
@@ -208,7 +208,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     resultsWithWarnings.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(1);
@@ -256,7 +256,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     resultsWithWarnings.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(1);
@@ -304,7 +304,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     resultsWithWarnings.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(1);
@@ -352,7 +352,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                     resultsWithWarnings.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(0);
@@ -400,7 +400,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     resultsWithWarnings.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(1);
@@ -450,7 +450,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     resultsWithWarnings.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(1);
@@ -500,7 +500,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                     resultsWithWarnings.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(0);
@@ -544,7 +544,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                     resultsWithWarnings.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(0);
@@ -590,7 +590,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     resultsWithWarnings.Count().Should().Be(0);
                     totalWarningIssues.Count().Should().Be(0);
@@ -644,7 +644,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                     resultsWithWarnings.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(0);
@@ -694,7 +694,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     resultsWithWarnings.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(1);
@@ -743,7 +743,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     resultsWithWarnings.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(1);
@@ -796,7 +796,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                     resultsWithWarnings.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(0);
@@ -848,7 +848,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     resultsWithWarnings.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(1);
@@ -899,7 +899,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     resultsWithWarnings.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(1);
@@ -951,7 +951,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                     resultsWithWarnings.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(0);
@@ -1001,7 +1001,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                     resultsWithWarnings.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(0);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/ClientPolicyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/ClientPolicyTests.cs
@@ -82,7 +82,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().Be(expectedResult);
+                    result.IsValid.Should().Be(expectedResult);
                     totalWarningIssues.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(expectedErrors);
                 }
@@ -143,7 +143,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().Be(expectedResult);
+                    result.IsValid.Should().Be(expectedResult);
                     totalWarningIssues.Count().Should().Be(expectedWarnings);
                     totalErrorIssues.Count().Should().Be(expectedErrors);
                 }
@@ -214,7 +214,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     totalWarningIssues.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(0);
                 }
@@ -274,7 +274,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     totalWarningIssues.Count().Should().Be(0);
                     totalErrorIssues.Count().Should().Be(0);
                 }
@@ -334,7 +334,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().Be(expectedResult);
+                    result.IsValid.Should().Be(expectedResult);
                     totalWarningIssues.Count().Should().Be(expectedWarnings);
                     totalErrorIssues.Count().Should().Be(expectedErrors);
                 }
@@ -394,7 +394,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().Be(expectedResult);
+                    result.IsValid.Should().Be(expectedResult);
                     totalWarningIssues.Count().Should().Be(expectedWarnings);
                     totalErrorIssues.Count().Should().Be(expectedErrors);
                 }

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/IntegrityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/IntegrityVerificationProviderTests.cs
@@ -80,7 +80,7 @@ namespace NuGet.Packaging.FuncTest
                     var result = await verifier.VerifySignaturesAsync(packageReader, policy, CancellationToken.None);
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                 }
             }
         }
@@ -110,7 +110,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     totalErrorIssues.Count().Should().Be(1);
                     totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3008);
@@ -155,7 +155,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     totalErrorIssues.Count().Should().Be(1);
                     totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3008);
@@ -199,7 +199,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     totalErrorIssues.Count().Should().Be(1);
                     totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3008);
@@ -240,7 +240,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     totalErrorIssues.Count().Should().Be(1);
                     totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3008);
@@ -284,7 +284,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     totalErrorIssues.Count().Should().Be(1);
                     totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3008);
@@ -325,7 +325,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().Be(expectedValidity);
+                    result.IsValid.Should().Be(expectedValidity);
                     if (!expectedValidity)
                     {
                         resultsWithErrors.Count().Should().Be(1);
@@ -363,7 +363,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().Be(expectedValidity);
+                    result.IsValid.Should().Be(expectedValidity);
                     if (!expectedValidity)
                     {
                         resultsWithErrors.Count().Should().Be(1);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -64,7 +64,7 @@ namespace NuGet.Packaging.FuncTest
                     var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                 }
             }
@@ -93,7 +93,7 @@ namespace NuGet.Packaging.FuncTest
                     var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                 }
             }
@@ -121,7 +121,7 @@ namespace NuGet.Packaging.FuncTest
                     var result = await verifier.VerifySignaturesAsync(packageReader, _verifyCommandSettings, CancellationToken.None);
                     var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
 
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                 }
             }
@@ -171,7 +171,7 @@ namespace NuGet.Packaging.FuncTest
 
                     var trustProvider = result.Results.Single();
 
-                    Assert.True(result.Valid);
+                    Assert.True(result.IsValid);
                     Assert.Equal(SignatureVerificationStatus.Valid, trustProvider.Trust);
                     Assert.Equal(0, trustProvider.Issues.Count(issue => issue.Level == LogLevel.Error));
                     Assert.Equal(0, trustProvider.Issues.Count(issue => issue.Level == LogLevel.Warning));
@@ -228,7 +228,7 @@ namespace NuGet.Packaging.FuncTest
                     var results = await verifier.VerifySignaturesAsync(packageReader, _verifyCommandSettings, CancellationToken.None);
                     var result = results.Results.Single();
 
-                    Assert.False(results.Valid);
+                    Assert.False(results.IsValid);
                     Assert.Equal(SignatureVerificationStatus.Disallowed, result.Trust);
                     Assert.Equal(1, result.Issues.Count(issue => issue.Level == LogLevel.Error));
                     Assert.Equal(0, result.Issues.Count(issue => issue.Level == LogLevel.Warning));
@@ -324,7 +324,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     totalErrorIssues.Count().Should().Be(1);
                     totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3027);
@@ -372,7 +372,7 @@ namespace NuGet.Packaging.FuncTest
                     var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                 }
             }
@@ -418,7 +418,7 @@ namespace NuGet.Packaging.FuncTest
                     var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                 }
             }
@@ -464,7 +464,7 @@ namespace NuGet.Packaging.FuncTest
                     var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                 }
             }
@@ -512,7 +512,7 @@ namespace NuGet.Packaging.FuncTest
                     var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                 }
             }
@@ -561,7 +561,7 @@ namespace NuGet.Packaging.FuncTest
                     var result = await verifier.VerifySignaturesAsync(packageReader, settings, CancellationToken.None);
                     var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
 
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                 }
             }
@@ -609,7 +609,7 @@ namespace NuGet.Packaging.FuncTest
                     var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                 }
             }
@@ -725,7 +725,7 @@ namespace NuGet.Packaging.FuncTest
                     var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                 }
             }
@@ -764,7 +764,7 @@ namespace NuGet.Packaging.FuncTest
                     var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                 }
             }
@@ -938,7 +938,7 @@ namespace NuGet.Packaging.FuncTest
                 var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                 // Assert
-                result.Valid.Should().BeFalse();
+                result.IsValid.Should().BeFalse();
                 resultsWithErrors.Count().Should().Be(1);
                 totalErrorIssues.Count().Should().Be(1);
                 totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3028);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
@@ -87,7 +87,7 @@ namespace NuGet.Packaging.FuncTest
                     var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                 }
             }
@@ -114,7 +114,7 @@ namespace NuGet.Packaging.FuncTest
                     var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                 }
             }
@@ -148,7 +148,7 @@ namespace NuGet.Packaging.FuncTest
                     var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                 }
             }
@@ -182,7 +182,7 @@ namespace NuGet.Packaging.FuncTest
                     var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                 }
             }
@@ -217,7 +217,7 @@ namespace NuGet.Packaging.FuncTest
                     var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
 
                     // Assert
-                    result.Valid.Should().BeTrue();
+                    result.IsValid.Should().BeTrue();
                     resultsWithErrors.Count().Should().Be(0);
                 }
             }
@@ -253,7 +253,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     totalErrorIssues.Count().Should().Be(1);
                     totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3005);
@@ -317,7 +317,7 @@ namespace NuGet.Packaging.FuncTest
                     var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                     // Assert
-                    result.Valid.Should().BeFalse();
+                    result.IsValid.Should().BeFalse();
                     resultsWithErrors.Count().Should().Be(1);
                     totalErrorIssues.Count().Should().Be(1);
                     totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3005);
@@ -415,7 +415,7 @@ namespace NuGet.Packaging.FuncTest
                         var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                         // Assert
-                        result.Valid.Should().BeFalse();
+                        result.IsValid.Should().BeFalse();
                         resultsWithErrors.Count().Should().Be(1);
                         totalErrorIssues.Count().Should().Be(1);
                         totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3005);
@@ -523,7 +523,7 @@ namespace NuGet.Packaging.FuncTest
                         var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                         // Assert
-                        result.Valid.Should().BeFalse();
+                        result.IsValid.Should().BeFalse();
                         resultsWithErrors.Count().Should().Be(1);
                         totalErrorIssues.Count().Should().Be(1);
                         totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3005);
@@ -599,7 +599,7 @@ namespace NuGet.Packaging.FuncTest
                         var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                         // Assert
-                        result.Valid.Should().BeFalse();
+                        result.IsValid.Should().BeFalse();
                         resultsWithErrors.Count().Should().Be(1);
                         totalErrorIssues.Count().Should().Be(1);
                         totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3005);
@@ -675,7 +675,7 @@ namespace NuGet.Packaging.FuncTest
                         var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                         // Assert
-                        result.Valid.Should().BeFalse();
+                        result.IsValid.Should().BeFalse();
                         resultsWithErrors.Count().Should().Be(1);
                         totalErrorIssues.Count().Should().Be(1);
                         totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3005);
@@ -751,7 +751,7 @@ namespace NuGet.Packaging.FuncTest
                         var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                         // Assert
-                        result.Valid.Should().BeFalse();
+                        result.IsValid.Should().BeFalse();
                         resultsWithErrors.Count().Should().Be(1);
                         totalErrorIssues.Count().Should().Be(1);
                         totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3005);
@@ -827,7 +827,7 @@ namespace NuGet.Packaging.FuncTest
                         var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                         // Assert
-                        result.Valid.Should().BeFalse();
+                        result.IsValid.Should().BeFalse();
                         resultsWithErrors.Count().Should().Be(1);
                         totalErrorIssues.Count().Should().Be(1);
                         totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3005);
@@ -906,7 +906,7 @@ namespace NuGet.Packaging.FuncTest
                         var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
 
                         // Assert
-                        result.Valid.Should().BeFalse();
+                        result.IsValid.Should().BeFalse();
                         resultsWithErrors.Count().Should().Be(1);
                         totalErrorIssues.Count().Should().Be(1);
                         totalErrorIssues.First().Code.Should().Be(NuGetLogCode.NU3005);


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7388

## Fix
Details: When a repository announces `allPackagesSigned` we pass this to the verification settings. This will make any unsigned package verification fail. The code that validated verification results only did this for signed packages, therefore ignored the case when an unsigned package is not valid.

The work for improving the error message to something more detailed is left to another PR.