### PR TITLE
Add package details URL to package management UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailedPackageMetadata.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailedPackageMetadata.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using NuGet.Packaging;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -41,6 +40,25 @@ namespace NuGet.PackageManagement.UI
             PrefixReserved = serverData.PrefixReserved;
             LicenseMetadata = serverData.LicenseMetadata;
             _localMetadata = serverData as LocalPackageSearchMetadata;
+
+            // Determine the package detauls URL and text.
+            PackageDetailsUrl = null;
+            PackageDetailsText = null;
+            if (serverData.PackageDetailsUrl != null
+                && serverData.PackageDetailsUrl.IsAbsoluteUri
+                && serverData.PackageDetailsUrl.Host != null)
+            {
+                PackageDetailsUrl = serverData.PackageDetailsUrl;
+                PackageDetailsText = serverData.PackageDetailsUrl.Host;
+
+                // Special case the subdomain "www." - we hide it. Other subdomains are not hidden.
+                const string wwwDot = "www.";
+                if (PackageDetailsText.StartsWith(wwwDot, StringComparison.OrdinalIgnoreCase)
+                    && PackageDetailsText.Length > wwwDot.Length)
+                {
+                    PackageDetailsText = PackageDetailsText.Substring(wwwDot.Length);
+                }
+            }
         }
 
         private readonly LocalPackageSearchMetadata _localMetadata;
@@ -64,6 +82,10 @@ namespace NuGet.PackageManagement.UI
         public Uri ProjectUrl { get; set; }
 
         public Uri ReportAbuseUrl { get; set; }
+
+        public Uri PackageDetailsUrl { get; set; }
+
+        public string PackageDetailsText { get; set; }
 
         public string Tags { get; set; }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.PackageManagement.UI {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -57,6 +57,24 @@ namespace NuGet.PackageManagement.UI {
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package details URL icon.
+        /// </summary>
+        public static string Accessibility_PackageDetailsUrlIcon {
+            get {
+                return ResourceManager.GetString("Accessibility_PackageDetailsUrlIcon", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package details link.
+        /// </summary>
+        public static string Accessibility_PackageDetailsUrlLink {
+            get {
+                return ResourceManager.GetString("Accessibility_PackageDetailsUrlLink", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -838,4 +838,10 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="WindowTitle_LicenseFileWindow" xml:space="preserve">
     <value>{0} License</value>
   </data>
+  <data name="Accessibility_PackageDetailsUrlIcon" xml:space="preserve">
+    <value>Package details URL icon</value>
+  </data>
+  <data name="Accessibility_PackageDetailsUrlLink" xml:space="preserve">
+    <value>Package details link</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DetailControl.xaml
@@ -6,6 +6,7 @@
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
+  xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
   Background="{Binding UIBrushes.DetailPaneBackground }"
   x:Name="_self"
   mc:Ignorable="d"
@@ -49,8 +50,7 @@
       <Grid
         Grid.Row="0"
         MinHeight="32"
-        Margin="0,8"
-        HorizontalAlignment="Left">
+        Margin="0,8">
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="auto"/>
           <ColumnDefinition Width="*"/>
@@ -61,25 +61,64 @@
           Margin="0,0,8,0"
           AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PackageIcon}"
           Style="{StaticResource PackageIconImageStyle}" />
-        <TextBox
-          Grid.Column="1"
-          Name="_packageId"
-          AutomationProperties.Name="{Binding Path=Id, Mode=OneWay}"
-          Style="{DynamicResource SelectableTextBlockStyle}"
-          Text="{Binding Path=Id, Mode=OneWay}"
-          FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font155PercentSizeConverter}}" />
-        <imaging:CrispImage
+        <Grid
+          Grid.Column="1">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="auto"/>
+            <ColumnDefinition Width="auto"/>
+          </Grid.ColumnDefinitions>
+          <TextBox
+            Grid.Column="0"
+            Name="_packageId"
+            AutomationProperties.Name="{Binding Path=Id, Mode=OneWay}"
+            Style="{DynamicResource SelectableTextBlockStyle}"
+            Text="{Binding Path=Id, Mode=OneWay}"
+            FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font155PercentSizeConverter}}" />
+          <imaging:CrispImage
+            Grid.Column="1"
+            x:Name="_prefixReservedMark"
+            Grid.Row="0"
+            Margin="5,7,0,0"
+            Width="16"
+            Height="16"
+            VerticalAlignment="Top"
+            AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PrefixReserved}"
+            Visibility="{Binding Path=PrefixReserved, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
+            ToolTip="{x:Static nuget:Resources.Tooltip_PrefixReserved}"
+            Moniker="{x:Static nuget:PackageIconMonikers.PrefixReservedIndicator}" />
+        </Grid>
+        <Grid
           Grid.Column="2"
-          x:Name="_prefixReservedMark"
           Grid.Row="0"
-          Margin="5,7,0,0"
-          Width="16"
-          Height="16"
-          VerticalAlignment="Top"
-          AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PrefixReserved}"
-          Visibility="{Binding Path=PrefixReserved, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
-          ToolTip="{x:Static nuget:Resources.Tooltip_PrefixReserved}"
-          Moniker="{x:Static nuget:PackageIconMonikers.PrefixReservedIndicator}" />
+          Visibility="{Binding Path=PackageMetadata.PackageDetailsUrl, FallbackValue=Collapsed, Converter={StaticResource NullToVisibilityConverter}}">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="auto"/>
+            <ColumnDefinition Width="auto"/>
+          </Grid.ColumnDefinitions>
+          <imaging:CrispImage
+            x:Name="_packageDetailsUrlIcon"
+            Width="20"
+            Height="20"
+            Grid.Column="0"
+            VerticalAlignment="Top"
+            Margin="0,5,0,0"
+            AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PackageDetailsUrlIcon}"
+            Moniker="{x:Static catalog:KnownMonikers.OpenWebSite}" />
+          <TextBlock
+            x:Name="_packageDetailsUrlLink"
+            Grid.Column="1"
+            VerticalAlignment="Top"
+            Margin="5,7,0,0">
+            <Hyperlink
+              NavigateUri="{Binding Path=PackageMetadata.PackageDetailsUrl}"
+              Style="{StaticResource HyperlinkStyle}"
+              AutomationProperties.Name="{x:Static nuget:Resources.Accessibility_PackageDetailsUrlLink}"
+              ToolTip="{Binding Path=PackageMetadata.PackageDetailsUrl}"
+              Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}">
+              <Run Text="{Binding Path=PackageMetadata.PackageDetailsText}" />
+            </Hyperlink>
+          </TextBlock>
+        </Grid>
       </Grid>
 
       <!-- project action when in project package manager -->

