### PR TITLE
Make sure to use the correct logger when creating a PackageExtractionContext

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -206,7 +206,7 @@ namespace NuGet.CommandLine
                         Packaging.PackageSaveMode.Defaultv2,
                         PackageExtractionBehavior.XmlDocFileSaveMode,
                         clientPolicyContext,
-                        packageRestoreContext.Logger)
+                        Console)
                 };
 
                 var downloadContext = new PackageDownloadContext(cacheContext, installPath, DirectDownload)

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -206,16 +206,12 @@ namespace NuGet.CommandLine
                         Packaging.PackageSaveMode.Defaultv2,
                         PackageExtractionBehavior.XmlDocFileSaveMode,
                         clientPolicyContext,
-                        Console)
+                        packageRestoreContext.Logger)
                 };
 
                 var downloadContext = new PackageDownloadContext(cacheContext, installPath, DirectDownload)
                 {
-                    ExtractionContext = new PackageExtractionContext(
-                        Packaging.PackageSaveMode.Defaultv3,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        clientPolicyContext,
-                        Console)
+                    ClientPolicyContext = clientPolicyContext
                 };
 
                 var result = await PackageRestoreManager.RestoreMissingPackagesAsync(
@@ -388,22 +384,18 @@ namespace NuGet.CommandLine
                             Console)
                     };
 
+                    if (EffectivePackageSaveMode != Packaging.PackageSaveMode.None)
+                    {
+                        projectContext.PackageExtractionContext.PackageSaveMode = EffectivePackageSaveMode;
+                    }
+
                     resolutionContext.SourceCacheContext.NoCache = NoCache;
                     resolutionContext.SourceCacheContext.DirectDownload = DirectDownload;
 
                     var downloadContext = new PackageDownloadContext(resolutionContext.SourceCacheContext, installPath, DirectDownload)
                     {
-                        ExtractionContext = new PackageExtractionContext(
-                            Packaging.PackageSaveMode.Defaultv3,
-                            PackageExtractionBehavior.XmlDocFileSaveMode,
-                            clientPolicyContext,
-                            Console)
+                        ClientPolicyContext = clientPolicyContext
                     };
-
-                    if (EffectivePackageSaveMode != Packaging.PackageSaveMode.None)
-                    {
-                        downloadContext.ExtractionContext.PackageSaveMode = EffectivePackageSaveMode;
-                    }
 
                     await packageManager.InstallPackageAsync(
                         project,

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -349,11 +352,7 @@ namespace NuGet.CommandLine
 
                 var downloadContext = new PackageDownloadContext(cacheContext, packagesFolderPath, DirectDownload)
                 {
-                    ExtractionContext = new PackageExtractionContext(
-                         Packaging.PackageSaveMode.Defaultv3,
-                         PackageExtractionBehavior.XmlDocFileSaveMode,
-                         clientPolicyContext,
-                         collectorLogger)
+                    ClientPolicyContext = clientPolicyContext
                 };
 
                 var result = await PackageRestoreManager.RestoreMissingPackagesAsync(

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -262,11 +262,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                         var downloadContext = new PackageDownloadContext(cacheContext)
                         {
                             ParentId = OperationId,
-                            ExtractionContext = new PackageExtractionContext(
-                                PackageSaveMode.Defaultv3,
-                                PackageExtractionBehavior.XmlDocFileSaveMode,
-                                ClientPolicyContext.GetClientPolicy(ConfigSettings, logger),
-                                logger)
+                            ClientPolicyContext = ClientPolicyContext.GetClientPolicy(ConfigSettings, logger)
                         };
 
                         var result = await PackageRestoreManager.RestoreMissingPackagesAsync(

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -19,8 +19,6 @@ using NuGet.Configuration;
 using NuGet.PackageManagement;
 using NuGet.PackageManagement.Telemetry;
 using NuGet.PackageManagement.VisualStudio;
-using NuGet.Packaging;
-using NuGet.Packaging.PackageExtraction;
 using NuGet.Packaging.Signing;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
@@ -537,11 +535,7 @@ namespace NuGet.SolutionRestoreManager
                 var downloadContext = new PackageDownloadContext(cacheContext)
                 {
                     ParentId = _nuGetProjectContext.OperationId,
-                    ExtractionContext = new PackageExtractionContext(
-                        PackageSaveMode.Defaultv3,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        ClientPolicyContext.GetClientPolicy(_settings, logger),
-                        logger)
+                    ClientPolicyContext = ClientPolicyContext.GetClientPolicy(_settings, logger)
                 };
 
                 await _packageRestoreManager.RestoreMissingPackagesAsync(

--- a/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
+++ b/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
@@ -49,6 +49,18 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup Condition="$(DefineConstants.Contains(SIGNED_BUILD))">
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>NuGet.Commands.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup Condition="!$(DefineConstants.Contains(SIGNED_BUILD))">
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>NuGet.Commands.Test</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets"/>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/OriginalCaseGlobalPackageFolder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/OriginalCaseGlobalPackageFolder.cs
@@ -13,9 +13,7 @@ using NuGet.DependencyResolver;
 using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
-using NuGet.Packaging.Signing;
 using NuGet.ProjectModel;
-using NuGet.Protocol;
 using NuGet.Repositories;
 
 namespace NuGet.Commands
@@ -61,6 +59,7 @@ namespace NuGet.Commands
             // Keep track of the packages we've already converted to original case.
             var converted = new HashSet<PackageIdentity>();
 
+            var originalCaseContext = GetPathContext();
             var versionFolderPathResolver = new VersionFolderPathResolver(_request.PackagesDirectory, _request.IsLowercasePackagesDirectory);
 
             // Iterate over every package node.
@@ -111,7 +110,7 @@ namespace NuGet.Commands
                             identity,
                             packageDependency,
                             versionFolderPathResolver,
-                            _request.PackageExtractionContext,
+                            originalCaseContext,
                             token,
                             ParentId);
 
@@ -138,6 +137,18 @@ namespace NuGet.Commands
                 var path = _pathResolver.GetPackageDirectory(library.Name, library.Version);
                 library.Path = PathUtility.GetPathWithForwardSlashes(path);
             }
+        }
+
+        private PackageExtractionContext GetPathContext()
+        {
+            return new PackageExtractionContext(
+                _request.PackageSaveMode,
+                _request.XmlDocFileSaveMode,
+                _request.ClientPolicyContext,
+                _request.Log)
+            {
+                SignedPackageVerifier = _request.SignedPackageVerifier
+            };
         }
 
         private static PackageIdentity GetPackageIdentity(RemoteMatch remoteMatch)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreRequest.cs
@@ -22,7 +22,14 @@ namespace NuGet.Commands
             ExistingLockFile = existingLockFile;
             MaxDegreeOfConcurrency = request.MaxDegreeOfConcurrency;
             Project = packageSpec;
-            PackageExtractionContext = request.PackageExtractionContext;
+            PackageExtractionContext = new PackageExtractionContext(
+                request.PackageSaveMode,
+                request.XmlDocFileSaveMode,
+                request.ClientPolicyContext,
+                log)
+            {
+                SignedPackageVerifier = request.SignedPackageVerifier
+            };
         }
 
         public SourceCacheContext CacheContext { get; }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Configuration;
