### PR TITLE
Skipping Compile-time assets for a dev dependency from lock file target libraries

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -920,7 +920,7 @@ namespace NuGet.Commands
         /// <summary>
         /// Replace excluded asset groups with _._ if they have > 0 items.
         /// </summary>
-        private static void ExcludeItems(LockFileTargetLibrary lockFileLib, LibraryIncludeFlags dependencyType)
+        public static void ExcludeItems(LockFileTargetLibrary lockFileLib, LibraryIncludeFlags dependencyType)
         {
             if ((dependencyType & LibraryIncludeFlags.Runtime) == LibraryIncludeFlags.None)
             {

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2789,7 +2789,7 @@ namespace NuGet.PackageManagement
                         if (buildIntegratedProject.ProjectStyle == ProjectStyle.PackageReference)
                         {
                             BuildIntegratedRestoreUtility.UpdatePackageReferenceMetadata(
-                                projectAction.RestoreResult.LockFile.PackageSpec,
+                                projectAction.RestoreResult.LockFile,
                                 pathResolver,
                                 originalAction.PackageIdentity);
 


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7084 
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: This is an improvement over https://github.com/NuGet/NuGet.Client/pull/2466 to skip compile-time assets from lock file target libraries.

## Testing/Validation
Tests Added: Yes  
Reason for not adding tests:  
Validation done:  
