### PR TITLE
Add proper handling of unlicensed

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLicenseUtilities.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLicenseUtilities.cs
@@ -51,8 +51,8 @@ namespace NuGet.PackageManagement.UI
             {
                 case LicenseType.Expression:
 
-                    if (metadata.LicenseExpression != null)
-                    {
+                    if (metadata.LicenseExpression != null && !metadata.LicenseExpression.IsUnlicensed())
+                    { 
                         var identifiers = new List<string>();
                         PopulateLicenseIdentifiers(metadata.LicenseExpression, identifiers);
 

--- a/src/NuGet.Core/NuGet.Packaging/Licenses/NuGetLicense.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Licenses/NuGetLicense.cs
@@ -43,7 +43,7 @@ namespace NuGet.Packaging.Licenses
         /// <returns>Prased NuGetLicense object</returns>
         /// <exception cref="NuGetLicenseExpressionParsingException">If the identifier is deprecated, contains invalid characters or is an exception identifier.</exception>
         /// <exception cref="ArgumentException">If it's null or empty.</exception>
-        internal static NuGetLicense ParseIdentifier(string licenseIdentifier)
+        internal static NuGetLicense ParseIdentifier(string licenseIdentifier, bool allowUnlicensed = false)
         {
             if (!string.IsNullOrWhiteSpace(licenseIdentifier))
             {
@@ -65,10 +65,10 @@ namespace NuGet.Packaging.Licenses
                                 new NuGetLicense(cleanIdentifier, plus: plus, isStandardLicense: true) :
                                 throw new NuGetLicenseExpressionParsingException(string.Format(CultureInfo.CurrentCulture, Strings.NuGetLicenseExpression_DeprecatedIdentifier, licenseIdentifier));
                         }
-                        return ProcessNonStandardLicense(cleanIdentifier, plus: plus);
+                        return ProcessLicenseNotInStandardData(cleanIdentifier, plus: plus, allowUnlicensed: allowUnlicensed);
                     }
 
-                    return ProcessNonStandardLicense(licenseIdentifier, plus: false);
+                    return ProcessLicenseNotInStandardData(licenseIdentifier, plus: false, allowUnlicensed: allowUnlicensed);
                 }
             }
             // This will not happen in production code as the tokenizer takes cares of that. 
@@ -88,13 +88,28 @@ namespace NuGet.Packaging.Licenses
             return regex.IsMatch(value);
         }
 
