### PR TITLE
Search for MSBuild first in the `Current` toolset

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildToolset.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildToolset.cs
@@ -111,15 +111,21 @@ namespace NuGet.CommandLine
                 return null;
             }
 
-            // Enumerate all versions of MSBuild present, take the highest
-            string msBuildDirectory = string.Empty;
-            var highestVersionRoot = Directory.EnumerateDirectories(msBuildRoot)
-                .OrderByDescending(ToFloatValue)
-                .FirstOrDefault(dir =>
-                {
-                    msBuildDirectory = SysPath.Combine(dir, "bin");
-                    return File.Exists(SysPath.Combine(msBuildDirectory, "msbuild.exe"));
-                });
+            // If "Current" MSBuild is available, it is the version to use
+            // see https://github.com/Microsoft/msbuild/issues/3778
+            string msBuildDirectory = SysPath.Combine(msBuildRoot, "Current", "bin");
+
+            if (!File.Exists(SysPath.Combine(msBuildDirectory, "msbuild.exe")))
+            {
+                // Enumerate all versions of MSBuild present, take the highest
+                var highestVersionRoot = Directory.EnumerateDirectories(msBuildRoot)
+                    .OrderByDescending(ToFloatValue)
+                    .FirstOrDefault(dir =>
+                    {
+                        msBuildDirectory = SysPath.Combine(dir, "bin");
+                        return File.Exists(SysPath.Combine(msBuildDirectory, "msbuild.exe"));
+                    });
+            }
 
             return msBuildDirectory;
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
@@ -69,6 +69,8 @@ namespace NuGet.Protocol.Plugins.Tests
         [Theory]
         [InlineData(@"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe",
             @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\Plugins")]
+        [InlineData(@"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe",
+            @"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\Plugins")]
         [InlineData(null, null)]
         public void PluginDiscoveryUtility_GetsNuGetPluginPathGivenMSBuildExeLocation(string given, string expected)
         {


### PR DESCRIPTION
This is a reaction to https://github.com/Microsoft/msbuild/issues/3778.

When `MSBuild.exe` is available in the new location, use it; otherwise
fall back to the previous behavior.