+using NuGet.Packaging.Signing;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using NuGet.Shared;
@@ -131,7 +132,7 @@ namespace NuGet.Commands
             var globalPath = GetPackagesPath(restoreArgs, projectPackageSpec);
             var settings = Settings.LoadSettingsGivenConfigPaths(projectPackageSpec.RestoreMetadata.ConfigFilePaths);
             var sources = restoreArgs.GetEffectiveSources(settings, projectPackageSpec.RestoreMetadata.Sources);
-            var extractionContext = restoreArgs.GetPackageExtractionContext(settings);
+            var clientPolicyContext = ClientPolicyContext.GetClientPolicy(settings, restoreArgs.Log);
 
             var sharedCache = _providerCache.GetOrCreate(
                 globalPath,
@@ -147,7 +148,7 @@ namespace NuGet.Commands
                 project.PackageSpec,
                 sharedCache,
                 restoreArgs.CacheContext,
-                extractionContext,
+                clientPolicyContext,
                 restoreArgs.Log)
             {
                 // Set properties from the restore metadata

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -9,8 +9,6 @@ using System.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Packaging;
-using NuGet.Packaging.PackageExtraction;
-using NuGet.Packaging.Signing;
 using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -176,15 +174,6 @@ namespace NuGet.Commands
             }
 
             return sourceObjects.Select(entry => CachingSourceProvider.CreateRepository(entry.Value)).ToList();
-        }
-
-        internal PackageExtractionContext GetPackageExtractionContext(ISettings settings)
-        {
-            return new PackageExtractionContext(
-                PackageSaveMode,
-                PackageExtractionBehavior.XmlDocFileSaveMode,
-                ClientPolicyContext.GetClientPolicy(settings, Log),
-                Log);
         }
 
         public void ApplyStandardProperties(RestoreRequest request)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -14,12 +14,10 @@ using NuGet.Common;
 using NuGet.DependencyResolver;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
-using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Repositories;
 using NuGet.RuntimeModel;
-using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.Commands

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
@@ -7,6 +7,8 @@ using System.IO;
 using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging;
+using NuGet.Packaging.PackageExtraction;
+using NuGet.Packaging.Signing;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 
@@ -20,7 +22,7 @@ namespace NuGet.Commands
             PackageSpec project,
             RestoreCommandProviders dependencyProviders,
             SourceCacheContext cacheContext,
