### PR TITLE
Add a provider for performing actions for adding, updating and syncing a trusted signer

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -71,6 +71,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The argument cannot be null or empty..
+        /// </summary>
+        internal static string ArgumentCannotBeNullOrEmpty {
+            get {
+                return ResourceManager.GetString("ArgumentCannotBeNullOrEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Building project &apos;{0}&apos; for target framework &apos;{1}&apos;..
         /// </summary>
         internal static string BuildingProjectTargetingFramework {
@@ -89,6 +98,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Author trust was expected but package is not author signed..
+        /// </summary>
+        internal static string Error_AuthorTrustExpectedAuthorSignature {
+            get {
+                return ResourceManager.GetString("Error_AuthorTrustExpectedAuthorSignature", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to build using &apos;{0} {1}&apos;..
         /// </summary>
         internal static string Error_BuildFailed {
@@ -103,6 +121,15 @@ namespace NuGet.Commands {
         internal static string Error_CannotFindMsbuild {
             get {
                 return ResourceManager.GetString("Error_CannotFindMsbuild", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The repository with service index &apos;{0}&apos; does not list any trusted certificate..
+        /// </summary>
+        internal static string Error_EmptyCertificateListInRepository {
+            get {
+                return ResourceManager.GetString("Error_EmptyCertificateListInRepository", resourceCulture);
             }
         }
         
@@ -139,6 +166,15 @@ namespace NuGet.Commands {
         internal static string Error_InvalidATF {
             get {
                 return ResourceManager.GetString("Error_InvalidATF", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &quot;Invalid certificate information from service index &apos;{0}&apos;.
+        /// </summary>
+        internal static string Error_InvalidCertificateInformationFromServer {
+            get {
+                return ResourceManager.GetString("Error_InvalidCertificateInformationFromServer", resourceCulture);
             }
         }
         
@@ -278,6 +314,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package is not signed..
+        /// </summary>
+        internal static string Error_PackageNotSigned {
+            get {
+                return ResourceManager.GetString("Error_PackageNotSigned", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The package {0} sha512 validation failed. The package is different than the last restore..
         /// </summary>
         internal static string Error_PackageValidationFailed {
@@ -323,6 +368,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Repository trust was expected but package is not repository signed..
+        /// </summary>
+        internal static string Error_RepoTrustExpectedRepoSignature {
+            get {
+                return ResourceManager.GetString("Error_RepoTrustExpectedRepoSignature", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The packages lock file is inconsistent with the project dependencies so restore can&apos;t be run in locked mode. Please disable RestoreLockedMode MSBuild property or pass explicit --force-evaluate flag to run restore to update the lock file..
         /// </summary>
         internal static string Error_RestoreInLockedMode {
@@ -337,6 +391,42 @@ namespace NuGet.Commands {
         internal static string Error_ToolsPackageWithExtraPackageTypes {
             get {
                 return ResourceManager.GetString("Error_ToolsPackageWithExtraPackageTypes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trusted author cannot have owners..
+        /// </summary>
+        internal static string Error_TrustedAuthorNoOwners {
+            get {
+                return ResourceManager.GetString("Error_TrustedAuthorNoOwners", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trusted repository with service index &apos;{0}&apos; already exists..
+        /// </summary>
+        internal static string Error_TrustedRepoAlreadyExists {
+            get {
+                return ResourceManager.GetString("Error_TrustedRepoAlreadyExists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trusted repository with name &apos;{0}&apos; does not exist..
+        /// </summary>
+        internal static string Error_TrustedRepositoryDoesNotExist {
+            get {
+                return ResourceManager.GetString("Error_TrustedRepositoryDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trusted signer with name &apos;{0}&apos; already exists..
+        /// </summary>
+        internal static string Error_TrustedSignerAlreadyExists {
+            get {
+                return ResourceManager.GetString("Error_TrustedSignerAlreadyExists", resourceCulture);
             }
         }
         
@@ -391,6 +481,15 @@ namespace NuGet.Commands {
         internal static string Error_UnknownBuildAction {
             get {
                 return ResourceManager.GetString("Error_UnknownBuildAction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The trust target &apos;{0}&apos; is unsupported..
+        /// </summary>
+        internal static string Error_UnsupportedTrustTarget {
+            get {
+                return ResourceManager.GetString("Error_UnsupportedTrustTarget", resourceCulture);
             }
         }
         
@@ -1517,6 +1616,15 @@ namespace NuGet.Commands {
         internal static string UnableToFindBuildOutput {
             get {
                 return ResourceManager.GetString("UnableToFindBuildOutput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unsupported hash algorithm: &apos;{0}&apos;.
+        /// </summary>
+        internal static string UnsupportedHashAlgorithm {
+            get {
+                return ResourceManager.GetString("UnsupportedHashAlgorithm", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -98,7 +98,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Author trust was expected but package is not author signed..
+        ///   Looks up a localized string similar to Unable to add trusted author. The package is not author signed..
         /// </summary>
         internal static string Error_AuthorTrustExpectedAuthorSignature {
             get {
@@ -125,7 +125,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The repository with service index &apos;{0}&apos; does not list any trusted certificate..
+        ///   Looks up a localized string similar to The repository with the service index &apos;{0}&apos; does not list any trusted certificates..
         /// </summary>
         internal static string Error_EmptyCertificateListInRepository {
             get {
@@ -170,7 +170,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &quot;Invalid certificate information from service index &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Invalid certificate information from the service index &apos;{0}&apos;.
         /// </summary>
         internal static string Error_InvalidCertificateInformationFromServer {
             get {
@@ -368,7 +368,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Repository trust was expected but package is not repository signed..
+        ///   Looks up a localized string similar to Unable to add trusted repository. The package is not repository signed or countersigned..
         /// </summary>
         internal static string Error_RepoTrustExpectedRepoSignature {
             get {
@@ -395,7 +395,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Trusted author cannot have owners..
+        ///   Looks up a localized string similar to A trusted author cannot have owners..
         /// </summary>
         internal static string Error_TrustedAuthorNoOwners {
             get {
@@ -404,7 +404,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Trusted repository with service index &apos;{0}&apos; already exists..
+        ///   Looks up a localized string similar to A trusted repository with the service index &apos;{0}&apos; already exists..
         /// </summary>
         internal static string Error_TrustedRepoAlreadyExists {
             get {
@@ -413,7 +413,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Trusted repository with name &apos;{0}&apos; does not exist..
+        ///   Looks up a localized string similar to A trusted repository with the name &apos;{0}&apos; does not exist..
         /// </summary>
         internal static string Error_TrustedRepositoryDoesNotExist {
             get {
@@ -422,7 +422,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Trusted signer with name &apos;{0}&apos; already exists..
+        ///   Looks up a localized string similar to A trusted signer with the name &apos;{0}&apos; already exists..
         /// </summary>
         internal static string Error_TrustedSignerAlreadyExists {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -170,7 +170,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid certificate information from the service index &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Invalid certificate information from the service index &apos;{0}&apos;..
         /// </summary>
         internal static string Error_InvalidCertificateInformationFromServer {
             get {
@@ -1620,7 +1620,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unsupported hash algorithm: &apos;{0}&apos;.
+        ///   Looks up a localized string similar to The hash algorithm is unsupported:  &apos;{0}&apos;..
         /// </summary>
         internal static string UnsupportedHashAlgorithm {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -722,4 +722,47 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="Error_NoMatchingCertificate" xml:space="preserve">
     <value>The package signature did not match any of the allowed certificate fingerprints.</value>
   </data>
+  <data name="ArgumentCannotBeNullOrEmpty" xml:space="preserve">
+    <value>The argument cannot be null or empty.</value>
+  </data>
+  <data name="Error_AuthorTrustExpectedAuthorSignature" xml:space="preserve">
+    <value>Author trust was expected but package is not author signed.</value>
+  </data>
+  <data name="Error_InvalidCertificateInformationFromServer" xml:space="preserve">
+    <value>"Invalid certificate information from service index '{0}'</value>
+    <comment>0 - service index</comment>
+  </data>
+  <data name="Error_PackageNotSigned" xml:space="preserve">
+    <value>The package is not signed.</value>
+  </data>
+  <data name="Error_RepoTrustExpectedRepoSignature" xml:space="preserve">
+    <value>Repository trust was expected but package is not repository signed.</value>
+  </data>
+  <data name="Error_TrustedAuthorNoOwners" xml:space="preserve">
+    <value>Trusted author cannot have owners.</value>
+  </data>
+  <data name="Error_TrustedRepoAlreadyExists" xml:space="preserve">
+    <value>Trusted repository with service index '{0}' already exists.</value>
+    <comment>0 - trusted repository name</comment>
+  </data>
+  <data name="Error_TrustedRepositoryDoesNotExist" xml:space="preserve">
+    <value>Trusted repository with name '{0}' does not exist.</value>
+    <comment>0 - trusted repository name</comment>
+  </data>
+  <data name="Error_TrustedSignerAlreadyExists" xml:space="preserve">
+    <value>Trusted signer with name '{0}' already exists.</value>
+    <comment>0 - trusted signer name</comment>
+  </data>
+  <data name="Error_UnsupportedTrustTarget" xml:space="preserve">
+    <value>The trust target '{0}' is unsupported.</value>
+    <comment>0 - VerificationTarget</comment>
+  </data>
+  <data name="UnsupportedHashAlgorithm" xml:space="preserve">
+    <value>Unsupported hash algorithm: '{0}'</value>
+    <comment>0 - hash algorithm</comment>
+  </data>
+  <data name="Error_EmptyCertificateListInRepository" xml:space="preserve">
+    <value>The repository with service index '{0}' does not list any trusted certificate.</value>
+    <comment>0 - service index</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -726,31 +726,31 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>The argument cannot be null or empty.</value>
   </data>
   <data name="Error_AuthorTrustExpectedAuthorSignature" xml:space="preserve">
-    <value>Author trust was expected but package is not author signed.</value>
+    <value>Unable to add trusted author. The package is not author signed.</value>
   </data>
   <data name="Error_InvalidCertificateInformationFromServer" xml:space="preserve">
-    <value>"Invalid certificate information from service index '{0}'</value>
+    <value>Invalid certificate information from the service index '{0}'</value>
     <comment>0 - service index</comment>
   </data>
   <data name="Error_PackageNotSigned" xml:space="preserve">
     <value>The package is not signed.</value>
   </data>
   <data name="Error_RepoTrustExpectedRepoSignature" xml:space="preserve">
-    <value>Repository trust was expected but package is not repository signed.</value>
+    <value>Unable to add trusted repository. The package is not repository signed or countersigned.</value>
   </data>
   <data name="Error_TrustedAuthorNoOwners" xml:space="preserve">
-    <value>Trusted author cannot have owners.</value>
+    <value>A trusted author cannot have owners.</value>
   </data>
   <data name="Error_TrustedRepoAlreadyExists" xml:space="preserve">
-    <value>Trusted repository with service index '{0}' already exists.</value>
+    <value>A trusted repository with the service index '{0}' already exists.</value>
     <comment>0 - trusted repository name</comment>
   </data>
   <data name="Error_TrustedRepositoryDoesNotExist" xml:space="preserve">
-    <value>Trusted repository with name '{0}' does not exist.</value>
+    <value>A trusted repository with the name '{0}' does not exist.</value>
     <comment>0 - trusted repository name</comment>
   </data>
   <data name="Error_TrustedSignerAlreadyExists" xml:space="preserve">
-    <value>Trusted signer with name '{0}' already exists.</value>
+    <value>A trusted signer with the name '{0}' already exists.</value>
     <comment>0 - trusted signer name</comment>
   </data>
   <data name="Error_UnsupportedTrustTarget" xml:space="preserve">
@@ -762,7 +762,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <comment>0 - hash algorithm</comment>
   </data>
   <data name="Error_EmptyCertificateListInRepository" xml:space="preserve">
-    <value>The repository with service index '{0}' does not list any trusted certificate.</value>
+    <value>The repository with the service index '{0}' does not list any trusted certificates.</value>
     <comment>0 - service index</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -729,7 +729,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>Unable to add trusted author. The package is not author signed.</value>
   </data>
   <data name="Error_InvalidCertificateInformationFromServer" xml:space="preserve">
-    <value>Invalid certificate information from the service index '{0}'</value>
+    <value>Invalid certificate information from the service index '{0}'.</value>
     <comment>0 - service index</comment>
   </data>
   <data name="Error_PackageNotSigned" xml:space="preserve">
@@ -758,7 +758,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <comment>0 - VerificationTarget</comment>
   </data>
   <data name="UnsupportedHashAlgorithm" xml:space="preserve">
-    <value>Unsupported hash algorithm: '{0}'</value>
+    <value>The hash algorithm is unsupported:  '{0}'.</value>
     <comment>0 - hash algorithm</comment>
   </data>
   <data name="Error_EmptyCertificateListInRepository" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignerActionsProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignerActionsProvider.cs
@@ -1,0 +1,310 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Packaging;
+using NuGet.Packaging.Signing;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.Commands
+{
+    public sealed class TrustedSignerActionsProvider
+    {
+        private readonly ITrustedSignersProvider _trustedSignersProvider;
+
+        /// <summary>
+        /// Internal SourceRepository usefull for overriding on tests to get
+        /// mocked responses from the server
+        /// </summary>
+        internal SourceRepository ServiceIndexSourceRepository { get; set; }
+
+        public TrustedSignerActionsProvider(ITrustedSignersProvider trustedSignersProvider)
+        {
+            _trustedSignersProvider = trustedSignersProvider ?? throw new ArgumentNullException(nameof(trustedSignersProvider));
+        }
+
+        /// <summary>
+        /// Refresh the certificates of a repository item with the ones the server is announcing.
+        /// </summary>
+        /// <param name="name">Name of the repository item to refresh.</param>
+        /// <param name="token">Cancellation token</param>
+        /// <exception cref="InvalidOperationException">When a repository item with the given name is not found.</exception>
+        public async Task SyncTrustedRepositoryAsync(string name, CancellationToken token)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(name));
+            }
+
+            var signers = _trustedSignersProvider.GetTrustedSigners();
+            foreach (var existingRepository in signers.OfType<RepositoryItem>())
+            {
+                if (string.Equals(existingRepository.Name, name, StringComparison.Ordinal))
+                {
+                    var certificateItems = await GetCertificateItemsFromServiceIndexAsync(existingRepository.ServiceIndex, token);
+
+                    existingRepository.Certificates.Clear();
+                    existingRepository.Certificates.AddRange(certificateItems);
+
+                    _trustedSignersProvider.AddOrUpdateTrustedSigner(existingRepository);
+
+                    return;
+                }
+            }
+
+            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_TrustedRepositoryDoesNotExist, name));
+        }
+
+#if IS_DESKTOP
+        /// <summary>
+        /// Adds a trusted signer item to the settings based a signed package.
+        /// </summary>
+        /// <param name="name">Name of the trusted signer.</param>
+        /// <param name="package">Package to read signature from.</param>
+        /// <param name="trustTarget">Signature to trust from package.</param>
+        /// <param name="allowUntrustedRoot">Specifies if allowUntrustedRoot should be set to true.</param>
+        /// <param name="owners">Trusted owners that should be set when trusting a repository.</param>
+        /// <param name="token">Cancellation token for async request</param>
+        public async Task AddTrustedSignerAsync(string name, ISignedPackageReader package, VerificationTarget trustTarget, bool allowUntrustedRoot, IEnumerable<string> owners, CancellationToken token)
+        {
+            if (package == null)
+            {
+                throw new ArgumentNullException(nameof(package));
+            }
+
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(name));
+            }
+
+            if (!Enum.IsDefined(typeof(VerificationTarget), trustTarget) || trustTarget == VerificationTarget.Unknown)
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnsupportedTrustTarget, trustTarget.ToString()));
+            }
+
+            if (trustTarget == VerificationTarget.Author && owners != null && owners.Any())
+            {
+                throw new ArgumentException(Strings.Error_TrustedAuthorNoOwners);
+            }
+
+            var v3ServiceIndex = string.Empty;
+            IRepositorySignature reposig = null;
+            var trustingRepository = trustTarget.HasFlag(VerificationTarget.Repository);
+
+            var primarySignature = await package.GetPrimarySignatureAsync(token);
+
+            if (primarySignature == null)
+            {
+                throw new InvalidOperationException(Strings.Error_PackageNotSigned);
+            }
+
+            if (trustingRepository)
+            {
+                if (primarySignature.Type == SignatureType.Repository)
+                {
+                    reposig = primarySignature as RepositoryPrimarySignature;
+                }
+                else
+                {
+                    var countersignature = RepositoryCountersignature.GetRepositoryCountersignature(primarySignature);
+                    reposig = countersignature ?? throw new InvalidOperationException(Strings.Error_RepoTrustExpectedRepoSignature);
+                }
+
+                v3ServiceIndex = reposig.V3ServiceIndexUrl.AbsoluteUri;
+            }
+
+            var signers = _trustedSignersProvider.GetTrustedSigners();
+            foreach (var existingSigner in signers)
+            {
+                if (string.Equals(existingSigner.Name, name, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_TrustedSignerAlreadyExists, name));
+                }
+
+                if (trustingRepository && existingSigner is RepositoryItem repoItem && string.Equals(repoItem.ServiceIndex, v3ServiceIndex, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_TrustedRepoAlreadyExists, v3ServiceIndex));
+                }
+            }
+
+            if (trustingRepository)
+            {
+                var certificateItem = GetCertificateItemForSignature(reposig, allowUntrustedRoot);
+
+                _trustedSignersProvider.AddOrUpdateTrustedSigner(new RepositoryItem(name, v3ServiceIndex, CreateOwnersList(owners), certificateItem));
+            }
+
+            if (trustTarget.HasFlag(VerificationTarget.Author))
+            {
+                if (primarySignature.Type != SignatureType.Author)
+                {
+                    throw new InvalidOperationException(Strings.Error_AuthorTrustExpectedAuthorSignature);
+                }
+
+                var certificateItem = GetCertificateItemForSignature(primarySignature, allowUntrustedRoot);
+
+                _trustedSignersProvider.AddOrUpdateTrustedSigner(new AuthorItem(name, certificateItem));
+            }
+        }
+
+#endif
+
+        /// <summary>
+        /// Adds a new trusted author to the settings.
+        /// If a trusted signer already exists with this name, adds a certificate item to it.
+        /// </summary>
+        /// <param name="name">Name of the trusted author.</param>
+        /// <param name="fingerprint">Fingerprint to be added to the certificate entry.</param>
+        /// <param name="hashAlgorithm">Hash algorithm used to calculate <paramref name="fingerprint"/>.</param>
+        /// <param name="allowUntrustedRoot">Specifies if allowUntrustedRoot should be set to true in the certificate entry.</param>
+        public void AddOrUpdateTrustedSigner(string name, string fingerprint, HashAlgorithmName hashAlgorithm, bool allowUntrustedRoot)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(name));
+            }
+
+            if (string.IsNullOrEmpty(fingerprint))
+            {
+                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(name));
+            }
+
+            if (!Enum.IsDefined(typeof(HashAlgorithmName), hashAlgorithm) || hashAlgorithm == HashAlgorithmName.Unknown)
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithm, hashAlgorithm.ToString()));
+            }
+
+            var certificateToAdd = new CertificateItem(fingerprint, hashAlgorithm, allowUntrustedRoot);
+            TrustedSignerItem signerToAdd = null;
+
+            var signers = _trustedSignersProvider.GetTrustedSigners();
+            foreach (var existingSigner in signers)
+            {
+                if (string.Equals(existingSigner.Name, name, StringComparison.Ordinal))
+                {
+                    signerToAdd = existingSigner;
+
+                    break;
+                }
+            }
+
+            if (signerToAdd == null)
+            {
+                signerToAdd = new AuthorItem(name, certificateToAdd);
+            }
+            else
+            {
+                signerToAdd.Certificates.Add(certificateToAdd);
+            }
+
+            _trustedSignersProvider.AddOrUpdateTrustedSigner(signerToAdd);
+        }
+
+        /// <summary>
+        /// Adds a trusted repository with information from <paramref name="serviceIndex"/>
+        /// </summary>
+        /// <param name="name">Name of the trusted repository.</param>
+        /// <param name="serviceIndex">Service index of the trusted repository. Trusted certificates information will be gotten from here.</param>
+        /// <param name="owners">Owners to be trusted from the repository.</param>
+        /// <param name="token">Cancellation token</param>
+        public async Task AddTrustedRepositoryAsync(string name, Uri serviceIndex, IEnumerable<string> owners, CancellationToken token)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(name));
+            }
+
+            if (serviceIndex == null)
+            {
+                throw new ArgumentNullException(nameof(serviceIndex));
+            }
+
+            var signers = _trustedSignersProvider.GetTrustedSigners();
+            foreach (var existingSigner in signers)
+            {
+                if (string.Equals(existingSigner.Name, name, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_TrustedSignerAlreadyExists, name));
+                }
+
+                if (existingSigner is RepositoryItem repoItem && string.Equals(repoItem.ServiceIndex, serviceIndex.AbsoluteUri, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_TrustedRepoAlreadyExists, serviceIndex.AbsoluteUri));
+                }
+            }
+
+            var certificateItems = await GetCertificateItemsFromServiceIndexAsync(serviceIndex.AbsoluteUri, token);
+
+            _trustedSignersProvider.AddOrUpdateTrustedSigner(
+                new RepositoryItem(name, serviceIndex.AbsoluteUri, CreateOwnersList(owners), certificateItems));
+        }
+#if IS_DESKTOP
+        private CertificateItem GetCertificateItemForSignature(ISignature signature, bool allowUntrustedRoot = false)
+        {
+            var defaultHashAlgorithm = HashAlgorithmName.SHA256;
+            var fingerprint = CertificateUtility.GetHashString(signature.SignerInfo.Certificate, defaultHashAlgorithm);
+
+            return new CertificateItem(fingerprint, defaultHashAlgorithm, allowUntrustedRoot);
+        }
+#endif
+        private async Task<CertificateItem[]> GetCertificateItemsFromServiceIndexAsync(string serviceIndex, CancellationToken token)
+        {
+            if (string.IsNullOrEmpty(serviceIndex))
+            {
+                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(serviceIndex));
+            }
+
+            if (ServiceIndexSourceRepository == null)
+            {
+                var packageSource = new PackageSource(serviceIndex);
+                ServiceIndexSourceRepository = new SourceRepository(packageSource, Repository.Provider.GetCoreV3());
+            }
+
+            var repositorySignatureResource = await ServiceIndexSourceRepository.GetResourceAsync<RepositorySignatureResource>(token);
+
+            if (repositorySignatureResource == null)
+            {
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidCertificateInformationFromServer, serviceIndex));
+            }
+
+            if (repositorySignatureResource.RepositoryCertificateInfos == null || !repositorySignatureResource.RepositoryCertificateInfos.Any())
+            {
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_EmptyCertificateListInRepository, serviceIndex));
+            }
+
+            var certs = new List<CertificateItem>();
+            foreach (var certInfo in repositorySignatureResource.RepositoryCertificateInfos)
+            {
+                foreach (var hashAlgorithm in SigningSpecifications.V1.AllowedHashAlgorithms)
+                {
+                    var fingerprint = certInfo.Fingerprints[hashAlgorithm.ConvertToOidString()];
+
+                    if (!string.IsNullOrEmpty(fingerprint))
+                    {
+                        certs.Add(new CertificateItem(fingerprint, hashAlgorithm));
+                    }
+                }
+            }
+
+            return certs.ToArray();
+        }
+
+        private string CreateOwnersList(IEnumerable<string> owners)
+        {
+            if (owners != null && owners.Any())
+            {
+                return string.Join(OwnersItem.OwnersListSeparator.ToString(), owners);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignerActionsProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignerActionsProvider.cs
@@ -21,7 +21,7 @@ namespace NuGet.Commands
         private readonly ITrustedSignersProvider _trustedSignersProvider;
 
         /// <summary>
-        /// Internal SourceRepository usefull for overriding on tests to get
+        /// Internal SourceRepository useful for overriding on tests to get
         /// mocked responses from the server
         /// </summary>
         internal SourceRepository ServiceIndexSourceRepository { get; set; }
@@ -95,7 +95,9 @@ namespace NuGet.Commands
                 throw new ArgumentException(Strings.Error_TrustedAuthorNoOwners);
             }
 
-            var v3ServiceIndex = string.Empty;
+            token.ThrowIfCancellationRequested();
+
+            string v3ServiceIndex = null;
             IRepositorySignature repositorySignature = null;
             var trustingRepository = trustTarget.HasFlag(VerificationTarget.Repository);
 
@@ -161,7 +163,7 @@ namespace NuGet.Commands
 
             if (string.IsNullOrEmpty(fingerprint))
             {
-                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(name));
+                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(fingerprint));
             }
 
             if (!Enum.IsDefined(typeof(HashAlgorithmName), hashAlgorithm) || hashAlgorithm == HashAlgorithmName.Unknown)

--- a/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignerActionsProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignerActionsProvider.cs
@@ -144,9 +144,10 @@ namespace NuGet.Commands
 #endif
 
         /// <summary>
-        /// Adds a new trusted author to the settings.
-        /// If a trusted signer already exists with this name, adds a certificate item to it.
+        /// Updates the certificate list of a trusted signer by adding the given certificate.
+        /// If the signer does not exists it creates a new one.
         /// </summary>
+        /// <remarks>This method defaults to adding a trusted author if the signer doesn't exist.</remarks>
         /// <param name="name">Name of the trusted author.</param>
         /// <param name="fingerprint">Fingerprint to be added to the certificate entry.</param>
         /// <param name="hashAlgorithm">Hash algorithm used to calculate <paramref name="fingerprint"/>.</param>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/AuthorItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/AuthorItem.cs
@@ -14,8 +14,6 @@ namespace NuGet.Configuration
 
         protected override IReadOnlyCollection<string> RequiredAttributes { get; } = new HashSet<string>() { ConfigurationConstants.NameAttribute };
 
-        public string Name => Attributes[ConfigurationConstants.NameAttribute];
-
         public AuthorItem(string name, params CertificateItem[] certificates)
             : base(name, certificates)
         {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/RepositoryItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/RepositoryItem.cs
@@ -16,18 +16,10 @@ namespace NuGet.Configuration
 
         public string ServiceIndex => Attributes[ConfigurationConstants.ServiceIndex];
 
-        public string Name
+        public new string Name
         {
-            get => Attributes[ConfigurationConstants.NameAttribute];
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                {
-                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.PropertyCannotBeNullOrEmpty, nameof(Name)));
-                }
-
-                UpdateAttribute(ConfigurationConstants.NameAttribute, value);
-            }
+            get => base.Name;
+            set => SetName(value);
         }
 
         private OwnersItem _owners;

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/TrustedSignerItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/TrustedSignerItem.cs
@@ -15,6 +15,18 @@ namespace NuGet.Configuration
 
         public IList<CertificateItem> Certificates { get; }
 
+        public virtual string Name => Attributes[ConfigurationConstants.NameAttribute];
+
+        protected void SetName(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.PropertyCannotBeNullOrEmpty, nameof(Name)));
+            }
+
+            UpdateAttribute(ConfigurationConstants.NameAttribute, value);
+        }
+
         internal readonly IEnumerable<SettingBase> _parsedDescendants;
 
         protected TrustedSignerItem(string name, IEnumerable<CertificateItem> certificates)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/ISignature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/ISignature.cs
@@ -1,17 +1,20 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
+#if IS_DESKTOP
+using System.Security.Cryptography.Pkcs;
+#endif
 
 namespace NuGet.Packaging.Signing
 {
-    public interface IRepositorySignature : ISignature
+    public interface ISignature
     {
 #if IS_DESKTOP
-        Uri V3ServiceIndexUrl { get; }
+        SignatureType Type { get; }
 
-        IReadOnlyList<string> PackageOwners { get; }
+        string FriendlyName { get; }
+
+        SignerInfo SignerInfo { get; }
 #endif
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/ISignature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/ISignature.cs
@@ -12,8 +12,6 @@ namespace NuGet.Packaging.Signing
 #if IS_DESKTOP
         SignatureType Type { get; }
 
-        string FriendlyName { get; }
-
         SignerInfo SignerInfo { get; }
 #endif
     }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
@@ -16,7 +16,7 @@ namespace NuGet.Packaging.Signing
     /// <summary>
     /// Package signature information.
     /// </summary>
-    public abstract class Signature
+    public abstract class Signature : ISignature
     {
 #if IS_DESKTOP
         private readonly Lazy<IReadOnlyList<Timestamp>> _timestamps;

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/NuGet.Commands.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/NuGet.Commands.Test.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
+    <ProjectReference Include="..\NuGet.Configuration.Test\NuGet.Configuration.Test.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
@@ -27,9 +28,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="System.Security">
+      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6\System.Security.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/NuGet.Commands.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/NuGet.Commands.Test.csproj
@@ -21,16 +21,11 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Security" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="compiler\resources\*" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Security">
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6\System.Security.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
@@ -1,0 +1,1303 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+#if IS_DESKTOP
+using System.Security.Cryptography.Pkcs;
+#endif
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Configuration.Test;
+using NuGet.Packaging;
+using NuGet.Packaging.Signing;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using Test.Utility;
+using Test.Utility.Signing;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class TrustedSignerActionsProviderTests
+    {
+        private const string _expectedCertificateFingerprint = "3f9001ea83c560d712c24cf213c3d312cb3bff51ee89435d3430bd06b5d0eece";
+
+        [Fact]
+        public void TrustedSignerActionsProvider_Constructor_WithNullTrustedSignersProvider()
+        {
+            // Act and Assert
+            var ex = Record.Exception(() => new TrustedSignerActionsProvider(trustedSignersProvider: null));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task SyncTrustedRepositoryAsync_WithNullOrEmptyName_ThrowsAsync(string name)
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+
+            // Act and Assert
+            var ex = await Record.ExceptionAsync(async () => await actionsProvider.SyncTrustedRepositoryAsync(name, CancellationToken.None));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentException>();
+            ex.Message.Should().Contain(Strings.ArgumentCannotBeNullOrEmpty);
+        }
+
+        [Fact]
+        public async Task SyncTrustedRepositoryAsync_WithNonExistantRepositoryItem_ThrowsAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    new RepositoryItem("repo1", "https://serviceIndex.test/api.json", new CertificateItem("abc", HashAlgorithmName.SHA256))
+                });
+
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+
+
+            // Act and Assert
+            var ex = await Record.ExceptionAsync(async () => await actionsProvider.SyncTrustedRepositoryAsync("repo2", CancellationToken.None));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<InvalidOperationException>();
+            ex.Message.Should().Be(string.Format(CultureInfo.CurrentCulture, Strings.Error_TrustedRepositoryDoesNotExist, "repo2"));
+        }
+
+        [Fact]
+        public async Task SyncTrustedRepositoryAsync_RepositoryWithoutRepositorySignatureEndpoint_ThrowsAsync()
+        {
+            // Arrange
+            var source = $"https://{Guid.NewGuid()}.unit.test/v3-with-flat-container/index.json";
+            var responses = new Dictionary<string, string>
+            {
+                { source, JsonData.IndexWithFlatContainer }
+            };
+
+            var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
+
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    new RepositoryItem("repo1", source, new CertificateItem("abc", HashAlgorithmName.SHA256))
+                });
+
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object)
+            {
+                ServiceIndexSourceRepository = repo
+            };
+
+            // Act and Assert
+            var ex = await Record.ExceptionAsync(async () => await actionsProvider.SyncTrustedRepositoryAsync("repo1", CancellationToken.None));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<InvalidOperationException>();
+            ex.Message.Should().Be(string.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidCertificateInformationFromServer, source));
+        }
+
+        [Fact]
+        public async Task SyncTrustedRepositoryAsync_RepositoryWithoutCerts_ThrowsAsync()
+        {
+            // Arrange
+            var source = $"https://{Guid.NewGuid()}.unit.test/v3-with-flat-container/index.json";
+            var responses = new Dictionary<string, string>
+            {
+                { source, JsonData.RepoSignIndexJsonData },
+                { "https://api.nuget.org/v3-index/repository-signatures/index.json", JsonData.RepoSignDataEmptyCertInfo }
+            };
+
+            var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
+
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    new RepositoryItem("repo1", source, new CertificateItem("abc", HashAlgorithmName.SHA256))
+                });
+
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object)
+            {
+                ServiceIndexSourceRepository = repo
+            };
+
+            // Act and Assert
+            var ex = await Record.ExceptionAsync(async () => await actionsProvider.SyncTrustedRepositoryAsync("repo1", CancellationToken.None));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<InvalidOperationException>();
+            ex.Message.Should().Be(string.Format(CultureInfo.CurrentCulture, Strings.Error_EmptyCertificateListInRepository, source));
+        }
+
+
+        [Fact]
+        public async Task SyncTrustedRepositoryAsync_WithExistingRepositoryItem_UpdatesCertificatesInItemWithLatestFromRepositoryAsync()
+        {
+            // Arrange
+            var source = $"https://{Guid.NewGuid()}.unit.test/v3-with-flat-container/index.json";
+            var responses = new Dictionary<string, string>
+            {
+                { source, JsonData.RepoSignIndexJsonData },
+                { "https://api.nuget.org/v3-index/repository-signatures/index.json", JsonData.RepoSignData }
+            };
+
+            var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
+
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    new RepositoryItem("repo1", source, new CertificateItem("abc", HashAlgorithmName.SHA256))
+                });
+
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object)
+            {
+                ServiceIndexSourceRepository = repo
+            };
+
+            var expectedCert = new CertificateItem(_expectedCertificateFingerprint, HashAlgorithmName.SHA256);
+
+            // Act
+            await actionsProvider.SyncTrustedRepositoryAsync("repo1", CancellationToken.None);
+
+            // Assert
+            trustedSignersProvider.Verify(p =>
+                p.AddOrUpdateTrustedSigner(It.Is<RepositoryItem>(i =>
+                    i.Certificates.Count == 1 &&
+                    SettingsTestUtils.DeepEquals(i.Certificates.First(), expectedCert))));
+        }
+
+#if IS_DESKTOP
+        [Fact]
+        public async Task AddTrustedSignerAsync_WithNullPackage_ThrowsAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+
+            // Act and Assert
+            var ex = await Record.ExceptionAsync(async () =>
+                await actionsProvider.AddTrustedSignerAsync(name: "signer", package: null, trustTarget: VerificationTarget.All, allowUntrustedRoot: false, owners: null, token: CancellationToken.None));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task AddTrustedSignerAsync_WithNullOrEmptyName_ThrowsAsync(string name)
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var packageReader = new Mock<ISignedPackageReader>();
+
+            // Act and Assert
+            var ex = await Record.ExceptionAsync(async () =>
+                await actionsProvider.AddTrustedSignerAsync(
+                    name,
+                    packageReader.Object,
+                    trustTarget: VerificationTarget.All,
+                    allowUntrustedRoot: false,
+                    owners: null,
+                    token: CancellationToken.None));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentException>();
+            ex.Message.Should().Contain(Strings.ArgumentCannotBeNullOrEmpty);
+        }
+
+        [Fact]
+        public async Task AddTrustedSignerAsync_WithUnknownTrustTarget_ThrowsAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var packageReader = new Mock<ISignedPackageReader>();
+
+            // Act and Assert
+            var ex = await Record.ExceptionAsync(async () =>
+                await actionsProvider.AddTrustedSignerAsync(
+                    name: "signer",
+                    package: packageReader.Object,
+                    trustTarget: VerificationTarget.Unknown,
+                    allowUntrustedRoot: false,
+                    owners: null,
+                    token: CancellationToken.None));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentException>();
+            ex.Message.Should().Contain(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnsupportedTrustTarget, VerificationTarget.Unknown.ToString()));
+        }
+
+        [Fact]
+        public async Task AddTrustedSignerAsync_WithUnsupportedTrustTarget_ThrowsAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var packageReader = new Mock<ISignedPackageReader>();
+
+            // Act and Assert
+            var ex = await Record.ExceptionAsync(async () =>
+                await actionsProvider.AddTrustedSignerAsync(
+                    name: "signer",
+                    package: packageReader.Object,
+                    trustTarget: (VerificationTarget)99,
+                    allowUntrustedRoot: false,
+                    owners: null,
+                    token: CancellationToken.None));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentException>();
+            ex.Message.Should().Contain(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnsupportedTrustTarget, ((VerificationTarget)99).ToString()));
+        }
+
+        [Fact]
+        public async Task AddTrustedSignerAsync_AuthorTrustTarget_SpecifyingOwners_ThrowsAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var packageReader = new Mock<ISignedPackageReader>();
+
+            // Act and Assert
+            var ex = await Record.ExceptionAsync(async () =>
+                await actionsProvider.AddTrustedSignerAsync(
+                    name: "signer",
+                    package: packageReader.Object,
+                    trustTarget: VerificationTarget.Author,
+                    allowUntrustedRoot: false,
+                    owners: new List<string>() { "one", "two" },
+                    token: CancellationToken.None));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentException>();
+            ex.Message.Should().Be(Strings.Error_TrustedAuthorNoOwners);
+        }
+
+        [Fact]
+        public async Task AddTrustedSignersAsync_UnsignedPackage_ThrowsAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var packageReader = new Mock<ISignedPackageReader>();
+
+            packageReader
+                .Setup(r => r.GetPrimarySignatureAsync(It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult<PrimarySignature>(null));
+
+            // Act and Assert
+            var ex = await Record.ExceptionAsync(async () =>
+                await actionsProvider.AddTrustedSignerAsync(
+                    name: "signer",
+                    package: packageReader.Object,
+                    trustTarget: VerificationTarget.Author,
+                    allowUntrustedRoot: false,
+                    owners: null,
+                    token: CancellationToken.None));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<InvalidOperationException>();
+            ex.Message.Should().Be(Strings.Error_PackageNotSigned);
+        }
+
+        [CIOnlyFact]
+        public async Task AddTrustedSignersAsync_TargetRepository_NonRepositorySignedPackage_ThrowsAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var packageContext = new SimpleTestPackageContext();
+
+            using (var directory = TestDirectory.Create())
+            using (var trustedCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            {
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(trustedCert.Source.Cert, packageContext, directory);
+
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act and Assert
+                    var ex = await Record.ExceptionAsync(async () =>
+                        await actionsProvider.AddTrustedSignerAsync(
+                            name: "signer",
+                            package: packageReader,
+                            trustTarget: VerificationTarget.Repository,
+                            allowUntrustedRoot: false,
+                            owners: null,
+                            token: CancellationToken.None));
+
+                    ex.Should().NotBeNull();
+                    ex.Should().BeOfType<InvalidOperationException>();
+                    ex.Message.Should().Be(Strings.Error_RepoTrustExpectedRepoSignature);
+                }
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task AddTrustedSignersAsync_NameAlreadyExists_ThrowsAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var packageContext = new SimpleTestPackageContext();
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    new AuthorItem("author1", new CertificateItem("abc", HashAlgorithmName.SHA256))
+                });
+
+            using (var directory = TestDirectory.Create())
+            using (var trustedCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            {
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(trustedCert.Source.Cert, packageContext, directory);
+
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act and Assert
+                    var ex = await Record.ExceptionAsync(async () =>
+                        await actionsProvider.AddTrustedSignerAsync(
+                            name: "author1",
+                            package: packageReader,
+                            trustTarget: VerificationTarget.Author,
+                            allowUntrustedRoot: false,
+                            owners: null,
+                            token: CancellationToken.None));
+
+                    ex.Should().NotBeNull();
+                    ex.Should().BeOfType<InvalidOperationException>();
+                    ex.Message.Should().Be(string.Format(CultureInfo.CurrentCulture, Strings.Error_TrustedSignerAlreadyExists, "author1"));
+                }
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task AddTrustedSignersAsync_ServiceIndexAlreadyExists_ThrowsAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var packageContext = new SimpleTestPackageContext();
+            var repoServiceIndex = "https://trustedv3serviceindex.test/api.json";
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    new RepositoryItem("repo1", repoServiceIndex, new CertificateItem("abc", HashAlgorithmName.SHA256))
+                });
+
+            using (var directory = TestDirectory.Create())
+            using (var trustedCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            {
+                var signedPackagePath = await SignedArchiveTestUtility.RepositorySignPackageAsync(trustedCert.Source.Cert, packageContext, directory, new Uri(repoServiceIndex));
+
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act and Assert
+                    var ex = await Record.ExceptionAsync(async () =>
+                        await actionsProvider.AddTrustedSignerAsync(
+                            name: "repo2",
+                            package: packageReader,
+                            trustTarget: VerificationTarget.Repository,
+                            allowUntrustedRoot: false,
+                            owners: null,
+                            token: CancellationToken.None));
+
+                    ex.Should().NotBeNull();
+                    ex.Should().BeOfType<InvalidOperationException>();
+                    ex.Message.Should().Be(string.Format(CultureInfo.CurrentCulture, Strings.Error_TrustedRepoAlreadyExists, repoServiceIndex));
+                }
+            }
+        }
+
+        [Fact]
+        public async Task AddTrustedSignersAsync_WithUnknownPrimarySignature_ThrowsAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var packageReader = new Mock<ISignedPackageReader>();
+
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var packageContext = new SimpleTestPackageContext();
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>());
+
+            using (var trustedCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            {
+                var content = new SignatureContent(
+                     SigningSpecifications.V1,
+                     HashAlgorithmName.SHA256,
+                     hashValue: "hash");
+
+                var contentInfo = new ContentInfo(content.GetBytes());
+                var signedCms = new SignedCms(contentInfo);
+                var cmsSigner = new CmsSigner(trustedCert.Source.Cert);
+                signedCms.ComputeSignature(cmsSigner);
+
+                var signature = PrimarySignature.Load(signedCms.Encode());
+
+                packageReader
+                    .Setup(r => r.GetPrimarySignatureAsync(It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(signature));
+
+                // Act and Assert
+                var ex = await Record.ExceptionAsync(async () =>
+                    await actionsProvider.AddTrustedSignerAsync(
+                        name: "author1",
+                        package: packageReader.Object,
+                        trustTarget: VerificationTarget.Author,
+                        allowUntrustedRoot: false,
+                        owners: null,
+                        token: CancellationToken.None));
+
+                ex.Should().NotBeNull();
+                ex.Should().BeOfType<InvalidOperationException>();
+                ex.Message.Should().Be(Strings.Error_AuthorTrustExpectedAuthorSignature);
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task AddTrustedSignersAsync_RepositorySignedPackage_AddsRepositoryCorrectlyAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var packageContext = new SimpleTestPackageContext();
+            var repoServiceIndex = "https://trustedV3ServiceIndex.test/api.json";
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>());
+
+            using (var directory = TestDirectory.Create())
+            using (var trustedCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            {
+                var certFingerprint = CertificateUtility.GetHashString(trustedCert.Source.Cert, HashAlgorithmName.SHA256);
+
+                var signedPackagePath = await SignedArchiveTestUtility.RepositorySignPackageAsync(trustedCert.Source.Cert, packageContext, directory, new Uri(repoServiceIndex));
+
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    await actionsProvider.AddTrustedSignerAsync(
+                        name: "repo1",
+                        package: packageReader,
+                        trustTarget: VerificationTarget.Repository,
+                        allowUntrustedRoot: false,
+                        owners: null,
+                        token: CancellationToken.None);
+
+                    var expectedCert = new CertificateItem(certFingerprint, HashAlgorithmName.SHA256);
+
+                    // Assert
+                    trustedSignersProvider.Verify(p =>
+                        p.AddOrUpdateTrustedSigner(It.Is<RepositoryItem>(i =>
+                            string.Equals(i.Name, "repo1", StringComparison.Ordinal) &&
+                            string.Equals(i.ServiceIndex, repoServiceIndex, StringComparison.OrdinalIgnoreCase) &&
+                            !i.Owners.Any() &&
+                            i.Certificates.Count == 1 &&
+                            SettingsTestUtils.DeepEquals(i.Certificates.First(), expectedCert))));
+                }
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task AddTrustedSignersAsync_RepositorySignedPackage_WithOwners_AddsRepositoryCorrectlyAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var packageContext = new SimpleTestPackageContext();
+            var repoServiceIndex = "https://trustedV3ServiceIndex.test/api.json";
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>());
+
+            using (var directory = TestDirectory.Create())
+            using (var trustedCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            {
+                var certFingerprint = CertificateUtility.GetHashString(trustedCert.Source.Cert, HashAlgorithmName.SHA256);
+                var expectedOwners = new List<string>() { "one", "two", "three" };
+
+                var signedPackagePath = await SignedArchiveTestUtility.RepositorySignPackageAsync(trustedCert.Source.Cert, packageContext, directory, new Uri(repoServiceIndex));
+
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    await actionsProvider.AddTrustedSignerAsync(
+                        name: "repo1",
+                        package: packageReader,
+                        trustTarget: VerificationTarget.Repository,
+                        allowUntrustedRoot: false,
+                        owners: expectedOwners,
+                        token: CancellationToken.None);
+
+                    var expectedCert = new CertificateItem(certFingerprint, HashAlgorithmName.SHA256);
+
+                    // Assert
+                    trustedSignersProvider.Verify(p =>
+                        p.AddOrUpdateTrustedSigner(It.Is<RepositoryItem>(i =>
+                            string.Equals(i.Name, "repo1", StringComparison.Ordinal) &&
+                            string.Equals(i.ServiceIndex, repoServiceIndex, StringComparison.OrdinalIgnoreCase) &&
+                            i.Owners.SequenceEqual(expectedOwners) &&
+                            i.Certificates.Count == 1 &&
+                            SettingsTestUtils.DeepEquals(i.Certificates.First(), expectedCert))));
+                }
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task AddTrustedSignersAsync_RepositorySignedPackage_WithAllowUntrustedRoot_AddsRepositoryCorrectlyAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var packageContext = new SimpleTestPackageContext();
+            var repoServiceIndex = "https://trustedV3ServiceIndex.test/api.json";
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>());
+
+            using (var directory = TestDirectory.Create())
+            using (var trustedCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            {
+                var certFingerprint = CertificateUtility.GetHashString(trustedCert.Source.Cert, HashAlgorithmName.SHA256);
+                var expectedOwners = new List<string>() { "one", "two", "three" };
+
+                var signedPackagePath = await SignedArchiveTestUtility.RepositorySignPackageAsync(trustedCert.Source.Cert, packageContext, directory, new Uri(repoServiceIndex));
+
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    await actionsProvider.AddTrustedSignerAsync(
+                        name: "repo1",
+                        package: packageReader,
+                        trustTarget: VerificationTarget.Repository,
+                        allowUntrustedRoot: true,
+                        owners: expectedOwners,
+                        token: CancellationToken.None);
+
+                    var expectedCert = new CertificateItem(certFingerprint, HashAlgorithmName.SHA256, allowUntrustedRoot: true);
+
+                    // Assert
+                    trustedSignersProvider.Verify(p =>
+                        p.AddOrUpdateTrustedSigner(It.Is<RepositoryItem>(i =>
+                            string.Equals(i.Name, "repo1", StringComparison.Ordinal) &&
+                            string.Equals(i.ServiceIndex, repoServiceIndex, StringComparison.OrdinalIgnoreCase) &&
+                            i.Owners.SequenceEqual(expectedOwners) &&
+                            i.Certificates.Count == 1 &&
+                            SettingsTestUtils.DeepEquals(i.Certificates.First(), expectedCert))));
+                }
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task AddTrustedSignersAsync_RepositoryCountersignedPackage_AddsRepositoryCorrectlyAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var packageContext = new SimpleTestPackageContext();
+            var repoServiceIndex = "https://trustedV3ServiceIndex.test/api.json";
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>());
+
+            using (var directory = TestDirectory.Create())
+            using (var authorCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            using (var repoCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            {
+                var certFingerprint = CertificateUtility.GetHashString(repoCert.Source.Cert, HashAlgorithmName.SHA256);
+
+                var authorSignedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(authorCert.Source.Cert, packageContext, directory);
+                var signedPackagePath = await SignedArchiveTestUtility.RepositorySignPackageAsync(repoCert.Source.Cert, authorSignedPackagePath, directory, new Uri(repoServiceIndex));
+
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    await actionsProvider.AddTrustedSignerAsync(
+                        name: "repo1",
+                        package: packageReader,
+                        trustTarget: VerificationTarget.Repository,
+                        allowUntrustedRoot: false,
+                        owners: null,
+                        token: CancellationToken.None);
+
+                    var expectedCert = new CertificateItem(certFingerprint, HashAlgorithmName.SHA256, allowUntrustedRoot: false);
+
+                    // Assert
+                    trustedSignersProvider.Verify(p =>
+                        p.AddOrUpdateTrustedSigner(It.Is<RepositoryItem>(i =>
+                            string.Equals(i.Name, "repo1", StringComparison.Ordinal) &&
+                            string.Equals(i.ServiceIndex, repoServiceIndex, StringComparison.OrdinalIgnoreCase) &&
+                            !i.Owners.Any() &&
+                            i.Certificates.Count == 1 &&
+                            SettingsTestUtils.DeepEquals(i.Certificates.First(), expectedCert))));
+                }
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task AddTrustedSignersAsync_RepositoryCountersignedPackage_WithOwners_AddsRepositoryCorrectlyAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var packageContext = new SimpleTestPackageContext();
+            var repoServiceIndex = "https://trustedV3ServiceIndex.test/api.json";
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>());
+
+            using (var directory = TestDirectory.Create())
+            using (var authorCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            using (var repoCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            {
+                var certFingerprint = CertificateUtility.GetHashString(repoCert.Source.Cert, HashAlgorithmName.SHA256);
+                var expectedOwners = new List<string>() { "one", "two", "three" };
+
+                var authorSignedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(authorCert.Source.Cert, packageContext, directory);
+                var signedPackagePath = await SignedArchiveTestUtility.RepositorySignPackageAsync(repoCert.Source.Cert, authorSignedPackagePath, directory, new Uri(repoServiceIndex));
+
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    await actionsProvider.AddTrustedSignerAsync(
+                        name: "repo1",
+                        package: packageReader,
+                        trustTarget: VerificationTarget.Repository,
+                        allowUntrustedRoot: false,
+                        owners: expectedOwners,
+                        token: CancellationToken.None);
+
+                    var expectedCert = new CertificateItem(certFingerprint, HashAlgorithmName.SHA256, allowUntrustedRoot: false);
+
+                    // Assert
+                    trustedSignersProvider.Verify(p =>
+                        p.AddOrUpdateTrustedSigner(It.Is<RepositoryItem>(i =>
+                            string.Equals(i.Name, "repo1", StringComparison.Ordinal) &&
+                            string.Equals(i.ServiceIndex, repoServiceIndex, StringComparison.OrdinalIgnoreCase) &&
+                            i.Owners.SequenceEqual(expectedOwners) &&
+                            i.Certificates.Count == 1 &&
+                            SettingsTestUtils.DeepEquals(i.Certificates.First(), expectedCert))));
+                }
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task AddTrustedSignersAsync_RepositoryCountersignedPackage_WithAllowUntrustedRoot_AddsRepositoryCorrectlyAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var packageContext = new SimpleTestPackageContext();
+            var repoServiceIndex = "https://trustedV3ServiceIndex.test/api.json";
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>());
+
+            using (var directory = TestDirectory.Create())
+            using (var authorCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            using (var repoCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            {
+                var certFingerprint = CertificateUtility.GetHashString(repoCert.Source.Cert, HashAlgorithmName.SHA256);
+                var expectedOwners = new List<string>() { "one", "two", "three" };
+
+                var authorSignedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(authorCert.Source.Cert, packageContext, directory);
+                var signedPackagePath = await SignedArchiveTestUtility.RepositorySignPackageAsync(repoCert.Source.Cert, authorSignedPackagePath, directory, new Uri(repoServiceIndex));
+
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    await actionsProvider.AddTrustedSignerAsync(
+                        name: "repo1",
+                        package: packageReader,
+                        trustTarget: VerificationTarget.Repository,
+                        allowUntrustedRoot: true,
+                        owners: expectedOwners,
+                        token: CancellationToken.None);
+
+                    var expectedCert = new CertificateItem(certFingerprint, HashAlgorithmName.SHA256, allowUntrustedRoot: true);
+
+                    // Assert
+                    trustedSignersProvider.Verify(p =>
+                        p.AddOrUpdateTrustedSigner(It.Is<RepositoryItem>(i =>
+                            string.Equals(i.Name, "repo1", StringComparison.Ordinal) &&
+                            string.Equals(i.ServiceIndex, repoServiceIndex, StringComparison.OrdinalIgnoreCase) &&
+                            i.Owners.SequenceEqual(expectedOwners) &&
+                            i.Certificates.Count == 1 &&
+                            SettingsTestUtils.DeepEquals(i.Certificates.First(), expectedCert))));
+                }
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task AddTrustedSignersAsync_AuthorSignedPackage_AddsAuthorCorrectlyAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var packageContext = new SimpleTestPackageContext();
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>());
+
+            using (var directory = TestDirectory.Create())
+            using (var authorCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            {
+                var certFingerprint = CertificateUtility.GetHashString(authorCert.Source.Cert, HashAlgorithmName.SHA256);
+
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(authorCert.Source.Cert, packageContext, directory);
+
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    await actionsProvider.AddTrustedSignerAsync(
+                        name: "author1",
+                        package: packageReader,
+                        trustTarget: VerificationTarget.Author,
+                        allowUntrustedRoot: false,
+                        owners: null,
+                        token: CancellationToken.None);
+
+                    var expectedCert = new CertificateItem(certFingerprint, HashAlgorithmName.SHA256, allowUntrustedRoot: false);
+
+                    // Assert
+                    trustedSignersProvider.Verify(p =>
+                        p.AddOrUpdateTrustedSigner(It.Is<AuthorItem>(i =>
+                            string.Equals(i.Name, "author1", StringComparison.Ordinal) &&
+                            i.Certificates.Count == 1 &&
+                            SettingsTestUtils.DeepEquals(i.Certificates.First(), expectedCert))));
+                }
+            }
+        }
+
+        [CIOnlyFact]
+        public async Task AddTrustedSignersAsync_AuthorSignedPackage_WithAllowUntrustedRoot_AddsAuthorCorrectlyAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var packageContext = new SimpleTestPackageContext();
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>());
+
+            using (var directory = TestDirectory.Create())
+            using (var authorCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            {
+                var certFingerprint = CertificateUtility.GetHashString(authorCert.Source.Cert, HashAlgorithmName.SHA256);
+
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(authorCert.Source.Cert, packageContext, directory);
+
+                using (var packageReader = new PackageArchiveReader(signedPackagePath))
+                {
+                    // Act
+                    await actionsProvider.AddTrustedSignerAsync(
+                        name: "author1",
+                        package: packageReader,
+                        trustTarget: VerificationTarget.Author,
+                        allowUntrustedRoot: true,
+                        owners: null,
+                        token: CancellationToken.None);
+
+                    var expectedCert = new CertificateItem(certFingerprint, HashAlgorithmName.SHA256, allowUntrustedRoot: true);
+
+                    // Assert
+                    trustedSignersProvider.Verify(p =>
+                        p.AddOrUpdateTrustedSigner(It.Is<AuthorItem>(i =>
+                            string.Equals(i.Name, "author1", StringComparison.Ordinal) &&
+                            i.Certificates.Count == 1 &&
+                            SettingsTestUtils.DeepEquals(i.Certificates.First(), expectedCert))));
+                }
+            }
+        }
+#endif
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void AddOrUpdateTrustedSigner_WithNullOrEmptyName_Throws(string name)
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+
+            // Act and Assert
+            var ex = Record.Exception(() => actionsProvider.AddOrUpdateTrustedSigner(name, fingerprint: "abc", hashAlgorithm: HashAlgorithmName.SHA256, allowUntrustedRoot: false));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentException>();
+            ex.Message.Should().Contain(Strings.ArgumentCannotBeNullOrEmpty);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void AddOrUpdateTrustedSigner_WithNullOrEmptyFingerprint_Throws(string fingerprint)
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+
+            // Act and Assert
+            var ex = Record.Exception(() => actionsProvider.AddOrUpdateTrustedSigner(name: "author1", fingerprint: fingerprint, hashAlgorithm: HashAlgorithmName.SHA256, allowUntrustedRoot: false));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentException>();
+            ex.Message.Should().Contain(Strings.ArgumentCannotBeNullOrEmpty);
+        }
+
+        [Fact]
+        public void AddOrUpdateTrustedSigner_WithUnknownHashAlgorithm_Throws()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+
+            // Act and Assert
+            var ex = Record.Exception(() => actionsProvider.AddOrUpdateTrustedSigner(name: "author1", fingerprint: "abc", hashAlgorithm: HashAlgorithmName.Unknown, allowUntrustedRoot: false));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentException>();
+            ex.Message.Should().Contain(string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithm, HashAlgorithmName.Unknown.ToString()));
+        }
+
+
+        [Fact]
+        public void AddOrUpdateTrustedSigner_WithUnsupportedHashAlgorithm_Throws()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+
+            // Act and Assert
+            var ex = Record.Exception(() => actionsProvider.AddOrUpdateTrustedSigner(name: "author1", fingerprint: "abc", hashAlgorithm: (HashAlgorithmName)99, allowUntrustedRoot: false));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentException>();
+            ex.Message.Should().Contain(string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedHashAlgorithm, ((HashAlgorithmName)99).ToString()));
+        }
+
+        [Fact]
+        public void AddOrUpdateTrustedSigner_NewAuthor_AddsAuthorSuccesffully()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>());
+
+            var expectedCerts = new List<CertificateItem>()
+            {
+                new CertificateItem("def", HashAlgorithmName.SHA256),
+            };
+
+            // Act
+            actionsProvider.AddOrUpdateTrustedSigner(name: "author1", fingerprint: "def", hashAlgorithm: HashAlgorithmName.SHA256, allowUntrustedRoot: false);
+
+            // Assert
+            trustedSignersProvider.Verify(p =>
+                p.AddOrUpdateTrustedSigner(It.Is<AuthorItem>(i =>
+                    string.Equals(i.Name, "author1", StringComparison.Ordinal) &&
+                    i.Certificates.Count == 1 &&
+                    SettingsTestUtils.SequenceDeepEquals(i.Certificates, expectedCerts))));
+        }
+
+        [Fact]
+        public void AddOrUpdateTrustedSigner_NewItem_AllowUntrustedRoot_AddsAuthorSuccesffully()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>());
+
+            var expectedCerts = new List<CertificateItem>()
+            {
+                new CertificateItem("def", HashAlgorithmName.SHA256, allowUntrustedRoot: true),
+            };
+
+            // Act
+            actionsProvider.AddOrUpdateTrustedSigner(name: "author1", fingerprint: "def", hashAlgorithm: HashAlgorithmName.SHA256, allowUntrustedRoot: true);
+
+            // Assert
+            trustedSignersProvider.Verify(p =>
+                p.AddOrUpdateTrustedSigner(It.Is<AuthorItem>(i =>
+                    string.Equals(i.Name, "author1", StringComparison.Ordinal) &&
+                    i.Certificates.Count == 1 &&
+                    SettingsTestUtils.SequenceDeepEquals(i.Certificates, expectedCerts))));
+        }
+
+        [Fact]
+        public void AddOrUpdateTrustedSigner_ExistingAuthor_UpdatesItemSuccessfully()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    new AuthorItem("author1", new CertificateItem("abc", HashAlgorithmName.SHA256, allowUntrustedRoot: true))
+                });
+
+
+            var expectedCerts = new List<CertificateItem>()
+            {
+                new CertificateItem("abc", HashAlgorithmName.SHA256, allowUntrustedRoot: true),
+                new CertificateItem("def", HashAlgorithmName.SHA256)
+            };
+
+            // Act
+            actionsProvider.AddOrUpdateTrustedSigner(name: "author1", fingerprint: "def", hashAlgorithm: HashAlgorithmName.SHA256, allowUntrustedRoot: false);
+
+            // Assert
+            trustedSignersProvider.Verify(p =>
+                p.AddOrUpdateTrustedSigner(It.Is<AuthorItem>(i =>
+                    string.Equals(i.Name, "author1", StringComparison.Ordinal) &&
+                    i.Certificates.Count == 2 &&
+                    SettingsTestUtils.SequenceDeepEquals(i.Certificates, expectedCerts))));
+        }
+
+        [Fact]
+        public void AddOrUpdateTrustedSigner_ExistingItem_AllowUntrustedRoot_UpdatesItemSuccessfully()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    new RepositoryItem("repo1", "https://serviceIndex.test/api.json", new CertificateItem("abc", HashAlgorithmName.SHA256))
+                });
+
+
+            var expectedCerts = new List<CertificateItem>()
+            {
+                new CertificateItem("abc", HashAlgorithmName.SHA256),
+                new CertificateItem("def", HashAlgorithmName.SHA256, allowUntrustedRoot: true)
+            };
+
+            // Act
+            actionsProvider.AddOrUpdateTrustedSigner(name: "repo1", fingerprint: "def", hashAlgorithm: HashAlgorithmName.SHA256, allowUntrustedRoot: true);
+
+            // Assert
+            trustedSignersProvider.Verify(p =>
+                p.AddOrUpdateTrustedSigner(It.Is<RepositoryItem>(i =>
+                    string.Equals(i.Name, "repo1", StringComparison.Ordinal) &&
+                    i.Certificates.Count == 2 &&
+                    SettingsTestUtils.SequenceDeepEquals(i.Certificates, expectedCerts))));
+        }
+
+        [Fact]
+        public void AddOrUpdateTrustedSigner_ExistingRepository_UpdatesItemSuccessfully()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    new RepositoryItem("repo1", "https://serviceIndex.test/api.json", new CertificateItem("abc", HashAlgorithmName.SHA256))
+                });
+
+
+            var expectedCerts = new List<CertificateItem>()
+            {
+                new CertificateItem("abc", HashAlgorithmName.SHA256),
+                new CertificateItem("def", HashAlgorithmName.SHA256)
+            };
+
+            // Act
+            actionsProvider.AddOrUpdateTrustedSigner(name: "repo1", fingerprint: "def", hashAlgorithm: HashAlgorithmName.SHA256, allowUntrustedRoot: false);
+
+            // Assert
+            trustedSignersProvider.Verify(p =>
+                p.AddOrUpdateTrustedSigner(It.Is<RepositoryItem>(i =>
+                    string.Equals(i.Name, "repo1", StringComparison.Ordinal) &&
+                    i.Certificates.Count == 2 &&
+                    SettingsTestUtils.SequenceDeepEquals(i.Certificates, expectedCerts))));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task AddTrustedRepositoryAsync_WithNullOrEmptyName_ThrowsAsync(string name)
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+
+            // Act and Assert
+            var ex = await Record.ExceptionAsync(async () => await actionsProvider.AddTrustedRepositoryAsync(name, new Uri("https://serviceIndex.test/v3/api.json"), owners: null, token: CancellationToken.None));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentException>();
+            ex.Message.Should().Contain(Strings.ArgumentCannotBeNullOrEmpty);
+        }
+
+        [Fact]
+        public async Task AddTrustedRepositoryAsync_WithNullServiceIndex_ThrowsAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+
+            // Act and Assert
+            var ex = await Record.ExceptionAsync(async () => await actionsProvider.AddTrustedRepositoryAsync("repo1", serviceIndex: null, owners: null, token: CancellationToken.None));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async Task AddTrustedRepositoryAsync_WithNameAlreadyUsedInItem_ThrowsAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    new RepositoryItem("repo1", "https://serviceIndex.test/api.json", new CertificateItem("abc", HashAlgorithmName.SHA256))
+                });
+
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+
+
+            // Act and Assert
+            var ex = await Record.ExceptionAsync(async () => await actionsProvider.AddTrustedRepositoryAsync("repo1", new Uri("https://serviceIndex.test/v3/api.json"), owners: null, token: CancellationToken.None));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<InvalidOperationException>();
+            ex.Message.Should().Be(string.Format(CultureInfo.CurrentCulture, Strings.Error_TrustedSignerAlreadyExists, "repo1"));
+        }
+
+        [Fact]
+        public async Task AddTrustedRepositoryAsync_WithServiceIndexAlreadyUsedInItem_ThrowsAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    new RepositoryItem("repo1", "https://serviceIndex.test/api.json", new CertificateItem("abc", HashAlgorithmName.SHA256))
+                });
+
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+
+
+            // Act and Assert
+            var ex = await Record.ExceptionAsync(async () => await actionsProvider.AddTrustedRepositoryAsync("repo2", new Uri("https://serviceIndex.test/api.json"), owners: null, token: CancellationToken.None));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<InvalidOperationException>();
+            ex.Message.Should().Be(string.Format(CultureInfo.CurrentCulture, Strings.Error_TrustedRepoAlreadyExists, "https://serviceindex.test/api.json"));
+        }
+
+        [Fact]
+        public async Task AddTrustedRepositoryAsync_RepositoryWithoutRepositorySignatureEndpoint_ThrowsAsync()
+        {
+            // Arrange
+            var source = $"https://{Guid.NewGuid()}.unit.test/v3-with-flat-container/index.json";
+            var responses = new Dictionary<string, string>
+            {
+                { source, JsonData.IndexWithFlatContainer }
+            };
+
+            var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
+
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    new RepositoryItem("repo1", "https://serviceIndex.test/api.json", new CertificateItem("abc", HashAlgorithmName.SHA256))
+                });
+
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object)
+            {
+                ServiceIndexSourceRepository = repo
+            };
+
+            // Act and Assert
+            var ex = await Record.ExceptionAsync(async () => await actionsProvider.AddTrustedRepositoryAsync("repo2", new Uri(source), owners: null, token: CancellationToken.None));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<InvalidOperationException>();
+            ex.Message.Should().Be(string.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidCertificateInformationFromServer, source));
+        }
+
+        [Fact]
+        public async Task AddTrustedRepositoryAsync_RepositoryWithoutCerts_ThrowsAsync()
+        {
+            // Arrange
+            var source = $"https://{Guid.NewGuid()}.unit.test/v3-with-flat-container/index.json";
+            var responses = new Dictionary<string, string>
+            {
+                { source, JsonData.RepoSignIndexJsonData },
+                { "https://api.nuget.org/v3-index/repository-signatures/index.json", JsonData.RepoSignDataEmptyCertInfo }
+            };
+
+            var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
+
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    new RepositoryItem("repo1", "https://serviceIndex.test/api.json", new CertificateItem("abc", HashAlgorithmName.SHA256))
+                });
+
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object)
+            {
+                ServiceIndexSourceRepository = repo
+            };
+
+            // Act and Assert
+            var ex = await Record.ExceptionAsync(async () => await actionsProvider.AddTrustedRepositoryAsync("repo2", new Uri(source), owners: null, token: CancellationToken.None));
+
+            ex.Should().NotBeNull();
+            ex.Should().BeOfType<InvalidOperationException>();
+            ex.Message.Should().Be(string.Format(CultureInfo.CurrentCulture, Strings.Error_EmptyCertificateListInRepository, source));
+        }
+
+        [Fact]
+        public async Task AddTrustedRepositoryAsync_AddsRepositoryItemSuccessfullyAsync()
+        {
+            // Arrange
+            var source = $"https://{Guid.NewGuid()}.unit.test/v3-with-flat-container/index.json";
+            var responses = new Dictionary<string, string>
+            {
+                { source, JsonData.RepoSignIndexJsonData },
+                { "https://api.nuget.org/v3-index/repository-signatures/index.json", JsonData.RepoSignData }
+            };
+
+            var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
+
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    new RepositoryItem("repo1", "https://serviceIndex.test/api.json", new CertificateItem("abc", HashAlgorithmName.SHA256))
+                });
+
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object)
+            {
+                ServiceIndexSourceRepository = repo
+            };
+
+            var expectedCert = new CertificateItem(_expectedCertificateFingerprint, HashAlgorithmName.SHA256);
+
+            // Act
+            await actionsProvider.AddTrustedRepositoryAsync("repo2", new Uri(source), owners: null, token: CancellationToken.None);
+
+            // Assert
+            trustedSignersProvider.Verify(p =>
+                p.AddOrUpdateTrustedSigner(It.Is<RepositoryItem>(i =>
+                    string.Equals(i.Name, "repo2", StringComparison.Ordinal) &&
+                    string.Equals(i.ServiceIndex, source, StringComparison.OrdinalIgnoreCase) &&
+                    !i.Owners.Any() &&
+                    i.Certificates.Count == 1 &&
+                    SettingsTestUtils.DeepEquals(i.Certificates.First(), expectedCert))));
+        }
+
+        [Fact]
+        public async Task AddTrustedRepositoryAsync_WithOwners_AddsRepositoryItemSuccessfullyAsync()
+        {
+            // Arrange
+            var source = $"https://{Guid.NewGuid()}.unit.test/v3-with-flat-container/index.json";
+            var responses = new Dictionary<string, string>
+            {
+                { source, JsonData.RepoSignIndexJsonData },
+                { "https://api.nuget.org/v3-index/repository-signatures/index.json", JsonData.RepoSignData }
+            };
+
+            var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
+
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    new RepositoryItem("repo1", "https://serviceIndex.test/api.json", new CertificateItem("abc", HashAlgorithmName.SHA256))
+                });
+
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object)
+            {
+                ServiceIndexSourceRepository = repo
+            };
+
+            var expectedCert = new CertificateItem(_expectedCertificateFingerprint, HashAlgorithmName.SHA256);
+            var expectedOwners = new List<string>() { "one", "two", "three" };
+
+            // Act
+            await actionsProvider.AddTrustedRepositoryAsync("repo2", new Uri(source), owners: expectedOwners, token: CancellationToken.None);
+
+            // Assert
+            trustedSignersProvider.Verify(p =>
+                p.AddOrUpdateTrustedSigner(It.Is<RepositoryItem>(i =>
+                    string.Equals(i.Name, "repo2", StringComparison.Ordinal) &&
+                    string.Equals(i.ServiceIndex, source, StringComparison.OrdinalIgnoreCase) &&
+                    i.Owners.Count == 3 &&
+                    i.Owners.SequenceEqual(expectedOwners) &&
+                    i.Certificates.Count == 1 &&
+                    SettingsTestUtils.DeepEquals(i.Certificates.First(), expectedCert))));
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
@@ -34,10 +34,7 @@ namespace NuGet.Commands.Test
         public void TrustedSignerActionsProvider_Constructor_WithNullTrustedSignersProvider()
         {
             // Act and Assert
-            var ex = Record.Exception(() => new TrustedSignerActionsProvider(trustedSignersProvider: null));
-
-            ex.Should().NotBeNull();
-            ex.Should().BeOfType<ArgumentNullException>();
+            Assert.Throws<ArgumentNullException>(() => new TrustedSignerActionsProvider(trustedSignersProvider: null));
         }
 
         [Theory]
