### PR TITLE
Adding packages lock file into Legacy PackageReference project hierarchy

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
@@ -87,6 +87,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public override Task AddFileToProjectAsync(string filePath)
         {
+            // sdk-style project system uses globbing to dynamically add files from project root into project
+            // so we dont need to do anything explicitly here.
             return Task.CompletedTask;
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
@@ -85,6 +85,11 @@ namespace NuGet.PackageManagement.VisualStudio
             return await GetAssetsFilePathAsync(shouldThrow: false);
         }
 
+        public override Task AddFileToProjectAsync(string filePath)
+        {
+            return Task.CompletedTask;
+        }
+
         private Task<string> GetAssetsFilePathAsync(bool shouldThrow)
         {
             var packageSpec = GetPackageSpec();

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -52,7 +52,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return envDTEProject.Kind != null && envDTEProject.Kind.Equals(VsProjectTypes.VsProjectItemKindSolutionFolder, StringComparison.OrdinalIgnoreCase);
         }
 
-        internal static async Task<bool> ContainsFile(EnvDTE.Project envDTEProject, string path)
+        public static async Task<bool> ContainsFile(EnvDTE.Project envDTEProject, string path)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2852,6 +2852,14 @@ namespace NuGet.PackageManagement
                     await RestoreRunner.CommitAsync(projectAction.RestoreResultPair, token);
                 }
 
+                // add packages lock file into project
+                if (PackagesLockFileUtilities.IsNuGetLockFileSupported(projectAction.RestoreResult.LockFile.PackageSpec))
+                {
+                    var lockFilePath = PackagesLockFileUtilities.GetNuGetLockFilePath(projectAction.RestoreResult.LockFile.PackageSpec);
+
+                    await buildIntegratedProject.AddFileToProjectAsync(lockFilePath);
+                }
+
                 // Write out a message for each action
                 foreach (var action in actions)
                 {

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/BuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/BuildIntegratedNuGetProject.cs
@@ -52,6 +52,13 @@ namespace NuGet.ProjectManagement.Projects
         /// </summary>
         public abstract Task<string> GetAssetsFilePathOrNullAsync();
 
+        /// <summary>
+        /// Add specified file to Project system
+        /// </summary>
+        /// <param name="filePath">file to be added</param>
+        /// <returns></returns>
+        public abstract Task AddFileToProjectAsync(string filePath);
+
         public abstract Task<IReadOnlyList<PackageSpec>> GetPackageSpecsAsync(DependencyGraphCacheContext context);
 
         public abstract Task<bool> InstallPackageAsync(

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
@@ -111,6 +111,11 @@ namespace NuGet.ProjectManagement.Projects
             return GetAssetsFilePathAsync();
         }
 
+        public override Task AddFileToProjectAsync(string filePath)
+        {
+            return Task.CompletedTask;
+        }
+
         /// <summary>
         /// project.json path
         /// </summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/FileSystemUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/FileSystemUtility.cs
@@ -491,6 +491,11 @@ namespace NuGet.ProjectManagement
             return fullPath.Substring(root.Length).TrimStart(Path.DirectorySeparatorChar);
         }
 
+        public static string GetRelativePath(string root, string fullPath)
+        {
+            return fullPath.Substring(root.Length).TrimStart(Path.DirectorySeparatorChar);
+        }
+
         internal static void DeleteFileSafe(string fullPath, INuGetProjectContext nuGetProjectContext)
         {
             DoSafeAction(() => DeleteFile(fullPath, nuGetProjectContext), nuGetProjectContext);

--- a/test/EndToEnd/ProjectTemplates/PackageReferenceClassLibraryWithLockFile.zip/AssemblyInfo.cs
+++ b/test/EndToEnd/ProjectTemplates/PackageReferenceClassLibraryWithLockFile.zip/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("$projectname$")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("$registeredorganization$")]
+[assembly: AssemblyProduct("$projectname$")]
+[assembly: AssemblyCopyright("Copyright © $registeredorganization$ $year$")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("$guid1$")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/EndToEnd/ProjectTemplates/PackageReferenceClassLibraryWithLockFile.zip/Class1.cs
+++ b/test/EndToEnd/ProjectTemplates/PackageReferenceClassLibraryWithLockFile.zip/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace $safeprojectname$
+{
+    public class Class1
+    {
+    }
+}

--- a/test/EndToEnd/ProjectTemplates/PackageReferenceClassLibraryWithLockFile.zip/ClassLibrary1.csproj
+++ b/test/EndToEnd/ProjectTemplates/PackageReferenceClassLibraryWithLockFile.zip/ClassLibrary1.csproj
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<ProjectGuid>$guid1$</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>$safeprojectname$</RootNamespace>
+		<AssemblyName>$safeprojectname$</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+	<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/test/EndToEnd/ProjectTemplates/PackageReferenceClassLibraryWithLockFile.zip/ProjectTemplate.vstemplate
+++ b/test/EndToEnd/ProjectTemplates/PackageReferenceClassLibraryWithLockFile.zip/ProjectTemplate.vstemplate
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005">
+  <TemplateData>
+    <Name>PackageReferenceClassLibrary</Name>
+    <Description>Template for class library projects</Description>
+    <ProjectType>CSharp</ProjectType>
+    <RequiredFrameworkVersion>4.6</RequiredFrameworkVersion>
+    <SortOrder>1000</SortOrder>
+    <CreateNewFolder>true</CreateNewFolder>
+    <DefaultName>ClassLibraryPR</DefaultName>
+    <ProvideDefaultName>true</ProvideDefaultName>
+    <Icon>__TemplateIcon.ico</Icon>
+  </TemplateData>
+  <TemplateContent>
+    <Project File="ClassLibrary1.csproj" ReplaceParameters="true">
+      <ProjectItem ReplaceParameters="true" TargetFileName="Class1.cs">Class1.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="Properties\AssemblyInfo.cs">AssemblyInfo.cs</ProjectItem>
+    </Project>
+  </TemplateContent>
+</VSTemplate>

--- a/test/EndToEnd/nuget.assert.ps1
+++ b/test/EndToEnd/nuget.assert.ps1
@@ -749,6 +749,19 @@ function Get-NetCorePackageInLockFile {
     }
 }
 
