### PR TITLE
Merge implementation of GetContentHash and GetContentHashForSignedPackage

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -338,7 +338,7 @@ namespace NuGet.Packaging
 #endif
         }
 
-        public override string GetContentHash(CancellationToken token, string fallbackHashFilePath = null)
+        public override string GetContentHash(CancellationToken token, Func<string> fallbackHashGenerator = null)
         {
             // Try to get the content hash for signed packages
             var contentHash = GetContentHashForSignedPackage(token);
@@ -346,9 +346,9 @@ namespace NuGet.Packaging
             if (string.IsNullOrEmpty(contentHash))
             {
                 // The package is unsigned, try to read the existing sha512 file
-                if (!string.IsNullOrEmpty(fallbackHashFilePath) && File.Exists(fallbackHashFilePath))
+                if (fallbackHashGenerator != null)
                 {
-                    var packageHash = File.ReadAllText(fallbackHashFilePath);
+                    var packageHash = fallbackHashGenerator();
 
                     if (!string.IsNullOrEmpty(packageHash))
                     {
@@ -356,7 +356,6 @@ namespace NuGet.Packaging
                     }
                 }
 
-                // sha512 file doesn't exist or is empty, try calculating it
                 ThrowIfZipReadStreamIsNull();
 
                 ZipReadStream.Seek(offset: 0, origin: SeekOrigin.Begin);

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -338,7 +338,7 @@ namespace NuGet.Packaging
 #endif
         }
 
-        public override string GetContentHash(CancellationToken token, Func<string> fallbackHashGenerator = null)
+        public override string GetContentHash(CancellationToken token, Func<string> GetUnsignedPackageHash = null)
         {
             // Try to get the content hash for signed packages
             var contentHash = GetContentHashForSignedPackage(token);
@@ -346,9 +346,9 @@ namespace NuGet.Packaging
             if (string.IsNullOrEmpty(contentHash))
             {
                 // The package is unsigned, try to read the existing sha512 file
-                if (fallbackHashGenerator != null)
+                if (GetUnsignedPackageHash != null)
                 {
-                    var packageHash = fallbackHashGenerator();
+                    var packageHash = GetUnsignedPackageHash();
 
                     if (!string.IsNullOrEmpty(packageHash))
                     {

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -515,7 +515,7 @@ namespace NuGet.Packaging
                                         File.WriteAllText(tempHashPath, packageHash);
 
                                         // get hash for the unsigned content of package
-                                        var contentHash = packageReader.GetContentHash(cancellationToken, fallbackHashGenerator: () => packageHash);
+                                        var contentHash = packageReader.GetContentHash(cancellationToken, GetUnsignedPackageHash: () => packageHash);
 
                                         // write the new hash file
                                         var hashFile = new NupkgMetadataFile()
@@ -819,7 +819,7 @@ namespace NuGet.Packaging
                             File.WriteAllText(tempHashPath, packageHash);
 
                             // get hash for the unsigned content of package
-                            var contentHash = packageDownloader.SignedPackageReader.GetContentHash(cancellationToken, fallbackHashGenerator: () => packageHash);
+                            var contentHash = packageDownloader.SignedPackageReader.GetContentHash(cancellationToken, GetUnsignedPackageHash: () => packageHash);
 
                             // write the new hash file
                             var hashFile = new NupkgMetadataFile()

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -509,20 +509,13 @@ namespace NuGet.Packaging
                                                 token);
                                         }
 
-                                        string packageHash;
                                         nupkgStream.Position = 0;
-                                        packageHash = Convert.ToBase64String(new CryptoHashProvider("SHA512").CalculateHash(nupkgStream));
+                                        var packageHash = Convert.ToBase64String(new CryptoHashProvider("SHA512").CalculateHash(nupkgStream));
 
                                         File.WriteAllText(tempHashPath, packageHash);
 
-                                        // get hash for the unsigned content of signed package
-                                        var contentHash = packageReader.GetContentHashForSignedPackage(cancellationToken);
-
-                                        // if null, then it's unsigned package so just use the existing hash
-                                        if (string.IsNullOrEmpty(contentHash))
-                                        {
-                                            contentHash = packageHash;
-                                        }
+                                        // get hash for the unsigned content of package
+                                        var contentHash = packageReader.GetContentHash(cancellationToken, fallbackHashFilePath: tempHashPath);
 
                                         // write the new hash file
                                         var hashFile = new NupkgMetadataFile()
@@ -825,19 +818,13 @@ namespace NuGet.Packaging
 
                             File.WriteAllText(tempHashPath, packageHash);
 
-                            // get hash for the unsigned content of signed package
-                            var contentHash = packageDownloader.SignedPackageReader.GetContentHashForSignedPackage(cancellationToken);
-
-                            // if null, then it's unsigned package so use the existing hash
-                            if (string.IsNullOrEmpty(contentHash))
-                            {
-                                contentHash = packageHash;
-                            }
+                            // get hash for the unsigned content of package
+                            var contentHash = packageDownloader.SignedPackageReader.GetContentHash(cancellationToken, fallbackHashFilePath: tempHashPath);
 
                             // write the new hash file
                             var hashFile = new NupkgMetadataFile()
                             {
-                                ContentHash = packageHash
+                                ContentHash = contentHash
                             };
 
                             NupkgMetadataFileFormat.Write(tempNupkgMetadataFilePath, hashFile);

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -515,7 +515,7 @@ namespace NuGet.Packaging
                                         File.WriteAllText(tempHashPath, packageHash);
 
                                         // get hash for the unsigned content of package
-                                        var contentHash = packageReader.GetContentHash(cancellationToken, fallbackHashFilePath: tempHashPath);
+                                        var contentHash = packageReader.GetContentHash(cancellationToken, fallbackHashGenerator: () => packageHash);
 
                                         // write the new hash file
                                         var hashFile = new NupkgMetadataFile()
@@ -819,7 +819,7 @@ namespace NuGet.Packaging
                             File.WriteAllText(tempHashPath, packageHash);
 
                             // get hash for the unsigned content of package
-                            var contentHash = packageDownloader.SignedPackageReader.GetContentHash(cancellationToken, fallbackHashFilePath: tempHashPath);
+                            var contentHash = packageDownloader.SignedPackageReader.GetContentHash(cancellationToken, fallbackHashGenerator: () => packageHash);
 
                             // write the new hash file
                             var hashFile = new NupkgMetadataFile()

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -240,17 +240,12 @@ namespace NuGet.Packaging
             throw new NotImplementedException();
         }
 
-        public override string GetContentHashForSignedPackage(CancellationToken token)
-        {
-            throw new NotImplementedException();
-        }
-
         public override bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings)
         {
             return false;
         }
         
-        public override string GetContentHash(CancellationToken token)
+        public override string GetContentHash(CancellationToken token, string fallbackHashFilePath = null)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -245,7 +245,7 @@ namespace NuGet.Packaging
             return false;
         }
         