@@ -50,11 +47,10 @@ namespace NuGet.Commands.Test
             var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
 
             // Act and Assert
-            var ex = await Record.ExceptionAsync(async () => await actionsProvider.SyncTrustedRepositoryAsync(name, CancellationToken.None));
+            var ex = await Assert.ThrowsAsync<ArgumentException>(async () => await actionsProvider.SyncTrustedRepositoryAsync(name, CancellationToken.None));
 
-            ex.Should().NotBeNull();
-            ex.Should().BeOfType<ArgumentException>();
             ex.Message.Should().Contain(Strings.ArgumentCannotBeNullOrEmpty);
+            ex.ParamName.Should().Be("name");
         }
 
         [Fact]
@@ -217,7 +213,7 @@ namespace NuGet.Commands.Test
             var packageReader = new Mock<ISignedPackageReader>();
 
             // Act and Assert
-            var ex = await Record.ExceptionAsync(async () =>
+            var ex = await Assert.ThrowsAsync<ArgumentException>(async () =>
                 await actionsProvider.AddTrustedSignerAsync(
                     name,
                     packageReader.Object,
@@ -226,9 +222,8 @@ namespace NuGet.Commands.Test
                     owners: null,
                     token: CancellationToken.None));
 
-            ex.Should().NotBeNull();
-            ex.Should().BeOfType<ArgumentException>();
             ex.Message.Should().Contain(Strings.ArgumentCannotBeNullOrEmpty);
+            ex.ParamName.Should().Be("name");
         }
 
         [Fact]