--- a/src/NuGet.Core/NuGet.Protocol/Constants.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Constants.cs
@@ -13,11 +13,13 @@ namespace NuGet.Protocol
         public static readonly string Version470 = "/4.7.0";
         public static readonly string Version490 = "/4.9.0";
         public static readonly string Version500 = "/5.0.0";
+        public static readonly string Version510 = "/5.1.0";
 
         public static readonly string[] SearchQueryService = { "SearchQueryService" + Versioned, "SearchQueryService" + Version340, "SearchQueryService" + Version300beta };
         public static readonly string[] RegistrationsBaseUrl = { "RegistrationsBaseUrl" + Versioned, "RegistrationsBaseUrl" + Version340, "RegistrationsBaseUrl" + Version300beta };
         public static readonly string[] SearchAutocompleteService = { "SearchAutocompleteService" + Versioned, "SearchAutocompleteService" + Version300beta };
         public static readonly string[] ReportAbuse = { "ReportAbuseUriTemplate" + Versioned, "ReportAbuseUriTemplate" + Version300 };
+        public static readonly string[] PackageDetailsUriTemplate = { "PackageDetailsUriTemplate" + Version510 };
         public static readonly string[] LegacyGallery = { "LegacyGallery" + Versioned, "LegacyGallery" + Version200 };
         public static readonly string[] PackagePublish = { "PackagePublish" + Versioned, "PackagePublish" + Version200 };
         public static readonly string[] PackageBaseAddress = { "PackageBaseAddress" + Versioned, "PackageBaseAddress" + Version300 };

--- a/src/NuGet.Core/NuGet.Protocol/FactoryExtensionsV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/FactoryExtensionsV3.cs
@@ -37,6 +37,7 @@ namespace NuGet.Protocol
             yield return new Lazy<INuGetResourceProvider>(() => new RegistrationResourceV3Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new SymbolPackageUpdateResourceV3Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new ReportAbuseResourceV3Provider());
+            yield return new Lazy<INuGetResourceProvider>(() => new PackageDetailsUriResourceV3Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new ServiceIndexResourceV3Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new ODataServiceDocumentResourceV2Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new HttpHandlerResourceV3Provider());

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedPackageInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedPackageInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -27,6 +27,7 @@ namespace NuGet.Protocol
         private readonly string _licenseUrl;
         private readonly string _projectUrl;
         private readonly string _reportAbuseUrl;
+        private readonly string _galleryDetailsUrl;
         private readonly string _tags;
         private readonly string _downloadCount;
         private readonly bool _requireLicenseAcceptance;
@@ -41,7 +42,7 @@ namespace NuGet.Protocol
         private const string NullString = "null";
 
         public V2FeedPackageInfo(PackageIdentity identity, string title, string summary, string description, IEnumerable<string> authors, IEnumerable<string> owners,
-            string iconUrl, string licenseUrl, string projectUrl, string reportAbuseUrl,
+            string iconUrl, string licenseUrl, string projectUrl, string reportAbuseUrl, string galleryDetailsUrl,
             string tags, DateTimeOffset? created, DateTimeOffset? lastEdited, DateTimeOffset? published, string dependencies, bool requireLicenseAccept, string downloadUrl, string downloadCount,
             string packageHash, string packageHashAlgorithm, NuGetVersion minClientVersion)
             : base(identity.Id, identity.Version)