-        public override string GetContentHash(CancellationToken token, Func<string> fallbackHashGenerator = null)
+        public override string GetContentHash(CancellationToken token, Func<string> GetUnsignedPackageHash = null)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -245,7 +245,7 @@ namespace NuGet.Packaging
             return false;
         }
         
-        public override string GetContentHash(CancellationToken token, string fallbackHashFilePath = null)
+        public override string GetContentHash(CancellationToken token, Func<string> fallbackHashGenerator = null)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -596,14 +596,8 @@ namespace NuGet.Packaging
         public abstract bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings);
 
         /// <summary>
-        /// Get contentHash for a signed package.
-        /// </summary>
-        /// <returns>null if the package is not signed</returns>
-        public abstract string GetContentHashForSignedPackage(CancellationToken token);
-
-        /// <summary>
         /// Get contenthash for a package.
         /// </summary>
-        public abstract string GetContentHash(CancellationToken token);
+        public abstract string GetContentHash(CancellationToken token, string fallbackHashFilePath = null);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -598,6 +598,6 @@ namespace NuGet.Packaging
         /// <summary>
         /// Get contenthash for a package.
         /// </summary>
-        public abstract string GetContentHash(CancellationToken token, string fallbackHashFilePath = null);
+        public abstract string GetContentHash(CancellationToken token, Func<string> fallbackHashGenerator = null);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -598,6 +598,6 @@ namespace NuGet.Packaging
         /// <summary>
         /// Get contenthash for a package.
         /// </summary>
