### PR TITLE
Skip signature verification for not supported scenarios

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
@@ -310,7 +310,11 @@ namespace NuGet.Commands
                         await _logger.LogAsync(e.AsLogMessage());
                     }
 
-                    await _logger.LogMessagesAsync(e.Results.SelectMany(p => p.Issues));
+                    if (e.Results != null)
+                    {
+                        await _logger.LogMessagesAsync(e.Results.SelectMany(p => p.Issues));
+                    }
+
                     return false;
                 }
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
@@ -310,6 +310,9 @@ namespace NuGet.Commands
                         await _logger.LogAsync(e.AsLogMessage());
                     }
 
+                    // If the package is unsigned and unsigned packages are not allowed a SignatureException
+                    // will be thrown but it won't have results because it didn't went through any
+                    // verification provider.
                     if (e.Results != null)
                     {
                         await _logger.LogMessagesAsync(e.Results.SelectMany(p => p.Issues));

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -446,6 +446,11 @@ namespace NuGet.Common
         NU3040 = 3040,
 
         /// <summary>
+        /// Downloading a package with a plugin is not supported since unsigned packages are not allowed.
+        /// </summary>
+        NU3041 = 3041,
+
+        /// <summary>
         /// Undefined Package Error.
         /// </summary>
         NU5000 = 5000,

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -446,7 +446,7 @@ namespace NuGet.Common
         NU3040 = 3040,
 
         /// <summary>
-        /// Downloading a package with a plugin is not supported since unsigned packages are not allowed.
+        /// Downloading a package from a plugin is not supported since unsigned packages are not allowed and package download plugins do not support signed package verification.
         /// </summary>
         NU3041 = 3041,
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -381,7 +381,7 @@ namespace NuGet.Packaging
 
         public override bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings)
         {
-            return false;
+            return true;
         }
 
         protected void ThrowIfZipReadStreamIsNull()

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -379,6 +379,11 @@ namespace NuGet.Packaging
             }
         }
 
+        public override bool SkipPackageSignatureVerification(SignedPackageVerifierSettings verifierSettings)
+        {
+            return false;
+        }
+
         protected void ThrowIfZipReadStreamIsNull()
         {
             if (ZipReadStream == null)

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -379,7 +379,7 @@ namespace NuGet.Packaging
             }
         }
 
-        public override bool SkipPackageSignatureVerification(SignedPackageVerifierSettings verifierSettings)
+        public override bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings)
         {
             return false;
         }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -1051,7 +1051,7 @@ namespace NuGet.Packaging
                     repositorySignatureInfo,
                     clientPolicyContext.VerifierSettings);
 
-                if (signedPackageReader.SkipPackageSignatureVerification(verificationSettings))
+                if (signedPackageReader.CanVerifySignedPackages(verificationSettings))
                 {
                     return;
                 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -1051,6 +1051,11 @@ namespace NuGet.Packaging
                     repositorySignatureInfo,
                     clientPolicyContext.VerifierSettings);
 
+                if (signedPackageReader.SkipPackageSignatureVerification(verificationSettings))
+                {
+                    return;
+                }
+
                 IPackageSignatureVerifier signedPackageVerifier = null;
                 if (packageExtractionContext.SignedPackageVerifier != null)
                 {

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -1051,7 +1051,7 @@ namespace NuGet.Packaging
                     repositorySignatureInfo,
                     clientPolicyContext.VerifierSettings);
 
-                if (signedPackageReader.CanVerifySignedPackages(verificationSettings))
+                if (!signedPackageReader.CanVerifySignedPackages(verificationSettings))
                 {
                     return;
                 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -247,7 +247,7 @@ namespace NuGet.Packaging
 
         public override bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings)
         {
-            return true;
+            return false;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -244,5 +244,10 @@ namespace NuGet.Packaging
         {
             throw new NotImplementedException();
         }
+
+        public override bool SkipPackageSignatureVerification(SignedPackageVerifierSettings verifierSettings)
+        {
+            return true;
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -245,7 +245,7 @@ namespace NuGet.Packaging
             throw new NotImplementedException();
         }
 
-        public override bool SkipPackageSignatureVerification(SignedPackageVerifierSettings verifierSettings)
+        public override bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings)
         {
             return true;
         }

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -595,6 +595,6 @@ namespace NuGet.Packaging
 
         public abstract string GetContentHashForSignedPackage(CancellationToken token);
 