@@ -861,11 +856,10 @@ namespace NuGet.Commands.Test
             var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
 
             // Act and Assert
-            var ex = Record.Exception(() => actionsProvider.AddOrUpdateTrustedSigner(name, fingerprint: "abc", hashAlgorithm: HashAlgorithmName.SHA256, allowUntrustedRoot: false));
+            var ex = Assert.Throws<ArgumentException>(() => actionsProvider.AddOrUpdateTrustedSigner(name, fingerprint: "abc", hashAlgorithm: HashAlgorithmName.SHA256, allowUntrustedRoot: false));
 
-            ex.Should().NotBeNull();
-            ex.Should().BeOfType<ArgumentException>();
             ex.Message.Should().Contain(Strings.ArgumentCannotBeNullOrEmpty);
+            ex.ParamName.Should().Be("name");
         }
 
         [Theory]
@@ -878,11 +872,10 @@ namespace NuGet.Commands.Test
             var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
 
             // Act and Assert
-            var ex = Record.Exception(() => actionsProvider.AddOrUpdateTrustedSigner(name: "author1", fingerprint: fingerprint, hashAlgorithm: HashAlgorithmName.SHA256, allowUntrustedRoot: false));
+            var ex = Assert.Throws<ArgumentException>(() => actionsProvider.AddOrUpdateTrustedSigner(name: "author1", fingerprint: fingerprint, hashAlgorithm: HashAlgorithmName.SHA256, allowUntrustedRoot: false));
 
