### PR TITLE
Add null checks for ISettings in SettingsUtility

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -24,6 +24,11 @@ namespace NuGet.Configuration
 
         public static string GetValueForAddItem(ISettings settings, string section, string key, bool isPath = false)
         {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
             var sectionElement = settings.GetSection(section);
             var item = sectionElement?.GetFirstItemWithAttribute<AddItem>(ConfigurationConstants.KeyAttribute, key);
 
@@ -42,6 +47,11 @@ namespace NuGet.Configuration
 
         public static bool DeleteValue(ISettings settings, string section, string attributeKey, string attributeValue)
         {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
             var sectionElement = settings.GetSection(section);
             var element = sectionElement?.GetFirstItemWithAttribute<SettingItem>(attributeKey, attributeValue);
 
@@ -104,6 +114,11 @@ namespace NuGet.Configuration
 
         public static string GetDecryptedValueForAddItem(ISettings settings, string section, string key, bool isPath = false)
         {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
             if (string.IsNullOrEmpty(section))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(section));
@@ -141,6 +156,11 @@ namespace NuGet.Configuration
 
         public static void SetEncryptedValueForAddItem(ISettings settings, string section, string key, string value)
         {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
             if (string.IsNullOrEmpty(section))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(section));
@@ -189,6 +209,11 @@ namespace NuGet.Configuration
         /// <param name="encrypt">Determines if the value needs to be encrypted prior to storing.</param>
         public static void SetConfigValue(ISettings settings, string key, string value, bool encrypt = false)
         {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
             if (encrypt == true)
             {
                 SetEncryptedValueForAddItem(settings, ConfigurationConstants.Config, key, value);
@@ -340,6 +365,11 @@ namespace NuGet.Configuration
 
         public static IEnumerable<PackageSource> GetEnabledSources(ISettings settings)
         {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
             var provider = new PackageSourceProvider(settings);
             return provider.LoadPackageSources().Where(e => e.IsEnabled == true).ToList();
         }
@@ -396,6 +426,11 @@ namespace NuGet.Configuration
         /// </summary>
         public static IEnumerable<string> GetConfigFilePaths(ISettings settings)
         {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
             if (settings is Settings settingsImpl)
             {
                 return settingsImpl.Priority.Select(config => Path.GetFullPath(Path.Combine(config.DirectoryPath, config.FileName)));
@@ -409,37 +444,17 @@ namespace NuGet.Configuration
         /// </summary>
         public static IEnumerable<string> GetConfigRoots(ISettings settings)
         {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
             if (settings is Settings settingsImpl)
             {
                 return settingsImpl.Priority.Select(config => config.DirectoryPath);
             }
 
             return Enumerable.Empty<string>();
-        }
-
-        private static string GetPathFromEnvOrConfig(string envVarName, string configKey, ISettings settings)
-        {
-            var path = Environment.GetEnvironmentVariable(envVarName);
-
-            if (!string.IsNullOrEmpty(path))
-            {
-                if (!Path.IsPathRooted(path))
-                {
-                    var message = string.Format(CultureInfo.CurrentCulture, Resources.RelativeEnvVarPath, envVarName, path);
-                    throw new NuGetConfigurationException(message);
-                }
-            }
-            else
-            {
-                path = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.NuGetHome), DefaultGlobalPackagesFolderPath);
-            }
-
-            if (!string.IsNullOrEmpty(path))
-            {
-                path = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-            }
-
-            return path;
         }
 
         /// <summary>

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
@@ -163,5 +163,149 @@ namespace NuGet.Configuration.Test
                 result.Should().BeNull();
             }
         }
+
+        [Fact]
+        public void GetValueForAddItem_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.GetValueForAddItem(settings: null, section: "randomSection", key: "randomKey"));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void DeleteValue_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.DeleteValue(settings: null, section: "randomSection", attributeKey: "randomKey", attributeValue: "randomValue"));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetRepositoryPath_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.GetRepositoryPath(settings: null));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetMaxHttpRequest_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.GetMaxHttpRequest(settings: null));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetSignatureValidationMode_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.GetSignatureValidationMode(settings: null));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetDecryptedValueForAddItem_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.GetDecryptedValueForAddItem(settings: null, section: "randomSection", key: "randomKey"));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void SetEncryptedValueForAddItem_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.SetEncryptedValueForAddItem(settings: null, section: "randomSection", key: "randomKey", value: "value"));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetConfigValue_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.GetConfigValue(settings: null, key: "randomKey"));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void SetConfigValue_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.SetConfigValue(settings: null, key: "randomKey", value: "value"));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void DeleteConfigValue_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.DeleteConfigValue(settings: null, key: "randomKey"));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetGlobalPackagesFolder_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.GetGlobalPackagesFolder(settings: null));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetFallbackPackageFolders_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.GetFallbackPackageFolders(settings: null));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetEnabledSources_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.GetEnabledSources(settings: null));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetDefaultPushSource_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.GetDefaultPushSource(settings: null));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetConfigFilePaths_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.GetConfigFilePaths(settings: null));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetConfigRoots_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.GetConfigRoots(settings: null));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
     }
 }


### PR DESCRIPTION
## Bug
There where some public APIs in `SettingsUtility` which where lacking null checks for `ISettings`. If `ISettings` with a `null` value was passed to these functions, a `null reference` error would have been produced.

This PR handles cleaning up these APIs so that they throw the appropriate `ArgumentNullException` and add tests for it.