-        public abstract bool SkipPackageSignatureVerification(SignedPackageVerifierSettings verifierSettings);
+        public abstract bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -594,5 +594,7 @@ namespace NuGet.Packaging
         public abstract Task<byte[]> GetArchiveHashAsync(HashAlgorithmName hashAlgorithm, CancellationToken token);
 
         public abstract string GetContentHashForSignedPackage(CancellationToken token);
+
+        public abstract bool SkipPackageSignatureVerification(SignedPackageVerifierSettings verifierSettings);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
@@ -45,12 +45,10 @@ namespace NuGet.Packaging.Signing
         string GetContentHashForSignedPackage(CancellationToken token);
 
         /// <summary>
-        /// Indicates if the signature verification should be skipped. This could be because of it being unsupported or
-        /// because a package should not be verified.
+        /// Indicates if the the ISignedPackageReader instance can verify signed packages.
         /// </summary>
         /// <param name="verifierSettings">Package verification settings. Include information about what is allowed.</param>
-        /// <exception cref="SignatureException">if the ISignedPackageReader does not support either verifing or skipping the signature verification.</exception>
-        /// <returns>boolean indicating if the verification of the signature should be skipped.</returns>
+        /// <exception cref="SignatureException">if the ISignedPackageReader does not support signed packages</exception>
         bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
@@ -49,8 +49,8 @@ namespace NuGet.Packaging.Signing
         /// because a package should not be verified.
         /// </summary>
         /// <param name="verifierSettings">Package verification settings. Include information about what is allowed.</param>
-        /// <throws>SignatureException if the ISignedPackageReader does not support either verifing or skipping the signature verification.</throws>
+        /// <exception cref="SignatureException">if the ISignedPackageReader does not support either verifing or skipping the signature verification.</exception>
         /// <returns>boolean indicating if the verification of the signature should be skipped.</returns>
-        bool SkipPackageSignatureVerification(SignedPackageVerifierSettings verifierSettings);
+        bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
@@ -43,5 +43,14 @@ namespace NuGet.Packaging.Signing
         /// <param name="token">Cancellation token</param>
         /// <returns>hash of the unsigned content of the signed package. but return null for unsigned package.</returns>
         string GetContentHashForSignedPackage(CancellationToken token);
+
+        /// <summary>
+        /// Indicates if the signature verification should be skipped. This could be because of it being unsupported or
+        /// because a package should not be verified.
+        /// </summary>
+        /// <param name="verifierSettings">Package verification settings. Include information about what is allowed.</param>
+        /// <throws>SignatureException if the ISignedPackageReader does not support either verifing or skipping the signature verification.</throws>
+        /// <returns>boolean indicating if the verification of the signature should be skipped.</returns>
+        bool SkipPackageSignatureVerification(SignedPackageVerifierSettings verifierSettings);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/VerifySignaturesResult.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/VerifySignaturesResult.cs
@@ -27,8 +27,8 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         public IReadOnlyList<PackageVerificationResult> Results { get; }
 
-        public VerifySignaturesResult(bool valid, bool signed)
-            : this(valid, signed, results: Enumerable.Empty<PackageVerificationResult>())
+        public VerifySignaturesResult(bool isValid, bool isSigned)
+            : this(isValid, isSigned, results: Enumerable.Empty<PackageVerificationResult>())
         {
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -1162,7 +1162,7 @@ namespace NuGet.Protocol.Plugins
                 throw new SignatureException(NuGetLogCode.NU3041, Strings.Plugin_DownloadNotSupportedSinceUnsignedNotAllowed);
             }
 
-            return true;
+            return false;
         }
 
         private sealed class FileStreamCreator : IDisposable

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -1155,6 +1155,16 @@ namespace NuGet.Protocol.Plugins
             return null;
         }
 
+        public override bool SkipPackageSignatureVerification(SignedPackageVerifierSettings verifierSettings)
+        {
+            if (!verifierSettings.AllowUnsigned)
+            {
+                throw new SignatureException(NuGetLogCode.NU3041, Strings.Plugin_DownloadNotSupportedSinceUnsignedNotAllowed);
+            }
+
+            return true;
+        }
+
         private sealed class FileStreamCreator : IDisposable
         {
             private readonly string _filePath;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -1155,7 +1155,7 @@ namespace NuGet.Protocol.Plugins
             return null;
         }
 