-            ex.Should().NotBeNull();
-            ex.Should().BeOfType<ArgumentException>();
             ex.Message.Should().Contain(Strings.ArgumentCannotBeNullOrEmpty);
+            ex.ParamName.Should().Be("fingerprint");
         }
 
         [Fact]
@@ -940,7 +933,7 @@ namespace NuGet.Commands.Test
                 p.AddOrUpdateTrustedSigner(It.Is<AuthorItem>(i =>
                     string.Equals(i.Name, "author1", StringComparison.Ordinal) &&
                     i.Certificates.Count == 1 &&
-                    SettingsTestUtils.SequenceDeepEquals(i.Certificates, expectedCerts))));
+                    SettingsTestUtils.SequenceDeepEquals(i.Certificates.ToList(), expectedCerts))));
         }
 
         [Fact]
@@ -967,7 +960,7 @@ namespace NuGet.Commands.Test
                 p.AddOrUpdateTrustedSigner(It.Is<AuthorItem>(i =>
                     string.Equals(i.Name, "author1", StringComparison.Ordinal) &&
                     i.Certificates.Count == 1 &&
-                    SettingsTestUtils.SequenceDeepEquals(i.Certificates, expectedCerts))));
+                    SettingsTestUtils.SequenceDeepEquals(i.Certificates.ToList(), expectedCerts))));
         }
 
         [Fact]
