### PR TITLE
Verification defaults to -All if none provided

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/VerifyCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/VerifyCommand.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Commands;
 using static NuGet.Commands.VerifyArgs;
@@ -16,7 +17,7 @@ namespace NuGet.CommandLine
         UsageExampleResourceName = "VerifyCommandUsageExamples")]
     public class VerifyCommand : Command
     {
-        protected VerifyCommand() : base()
+        internal VerifyCommand() : base()
         {
             CertificateFingerprint = new List<string>();
         }
@@ -29,6 +30,8 @@ namespace NuGet.CommandLine
 
         [Option(typeof(NuGetCommand), "VerifyCommandAllDescription")]
         public bool All { get; set; }
+
+        internal IVerifyCommandRunner VerifyCommandRunner { get; set; }
 
         public override Task ExecuteCommandAsync()
         {
@@ -60,8 +63,12 @@ namespace NuGet.CommandLine
                     break;
             }
 
-            var verifyCommandRunner = new VerifyCommandRunner();
-            var result = verifyCommandRunner.ExecuteCommandAsync(verifyArgs).Result;
+            if (VerifyCommandRunner == null)
+            {
+                VerifyCommandRunner = new VerifyCommandRunner();
+            }
+
+            var result = VerifyCommandRunner.ExecuteCommandAsync(verifyArgs).Result;
             if (result > 0)
             {
                 throw new ExitCodeException(1);
@@ -81,6 +88,11 @@ namespace NuGet.CommandLine
             if (Signatures)
             {
                 verifications.Add(Verification.Signatures);
+            }
+
+            if (!verifications.Any())
+            {
+                verifications.Add(Verification.All);
             }
 
             return verifications;

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -25,6 +25,18 @@
     <ComVisible>false</ComVisible>
   </PropertyGroup>
 
+  <ItemGroup Condition="$(DefineConstants.Contains(SIGNED_BUILD))">
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>NuGet.CommandLine.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup Condition="!$(DefineConstants.Contains(SIGNED_BUILD))">
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>NuGet.CommandLine.Test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
   <ItemGroup>
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6942

## Fix
This improves the experience of using the verify command. If no verification type (e.g. `-Signatures`) is provided. It defaults to `-All`.