-        public override bool SkipPackageSignatureVerification(SignedPackageVerifierSettings verifierSettings)
+        public override bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings)
         {
             if (!verifierSettings.AllowUnsigned)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -602,7 +602,7 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Downloading a package from a plugin is not supported since unsigned packages are not allowed and plugings do not support package signing..
+        ///   Looks up a localized string similar to Downloading a package from a plugin is not supported since unsigned packages are not allowed and package download plugins do not support signed package verification..
         /// </summary>
         internal static string Plugin_DownloadNotSupportedSinceUnsignedNotAllowed {
             get {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -602,6 +602,15 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Downloading a package from a plugin is not supported since unsigned packages are not allowed and plugings do not support package signing..
+        /// </summary>
+        internal static string Plugin_DownloadNotSupportedSinceUnsignedNotAllowed {
+            get {
+                return ResourceManager.GetString("Plugin_DownloadNotSupportedSinceUnsignedNotAllowed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Plugin &apos;{0}&apos; failed with the exception:  {1}.
         /// </summary>
         internal static string Plugin_Exception {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -500,4 +500,7 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
   <data name="NuGetLicenseExpression_NonStandardIdentifier" xml:space="preserve">
     <value>The license identifier(s) {0} is(are) not recognized by the current toolset.</value>
   </data>
+  <data name="Plugin_DownloadNotSupportedSinceUnsignedNotAllowed" xml:space="preserve">
+    <value>Downloading a package from a plugin is not supported since unsigned packages are not allowed and plugings do not support package signing.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -501,6 +501,6 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
     <value>The license identifier(s) {0} is(are) not recognized by the current toolset.</value>
   </data>
   <data name="Plugin_DownloadNotSupportedSinceUnsignedNotAllowed" xml:space="preserve">
-    <value>Downloading a package from a plugin is not supported since unsigned packages are not allowed and plugings do not support package signing.</value>
+    <value>Downloading a package from a plugin is not supported since unsigned packages are not allowed and package download plugins do not support signed package verification.</value>
   </data>
 </root>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1016,7 +1016,7 @@ namespace NuGet.Commands.Test
                     It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, _defaultSettings)),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(valid: false, signed: true));
+                    ReturnsAsync(new VerifySignaturesResult(isValid: false, isSigned: true));
 
                 var extractionContext = new PackageExtractionContext(
                     PackageSaveMode.Defaultv3,
@@ -1093,7 +1093,7 @@ namespace NuGet.Commands.Test
                     It.Is<SignedPackageVerifierSettings>(s => SigningTestUtility.AreVerifierSettingsEqual(s, _defaultSettings)),
                     It.IsAny<CancellationToken>(),
                     It.IsAny<Guid>())).
-                    ReturnsAsync(new VerifySignaturesResult(valid: true, signed: true));
+                    ReturnsAsync(new VerifySignaturesResult(isValid: true, isSigned: true));
 
                 var extractionContext = new PackageExtractionContext(
                     PackageSaveMode.Defaultv3,

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
@@ -268,7 +268,7 @@ namespace NuGet.Protocol.Tests
                 throw new NotImplementedException();
             }
 
-            public override bool SkipPackageSignatureVerification(SignedPackageVerifierSettings verifierSettings)
+            public override bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings)
             {
                 return true;
             }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
@@ -270,7 +270,7 @@ namespace NuGet.Protocol.Tests
 
             public override bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings)
             {
-                return true;
+                return false;
             }
 
             protected override void Dispose(bool disposing)

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
@@ -268,6 +268,11 @@ namespace NuGet.Protocol.Tests
                 throw new NotImplementedException();
             }
 
+            public override bool SkipPackageSignatureVerification(SignedPackageVerifierSettings verifierSettings)
+            {
+                return true;
+            }
+
             protected override void Dispose(bool disposing)
             {
             }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7394

## Fix
This PR fixes two scenarios:
- On PC, when a package is installed, it first gets extracted to the global packages folder and then to the solution level packages folder. Since the extraction to the solution level packages folder happens from the package in the global packages folder, we don't have access to the signature all the time, therefore the package is taken as unsigned. If `allowUnsigned` is set to `false` (this happens for require mode or when a server announces all their packages are signed) the extraction to solution level packages folder fails. This PR skips the signature verification if the action is a copy extraction instead of a download extraction.
- When using a download plugin, if unsigned packages are not allowed we should fail. Since current plugins are not aware of signatures and don't know how to verify them.


cc. @rrelyea 
