### PR TITLE
Add GetConfigRoot and GetConfigFilePaths to ISettings

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -368,7 +368,7 @@ namespace NuGet.CommandLine
                 return new RestoreSummary(
                     result.Restored,
                     "packages.config projects",
-                    SettingsUtility.GetConfigFilePaths(Settings),
+                    Settings.GetConfigFilePaths(),
                     packageSources.Select(x => x.Source),
                     installCount,
                     collectorLogger.Errors.Concat(ProcessFailedEventsIntoRestoreLogs(failedEvents)));

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -291,7 +291,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private IList<string> GetConfigFilePaths(ISettings settings)
         {
-            return settings.GetConfigFilePaths().ToList();
+            return settings.GetConfigFilePaths();
         }
 
         private static PackageReference[] GetPackageReferences(PackageSpec packageSpec)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -291,7 +291,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private IList<string> GetConfigFilePaths(ISettings settings)
         {
-            return SettingsUtility.GetConfigFilePaths(settings).ToList();
+            return settings.GetConfigFilePaths().ToList();
         }
 
         private static PackageReference[] GetPackageReferences(PackageSpec packageSpec)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
@@ -185,7 +185,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private IList<string> GetConfigFilePaths(ISettings settings)
         {
-            return settings.GetConfigFilePaths().ToList();
+            return settings.GetConfigFilePaths();
         }
 
         private void IgnoreUnsupportProjectReference(PackageSpec project)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
@@ -185,7 +185,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private IList<string> GetConfigFilePaths(ISettings settings)
         {
-            return SettingsUtility.GetConfigFilePaths(settings).ToList();
+            return settings.GetConfigFilePaths().ToList();
         }
 
         private void IgnoreUnsupportProjectReference(PackageSpec project)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
@@ -120,9 +120,9 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
-        public IEnumerable<string> GetConfigFilePaths() => SolutionSettings.GetConfigFilePaths();
+        public IList<string> GetConfigFilePaths() => SolutionSettings.GetConfigFilePaths();
 
-        public IEnumerable<string> GetConfigRoots() => SolutionSettings.GetConfigRoots();
+        public IList<string> GetConfigRoots() => SolutionSettings.GetConfigRoots();
 
         // The value for SolutionSettings can't possibly be null, but it could be a read-only instance
         private bool CanChangeSettings => !ReferenceEquals(SolutionSettings, NullSettings.Instance);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
@@ -120,6 +120,10 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
+        public IEnumerable<string> GetConfigFilePaths() => SolutionSettings.GetConfigFilePaths();
+
+        public IEnumerable<string> GetConfigRoots() => SolutionSettings.GetConfigRoots();
+
         // The value for SolutionSettings can't possibly be null, but it could be a read-only instance
         private bool CanChangeSettings => !ReferenceEquals(SolutionSettings, NullSettings.Instance);
 

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
@@ -70,7 +70,7 @@ namespace NuGet.Commands
                         ProjectUniqueName = projectPath,
                         OutputPath = Path.GetTempPath(),
                         OriginalTargetFrameworks = TargetFrameworks.Select(i => i.ToString()).ToList(),
-                        ConfigFilePaths = SettingsUtility.GetConfigFilePaths(settings).ToList(),
+                        ConfigFilePaths = settings.GetConfigFilePaths().ToList(),
                         PackagesPath = SettingsUtility.GetGlobalPackagesFolder(settings),
                         Sources = SettingsUtility.GetEnabledSources(settings).ToList(),
                         FallbackFolders = SettingsUtility.GetFallbackPackageFolders(settings).ToList()

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
@@ -70,7 +70,7 @@ namespace NuGet.Commands
                         ProjectUniqueName = projectPath,
                         OutputPath = Path.GetTempPath(),
                         OriginalTargetFrameworks = TargetFrameworks.Select(i => i.ToString()).ToList(),
