### PR TITLE
Make sure package is not expanded on signing error

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -1123,6 +1123,15 @@ namespace NuGet.Packaging
                         {
                             await packageExtractionContext.Logger.LogAsync(warning);
                         }
+
+                        if (packageExtractionContext.Logger is ICollectorLogger collectorLogger)
+                        {
+                            if (collectorLogger.Errors.Any())
+                            {
+                                // Send empty results since errors and warnings have already been logged
+                                throw new SignatureException(results: Enumerable.Empty<PackageVerificationResult>().ToList(), package: package);
+                            }
+                        }
                     }
                     else
                     {

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
@@ -220,7 +220,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         }
 
         [CIOnlyFact]
-        public async Task Restore_PackageWithCompressedSignature_WarnAsError_FailsAsync()
+        public async Task Restore_PackageWithCompressedSignature_WarnAsError_FailsAndDoesNotExpandAsync()
         {
             // Arrange
             var packageX = new SimpleTestPackageContext();
@@ -290,6 +290,9 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 errors.First().LibraryId.Should().Be(packageX.Id);
 
                 warnings.Count().Should().Be(0);
+
+                var installedPackageDir = Path.Combine(pathContext.UserPackagesFolder, packageX.Identity.Id);
+                Directory.Exists(installedPackageDir).Should().BeFalse();
             }
         }
 


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7423

## Fix
Details: When a signing warning gets converted into an error by the collector logger, the package was still being extracted. This meant that the next restore would succeed without any issues. This PR fixes that making it so that if there's any signing warning that becomes an error, extraction fails and the package is not expanded.

cc. @rrelyea 