### PR TITLE
Add tests for equals, ElementName and Clone

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/ClearItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/ClearItem.cs
@@ -21,7 +21,18 @@ namespace NuGet.Configuration
         {
         }
 
-        internal override SettingBase Clone() => new ClearItem();
+        internal override SettingBase Clone()
+        {
+            var newItem = new ClearItem();
+
+            if (Origin != null)
+            {
+                newItem.SetOrigin(Origin);
+            }
+
+            return newItem;
+        }
+
         public override bool Equals(object other) => other is ClearItem;
         public override int GetHashCode() => ElementName.GetHashCode();
     }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
@@ -190,6 +190,11 @@ namespace NuGet.Configuration
                 newSetting.SetOrigin(Origin);
             }
 
+            foreach(var attr in Attributes)
+            {
+                newSetting.AddAttribute(attr.Key, attr.Value);
+            }
+
             return newSetting;
         }
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingElement.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingElement.cs
@@ -46,12 +46,12 @@ namespace NuGet.Configuration
         /// <summary>
         ///  Key-value pairs that give more information about the element
         /// </summary>
-        protected IDictionary<string, string> MutableAttributes { get; }
+        protected Dictionary<string, string> MutableAttributes { get; }
 
         /// <summary>
         /// Read only key-value pairs that give more information about the element
         /// </summary>
-        internal IReadOnlyDictionary<string, string> Attributes => new ReadOnlyDictionary<string, string>(MutableAttributes);
+        internal IReadOnlyDictionary<string, string> Attributes => MutableAttributes;
 
         /// <summary>
         /// Specifies if the element is empty.

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/AddItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/AddItemTests.cs
@@ -386,7 +386,7 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void AddItem_Clone_CopiesTheSameItem()
+        public void AddItem_Clone_ReturnsItemClone()
         {
             // Arrange
             var config = @"

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/AddItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/AddItemTests.cs
@@ -358,5 +358,63 @@ namespace NuGet.Configuration.Test
                 }
             }
         }