@@ -999,7 +992,7 @@ namespace NuGet.Commands.Test
                 p.AddOrUpdateTrustedSigner(It.Is<AuthorItem>(i =>
                     string.Equals(i.Name, "author1", StringComparison.Ordinal) &&
                     i.Certificates.Count == 2 &&
-                    SettingsTestUtils.SequenceDeepEquals(i.Certificates, expectedCerts))));
+                    SettingsTestUtils.SequenceDeepEquals(i.Certificates.ToList(), expectedCerts))));
         }
 
         [Fact]
@@ -1031,7 +1024,7 @@ namespace NuGet.Commands.Test
                 p.AddOrUpdateTrustedSigner(It.Is<RepositoryItem>(i =>
                     string.Equals(i.Name, "repo1", StringComparison.Ordinal) &&
                     i.Certificates.Count == 2 &&
-                    SettingsTestUtils.SequenceDeepEquals(i.Certificates, expectedCerts))));
+                    SettingsTestUtils.SequenceDeepEquals(i.Certificates.ToList(), expectedCerts))));
         }
 
         [Fact]
@@ -1063,7 +1056,7 @@ namespace NuGet.Commands.Test
                 p.AddOrUpdateTrustedSigner(It.Is<RepositoryItem>(i =>
                     string.Equals(i.Name, "repo1", StringComparison.Ordinal) &&
                     i.Certificates.Count == 2 &&
-                    SettingsTestUtils.SequenceDeepEquals(i.Certificates, expectedCerts))));
+                    SettingsTestUtils.SequenceDeepEquals(i.Certificates.ToList(), expectedCerts))));
         }
 
         [Theory]