-            PackageExtractionContext extractionContext,
+            ClientPolicyContext clientPolicyContext,
             ILogger log)
         {
 
@@ -28,7 +30,7 @@ namespace NuGet.Commands
             Log = log ?? throw new ArgumentNullException(nameof(log));
             Project = project ?? throw new ArgumentNullException(nameof(project));
             DependencyProviders = dependencyProviders ?? throw new ArgumentNullException(nameof(dependencyProviders));
-            PackageExtractionContext = extractionContext ?? throw new ArgumentNullException(nameof(extractionContext));
+            ClientPolicyContext = clientPolicyContext;
 
             ExternalProjects = new List<ExternalProjectReference>();
             CompatibilityProfiles = new HashSet<FrameworkRuntimePair>();
@@ -144,7 +146,19 @@ namespace NuGet.Commands
         /// </summary>
         public bool HideWarningsAndErrors { get; set; } = false;
 
-        public PackageExtractionContext PackageExtractionContext { get; set; }
+        /// <summary>
+        /// Gets or sets the <see cref="Packaging.PackageSaveMode"/>. 
+        /// </summary> 
+        public PackageSaveMode PackageSaveMode { get; set; } = PackageSaveMode.Defaultv3;
+
+        public XmlDocFileSaveMode XmlDocFileSaveMode { get; set; } = PackageExtractionBehavior.XmlDocFileSaveMode;
+
+        public ClientPolicyContext ClientPolicyContext { get; }
+
+        /// <remarks>
+        /// This property should only be used to override the default verifier on tests.
+        /// </remarks>
+        internal IPackageSignatureVerifier SignedPackageVerifier { get; set; }
 
         public Guid ParentId { get; set;}
 

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
@@ -197,11 +197,7 @@ namespace NuGet.PackageManagement
                 var downloadContext = new PackageDownloadContext(cacheContext)
                 {
                     ParentId = nuGetProjectContext.OperationId,
-                    ExtractionContext = new PackageExtractionContext(
-                        PackageSaveMode.Defaultv3,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        ClientPolicyContext.GetClientPolicy(Settings, logger),
-                        logger)
+                    ClientPolicyContext = ClientPolicyContext.GetClientPolicy(Settings, logger)
                 };
 
                 return await RestoreMissingPackagesAsync(
@@ -239,11 +235,7 @@ namespace NuGet.PackageManagement
                 var downloadContext = new PackageDownloadContext(cacheContext)
                 {
                     ParentId = nuGetProjectContext.OperationId,
-                    ExtractionContext = new PackageExtractionContext(
-                        PackageSaveMode.Defaultv3,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        ClientPolicyContext.GetClientPolicy(Settings, adapterLogger),
-                        adapterLogger)
+                    ClientPolicyContext = ClientPolicyContext.GetClientPolicy(Settings, adapterLogger)
                 };
 
                 return await RestoreMissingPackagesAsync(

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -16,7 +16,6 @@ using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
-using NuGet.Packaging.PackageExtraction;
 using NuGet.Packaging.Signing;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
@@ -195,11 +194,7 @@ namespace NuGet.PackageManagement
             var downloadContext = new PackageDownloadContext(resolutionContext.SourceCacheContext)
             {
                 ParentId = nuGetProjectContext.OperationId,
-                ExtractionContext = new PackageExtractionContext(
-                    PackageSaveMode.Defaultv3,
-                    PackageExtractionBehavior.XmlDocFileSaveMode,
-                    ClientPolicyContext.GetClientPolicy(Settings, logger),
-                    logger)
+                ClientPolicyContext = ClientPolicyContext.GetClientPolicy(Settings, logger)
             };
 
             return InstallPackageAsync(
@@ -253,11 +248,7 @@ namespace NuGet.PackageManagement
             var downloadContext = new PackageDownloadContext(resolutionContext.SourceCacheContext)
             {
                 ParentId = nuGetProjectContext.OperationId,
-                ExtractionContext = new PackageExtractionContext(
-                    PackageSaveMode.Defaultv3,
-                    PackageExtractionBehavior.XmlDocFileSaveMode,
-                    ClientPolicyContext.GetClientPolicy(Settings, logger),
-                    logger)
+                ClientPolicyContext = ClientPolicyContext.GetClientPolicy(Settings, logger)
             };
 
             await InstallPackageAsync(
@@ -331,11 +322,7 @@ namespace NuGet.PackageManagement
             var downloadContext = new PackageDownloadContext(resolutionContext.SourceCacheContext)
             {
                 ParentId = nuGetProjectContext.OperationId,
-                ExtractionContext = new PackageExtractionContext(
-                    PackageSaveMode.Defaultv3,
-                    PackageExtractionBehavior.XmlDocFileSaveMode,
-                    ClientPolicyContext.GetClientPolicy(Settings, logger),
-                    logger)
+                ClientPolicyContext = ClientPolicyContext.GetClientPolicy(Settings, logger)
             };
 
             return InstallPackageAsync(
@@ -392,11 +379,7 @@ namespace NuGet.PackageManagement
             var downloadContext = new PackageDownloadContext(resolutionContext.SourceCacheContext)
             {
                 ParentId = nuGetProjectContext.OperationId,
-                ExtractionContext = new PackageExtractionContext(
-                    PackageSaveMode.Defaultv3,
-                    PackageExtractionBehavior.XmlDocFileSaveMode,
-                    ClientPolicyContext.GetClientPolicy(Settings, logger),
-                    logger)
+                ClientPolicyContext = ClientPolicyContext.GetClientPolicy(Settings, logger)
             };
 
             await InstallPackageAsync(
@@ -2147,11 +2130,7 @@ namespace NuGet.PackageManagement
             var downloadContext = new PackageDownloadContext(sourceCacheContext)
             {
                 ParentId = nuGetProjectContext.OperationId,
-                ExtractionContext = new PackageExtractionContext(
-                    PackageSaveMode.Defaultv3,
-                    PackageExtractionBehavior.XmlDocFileSaveMode,
-                    ClientPolicyContext.GetClientPolicy(Settings, logger),
-                    logger)
+                ClientPolicyContext = ClientPolicyContext.GetClientPolicy(Settings, logger)
             };
 
             await ExecuteNuGetProjectActionsAsync(nuGetProject,

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackageExtractionContext.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackageExtractionContext.cs
@@ -21,8 +21,9 @@ namespace NuGet.Packaging
 
         /// <remarks>
         /// This property should only be used to override the default verifier on tests.
+        /// It is public only so that NuGet.Commands.RestoreRequest can pass this property through
         /// </remarks>
-        internal IPackageSignatureVerifier SignedPackageVerifier { get; set; }
+        public IPackageSignatureVerifier SignedPackageVerifier { get; set; }
 
         public PackageExtractionContext(
             PackageSaveMode packageSaveMode,

--- a/src/NuGet.Core/NuGet.Protocol/PackageDownloadContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/PackageDownloadContext.cs
@@ -2,8 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using NuGet.Packaging;
+using NuGet.Packaging.Signing;
 
 namespace NuGet.Protocol.Core.Types
 {
@@ -44,6 +43,6 @@ namespace NuGet.Protocol.Core.Types
 
         public Guid ParentId { get; set; }
 
-        public PackageExtractionContext ExtractionContext { get; set; }
+        public ClientPolicyContext ClientPolicyContext { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Utility/GetDownloadResultUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/GetDownloadResultUtility.cs
@@ -93,7 +93,7 @@ namespace NuGet.Protocol
                                     packageStream,
                                     globalPackagesFolder,
                                     downloadContext.ParentId,
-                                    downloadContext.ExtractionContext,
+                                    downloadContext.ClientPolicyContext,
                                     logger,
                                     token);
                             }

--- a/src/NuGet.Core/NuGet.Protocol/Utility/GlobalPackagesFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/GlobalPackagesFolderUtility.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -88,7 +87,7 @@ namespace NuGet.Protocol
             Stream packageStream,
             string globalPackagesFolder,
             Guid parentId,
-            PackageExtractionContext extractionContext,
+            ClientPolicyContext clientPolicyContext,
             ILogger logger,
             CancellationToken token)
         {
@@ -110,6 +109,12 @@ namespace NuGet.Protocol
             // The following call adds it to the global packages folder.
             // Addition is performed using ConcurrentUtils, such that,
             // multiple processes may add at the same time
+
+            var extractionContext = new PackageExtractionContext(
+               PackageSaveMode.Defaultv3,
+               PackageExtractionBehavior.XmlDocFileSaveMode,
+               clientPolicyContext,
+               logger);
 
             var versionFolderPathResolver = new VersionFolderPathResolver(globalPackagesFolder);
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTestContext.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -8,7 +11,6 @@ using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
-using NuGet.Packaging.PackageExtraction;
 using NuGet.ProjectManagement;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -322,11 +324,7 @@ namespace NuGet.CommandLine.Test.Caching
                     packageStream: fileStream,
                     globalPackagesFolder: GlobalPackagesPath,
                     parentId: Guid.Empty,
-                    extractionContext: new PackageExtractionContext(
-                        PackageSaveMode.Defaultv3,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        clientPolicyContext: null,
-                        logger: NullLogger.Instance),
+                    clientPolicyContext: null,
                     logger: NullLogger.Instance,
                     token: CancellationToken.None))
                 {

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -452,7 +452,7 @@ namespace NuGet.Commands.FuncTest
                         new VersionFolderPathResolver(packagesDir),
                         new PackageExtractionContext(
                             PackageSaveMode.Defaultv3,
-                            PackageExtractionBehavior.XmlDocFileSaveMode,
+                            XmlDocFileSaveMode.None,
                             clientPolicyContext: null,
                             logger: logger),
                         CancellationToken.None);
@@ -2008,13 +2008,7 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
-                    var packageExtractionContext = new PackageExtractionContext(
-                         PackageSaveMode.Defaultv3,
-                         PackageExtractionBehavior.XmlDocFileSaveMode,
-                         clientPolicyContext: null,
-                         logger: logger);
-
-                    var request = new RestoreRequest(spec, provider, context, packageExtractionContext, logger)
+                    var request = new RestoreRequest(spec, provider, context, clientPolicyContext: null, log: logger)
                     {
                         LockFilePath = Path.Combine(projectDir, "project.lock.json")
                     };
@@ -2063,12 +2057,7 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
-                    var packageExtractionContext = new PackageExtractionContext(
-                         PackageSaveMode.Defaultv3,
-                         PackageExtractionBehavior.XmlDocFileSaveMode,
-                         clientPolicyContext: null,
-                         logger: logger);
-                    var request = new RestoreRequest(spec, provider, context, packageExtractionContext, logger)
+                    var request = new RestoreRequest(spec, provider, context, clientPolicyContext: null, log: logger)
                     {
                         LockFilePath = Path.Combine(projectDir, "project.lock.json")
                     };
@@ -2117,12 +2106,7 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
-                    var packageExtractionContext = new PackageExtractionContext(
-                         PackageSaveMode.Defaultv3,
-                         PackageExtractionBehavior.XmlDocFileSaveMode,
-                         clientPolicyContext: null,
-                         logger: logger);
-                    var request = new RestoreRequest(spec, provider, context, packageExtractionContext, logger)
+                    var request = new RestoreRequest(spec, provider, context, clientPolicyContext: null, log: logger)
                     {
                         LockFilePath = Path.Combine(projectDir, "project.lock.json")
                     };
@@ -2171,12 +2155,7 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
-                    var packageExtractionContext = new PackageExtractionContext(
-                         PackageSaveMode.Defaultv3,
-                         PackageExtractionBehavior.XmlDocFileSaveMode,
-                         clientPolicyContext: null,
-                         logger: logger);
-                    var request = new RestoreRequest(spec, provider, context, packageExtractionContext, logger)
+                    var request = new RestoreRequest(spec, provider, context, clientPolicyContext: null, log: logger)
                     {
                         LockFilePath = Path.Combine(projectDir, "project.lock.json")
                     };
@@ -2225,12 +2204,7 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
-                    var packageExtractionContext = new PackageExtractionContext(
-                         PackageSaveMode.Defaultv3,
-                         PackageExtractionBehavior.XmlDocFileSaveMode,
-                         clientPolicyContext: null,
-                         logger: logger);
-                    var request = new RestoreRequest(spec, provider, context, packageExtractionContext, logger)
+                    var request = new RestoreRequest(spec, provider, context, clientPolicyContext: null, log: logger)
                     {
                         LockFilePath = Path.Combine(projectDir, "project.lock.json")
                     };
@@ -2279,12 +2253,7 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
-                    var packageExtractionContext = new PackageExtractionContext(
-                         PackageSaveMode.Defaultv3,
-                         PackageExtractionBehavior.XmlDocFileSaveMode,
-                         clientPolicyContext: null,
-                         logger: logger);
-                    var request = new RestoreRequest(spec, provider, context, packageExtractionContext, logger)
+                    var request = new RestoreRequest(spec, provider, context, clientPolicyContext: null, log: logger)
                     {
                         LockFilePath = Path.Combine(projectDir, "project.lock.json")
                     };
@@ -2333,12 +2302,7 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
-                    var packageExtractionContext = new PackageExtractionContext(
-                         PackageSaveMode.Defaultv3,
-                         PackageExtractionBehavior.XmlDocFileSaveMode,
-                         clientPolicyContext: null,
-                         logger: logger);
-                    var request = new RestoreRequest(spec, provider, context, packageExtractionContext, logger)
+                    var request = new RestoreRequest(spec, provider, context, clientPolicyContext: null, log: logger)
                     {
                         LockFilePath = Path.Combine(projectDir, "project.lock.json")
                     };
@@ -2387,13 +2351,7 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalPackageFileCache(), logger);
-
-                    var packageExtractionContext = new PackageExtractionContext(
-                         PackageSaveMode.Defaultv3,
-                         PackageExtractionBehavior.XmlDocFileSaveMode,
-                         clientPolicyContext: null,
-                         logger: logger);
-                    var request = new RestoreRequest(spec, provider, context, packageExtractionContext, logger)
+                    var request = new RestoreRequest(spec, provider, context, clientPolicyContext: null, log: logger)
                     {
                         LockFilePath = Path.Combine(projectDir, "project.lock.json")
                     };

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
@@ -10,8 +10,6 @@ using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Commands.Test;
 using NuGet.Configuration;
-using NuGet.Packaging;
-using NuGet.Packaging.PackageExtraction;
 using NuGet.Packaging.Signing;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
@@ -150,12 +148,8 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var extractionContext = new PackageExtractionContext(
-                    PackageSaveMode.Defaultv3,
-                    PackageExtractionBehavior.XmlDocFileSaveMode,
-                    ClientPolicyContext.GetClientPolicy(NullSettings.Instance, logger),
-                    logger);
-                var request = new TestRestoreRequest(spec, sources, packagesDir, cacheContext, extractionContext, logger)
+                var clientPolicyContext = ClientPolicyContext.GetClientPolicy(NullSettings.Instance, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, cacheContext, clientPolicyContext, logger)
                 {
                     LockFilePath = Path.Combine(projectDir, "project.lock.json")
                 };

--- a/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/V2FeedParserTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/V2FeedParserTests.cs
@@ -6,9 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
-using NuGet.Packaging;
 using NuGet.Packaging.Core;
-using NuGet.Packaging.PackageExtraction;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
@@ -32,29 +30,18 @@ namespace NuGet.Core.FuncTest
             // Act & Assert
             using (var packagesFolder = TestDirectory.Create())
             using (var cacheContext = new SourceCacheContext())
+            using (var downloadResult = await parser.DownloadFromUrl(
+                new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("6.2.0")),
+                new Uri("https://www.nuget.org/api/v2/package/WindowsAzure.Storage/6.2.0"),
+                new PackageDownloadContext(cacheContext),
+                packagesFolder,
+                NullLogger.Instance,
+                CancellationToken.None))
             {
-                var downloadContext = new PackageDownloadContext(cacheContext)
-                {
-                    ExtractionContext = new PackageExtractionContext(
-                    PackageSaveMode.Defaultv3,
-                    PackageExtractionBehavior.XmlDocFileSaveMode,
-                    clientPolicyContext: null,
-                    logger: NullLogger.Instance)
-                };
+                var packageReader = downloadResult.PackageReader;
+                var files = packageReader.GetFiles();
 
-                using (var downloadResult = await parser.DownloadFromUrl(
-                    new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("6.2.0")),
-                    new Uri("https://www.nuget.org/api/v2/package/WindowsAzure.Storage/6.2.0"),
-                    downloadContext,
-                    packagesFolder,
-                    NullLogger.Instance,
-                    CancellationToken.None))
-                {
-                    var packageReader = downloadResult.PackageReader;
-                    var files = packageReader.GetFiles();
-
-                    Assert.Equal(13, files.Count());
-                }
+                Assert.Equal(13, files.Count());
             }
         }
     }

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
@@ -6,15 +6,11 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using Xunit;
-using NuGet.Protocol;
 using NuGet.Test.Utility;
-using NuGet.Packaging;
-using NuGet.Packaging.PackageExtraction;
 
 namespace NuGet.Protocol.FuncTest
 {
@@ -33,29 +29,17 @@ namespace NuGet.Protocol.FuncTest
             // Act & Assert
             using (var packagesFolder = TestDirectory.Create())
             using (var cacheContext = new SourceCacheContext())
+            using (var downloadResult = await downloadResource.GetDownloadResourceResultAsync(
+                package,
+                new PackageDownloadContext(cacheContext),
+                packagesFolder,
+                NullLogger.Instance,
+                CancellationToken.None))
             {
-                var downloadContext = new PackageDownloadContext(cacheContext)
-                {
-                    ExtractionContext = new PackageExtractionContext(
-                        PackageSaveMode.Defaultv3,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        clientPolicyContext: null,
-                        logger: NullLogger.Instance)
-                };
+                var packageReader = downloadResult.PackageReader;
+                var files = packageReader.GetFiles();
 
-                using (var downloadResult = await downloadResource.GetDownloadResourceResultAsync(
-                    package,
-                    downloadContext,
-                    packagesFolder,
-                    NullLogger.Instance,
-                    CancellationToken.None))
-                {
-                    var packageReader = downloadResult.PackageReader;
-                    var files = packageReader.GetFiles();
-
-
-                    Assert.Equal(13, files.Count());
-                }
+                Assert.Equal(13, files.Count());
             }
         }
 
@@ -72,28 +56,17 @@ namespace NuGet.Protocol.FuncTest
             // Act & Assert
             using (var packagesFolder = TestDirectory.Create())
             using (var cacheContext = new SourceCacheContext())
+            using (var downloadResult = await downloadResource.GetDownloadResourceResultAsync(
+                package,
+                new PackageDownloadContext(cacheContext),
+                packagesFolder,
+                NullLogger.Instance,
+                CancellationToken.None))
             {
-                var downloadContext = new PackageDownloadContext(cacheContext)
-                {
-                    ExtractionContext = new PackageExtractionContext(
-                    PackageSaveMode.Defaultv3,
-                    PackageExtractionBehavior.XmlDocFileSaveMode,
-                    clientPolicyContext: null,
-                    logger: NullLogger.Instance)
-                };
+                var packageReader = downloadResult.PackageReader;
+                var files = packageReader.GetFiles();
 
-                using (var downloadResult = await downloadResource.GetDownloadResourceResultAsync(
-                    package,
-                    downloadContext,
-                    packagesFolder,
-                    NullLogger.Instance,
-                    CancellationToken.None))
-                {
-                    var packageReader = downloadResult.PackageReader;
-                    var files = packageReader.GetFiles();
-
-                    Assert.Equal(13, files.Count());
-                }
+                Assert.Equal(13, files.Count());
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/V2FeedParserTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/V2FeedParserTests.cs
@@ -91,29 +91,18 @@ namespace NuGet.Protocol.FuncTest
             // Act & Assert
             using (var packagesFolder = TestDirectory.Create())
             using (var cacheContext = new SourceCacheContext())
+            using (var downloadResult = await parser.DownloadFromIdentity(
+                new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("6.2.0")),
+                new PackageDownloadContext(cacheContext),
+                packagesFolder,
+                cacheContext,
+                NullLogger.Instance,
+                CancellationToken.None))
             {
-                var downloadContext = new PackageDownloadContext(cacheContext)
-                {
-                    ExtractionContext = new PackageExtractionContext(
-                    PackageSaveMode.Defaultv3,
-                    PackageExtractionBehavior.XmlDocFileSaveMode,
-                    clientPolicyContext: null,
-                    logger: NullLogger.Instance)
-                };
+                var packageReader = downloadResult.PackageReader;
+                var files = packageReader.GetFiles();
 
-                using (var downloadResult = await parser.DownloadFromIdentity(
-                    new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("6.2.0")),
-                    downloadContext,
-                    packagesFolder,
-                    cacheContext,
-                    NullLogger.Instance,
-                    CancellationToken.None))
-                {
-                    var packageReader = downloadResult.PackageReader;
-                    var files = packageReader.GetFiles();
-
-                    Assert.Equal(13, files.Count());
-                }
+                Assert.Equal(13, files.Count());
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1018,18 +1018,11 @@ namespace NuGet.Commands.Test
                     It.IsAny<Guid>())).
                     ReturnsAsync(new VerifySignaturesResult(isValid: false, isSigned: true));
 
