### PR TITLE
Avoid throwing from plugin downloader to read content hash for signed packages

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -1151,7 +1151,8 @@ namespace NuGet.Protocol.Plugins
 
         public override string GetContentHashForSignedPackage(CancellationToken token)
         {
-            throw new NotImplementedException();
+            // Plugin Download doesn't support signed packages so simply return null.
+            return null;
         }
 
         private sealed class FileStreamCreator : IDisposable


### PR DESCRIPTION
As part of adding `.nupkg.metadata` file, we were throwing `NotImplementedException` from plugin downloader while retrieving content hash for a signed package which started failing installing package from plugin. So instead of throwing, we should just skip it since plugin downloader doesn't support signed packages.

Added missing test for the end-to-end case.