-                        ConfigFilePaths = settings.GetConfigFilePaths().ToList(),
+                        ConfigFilePaths = settings.GetConfigFilePaths(),
                         PackagesPath = SettingsUtility.GetGlobalPackagesFolder(settings),
                         Sources = SettingsUtility.GetEnabledSources(settings).ToList(),
                         FallbackFolders = SettingsUtility.GetFallbackPackageFolders(settings).ToList()

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
@@ -120,7 +120,7 @@ namespace NuGet.Build.Tasks
                 // is something that could happen, but it is not supported.
                 var absoluteConfigFilePath = GetGlobalAbsolutePath(RestoreConfigFile);
                 var settings = RestoreSettingsUtils.ReadSettings(RestoreSolutionDirectory, string.IsNullOrEmpty(RestoreRootConfigDirectory) ? Path.GetDirectoryName(ProjectUniqueName) : RestoreRootConfigDirectory, absoluteConfigFilePath, _machineWideSettings);
-                OutputConfigFilePaths = SettingsUtility.GetConfigFilePaths(settings).ToArray();
+                OutputConfigFilePaths = settings.GetConfigFilePaths().ToArray();
 
                 // PackagesPath
                 OutputPackagesPath = RestoreSettingsUtils.GetValue(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -173,7 +173,7 @@ namespace NuGet.Commands
             var summaryRequest = new RestoreSummaryRequest(
                 request,
                 project.MSBuildProjectPath,
-                SettingsUtility.GetConfigFilePaths(settings),
+                settings.GetConfigFilePaths(),
                 sources);
 
             return summaryRequest;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -127,7 +127,7 @@ namespace NuGet.Commands
             {
                 throw new ArgumentNullException(nameof(settings));
             }
-            var values = settings.GetConfigRoots().AsList();
+            var values = settings.GetConfigRoots();
             if(dgSpecSources != null)
             {
                 values.AddRange(dgSpecSources.Select(e => e.Source));

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -127,7 +127,7 @@ namespace NuGet.Commands
             {
                 throw new ArgumentNullException(nameof(settings));
             }
-            var values = SettingsUtility.GetConfigRoots(settings).AsList();
+            var values = settings.GetConfigRoots().AsList();
             if(dgSpecSources != null)
             {
                 values.AddRange(dgSpecSources.Select(e => e.Source));

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
@@ -161,11 +161,11 @@ namespace NuGet.Configuration
         /// <summary>
         /// Get a list of all the paths of the settings files used as part of this settings object
         /// </summary>
-        IEnumerable<string> GetConfigFilePaths();
+        IList<string> GetConfigFilePaths();
 
         /// <summary>
         /// Get a list of all the roots of the settings files used as part of this settings object
         /// </summary>
-        IEnumerable<string> GetConfigRoots();
+        IList<string> GetConfigRoots();
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
@@ -157,5 +157,15 @@ namespace NuGet.Configuration
         /// Event raised when the setting have been changed.
         /// </summary>
         event EventHandler SettingsChanged;
+
+        /// <summary>
+        /// Get a list of all the paths of the settings files used as part of this settings object
+        /// </summary>
+        IEnumerable<string> GetConfigFilePaths();
+
+        /// <summary>
+        /// Get a list of all the roots of the settings files used as part of this settings object
+        /// </summary>
+        IEnumerable<string> GetConfigRoots();
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 
 namespace NuGet.Configuration
 {
@@ -20,6 +21,10 @@ namespace NuGet.Configuration
         public void Remove(string sectionName, SettingItem item) => throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.InvalidNullSettingsOperation, nameof(Remove)));
 
         public void SaveToDisk() { }
+
+        public IEnumerable<string> GetConfigFilePaths() => Enumerable.Empty<string>();
+
+        public IEnumerable<string> GetConfigRoots() => Enumerable.Empty<string>();
 
         //TODO: Remove deprecated methods https://github.com/NuGet/Home/issues/7294
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
@@ -22,9 +22,9 @@ namespace NuGet.Configuration
 
         public void SaveToDisk() { }
 
-        public IEnumerable<string> GetConfigFilePaths() => Enumerable.Empty<string>();
+        public IList<string> GetConfigFilePaths() => Enumerable.Empty<string>().ToList();
 
-        public IEnumerable<string> GetConfigRoots() => Enumerable.Empty<string>();
+        public IList<string> GetConfigRoots() => Enumerable.Empty<string>().ToList();
 
         //TODO: Remove deprecated methods https://github.com/NuGet/Home/issues/7294
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -576,6 +576,22 @@ namespace NuGet.Configuration
             return new Tuple<string, string>(fileName, directory);
         }
 
+        /// <summary>
+        /// Get a list of all the paths of the settings files used as part of this settings object
+        /// </summary>
+        public IEnumerable<string> GetConfigFilePaths()
+        {
+            return Priority.Select(config => Path.GetFullPath(Path.Combine(config.DirectoryPath, config.FileName)));
+        }
+
+        /// <summary>
+        /// Get a list of all the roots of the settings files used as part of this settings object
+        /// </summary>
+        public IEnumerable<string> GetConfigRoots()
+        {
+            return Priority.Select(config => config.DirectoryPath).Distinct();
+        }
+
         internal static string ResolvePathFromOrigin(string originDirectoryPath, string originFilePath, string path)
         {
             if (Uri.TryCreate(path, UriKind.Relative, out var _) &&

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -579,17 +579,17 @@ namespace NuGet.Configuration
         /// <summary>
         /// Get a list of all the paths of the settings files used as part of this settings object
         /// </summary>
-        public IEnumerable<string> GetConfigFilePaths()
+        public IList<string> GetConfigFilePaths()
         {
-            return Priority.Select(config => Path.GetFullPath(Path.Combine(config.DirectoryPath, config.FileName)));
+            return Priority.Select(config => Path.GetFullPath(Path.Combine(config.DirectoryPath, config.FileName))).ToList();
         }
 
         /// <summary>
         /// Get a list of all the roots of the settings files used as part of this settings object
         /// </summary>
-        public IEnumerable<string> GetConfigRoots()
+        public IList<string> GetConfigRoots()
         {
-            return Priority.Select(config => config.DirectoryPath).Distinct();
+            return Priority.Select(config => config.DirectoryPath).Distinct().ToList();
         }
 
         internal static string ResolvePathFromOrigin(string originDirectoryPath, string originFilePath, string path)

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -413,37 +413,10 @@ namespace NuGet.Configuration
         /// <summary>
         /// Get a list of all the paths of the settings files used as part of this settings object
         /// </summary>
+        [Obsolete("GetConfigFilePaths(ISettings) has been deprecated. Please use ISettings.GetConfigFilePaths() instead.", error: true)]
         public static IEnumerable<string> GetConfigFilePaths(ISettings settings)
         {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
-
-            if (settings is Settings settingsImpl)
-            {
-                return settingsImpl.Priority.Select(config => Path.GetFullPath(Path.Combine(config.DirectoryPath, config.FileName)));
-            }
-
-            return Enumerable.Empty<string>();
-        }
-
-        /// <summary>
-        /// Get a list of all the roots of the settings files used as part of this settings object
-        /// </summary>
-        public static IEnumerable<string> GetConfigRoots(ISettings settings)
-        {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
-
-            if (settings is Settings settingsImpl)
-            {
-                return settingsImpl.Priority.Select(config => config.DirectoryPath);
-            }
-
-            return Enumerable.Empty<string>();
+            throw new NotSupportedException();
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -413,10 +413,15 @@ namespace NuGet.Configuration
         /// <summary>
         /// Get a list of all the paths of the settings files used as part of this settings object
         /// </summary>
-        [Obsolete("GetConfigFilePaths(ISettings) has been deprecated. Please use ISettings.GetConfigFilePaths() instead.", error: true)]
+        [Obsolete("GetConfigFilePaths(ISettings) has been deprecated. Please use ISettings.GetConfigFilePaths() instead.")]
         public static IEnumerable<string> GetConfigFilePaths(ISettings settings)
         {
-            throw new NotSupportedException();
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            return settings.GetConfigFilePaths();
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
@@ -243,7 +243,7 @@ namespace NuGet.ProjectManagement.Projects
                 packageSpec.RestoreMetadata.PackagesPath = SettingsUtility.GetGlobalPackagesFolder(settings);
                 packageSpec.RestoreMetadata.Sources = SettingsUtility.GetEnabledSources(settings).AsList();
                 packageSpec.RestoreMetadata.FallbackFolders = SettingsUtility.GetFallbackPackageFolders(settings).AsList();
-                packageSpec.RestoreMetadata.ConfigFilePaths = SettingsUtility.GetConfigFilePaths(settings).AsList();
+                packageSpec.RestoreMetadata.ConfigFilePaths = settings.GetConfigFilePaths().AsList();
 
                 context?.PackageSpecCache.Add(MSBuildProjectPath, packageSpec);
             }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
@@ -243,7 +243,7 @@ namespace NuGet.ProjectManagement.Projects
                 packageSpec.RestoreMetadata.PackagesPath = SettingsUtility.GetGlobalPackagesFolder(settings);
                 packageSpec.RestoreMetadata.Sources = SettingsUtility.GetEnabledSources(settings).AsList();
                 packageSpec.RestoreMetadata.FallbackFolders = SettingsUtility.GetFallbackPackageFolders(settings).AsList();
-                packageSpec.RestoreMetadata.ConfigFilePaths = settings.GetConfigFilePaths().AsList();
+                packageSpec.RestoreMetadata.ConfigFilePaths = settings.GetConfigFilePaths();
 
                 context?.PackageSpecCache.Add(MSBuildProjectPath, packageSpec);
             }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -288,6 +289,84 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 errors.First().Code.Should().Be(NuGetLogCode.NU3005);
                 errors.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(_NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource));
                 errors.First().LibraryId.Should().Be(packageX.Id);
+
+                warnings.Count().Should().Be(0);
+
+                var installedPackageDir = Path.Combine(pathContext.UserPackagesFolder, packageX.Identity.Id);
+                Directory.Exists(installedPackageDir).Should().BeFalse();
+            }
+        }
+
+
+        [CIOnlyFact]
+        public async Task Restore_PackageWithCompressedSignature_RequireMode_FailsAndDoesNotExpandAsync()
+        {
+            // Arrange
+            var packageX = new SimpleTestPackageContext();
+
+            using (var pathContext = new SimpleTestPathContext())
+            using (var packageStream = await packageX.CreateAsStreamAsync())
+            using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
+            {
+                var signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+                using (var package = new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: true))
+                {
+                    var signatureEntry = package.CreateEntry(SigningSpecifications.V1.SignaturePath);
+                    using (var signatureStream = new MemoryStream(signature.GetBytes()))
+                    using (var signatureEntryStream = signatureEntry.Open())
+                    {
+                        signatureStream.CopyTo(signatureEntryStream);
+                    }
+                }
+
+                var packagePath = Path.Combine(pathContext.PackageSource, $"{packageX.ToString()}.nupkg");
+                packageStream.Seek(offset: 0, loc: SeekOrigin.Begin);
+
+                using (var fileStream = File.OpenWrite(packagePath))
+                {
+                    packageStream.CopyTo(fileStream);
+                }
+
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var propsFile = Path.Combine(pathContext.SolutionRoot, "NuGet.Config");
+
+                using (var stream = File.OpenWrite(propsFile))
+                using (var textWritter = new StreamWriter(stream))
+                {
+                    textWritter.Write(@"<configuration><config><add key=""signatureValidationMode"" value=""require"" /></config></configuration>");
+                }
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("NETStandard2.0"));
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                var args = new string[]
+                {
+                    projectA.ProjectPath
+                };
+
+                // Act
+                var result = RunRestore(_nugetExePath, pathContext, expectedExitCode: 1, additionalArgs: args);
+                var assetFileReader = new LockFileFormat();
+                var assetsFile = assetFileReader.Read(projectA.AssetsFileOutputPath);
+                var errors = assetsFile.LogMessages.Where(m => m.Level == LogLevel.Error);
+                var warnings = assetsFile.LogMessages.Where(m => m.Level == LogLevel.Warning);
+
+                // Assert
+                result.ExitCode.Should().Be(1);
+                result.Errors.Should().Contain(string.Format(_NU3005, SigningTestUtility.AddSignatureLogPrefix(_NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource)));
+
+                errors.Count().Should().Be(1);
+                errors.First().Code.Should().Be(NuGetLogCode.NU3005);
+                errors.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(_NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource));
+                errors.First().LibraryId.Should().Be(packageX.Identity.ToString());
 
                 warnings.Count().Should().Be(0);
 

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreSettingTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreSettingTaskTests.cs
@@ -92,7 +92,7 @@ namespace NuGet.Build.Tasks.Test
                 // Test
 
                 var settings = RestoreSettingsUtils.ReadSettings(mockBaseDirectory, mockBaseDirectory,null, machineWideSettings);