@@ -1076,11 +1069,10 @@ namespace NuGet.Commands.Test
             var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
 
             // Act and Assert
-            var ex = await Record.ExceptionAsync(async () => await actionsProvider.AddTrustedRepositoryAsync(name, new Uri("https://serviceIndex.test/v3/api.json"), owners: null, token: CancellationToken.None));
+            var ex = await Assert.ThrowsAsync<ArgumentException>(async () => await actionsProvider.AddTrustedRepositoryAsync(name, new Uri("https://serviceIndex.test/v3/api.json"), owners: null, token: CancellationToken.None));
 
-            ex.Should().NotBeNull();
-            ex.Should().BeOfType<ArgumentException>();
             ex.Message.Should().Contain(Strings.ArgumentCannotBeNullOrEmpty);
+            ex.ParamName.Should().Be("name");
         }
 
         [Fact]
@@ -1091,10 +1083,7 @@ namespace NuGet.Commands.Test
             var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
 
             // Act and Assert
-            var ex = await Record.ExceptionAsync(async () => await actionsProvider.AddTrustedRepositoryAsync("repo1", serviceIndex: null, owners: null, token: CancellationToken.None));
-
-            ex.Should().NotBeNull();
-            ex.Should().BeOfType<ArgumentNullException>();
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await actionsProvider.AddTrustedRepositoryAsync("repo1", serviceIndex: null, owners: null, token: CancellationToken.None));
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Commands.Test
         private const string _expectedCertificateFingerprint = "3f9001ea83c560d712c24cf213c3d312cb3bff51ee89435d3430bd06b5d0eece";
 
         [Fact]