-                var extractionContext = new PackageExtractionContext(
-                    PackageSaveMode.Defaultv3,
-                     PackageExtractionBehavior.XmlDocFileSaveMode,
-                     ClientPolicyContext.GetClientPolicy(NullSettings.Instance, logger),
-                     logger)
-                {
-                    SignedPackageVerifier = signedPackageVerifier.Object
-                };
-
-                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, extractionContext, logger)
+                var clientPolicyContext = ClientPolicyContext.GetClientPolicy(NullSettings.Instance, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, clientPolicyContext, logger)
                 {
                     LockFilePath = Path.Combine(project1.FullName, "project.lock.json"),
+                    SignedPackageVerifier = signedPackageVerifier.Object
                 };
 
                 var packageAContext = new SimpleTestPackageContext("packageA");
@@ -1095,18 +1088,11 @@ namespace NuGet.Commands.Test
                     It.IsAny<Guid>())).
                     ReturnsAsync(new VerifySignaturesResult(isValid: true, isSigned: true));
 
-                var extractionContext = new PackageExtractionContext(
-                    PackageSaveMode.Defaultv3,
-                     PackageExtractionBehavior.XmlDocFileSaveMode,
-                     ClientPolicyContext.GetClientPolicy(NullSettings.Instance, logger),
-                     logger)
-                {
-                    SignedPackageVerifier = signedPackageVerifier.Object
-                };
-
-                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, extractionContext, logger)
+                var clientPolicyContext = ClientPolicyContext.GetClientPolicy(NullSettings.Instance, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, clientPolicyContext, logger)
                 {
                     LockFilePath = Path.Combine(project1.FullName, "project.lock.json"),
+                    SignedPackageVerifier = signedPackageVerifier.Object
                 };
 
                 var packageAContext = new SimpleTestPackageContext("packageA");

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -18,7 +18,6 @@ using NuGet.Frameworks;
 using NuGet.PackageManagement;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