-                var filePaths = SettingsUtility.GetConfigFilePaths(settings);
+                var filePaths = settings.GetConfigFilePaths();
 
                 Assert.Equal(3, filePaths.Count()); // Solution, app data + machine wide
                 Assert.True(filePaths.Contains(Path.Combine(solutionDirectoryConfig, baseConfigPath)));
@@ -100,7 +100,7 @@ namespace NuGet.Build.Tasks.Test
 
                 // Test 
                  settings = RestoreSettingsUtils.ReadSettings(mockBaseDirectory, mockBaseDirectory, Path.Combine(subFolder, baseConfigPath), machineWideSettings);
-                 filePaths = SettingsUtility.GetConfigFilePaths(settings);
+                 filePaths = settings.GetConfigFilePaths();
 
                 Assert.Equal(1, filePaths.Count());
                 Assert.True(filePaths.Contains(Path.Combine(subFolder, baseConfigPath)));
@@ -135,8 +135,8 @@ namespace NuGet.Build.Tasks.Test
                 // Assert
                 Assert.Equal("inner-value", innerValue);
                 Assert.Equal("outer-value", outerValue);
-                Assert.True(SettingsUtility.GetConfigFilePaths(settings).Contains(innerConfigFile));
-                Assert.True(SettingsUtility.GetConfigFilePaths(settings).Contains(outerConfigFile));
+                Assert.True(settings.GetConfigFilePaths().Contains(innerConfigFile));
+                Assert.True(settings.GetConfigFilePaths().Contains(outerConfigFile));
             }
         }
 
