### PR TITLE
Have stronger validation for credentials parsing

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -161,6 +161,33 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A credentials item must only have one Password or ClearTextPassword entry..
+        /// </summary>
+        internal static string Error_MoreThanOnePassword {
+            get {
+                return ResourceManager.GetString("Error_MoreThanOnePassword", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A credentials item must only have one Username entry..
+        /// </summary>
+        internal static string Error_MoreThanOneUsername {
+            get {
+                return ResourceManager.GetString("Error_MoreThanOneUsername", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A credentials item must only have one ValidAuthenticationTypes entry..
+        /// </summary>
+        internal static string Error_MoreThanOneValidAuthenticationTypes {
+            get {
+                return ResourceManager.GetString("Error_MoreThanOneValidAuthenticationTypes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There are no writable config files..
         /// </summary>
         internal static string Error_NoWritableConfig {

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -161,7 +161,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A credentials item must only have one Password or ClearTextPassword entry..
+        ///   Looks up a localized string similar to A credentials item must have only one Password or ClearTextPassword entry..
         /// </summary>
         internal static string Error_MoreThanOnePassword {
             get {
@@ -170,7 +170,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A credentials item must only have one Username entry..
+        ///   Looks up a localized string similar to A credentials item must have only one Username entry..
         /// </summary>
         internal static string Error_MoreThanOneUsername {
             get {
@@ -179,7 +179,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A credentials item must only have one ValidAuthenticationTypes entry..
+        ///   Looks up a localized string similar to A credentials item must have only one ValidAuthenticationTypes entry..
         /// </summary>
         internal static string Error_MoreThanOneValidAuthenticationTypes {
             get {

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -158,13 +158,13 @@
     <value>Cannot merge two different sections.</value>
   </data>
   <data name="Error_MoreThanOnePassword" xml:space="preserve">
-    <value>A credentials item must only have one Password or ClearTextPassword entry.</value>
+    <value>A credentials item must have only one Password or ClearTextPassword entry.</value>
   </data>
   <data name="Error_MoreThanOneUsername" xml:space="preserve">
-    <value>A credentials item must only have one Username entry.</value>
+    <value>A credentials item must have only one Username entry.</value>
   </data>
   <data name="Error_MoreThanOneValidAuthenticationTypes" xml:space="preserve">
-    <value>A credentials item must only have one ValidAuthenticationTypes entry.</value>
+    <value>A credentials item must have only one ValidAuthenticationTypes entry.</value>
   </data>
   <data name="Error_NoWritableConfig" xml:space="preserve">
     <value>There are no writable config files.</value>

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -157,6 +157,15 @@
   <data name="Error_MergeTwoDifferentSections" xml:space="preserve">
     <value>Cannot merge two different sections.</value>
   </data>
+  <data name="Error_MoreThanOnePassword" xml:space="preserve">
+    <value>A credentials item must only have one Password or ClearTextPassword entry.</value>
+  </data>
+  <data name="Error_MoreThanOneUsername" xml:space="preserve">
+    <value>A credentials item must only have one Username entry.</value>
+  </data>
+  <data name="Error_MoreThanOneValidAuthenticationTypes" xml:space="preserve">
+    <value>A credentials item must only have one ValidAuthenticationTypes entry.</value>
+  </data>
   <data name="Error_NoWritableConfig" xml:space="preserve">
     <value>There are no writable config files.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
@@ -145,33 +145,41 @@ namespace NuGet.Configuration
             {
                 if (string.Equals(item.Key, ConfigurationConstants.UsernameToken, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (_username == null)
+                    if (_username != null)
                     {
-                        _username = item;
+                        throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.UserSettings_UnableToParseConfigFile, Resources.Error_MoreThanOneUsername, origin.ConfigFilePath));
                     }
+
+                    _username = item;
                 }
                 else if (string.Equals(item.Key, ConfigurationConstants.PasswordToken, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (_password == null)
+                    if (_password != null)
                     {
-                        _password = item;
-                        IsPasswordClearText = false;
+                        throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.UserSettings_UnableToParseConfigFile, Resources.Error_MoreThanOnePassword, origin.ConfigFilePath));
                     }
+
+                    _password = item;
+                    IsPasswordClearText = false;
                 }
                 else if (string.Equals(item.Key, ConfigurationConstants.ClearTextPasswordToken, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (_password == null)
+                    if (_password != null)
                     {
-                        _password = item;
-                        IsPasswordClearText = true;
+                        throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.UserSettings_UnableToParseConfigFile, Resources.Error_MoreThanOnePassword, origin.ConfigFilePath));
                     }
+
+                    _password = item;
+                    IsPasswordClearText = true;
                 }
                 else if (string.Equals(item.Key, ConfigurationConstants.ValidAuthenticationTypesToken, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (_validAuthenticationTypes == null)
+                    if (_validAuthenticationTypes != null)
                     {
-                        _validAuthenticationTypes = item;
+                        throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture, Resources.UserSettings_UnableToParseConfigFile, Resources.Error_MoreThanOneValidAuthenticationTypes, origin.ConfigFilePath));
                     }
+
+                    _validAuthenticationTypes = item;
                 }
             }
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
@@ -13,9 +13,9 @@ namespace NuGet.Configuration.Test
 {
     public class CredentialsItemTests
     {
-        private static readonly string _moreThanOneUsername = "A credentials item must only have one Username entry.";
-        private static readonly string _moreThanOnePassword = "A credentials item must only have one Password or ClearTextPassword entry.";
-        private static readonly string _moreThanOneValidAuthenticationTypes = "A credentials item must only have one ValidAuthenticationTypes entry.";
+        private static readonly string _moreThanOneUsername = Resources.Error_MoreThanOneUsername;
+        private static readonly string _moreThanOnePassword = Resources.Error_MoreThanOnePassword;
+        private static readonly string _moreThanOneValidAuthenticationTypes = Resources.Error_MoreThanOneValidAuthenticationTypes;
 
         [Theory]
         [InlineData(null, "user", "pass")]

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
@@ -13,6 +13,10 @@ namespace NuGet.Configuration.Test
 {
     public class CredentialsItemTests
     {
+        private static readonly string _moreThanOneUsername = "A credentials item must only have one Username entry.";
+        private static readonly string _moreThanOnePassword = "A credentials item must only have one Password or ClearTextPassword entry.";
+        private static readonly string _moreThanOneValidAuthenticationTypes = "A credentials item must only have one ValidAuthenticationTypes entry.";
+
         [Theory]
         [InlineData(null, "user", "pass")]
         [InlineData("", "user", "pass")]
@@ -82,7 +86,7 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void CredentialsItem_Parsing_WithUsernamePasswordAndClearTextPassword_TakesFirstAndIgnoresRest()
+        public void CredentialsItem_Parsing_WithUsernamePasswordAndClearTextPassword_Throws()
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
@@ -102,23 +106,71 @@ namespace NuGet.Configuration.Test
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
 
                 // Act and Assert
-                var settingsFile = new SettingsFile(mockBaseDirectory);
-                settingsFile.Should().NotBeNull();
-
-                var section = settingsFile.GetSection("packageSourceCredentials");
-                section.Should().NotBeNull();
-                section.Items.Count.Should().Be(1);
-
-                var item = section.Items.First() as CredentialsItem;
-                item.Should().NotBeNull();
-
-                item.Password.Should().Be("password");
-                item.IsPasswordClearText.Should().BeFalse();
+                var ex = Record.Exception(() => new SettingsFile(mockBaseDirectory));
+                ex.Should().NotBeNull();
+                ex.Should().BeOfType<NuGetConfigurationException>();
+                ex.Message.Should().Be(string.Format("Unable to parse config file because: {0} Path: '{1}'.", _moreThanOnePassword, Path.Combine(mockBaseDirectory, nugetConfigPath)));
             }
         }
 
         [Fact]
-        public void CredentialsItem_Parsing_WithMultipleUsernames_TakesFirstAndIgnoresRest()
+        public void CredentialsItem_Parsing_WithMultiplePassword_Throws()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"
+<configuration>
+    <packageSourceCredentials>
+        <NuGet.Org meta1='data1'>
+            <add key='Username' value='username' />
+            <add key='Password' value='password' />
+            <add key='Password' value='password' />
+        </NuGet.Org>
+    </packageSourceCredentials>
+</configuration>";
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+
+                // Act and Assert
+                var ex = Record.Exception(() => new SettingsFile(mockBaseDirectory));
+                ex.Should().NotBeNull();
+                ex.Should().BeOfType<NuGetConfigurationException>();
+                ex.Message.Should().Be(string.Format("Unable to parse config file because: {0} Path: '{1}'.", _moreThanOnePassword, Path.Combine(mockBaseDirectory, nugetConfigPath)));
+            }
+        }
+
+        [Fact]
+        public void CredentialsItem_Parsing_WithMultipleClearTextPassword_Throws()
+        {
+            // Arrange
+            var nugetConfigPath = "NuGet.Config";
+            var config = @"
+<configuration>
+    <packageSourceCredentials>
+        <NuGet.Org meta1='data1'>
+            <add key='Username' value='username' />
+            <add key='ClearTextPassword' value='clearTextPassword' />
+            <add key='ClearTextPassword' value='clearTextPassword' />
+        </NuGet.Org>
+    </packageSourceCredentials>
+</configuration>";
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+
+                // Act and Assert
+                var ex = Record.Exception(() => new SettingsFile(mockBaseDirectory));
+                ex.Should().NotBeNull();
+                ex.Should().BeOfType<NuGetConfigurationException>();
+                ex.Message.Should().Be(string.Format("Unable to parse config file because: {0} Path: '{1}'.", _moreThanOnePassword, Path.Combine(mockBaseDirectory, nugetConfigPath)));
+            }
+        }
+
+        [Fact]
+        public void CredentialsItem_Parsing_WithMultipleUsernames_Throws()
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
@@ -138,22 +190,15 @@ namespace NuGet.Configuration.Test
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
 
                 // Act and Assert
-                var settingsFile = new SettingsFile(mockBaseDirectory);
-                settingsFile.Should().NotBeNull();
-
-                var section = settingsFile.GetSection("packageSourceCredentials");
-                section.Should().NotBeNull();
-                section.Items.Count.Should().Be(1);
-
-                var item = section.Items.First() as CredentialsItem;
-                item.Should().NotBeNull();
-
-                item.Username.Should().Be("username");
+                var ex = Record.Exception(() => new SettingsFile(mockBaseDirectory));
+                ex.Should().NotBeNull();
+                ex.Should().BeOfType<NuGetConfigurationException>();
+                ex.Message.Should().Be(string.Format("Unable to parse config file because: {0} Path: '{1}'.", _moreThanOneUsername, Path.Combine(mockBaseDirectory, nugetConfigPath)));
             }
         }
 
         [Fact]
-        public void CredentialsItem_Parsing_WithMultipleValidAuthenticationTypes_TakesFirstAndIgnoresRest()
+        public void CredentialsItem_Parsing_WithMultipleValidAuthenticationTypes_Throws()
         {
             // Arrange
             var nugetConfigPath = "NuGet.Config";
@@ -174,17 +219,10 @@ namespace NuGet.Configuration.Test
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
 
                 // Act and Assert
-                var settingsFile = new SettingsFile(mockBaseDirectory);
-                settingsFile.Should().NotBeNull();
-
-                var section = settingsFile.GetSection("packageSourceCredentials");
-                section.Should().NotBeNull();
-                section.Items.Count.Should().Be(1);
-
-                var item = section.Items.First() as CredentialsItem;
-                item.Should().NotBeNull();
-
-                item.ValidAuthenticationTypes.Should().Be("one,two,three");
+                var ex = Record.Exception(() => new SettingsFile(mockBaseDirectory));
+                ex.Should().NotBeNull();
+                ex.Should().BeOfType<NuGetConfigurationException>();
+                ex.Message.Should().Be(string.Format("Unable to parse config file because: {0} Path: '{1}'.", _moreThanOneValidAuthenticationTypes, Path.Combine(mockBaseDirectory, nugetConfigPath)));
             }
         }
 


### PR DESCRIPTION
## Bug
Currently when we read `CredentialsItem`s we skip any duplicate entries and just ignore them. This lets the user have incorrect nuget.configs without failing.

As part of https://github.com/NuGet/NuGet.Client/pull/2370 we talked about making parsing rules more strict to fail when the configuration item has information that is not valid. It was not done right away in that PR because it can be considered a braking change, so it was agreed to have this change in dev16.

This PR adds a more strict validation so that duplicate entries are not allowed inside a `CredentialsItem`. This still lets unknown entries be part of the item, which helps for the future if we add new entries.

cc. @rrelyea 