-using NuGet.Packaging.PackageExtraction;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.Protocol;
@@ -4921,14 +4920,7 @@ namespace NuGet.Test
                 // Act
                 using (var cacheContext = new SourceCacheContext())
                 {
-                    var packageDownloadContext = new PackageDownloadContext(cacheContext)
-                    {
-                        ExtractionContext = new PackageExtractionContext(
-                        PackageSaveMode.Defaultv3,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        clientPolicyContext: null,
-                        logger: NullLogger.Instance)
-                    };
+                    var packageDownloadContext = new PackageDownloadContext(cacheContext);
 
                     await nuGetPackageManager.RestorePackageAsync(
                         packageOld,

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
@@ -12,7 +12,6 @@ using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
-using NuGet.Packaging.PackageExtraction;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
@@ -310,32 +309,21 @@ namespace NuGet.PackageManagement
 
             // Act
             using (var cacheContext = new SourceCacheContext())
+            using (var packagesDirectory = TestDirectory.Create())
+            using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
+                v2sourceRepository,
+                packageIdentity,
+                new PackageDownloadContext(cacheContext),
+                packagesDirectory,
+                NullLogger.Instance,
+                CancellationToken.None))
             {
-                var downloadContext = new PackageDownloadContext(cacheContext)
-                {
-                    ExtractionContext = new PackageExtractionContext(
-                        PackageSaveMode.Defaultv3,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        clientPolicyContext: null,
-                        logger: NullLogger.Instance)
-                };
+                var targetPackageStream = downloadResult.PackageStream;
 
-                using (var packagesDirectory = TestDirectory.Create())
-                using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
-                    v2sourceRepository,
-                    packageIdentity,
-                    downloadContext,
-                    packagesDirectory,
-                    NullLogger.Instance,
-                    CancellationToken.None))
-                {
-                    var targetPackageStream = downloadResult.PackageStream;
-
-                    // Assert
-                    // jQuery.1.8.2 is of size 185476 bytes. Make sure the download is successful
-                    Assert.Equal(185476, targetPackageStream.Length);
-                    Assert.True(targetPackageStream.CanSeek);
-                }
+                // Assert
+                // jQuery.1.8.2 is of size 185476 bytes. Make sure the download is successful
+                Assert.Equal(185476, targetPackageStream.Length);
+                Assert.True(targetPackageStream.CanSeek);
             }
         }
 
