### PR TITLE
Add PackageArchiveReader.GetContentHash and fix 4 failing functional tests

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -360,7 +360,17 @@ namespace NuGet.Packaging
             {
                 return SignedPackageArchiveUtility.GetPackageContentHash(reader);
             }
+        }
 
+        public override string GetContentHashForPackage(CancellationToken token)
+        {
+            var contentHash = GetContentHashForSignedPackage(token);
+            if (contentHash == null)
+            {
+                contentHash =  Convert.ToBase64String(new CryptoHashProvider("SHA512").CalculateHash(ZipReadStream));
+            }
+
+            return contentHash;
         }
 
         public override Task<byte[]> GetArchiveHashAsync(HashAlgorithmName hashAlgorithmName, CancellationToken token)

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -362,12 +362,11 @@ namespace NuGet.Packaging
             }
         }
 
-        public override string GetContentHashForPackage(CancellationToken token)
+        public override string GetContentHash(CancellationToken token)
         {
             var contentHash = GetContentHashForSignedPackage(token);
             if (contentHash == null)
             {
-                // Return the zip stream position to the begining
                 ZipReadStream.Position = 0;
 
                 contentHash = Convert.ToBase64String(new CryptoHashProvider("SHA512").CalculateHash(ZipReadStream));

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -362,12 +362,15 @@ namespace NuGet.Packaging
             }
         }
 
-        public override string GetContentHash(CancellationToken token)
+        public override string GetContentHashForPackage(CancellationToken token)
         {
             var contentHash = GetContentHashForSignedPackage(token);
             if (contentHash == null)
             {
-                contentHash =  Convert.ToBase64String(new CryptoHashProvider("SHA512").CalculateHash(ZipReadStream));
+                // Return the zip stream position to the begining
+                ZipReadStream.Position = 0;
+
+                contentHash = Convert.ToBase64String(new CryptoHashProvider("SHA512").CalculateHash(ZipReadStream));
             }
 
             return contentHash;

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -362,7 +362,7 @@ namespace NuGet.Packaging
             }
         }
 
-        public override string GetContentHashForPackage(CancellationToken token)
+        public override string GetContentHash(CancellationToken token)
         {
             var contentHash = GetContentHashForSignedPackage(token);
             if (contentHash == null)

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -367,7 +367,9 @@ namespace NuGet.Packaging
             var contentHash = GetContentHashForSignedPackage(token);
             if (contentHash == null)
             {
-                ZipReadStream.Position = 0;
+                ThrowIfZipReadStreamIsNull();
+
+                ZipReadStream.Seek(offset: 0, origin: SeekOrigin.Begin);
 
                 contentHash = Convert.ToBase64String(new CryptoHashProvider("SHA512").CalculateHash(ZipReadStream));
             }

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -249,5 +249,10 @@ namespace NuGet.Packaging
         {
             return false;
         }
+        
+        public override string GetContentHash(CancellationToken token)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -250,7 +250,7 @@ namespace NuGet.Packaging
             return false;
         }
         
-        public override string GetContentHashForPackage(CancellationToken token)
+        public override string GetContentHash(CancellationToken token)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -250,7 +250,7 @@ namespace NuGet.Packaging
             return false;
         }
         
-        public override string GetContentHash(CancellationToken token)
+        public override string GetContentHashForPackage(CancellationToken token)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -607,6 +607,6 @@ namespace NuGet.Packaging
         /// </summary>
         /// <param name="token"></param>
         /// <returns></returns>
-        public abstract string GetContentHashForPackage(CancellationToken token);
+        public abstract string GetContentHash(CancellationToken token);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -607,6 +607,6 @@ namespace NuGet.Packaging
         /// </summary>
         /// <param name="token"></param>
         /// <returns></returns>
-        public abstract string GetContentHash(CancellationToken token);
+        public abstract string GetContentHashForPackage(CancellationToken token);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -593,8 +593,20 @@ namespace NuGet.Packaging
 
         public abstract Task<byte[]> GetArchiveHashAsync(HashAlgorithmName hashAlgorithm, CancellationToken token);
 
+        public abstract bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings);
+
+        /// <summary>
+        /// Get contentHash for a signed package.
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns>null if the package is not signed</returns>
         public abstract string GetContentHashForSignedPackage(CancellationToken token);
 
-        public abstract bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings);
+        /// <summary>
+        /// Get contenthash for a package.
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        public abstract string GetContentHashForPackage(CancellationToken token);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -598,15 +598,12 @@ namespace NuGet.Packaging
         /// <summary>
         /// Get contentHash for a signed package.
         /// </summary>
