### PR TITLE
Pass SolutionFileName into RestoreGraphEvaluation to avoid problem with imports based on it

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -78,6 +78,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       _RestoreSolutionFileUsed=true;
       SolutionDir=$(SolutionDir);
       SolutionName=$(SolutionName);
+      SolutionFileName=$(SolutionFileName);
+      SolutionPath=$(SolutionPath);
+      SolutionExt=$(SolutionExt);
     </_GenerateRestoreGraphProjectEntryInputProperties>
   </PropertyGroup>
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -64,7 +64,7 @@ EndGlobal";
                     new XAttribute(XName.Get("Name"), "ErrorOnSolutionDir"),
                     new XAttribute(XName.Get("BeforeTargets"), "CollectPackageReferences"),
                     new XElement(XName.Get("Error"),
-                        new XAttribute(XName.Get("Text"), $"|SOLUTION $(SolutionDir) $(SolutionName)|"))));
+                        new XAttribute(XName.Get("Text"), $"|SOLUTION $(SolutionDir) $(SolutionName) $(SolutionExt) $(SolutionFileName) $(SolutionPath)|"))));
 
                 File.Delete(projPath);
                 File.WriteAllText(projPath, doc.ToString());
@@ -72,7 +72,7 @@ EndGlobal";
                 var result = _msbuildFixture.RunDotnet(pathContext.SolutionRoot, "msbuild proj.sln /t:restore /p:DisableImplicitFrameworkReferences=true", ignoreExitCode: true);
 
                 result.ExitCode.Should().Be(1, "error text should be displayed");
-                result.AllOutput.Should().Contain($"|SOLUTION {PathUtility.EnsureTrailingSlash(pathContext.SolutionRoot)} proj|");
+                result.AllOutput.Should().Contain($"|SOLUTION {PathUtility.EnsureTrailingSlash(pathContext.SolutionRoot)} proj .sln proj.sln {slnPath}|");
             }
         }
 


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7442
Regression: No
If Regression then when did it last work:
If Regression then how are we preventing it in future:

If I have project:
ConsoleApp1.csproj in solution ConsoleApp1.sln
```
<?xml version="1.0" encoding="utf-8"?>
<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
    <Import Project="$(SolutionFileName).Targets" />
</Project>
```
with sdk in imports: ConsoleApp1.sln.Targets
```
<?xml version="1.0" encoding="utf-8"?>
<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
  <Import Project="Sdk.props" Sdk="Microsoft.Net.Sdk" />
  <Import Project="Sdk.targets" Sdk="Microsoft.Net.Sdk" />
</Project>
```
Restore would fail because SolutionFileName not passed into child MSBuild call in target: _FilterRestoreGraphProjectInputItems
## Fix
Details: Fix pass SolutionFileName in child MSBuild call.