@@ -349,32 +337,21 @@ namespace NuGet.PackageManagement
 
             // Act
             using (var cacheContext = new SourceCacheContext())
+            using (var packagesDirectory = TestDirectory.Create())
+            using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
+                v3sourceRepository,
+                packageIdentity,
+                new PackageDownloadContext(cacheContext),
+                packagesDirectory,
+                NullLogger.Instance,
+                CancellationToken.None))
             {
-                var downloadContext = new PackageDownloadContext(cacheContext)
-                {
-                    ExtractionContext = new PackageExtractionContext(
-                        PackageSaveMode.Defaultv3,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        clientPolicyContext: null,
-                        logger: NullLogger.Instance)
-                };
+                var targetPackageStream = downloadResult.PackageStream;
 
-                using (var packagesDirectory = TestDirectory.Create())
-                using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
-                    v3sourceRepository,
-                    packageIdentity,
-                    downloadContext,
-                    packagesDirectory,
-                    NullLogger.Instance,
-                    CancellationToken.None))
-                {
-                    var targetPackageStream = downloadResult.PackageStream;
-
-                    // Assert
-                    // jQuery.1.8.2 is of size 185476 bytes. Make sure the download is successful
-                    Assert.Equal(185476, targetPackageStream.Length);
-                    Assert.True(targetPackageStream.CanSeek);
-                }
+                // Assert
+                // jQuery.1.8.2 is of size 185476 bytes. Make sure the download is successful
+                Assert.Equal(185476, targetPackageStream.Length);
+                Assert.True(targetPackageStream.CanSeek);
             }
         }
 