@@ -440,7 +440,7 @@ namespace NuGet.Build.Tasks.Test
                 // Test
 
                 var settings = RestoreSettingsUtils.ReadSettings(null, probePath, null, machineWideSettings);
-                var filePaths = SettingsUtility.GetConfigFilePaths(settings);
+                var filePaths = settings.GetConfigFilePaths();
 
                 Assert.Equal(4, filePaths.Count()); // base, parent, app data + machine wide
                 Assert.Contains(Path.Combine(basePath, configName), filePaths);

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -1923,7 +1923,7 @@ namespace NuGet.Configuration.Test
                     Path.Combine(mockBaseDirectory, "nuget", "Config"), "IDE", "Version", "SKU", "TestDir");
 
                 // Assert
-                var files = settings.GetConfigFilePaths().ToArray();
+                var files = settings.GetConfigFilePaths();
 
                 files.Count().Should().Be(9);
                 files.Should().Contain(Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU", "a2.config"));
@@ -2223,7 +2223,7 @@ namespace NuGet.Configuration.Test
                                                                                           configPath10 });
 
                 // Assert
-                var files = settings.GetConfigFilePaths().ToArray();
+                var files = settings.GetConfigFilePaths();
 
                 files.Count().Should().Be(10);
                 files.Should().Contain(configPath1);
