### PR TITLE
Restore:  improve thread pool starvation fix by disabling asynchronous I/O

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
@@ -176,8 +176,7 @@ namespace NuGet.Packaging
                     FileMode.Create,
                     FileAccess.ReadWrite,
                     FileShare.ReadWrite | FileShare.Delete,
-                    bufferSize: 4096,
-                    useAsync: false))
+                    bufferSize: 4096))
                 {
                     // This value comes from NuGet.Protocol.StreamExtensions.CopyToAsync(...).
                     // While 8K may or may not be the optimal buffer size for copy performance,
@@ -285,8 +284,7 @@ namespace NuGet.Packaging
                FileMode.Open,
                FileAccess.Read,
                FileShare.Read,
-               bufferSize: 4096,
-               useAsync: true);
+               bufferSize: 4096);
         }
 
         private void ThrowIfDisposed()

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -458,12 +458,11 @@ namespace NuGet.Packaging
                             {
                                 // Extract the nupkg
                                 using (var nupkgStream = new FileStream(
-                                        targetTempNupkg,
-                                        FileMode.Create,
-                                        FileAccess.ReadWrite,
-                                        FileShare.ReadWrite | FileShare.Delete,
-                                        bufferSize: 4096,
-                                        useAsync: true))
+                                    targetTempNupkg,
+                                    FileMode.Create,
+                                    FileAccess.ReadWrite,
+                                    FileShare.ReadWrite | FileShare.Delete,
+                                    bufferSize: 4096))
                                 {
                                     await copyToAsync(nupkgStream);
                                     nupkgStream.Seek(0, SeekOrigin.Begin);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheEntry.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheEntry.cs
@@ -87,8 +87,7 @@ namespace NuGet.Protocol.Plugins
                     FileMode.Create,
                     FileAccess.ReadWrite,
                     FileShare.None,
-                    CachingUtility.BufferSize,
-                    useAsync: true))
+                    CachingUtility.BufferSize))
                 {
                     var json = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(OperationClaims, Formatting.Indented));
                     await fileStream.WriteAsync(json, 0, json.Length);

--- a/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
@@ -172,8 +172,7 @@ namespace NuGet.Protocol
                     FileMode.Create,
                     FileAccess.ReadWrite,
                     FileShare.ReadWrite | FileShare.Delete,
-                    bufferSize: 4096,
-                    useAsync: true))
+                    bufferSize: 4096))
                 {
                     var result = await _resource.CopyNupkgToStreamAsync(
                         _packageIdentity.Id,
@@ -286,8 +285,7 @@ namespace NuGet.Protocol
                FileMode.Open,
                FileAccess.Read,
                FileShare.Read,
-               bufferSize: 4096,
-               useAsync: true);
+               bufferSize: 4096);
         }
 
         private void ThrowIfDisposed()

--- a/src/NuGet.Core/NuGet.Protocol/Utility/CachingUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/CachingUtility.cs
@@ -45,8 +45,7 @@ namespace NuGet.Protocol
                         FileMode.Open,
                         FileAccess.Read,
                         FileShare.Read | FileShare.Delete,
-                        BufferSize,
-                        useAsync: true);
+                        BufferSize);
 
                     return stream;
                 }
@@ -63,7 +62,7 @@ namespace NuGet.Protocol
             {
                 stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
             }
-            catch(FileNotFoundException)
+            catch (FileNotFoundException)
             {
                 return false;
             }

--- a/src/NuGet.Core/NuGet.Protocol/Utility/FindPackagesByIdNupkgDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/FindPackagesByIdNupkgDownloader.cs
@@ -55,7 +55,7 @@ namespace NuGet.Protocol
             CancellationToken token)
         {
             NuspecReader reader = null;
-            
+
             lock (_nuspecReadersLock)
             {
                 if (_nuspecReaders.TryGetValue(url, out reader))
@@ -76,7 +76,7 @@ namespace NuGet.Protocol
                 cacheContext,
                 logger,
                 token);
-            
+
             if (reader == null)
             {
                 // The package was not found on the feed. This typically means
@@ -245,7 +245,7 @@ namespace NuGet.Protocol
                 logger,
                 token);
         }
-        
+
         private async Task<T> ProcessHttpSourceResultAsync<T>(
             PackageIdentity identity,
             string url,
@@ -336,8 +336,7 @@ namespace NuGet.Protocol
                         FileMode.Open,
                         FileAccess.Read,
                         FileShare.ReadWrite | FileShare.Delete,
-                        StreamExtensions.BufferSize,
-                        useAsync: true));
+                        StreamExtensions.BufferSize));
                 },
                 token))
             {
@@ -354,7 +353,7 @@ namespace NuGet.Protocol
                 CacheFile = cacheFile;
                 AlreadyProcessed = alreadyProcessed;
             }
-            
+
             public string CacheFile { get; }
             public bool AlreadyProcessed { get; }
         }

--- a/src/NuGet.Core/NuGet.Protocol/Utility/GetDownloadResultUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/GetDownloadResultUtility.cs
@@ -202,7 +202,7 @@ namespace NuGet.Protocol
                    FileAccess.ReadWrite,
                    FileShare.Read,
                    BufferSize,
-                   FileOptions.Asynchronous | FileOptions.DeleteOnClose);
+                   FileOptions.DeleteOnClose);
 
                 await packageStream.CopyToAsync(fileStream, BufferSize, token);
 


### PR DESCRIPTION
Resolve https://github.com/NuGet/Home/issues/7314.

The fix is to disable asynchronous I/O in the `FileSystem` class.

Ignoring the [previous change](https://github.com/NuGet/NuGet.Client/pull/2430), this change improves restore performance under .NET Core 2.1+ by ~70% using .NET Core 2.2 Preview 3 (2.2.100-preview3-009430) and the repro for https://github.com/dotnet/corefx/issues/31914.

Trial | Baseline (seconds) | With `useAsync == false` (seconds)
-- | -- | --
1 | 293.6 | 66.99
2 | 280.06 | 65.87
3 | 276.75 | 73.42
4 | 273.04 | 81.44
5 | 287.19 | 102.84
6 | 269.03 | 72.28
7 | 288.72 | 100.19
8 | 298.51 | 109.87
9 | 275.34 | 78.8
10 | 268.6 | 84.41
Average | 281.084 | 83.611

All baseline trials ultimately failed with:

    The SSL connection could not be established, see inner exception.
    Authentication failed because the remote party has closed the transport stream.

None of the trials with the fix failed.

This fix was intended for .NET Core 2.1+ as its HTTP rewrite was the catalyst for this performance regression.  However, I tested the same fix with NuGet.exe and found a ~44% improvement in restore performance.

Trial | Baseline (seconds) | With `useAsync == false` (seconds)
-- | -- | --
1 | 85.8 | 47.2
2 | 78.0 | 42.2
3 | 84.0 | 45.5
4 | 88.2 | 45.5
5 | 96.0 | 49.6
6 | 89.4 | 66.0
7 | 96.0 | 45.4
8 | 81.6 | 47.1
9 | 84.0 | 45.6
10 | 82.2 | 47.7
Average | 86.5 | 48.2