-        public abstract string GetContentHash(CancellationToken token, Func<string> fallbackHashGenerator = null);
+        public abstract string GetContentHash(CancellationToken token, Func<string> GetUnsignedPackageHash = null);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
@@ -39,10 +39,12 @@ namespace NuGet.Packaging.Signing
 
         /// <summary>
         /// Get the hash of the package content excluding signature context for signed package.
+        /// If the package is not signed it calculates it from the whole package.
         /// </summary>
-        /// <param name="token">Cancellation token</param>
-        /// <returns>hash of the unsigned content of the signed package. but return null for unsigned package.</returns>
-        string GetContentHashForSignedPackage(CancellationToken token);
+        /// <param name="token">Cancellation token.</param>
+        /// <remarks>The method takes an optional fallback hash filepath to read the hash of an unsigned package instead of calculating it.</remarks>
+        /// <returns>hash of the unsigned content of the package.</returns>
+        string GetContentHash(CancellationToken token, string fallbackHashFilePath = null);
 
         /// <summary>
         /// Indicates if the the ISignedPackageReader instance can verify signed packages.

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
@@ -42,11 +42,10 @@ namespace NuGet.Packaging.Signing
         /// If the package is not signed it calculates it from the whole package.
         /// </summary>
         /// <param name="token">Cancellation token.</param>
-        /// <param name="fallbackHashGenerator">Function to return the hash in case the package is not signed.
-        /// This is helpfull when the hashFile has already been created and we want to avoid reading that file or calculating the hash again.</param>
-        /// <remarks>The method takes an optional fallback hash filepath to read the hash of an unsigned package instead of calculating it.</remarks>
+        /// <param name="GetUnsignedPackageHash">Function to return the hash in case the package is not signed.</param>
+        /// <remarks>The method takes an optional function to get the hash of an unsigned package instead of calculating it.</remarks>
         /// <returns>hash of the unsigned content of the package.</returns>
-        string GetContentHash(CancellationToken token, Func<string> fallbackHashGenerator = null);
+        string GetContentHash(CancellationToken token, Func<string> GetUnsignedPackageHash = null);
 
         /// <summary>
         /// Indicates if the the ISignedPackageReader instance can verify signed packages.

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageReader.cs
@@ -42,9 +42,11 @@ namespace NuGet.Packaging.Signing
         /// If the package is not signed it calculates it from the whole package.
         /// </summary>
         /// <param name="token">Cancellation token.</param>
+        /// <param name="fallbackHashGenerator">Function to return the hash in case the package is not signed.
+        /// This is helpfull when the hashFile has already been created and we want to avoid reading that file or calculating the hash again.</param>
         /// <remarks>The method takes an optional fallback hash filepath to read the hash of an unsigned package instead of calculating it.</remarks>
         /// <returns>hash of the unsigned content of the package.</returns>
-        string GetContentHash(CancellationToken token, string fallbackHashFilePath = null);
+        string GetContentHash(CancellationToken token, Func<string> fallbackHashGenerator = null);
 
         /// <summary>
         /// Indicates if the the ISignedPackageReader instance can verify signed packages.

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -1149,12 +1149,6 @@ namespace NuGet.Protocol.Plugins
             throw new NotImplementedException();
         }
 
-        public override string GetContentHashForSignedPackage(CancellationToken token)
-        {
-            // Plugin Download doesn't support signed packages so simply return null.
-            return null;
-        }
-
         public override bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings)
         {
             if (!verifierSettings.AllowUnsigned)
@@ -1165,7 +1159,7 @@ namespace NuGet.Protocol.Plugins
             return false;
         }
         
-        public override string GetContentHash(CancellationToken token)
+        public override string GetContentHash(CancellationToken token, string fallbackHashFilePath = null)
         {
             // Plugin Download doesn't support signed packages so simply return null... and even then they aren't always packages.
             return null;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -1159,7 +1159,7 @@ namespace NuGet.Protocol.Plugins
             return false;
         }
         
