### PR TITLE
Fix license window accessibility issues

### DIFF
--- a/NuGet.sln
+++ b/NuGet.sln
@@ -222,7 +222,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Shared.Tests", "test\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.MSSigning.Extensions.FuncTest", "test\NuGet.Clients.FuncTests\NuGet.MSSigning.Extensions.FuncTest\NuGet.MSSigning.Extensions.FuncTest.csproj", "{BA7F681E-FDC7-42B6-8BF1-74DA6421BA1A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.MSSigning.Extensions.Test", "test\NuGet.Clients.Tests\NuGet.MSSigning.Extensions.Test\NuGet.MSSigning.Extensions.Test.csproj", "{2A604A43-C72A-4A03-B68B-66AF4B6F430E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.MSSigning.Extensions.Test", "test\NuGet.Clients.Tests\NuGet.MSSigning.Extensions.Test\NuGet.MSSigning.Extensions.Test.csproj", "{2A604A43-C72A-4A03-B68B-66AF4B6F430E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Build.NuGetSdkResolver", "src\NuGet.Core\Microsoft.Build.NuGetSdkResolver\Microsoft.Build.NuGetSdkResolver.csproj", "{299B3E44-5372-4D6B-A4E9-3DBEA4705701}"
 EndProject
@@ -538,6 +538,14 @@ Global
 		{21522CF8-12F2-4A30-94D5-6C794D4B043F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{21522CF8-12F2-4A30-94D5-6C794D4B043F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{21522CF8-12F2-4A30-94D5-6C794D4B043F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BA7F681E-FDC7-42B6-8BF1-74DA6421BA1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA7F681E-FDC7-42B6-8BF1-74DA6421BA1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA7F681E-FDC7-42B6-8BF1-74DA6421BA1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA7F681E-FDC7-42B6-8BF1-74DA6421BA1A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A604A43-C72A-4A03-B68B-66AF4B6F430E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A604A43-C72A-4A03-B68B-66AF4B6F430E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A604A43-C72A-4A03-B68B-66AF4B6F430E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A604A43-C72A-4A03-B68B-66AF4B6F430E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{299B3E44-5372-4D6B-A4E9-3DBEA4705701}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{299B3E44-5372-4D6B-A4E9-3DBEA4705701}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{299B3E44-5372-4D6B-A4E9-3DBEA4705701}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/NuGet.sln
+++ b/NuGet.sln
@@ -222,7 +222,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Shared.Tests", "test\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.MSSigning.Extensions.FuncTest", "test\NuGet.Clients.FuncTests\NuGet.MSSigning.Extensions.FuncTest\NuGet.MSSigning.Extensions.FuncTest.csproj", "{BA7F681E-FDC7-42B6-8BF1-74DA6421BA1A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.MSSigning.Extensions.Test", "test\NuGet.Clients.Tests\NuGet.MSSigning.Extensions.Test\NuGet.MSSigning.Extensions.Test.csproj", "{2A604A43-C72A-4A03-B68B-66AF4B6F430E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.MSSigning.Extensions.Test", "test\NuGet.Clients.Tests\NuGet.MSSigning.Extensions.Test\NuGet.MSSigning.Extensions.Test.csproj", "{2A604A43-C72A-4A03-B68B-66AF4B6F430E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Build.NuGetSdkResolver", "src\NuGet.Core\Microsoft.Build.NuGetSdkResolver\Microsoft.Build.NuGetSdkResolver.csproj", "{299B3E44-5372-4D6B-A4E9-3DBEA4705701}"
 EndProject
@@ -538,14 +538,6 @@ Global
 		{21522CF8-12F2-4A30-94D5-6C794D4B043F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{21522CF8-12F2-4A30-94D5-6C794D4B043F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{21522CF8-12F2-4A30-94D5-6C794D4B043F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BA7F681E-FDC7-42B6-8BF1-74DA6421BA1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BA7F681E-FDC7-42B6-8BF1-74DA6421BA1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BA7F681E-FDC7-42B6-8BF1-74DA6421BA1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BA7F681E-FDC7-42B6-8BF1-74DA6421BA1A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2A604A43-C72A-4A03-B68B-66AF4B6F430E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2A604A43-C72A-4A03-B68B-66AF4B6F430E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2A604A43-C72A-4A03-B68B-66AF4B6F430E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2A604A43-C72A-4A03-B68B-66AF4B6F430E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{299B3E44-5372-4D6B-A4E9-3DBEA4705701}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{299B3E44-5372-4D6B-A4E9-3DBEA4705701}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{299B3E44-5372-4D6B-A4E9-3DBEA4705701}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/LicenseFileData.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/LicenseFileData.cs
@@ -21,13 +21,13 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        public FlowDocument LicenseContent
+        public FlowDocument LicenseText
         {
             get => _content;
             set
             {
                 _content = value;
-                OnPropertyChanged("LicenseContent");
+                OnPropertyChanged("LicenseText");
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/LicenseFileData.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/LicenseFileData.cs
@@ -2,13 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel;
+using System.Windows.Documents;
 
 namespace NuGet.PackageManagement.UI
 {
     public class LicenseFileData : INotifyPropertyChanged
     {
         private string _header { get; set; }
-        private string _content { get; set; }
+        private FlowDocument _content { get; set; }
 
         public string Header
         {
@@ -20,7 +21,7 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        public string LicenseContent
+        public FlowDocument LicenseContent
         {
             get => _content;
             set

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/LicenseFileText.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/LicenseFileText.cs
@@ -37,7 +37,8 @@ namespace NuGet.PackageManagement.UI
                     NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                     {
                         var content = _loadFileFromPackage(_licenseFileLocation);
-                        var flowDoc = new FlowDocument(new Paragraph(new Run(content))); // TODO GenerateParagraphs
+                        var flowDoc = new FlowDocument();
+                        flowDoc.Blocks.AddRange(PackageLicenseUtilities.GenerateParagraphs(content));
                         await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                         LicenseText = flowDoc;
                     });

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/LicenseFileText.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/LicenseFileText.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel;
 using System.Threading;
+using System.Windows.Documents;
 using NuGet.VisualStudio;
 
 namespace NuGet.PackageManagement.UI
@@ -11,18 +12,18 @@ namespace NuGet.PackageManagement.UI
     internal class LicenseFileText : IText, INotifyPropertyChanged
     {
         private string _text;
-        private string _licenseText;
+        private FlowDocument _licenseText;
         private string _licenseHeader;
         private readonly string _licenseFileLocation;
         private Func<string, string> _loadFileFromPackage;
 
         private int _initialized;
 
-        internal LicenseFileText(string text, string licenseFileHeader, Func<string,string> loadFileFromPackage, string licenseFileLocation)
+        internal LicenseFileText(string text, string licenseFileHeader, Func<string, string> loadFileFromPackage, string licenseFileLocation)
         {
             _text = text;
             _licenseHeader = licenseFileHeader;
-            _licenseText = Resources.LicenseFile_Loading;
+            _licenseText = new FlowDocument(new Paragraph(new Run(Resources.LicenseFile_Loading)));
             _loadFileFromPackage = loadFileFromPackage;
             _licenseFileLocation = licenseFileLocation;
         }
@@ -36,8 +37,9 @@ namespace NuGet.PackageManagement.UI
                     NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                     {
                         var content = _loadFileFromPackage(_licenseFileLocation);
+                        var flowDoc = new FlowDocument(new Paragraph(new Run(content))); // TODO GenerateParagraphs
                         await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                        LicenseText = content;
+                        LicenseText = flowDoc;
                     });
                 }
             }
@@ -63,7 +65,7 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        public string LicenseText
+        public FlowDocument LicenseText
         {
             get => _licenseText;
             set

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLicenseUtilities.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLicenseUtilities.cs
@@ -46,11 +46,10 @@ namespace NuGet.PackageManagement.UI
         internal static Paragraph[] GenerateParagraphs(string licenseContent)
         {
             var textParagraphs = licenseContent.Split(
-                new[] { "\n\n", "\r\n\r\n" },
+                new[] { "\n\n", "\r\n\r\n" }, // Take care of paragraphs regardless of the name ending. It's a best effort, so weird line ending combinations might not work too well.
                 StringSplitOptions.None);
 
             var paragraphs = new Paragraph[textParagraphs.Length];
-
             for (var i = 0; i < textParagraphs.Length; i++)
             {
                 paragraphs[i] = new Paragraph(new Run(textParagraphs[i]));

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLicenseUtilities.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLicenseUtilities.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Windows.Documents;
 using NuGet.Packaging;
 using NuGet.Packaging.Licenses;
 using NuGet.Protocol;
@@ -40,6 +41,21 @@ namespace NuGet.PackageManagement.UI
                 return new List<IText>() { new LicenseText(Resources.Text_ViewLicense, licenseUrl) };
             }
             return new List<IText>();
+        }
+
+        internal static Paragraph[] GenerateParagraphs(string licenseContent)
+        {
+            var textParagraphs = licenseContent.Split(
+                new[] { "\n\n", "\r\n\r\n" },
+                StringSplitOptions.None);
+
+            var paragraphs = new Paragraph[textParagraphs.Length];
+
+            for (var i = 0; i < textParagraphs.Length; i++)
+            {
+                paragraphs[i] = new Paragraph(new Run(textParagraphs[i]));
+            }
+            return paragraphs;
         }
 
         // Internal for testing purposes.

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
@@ -24,6 +24,7 @@
   FocusManager.FocusedElement="{Binding ElementName=_acceptButton}">
   <Window.Resources>
     <ResourceDictionary>
+
       <ResourceDictionary.MergedDictionaries>
         <nuget:SharedResources />
       </ResourceDictionary.MergedDictionaries>
@@ -97,6 +98,11 @@
           </ItemsControl>
         </StackPanel>
       </DataTemplate>
+
+      <Style TargetType="{x:Type FlowDocument}">
+        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="PagePadding" Value="3"/>
+      </Style>
     </ResourceDictionary>
   </Window.Resources>
   <Grid>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
@@ -220,20 +220,10 @@
       Visibility="Collapsed"
       BorderBrush="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}"
       >
-      <ScrollViewer
-              Padding="3"
-              CanContentScroll="True"
-              VerticalScrollBarVisibility="Visible"
-              HorizontalScrollBarVisibility="Disabled"
-        >
-        <TextBox
-          Style="{DynamicResource SelectableTextBlockStyle}" 
-          Margin="12,0,12,12"
-          x:Name="_licenseFileText"
-          AutomationProperties.Name="{Binding Text}"
-          Text="{Binding LicenseText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-          TextWrapping="Wrap" />
-      </ScrollViewer>
+      <FlowDocumentScrollViewer
+          Name="_flowDocumentViewer"
+          AutomationProperties.Name="License content viewer"
+          Document="{Binding LicenseText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
     </Border>
   </Grid>
 </nuget:VsDialogWindow>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
@@ -222,7 +222,7 @@
       >
       <FlowDocumentScrollViewer
           Name="_flowDocumentViewer"
-          AutomationProperties.Name="License content viewer"
+          AutomationProperties.LabeledBy="{Binding ElementName=EmbeddedLicense}"
           Document="{Binding LicenseText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
     </Border>
   </Grid>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseFileWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseFileWindow.xaml
@@ -31,18 +31,10 @@
       Name="borderLicenseFile"
       BorderThickness="1"
       BorderBrush="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}">
-      <ScrollViewer
-              Name="scrollViewerLicenseFile"
-              CanContentScroll="True"
-              VerticalScrollBarVisibility="Visible"
-              HorizontalScrollBarVisibility="Disabled">
-        <TextBox
-            Style="{DynamicResource SelectableTextBlockStyle}" 
-            Name="textBlockLicenseFile"
-            Margin="12,8,12,8"
-            TextWrapping="Wrap"
-          Text="{Binding LicenseContent, Mode=TwoWay,  UpdateSourceTrigger=PropertyChanged}"/>
-      </ScrollViewer>
+      <FlowDocumentScrollViewer
+          Name="_flowDocumentViewer"
+          Document="{Binding LicenseContent}"
+        />
     </Border>
   </Grid>
 </nuget:VsDialogWindow>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseFileWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseFileWindow.xaml
@@ -30,11 +30,12 @@
     <Border
       Name="borderLicenseFile"
       BorderThickness="1"
+      AutomationProperties.Name="{Binding Header, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
       BorderBrush="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}">
       <FlowDocumentScrollViewer
           Name="_flowDocumentViewer"
-          Document="{Binding LicenseContent}"
-        />
+          AutomationProperties.LabeledBy="{Binding ElementName=borderLicenseFile}"
+          Document="{Binding LicenseText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
     </Border>
   </Grid>
 </nuget:VsDialogWindow>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseFileWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/LicenseFileWindow.xaml
@@ -23,6 +23,9 @@
       <ResourceDictionary.MergedDictionaries>
         <nuget:SharedResources />
       </ResourceDictionary.MergedDictionaries>
+      <Style TargetType="{x:Type FlowDocument}">
+        <Setter Property="FontSize" Value="12"/>
+      </Style>
     </ResourceDictionary>
   </Window.Resources>
 
@@ -35,7 +38,8 @@
       <FlowDocumentScrollViewer
           Name="_flowDocumentViewer"
           AutomationProperties.LabeledBy="{Binding ElementName=borderLicenseFile}"
-          Document="{Binding LicenseText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+          Document="{Binding LicenseText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+      </FlowDocumentScrollViewer>
     </Border>
   </Grid>
 </nuget:VsDialogWindow>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Globalization;
 using System.Threading.Tasks;
 using System.Windows;
@@ -42,8 +43,8 @@ namespace NuGet.PackageManagement.UI
                 NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
                     var content = metadata.LoadFileAsText(metadata.LicenseMetadata.License);
-                    var flowDoc = new FlowDocument(new Paragraph(new Run(content))); // TODO GenerateParagraphs
-
+                    var flowDoc = new FlowDocument();
+                    flowDoc.Blocks.AddRange(PackageLicenseUtilities.GenerateParagraphs(content));
                     await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                     (window.DataContext as LicenseFileData).LicenseText = flowDoc;
                 });
@@ -56,6 +57,8 @@ namespace NuGet.PackageManagement.UI
                 }
             }
         }
+
+
 
         private void PackageMetadataControl_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
@@ -35,7 +35,7 @@ namespace NuGet.PackageManagement.UI
                     DataContext = new LicenseFileData
                     {
                         Header = string.Format(CultureInfo.CurrentCulture, UI.Resources.WindowTitle_LicenseFileWindow, metadata.Id),
-                        LicenseContent = new FlowDocument(new Paragraph(new Run(UI.Resources.LicenseFile_Loading)))
+                        LicenseText = new FlowDocument(new Paragraph(new Run(UI.Resources.LicenseFile_Loading)))
                     }
                 };
 
@@ -45,7 +45,7 @@ namespace NuGet.PackageManagement.UI
                     var flowDoc = new FlowDocument(new Paragraph(new Run(content))); // TODO GenerateParagraphs
 
                     await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                    (window.DataContext as LicenseFileData).LicenseContent = flowDoc;
+                    (window.DataContext as LicenseFileData).LicenseText = flowDoc;
                 });
 
                 using (NuGetEventTrigger.TriggerEventBeginEnd(

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Documents;
 using Microsoft.VisualStudio.Threading;
 using NuGet.VisualStudio;
 
@@ -28,20 +29,23 @@ namespace NuGet.PackageManagement.UI
         {
             if (DataContext is DetailedPackageMetadata metadata)
             {
+          
                 var window = new LicenseFileWindow()
                 {
                     DataContext = new LicenseFileData
                     {
                         Header = string.Format(CultureInfo.CurrentCulture, UI.Resources.WindowTitle_LicenseFileWindow, metadata.Id),
-                        LicenseContent = UI.Resources.LicenseFile_Loading
+                        LicenseContent = new FlowDocument(new Paragraph(new Run(UI.Resources.LicenseFile_Loading)))
                     }
                 };
 
                 NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
                     var content = metadata.LoadFileAsText(metadata.LicenseMetadata.License);
+                    var flowDoc = new FlowDocument(new Paragraph(new Run(content))); // TODO GenerateParagraphs
+
                     await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                    (window.DataContext as LicenseFileData).LicenseContent = content;
+                    (window.DataContext as LicenseFileData).LicenseContent = flowDoc;
                 });
 
                 using (NuGetEventTrigger.TriggerEventBeginEnd(

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageMetadataControl.xaml.cs
@@ -58,8 +58,6 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-
-
         private void PackageMetadataControl_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             if (DataContext is DetailedPackageMetadata)

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageLicenseUtilitiesTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageLicenseUtilitiesTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows.Documents;
 using NuGet.Packaging;
 using NuGet.Packaging.Licenses;
 using Xunit;
@@ -164,7 +165,7 @@ namespace NuGet.PackageManagement.UI.Test
             Assert.True(links[0] is LicenseFileText);
             var licenseFileText = links[0] as LicenseFileText;
             Assert.Equal(Resources.Text_ViewLicense, licenseFileText.Text);
-            Assert.Equal(Resources.LicenseFile_Loading, licenseFileText.LicenseText);
+            Assert.Equal(Resources.LicenseFile_Loading, ((Run)((Paragraph)licenseFileText.LicenseText.Blocks.AsEnumerable().First()).Inlines.First()).Text);
         }
     }
 }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7452
Regression:   
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
- Use a Flow Document viewer to display the license content to make it narratable. 
- Do a best effort to split the license text into paragraphs. 

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  UI
Validation done:  Manual