-        private static NuGetLicense ProcessNonStandardLicense(string licenseIdentifier, bool plus)
+        private static NuGetLicense ProcessLicenseNotInStandardData(string licenseIdentifier, bool plus, bool allowUnlicensed)
         {
             if (!NuGetLicenseData.ExceptionList.TryGetValue(licenseIdentifier, out var exceptionData))
             {
                 if (HasValidCharacters(licenseIdentifier))
                 {
-                    return new NuGetLicense(licenseIdentifier, plus: plus, isStandardLicense: false);
+                    if (licenseIdentifier.Equals(UNLICENSED))
+                    {
+                        if (plus)
+                        {
+                            throw new NuGetLicenseExpressionParsingException(string.Format(CultureInfo.CurrentCulture, Strings.NuGetLicenseExpression_IllegalUnlicensedOperator));
+                        }
+                        if (allowUnlicensed)
+                        {
+                            return new NuGetLicense(licenseIdentifier, plus: false, isStandardLicense: true); // UNLICENSED is considered a standard license.
+                        }
+                        throw new NuGetLicenseExpressionParsingException(string.Format(CultureInfo.CurrentCulture, Strings.NuGetLicenseExpression_UnexpectedIdentifier, licenseIdentifier));
+                    }
+                    else
+                    {
+                        return new NuGetLicense(licenseIdentifier, plus: plus, isStandardLicense: false);
+                    }
                 }
                 else
                 {
@@ -103,6 +118,8 @@ namespace NuGet.Packaging.Licenses
             }
             throw new NuGetLicenseExpressionParsingException(string.Format(CultureInfo.CurrentCulture, Strings.NuGetLicenseExpression_LicenseIdentifierIsException, licenseIdentifier));
         }
+
+        internal static string UNLICENSED = nameof(UNLICENSED);
 
         public override string ToString()
         {

--- a/src/NuGet.Core/NuGet.Packaging/Licenses/NuGetLicense.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Licenses/NuGetLicense.cs
@@ -40,9 +40,11 @@ namespace NuGet.Packaging.Licenses
         /// Parse a licenseIdentifier. If a licenseIdentifier is deprecated, this will throw. Non-standard licenses get parsed into a object model as well.
         /// </summary>
         /// <param name="licenseIdentifier">license identifier to be parsed</param>
+        /// <param name="allowUnlicensed">Whether the parser allows the UNLICENSED identifier</param>
         /// <returns>Prased NuGetLicense object</returns>
         /// <exception cref="NuGetLicenseExpressionParsingException">If the identifier is deprecated, contains invalid characters or is an exception identifier.</exception>
         /// <exception cref="ArgumentException">If it's null or empty.</exception>
+        /// <remarks>The purpose of the <paramref name="allowUnlicensed"/> switch is to allow the expression parser communicate at which operand location the unlicensed identifier is legal. </remarks>
         internal static NuGetLicense ParseIdentifier(string licenseIdentifier, bool allowUnlicensed = false)
         {
             if (!string.IsNullOrWhiteSpace(licenseIdentifier))
@@ -119,7 +121,7 @@ namespace NuGet.Packaging.Licenses
             throw new NuGetLicenseExpressionParsingException(string.Format(CultureInfo.CurrentCulture, Strings.NuGetLicenseExpression_LicenseIdentifierIsException, licenseIdentifier));
         }
 
-        internal static string UNLICENSED = nameof(UNLICENSED);
+        internal static string UNLICENSED = "UNLICENSED";
 
         public override string ToString()
         {

--- a/src/NuGet.Core/NuGet.Packaging/Licenses/NuGetLicenseExpressionExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Licenses/NuGetLicenseExpressionExtensions.cs
@@ -78,5 +78,23 @@ namespace NuGet.Packaging.Licenses
                     break;
             }
         }
+
+        public static bool IsUnlicensed(this NuGetLicense license)
+        {
+            return license.Identifier.Equals(NuGetLicense.UNLICENSED);
+        }
+
+        public static bool IsUnlicensed(this NuGetLicenseExpression expression)
+        {
+            switch (expression.Type)
+            {
+                case LicenseExpressionType.License:
+                    return ((NuGetLicense)expression).IsUnlicensed();
+
+                case LicenseExpressionType.Operator: // expressions with operators cannot be unlicensed.
+                default:
+                    return false;
+            }
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Licenses/NuGetLicenseExpressionParser.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Licenses/NuGetLicenseExpressionParser.cs
@@ -135,7 +135,7 @@ namespace NuGet.Packaging.Licenses
                 {
                     var value = operandStack.Pop();
 
-                    return value.Item1 ? NuGetLicense.ParseIdentifier(((LicenseExpressionToken)value.Item2).Value) : (NuGetLicenseExpression)value.Item2;
+                    return value.Item1 ? NuGetLicense.ParseIdentifier(((LicenseExpressionToken)value.Item2).Value, allowUnlicensed: true) : (NuGetLicenseExpression)value.Item2;
                 }
             }
             catch (NuGetLicenseExpressionParsingException)

--- a/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
@@ -482,6 +482,14 @@ namespace NuGet.Packaging
                                         }
                                         errors.Add(string.Format(CultureInfo.CurrentCulture, Strings.NuGetLicenseExpression_NonStandardIdentifier, string.Join(", ", invalidLicenseIdentifiers)));
                                     }
