### PR TITLE
Added multiple CLI/SDK branches to raise NuGet insertion PRs

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -195,7 +195,7 @@ Function Install-DotnetCLI {
         [switch]$Force
     )
     $msbuildExe = 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\bin\msbuild.exe'
-    $CliTargetBranch = & $msbuildExe $NuGetClientRoot\build\config.props /v:m /nologo /t:GetCliTargetBranch
+    $CliTargetBranch = & $msbuildExe $NuGetClientRoot\build\config.props /v:m /nologo /t:GetCliTargetBranch1
 
     $cli = @{
             Root = $CLIRoot

--- a/build/config.props
+++ b/build/config.props
@@ -9,10 +9,12 @@
     <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">$(MajorNuGetVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</SemanticVersion>
     <VsTargetBranch>lab/d16.$(MinorNuGetVersion)stg</VsTargetBranch>
     <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d16.$(MinorNuGetVersion)</VsTargetBranch>
-    <CliTargetBranch Condition="'$(OverrideCliTargetBranch)' != ''">$(OverrideCliTargetBranch)</CliTargetBranch>
-    <CliTargetBranch Condition="'$(OverrideCliTargetBranch)' == ''">master</CliTargetBranch>
-    <SdkTargetBranch Condition="'$(OverrideCliTargetBranch)' != ''">$(OverrideCliTargetBranch)</SdkTargetBranch>
-    <SdkTargetBranch Condition="'$(OverrideCliTargetBranch)' == ''">master</SdkTargetBranch>
+    <CliTargetBranch1 Condition="'$(OverrideCliTargetBranch)' != ''">$(OverrideCliTargetBranch)</CliTargetBranch1>
+    <CliTargetBranch1 Condition="'$(OverrideCliTargetBranch)' == ''">release/2.2.2xx</CliTargetBranch1>
+    <CliTargetBranch2>release/2.1.6xx</CliTargetBranch2>
+    <SdkTargetBranch1 Condition="'$(OverrideCliTargetBranch)' != ''">$(OverrideCliTargetBranch)</SdkTargetBranch1>
+    <SdkTargetBranch1 Condition="'$(OverrideCliTargetBranch)' == ''">release/2.2.2xx</SdkTargetBranch1>
+    <SdkTargetBranch2>release/2.1.6xx</SdkTargetBranch2>
     <!-- We need to update this netcoreassembly build number with every milestone to workaround any breaking api
     changes we might have made-->
     <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">1</NetCoreAssemblyBuildNumber>
@@ -56,10 +58,16 @@
   <Target Name="GetVsTargetBranch">
     <Message Text="$(VsTargetBranch)" Importance="High"/>
   </Target>
-  <Target Name="GetCliTargetBranch">
-    <Message Text="$(CliTargetBranch)" Importance="High"/>
+  <Target Name="GetCliTargetBranch1">
+    <Message Text="$(CliTargetBranch1)" Importance="High"/>
   </Target>
-  <Target Name="GetSdkTargetBranch">
-    <Message Text="$(SdkTargetBranch)" Importance="High"/>
+  <Target Name="GetCliTargetBranch2">
+    <Message Text="$(CliTargetBranch2)" Importance="High"/>
+  </Target>
+  <Target Name="GetSdkTargetBranch1">
+    <Message Text="$(SdkTargetBranch1)" Importance="High"/>
+  </Target>
+  <Target Name="GetSdkTargetBranch2">
+    <Message Text="$(SdkTargetBranch2)" Importance="High"/>
   </Target>
 </Project>

--- a/build/config.props
+++ b/build/config.props
@@ -9,12 +9,14 @@
     <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">$(MajorNuGetVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</SemanticVersion>
     <VsTargetBranch>lab/d16.$(MinorNuGetVersion)stg</VsTargetBranch>
     <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d16.$(MinorNuGetVersion)</VsTargetBranch>
-    <CliTargetBranch1 Condition="'$(OverrideCliTargetBranch)' != ''">$(OverrideCliTargetBranch)</CliTargetBranch1>
-    <CliTargetBranch1 Condition="'$(OverrideCliTargetBranch)' == ''">release/2.2.2xx</CliTargetBranch1>
-    <CliTargetBranch2>release/2.1.6xx</CliTargetBranch2>
-    <SdkTargetBranch1 Condition="'$(OverrideCliTargetBranch)' != ''">$(OverrideCliTargetBranch)</SdkTargetBranch1>
-    <SdkTargetBranch1 Condition="'$(OverrideCliTargetBranch)' == ''">release/2.2.2xx</SdkTargetBranch1>
-    <SdkTargetBranch2>release/2.1.6xx</SdkTargetBranch2>
+    <CliTargetBranch1 Condition="'$(OverrideCliTargetBranch1)' != ''">$(OverrideCliTargetBranch1)</CliTargetBranch1>
+    <CliTargetBranch1 Condition="'$(OverrideCliTargetBranch1)' == ''">release/2.2.2xx</CliTargetBranch1>
+    <CliTargetBranch2 Condition="'$(OverrideCliTargetBranch2)' != ''">$(OverrideCliTargetBranch2)</CliTargetBranch2>
+    <CliTargetBranch2 Condition="'$(OverrideCliTargetBranch2)' == ''">release/2.1.6xx</CliTargetBranch2>
+    <SdkTargetBranch1 Condition="'$(OverrideCliTargetBranch1)' != ''">$(OverrideCliTargetBranch1)</SdkTargetBranch1>
+    <SdkTargetBranch1 Condition="'$(OverrideCliTargetBranch1)' == ''">release/2.2.2xx</SdkTargetBranch1>
+    <SdkTargetBranch2 Condition="'$(OverrideCliTargetBranch2)' != ''">$(OverrideCliTargetBranch2)</SdkTargetBranch2>
+    <SdkTargetBranch2 Condition="'$(OverrideCliTargetBranch2)' == ''">release/2.1.6xx</SdkTargetBranch2>
     <!-- We need to update this netcoreassembly build number with every milestone to workaround any breaking api
     changes we might have made-->
     <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">1</NetCoreAssemblyBuildNumber>

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -185,8 +185,10 @@ else
     }
 
     $VsTargetBranch = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetBranch
-    $CliTargetBranch = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetCliTargetBranch
-    $SdkTargetBranch = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSdkTargetBranch
+    $CliTargetBranch1 = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetCliTargetBranch1
+    $CliTargetBranch2 = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetCliTargetBranch2
+    $SdkTargetBranch1 = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSdkTargetBranch1
+    $SdkTargetBranch2 = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSdkTargetBranch2
     Write-Host $VsTargetBranch
     $jsonRepresentation = @{
         BuildNumber = $newBuildCounter
@@ -195,8 +197,10 @@ else
         LocalizationRepositoryBranch = $NuGetLocalizationRepoBranch
         LocalizationRepositoryCommitHash = $LocalizationRepoCommitHash
         VsTargetBranch = $VsTargetBranch.Trim()
-        CliTargetBranch = $CliTargetBranch.Trim()
-        SdkTargetBranch = $SdkTargetBranch.Trim()
+        CliTargetBranch1 = $CliTargetBranch1.Trim()
+        CliTargetBranch2 = $CliTargetBranch2.Trim()
+        SdkTargetBranch1 = $SdkTargetBranch1.Trim()
+        SdkTargetBranch2 = $SdkTargetBranch2.Trim()
     }   
 
     New-Item $BuildInfoJsonFile -Force


### PR DESCRIPTION
With dev16, there will be 2 dotnet sdks within VS a) 2.2.2xx channel and b) 2.1.6xx channel. So this PR to change our SDK/CLI target branches for both and raise PRs against both channels.

Once this PR is merged, I've update the NuGet release definition to accept these changes.