+
+        [Fact]
+        public void AddItem_Equals_WithSameKey_ReturnsTrue()
+        {
+            var add1 = new AddItem("key1", "value1", new Dictionary<string, string>() { { "meta", "data" } });
+            var add2 = new AddItem("key1", "valueN");
+
+            add1.Equals(add2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void AddItem_Equals_WithDifferentKey_ReturnsFalse()
+        {
+            var add1 = new AddItem("key1", "value1");
+            var add2 = new AddItem("keyN", "value1");
+
+            add1.Equals(add2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void AddItem_ElementName_IsCorrect()
+        {
+            var addItem = new AddItem("key1", "value1");
+
+            addItem.ElementName.Should().Be("add");
+        }
+
+        [Fact]
+        public void AddItem_Clone_CopiesTheSameItem()
+        {
+            // Arrange
+            var config = @"
+<configuration>
+    <SectionName>
+        <add key=""key1"" value=""val"" meta=""data"" />
+    </SectionName>
+</configuration>";
+            var nugetConfigPath = "NuGet.Config";
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+
+                // Act and Assert
+                var settingsFile = new SettingsFile(mockBaseDirectory);
+                settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
+                section.Should().NotBeNull();
+
+                section.Items.Count.Should().Be(1);
+                var item = section.Items.First();
+                item.IsCopy().Should().BeFalse();
+                item.Origin.Should().NotBeNull();
+
+                var clone = item.Clone() as AddItem;
+                clone.IsCopy().Should().BeTrue();
+                clone.Origin.Should().NotBeNull();
+                SettingsTestUtils.DeepEquals(clone, item).Should().BeTrue();
+            }
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/ClearItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/ClearItemTests.cs
@@ -137,9 +137,9 @@ namespace NuGet.Configuration.Test
         public void ClearItem_Equals_WithDifferentItem_ReturnsFalse()
         {
             var clear1 = new ClearItem();
-            var randomItem = new AddItem("keyN", "value1");
+            var differentItem = new AddItem("keyN", "value1");
 
-            clear1.Equals(randomItem).Should().BeFalse();
+            clear1.Equals(differentItem).Should().BeFalse();
         }
 
         [Fact]
@@ -151,7 +151,7 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void ClearItem_Clone_CopiesTheSameItem()
+        public void ClearItem_Clone_ReturnsItemClone()
         {
             // Arrange
             var config = @"

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/ClearItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/ClearItemTests.cs
@@ -123,5 +123,63 @@ namespace NuGet.Configuration.Test
                 ex.Message.Should().Be(string.Format("Error parsing NuGet.Config. Element '{0}' cannot have descendant elements. Path: '{1}'.", "clear", Path.Combine(mockBaseDirectory, nugetConfigPath)));
             }
         }
+
+        [Fact]
+        public void ClearItem_Equals_WithAnotherClearItem_ReturnsTrue()
+        {
+            var clear1 = new ClearItem();
+            var clear2 = new ClearItem();
+
+            clear1.Equals(clear2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void ClearItem_Equals_WithDifferentItem_ReturnsFalse()
+        {
+            var clear1 = new ClearItem();
+            var randomItem = new AddItem("keyN", "value1");
+
+            clear1.Equals(randomItem).Should().BeFalse();
+        }
+
+        [Fact]
+        public void ClearItem_ElementName_IsCorrect()
+        {
+            var clearItem = new ClearItem();
+
+            clearItem.ElementName.Should().Be("clear");
+        }
+
+        [Fact]
+        public void ClearItem_Clone_CopiesTheSameItem()
+        {
+            // Arrange
+            var config = @"
+<configuration>
+    <SectionName>
+        <clear />
+    </SectionName>
+</configuration>";
+            var nugetConfigPath = "NuGet.Config";
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+
+                // Act and Assert
+                var settingsFile = new SettingsFile(mockBaseDirectory);
+                settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
+                section.Should().NotBeNull();
+
+                section.Items.Count.Should().Be(1);
+                var item = section.Items.First();
+                item.IsCopy().Should().BeFalse();
+                item.Origin.Should().NotBeNull();
+
+                var clone = item.Clone() as ClearItem;
+                clone.IsCopy().Should().BeTrue();
+                clone.Origin.Should().NotBeNull();
+                SettingsTestUtils.DeepEquals(clone, item).Should().BeTrue();
+            }
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
@@ -492,5 +492,67 @@ namespace NuGet.Configuration.Test
             elattr[0].Value.Should().Be("ClearTextPassword");
             elattr[1].Value.Should().Be("password");
         }
+
+        [Fact]
+        public void CredentialsItem_Equals_WithSameElementName_ReturnsTrue()
+        {
+            var credentials1 = new CredentialsItem("source", "user", "pass", isPasswordClearText: true, validAuthenticationTypes: "one,two,three");
+            var credentials2 = new CredentialsItem("source", "user2", "pass", isPasswordClearText: false, validAuthenticationTypes: null);
+
+            credentials1.Equals(credentials2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void CredentialsItem_Equals_WithDifferentElemenName_ReturnsFalse()
+        {
+            var credentials1 = new CredentialsItem("source1", "user", "pass", isPasswordClearText: true, validAuthenticationTypes: "one,two,three");
+            var credentials2 = new CredentialsItem("source2", "user", "pass", isPasswordClearText: true, validAuthenticationTypes: "one,two,three");
+
+            credentials1.Equals(credentials2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void CredentialsItem_ElementName_IsCorrect()
+        {
+            var credentialsItem = new CredentialsItem("source", "user", "pass", isPasswordClearText: false, validAuthenticationTypes: null);
+
+            credentialsItem.ElementName.Should().Be("source");
+        }
+
+        [Fact]
+        public void CredentialsItem_Clone_CopiesTheSameItem()
+        {
+            // Arrange
+            var config = @"
+<configuration>
+    <packageSourceCredentials>
+        <NuGet.Org meta1='data1'>
+            <add key='Username' value='username' />
+            <add key='Password' value='password' />
+            <add key='ValidAuthenticationTypes' value='one,two,three' />
+        </NuGet.Org>
+    </packageSourceCredentials>
+</configuration>";
+            var nugetConfigPath = "NuGet.Config";
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+
+                // Act and Assert
+                var settingsFile = new SettingsFile(mockBaseDirectory);
+                settingsFile.TryGetSection("packageSourceCredentials", out var section).Should().BeTrue();
+                section.Should().NotBeNull();
+
+                section.Items.Count.Should().Be(1);
+                var item = section.Items.First();
+                item.IsCopy().Should().BeFalse();
+                item.Origin.Should().NotBeNull();
+
+                var clone = item.Clone() as CredentialsItem;
+                clone.IsCopy().Should().BeTrue();
+                clone.Origin.Should().NotBeNull();
+                SettingsTestUtils.DeepEquals(clone, item).Should().BeTrue();
+            }
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
@@ -520,7 +520,7 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void CredentialsItem_Clone_CopiesTheSameItem()
+        public void CredentialsItem_Clone_ReturnsItemClone()
         {
             // Arrange
             var config = @"

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/NuGetConfigurationTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/NuGetConfigurationTests.cs
@@ -46,5 +46,31 @@ namespace NuGet.Configuration.Test
                 settingsFile.Should().NotBeNull();
             }
         }
+
+        [Fact]
+        public void NuGetConfiguration_Equals_WithSameSections_ReturnsTrue()
+        {
+            var configuration1 = new NuGetConfiguration(new VirtualSettingSection("section1"), new VirtualSettingSection("section2"));
+            var configuration2 = new NuGetConfiguration(new VirtualSettingSection("section1"), new VirtualSettingSection("section2"));
+
+            configuration1.Equals(configuration2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void NuGetConfiguration_Equals_WithDifferentSections_ReturnsFalse()
+        {
+            var configuration1 = new NuGetConfiguration(new VirtualSettingSection("section1"), new VirtualSettingSection("section2"));
+            var configuration2 = new NuGetConfiguration(new VirtualSettingSection("section1"));
+
+            configuration1.Equals(configuration2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void NuGetConfiguration_ElementName_IsCorrect()
+        {
+            var nugetConfiguration = new NuGetConfiguration();
+
+            nugetConfiguration.ElementName.Should().Be("configuration");
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingSectionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingSectionTests.cs
@@ -445,7 +445,7 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void AddItem_Clone_CopiesTheSameItem()
+        public void SettingSection_Clone_ReturnsSectionClone()
         {
             // Arrange
             var config = @"

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingTextTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingTextTests.cs
@@ -95,5 +95,60 @@ namespace NuGet.Configuration.Test
                 text.Value.Should().Be("This is another test");
             }
         }
+
+        [Fact]
+        public void SettingText_Equals_WithSameText_ReturnsTrue()
+        {
+            var text1 = new SettingText("some text");
+            var text2 = new SettingText("some text");
+
+            text1.Equals(text2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SettingText_Equals_WithDifferentText_ReturnsFalse()
+        {
+            var text1 = new SettingText("some text");
+            var text2 = new SettingText("other text");
+
+            text1.Equals(text2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SettingText_Clone_CopiesTheSameItem()
+        {
+            // Arrange
+            var config = @"
+<configuration>
+    <SectionName>
+        <item>Some text</item>
+    </SectionName>
+</configuration>";
+            var nugetConfigPath = "NuGet.Config";
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+
+                // Act and Assert
+                var settingsFile = new SettingsFile(mockBaseDirectory);
+                settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
+                section.Should().NotBeNull();
+
+                section.Items.Count.Should().Be(1);
+                var item = section.Items.First() as UnknownItem;
+                item.IsCopy().Should().BeFalse();
+                item.Origin.Should().NotBeNull();
+
+                item.Children.Count.Should().Be(1);
+                var text = item.Children.First();
+                text.IsCopy().Should().BeFalse();
+                text.Origin.Should().NotBeNull();
+
+                var clone = text.Clone() as SettingText;
+                clone.IsCopy().Should().BeTrue();
+                clone.Origin.Should().NotBeNull();
+                SettingsTestUtils.DeepEquals(clone, text).Should().BeTrue();
+            }
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingTextTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingTextTests.cs
@@ -115,7 +115,7 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void SettingText_Clone_CopiesTheSameItem()
+        public void SettingText_Clone_ReturnsSettingClone()
         {
             // Arrange
             var config = @"

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
@@ -151,7 +151,7 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void SourceItem_Clone_CopiesTheSameItem()
+        public void SourceItem_Clone_ReturnsItemClone()
         {
             // Arrange
             var config = @"

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SourceItemTests.cs
@@ -114,5 +114,72 @@ namespace NuGet.Configuration.Test
                 ex.Message.Should().Be(string.Format("Error parsing NuGet.Config. Element '{0}' cannot have descendant elements. Path: '{1}'.", "add", Path.Combine(mockBaseDirectory, nugetConfigPath)));
             }
         }
+
+        [Fact]
+        public void SourceItem_Equals_WithSameKeyAndProtocol_ReturnsTrue()
+        {
+            var source1 = new SourceItem("key1", "value1", "3");
+            var source2 = new SourceItem("key1", "valueN", "3");
+
+            source1.Equals(source2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SourceItem_Equals_WithSameKeyDifferentProtocol_ReturnsFalse()
+        {
+            var source1 = new SourceItem("key1", "value1", "2");
+            var source2 = new SourceItem("key1", "value1", "3");
+
+            source1.Equals(source2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SourceItem_Equals_WithSameProtocolDifferentKey_ReturnsFalse()
+        {
+            var source1 = new SourceItem("key1", "value1", "3");
+            var source2 = new SourceItem("keyN", "value1", "3");
+
+            source1.Equals(source2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SourceItem_ElementName_IsCorrect()
+        {
+            var sourceItem = new SourceItem("key1", "value1");
+
+            sourceItem.ElementName.Should().Be("add");
+        }
+
+        [Fact]
+        public void SourceItem_Clone_CopiesTheSameItem()
+        {
+            // Arrange
+            var config = @"
+<configuration>
+    <packageSources>
+        <add key=""key1"" value=""val"" protocolVersion=""5"" />
+    </packageSources>
+</configuration>";
+            var nugetConfigPath = "NuGet.Config";
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+
+                // Act and Assert
+                var settingsFile = new SettingsFile(mockBaseDirectory);
+                settingsFile.TryGetSection("packageSources", out var section).Should().BeTrue();
+                section.Should().NotBeNull();
+
+                section.Items.Count.Should().Be(1);
+                var item = section.Items.First();
+                item.IsCopy().Should().BeFalse();
+                item.Origin.Should().NotBeNull();
+
+                var clone = item.Clone() as SourceItem;
+                clone.IsCopy().Should().BeTrue();
+                clone.Origin.Should().NotBeNull();
+                SettingsTestUtils.DeepEquals(clone, item).Should().BeTrue();
+            }
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/UnknownItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/UnknownItemTests.cs
@@ -873,5 +873,65 @@ namespace NuGet.Configuration.Test
 
             SettingsTestUtils.DeepEquals(originalSetting, expectedSetting).Should().BeTrue();
         }
+
+        [Fact]
+        public void UnknownItem_Equals_WithSameElementName_ReturnsTrue()
+        {
+            var unkown1 = new UnknownItem("item1", attributes: new Dictionary<string, string>() { { "meta1", "data1" } }, children: new List<SettingBase>() { new AddItem("key", "val") });
+            var unkown2 = new UnknownItem("item1", attributes: new Dictionary<string, string>() { { "meta2", "data2" }, { "meta3", "data4" } }, children: new List<SettingBase>() { new ClearItem() });
+
+            unkown1.Equals(unkown2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void UnknownItem_Equals_WithDifferentElementName_ReturnsFalse()
+        {
+            var unkown1 = new UnknownItem("item1", attributes: new Dictionary<string, string>() { { "meta1", "data1" } }, children: new List<SettingBase>() { new AddItem("key", "val") });
+            var unkown2 = new UnknownItem("item2", attributes: new Dictionary<string, string>() { { "meta1", "data1" } }, children: new List<SettingBase>() { new AddItem("key", "val") });
+
+            unkown1.Equals(unkown2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void UnknownItem_ElementName_IsCorrect()
+        {
+            var unkownItem = new UnknownItem("item", attributes: null, children: null);
+
+            unkownItem.ElementName.Should().Be("item");
+        }
+
+        [Fact]
+        public void UnknownItem_Clone_CopiesTheSameItem()
+        {
+            // Arrange
+            var config = @"
+<configuration>
+    <SectionName>
+        <item meta=""data"">
+            <add key=""key1"" value=""val"" meta=""data"" />
+        </item>
+    </SectionName>
+</configuration>";
+            var nugetConfigPath = "NuGet.Config";
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+
+                // Act and Assert
+                var settingsFile = new SettingsFile(mockBaseDirectory);
+                settingsFile.TryGetSection("SectionName", out var section).Should().BeTrue();
+                section.Should().NotBeNull();
+
+                section.Items.Count.Should().Be(1);
+                var item = section.Items.First();
+                item.IsCopy().Should().BeFalse();
+                item.Origin.Should().NotBeNull();
+
+                var clone = item.Clone() as UnknownItem;
+                clone.IsCopy().Should().BeTrue();
+                clone.Origin.Should().NotBeNull();
+                SettingsTestUtils.DeepEquals(clone, item).Should().BeTrue();
+            }
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/UnknownItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/UnknownItemTests.cs
@@ -901,7 +901,7 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void UnknownItem_Clone_CopiesTheSameItem()
+        public void UnknownItem_Clone_ReturnsItemClone()
         {
             // Arrange
             var config = @"


### PR DESCRIPTION
There was a test gap for children of `SettingBase`. This PR adds tests for the `Equals` and `Clone` methods, as well as the `ElementName` property of those classes.