@@ -54,6 +55,7 @@ namespace NuGet.Protocol
             _licenseUrl = licenseUrl;
             _projectUrl = projectUrl;
             _reportAbuseUrl = reportAbuseUrl;
+            _galleryDetailsUrl = galleryDetailsUrl;
             _description = description;
             _summary = summary;
             _tags = tags;
@@ -147,6 +149,14 @@ namespace NuGet.Protocol
             get
             {
                 return _reportAbuseUrl;
+            }
+        }
+
+        public string GalleryDetailsUrl
+        {
+            get
+            {
+                return _galleryDetailsUrl;
             }
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedParser.cs
@@ -43,6 +43,7 @@ namespace NuGet.Protocol
         private static readonly XName _xnameLicenseUrl = XName.Get("LicenseUrl", DataServicesNS);
         private static readonly XName _xnameProjectUrl = XName.Get("ProjectUrl", DataServicesNS);
         private static readonly XName _xnameTags = XName.Get("Tags", DataServicesNS);
+        private static readonly XName _xnameGalleryDetailsUrl = XName.Get("GalleryDetailsUrl", DataServicesNS);
         private static readonly XName _xnameReportAbuseUrl = XName.Get("ReportAbuseUrl", DataServicesNS);
         private static readonly XName _xnameDependencies = XName.Get("Dependencies", DataServicesNS);
         private static readonly XName _xnameRequireLicenseAcceptance = XName.Get("RequireLicenseAcceptance", DataServicesNS);
@@ -345,6 +346,7 @@ namespace NuGet.Protocol
             var iconUrl = metadataCache.GetString(GetString(properties, _xnameIconUrl));
             var licenseUrl = metadataCache.GetString(GetString(properties, _xnameLicenseUrl));
             var projectUrl = metadataCache.GetString(GetString(properties, _xnameProjectUrl));
+            var galleryDetailsUrl = metadataCache.GetString(GetString(properties, _xnameGalleryDetailsUrl));
             var reportAbuseUrl = metadataCache.GetString(GetString(properties, _xnameReportAbuseUrl));
             var tags = metadataCache.GetString(GetString(properties, _xnameTags));
             var dependencies = metadataCache.GetString(GetString(properties, _xnameDependencies));
@@ -380,9 +382,9 @@ namespace NuGet.Protocol
             }
 
             return new V2FeedPackageInfo(new PackageIdentity(identityId, version), title, summary, description, authors,
-                owners, iconUrl, licenseUrl, projectUrl, reportAbuseUrl, tags, created, lastEdited, published,
-                dependencies, requireLicenseAcceptance, downloadUrl, downloadCount, packageHash, packageHashAlgorithm,
-                minClientVersion);
+                owners, iconUrl, licenseUrl, projectUrl, reportAbuseUrl, galleryDetailsUrl, tags, created, lastEdited,
+                published, dependencies, requireLicenseAcceptance, downloadUrl, downloadCount, packageHash,
+                packageHashAlgorithm, minClientVersion);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/Model/IPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/IPackageSearchMetadata.cs
@@ -24,6 +24,7 @@ namespace NuGet.Protocol.Core.Types
         Uri LicenseUrl { get; }
         Uri ProjectUrl { get; }
         Uri ReportAbuseUrl { get; }
+        Uri PackageDetailsUrl { get; }
         DateTimeOffset? Published { get; }
         string Owners { get; }
         bool RequireLicenseAcceptance { get; }

--- a/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
@@ -49,6 +49,8 @@ namespace NuGet.Protocol
         // There is no report abuse url for local packages.
         public Uri ReportAbuseUrl => null;
 
+        public Uri PackageDetailsUrl => null;
+
         public bool RequireLicenseAcceptance => _nuspec.GetRequireLicenseAcceptance();
 
         public string Summary => !string.IsNullOrEmpty(_nuspec.GetSummary()) ? _nuspec.GetSummary() : Description;

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
@@ -67,6 +67,9 @@ namespace NuGet.Protocol
         [JsonIgnore]
         public Uri ReportAbuseUrl { get; set; }
 
+        [JsonIgnore]
+        public Uri PackageDetailsUrl { get; set; }
+
         [JsonProperty(PropertyName = JsonProperties.RequireLicenseAcceptance, DefaultValueHandling = DefaultValueHandling.Populate)]
         [DefaultValue(false)]
         [JsonConverter(typeof(SafeBoolConverter))]

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataBuilder.cs
@@ -32,6 +32,7 @@ namespace NuGet.Protocol.Core.Types
             public Uri ProjectUrl { get; set; }
             public DateTimeOffset? Published { get; set; }
             public Uri ReportAbuseUrl { get; set; }
+            public Uri PackageDetailsUrl { get; set; }
             public bool RequireLicenseAcceptance { get; set; }
             public string Summary { get; set; }
             public string Tags { get; set; }
@@ -76,6 +77,7 @@ namespace NuGet.Protocol.Core.Types
                 ProjectUrl = _metadata.ProjectUrl,
                 Published = _metadata.Published,
                 ReportAbuseUrl = _metadata.ReportAbuseUrl,