@@ -2300,7 +2300,7 @@ namespace NuGet.Configuration.Test
                 var configRoot6 = Path.Combine(mockBaseDirectory, "nuget");
 
                 // Assert
-                var files = settings.GetConfigRoots().ToArray();
+                var files = settings.GetConfigRoots();
 
                 files.Count().Should().Be(6);
                 files.Should().Contain(configRoot1);
@@ -5622,7 +5622,7 @@ namespace NuGet.Configuration.Test
                     Path.Combine(mockBaseDirectory, "nuget", "Config"), "IDE", "Version", "SKU", "TestDir");
 
                 // Assert
-                var files = settings.GetConfigFilePaths().ToArray();
+                var files = settings.GetConfigFilePaths();
 
                 Assert.Equal(9, files.Count());
                 Assert.True(files.Contains(Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU", "a2.config")));

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -1923,7 +1923,7 @@ namespace NuGet.Configuration.Test
                     Path.Combine(mockBaseDirectory, "nuget", "Config"), "IDE", "Version", "SKU", "TestDir");
 
                 // Assert
-                var files = SettingsUtility.GetConfigFilePaths(settings).ToArray();
+                var files = settings.GetConfigFilePaths().ToArray();
 
                 files.Count().Should().Be(9);
                 files.Should().Contain(Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU", "a2.config"));
@@ -2179,6 +2179,148 @@ namespace NuGet.Configuration.Test
             machineWidePathTuple.Item1.Should().Be("NuGet.Config");
             globalConfigTuple.Item2.Should().Be(Path.Combine(userSetting, "NuGet"));
             globalConfigTuple.Item1.Should().Be("NuGet.Config");
+        }
+
+        [Fact]
+        public void GetConfigFilePaths_ReadsFilesCorrectly()
+        {
+            // Arrange
+            var fileContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
+        <configuration>
+          <SectionName>
+            <add key=""key"" value=""value"" />
+          </SectionName>
+        </configuration>";
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile("a1.config", Path.Combine(mockBaseDirectory, "nuget"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a1.config", Path.Combine(mockBaseDirectory, "nuget", "Config"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a2.config", Path.Combine(mockBaseDirectory, "nuget", "Config"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a1.config", Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a2.config", Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a1.config", Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a2.config", Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a1.config", Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a2.config", Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a1.config", Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU", "Dir"), fileContent);
+
+                var configPath1 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU", "Dir", "a1.config");
+                var configPath2 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU", "a1.config");
+                var configPath3 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU", "a2.config");
+                var configPath4 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "a1.config");
+                var configPath5 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "a2.config");
+                var configPath6 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "a1.config");
+                var configPath7 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "a2.config");
+                var configPath8 = Path.Combine(mockBaseDirectory, "nuget", "Config", "a1.config");
+                var configPath9 = Path.Combine(mockBaseDirectory, "nuget", "Config", "a2.config");
+                var configPath10 = Path.Combine(mockBaseDirectory, "nuget", "a1.config");
+
+                // Act
+                var settings = Settings.LoadSettingsGivenConfigPaths(new List<string>() { configPath1, configPath2, configPath3,
+                                                                                          configPath4, configPath5, configPath6,
+                                                                                          configPath7, configPath8, configPath9,
+                                                                                          configPath10 });
+
+                // Assert
+                var files = settings.GetConfigFilePaths().ToArray();
+
+                files.Count().Should().Be(10);
+                files.Should().Contain(configPath1);
+                files.Should().Contain(configPath2);
+                files.Should().Contain(configPath3);
+                files.Should().Contain(configPath4);
+                files.Should().Contain(configPath5);
+                files.Should().Contain(configPath6);
+                files.Should().Contain(configPath7);
+                files.Should().Contain(configPath8);
+                files.Should().Contain(configPath9);
+                files.Should().Contain(configPath10);
+            }
+        }
+
+        [Fact]
+        public void GetConfigFilePaths_SettingsWithoutFiles_ReturnEmptyList()
+        {
+            var settings = new Settings(settingsHead: null);
+
+            var configFilePaths = settings.GetConfigFilePaths();
+
+            configFilePaths.Should().NotBeNull();
+            configFilePaths.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GetConfigRoots_ReadsFilesCorrectly()
+        {
+            // Arrange
+            var fileContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
+        <configuration>
+          <SectionName>
+            <add key=""key"" value=""value"" />
+          </SectionName>
+        </configuration>";
+
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile("a1.config", Path.Combine(mockBaseDirectory, "nuget"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a1.config", Path.Combine(mockBaseDirectory, "nuget", "Config"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a2.config", Path.Combine(mockBaseDirectory, "nuget", "Config"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a1.config", Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a2.config", Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a1.config", Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a2.config", Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a1.config", Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a2.config", Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU"), fileContent);
+                SettingsTestUtils.CreateConfigurationFile("a1.config", Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU", "Dir"), fileContent);
+
+                var configPath1 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU", "Dir", "a1.config");
+                var configPath2 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU", "a1.config");
+                var configPath3 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU", "a2.config");
+                var configPath4 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "a1.config");
+                var configPath5 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "a2.config");
+                var configPath6 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "a1.config");
+                var configPath7 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "a2.config");
+                var configPath8 = Path.Combine(mockBaseDirectory, "nuget", "Config", "a1.config");
+                var configPath9 = Path.Combine(mockBaseDirectory, "nuget", "Config", "a2.config");
+                var configPath10 = Path.Combine(mockBaseDirectory, "nuget", "a1.config");
+
+                // Act
+                var settings = Settings.LoadSettingsGivenConfigPaths(new List<string>() { configPath1, configPath2, configPath3,
+                                                                                          configPath4, configPath5, configPath6,
+                                                                                          configPath7, configPath8, configPath9,
+                                                                                          configPath10 });
+
+
+                var configRoot1 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU", "Dir");
+                var configRoot2 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU");
+                var configRoot3 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version");
+                var configRoot4 = Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE");
+                var configRoot5 = Path.Combine(mockBaseDirectory, "nuget", "Config");
+                var configRoot6 = Path.Combine(mockBaseDirectory, "nuget");
+
+                // Assert
+                var files = settings.GetConfigRoots().ToArray();
+
+                files.Count().Should().Be(6);
+                files.Should().Contain(configRoot1);
+                files.Should().Contain(configRoot2);
+                files.Should().Contain(configRoot3);
+                files.Should().Contain(configRoot4);
+                files.Should().Contain(configRoot5);
+                files.Should().Contain(configRoot6);
+            }
+        }
+
+        [Fact]
+        public void GetConfigRoots_SettingsWithoutFiles_ReturnEmptyList()
+        {
+            var settings = new Settings(settingsHead: null);
+
+            var configRoots = settings.GetConfigRoots();
+
+            configRoots.Should().NotBeNull();
+            configRoots.Should().BeEmpty();
         }
 
         //TODO: remove deprecated APIs
