### PR TITLE
Fix auth when credentials in different config

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -171,9 +171,6 @@ namespace NuGet.Build.Tasks
 
                 providers.Add(new DependencyGraphSpecRequestProvider(providerCache, dgFile));
 
-                var defaultSettings = Settings.LoadDefaultSettings(root: null, configFileName: null, machineWideSettings: null);
-                var sourceProvider = new CachingSourceProvider(new PackageSourceProvider(defaultSettings));
-
                 var restoreContext = new RestoreArgs()
                 {
                     CacheContext = cacheContext,
@@ -182,7 +179,6 @@ namespace NuGet.Build.Tasks
                     Log = log,
                     MachineWideSettings = new XPlatMachineWideSetting(),
                     PreLoadedRequestProviders = providers,
-                    CachingSourceProvider = sourceProvider,
                     AllowNoOp = !RestoreForce,
                     HideWarningsAndErrors = HideWarningsAndErrors,
                     RestoreForceEvaluate = RestoreForceEvaluate


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/3580

## Fix
The restore task was initializing the cache source provider with only the values from the user-wide config file. In the case that the user-wide config had the source information, but another config had extra information about the source (e.g. credentials), this cache source provider would return the empty source read from the user-wide instead of the full source that is read once the whole settings are read.

By deleting the default cache source provider, we let restore handle its settings and generate the cache when the appropriate settings are loaded.