@@ -413,30 +390,19 @@ namespace NuGet.PackageManagement
 
             // Act
             using (var cacheContext = new SourceCacheContext())
+            using (var packagesDirectory = TestDirectory.Create())
+            using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
+                sourceRepositoryProvider.GetRepositories(),
+                packageIdentity,
+                new PackageDownloadContext(cacheContext),
+                packagesDirectory,
+                NullLogger.Instance,
+                CancellationToken.None))
             {
-                var downloadContext = new PackageDownloadContext(cacheContext)
-                {
-                    ExtractionContext = new PackageExtractionContext(
-                        PackageSaveMode.Defaultv3,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        clientPolicyContext: null,
-                        logger: NullLogger.Instance)
-                };
+                var targetPackageStream = downloadResult.PackageStream;
 
-                using (var packagesDirectory = TestDirectory.Create())
-                using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
-                    sourceRepositoryProvider.GetRepositories(),
-                    packageIdentity,
-                    downloadContext,
-                    packagesDirectory,
-                    NullLogger.Instance,
-                    CancellationToken.None))
-                {
-                    var targetPackageStream = downloadResult.PackageStream;
-
-                    // Assert
-                    Assert.True(targetPackageStream.CanSeek);
-                }
+                // Assert
+                Assert.True(targetPackageStream.CanSeek);
             }
         }
 