-        /// <param name="token"></param>
         /// <returns>null if the package is not signed</returns>
         public abstract string GetContentHashForSignedPackage(CancellationToken token);
 
         /// <summary>
         /// Get contenthash for a package.
         /// </summary>
-        /// <param name="token"></param>
-        /// <returns></returns>
-        public abstract string GetContentHashForPackage(CancellationToken token);
+        public abstract string GetContentHash(CancellationToken token);
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -1165,9 +1165,9 @@ namespace NuGet.Protocol.Plugins
             return false;
         }
         
-        public override string GetContentHashForPackage(CancellationToken token)
+        public override string GetContentHash(CancellationToken token)
         {
-            // Plugin Download doesn't support signed packages so simply return null...and even then their aren't always packages.
+            // Plugin Download doesn't support signed packages so simply return null... and even then they aren't always packages.
             return null;
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -1164,6 +1164,12 @@ namespace NuGet.Protocol.Plugins
 
             return false;
         }
+        
+        public override string GetContentHash(CancellationToken token)
+        {
+            // Plugin Download doesn't support signed packages so simply return null...and even then their aren't always packages.
+            return null;
+        }
 
         private sealed class FileStreamCreator : IDisposable
         {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -1165,7 +1165,7 @@ namespace NuGet.Protocol.Plugins
             return false;
         }
         
-        public override string GetContentHash(CancellationToken token)
+        public override string GetContentHashForPackage(CancellationToken token)
         {
             // Plugin Download doesn't support signed packages so simply return null...and even then their aren't always packages.
             return null;

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
@@ -320,9 +320,14 @@ namespace NuGet.PackageManagement
             {
                 var targetPackageStream = downloadResult.PackageStream;
 
+                // calculate contentHash to verify we got the package correctly.
+                var packageArchiveReader = new PackageArchiveReader(targetPackageStream);
+                var contentHash = packageArchiveReader.GetContentHashForPackage(new CancellationToken());
+
                 // Assert
-                // jQuery.1.8.2 is of size 185476 bytes. Make sure the download is successful
-                Assert.Equal(185476, targetPackageStream.Length);
+                // jQuery.1.8.2 has the following contentHash:
+                Assert.Equal("cXOJxYC6ccYDP5FW1iOXhZww+7CyKdpiJbkR0YZxILNJ2zvM4VsrqOVKNRHnIWF78IixUfo/cw7Hz4M70MUbGg==",
+                    contentHash);
                 Assert.True(targetPackageStream.CanSeek);
             }
         }
@@ -348,10 +353,15 @@ namespace NuGet.PackageManagement
             {
                 var targetPackageStream = downloadResult.PackageStream;
 
+                // calculate contentHash to verify we got the package correctly.
+                var packageArchiveReader = new PackageArchiveReader(targetPackageStream);
+                var contentHash = packageArchiveReader.GetContentHashForSignedPackage(new CancellationToken());
+
                 // Assert
-                // jQuery.1.8.2 is of size 185476 bytes. Make sure the download is successful
-                Assert.Equal(185476, targetPackageStream.Length);
-                Assert.True(targetPackageStream.CanSeek);
+                // jQuery.1.8.2 has the following contentHash:
+                Assert.Equal("cXOJxYC6ccYDP5FW1iOXhZww+7CyKdpiJbkR0YZxILNJ2zvM4VsrqOVKNRHnIWF78IixUfo/cw7Hz4M70MUbGg==",
+                    contentHash);
+                Assert.True(targetPackageStream.CanSeek);}
             }
         }
 
