### PR TITLE
Improve perf when searching in a local package source

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageSearchResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageSearchResource.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -51,7 +51,7 @@ namespace NuGet.Protocol
                 if (!string.IsNullOrEmpty(searchTerm))
                 {
                     var terms = searchTerm.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-                    query = terms.SelectMany(term => _localResource.FindPackagesById(term, log, token));
+                    query = terms.SelectMany(term => _localResource.FindPackagesById(term, log, token)); // further parallelization is possible, but this is good enough for now
                 }
                 else
                 {

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageSearchResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageSearchResource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -45,17 +45,21 @@ namespace NuGet.Protocol
                         _localResource.Root));
                 }
 
-                var query = _localResource.GetPackages(log, token);
-
-                // Filter on prerelease
-                query = query.Where(package => filters.IncludePrerelease || !package.Identity.Version.IsPrerelease);
+                IEnumerable<LocalPackageInfo> query;
 
                 // Filter on search terms
                 if (!string.IsNullOrEmpty(searchTerm))
                 {
                     var terms = searchTerm.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-                    query = query.Where(package => ContainsAnyTerm(terms, package));
+                    query = terms.SelectMany(term => _localResource.FindPackagesById(term, log, token));
                 }
+                else
+                {
+                    query = _localResource.GetPackages(log, token);
+                }
+
+                // Filter on prerelease
+                query = query.Where(package => filters.IncludePrerelease || !package.Identity.Version.IsPrerelease);
 
                 // Collapse to the highest version per id
                 var collapsedQuery = CollapseToHighestVersion(query);


### PR DESCRIPTION
## Bug
Fixes: #7403
Regression: No  

## Fix
When searching for a package in a large Local/UNC package source, the LocalPackageSearchResource would enumerate the entire feed and parse all folders into LocalPackageInfo, and only then filter out anything that doesn't match the search terms.
This change greatly improves the performance (minutes -> sub-second on my machine with my large UNC package feed) of the search by avoiding parsing packages which don't match the search terms.
It is possible to improve perf further by parallelizing the searches for every term, but sub-second is good enough for my purposes.

## Testing/Validation
Tests Added: No  
Reason for not adding tests: There is no expected difference in behavior. Tests for this behavior would require mocking the file-system.
Validation done: Searched the same package source and saw response time drop to sub-second and the correct package info returned.
