### PR TITLE
Remove obsolete API from settingsUtility

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -408,20 +408,6 @@ namespace NuGet.Configuration
         }
 
         /// <summary>
-        /// Get a list of all the paths of the settings files used as part of this settings object
-        /// </summary>
-        [Obsolete("GetConfigFilePaths(ISettings) has been deprecated. Please use ISettings.GetConfigFilePaths() instead.")]
-        public static IEnumerable<string> GetConfigFilePaths(ISettings settings)
-        {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
-
-            return settings.GetConfigFilePaths();
-        }
-
-        /// <summary>
         /// Throw if a path is relative.
         /// </summary>
         private static void VerifyPathIsRooted(string key, string path)

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsUtilityTests.cs
@@ -289,17 +289,5 @@ namespace NuGet.Configuration.Test
             ex.Should().NotBeNull();
             ex.Should().BeOfType<ArgumentNullException>();
         }
-
-        //TODO: Delete all obsolete APIs. https://github.com/NuGet/Home/issues/7294
-#pragma warning disable CS0618 // Type or member is obsolete
-        [Fact]
-        public void GetConfigFilePaths_WithNullSettings_Throws()
-        {
-            var ex = Record.Exception(() => SettingsUtility.GetConfigFilePaths(settings: null));
-
-            ex.Should().NotBeNull();
-            ex.Should().BeOfType<ArgumentNullException>();
-        }
-#pragma warning restore CS0618 // Type or member is obsolete
     }
 }


### PR DESCRIPTION
As part of https://github.com/NuGet/NuGet.Client/pull/2506, `GetConfigFilePaths` was made obsolete in 15.9... This PR is to remove it 16.0.