@@ -575,9 +585,14 @@ namespace NuGet.PackageManagement
                 {
                     var targetPackageStream = downloadResult.PackageStream;
 
+                    // calculate contentHash to verify we got the package correctly.
+                    var packageArchiveReader = new PackageArchiveReader(targetPackageStream);
+                    var contentHash = packageArchiveReader.GetContentHashForPackage(new CancellationToken());
+
                     // Assert
-                    // jQuery.1.8.2 is of size 185476 bytes. Make sure the download is successful
-                    Assert.Equal(185476, targetPackageStream.Length);
+                    // jQuery.1.8.2 has the following contentHash:
+                    Assert.Equal("cXOJxYC6ccYDP5FW1iOXhZww+7CyKdpiJbkR0YZxILNJ2zvM4VsrqOVKNRHnIWF78IixUfo/cw7Hz4M70MUbGg==",
+                        contentHash);
                     Assert.True(targetPackageStream.CanSeek);
                 }
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
@@ -23,6 +23,8 @@ namespace NuGet.PackageManagement
 {
     public class PackageDownloaderTests
     {
+        private static readonly string _jQuery182ContentHash = "cXOJxYC6ccYDP5FW1iOXhZww+7CyKdpiJbkR0YZxILNJ2zvM4VsrqOVKNRHnIWF78IixUfo/cw7Hz4M70MUbGg==";
+
         [Fact]
         public async Task GetDownloadResourceResultAsync_Sources_ThrowsForNullSources()
         {
@@ -320,15 +322,14 @@ namespace NuGet.PackageManagement
             {
                 var targetPackageStream = downloadResult.PackageStream;
 
-                // calculate contentHash to verify we got the package correctly.
-                var packageArchiveReader = new PackageArchiveReader(targetPackageStream);
-                var contentHash = packageArchiveReader.GetContentHashForPackage(new CancellationToken());
+                using (var packageArchiveReader = new PackageArchiveReader(targetPackageStream))
+                {
+                    var contentHash = packageArchiveReader.GetContentHashForPackage(CancellationToken.None);
 
-                // Assert
-                // jQuery.1.8.2 has the following contentHash:
-                Assert.Equal("cXOJxYC6ccYDP5FW1iOXhZww+7CyKdpiJbkR0YZxILNJ2zvM4VsrqOVKNRHnIWF78IixUfo/cw7Hz4M70MUbGg==",
-                    contentHash);
-                Assert.True(targetPackageStream.CanSeek);
+                    // Assert
+                    Assert.Equal(_jQuery182ContentHash, contentHash);
+                    Assert.True(targetPackageStream.CanSeek);
+                }
             }
         }
 
@@ -353,15 +354,14 @@ namespace NuGet.PackageManagement
             {
                 var targetPackageStream = downloadResult.PackageStream;
 
-                // calculate contentHash to verify we got the package correctly.
-                var packageArchiveReader = new PackageArchiveReader(targetPackageStream);
-                var contentHash = packageArchiveReader.GetContentHashForSignedPackage(new CancellationToken());
+                using (var packageArchiveReader = new PackageArchiveReader(targetPackageStream))
+                {
+                    var contentHash = packageArchiveReader.GetContentHashForSignedPackage(CancellationToken.None);
 
-                // Assert
-                // jQuery.1.8.2 has the following contentHash:
-                Assert.Equal("cXOJxYC6ccYDP5FW1iOXhZww+7CyKdpiJbkR0YZxILNJ2zvM4VsrqOVKNRHnIWF78IixUfo/cw7Hz4M70MUbGg==",
-                    contentHash);
-                Assert.True(targetPackageStream.CanSeek);
+                    // Assert
+                    Assert.Equal(_jQuery182ContentHash, contentHash);
+                    Assert.True(targetPackageStream.CanSeek);
+                }
             }
         }
 
@@ -372,7 +372,7 @@ namespace NuGet.PackageManagement
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
             // Act & Assert
-            await VerifyDirectDownloadSkipsGlobalPackagesFolder(sourceRepositoryProvider);
+            await VerifyDirectDownloadSkipsGlobalPackagesFolderAsync(sourceRepositoryProvider);
         }
 
         [Fact]
@@ -382,7 +382,7 @@ namespace NuGet.PackageManagement
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
 
             // Act & Assert
-            await VerifyDirectDownloadSkipsGlobalPackagesFolder(sourceRepositoryProvider);
+            await VerifyDirectDownloadSkipsGlobalPackagesFolderAsync(sourceRepositoryProvider);
         }
 
         [Fact]
@@ -558,7 +558,7 @@ namespace NuGet.PackageManagement
             }
         }
 