-        public override string GetContentHash(CancellationToken token, Func<string> fallbackHashGenerator = null)
+        public override string GetContentHash(CancellationToken token, Func<string> GetUnsignedPackageHash = null)
         {
             // Plugin Download doesn't support signed packages so simply return null... and even then they aren't always packages.
             return null;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -1159,7 +1159,7 @@ namespace NuGet.Protocol.Plugins
             return false;
         }
         
-        public override string GetContentHash(CancellationToken token, string fallbackHashFilePath = null)
+        public override string GetContentHash(CancellationToken token, Func<string> fallbackHashGenerator = null)
         {
             // Plugin Download doesn't support signed packages so simply return null... and even then they aren't always packages.
             return null;

--- a/src/NuGet.Core/NuGet.Protocol/Utility/LocalFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/LocalFolderUtility.cs
@@ -1170,13 +1170,7 @@ namespace NuGet.Protocol
                         using (var packageReader = new PackageArchiveReader(stream))
                         {
                             // get hash of unsigned content of signed package
-                            var packageHash = packageReader.GetContentHashForSignedPackage(CancellationToken.None);
-
-                            // if null, then it's unsigned package so just read the existing sha512 file
-                            if (string.IsNullOrEmpty(packageHash))
-                            {
-                                packageHash = File.ReadAllText(hashPath);
-                            }
+                            var packageHash = packageReader.GetContentHash(CancellationToken.None, hashPath);
 
                             // write the new hash file
                             var hashFile = new NupkgMetadataFile()

--- a/src/NuGet.Core/NuGet.Protocol/Utility/LocalFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/LocalFolderUtility.cs
@@ -1170,7 +1170,17 @@ namespace NuGet.Protocol
                         using (var packageReader = new PackageArchiveReader(stream))
                         {
                             // get hash of unsigned content of signed package
-                            var packageHash = packageReader.GetContentHash(CancellationToken.None, hashPath);
+                            var packageHash = packageReader.GetContentHash(
+                                CancellationToken.None,
+                                fallbackHashGenerator:
+                                () => {
+                                    if (!string.IsNullOrEmpty(hashPath) && File.Exists(hashPath))
+                                    {
+                                        return File.ReadAllText(hashPath);
+                                    }
+
+                                    return null;
+                                });
 
                             // write the new hash file
                             var hashFile = new NupkgMetadataFile()

--- a/src/NuGet.Core/NuGet.Protocol/Utility/LocalFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/LocalFolderUtility.cs
@@ -1172,7 +1172,7 @@ namespace NuGet.Protocol
                             // get hash of unsigned content of signed package
                             var packageHash = packageReader.GetContentHash(
                                 CancellationToken.None,
-                                fallbackHashGenerator:
+                                GetUnsignedPackageHash:
                                 () => {
                                     if (!string.IsNullOrEmpty(hashPath) && File.Exists(hashPath))
                                     {

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
@@ -356,7 +356,7 @@ namespace NuGet.PackageManagement
 
                 using (var packageArchiveReader = new PackageArchiveReader(targetPackageStream))
                 {
-                    var contentHash = packageArchiveReader.GetContentHashForSignedPackage(CancellationToken.None);
+                    var contentHash = packageArchiveReader.GetContentHash(CancellationToken.None);
 
                     // Assert
                     Assert.Equal(_jQuery182ContentHash, contentHash);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -1734,7 +1734,7 @@ namespace NuGet.Packaging.Test
             using (var root = TestDirectory.Create())
             using (var test = PackageReaderTest.Create(TestPackagesCore.GetPackageCoreReaderTestPackage()))
             {
-                var result = test.Reader.GetContentHash(CancellationToken.None, fallbackHashGenerator: () => "abcde");
+                var result = test.Reader.GetContentHash(CancellationToken.None, GetUnsignedPackageHash: () => "abcde");
 
                 Assert.Equal("abcde", result);
             }
@@ -1747,7 +1747,7 @@ namespace NuGet.Packaging.Test
         {
             using (var test = PackageReaderTest.Create(TestPackagesCore.GetPackageCoreReaderTestPackage()))
             {
-                var result = test.Reader.GetContentHash(CancellationToken.None, fallbackHashGenerator: () => data);
+                var result = test.Reader.GetContentHash(CancellationToken.None, GetUnsignedPackageHash: () => data);
 
                 test.Stream.Seek(offset: 0, origin: SeekOrigin.Begin);
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -2527,7 +2527,7 @@ namespace NuGet.Packaging.Test
                     })
                 .ReturnsAsync(() => copiedFilePaths);
 
-            signedReader.Setup(x => x.GetContentHashForSignedPackage(It.IsAny<CancellationToken>()))
+            signedReader.Setup(x => x.GetContentHash(It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .Returns(string.Empty);
 
             var packageIdentity = new PackageIdentity(id: "a", version: NuGetVersion.Parse("1.0.0"));
@@ -2602,7 +2602,7 @@ namespace NuGet.Packaging.Test
                     })
                 .ReturnsAsync(() => copiedFilePaths);
 
-            signedReader.Setup(x => x.GetContentHashForSignedPackage(It.IsAny<CancellationToken>()))
+            signedReader.Setup(x => x.GetContentHash(It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .Returns(string.Empty);
 
             var packageIdentity = new PackageIdentity(id: "a", version: NuGetVersion.Parse("1.0.0"));

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -2527,7 +2527,7 @@ namespace NuGet.Packaging.Test
                     })
                 .ReturnsAsync(() => copiedFilePaths);
 
-            signedReader.Setup(x => x.GetContentHash(It.IsAny<CancellationToken>(), It.IsAny<string>()))
+            signedReader.Setup(x => x.GetContentHash(It.IsAny<CancellationToken>(), It.IsAny<Func<string>>()))
                 .Returns(string.Empty);
 
             var packageIdentity = new PackageIdentity(id: "a", version: NuGetVersion.Parse("1.0.0"));
@@ -2602,7 +2602,7 @@ namespace NuGet.Packaging.Test
                     })
                 .ReturnsAsync(() => copiedFilePaths);
 
-            signedReader.Setup(x => x.GetContentHash(It.IsAny<CancellationToken>(), It.IsAny<string>()))
+            signedReader.Setup(x => x.GetContentHash(It.IsAny<CancellationToken>(), It.IsAny<Func<string>>()))
                 .Returns(string.Empty);
 
             var packageIdentity = new PackageIdentity(id: "a", version: NuGetVersion.Parse("1.0.0"));

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
@@ -228,12 +228,7 @@ namespace NuGet.Protocol.Tests
                 throw new NotImplementedException();
             }
 
-            public override string GetContentHashForSignedPackage(CancellationToken token)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override string GetContentHash(CancellationToken token)
+            public override string GetContentHash(CancellationToken token, string fallbackHashFilePath = null)
             {
                 throw new NotImplementedException();
             }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
@@ -228,7 +228,7 @@ namespace NuGet.Protocol.Tests
                 throw new NotImplementedException();
             }
 
-            public override string GetContentHash(CancellationToken token, Func<string> fallbackHashGenerator = null)
+            public override string GetContentHash(CancellationToken token, Func<string> GetUnsignedPackageHash = null)
             {
                 throw new NotImplementedException();
             }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceResultTests.cs
@@ -228,7 +228,7 @@ namespace NuGet.Protocol.Tests
                 throw new NotImplementedException();
             }
 
-            public override string GetContentHash(CancellationToken token, string fallbackHashFilePath = null)
+            public override string GetContentHash(CancellationToken token, Func<string> fallbackHashGenerator = null)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
Based on https://github.com/NuGet/NuGet.Client/pull/2483#discussion_r230126073, the implementation of `PackageReaderBase.GetContentHash(…)` and `PackageReaderBase.GetContentHashForSignedPackage(…)` should be merged and used throughout the product. 

This method now takes an optional `HashFilePath` to fallback instead of calculating the hash of the whole package. If the package is not signed and the file is empty or doesn't exist, it will read from the file.