+                PackageDetailsUrl = _metadata.PackageDetailsUrl,
                 RequireLicenseAcceptance = _metadata.RequireLicenseAcceptance,
                 Summary = _metadata.Summary,
                 Tags = _metadata.Tags,

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
@@ -28,6 +28,7 @@ namespace NuGet.Protocol
             LastEdited = package.LastEdited;
             Published = package.Published;
             ReportAbuseUrl = GetUriSafe(package.ReportAbuseUrl);
+            PackageDetailsUrl = GetUriSafe(package.GalleryDetailsUrl);
             RequireLicenseAcceptance = package.RequireLicenseAcceptance;
             Summary = package.Summary;
             Tags = package.Tags;
@@ -55,6 +56,7 @@ namespace NuGet.Protocol
             LastEdited = package.LastEdited;
             Published = package.Published;
             ReportAbuseUrl = GetUriSafe(package.ReportAbuseUrl);
+            PackageDetailsUrl = GetUriSafe(package.GalleryDetailsUrl);
             RequireLicenseAcceptance = package.RequireLicenseAcceptance;
             Summary = package.Summary;
             Tags = package.Tags;
@@ -99,6 +101,8 @@ namespace NuGet.Protocol
         public DateTimeOffset? Published { get; private set; }
 
         public Uri ReportAbuseUrl { get; private set; }
+
+        public Uri PackageDetailsUrl { get; private set; }
 
         public bool RequireLicenseAcceptance { get; private set; }
 