-        private static async Task VerifyDirectDownloadSkipsGlobalPackagesFolder(
+        private static async Task VerifyDirectDownloadSkipsGlobalPackagesFolderAsync(
             SourceRepositoryProvider sourceRepositoryProvider)
         {
             // Arrange
@@ -585,15 +585,14 @@ namespace NuGet.PackageManagement
                 {
                     var targetPackageStream = downloadResult.PackageStream;
 
-                    // calculate contentHash to verify we got the package correctly.
-                    var packageArchiveReader = new PackageArchiveReader(targetPackageStream);
-                    var contentHash = packageArchiveReader.GetContentHash(new CancellationToken());
+                    using (var packageArchiveReader = new PackageArchiveReader(targetPackageStream))
+                    {
+                        var contentHash = packageArchiveReader.GetContentHashForPackage(CancellationToken.None);
 
-                    // Assert
-                    // jQuery.1.8.2 has the following contentHash:
-                    Assert.Equal("cXOJxYC6ccYDP5FW1iOXhZww+7CyKdpiJbkR0YZxILNJ2zvM4VsrqOVKNRHnIWF78IixUfo/cw7Hz4M70MUbGg==",
-                        contentHash);
-                    Assert.True(targetPackageStream.CanSeek);
+                        // Assert
+                        Assert.Equal(_jQuery182ContentHash, contentHash);
+                        Assert.True(targetPackageStream.CanSeek);
+                    }
                 }
 
                 // Verify that the direct download directory is empty. The package should be downloaded to a temporary

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
@@ -361,7 +361,7 @@ namespace NuGet.PackageManagement
                 // jQuery.1.8.2 has the following contentHash:
                 Assert.Equal("cXOJxYC6ccYDP5FW1iOXhZww+7CyKdpiJbkR0YZxILNJ2zvM4VsrqOVKNRHnIWF78IixUfo/cw7Hz4M70MUbGg==",
                     contentHash);
-                Assert.True(targetPackageStream.CanSeek);}
+                Assert.True(targetPackageStream.CanSeek);
             }
         }
 
@@ -587,7 +587,7 @@ namespace NuGet.PackageManagement
 
                     // calculate contentHash to verify we got the package correctly.
                     var packageArchiveReader = new PackageArchiveReader(targetPackageStream);
