### PR TITLE
Check for either old hash file or new nupkg metadata file to know if package is installed

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/FallbackPackagePathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/FallbackPackagePathResolver.cs
@@ -120,9 +120,10 @@ namespace NuGet.Packaging
             // Check each folder for the package.
             foreach (var resolver in _pathResolvers)
             {
-                var hashPath = resolver.GetNupkgMetadataPath(packageId, version);
+                var hashPath = resolver.GetHashPath(packageId, version);
+                var nupkgMetadataFilePath = resolver.GetNupkgMetadataPath(packageId, version);
 
-                if (File.Exists(hashPath))
+                if (File.Exists(hashPath) || File.Exists(nupkgMetadataFilePath))
                 {
                     // If the hash exists we can use this path
                     return new FallbackPackagePathInfo(packageId, version, resolver);


### PR DESCRIPTION
Currently if a package was installed with NuGet < 15.9 then it wont have `.nupkg.metadata` file in packages folder but when if NuGet 15.9 tries to check if this package is installed then it will fail. This breaks dotnet SDK scenario when packages is installed with NuGet 15.8 bits and when they tries to get package directory from FallbackPackagePathResolver with 15.9 bits, it returns null and break build.

So to be consistent with our NoOp check, we'll check for either hash file or nupkg metadata file to be present in order to confirm if package is installed or not. But as part of restore resolution, we'll only use nupkg metadata file to consume it either from fallback folder or global packages folder.