@@ -483,30 +449,19 @@ namespace NuGet.PackageManagement
 
             // Act
             using (var cacheContext = new SourceCacheContext())
+            using (var packagesDirectory = TestDirectory.Create())
+            using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
+                sourceRepositoryProvider.GetRepositories(),
+                packageIdentity,
+                new PackageDownloadContext(cacheContext),
+                packagesDirectory,
+                NullLogger.Instance,
+                CancellationToken.None))
             {
-                var downloadContext = new PackageDownloadContext(cacheContext)
-                {
-                    ExtractionContext = new PackageExtractionContext(
-                        PackageSaveMode.Defaultv3,
-                        PackageExtractionBehavior.XmlDocFileSaveMode,
-                        clientPolicyContext: null,
-                        logger: NullLogger.Instance)
-                };
+                var targetPackageStream = downloadResult.PackageStream;
 
-                using (var packagesDirectory = TestDirectory.Create())
-                using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
-                    sourceRepositoryProvider.GetRepositories(),
-                    packageIdentity,
-                    downloadContext,
-                    packagesDirectory,
-                    NullLogger.Instance,
-                    CancellationToken.None))
-                {
-                    var targetPackageStream = downloadResult.PackageStream;
-
-                    // Assert
-                    Assert.True(targetPackageStream.CanSeek);
-                }
+                // Assert
+                Assert.True(targetPackageStream.CanSeek);
             }
         }
 

--- a/test/TestUtilities/Test.Utility/Commands/TestRestoreRequest.cs
+++ b/test/TestUtilities/Test.Utility/Commands/TestRestoreRequest.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
-using NuGet.Packaging;
-using NuGet.Packaging.PackageExtraction;
 using NuGet.Packaging.Signing;
 using NuGet.ProjectModel;
 using NuGet.Protocol;
@@ -35,7 +33,7 @@ namespace NuGet.Commands.Test
             PackageSpec project,
             IEnumerable<PackageSource> sources,
             string packagesDirectory,
-            PackageExtractionContext extractionContext,
+            ClientPolicyContext clientPolicyContext,
             ILogger log)
             : this(
                   project,
@@ -43,7 +41,7 @@ namespace NuGet.Commands.Test
                   packagesDirectory,
                   new List<string>(),
                   new TestSourceCacheContext(),
-                  extractionContext,
+                  clientPolicyContext,
                   log)
         {
         }
@@ -69,7 +67,7 @@ namespace NuGet.Commands.Test
             IEnumerable<PackageSource> sources,
             string packagesDirectory,
             SourceCacheContext cacheContext,
-            PackageExtractionContext extractionContext,
+            ClientPolicyContext clientPolicyContext,
             ILogger log) : base(
                 project,
                 RestoreCommandProviders.Create(
@@ -80,7 +78,7 @@ namespace NuGet.Commands.Test
                     packageFileCache: new LocalPackageFileCache(),
                     log: log),
                 cacheContext,
-                extractionContext,
+                clientPolicyContext,
                 log)
         {
         }
@@ -114,11 +112,7 @@ namespace NuGet.Commands.Test
                   packagesDirectory,
                   fallbackPackageFolders,
                   cacheContext,
-                  new PackageExtractionContext(
-                    PackageSaveMode.Defaultv3,
-                     PackageExtractionBehavior.XmlDocFileSaveMode,
-                     ClientPolicyContext.GetClientPolicy(NullSettings.Instance, log),
-                     log),
+                  ClientPolicyContext.GetClientPolicy(NullSettings.Instance, log),
                   log)
         {
         }
@@ -134,11 +128,7 @@ namespace NuGet.Commands.Test
                 packagesDirectory,
                 fallbackPackageFolders,
                 new TestSourceCacheContext(),
-                new PackageExtractionContext(
-                    PackageSaveMode.Defaultv3,
-                     PackageExtractionBehavior.XmlDocFileSaveMode,
-                     ClientPolicyContext.GetClientPolicy(NullSettings.Instance, log),
-                     log),
+                ClientPolicyContext.GetClientPolicy(NullSettings.Instance, log),
                 log)
         {
         }
@@ -149,7 +139,7 @@ namespace NuGet.Commands.Test
             string packagesDirectory,
             IEnumerable<string> fallbackPackageFolders,
             SourceCacheContext cacheContext,
-            PackageExtractionContext extractionContext,
+            ClientPolicyContext clientPolicyContext,
             ILogger log) : base(
                 project,
                 RestoreCommandProviders.Create(
@@ -160,7 +150,7 @@ namespace NuGet.Commands.Test
                     packageFileCache: new LocalPackageFileCache(),
                     log: log),
                 cacheContext,
-                extractionContext,
+                clientPolicyContext,
                 log)
         {
         }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7445
Regression: Yes

## Fix
When creating the `PackageExtractionContext` some code paths didn't use the appropriate logger.

This is a regression introduced in 15.9 by https://github.com/NuGet/NuGet.Client/pull/2428. This PR fixes this regression by removing the `PackageExtractionContext` from the `Downloadcontext` and just passing the `ClientPolicyContext`. I also analyzed carefully the changes made in the referenced PR to make sure every other `PackageExtractionContext` has the exact same values for every property as they used to before that change.