@@ -5480,7 +5622,7 @@ namespace NuGet.Configuration.Test
                     Path.Combine(mockBaseDirectory, "nuget", "Config"), "IDE", "Version", "SKU", "TestDir");
 
                 // Assert
-                var files = SettingsUtility.GetConfigFilePaths(settings).ToArray();
+                var files = settings.GetConfigFilePaths().ToArray();
 
                 Assert.Equal(9, files.Count());
                 Assert.True(files.Contains(Path.Combine(mockBaseDirectory, "nuget", "Config", "IDE", "Version", "SKU", "a2.config")));

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
@@ -280,5 +280,17 @@ namespace NuGet.Configuration.Test
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
         }
+
+        //TODO: Delete all obsolete APIs. https://github.com/NuGet/Home/issues/7294
+#pragma warning disable CS0618 // Type or member is obsolete
+        [Fact]
+        public void GetConfigFilePaths_WithNullSettings_Throws()
+        {
+            var ex = Record.Exception(() => SettingsUtility.GetConfigFilePaths(settings: null));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
@@ -280,23 +280,5 @@ namespace NuGet.Configuration.Test
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
         }
-
-        [Fact]
-        public void GetConfigFilePaths_WithNullSettings_Throws()
-        {
-            var ex = Record.Exception(() => SettingsUtility.GetConfigFilePaths(settings: null));
-
-            ex.Should().NotBeNull();
-            ex.Should().BeOfType<ArgumentNullException>();
-        }
-
-        [Fact]
-        public void GetConfigRoots_WithNullSettings_Throws()
-        {
-            var ex = Record.Exception(() => SettingsUtility.GetConfigRoots(settings: null));
-
-            ex.Should().NotBeNull();
-            ex.Should().BeOfType<ArgumentNullException>();
-        }
     }
 }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7461
Regression: **Yes**
If Regression then when did it last work: **15.8**
If Regression then how are we preventing it in future: **Add vendor testing for client policy scenarios**

## Fix
As part of https://github.com/NuGet/NuGet.Client/pull/2370, `SettingsUtility.GetConfigRoots()` was added, the implementation for `SettingsUtility.GetConfigFilePaths()` was changed and `Priority` was removed from `ISettings` and made internal in `Settings`.

The implementation for these methods assumed that the only implementation of `ISettings` that we used and had enough information to get the config roots and file paths was `Settings`. 

Since we also use `VSSettings`, whenever any of these methods is being called from Visual Studio using `VSSettings`, these will return an empty list. 

This brought an issue where in restore, the settings where always being set to `NullSettings` and therefore we could not read some things correctly (i.e. any client policy related information).

This PR fixes that by moving the implementation of these methods to `ISettings` and deprecating `SettingsUtility.GetConfigFilePaths()` so customers using this API know how to get the same behavior.
The other approach that could be taken is to add back `Priority` to `ISettings`. For this change we would need to make expose not only `Priority`, but also `SettingsFile`.

## Testing/Validation
I will write a couple of test cases for nuget vendor team to test manually with each signing run.

/cc. @rido-min @rrelyea 