+                                    if (expression.IsUnlicensed())
+                                    {
+                                        if (errors == null)
+                                        {
+                                            errors = new List<string>();
+                                        }
+                                        errors.Add(string.Format(CultureInfo.CurrentCulture, Strings.NuGetLicenseExpression_UnlicensedPackageWarning));
+                                    }
 
                                     return new LicenseMetadata(type: licenseType, license: license, expression: expression, warningsAndErrors: errors, version: version);
                                 }

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -863,6 +863,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The &apos;UNLICENSED&apos; license identifier cannot be combined with the &apos;+&apos; operator..
+        /// </summary>
+        internal static string NuGetLicenseExpression_IllegalUnlicensedOperator {
+            get {
+                return ResourceManager.GetString("NuGetLicenseExpression_IllegalUnlicensedOperator", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The license expression &apos;{0}&apos; contains invalid characters..
         /// </summary>
         internal static string NuGetLicenseExpression_InvalidCharacters {
@@ -931,6 +940,24 @@ namespace NuGet.Packaging {
         internal static string NuGetLicenseExpression_NonStandardIdentifier {
             get {
                 return ResourceManager.GetString("NuGetLicenseExpression_NonStandardIdentifier", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unexpected license identifier &apos;{0}&apos;. The identifier is not allowed in this context..
+        /// </summary>
+        internal static string NuGetLicenseExpression_UnexpectedIdentifier {
+            get {
+                return ResourceManager.GetString("NuGetLicenseExpression_UnexpectedIdentifier", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The owner has marked this package as &apos;UNLICENSED&apos;. This means that there is no license that allows this package to be used outside of the copyright owner..
+        /// </summary>
+        internal static string NuGetLicenseExpression_UnlicensedPackageWarning {
+            get {
+                return ResourceManager.GetString("NuGetLicenseExpression_UnlicensedPackageWarning", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -796,4 +796,14 @@ Valid from:</comment>
   <data name="Error_RequireMode_UnsignedPackage" xml:space="preserve">
     <value>signatureValidationMode is set to require, so packages are allowed only if signed by trusted signers; however, this package is unsigned.</value>
   </data>
+  <data name="NuGetLicenseExpression_IllegalUnlicensedOperator" xml:space="preserve">
+    <value>The 'UNLICENSED' license identifier cannot be combined with the '+' operator.</value>
+  </data>
+  <data name="NuGetLicenseExpression_UnexpectedIdentifier" xml:space="preserve">
+    <value>Unexpected license identifier '{0}'. The identifier is not allowed in this context.</value>
+    <comment>0 - the license identifier.</comment>
+  </data>
+  <data name="NuGetLicenseExpression_UnlicensedPackageWarning" xml:space="preserve">
+    <value>The owner has marked this package as 'UNLICENSED'. This means that there is no license that allows this package to be used outside of the copyright owner.</value>
+  </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageLicenseUtilitiesTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageLicenseUtilitiesTests.cs
@@ -73,6 +73,56 @@ namespace NuGet.PackageManagement.UI.Test
         }
 
         [Fact]
+        public void PackageLicenseUtility_UnlicensedGeneratesNoLinksAndAWarning()
+        {
+            var license = "UNLICENSED";
+            NuGetLicenseExpression expression = null;
+            var warnings = new List<string>();
+            try
+            {
+                expression = NuGetLicenseExpression.Parse(license);
+            }
+            catch (NuGetLicenseExpressionParsingException e)
+            {
+                warnings.Add(e.Message);
+            }
+            // Setup
+            var licenseData = new LicenseMetadata(LicenseType.Expression, license, expression, warnings, LicenseMetadata.CurrentVersion);
+
+            // Act
+            var links = PackageLicenseUtilities.GenerateLicenseLinks(licenseData);
+
+            Assert.Equal(links.Count, 2);
+            Assert.True(links[0] is WarningText);
+            Assert.True(links[1] is FreeText);
+        }
+
+        [Fact]
+        public void PackageLicenseUtility_BadUnlicensedGeneratesNoLinksAndAWarning()
+        {
+            var license = "UNLICENSED OR MIT";
+            NuGetLicenseExpression expression = null;
+            var warnings = new List<string>();
+            try
+            {
+                expression = NuGetLicenseExpression.Parse(license);
+            }
+            catch (NuGetLicenseExpressionParsingException e)
+            {
+                warnings.Add(e.Message);
+            }
+            // Setup
+            var licenseData = new LicenseMetadata(LicenseType.Expression, license, expression, warnings, LicenseMetadata.CurrentVersion);
+
+            // Act
+            var links = PackageLicenseUtilities.GenerateLicenseLinks(licenseData);
+
+            Assert.Equal(links.Count, 2);
+            Assert.True(links[0] is WarningText);
+            Assert.True(links[1] is FreeText);
+        }
+
+        [Fact]
         public void PackageLicenseUtility_GeneratesLinkForFiles()
         {
             // Setup

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/LicensesTests/NuGetLicenseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/LicensesTests/NuGetLicenseTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root flicense information.
+
+using Xunit;
+
+namespace NuGet.Packaging.Licenses.Test
+{
+    public class NuGetLicenseTests
+    {
+        [Theory]
+        [InlineData("MIT++", true)] // standard license++
+        [InlineData("MIT++", false)] // standard license++
+        [InlineData("RandomLicense++", true)] // non standard license ++
+        [InlineData("RandomLicense++", false)] // non standard license ++
+        [InlineData("389-exception", true)] // exception
+        [InlineData("389-exception", false)] // exception
+        [InlineData("LicenseWith Bad Characters", true)]
+        [InlineData("LicenseWith Bad Characters", false)]
+        [InlineData("GFDL-1.1", true)] // deprecatated license id
+        [InlineData("GFDL-1.1", false)] // deprecatated license id
+        [InlineData("UNLICENSED", false)] // unlicensed is not allowed
+        [InlineData("UNLICENSED+", true)] // unlicensed+ is bad in both cases
+        [InlineData("UNLICENSED+", false)] // unlicensed+ is bad in both cases
+        [InlineData("UNLICENSED++", true)] // unlicensed++ is bad in both bases.
+        [InlineData("UNLICENSED++", false)] // unlicensed++ is bad in both bases.
+        public void NuGetLicenseParser_ThrowsForInvalidLicenseIdentifiers(string expression, bool allowUnlicensed)
+        {
+            Assert.Throws<NuGetLicenseExpressionParsingException>(() => NuGetLicense.ParseIdentifier(expression, allowUnlicensed: allowUnlicensed));
+        }
+
+        [Theory]
+        [InlineData("MIT", true, false, true)]
+        [InlineData("MIT", true, false, false)]
+        [InlineData("AFL-1.1+", true, true, true)]
+        [InlineData("AFL-1.1+", true, true, false)]
+        [InlineData("MyFancyLicense", false, false, true)]
+        [InlineData("MyFancyLicense", false, false, false)]
+        [InlineData("MyFancyLicense+", false, true, true)]
+        [InlineData("MyFancyLicense+", false, true, false)]
+        [InlineData("UNLICENSED", true, false, true)]
+        public void NuGetLicenseParser_ParsesLicensesCorrectly(string expression, bool hasStandardIdentifiers, bool hasPlus, bool allowUnlicensed)
+        {
+            var license = NuGetLicense.ParseIdentifier(expression, allowUnlicensed: allowUnlicensed);
+            Assert.Equal(expression, license.ToString());
+            Assert.Equal(license.HasOnlyStandardIdentifiers(), hasStandardIdentifiers);
+            Assert.Equal(hasPlus, license.Plus);
+            Assert.Equal(expression.Equals(NuGetLicense.UNLICENSED), license.IsUnlicensed());
+        }
+
+        [Fact]
+        public void NuGetLicenseParser_ParsesUnlicensedCorrectly()
+        {
+            var expression = NuGetLicense.UNLICENSED;
+            var license = NuGetLicense.ParseIdentifier(expression, allowUnlicensed: true);
+            Assert.Equal(expression, license.ToString());
+            Assert.True(license.HasOnlyStandardIdentifiers());
+            Assert.True(license.IsUnlicensed());
+            Assert.False(license.Plus);
+        }
+    }
+}


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7447
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
Add a proper implementation of unlicensed. 
The only valid encounter of UNLICENSED is as a singular license identifier "UNLICENSED". 

Everything else is invalid. 
Whenever a package is marked as unlicensed a warning is added in the UI. 

//cc @agr 

## Testing/Validation
Tests Added: Yes  
Reason for not adding tests:  
Validation done:  