-        public void TrustedSignerActionsProvider_Constructor_WithNullTrustedSignersProvider()
+        public void TrustedSignerActionsProvider_Constructor_WithNullTrustedSignersProvider_Throws()
         {
             // Act and Assert
             Assert.Throws<ArgumentNullException>(() => new TrustedSignerActionsProvider(trustedSignersProvider: null));

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/TrustedSignerItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/TrustedSignerItemTests.cs
@@ -38,10 +38,17 @@ namespace NuGet.Configuration.Test
                 var items = section.Items.ToList();
 
                 items.Count.Should().Be(2);
+
+                var trustedSignerItem = items[0] as TrustedSignerItem;
+                trustedSignerItem.Name.Should().Be("repositoryName");
+
                 var repositoryitem = items[0] as RepositoryItem;
                 var expectedRepositoryItem = new RepositoryItem("repositoryName", "https://api.test/index/", "test;text",
                     new CertificateItem("abcdefg", Common.HashAlgorithmName.SHA256, allowUntrustedRoot: true));
                 SettingsTestUtils.DeepEquals(repositoryitem, expectedRepositoryItem).Should().BeTrue();
+
+                trustedSignerItem = items[1] as TrustedSignerItem;
+                trustedSignerItem.Name.Should().Be("authorName");
 
                 var authorItem = items[1] as AuthorItem;
                 var expectedAuthorItem = new AuthorItem("authorName",

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTestUtils.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTestUtils.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -35,6 +36,34 @@ namespace NuGet.Configuration.Test
         public static string RemoveWhitespace(string s)
         {
             return Regex.Replace(s, @"\s+", string.Empty);
+        }
+
+        public static bool SequenceDeepEquals<T>(IList<T> settings1, IList<T> settings2) where T : SettingBase
+        {
+            if (settings1 == null && settings2 == null)
+            {
+                return true;
+            }
+
+            if (settings1 == null || settings2 == null)
+            {
+                return false;
+            }
+
+            if (settings1.Count() != settings2.Count())
+            {
+                return false;
+            }
+
+            for (var i = 0; i < settings1.Count(); i++)
+            {
+                if (!DeepEquals(settings1[0], settings2[0]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         public static bool DeepEquals(SettingBase setting1, SettingBase setting2)

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTestUtils.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTestUtils.cs
@@ -38,7 +38,7 @@ namespace NuGet.Configuration.Test
             return Regex.Replace(s, @"\s+", string.Empty);
         }
 
-        public static bool SequenceDeepEquals<T>(IList<T> settings1, IList<T> settings2) where T : SettingBase
+        public static bool SequenceDeepEquals<T>(IReadOnlyList<T> settings1, IReadOnlyList<T> settings2) where T : SettingBase
         {
             if (settings1 == null && settings2 == null)
             {
@@ -50,14 +50,21 @@ namespace NuGet.Configuration.Test
                 return false;
             }
 
-            if (settings1.Count() != settings2.Count())
+            if (settings1.Count != settings2.Count)
             {
                 return false;
             }
 
-            for (var i = 0; i < settings1.Count(); i++)
+            for (var i = 0; i < settings1.Count; i++)
             {
-                if (!DeepEquals(settings1[0], settings2[0]))
+                var val2 = settings2.Where(s => s.Equals(settings1[i]));
+
+                if (val2 == null || val2.Count() != 1)
+                {
+                    return false;
+                }
+
+                if (!DeepEquals(settings1[i], val2.First()))
                 {
                     return false;
                 }

--- a/test/TestUtilities/Test.Utility/JsonData.cs
+++ b/test/TestUtilities/Test.Utility/JsonData.cs
@@ -4650,6 +4650,14 @@ namespace Test.Utility
 }";
         #endregion
 
+        #region repoSignResponseEmptyCertInfo
+
+        public const string RepoSignDataEmptyCertInfo = @"{
+  ""allRepositorySigned"": false,
+  ""signingCertificates"": []
+}";
+        #endregion
+
 
         #region PackageARegisteration
 


### PR DESCRIPTION
## Bug
Fixes: Second part of https://github.com/NuGet/Home/issues/7480

## Fix
Continues to add the code for supporting a command line gesture to interact with the trusted signers section in the nuget.config. This second wave adds a `TrustedSignerActionsProvider` which adds the ability to 
- sync a trusted repository based on a name
- add a trusted signer based on a package
- add a trusted signer with a given certificate information 
- add a trusted repository given a service index.