+function Get-PackagesLockFilePath {
+    param(
+        [parameter(Mandatory = $true)]
+        $Project
+    )
+    
+    $dir = Split-Path -parent $Project.FullName
+
+    $packagesLockFilePath = Join-Path $dir "packages.lock.json"
+
+    return $packagesLockFilePath
+}
+
 function Assert-NetCoreProjectCreation {
     param(
         [parameter(Mandatory = $true)]
@@ -892,4 +905,17 @@ function Assert-NetCoreLockFileLocked{
 function Get-PackagesDir {
     # TODO: Handle when the package location changes
     Join-Path (Get-SolutionDir) packages
+}
+
+function Assert-PackagesLockFile {
+    param(
+        [parameter(Mandatory = $true)]
+        $project
+    )
+
+    $lockFilePath = Get-PackagesLockFilePath $project
+
+    $result = [API.Test.InternalAPITestHook]::IsFileExistsInProject($project.FullName,$lockFilePath)
+
+    Assert-True $result
 }

--- a/test/EndToEnd/tests/BuildIntegratedTest.ps1
+++ b/test/EndToEnd/tests/BuildIntegratedTest.ps1
@@ -692,6 +692,18 @@ function Test-BuildIntegratedVSandMSBuildNoOp {
     Assert-True ($MsBuildRestoreTimestamp -eq $VSRestoreTimestamp)
 }
 
+function Test-PackageReferenceProjectWithLockFile{
+    [SkipTestForVS14()]
+    param()
+
+    $projectT = New-Project PackageReferenceClassLibraryWithLockFile
+    $projectT | Install-Package Newtonsoft.Json -Version 9.0.1
+    $projectT.Save();
+    
+    #Assert
+    Assert-PackagesLockFile $projectT
+}
+
 function BuildProjectTemplateTestCases([string[]]$ProjectTemplates) {		
     $ProjectTemplates | ForEach-Object{		
         $testCase = New-Object System.Object		

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
@@ -474,6 +474,11 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 throw new NotImplementedException();
             }
 
+            public override Task AddFileToProjectAsync(string filePath)
+            {
+                throw new NotImplementedException();
+            }
+
             public override Task<string> GetCacheFilePathAsync()
             {
                 throw new NotImplementedException();

--- a/test/TestExtensions/API.Test/API.Test.csproj
+++ b/test/TestExtensions/API.Test/API.Test.csproj
@@ -17,12 +17,6 @@
     <PackageReference Include="Microsoft.PowerShell.3.ReferenceAssemblies" Version="1.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="$(NuGetClientsSrcDirectory)NuGet.VisualStudio\NuGet.VisualStudio.csproj">
-      <EmbedInteropTypes>true</EmbedInteropTypes>
-    </ProjectReference>
-  </ItemGroup>
-
   <ItemGroup Condition="'$(VisualStudioVersion)' == '15.0'">
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime">
       <HintPath>$(SolutionPackagesFolder)Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime.15.0.26201\lib\Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime.dll</HintPath>
@@ -38,6 +32,10 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.14.0" Version="14.2.25123" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost.NuGet" Version="14.0.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="14.1.131" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.PackageManagement.VisualStudio\NuGet.PackageManagement.VisualStudio.csproj" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets" />


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7335
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: With lock file feature, we now generates a `packages.lock.json` file at the project root directory to keep track of all the resolved dependencies and recommend customers to add this file into their source control so that a git clone on another machine makes sure to use this file to resolve all existing dependencies. But we're not adding this file into project hierarchy by default because of which customers often forget to add this file in their source control.

With this PR, if a customer has opt into lock file feature, then with every install/ uninstall operation within VS will result into adding/ updating this file into project hierarchy as well as project source control so that it's by default checked out as well. This will be similar to `packages.config` file experience.

## Testing/Validation
Tests Added: Yes
Reason for not adding tests:  
Validation done:  
