### PR TITLE
Update attribute validation collections to immutable interfaces

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/AddItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/AddItem.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Xml.Linq;
-using NuGet.Shared;
 
 namespace NuGet.Configuration
 {
@@ -28,12 +27,13 @@ namespace NuGet.Configuration
                 !string.Equals(a.Key, ConfigurationConstants.ValueAttribute, StringComparison.OrdinalIgnoreCase)
             ).ToDictionary(a => a.Key, a => a.Value));
 
-        protected override HashSet<string> RequiredAttributes => new HashSet<string>() { ConfigurationConstants.KeyAttribute, ConfigurationConstants.ValueAttribute };
+        protected override IReadOnlyCollection<string> RequiredAttributes { get; } = new HashSet<string>() { ConfigurationConstants.KeyAttribute, ConfigurationConstants.ValueAttribute };
 
-        protected override Dictionary<string, HashSet<string>> DisallowedValues => new Dictionary<string, HashSet<string>>()
-        {
-            { ConfigurationConstants.KeyAttribute, new HashSet<string>() { string.Empty } }
-        };
+        protected override IReadOnlyDictionary<string, IReadOnlyCollection<string>> DisallowedValues { get; } = new ReadOnlyDictionary<string, IReadOnlyCollection<string>>(
+            new Dictionary<string, IReadOnlyCollection<string>>()
+            {
+                { ConfigurationConstants.KeyAttribute, new HashSet<string>() { string.Empty } }
+            });
 
         public AddItem(string key, string value)
             : this(key, value, additionalAttributes: null)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/AuthorItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/AuthorItem.cs
@@ -12,7 +12,7 @@ namespace NuGet.Configuration
     {
         public override string ElementName => ConfigurationConstants.Author;
 
-        protected override HashSet<string> RequiredAttributes { get; } = new HashSet<string>() { ConfigurationConstants.NameAttribute };
+        protected override IReadOnlyCollection<string> RequiredAttributes { get; } = new HashSet<string>() { ConfigurationConstants.NameAttribute };
 
         public string Name => Attributes[ConfigurationConstants.NameAttribute];
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/CertificateItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/CertificateItem.cs
@@ -55,7 +55,7 @@ namespace NuGet.Configuration
             set => UpdateAttribute(ConfigurationConstants.AllowUntrustedRoot, value.ToString().ToLower());
         }
 
-    protected override HashSet<string> RequiredAttributes { get; } = new HashSet<string>() { ConfigurationConstants.Fingerprint, ConfigurationConstants.HashAlgorithm, ConfigurationConstants.AllowUntrustedRoot };
+    protected override IReadOnlyCollection<string> RequiredAttributes { get; } = new HashSet<string>() { ConfigurationConstants.Fingerprint, ConfigurationConstants.HashAlgorithm, ConfigurationConstants.AllowUntrustedRoot };
 
         public CertificateItem(string fingerprint, HashAlgorithmName hashAlgorithm, bool allowUntrustedRoot = false)
             : base()

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/RepositoryItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/RepositoryItem.cs
@@ -34,7 +34,7 @@ namespace NuGet.Configuration
 
         public IList<string> Owners { get; private set; }
 
-        protected override HashSet<string> RequiredAttributes { get; } = new HashSet<string>() { ConfigurationConstants.NameAttribute, ConfigurationConstants.ServiceIndex };
+        protected override IReadOnlyCollection<string> RequiredAttributes { get; } = new HashSet<string>() { ConfigurationConstants.NameAttribute, ConfigurationConstants.ServiceIndex };
 
         public RepositoryItem(string name, string serviceIndex, params CertificateItem[] certificates)
             : this(name, serviceIndex, owners: null, certificates: certificates)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingElement.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingElement.cs
@@ -21,27 +21,27 @@ namespace NuGet.Configuration
         /// Specifies the keys for the attributes that the element can have
         /// </summary>
         /// <remarks>If null then all attributes are allowed</remarks>
-        protected virtual HashSet<string> AllowedAttributes => null;
+        protected virtual IReadOnlyCollection<string> AllowedAttributes { get; } = null;
 
         /// <summary>
         /// Specifies the keys for the attributes that the element should have
         /// </summary>
         /// <remarks>If null or empty then no attributes are required</remarks>
-        protected virtual HashSet<string> RequiredAttributes => null;
+        protected virtual IReadOnlyCollection<string> RequiredAttributes { get; } = null;
 
         /// <summary>
         /// Specifies which values are allowed for a specific attribute.
         /// If an attribute is not defined every value is allowed.
         /// Having allowed values does not imply that the attribute is required.
         /// </summary>
-        protected virtual Dictionary<string, HashSet<string>> AllowedValues => null;
+        protected virtual IReadOnlyDictionary<string, IReadOnlyCollection<string>> AllowedValues { get; } = null;
 
         /// <summary>
         /// Specifies values that are explicitely disallowed for a specific attribute.
         /// If an attribute is not defined no value is disallowed.
         /// Having disallowed values does not imply that the attribute is required.
         /// </summary>
-        protected virtual Dictionary<string, HashSet<string>> DisallowedValues => null;
+        protected virtual IReadOnlyDictionary<string, IReadOnlyCollection<string>> DisallowedValues { get; } = null;
 
         /// <summary>
         ///  Key-value pairs that give more information about the element


### PR DESCRIPTION
## Bug
Based on https://github.com/NuGet/NuGet.Client/pull/2426#discussion_r218957422... Attribute validation collections should use an immutable collection, should use an interface rather than a class in the definition, and should not use `=>` to avoid creating a new object every time the property is used.