-                    var contentHash = packageArchiveReader.GetContentHashForPackage(new CancellationToken());
+                    var contentHash = packageArchiveReader.GetContentHash(new CancellationToken());
 
                     // Assert
                     // jQuery.1.8.2 has the following contentHash:

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
@@ -23,7 +23,7 @@ namespace NuGet.PackageManagement
 {
     public class PackageDownloaderTests
     {
-        private static readonly string _jQuery182ContentHash = "cXOJxYC6ccYDP5FW1iOXhZww+7CyKdpiJbkR0YZxILNJ2zvM4VsrqOVKNRHnIWF78IixUfo/cw7Hz4M70MUbGg==";
+        private static readonly string _jQuery182ContentHash = "uhcB1DuO8O6WW6wWe7SDn0Rz4vZZPqNJHld10yrtG9Z/l4HiTHBhncn2GWAzF7Yv6hoNC/+kAM/6WMsrIdThWA==";
 
         [Fact]
         public async Task GetDownloadResourceResultAsync_Sources_ThrowsForNullSources()
@@ -324,7 +324,7 @@ namespace NuGet.PackageManagement
 
                 using (var packageArchiveReader = new PackageArchiveReader(targetPackageStream))
                 {
-                    var contentHash = packageArchiveReader.GetContentHashForPackage(CancellationToken.None);
+                    var contentHash = packageArchiveReader.GetContentHash(CancellationToken.None);
 
                     // Assert
                     Assert.Equal(_jQuery182ContentHash, contentHash);
@@ -587,7 +587,7 @@ namespace NuGet.PackageManagement
 
                     using (var packageArchiveReader = new PackageArchiveReader(targetPackageStream))
                     {
-                        var contentHash = packageArchiveReader.GetContentHashForPackage(CancellationToken.None);
+                        var contentHash = packageArchiveReader.GetContentHash(CancellationToken.None);
 
                         // Assert
                         Assert.Equal(_jQuery182ContentHash, contentHash);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -901,7 +902,7 @@ namespace NuGet.Packaging.Test
                     // Act & Assert
                     Assert.Throws<UnsafePackageEntryException>(() => packageReader.CopyFiles(
                         root.Path,
-                        new[] { "../../A.dll", "content/net40/B.nuspec"},
+                        new[] { "../../A.dll", "content/net40/B.nuspec" },
                         ExtractFile,
                         NullLogger.Instance,
                         CancellationToken.None));
@@ -1722,6 +1723,46 @@ namespace NuGet.Packaging.Test
                 Assert.Null(result);
             }
         }
+
+#if IS_DESKTOP
+        [Fact]
+        public async Task GetContentHash_IsSameForUnsignedAndSignedPackageAsync()
+        {
+            // this test will create an unsiged package, copy it, then sign it. then compare the contentHash
+            var nupkg = new SimpleTestPackageContext("Package.Content.Hash.Test", "1.0.0");
+
+            using (var unsignedDir = TestDirectory.Create())
+            {
+                var nupkgFileName = $"{nupkg.Identity.Id}.{nupkg.Identity.Version}.nupkg";
+                var nupkgFileInfo = await nupkg.CreateAsFileAsync(unsignedDir, nupkgFileName);
+
+                using (var signedDir = TestDirectory.Create())
+                {
+                    Uri timestampService = null;
+                    var signatureHashAlgorithm = HashAlgorithmName.SHA256;
+                    var timestampHashAlgorithm = HashAlgorithmName.SHA256;
+
+                    var signedPackagePath = Path.Combine(signedDir.Path, nupkgFileName);
+
+                    using (var originalPackage = File.OpenRead(nupkgFileInfo.FullName))
+                    using (var signedPackage = File.Open(signedPackagePath, FileMode.OpenOrCreate, FileAccess.ReadWrite))
+                    using (var request = new AuthorSignPackageRequest(
+                        new X509Certificate2(),
+                        signatureHashAlgorithm,
+                        timestampHashAlgorithm))
+                    {
+                        await SignedArchiveTestUtility.CreateSignedPackageAsync(request, originalPackage, signedPackage, timestampService);
+                    }
+
+                    var contentHashUnsigned = new PackageArchiveReader(nupkgFileInfo.FullName).GetContentHash(CancellationToken.None);
+                    var contentHashSigned = new PackageArchiveReader(signedPackagePath).GetContentHash(CancellationToken.None);
+
+                    Assert.Equal(contentHashUnsigned, contentHashSigned);
+                }
+            }
+        }
+
+#endif 
 
         private static Zip CreateZipWithNestedStoredZipArchives()
         {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -1758,8 +1758,8 @@ namespace NuGet.Packaging.Test
                     using (var unsignedReader = new PackageArchiveReader(nupkgFileInfo.FullName))
                     using (var signedReader = new PackageArchiveReader(signedPackagePath))
                     {
-                        var contentHashUnsigned = unsignedReader.GetContentHashForPackage(CancellationToken.None);
-                        var contentHashSigned = signedReader.GetContentHashForPackage(CancellationToken.None);
+                        var contentHashUnsigned = unsignedReader.GetContentHash(CancellationToken.None);
+                        var contentHashSigned = signedReader.GetContentHash(CancellationToken.None);
 
                         Assert.Equal(contentHashUnsigned, contentHashSigned);
                     }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
@@ -233,7 +233,7 @@ namespace NuGet.Protocol.Tests
                 throw new NotImplementedException();
             }
 
-            public override string GetContentHashForPackage(CancellationToken token)
+            public override string GetContentHash(CancellationToken token)
             {
                 throw new NotImplementedException();
             }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
@@ -233,7 +233,7 @@ namespace NuGet.Protocol.Tests
                 throw new NotImplementedException();
             }
 
-            public override string GetContentHash(CancellationToken token)
+            public override string GetContentHashForPackage(CancellationToken token)
             {
                 throw new NotImplementedException();
             }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
@@ -233,6 +233,11 @@ namespace NuGet.Protocol.Tests
                 throw new NotImplementedException();
             }
 
+            public override string GetContentHash(CancellationToken token)
+            {
+                throw new NotImplementedException();
+            }
+
             public override Task<byte[]> GetArchiveHashAsync(HashAlgorithmName hashAlgorithm, CancellationToken token)
             {
                 throw new NotImplementedException();

--- a/tests.playlist
+++ b/tests.playlist
@@ -1,0 +1,1 @@
+<Playlist Version="1.0"><Add Test="NuGet.Packaging.Test.PackageArchiveReaderTests.GetContentHash_IsSameForUnsignedAndSignedPackageAsync" /></Playlist>

--- a/tests.playlist
+++ b/tests.playlist
@@ -1,1 +1,0 @@
-<Playlist Version="1.0"><Add Test="NuGet.Packaging.Test.PackageArchiveReaderTests.GetContentHash_IsSameForUnsignedAndSignedPackageAsync" /></Playlist>


### PR DESCRIPTION
Add implementation for `PackageArchiveReader.GetContentHash(…)` and use it to fix 4 failing functional tests in a resilient way.

## Fix
Details: Currently, there is a method `PackageArchiveReader.GetContentHashForSignedPackage(…)`, but since this only works for signed packages, added `PackageArchiveReader.GetContentHash(…)`, which will return the Content hash regardless of if the package signed or not. This is helpful for non-extraction scenarios.

@NuGet/nuget-client 