### PR TITLE
Skipping validating signature entry while generating .nupkg.metadata file

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveIOUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveIOUtility.cs
@@ -198,8 +198,9 @@ namespace NuGet.Packaging.Signing
         /// Read ZIP's offsets and positions of offsets.
         /// </summary>
         /// <param name="reader">binary reader to zip archive</param>
+        /// <param name="validateSignatureEntry">boolean to skip validate signature entry</param>
         /// <returns>metadata with offsets and positions for entries</returns>
-        public static SignedPackageArchiveMetadata ReadSignedArchiveMetadata(BinaryReader reader)
+        public static SignedPackageArchiveMetadata ReadSignedArchiveMetadata(BinaryReader reader, bool validateSignatureEntry = true)
         {
             if (reader == null)
             {
@@ -272,7 +273,10 @@ namespace NuGet.Packaging.Signing
             metadata.CentralDirectoryHeaders = centralDirectoryRecords;
             metadata.SignatureCentralDirectoryHeaderIndex = packageSignatureFileMetadataIndex;
 
-            AssertSignatureEntryMetadata(reader, metadata);
+            if (validateSignatureEntry)
+            {
+                AssertSignatureEntryMetadata(reader, metadata);
+            }
 
             return metadata;
         }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveUtility.cs
@@ -552,7 +552,9 @@ namespace NuGet.Packaging.Signing
         {
             using (var hashFunc = new Sha512HashFunction())
             {
-                var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
+                // skip validating signature entry since we're just trying to get the content hash here instead of
+                // verifying signature entry.
+                var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader, validateSignatureEntry: false);
                 var signatureCentralDirectoryHeader = metadata.GetPackageSignatureFileCentralDirectoryHeaderMetadata();
                 var centralDirectoryRecordsWithoutSignature = RemoveSignatureAndOrderByOffset(metadata);
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
@@ -984,15 +984,14 @@ namespace NuGet.Packaging.FuncTest
             // Arrange
             var nupkg = new SimpleTestPackageContext();
 
-            using (var dir = TestDirectory.Create())
             using (var packageStream = await nupkg.CreateAsStreamAsync())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signarture = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+                var signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
                 using (var package = new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: true))
                 {
                     var signatureEntry = package.CreateEntry(_specification.SignaturePath, CompressionLevel.Optimal);
-                    using (var signatureStream = new MemoryStream(signarture.GetBytes()))
+                    using (var signatureStream = new MemoryStream(signature.GetBytes()))
                     using (var signatureEntryStream = signatureEntry.Open())
                     {
                         signatureStream.CopyTo(signatureEntryStream);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
@@ -1000,7 +1000,7 @@ namespace NuGet.Packaging.FuncTest
 
                 using (var reader = new BinaryReader(packageStream, _readerEncoding, leaveOpen: true))
                 {
-                    var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader);
+                    var metadata = SignedPackageArchiveIOUtility.ReadSignedArchiveMetadata(reader, validateSignatureEntry:false);
 
                     Assert.NotNull(metadata);
                 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveUtilityTests.cs
@@ -250,6 +250,17 @@ namespace NuGet.Packaging.Test
             }
         }
 
+        [Fact]
+        public void GetPackageContentHash_WithCompressedSignatureFileEntry_NotThrows()
+        {
+            using (var test = new Test(SigningTestUtility.GetResourceBytes("SignatureFileWithDeflateCompressionMethodAndDefaultCompressionLevel.zip")))
+            {
+                var contentHash = SignedPackageArchiveUtility.GetPackageContentHash(test.Reader);
+
+                Assert.NotNull(contentHash);
+            }
+        }
+
 #if IS_DESKTOP
         [Fact]
         public async Task RemoveRepositorySignaturesAsync_WithNullInput_Throws()


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7424 
Regression: No
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: If there is a tempered signed package in global packages folder and we try to get the content hash to generates `.nupkg.metadata` file then it throw signing error since the current implementation also tries to verify signature entry. After discussing within the team, we decided to skip validating signature entry as part of this workflow and just get the content hash of the signed package ignoring signature entry. Although if the zip itself has been corrupted then it will still continue to throw relevant exception.

## Testing/Validation
Tests Added: Yes
Reason for not adding tests:  
Validation done:  