--- a/src/NuGet.Core/NuGet.Protocol/Providers/PackageDetailsUriResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/PackageDetailsUriResourceV3Provider.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.Protocol
+{
+    public class PackageDetailsUriResourceV3Provider : ResourceProvider
+    {
+        public PackageDetailsUriResourceV3Provider()
+            : base(typeof(PackageDetailsUriResourceV3),
+                  nameof(PackageDetailsUriResourceV3),
+                  NuGetResourceProviderPositions.Last)
+        {
+        }
+
+        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        {
+            PackageDetailsUriResourceV3 resource = null;
+            var serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
+            if (serviceIndex != null)
+            {
+                var uri = serviceIndex.GetServiceEntryUri(ServiceTypes.PackageDetailsUriTemplate);
+                resource = PackageDetailsUriResourceV3.CreateOrNull(uri?.OriginalString);
+            }
+
+            return new Tuple<bool, INuGetResource>(resource != null, resource);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Providers/PackageMetadataResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/PackageMetadataResourceV3Provider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -24,11 +24,16 @@ namespace NuGet.Protocol
             {
                 var regResource = await source.GetResourceAsync<RegistrationResourceV3>();
                 var reportAbuseResource = await source.GetResourceAsync<ReportAbuseResourceV3>();
+                var packageDetailsUriResource = await source.GetResourceAsync<PackageDetailsUriResourceV3>();
 
                 var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
 
                 // construct a new resource
-                curResource = new PackageMetadataResourceV3(httpSourceResource.HttpSource, regResource, reportAbuseResource);
+                curResource = new PackageMetadataResourceV3(
+                    httpSourceResource.HttpSource,
+                    regResource,
+                    reportAbuseResource,
+                    packageDetailsUriResource);
             }
 
             return new Tuple<bool, INuGetResource>(curResource != null, curResource);

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageDetailsUriResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageDetailsUriResourceV3.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+namespace NuGet.Protocol
+{
+    public class PackageDetailsUriResourceV3 : INuGetResource
+    {
+        private readonly string _template;
+
+        private PackageDetailsUriResourceV3(string template)
+        {
+            _template = template ?? throw new ArgumentNullException(nameof(template));
+        }
+
+        public static PackageDetailsUriResourceV3 CreateOrNull(string uriTemplate)
+        {
+            if (string.IsNullOrWhiteSpace(uriTemplate)
+                || !IsValidUriTemplate(uriTemplate))
+            {
+                return null;
+            }
+
+            return new PackageDetailsUriResourceV3(uriTemplate);
+        }
+
+        private static bool IsValidUriTemplate(string uriTemplate)
+        {
+            Uri uri;
+            var isValidUri = Uri.TryCreate(uriTemplate, UriKind.Absolute, out uri);
+
+            // Only allow HTTPS package details URLs.
+            if (isValidUri && !uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return isValidUri;
+        }
+
+        /// <summary>
+        /// Gets a URL for viewing package details outside of Visual Studio. The URL will not be verified to exist.
+        /// </summary>
+        /// <param name="id">The package id (any casing).</param>
+        /// <param name="version">The package version.</param>
+        /// <returns>The first URL from the resource, with the URI template applied.</returns>
+        public Uri GetUri(string id, NuGetVersion version)
+        {
+            var uriString = _template
+               .Replace("{id}", id)
+               .Replace("{version}", version.ToNormalizedString());
+
+            return new Uri(uriString);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
@@ -15,13 +15,19 @@ namespace NuGet.Protocol
     {
         private readonly RegistrationResourceV3 _regResource;
         private readonly ReportAbuseResourceV3 _reportAbuseResource;
+        private readonly PackageDetailsUriResourceV3 _packageDetailsUriResource;
         private readonly HttpSource _client;
 
-        public PackageMetadataResourceV3(HttpSource client, RegistrationResourceV3 regResource, ReportAbuseResourceV3 reportAbuseResource)
+        public PackageMetadataResourceV3(
+            HttpSource client,
+            RegistrationResourceV3 regResource,
+            ReportAbuseResourceV3 reportAbuseResource,
+            PackageDetailsUriResourceV3 packageDetailsUriResource)
         {
             _regResource = regResource;
             _client = client;
             _reportAbuseResource = reportAbuseResource;
+            _packageDetailsUriResource = packageDetailsUriResource;
         }
 
         public override async Task<IEnumerable<IPackageSearchMetadata>> GetMetadataAsync(
@@ -61,6 +67,7 @@ namespace NuGet.Protocol
         {
             var parsed = metadata.FromJToken<PackageSearchMetadataRegistration>();
             parsed.ReportAbuseUrl = _reportAbuseResource?.GetReportAbuseUrl(parsed.PackageId, parsed.Version);
+            parsed.PackageDetailsUrl = _packageDetailsUriResource?.GetUri(parsed.PackageId, parsed.Version);
             return parsed;
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/DetailedPackageMetadataTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/DetailedPackageMetadataTests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Moq;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.PackageManagement.UI
+{
+    public class DetailedPackageMetadataTests
+    {
+        [Theory]
+        [InlineData("https://www.nuget.org/", "nuget.org")]
+        [InlineData("https://wwwnuget.example/", "wwwnuget.example")]
+        [InlineData("https://foo.www.nuget.org/", "foo.www.nuget.org")]
+        [InlineData("https://WWW.NUGET.ORG/", "nuget.org")]
+        [InlineData("https://wWw.NUGET.ORG/", "nuget.org")]
+        [InlineData("https://www.nüget.org/", "nüget.org")]
+        [InlineData("https://nuget.org/", "nuget.org")]
+        [InlineData("https://www.nugettest.org/", "nugettest.org")]
+        [InlineData("https://dev.nugettest.org/", "dev.nugettest.org")]
+        [InlineData("https://www.example/", "example")]
+        [InlineData("https://www/", "www")]
+        [InlineData("https://www./", "www.")]
+        [InlineData("https://www.a/", "a")]
+        [InlineData("https://example/", "example")]
+        [InlineData("https://dotnet.myget.example/", "dotnet.myget.example")]
+        [InlineData("https://www.myget.example/", "myget.example")]
+        [InlineData("http://www.nuget.org/", "nuget.org")]
+        [InlineData("ftp://www.nuget.org/", "nuget.org")]
+        public void RemovesWwwSubdomainFromPackageDetailsText(string url, string expected)
+        {
+            var metadata = new Mock<IPackageSearchMetadata>();
+            metadata.Setup(x => x.Identity).Returns(new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("4.3.0")));
+            metadata.Setup(x => x.PackageDetailsUrl).Returns(() => new Uri(url));
+
+            var target = new DetailedPackageMetadata(metadata.Object, downloadCount: null);
+
+            Assert.Equal(expected, target.PackageDetailsText);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
@@ -29,6 +29,7 @@
     <Compile Include="Converters\VersionToStringConverterTests.cs" />
     <Compile Include="ConverterTests.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Models\DetailedPackageMetadataTests.cs" />
     <Compile Include="PackageItemLoaderTests.cs" />
     <Compile Include="PackageLicenseUtilitiesTests.cs" />
     <Compile Include="PackageManagerListItemsTest.cs" />

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalPackageMetadataResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalPackageMetadataResourceTests.cs
@@ -308,6 +308,7 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(new Uri("http://nuget.org/"), package.ProjectUrl);
                 Assert.NotNull(package.Published);
                 Assert.Null(package.ReportAbuseUrl);
+                Assert.Null(package.PackageDetailsUrl);
                 Assert.True(package.RequireLicenseAcceptance);
                 Assert.Equal("sum", package.Summary);
                 Assert.Equal("a b c", package.Tags);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageDetailsUriResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageDetailsUriResourceV3Tests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class PackageDetailsUriResourceV3Tests
+    {
+        [Theory]
+        [InlineData("https://ex/packages/{id}/{version}", "https://ex/packages/Test/1.0.0-ALPHA")]
+        [InlineData("HTTPS://EX/packages/{id}/{version}", "https://ex/packages/Test/1.0.0-ALPHA")]
+        [InlineData("https://ex/packages/{id}", "https://ex/packages/Test")]
+        [InlineData("https://ex/packages/{version}", "https://ex/packages/1.0.0-ALPHA")]
+        [InlineData("https://ex/packages", "https://ex/packages")]
+        [InlineData("https://ex", "https://ex/")]
+        public void GetUriReplacesIdAndVersionTokensInUriTemplateWhenAvailable(string template, string expected)
+        {
+            var resource = PackageDetailsUriResourceV3.CreateOrNull(template);
+
+            var actual = resource.GetUri("Test", NuGetVersion.Parse("1.0.0.0-ALPHA+git"));
+
+            Assert.Equal(expected, actual.ToString());
+        }
+
+        [Theory]
+        [InlineData("ex/packages/{id}/{version}")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  \t\n")]
+        [InlineData("foo!")]
+        [InlineData("https://")]
+        [InlineData("http://ex/packages")]
+        [InlineData("ftp://ex/packages")]
+        [InlineData("//ex/packages")]
+        [InlineData("../somepath")]
+        [InlineData(@"C:\packages\{id}\{version}\index.html")]
+        [InlineData("http://unit.test/packages/{id}/{version}")]
+        [InlineData("file:///my/path")]
+        public void CreateOrNullReturnsNullForInvalid(string template)
+        {
+            var resource = PackageDetailsUriResourceV3.CreateOrNull(template);
+
+            Assert.Null(resource);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchMetadataV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchMetadataV2FeedTests.cs
@@ -1,10 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using Xunit;
@@ -22,8 +20,8 @@ namespace NuGet.Protocol.Tests
                                                     "https://raw.githubusercontent.com/xunit/media/master/logo-512-transparent.png",
                                                     "https://github.com/xunit/xunit",
                                                     "",
-                                                    "invalidUri"
-                                                    );
+                                                    "invalidUri",
+                                                    "anotherInvalidUri");
 
             // Act
             var metaData = new PackageSearchMetadataV2Feed(testPackage);
@@ -35,15 +33,55 @@ namespace NuGet.Protocol.Tests
             Assert.Equal("https://github.com/xunit/xunit", metaData.LicenseUrl.AbsoluteUri);
             Assert.Null(metaData.ProjectUrl);
             Assert.Null(metaData.ReportAbuseUrl);
+            Assert.Null(metaData.PackageDetailsUrl);
         }
 
+        [Fact]
+        public void PackageSearchMetadata_ValidReportAbuseUrl()
+        {
+            // Arrange
+            var url = "https://www.nuget.org/packages/xunit/2.4.1/ReportAbuse";
+            var testPackage = CreateTestPackageInfo(new List<string>() { "James Newkirk", "Brad Wilson" },
+                                                    null,
+                                                    "https://raw.githubusercontent.com/xunit/media/master/logo-512-transparent.png",
+                                                    "https://github.com/xunit/xunit",
+                                                    "",
+                                                    url,
+                                                    "anotherInvalidUri");
+
+            // Act
+            var metaData = new PackageSearchMetadataV2Feed(testPackage);
+
+            // Assert
+            Assert.Equal(new Uri(url), metaData.ReportAbuseUrl);
+        }
+
+        [Fact]
+        public void PackageSearchMetadata_ValidPackageDetailsUrl()
+        {
+            // Arrange
+            var url = "https://www.nuget.org/packages/xunit/2.4.1";
+            var testPackage = CreateTestPackageInfo(new List<string>() { "James Newkirk", "Brad Wilson" },
+                                                    null,
+                                                    "https://raw.githubusercontent.com/xunit/media/master/logo-512-transparent.png",
+                                                    "https://github.com/xunit/xunit",
+                                                    "",
+                                                    "invalidUri",
+                                                    url);
+
+            // Act
+            var metaData = new PackageSearchMetadataV2Feed(testPackage);
+
+            // Assert
+            Assert.Equal(new Uri(url), metaData.PackageDetailsUrl);
+        }
 
         private V2FeedPackageInfo CreateTestPackageInfo(IEnumerable<string> authors, IEnumerable<string> owners,
-            string iconUrl, string licenseUrl, string projectUrl, string reportAbuseUrl)
+            string iconUrl, string licenseUrl, string projectUrl, string reportAbuseUrl, string galleryDetailsUrl)
         {
             return new V2FeedPackageInfo(new PackageIdentity("test", NuGetVersion.Parse("1.0.0")),
                                          "title", "summary", "description", authors, owners,
-                                         iconUrl, licenseUrl, projectUrl, reportAbuseUrl, "tags", null, null, null, "dependencies",
+                                         iconUrl, licenseUrl, projectUrl, reportAbuseUrl, galleryDetailsUrl, "tags", null, null, null, "dependencies",
                                          false, "downloadUrl", "0", "packageHash", "packageHashAlgorithm", new NuGetVersion("3.0"));
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/PackageDetailsUriResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/PackageDetailsUriResourceV3ProviderTests.cs
@@ -1,0 +1,142 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json.Linq;
+using NuGet.Configuration;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Protocol.Tests.Providers
+{
+    public class PackageDetailsUriResourceV3ProviderTests
+    {
+        private const string _resourceType = "PackageDetailsUriTemplate/5.1.0";
+
+        private static readonly SemanticVersion _defaultVersion = new SemanticVersion(0, 0, 0);
+
+        private readonly PackageSource _packageSource;
+        private readonly PackageDetailsUriResourceV3Provider _target;
+
+        public PackageDetailsUriResourceV3ProviderTests()
+        {
+            _packageSource = new PackageSource("https://unit.test");
+            _target = new PackageDetailsUriResourceV3Provider();
+        }
+
+        [Fact]
+        public async Task TryCreate_WhenResourceDoesNotExist_ReturnsNoResource()
+        {
+            var resourceProviders = new ResourceProvider[]
+            {
+                CreateServiceIndexResourceV3Provider(),
+                _target
+            };
+            var sourceRepository = new SourceRepository(_packageSource, resourceProviders);
+
+            var result = await _target.TryCreate(sourceRepository, CancellationToken.None);
+
+            Assert.False(result.Item1);
+            Assert.Null(result.Item2);
+        }
+
+        [Theory]
+        [InlineData("foo")]
+        [InlineData("../somepath")]
+        [InlineData(@"C:\packages\{id}\{version}\index.html")]
+        [InlineData("http://unit.test/packages/{id}/{version}")]
+        [InlineData("file:///my/path")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  \t\n")]
+        public async Task TryCreate_WhenResourceHasInvalidAbsoluteUri_ReturnsNoResource(string uri)
+        {
+            var serviceEntry = new RawServiceIndexEntry(uri, _resourceType);
+            var resourceProviders = new ResourceProvider[]
+            {
+                CreateServiceIndexResourceV3Provider(serviceEntry),
+                _target
+            };
+            var sourceRepository = new SourceRepository(_packageSource, resourceProviders);
+
+            var result = await _target.TryCreate(sourceRepository, CancellationToken.None);
+
+            Assert.False(result.Item1);
+            Assert.Null(result.Item2);
+        }
+
+        [Fact]
+        public async Task TryCreate_WhenResourceExists_ReturnsValidResource()
+        {
+            var serviceEntry = new RawServiceIndexEntry("https://unit.test/packages/{id}/{version}", _resourceType);
+            var resourceProviders = new ResourceProvider[]
+            {
+                CreateServiceIndexResourceV3Provider(serviceEntry),
+                _target
+            };
+            var sourceRepository = new SourceRepository(_packageSource, resourceProviders);
+
+            var result = await _target.TryCreate(sourceRepository, CancellationToken.None);
+
+            Assert.True(result.Item1);
+            Assert.NotNull(result.Item2);
+            var resource = Assert.IsType<PackageDetailsUriResourceV3>(result.Item2);
+            Assert.Equal(
+                "https://unit.test/packages/MyPackage/1.0.0",
+                resource.GetUri("MyPackage", NuGetVersion.Parse("1.0.0")).OriginalString);
+        }
+
+        private static ServiceIndexResourceV3Provider CreateServiceIndexResourceV3Provider(params RawServiceIndexEntry[] entries)
+        {
+            var provider = new Mock<ServiceIndexResourceV3Provider>();
+
+            provider.Setup(x => x.Name)
+                .Returns(nameof(ServiceIndexResourceV3Provider));
+            provider.Setup(x => x.ResourceType)
+                .Returns(typeof(ServiceIndexResourceV3));
+
+            var resources = new JArray();
+
+            foreach (var entry in entries)
+            {
+                resources.Add(
+                    new JObject(
+                        new JProperty("@id", entry.Uri),
+                        new JProperty("@type", entry.Type)));
+            }
+
+            var index = new JObject();
+
+            index.Add("version", "3.0.0");
+            index.Add("resources", resources);
+            index.Add("@context",
+                new JObject(
+                    new JProperty("@vocab", "http://schema.nuget.org/schema#"),
+                    new JProperty("comment", "http://www.w3.org/2000/01/rdf-schema#comment")));
+
+            var serviceIndexResource = new ServiceIndexResourceV3(index, DateTime.UtcNow);
+            var tryCreateResult = new Tuple<bool, INuGetResource>(true, serviceIndexResource);
+
+            provider.Setup(x => x.TryCreate(It.IsAny<SourceRepository>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(tryCreateResult));
+
+            return provider.Object;
+        }
+
+        private class RawServiceIndexEntry
+        {
+            public RawServiceIndexEntry(string uri, string type)
+            {
+                Uri = uri;
+                Type = type ?? throw new ArgumentNullException(nameof(type));
+            }
+
+            public string Uri { get; }
+            public string Type { get; }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/V2FeedPackageInfoTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/V2FeedPackageInfoTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -143,7 +143,7 @@ namespace NuGet.Protocol.Tests
         {
             return new V2FeedPackageInfo(new PackageIdentity("test", NuGetVersion.Parse("1.0.0")),
                                          "title", "summary", "description", Enumerable.Empty<string>(), Enumerable.Empty<string>(),
-                                         "iconUrl", "licenseUrl", "projectUrl", "reportAbuseUrl", "tags", null, null, null, dependencies,
+                                         "iconUrl", "licenseUrl", "projectUrl", "reportAbuseUrl", "galleryDetailsUrl", "tags", null, null, null, dependencies,
                                          false, "downloadUrl", "0", "packageHash", "packageHashAlgorithm", new NuGetVersion("3.0"));
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/V2FeedParserTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/V2FeedParserTests.cs
@@ -110,6 +110,7 @@ namespace NuGet.Protocol.Tests
             Assert.Equal(DateTimeOffset.Parse("2015-12-11T01:25:11.37"), latest.Published.Value);
             Assert.Null(latest.LastEdited);
             Assert.Equal("https://www.nuget.org/package/ReportAbuse/WindowsAzure.Storage/6.2.2-preview", latest.ReportAbuseUrl);
+            Assert.Equal("https://www.nuget.org/packages/WindowsAzure.Storage/6.2.2-preview", latest.GalleryDetailsUrl);
             Assert.True(latest.RequireLicenseAcceptance);
             Assert.Equal("A client library for working with Microsoft Azure storage services including blobs, files, tables, and queues.", latest.Summary);
             Assert.Equal("Microsoft Azure Storage Table Blob File Queue Scalable windowsazureofficial", latest.Tags);
@@ -219,6 +220,7 @@ namespace NuGet.Protocol.Tests
             Assert.Equal(DateTimeOffset.Parse("2016-12-10T22:39:05.103"), package.LastEdited.Value);
             Assert.Equal(DateTimeOffset.Parse("2015-12-10T22:39:05.103"), package.Published.Value);
             Assert.Equal("https://www.nuget.org/package/ReportAbuse/WindowsAzure.Storage/6.2.0", package.ReportAbuseUrl);
+            Assert.Equal("https://www.nuget.org/packages/WindowsAzure.Storage/6.2.0", package.GalleryDetailsUrl);
             Assert.True(package.RequireLicenseAcceptance);
             Assert.Equal("A client library for working with Microsoft Azure storage services including blobs, files, tables, and queues.", package.Summary);
             Assert.Equal("Microsoft Azure Storage Table Blob File Queue Scalable windowsazureofficial", package.Tags);
@@ -433,6 +435,7 @@ namespace NuGet.Protocol.Tests
             Assert.Equal(DateTimeOffset.Parse("2014-11-12T22:19:16.297"), package.Created.Value);
             Assert.Null(package.LastEdited);
             Assert.Equal("https://www.nuget.org/package/ReportAbuse/WindowsAzure.Storage/4.3.2-preview", package.ReportAbuseUrl);
+            Assert.Equal("https://www.nuget.org/packages/WindowsAzure.Storage/4.3.2-preview", package.GalleryDetailsUrl);
             Assert.True(package.RequireLicenseAcceptance);
             Assert.Equal("A client library for working with Microsoft Azure storage services including blobs, files, tables, and queues.", package.Summary);
             Assert.Equal("Microsoft Azure Storage Table Blob File Queue Scalable windowsazureofficial", package.Tags);
@@ -501,6 +504,7 @@ namespace NuGet.Protocol.Tests
             Assert.Equal(DateTimeOffset.Parse("2014-11-12T22:19:16.297"), package.Created.Value);
             Assert.Null(package.LastEdited);
             Assert.Equal("https://www.nuget.org/package/ReportAbuse/WindowsAzure.Storage/4.3.2-preview", package.ReportAbuseUrl);
+            Assert.Equal("https://www.nuget.org/packages/WindowsAzure.Storage/4.3.2-preview", package.GalleryDetailsUrl);
             Assert.True(package.RequireLicenseAcceptance);
             Assert.Equal("A client library for working with Microsoft Azure storage services including blobs, files, tables, and queues.", package.Summary);
             Assert.Equal("Microsoft Azure Storage Table Blob File Queue Scalable windowsazureofficial", package.Tags);


### PR DESCRIPTION
Users have requested multiple times (https://github.com/NuGet/Home/issues/5299, https://github.com/NuGet/Home/issues/7470) for a link from the VS UI to the nuget.org UI.

So I think, hey, that ain't too hard. With a protocol enhancement in V3 and leveraging an unused field in nuget.org's V2, we can get this working for both V2 and V3.

Dark theme:

![image](https://user-images.githubusercontent.com/94054/53671389-fd775b80-3c32-11e9-946b-ff023439a03e.png)

Light theme:

![image](https://user-images.githubusercontent.com/94054/53671442-2ef02700-3c33-11e9-9042-c17277119f50.png)

Other themes look okay too.

Tested Narrator. When tabbing to the link, it says "Package details link ... ... ... hyperlink".

It works by adding the following resource to V3, which works a lot like the [`ReportAbuseUriTemplate` protocol](https://docs.microsoft.com/en-us/nuget/api/report-abuse-resource).

```json
{
  "@id": "https://www.nuget.org/packages/{id}/{version}",
  "@type": "PackageDetailsUriTemplate/5.1.0",
  "comment": "URI template used by NuGet Client to construct details URL for packages"
}
```

You can try it with this service index:
https://jverstorage.blob.core.windows.net/v3-index/index.json

Docs PR: https://github.com/NuGet/docs.microsoft.com-nuget/pull/1336
Service index PR: https://github.com/NuGet/NuGet.Services.Index/pull/132