### PR TITLE
Fix the test compilation error in NuGetPackCommandTest

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -5093,7 +5093,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     Assert.Equal(packageName, nuspecReader.GetId());
                     Assert.Equal(version, nuspecReader.GetVersion().ToFullString());
                     Assert.Equal(requireLicenseAcceptance, nuspecReader.GetRequireLicenseAcceptance());
-                    Assert.Equal(LicenseMetadata.DeprecateUrl, new Uri(nuspecReader.GetLicenseUrl()));
+                    Assert.Equal(LicenseMetadata.LicenseFileDeprecationUrl, new Uri(nuspecReader.GetLicenseUrl()));
                     var licenseMetadata = nuspecReader.GetLicenseMetadata();
                     Assert.NotNull(licenseMetadata);
                     Assert.Equal(licenseMetadata.Type, LicenseType.File);


### PR DESCRIPTION
## Bug
Fixes: 
Regression:   
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 

In https://github.com/NuGet/NuGet.Client/pull/2500, VS refactoring did not catch the change in the NuGetPackCommandTest

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  
Validation done:  
