### PR TITLE
Do not fail signature verification if only warnings where produced on restore

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -1126,7 +1126,8 @@ namespace NuGet.Packaging
 
                         if (packageExtractionContext.Logger is ICollectorLogger collectorLogger)
                         {
-                            if (collectorLogger.Errors.Any())
+                            // collectorLogger.Errors is a collection of errors and warnings, we just need to fail if there are errors.
+                            if (collectorLogger.Errors.Where(e => e.Level >= LogLevel.Error).Any())
                             {
                                 // Send empty results since errors and warnings have already been logged
                                 throw new SignatureException(results: Enumerable.Empty<PackageVerificationResult>().ToList(), package: package);


### PR DESCRIPTION
## Bug
Fixes an issue caught by a test on `release-4.9.0-preview5` branch. On restore, signing verification was being failed at the `PackageExtractor` level if the verification produced any error or warning.

This verification should only fail if there are errors.
