### PR TITLE
Expose trusted signers command

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/TrustedSignersCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/TrustedSignersCommand.cs
@@ -1,0 +1,104 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using static NuGet.Commands.TrustedSignersArgs;
+
+namespace NuGet.CommandLine.Commands
+{
+    [Command(typeof(NuGetCommand), "trusted-signers", "TrustedSignersCommandDescription",
+        MinArgs = 0,
+        MaxArgs = 2,
+        UsageSummaryResourceName = "TrustedSignersCommandUsageSummary",
+        UsageExampleResourceName = "TrustedSignersCommandUsageExamples")]
+    public class TrustedSignersCommand : Command
+    {
+        [Option(typeof(NuGetCommand), "TrustedSignersCommandNameDescription")]
+        public string Name { get; set; }
+
+        [Option(typeof(NuGetCommand), "TrustedSignersCommandServiceIndexDescription")]
+        public string ServiceIndex { get; set; }
+
+        [Option(typeof(NuGetCommand), "TrustedSignersCommandCertificateFingerprintDescription")]
+        public string CertificateFingerprint { get; set; }
+
+        [Option(typeof(NuGetCommand), "TrustedSignersCommandFingerprintAlgorithmDescription")]
+        public string FingerprintAlgorithm { get; set; }
+
+        [Option(typeof(NuGetCommand), "TrustedSignersCommandAllowUntrustedRootDescription")]
+        public bool AllowUntrustedRoot { get; set; }
+
+        [Option(typeof(NuGetCommand), "TrustedSignersCommandAuthorDescription")]
+        public bool Author { get; set; }
+
+        [Option(typeof(NuGetCommand), "TrustedSignersCommandRepositoryDescription")]
+        public bool Repository { get; set; }
+
+        [Option(typeof(NuGetCommand), "TrustedSignersCommandOwnersDescription")]
+        public ICollection<string> Owners { get; set; }
+
+        internal ITrustedSignersCommandRunner TrustedSignersCommandRunner { get; set; }
+
+        internal TrustedSignersCommand() : base()
+        {
+            Owners = new List<string>();
+        }
+
+        public override async Task ExecuteCommandAsync()
+        {
+            var actionString = Arguments.FirstOrDefault();
+
+            TrustedSignersAction action;
+            if (string.IsNullOrEmpty(actionString))
+            {
+                action = TrustedSignersAction.List;
+            }
+            else if (!Enum.TryParse(actionString, ignoreCase: true, result: out action))
+            {
+                throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture, NuGetResources.Error_UnknownAction, actionString));
+            }
+
+            string packagePath = null;
+            if (Arguments.Count() > 1)
+            {
+                packagePath = Arguments[1];
+            }
+
+            var trustedSignersProvider = new TrustedSignersProvider(Settings);
+
+            var trustedSignersArgs = new TrustedSignersArgs()
+            {
+                Action = action,
+                PackagePath = packagePath,
+                Name = Name,
+                ServiceIndex = ServiceIndex,
+                CertificateFingerprint = CertificateFingerprint,
+                FingerprintAlgorithm = FingerprintAlgorithm,
+                AllowUntrustedRoot = AllowUntrustedRoot,
+                Author = Author,
+                Repository = Repository,
+                Owners = Owners,
+                Logger = Console
+            };
+
+            if (TrustedSignersCommandRunner == null)
+            {
+                TrustedSignersCommandRunner = new TrustedSignersCommandRunner(trustedSignersProvider, SourceProvider);
+            }
+
+            var result = await TrustedSignersCommandRunner.ExecuteCommandAsync(trustedSignersArgs);
+
+            if (result > 0)
+            {
+                throw new ExitCodeException(1);
+            }
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -25,6 +25,18 @@
     <ComVisible>false</ComVisible>
   </PropertyGroup>
 
+  <ItemGroup Condition="$(DefineConstants.Contains(SIGNED_BUILD))">
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>NuGet.CommandLine.FuncTest, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup Condition="!$(DefineConstants.Contains(SIGNED_BUILD))">
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>NuGet.CommandLine.FuncTest</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
   <ItemGroup>
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -13461,6 +13461,115 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to If specified, chaining to an untrusted root should be allowed for the trusted signer..
+        /// </summary>
+        internal static string TrustedSignersCommandAllowUntrustedRootDescription {
+            get {
+                return ResourceManager.GetString("TrustedSignersCommandAllowUntrustedRootDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If specified, the author signature of the package should be trusted..
+        /// </summary>
+        internal static string TrustedSignersCommandAuthorDescription {
+            get {
+                return ResourceManager.GetString("TrustedSignersCommandAuthorDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Certificate fingerprint for trusted author..
+        /// </summary>
+        internal static string TrustedSignersCommandCertificateFingerprintDescription {
+            get {
+                return ResourceManager.GetString("TrustedSignersCommandCertificateFingerprintDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Provides the ability to manage list of trusted signers located in NuGet.Config.
+        /// </summary>
+        internal static string TrustedSignersCommandDescription {
+            get {
+                return ResourceManager.GetString("TrustedSignersCommandDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hash algorithm used to calculate certificate fingerprint. Defaults to SHA256..
+        /// </summary>
+        internal static string TrustedSignersCommandFingerprintAlgorithmDescription {
+            get {
+                return ResourceManager.GetString("TrustedSignersCommandFingerprintAlgorithmDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name of the trusted signer..
+        /// </summary>
+        internal static string TrustedSignersCommandNameDescription {
+            get {
+                return ResourceManager.GetString("TrustedSignersCommandNameDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to List of owners allowed for a package signed with the trusted repository..
+        /// </summary>
+        internal static string TrustedSignersCommandOwnersDescription {
+            get {
+                return ResourceManager.GetString("TrustedSignersCommandOwnersDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If specified, the repository signature of the package should be trusted..
+        /// </summary>
+        internal static string TrustedSignersCommandRepositoryDescription {
+            get {
+                return ResourceManager.GetString("TrustedSignersCommandRepositoryDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Service Index for trusted repository..
+        /// </summary>
+        internal static string TrustedSignersCommandServiceIndexDescription {
+            get {
+                return ResourceManager.GetString("TrustedSignersCommandServiceIndexDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nuget trusted-signers
+        ///
+        ///nuget trusted-signers Add -Name existingSource
+        ///
+        ///nuget trusted-signers Add -Name trustedRepo -ServiceIndex https://trustedRepo.test/v3ServiceIndex
+        ///
+        ///nuget trusted-signers Add -Name author1 -CertificateFingerprint CE40881FF5F0AD3E58965DA20A9F571EF1651A56933748E1BF1C99E537C4E039 -FingerprintAlgorithm SHA256
+        ///
+        ///nuget trusted-signers Add -Repository .\..\MyRepositorySignedPackage.nupkg -Name TrustedRepo
+        ///
+        ///nuget-trusted-signers Remove -Name TrustedRepo.
+        /// </summary>
+        internal static string TrustedSignersCommandUsageExamples {
+            get {
+                return ResourceManager.GetString("TrustedSignersCommandUsageExamples", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;List|Add|Remove|Sync&gt; [options].
+        /// </summary>
+        internal static string TrustedSignersCommandUsageSummary {
+            get {
+                return ResourceManager.GetString("TrustedSignersCommandUsageSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Update packages to latest available versions. This command also updates NuGet.exe itself..
         /// </summary>
         internal static string UpdateCommandDescription {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -13461,7 +13461,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If specified, chaining to an untrusted root should be allowed for the trusted signer..
+        ///   Looks up a localized string similar to Set allowUntrustedRoot to true for the trusted signer&apos;s certificate to be added..
         /// </summary>
         internal static string TrustedSignersCommandAllowUntrustedRootDescription {
             get {
@@ -13470,7 +13470,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If specified, the author signature of the package should be trusted..
+        ///   Looks up a localized string similar to Add the author signature of the package as a trusted author..
         /// </summary>
         internal static string TrustedSignersCommandAuthorDescription {
             get {
@@ -13479,7 +13479,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Certificate fingerprint for trusted author..
+        ///   Looks up a localized string similar to Fingerprint of the certificate to trust..
         /// </summary>
         internal static string TrustedSignersCommandCertificateFingerprintDescription {
             get {
@@ -13488,7 +13488,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provides the ability to manage list of trusted signers located in NuGet.Config.
+        ///   Looks up a localized string similar to Provides the ability to manage the list of trusted signers..
         /// </summary>
         internal static string TrustedSignersCommandDescription {
             get {
@@ -13497,7 +13497,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hash algorithm used to calculate certificate fingerprint. Defaults to SHA256..
+        ///   Looks up a localized string similar to Hash algorithm used to calculate the certificate fingerprint. Defaults to SHA256..
         /// </summary>
         internal static string TrustedSignersCommandFingerprintAlgorithmDescription {
             get {
@@ -13524,7 +13524,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If specified, the repository signature of the package should be trusted..
+        ///   Looks up a localized string similar to Add the repository signature or countersignature of the package as a trusted repository..
         /// </summary>
         internal static string TrustedSignersCommandRepositoryDescription {
             get {
@@ -13533,7 +13533,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Service Index for trusted repository..
+        ///   Looks up a localized string similar to Service index for a repository to be trusted..
         /// </summary>
         internal static string TrustedSignersCommandServiceIndexDescription {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5483,4 +5483,47 @@ This option should be used when specifying the certificate via -CertificateSubje
     <value>When creating a symbols package, allows to choose between the 'snupkg' and 'symbols.nupkg' format.</value>
     <comment>Do not localize snupkg and symbols.nupkg</comment>
   </data>
+  <data name="TrustedSignersCommandDescription" xml:space="preserve">
+    <value>Provides the ability to manage list of trusted signers located in NuGet.Config</value>
+  </data>
+  <data name="TrustedSignersCommandUsageExamples" xml:space="preserve">
+    <value>nuget trusted-signers
+
+nuget trusted-signers Add -Name existingSource
+
+nuget trusted-signers Add -Name trustedRepo -ServiceIndex https://trustedRepo.test/v3ServiceIndex
+
+nuget trusted-signers Add -Name author1 -CertificateFingerprint CE40881FF5F0AD3E58965DA20A9F571EF1651A56933748E1BF1C99E537C4E039 -FingerprintAlgorithm SHA256
+
+nuget trusted-signers Add -Repository .\..\MyRepositorySignedPackage.nupkg -Name TrustedRepo
+
+nuget-trusted-signers Remove -Name TrustedRepo</value>
+  </data>
+  <data name="TrustedSignersCommandUsageSummary" xml:space="preserve">
+    <value>&lt;List|Add|Remove|Sync&gt; [options]</value>
+  </data>
+  <data name="TrustedSignersCommandAllowUntrustedRootDescription" xml:space="preserve">
+    <value>If specified, chaining to an untrusted root should be allowed for the trusted signer.</value>
+  </data>
+  <data name="TrustedSignersCommandAuthorDescription" xml:space="preserve">
+    <value>If specified, the author signature of the package should be trusted.</value>
+  </data>
+  <data name="TrustedSignersCommandCertificateFingerprintDescription" xml:space="preserve">
+    <value>Certificate fingerprint for trusted author.</value>
+  </data>
+  <data name="TrustedSignersCommandFingerprintAlgorithmDescription" xml:space="preserve">
+    <value>Hash algorithm used to calculate certificate fingerprint. Defaults to SHA256.</value>
+  </data>
+  <data name="TrustedSignersCommandNameDescription" xml:space="preserve">
+    <value>Name of the trusted signer.</value>
+  </data>
+  <data name="TrustedSignersCommandOwnersDescription" xml:space="preserve">
+    <value>List of owners allowed for a package signed with the trusted repository.</value>
+  </data>
+  <data name="TrustedSignersCommandRepositoryDescription" xml:space="preserve">
+    <value>If specified, the repository signature of the package should be trusted.</value>
+  </data>
+  <data name="TrustedSignersCommandServiceIndexDescription" xml:space="preserve">
+    <value>Service Index for trusted repository.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5484,7 +5484,7 @@ This option should be used when specifying the certificate via -CertificateSubje
     <comment>Do not localize snupkg and symbols.nupkg</comment>
   </data>
   <data name="TrustedSignersCommandDescription" xml:space="preserve">
-    <value>Provides the ability to manage list of trusted signers located in NuGet.Config</value>
+    <value>Provides the ability to manage the list of trusted signers.</value>
   </data>
   <data name="TrustedSignersCommandUsageExamples" xml:space="preserve">
     <value>nuget trusted-signers
@@ -5503,16 +5503,16 @@ nuget-trusted-signers Remove -Name TrustedRepo</value>
     <value>&lt;List|Add|Remove|Sync&gt; [options]</value>
   </data>
   <data name="TrustedSignersCommandAllowUntrustedRootDescription" xml:space="preserve">
-    <value>If specified, chaining to an untrusted root should be allowed for the trusted signer.</value>
+    <value>Set allowUntrustedRoot to true for the trusted signer's certificate to be added.</value>
   </data>
   <data name="TrustedSignersCommandAuthorDescription" xml:space="preserve">
-    <value>If specified, the author signature of the package should be trusted.</value>
+    <value>Add the author signature of the package as a trusted author.</value>
   </data>
   <data name="TrustedSignersCommandCertificateFingerprintDescription" xml:space="preserve">
-    <value>Certificate fingerprint for trusted author.</value>
+    <value>Fingerprint of the certificate to trust.</value>
   </data>
   <data name="TrustedSignersCommandFingerprintAlgorithmDescription" xml:space="preserve">
-    <value>Hash algorithm used to calculate certificate fingerprint. Defaults to SHA256.</value>
+    <value>Hash algorithm used to calculate the certificate fingerprint. Defaults to SHA256.</value>
   </data>
   <data name="TrustedSignersCommandNameDescription" xml:space="preserve">
     <value>Name of the trusted signer.</value>
@@ -5521,9 +5521,9 @@ nuget-trusted-signers Remove -Name TrustedRepo</value>
     <value>List of owners allowed for a package signed with the trusted repository.</value>
   </data>
   <data name="TrustedSignersCommandRepositoryDescription" xml:space="preserve">
-    <value>If specified, the repository signature of the package should be trusted.</value>
+    <value>Add the repository signature or countersignature of the package as a trusted repository.</value>
   </data>
   <data name="TrustedSignersCommandServiceIndexDescription" xml:space="preserve">
-    <value>Service Index for trusted repository.</value>
+    <value>Service index for a repository to be trusted.</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -3436,6 +3436,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The action &apos;{0}&apos; is not recognized..
+        /// </summary>
+        public static string Error_UnknownAction {
+            get {
+                return ResourceManager.GetString("Error_UnknownAction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This version of msbuild is not supported: &apos;{0}&apos;.
         /// </summary>
         public static string Error_UnsupportedMsbuild {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6173,4 +6173,8 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="SourcesCommandClearingExistingAuthTypes" xml:space="preserve">
     <value>Clearing existing authentication types settings for package source '{0}'.</value>
   </data>
+  <data name="Error_UnknownAction" xml:space="preserve">
+    <value>The action '{0}' is not recognized.</value>
+    <comment>0 - action</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/Program.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Program.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 extern alias CoreV2;
 
 using System;

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -125,7 +125,52 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The repository with the service index &apos;{0}&apos; does not list any trusted certificates..
+        ///   Looks up a localized string similar to Trusted owners are not supported in trusted author items..
+        /// </summary>
+        internal static string Error_CannotTrustOwnersForAuthor {
+            get {
+                return ResourceManager.GetString("Error_CannotTrustOwnersForAuthor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not add trusted signer: {0}.
+        /// </summary>
+        internal static string Error_CouldNotAdd {
+            get {
+                return ResourceManager.GetString("Error_CouldNotAdd", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not list trusted signers: {0}.
+        /// </summary>
+        internal static string Error_CouldNotList {
+            get {
+                return ResourceManager.GetString("Error_CouldNotList", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not remove trusted signer: {0}.
+        /// </summary>
+        internal static string Error_CouldNotRemove {
+            get {
+                return ResourceManager.GetString("Error_CouldNotRemove", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not sync trusted repository: {0}.
+        /// </summary>
+        internal static string Error_CouldNotSync {
+            get {
+                return ResourceManager.GetString("Error_CouldNotSync", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The repository with service index &apos;{0}&apos; does not list any trusted certificate..
         /// </summary>
         internal static string Error_EmptyCertificateListInRepository {
             get {
@@ -175,6 +220,15 @@ namespace NuGet.Commands {
         internal static string Error_InvalidCertificateInformationFromServer {
             get {
                 return ResourceManager.GetString("Error_InvalidCertificateInformationFromServer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid combination of arguments..
+        /// </summary>
+        internal static string Error_InvalidCombinationOfArguments {
+            get {
+                return ResourceManager.GetString("Error_InvalidCombinationOfArguments", resourceCulture);
             }
         }
         
@@ -287,11 +341,38 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No signature was specified to be trusted for package &apos;{0}&apos;. Please specify either Author or Repository..
+        /// </summary>
+        internal static string Error_NoSignatureTrustedForPackage {
+            get {
+                return ResourceManager.GetString("Error_NoSignatureTrustedForPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to get package sources information..
+        /// </summary>
+        internal static string Error_NoSourcesInformation {
+            get {
+                return ResourceManager.GetString("Error_NoSourcesInformation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to find a stable package {0} with version {1}.
         /// </summary>
         internal static string Error_NoStablePackageVersionsExist {
             get {
                 return ResourceManager.GetString("Error_NoStablePackageVersionsExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is not a supported hash algorithm..
+        /// </summary>
+        internal static string Error_NotSupportedHashAlgorithm {
+            get {
+                return ResourceManager.GetString("Error_NotSupportedHashAlgorithm", resourceCulture);
             }
         }
         
@@ -368,7 +449,16 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to add trusted repository. The package is not repository signed or countersigned..
+        ///   Looks up a localized string similar to Property &apos;{0}&apos; should not be null or empty..
+        /// </summary>
+        internal static string Error_PropertyCannotBeNullOrEmpty {
+            get {
+                return ResourceManager.GetString("Error_PropertyCannotBeNullOrEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Repository trust was expected but package is not repository signed..
         /// </summary>
         internal static string Error_RepoTrustExpectedRepoSignature {
             get {
@@ -382,6 +472,15 @@ namespace NuGet.Commands {
         internal static string Error_RestoreInLockedMode {
             get {
                 return ResourceManager.GetString("Error_RestoreInLockedMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The repository service index &apos;{0}&apos; is not a valid HTTPS url..
+        /// </summary>
+        internal static string Error_ServiceIndexShouldBeHttps {
+            get {
+                return ResourceManager.GetString("Error_ServiceIndexShouldBeHttps", resourceCulture);
             }
         }
         
@@ -472,6 +571,15 @@ namespace NuGet.Commands {
         internal static string Error_UnableToSignPackage {
             get {
                 return ResourceManager.GetString("Error_UnableToSignPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Source with name &apos;{0}&apos; does not exist or cannot be retrived..
+        /// </summary>
+        internal static string Error_UnavailableSource {
+            get {
+                return ResourceManager.GetString("Error_UnavailableSource", resourceCulture);
             }
         }
         
@@ -1350,6 +1458,24 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to There are no trusted signers..
+        /// </summary>
+        internal static string NoTrustedSigners {
+            get {
+                return ResourceManager.GetString("NoTrustedSigners", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No trusted signers with name: &apos;{0}&apos; where found..
+        /// </summary>
+        internal static string NoTrustedSignersMatching {
+            get {
+                return ResourceManager.GetString("NoTrustedSignersMatching", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to http://docs.nuget.org/.
         /// </summary>
         internal static string NuGetDocs {
@@ -1409,6 +1535,15 @@ namespace NuGet.Commands {
         internal static string PropertyNotAllowedForProjectType {
             get {
                 return ResourceManager.GetString("PropertyNotAllowedForProjectType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Registered trusted signers:.
+        /// </summary>
+        internal static string RegsiteredTrustedSigners {
+            get {
+                return ResourceManager.GetString("RegsiteredTrustedSigners", resourceCulture);
             }
         }
         
@@ -1598,6 +1733,105 @@ namespace NuGet.Commands {
         internal static string SpecValidationZeroRestoreRequests {
             get {
                 return ResourceManager.GetString("SpecValidationZeroRestoreRequests", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Successfully updated trusted signer with name: &apos;{0}&apos;..
+        /// </summary>
+        internal static string SuccessfullUpdatedTrustedSigner {
+            get {
+                return ResourceManager.GetString("SuccessfullUpdatedTrustedSigner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Successfully added trusted author with name: &apos;{0}&apos;..
+        /// </summary>
+        internal static string SuccessfullyAddedTrustedAuthor {
+            get {
+                return ResourceManager.GetString("SuccessfullyAddedTrustedAuthor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Successfully added trusted repository with name: &apos;{0}&apos;..
+        /// </summary>
+        internal static string SuccessfullyAddedTrustedRepository {
+            get {
+                return ResourceManager.GetString("SuccessfullyAddedTrustedRepository", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Successfully removed trusted signers with name: &apos;{0}&apos;..
+        /// </summary>
+        internal static string SuccessfullyRemovedTrustedSigner {
+            get {
+                return ResourceManager.GetString("SuccessfullyRemovedTrustedSigner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Successfully synchronized trusted repository with name: &apos;{0}&apos;..
+        /// </summary>
+        internal static string SuccessfullySynchronizedTrustedRepository {
+            get {
+                return ResourceManager.GetString("SuccessfullySynchronizedTrustedRepository", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Certificate fingerprint(s):.
+        /// </summary>
+        internal static string TrustedSignerLogCertificates {
+            get {
+                return ResourceManager.GetString("TrustedSignerLogCertificates", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [U] {0} - {1}.
+        /// </summary>
+        internal static string TrustedSignerLogCertificateSummaryAllowUntrustedRoot {
+            get {
+                return ResourceManager.GetString("TrustedSignerLogCertificateSummaryAllowUntrustedRoot", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} - {1}.
+        /// </summary>
+        internal static string TrustedSignerLogCertificateSummaryUnallowUntrustedRoot {
+            get {
+                return ResourceManager.GetString("TrustedSignerLogCertificateSummaryUnallowUntrustedRoot", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trusted owners: {0}.
+        /// </summary>
+        internal static string TrustedSignerLogOwners {
+            get {
+                return ResourceManager.GetString("TrustedSignerLogOwners", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Service Index: {0}.
+        /// </summary>
+        internal static string TrustedSignerLogServiceIndex {
+            get {
+                return ResourceManager.GetString("TrustedSignerLogServiceIndex", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} [{1}].
+        /// </summary>
+        internal static string TrustedSignerLogTitle {
+            get {
+                return ResourceManager.GetString("TrustedSignerLogTitle", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -134,7 +134,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not add trusted signer: {0}.
+        ///   Looks up a localized string similar to Could not add the trusted signer: {0}.
         /// </summary>
         internal static string Error_CouldNotAdd {
             get {
@@ -143,7 +143,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not list trusted signers: {0}.
+        ///   Looks up a localized string similar to Could not list the trusted signers: {0}.
         /// </summary>
         internal static string Error_CouldNotList {
             get {
@@ -152,7 +152,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not remove trusted signer: {0}.
+        ///   Looks up a localized string similar to Could not remove the trusted signer: {0}.
         /// </summary>
         internal static string Error_CouldNotRemove {
             get {
@@ -161,7 +161,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not sync trusted repository: {0}.
+        ///   Looks up a localized string similar to Could not sync the trusted repository: {0}.
         /// </summary>
         internal static string Error_CouldNotSync {
             get {
@@ -170,7 +170,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The repository with service index &apos;{0}&apos; does not list any trusted certificate..
+        ///   Looks up a localized string similar to The repository with the service index &apos;{0}&apos; does not list any trusted certificates..
         /// </summary>
         internal static string Error_EmptyCertificateListInRepository {
             get {
@@ -341,7 +341,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No signature was specified to be trusted for package &apos;{0}&apos;. Please specify either Author or Repository..
+        ///   Looks up a localized string similar to No signature to be trusted was specified for the package &apos;{0}&apos;. Please specify either Author or Repository..
         /// </summary>
         internal static string Error_NoSignatureTrustedForPackage {
             get {
@@ -458,7 +458,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Repository trust was expected but package is not repository signed..
+        ///   Looks up a localized string similar to Unable to add trusted repository. The package is not repository signed or countersigned..
         /// </summary>
         internal static string Error_RepoTrustExpectedRepoSignature {
             get {
@@ -512,7 +512,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A trusted repository with the name &apos;{0}&apos; does not exist..
+        ///   Looks up a localized string similar to A trusted repository &apos;{0}&apos; does not exist..
         /// </summary>
         internal static string Error_TrustedRepositoryDoesNotExist {
             get {
@@ -521,7 +521,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A trusted signer with the name &apos;{0}&apos; already exists..
+        ///   Looks up a localized string similar to A trusted signer &apos;{0}&apos; already exists..
         /// </summary>
         internal static string Error_TrustedSignerAlreadyExists {
             get {
@@ -575,7 +575,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Source with name &apos;{0}&apos; does not exist or cannot be retrived..
+        ///   Looks up a localized string similar to Source &apos;{0}&apos; does not exist or cannot be retrived..
         /// </summary>
         internal static string Error_UnavailableSource {
             get {
@@ -1467,7 +1467,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No trusted signers with name: &apos;{0}&apos; where found..
+        ///   Looks up a localized string similar to No trusted signers with the name: &apos;{0}&apos; were found..
         /// </summary>
         internal static string NoTrustedSignersMatching {
             get {
@@ -1737,7 +1737,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Successfully updated trusted signer with name: &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Successfully updated the trusted signer &apos;{0}&apos;..
         /// </summary>
         internal static string SuccessfullUpdatedTrustedSigner {
             get {
@@ -1746,7 +1746,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Successfully added trusted author with name: &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Successfully added a trusted author &apos;{0}&apos;..
         /// </summary>
         internal static string SuccessfullyAddedTrustedAuthor {
             get {
@@ -1755,7 +1755,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Successfully added trusted repository with name: &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Successfully added a trusted repository &apos;{0}&apos;..
         /// </summary>
         internal static string SuccessfullyAddedTrustedRepository {
             get {
@@ -1764,7 +1764,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Successfully removed trusted signers with name: &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Successfully removed the trusted signer &apos;{0}&apos;..
         /// </summary>
         internal static string SuccessfullyRemovedTrustedSigner {
             get {
@@ -1773,7 +1773,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Successfully synchronized trusted repository with name: &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Successfully synchronized the trusted repository &apos;{0}&apos;..
         /// </summary>
         internal static string SuccessfullySynchronizedTrustedRepository {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -722,6 +722,76 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="Error_NoMatchingCertificate" xml:space="preserve">
     <value>The package signature did not match any of the allowed certificate fingerprints.</value>
   </data>
+  <data name="Error_CannotTrustOwnersForAuthor" xml:space="preserve">
+    <value>Trusted owners are not supported in trusted author items.</value>
+  </data>
+  <data name="Error_InvalidCombinationOfArguments" xml:space="preserve">
+    <value>Invalid combination of arguments.</value>
+  </data>
+  <data name="Error_NoSignatureTrustedForPackage" xml:space="preserve">
+    <value>No signature was specified to be trusted for package '{0}'. Please specify either Author or Repository.</value>
+    <comment>0 - Package path</comment>
+  </data>
+  <data name="Error_NoSourcesInformation" xml:space="preserve">
+    <value>Unable to get package sources information.</value>
+  </data>
+  <data name="Error_NotSupportedHashAlgorithm" xml:space="preserve">
+    <value>'{0}' is not a supported hash algorithm.</value>
+    <comment>0 - hash algorithm</comment>
+  </data>
+  <data name="Error_PropertyCannotBeNullOrEmpty" xml:space="preserve">
+    <value>Property '{0}' should not be null or empty.</value>
+    <comment>0 - property name</comment>
+  </data>
+  <data name="Error_ServiceIndexShouldBeHttps" xml:space="preserve">
+    <value>The repository service index '{0}' is not a valid HTTPS url.</value>
+    <comment>0 - service index</comment>
+  </data>
+  <data name="Error_UnavailableSource" xml:space="preserve">
+    <value>Source with name '{0}' does not exist or cannot be retrived.</value>
+    <comment>0 - source name</comment>
+  </data>
+  <data name="NoTrustedSigners" xml:space="preserve">
+    <value>There are no trusted signers.</value>
+  </data>
+  <data name="NoTrustedSignersMatching" xml:space="preserve">
+    <value>No trusted signers with name: '{0}' where found.</value>
+    <comment>0 - trusted signer name</comment>
+  </data>
+  <data name="RegsiteredTrustedSigners" xml:space="preserve">
+    <value>Registered trusted signers:</value>
+  </data>
+  <data name="SuccessfullyRemovedTrustedSigner" xml:space="preserve">
+    <value>Successfully removed trusted signers with name: '{0}'.</value>
+    <comment>0 - trusted signer name</comment>
+  </data>
+  <data name="TrustedSignerLogCertificates" xml:space="preserve">
+    <value>Certificate fingerprint(s):</value>
+  </data>
+  <data name="TrustedSignerLogCertificateSummaryAllowUntrustedRoot" xml:space="preserve">
+    <value>[U] {0} - {1}</value>
+    <comment>0 - fingerprint algorithm
+1 - fingerprint</comment>
+  </data>
+  <data name="TrustedSignerLogCertificateSummaryUnallowUntrustedRoot" xml:space="preserve">
+    <value>{0} - {1}</value>
+    <comment>0 - fingerprint algorithm
+1 - fingerprint</comment>
+  </data>
+  <data name="TrustedSignerLogOwners" xml:space="preserve">
+    <value>Trusted owners: {0}</value>
+    <comment>0 - semi-colon separated owners list</comment>
+  </data>
+  <data name="TrustedSignerLogServiceIndex" xml:space="preserve">
+    <value>Service Index: {0}</value>
+    <comment>0 - service index</comment>
+  </data>
+  <data name="TrustedSignerLogTitle" xml:space="preserve">
+    <value>{0} [{1}]</value>
+    <comment>0 - signer name
+1 - signer type
+</comment>
+  </data>
   <data name="ArgumentCannotBeNullOrEmpty" xml:space="preserve">
     <value>The argument cannot be null or empty.</value>
   </data>
@@ -764,5 +834,37 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="Error_EmptyCertificateListInRepository" xml:space="preserve">
     <value>The repository with the service index '{0}' does not list any trusted certificates.</value>
     <comment>0 - service index</comment>
+  </data>
+  <data name="Error_CouldNotAdd" xml:space="preserve">
+    <value>Could not add trusted signer: {0}</value>
+    <comment>0 - Reason</comment>
+  </data>
+  <data name="Error_CouldNotList" xml:space="preserve">
+    <value>Could not list trusted signers: {0}</value>
+    <comment>0 - Reason</comment>
+  </data>
+  <data name="Error_CouldNotRemove" xml:space="preserve">
+    <value>Could not remove trusted signer: {0}</value>
+    <comment>0 - Reason</comment>
+  </data>
+  <data name="Error_CouldNotSync" xml:space="preserve">
+    <value>Could not sync trusted repository: {0}</value>
+    <comment>0 - Reason</comment>
+  </data>
+  <data name="SuccessfullUpdatedTrustedSigner" xml:space="preserve">
+    <value>Successfully updated trusted signer with name: '{0}'.</value>
+    <comment>0 - name</comment>
+  </data>
+  <data name="SuccessfullyAddedTrustedAuthor" xml:space="preserve">
+    <value>Successfully added trusted author with name: '{0}'.</value>
+    <comment>0 - name</comment>
+  </data>
+  <data name="SuccessfullyAddedTrustedRepository" xml:space="preserve">
+    <value>Successfully added trusted repository with name: '{0}'.</value>
+    <comment>0 - name</comment>
+  </data>
+  <data name="SuccessfullySynchronizedTrustedRepository" xml:space="preserve">
+    <value>Successfully synchronized trusted repository with name: '{0}'.</value>
+    <comment>0 - name</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -729,7 +729,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>Invalid combination of arguments.</value>
   </data>
   <data name="Error_NoSignatureTrustedForPackage" xml:space="preserve">
-    <value>No signature was specified to be trusted for package '{0}'. Please specify either Author or Repository.</value>
+    <value>No signature to be trusted was specified for the package '{0}'. Please specify either Author or Repository.</value>
     <comment>0 - Package path</comment>
   </data>
   <data name="Error_NoSourcesInformation" xml:space="preserve">
@@ -748,21 +748,21 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <comment>0 - service index</comment>
   </data>
   <data name="Error_UnavailableSource" xml:space="preserve">
-    <value>Source with name '{0}' does not exist or cannot be retrived.</value>
+    <value>Source '{0}' does not exist or cannot be retrived.</value>
     <comment>0 - source name</comment>
   </data>
   <data name="NoTrustedSigners" xml:space="preserve">
     <value>There are no trusted signers.</value>
   </data>
   <data name="NoTrustedSignersMatching" xml:space="preserve">
-    <value>No trusted signers with name: '{0}' where found.</value>
+    <value>No trusted signers with the name: '{0}' were found.</value>
     <comment>0 - trusted signer name</comment>
   </data>
   <data name="RegsiteredTrustedSigners" xml:space="preserve">
     <value>Registered trusted signers:</value>
   </data>
   <data name="SuccessfullyRemovedTrustedSigner" xml:space="preserve">
-    <value>Successfully removed trusted signers with name: '{0}'.</value>
+    <value>Successfully removed the trusted signer '{0}'.</value>
     <comment>0 - trusted signer name</comment>
   </data>
   <data name="TrustedSignerLogCertificates" xml:space="preserve">
@@ -770,12 +770,16 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   </data>
   <data name="TrustedSignerLogCertificateSummaryAllowUntrustedRoot" xml:space="preserve">
     <value>[U] {0} - {1}</value>
-    <comment>0 - fingerprint algorithm
+    <comment>Do not localize
+
+0 - fingerprint algorithm
 1 - fingerprint</comment>
   </data>
   <data name="TrustedSignerLogCertificateSummaryUnallowUntrustedRoot" xml:space="preserve">
     <value>{0} - {1}</value>
-    <comment>0 - fingerprint algorithm
+    <comment>Do not localize
+
+0 - fingerprint algorithm
 1 - fingerprint</comment>
   </data>
   <data name="TrustedSignerLogOwners" xml:space="preserve">
@@ -816,11 +820,11 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <comment>0 - trusted repository name</comment>
   </data>
   <data name="Error_TrustedRepositoryDoesNotExist" xml:space="preserve">
-    <value>A trusted repository with the name '{0}' does not exist.</value>
+    <value>A trusted repository '{0}' does not exist.</value>
     <comment>0 - trusted repository name</comment>
   </data>
   <data name="Error_TrustedSignerAlreadyExists" xml:space="preserve">
-    <value>A trusted signer with the name '{0}' already exists.</value>
+    <value>A trusted signer '{0}' already exists.</value>
     <comment>0 - trusted signer name</comment>
   </data>
   <data name="Error_UnsupportedTrustTarget" xml:space="preserve">
@@ -836,35 +840,35 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <comment>0 - service index</comment>
   </data>
   <data name="Error_CouldNotAdd" xml:space="preserve">
-    <value>Could not add trusted signer: {0}</value>
+    <value>Could not add the trusted signer: {0}</value>
     <comment>0 - Reason</comment>
   </data>
   <data name="Error_CouldNotList" xml:space="preserve">
-    <value>Could not list trusted signers: {0}</value>
+    <value>Could not list the trusted signers: {0}</value>
     <comment>0 - Reason</comment>
   </data>
   <data name="Error_CouldNotRemove" xml:space="preserve">
-    <value>Could not remove trusted signer: {0}</value>
+    <value>Could not remove the trusted signer: {0}</value>
     <comment>0 - Reason</comment>
   </data>
   <data name="Error_CouldNotSync" xml:space="preserve">
-    <value>Could not sync trusted repository: {0}</value>
+    <value>Could not sync the trusted repository: {0}</value>
     <comment>0 - Reason</comment>
   </data>
   <data name="SuccessfullUpdatedTrustedSigner" xml:space="preserve">
-    <value>Successfully updated trusted signer with name: '{0}'.</value>
+    <value>Successfully updated the trusted signer '{0}'.</value>
     <comment>0 - name</comment>
   </data>
   <data name="SuccessfullyAddedTrustedAuthor" xml:space="preserve">
-    <value>Successfully added trusted author with name: '{0}'.</value>
+    <value>Successfully added a trusted author '{0}'.</value>
     <comment>0 - name</comment>
   </data>
   <data name="SuccessfullyAddedTrustedRepository" xml:space="preserve">
-    <value>Successfully added trusted repository with name: '{0}'.</value>
+    <value>Successfully added a trusted repository '{0}'.</value>
     <comment>0 - name</comment>
   </data>
   <data name="SuccessfullySynchronizedTrustedRepository" xml:space="preserve">
-    <value>Successfully synchronized trusted repository with name: '{0}'.</value>
+    <value>Successfully synchronized the trusted repository '{0}'.</value>
     <comment>0 - name</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/ITrustedSignersCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/ITrustedSignersCommandRunner.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace NuGet.Commands
+{
+    public interface ITrustedSignersCommandRunner
+    {
+        Task<int> ExecuteCommandAsync(TrustedSignersArgs trustedSignersArgs);
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignerActionsProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignerActionsProvider.cs
@@ -22,7 +22,7 @@ namespace NuGet.Commands
         private readonly ILogger _logger;
 
         /// <summary>
-        /// Internal SourceRepository usefull for overriding on tests to get
+        /// Internal SourceRepository useful for overriding on tests to get
         /// mocked responses from the server
         /// </summary>
         internal SourceRepository ServiceIndexSourceRepository { get; set; }
@@ -155,9 +155,10 @@ namespace NuGet.Commands
 #endif
 
         /// <summary>
-        /// Adds a new trusted author to the settings.
-        /// If a trusted signer already exists with this name, adds a certificate item to it.
+        /// Updates the certificate list of a trusted signer by adding the given certificate.
+        /// If the signer does not exists it creates a new one.
         /// </summary>
+        /// <remarks>This method defaults to adding a trusted author if the signer doesn't exist.</remarks>
         /// <param name="name">Name of the trusted author.</param>
         /// <param name="fingerprint">Fingerprint to be added to the certificate entry.</param>
         /// <param name="hashAlgorithm">Hash algorithm used to calculate <paramref name="fingerprint"/>.</param>
@@ -265,6 +266,7 @@ namespace NuGet.Commands
             return new CertificateItem(fingerprint, defaultHashAlgorithm, allowUntrustedRoot);
         }
 #endif
+
         private async Task<CertificateItem[]> GetCertificateItemsFromServiceIndexAsync(string serviceIndex, CancellationToken token)
         {
             if (string.IsNullOrEmpty(serviceIndex))

--- a/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignersArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignersArgs.cs
@@ -1,0 +1,78 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Common;
+
+namespace NuGet.Commands
+{
+    public class TrustedSignersArgs
+    {
+        public enum TrustedSignersAction
+        {
+            Add,
+            List,
+            Remove,
+            Sync
+        }
+
+        /// <summary>
+        /// Action to be performed by the trusted signers command.
+        /// </summary>
+        public TrustedSignersAction Action { get; set; }
+
+        /// <summary>
+        /// Name of the trusted signer.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Service index of the trusted repository.
+        /// </summary>
+        public string ServiceIndex { get; set; }
+
+        /// <summary>
+        /// Fingerprint of certificate added to a trusted signer
+        /// </summary>
+        public string CertificateFingerprint { get; set; }
+
+        /// <summary>
+        /// Algorithm used to calculate fingerprint. <see cref="CertificateFingerprint"/>
+        /// </summary>
+        public string FingerprintAlgorithm { get; set; }
+
+        /// <summary>
+        /// Specifies if the certificate to be added to a trusted signer
+        /// should allow to chain to an untrusted root.
+        /// </summary>
+        public bool AllowUntrustedRoot { get; set; }
+
+        /// <summary>
+        /// Specifies if the signature to be trusted is the author signature.
+        /// Only valid when specifying a packge path <see cref="PackagePath"/>
+        /// </summary>
+        public bool Author { get; set; }
+
+        /// <summary>
+        /// Specifies if the signature to be trusted is the repository signature or countersignature.
+        /// Only valid when specifying a packge path <see cref="PackagePath"/>
+        /// </summary>
+        public bool Repository { get; set; }
+
+        /// <summary>
+        /// Owners to be trusted from a specific repository.
+        /// Only valid when adding trust for a repository.
+        /// </summary>
+        public IEnumerable<string> Owners { get; set; }
+
+        /// <summary>
+        /// Path to the signed package to be trusted.
+        /// </summary>
+        public string PackagePath { get; set; }
+
+        /// <summary>
+        /// Logger to be used to display the logs during the execution of sign command.
+        /// </summary>
+        public ILogger Logger { get; set; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignersCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/TrustedSignersCommand/TrustedSignersCommandRunner.cs
@@ -1,0 +1,362 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Packaging;
+using NuGet.Packaging.Signing;
+using NuGet.Protocol;
+using static NuGet.Commands.TrustedSignersArgs;
+
+namespace NuGet.Commands
+{
+    /// <summary>
+    /// Command Runner used to run the business logic for nuget trusted-signers command
+    /// </summary>
+    public class TrustedSignersCommandRunner : ITrustedSignersCommandRunner
+    {
+        private const int SuccessCode = 0;
+        private const int FailureCode = 1;
+
+        private readonly ITrustedSignersProvider _trustedSignersProvider;
+        private readonly IPackageSourceProvider _packageSourceProvider;
+
+        public TrustedSignersCommandRunner(ITrustedSignersProvider trustedSignersProvider, IPackageSourceProvider packageSourceProvider)
+        {
+            _trustedSignersProvider = trustedSignersProvider ?? throw new ArgumentNullException(nameof(trustedSignersProvider));
+            _packageSourceProvider = packageSourceProvider;
+        }
+
+        public async Task<int> ExecuteCommandAsync(TrustedSignersArgs trustedSignersArgs)
+        {
+            var logger = trustedSignersArgs.Logger ?? NullLogger.Instance;
+            var actionsProvider = new TrustedSignerActionsProvider(_trustedSignersProvider, logger);
+
+            switch (trustedSignersArgs.Action)
+            {
+                case TrustedSignersAction.List:
+                    ValidateListArguments(trustedSignersArgs);
+
+                    await ListAllTrustedSignersAsync(logger);
+
+                    break;
+
+                case TrustedSignersAction.Add:
+                    ValidateNameExists(trustedSignersArgs.Name);
+
+                    var isPackagePathProvided = !string.IsNullOrEmpty(trustedSignersArgs.PackagePath);
+                    var isServiceIndexProvided = !string.IsNullOrEmpty(trustedSignersArgs.ServiceIndex);
+                    var isFingerprintProvided = !string.IsNullOrEmpty(trustedSignersArgs.CertificateFingerprint);
+                    var isAlgorithmProvided = !string.IsNullOrEmpty(trustedSignersArgs.FingerprintAlgorithm);
+
+                    if (isPackagePathProvided)
+                    {
+#if IS_DESKTOP
+                        if (isServiceIndexProvided || isFingerprintProvided || isAlgorithmProvided)
+                        {
+                            throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_CouldNotAdd, Strings.Error_InvalidCombinationOfArguments));
+                        }
+
+                        if (!(trustedSignersArgs.Repository ^ trustedSignersArgs.Author))
+                        {
+                            throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_NoSignatureTrustedForPackage, trustedSignersArgs.PackagePath));
+                        }
+
+                        var trustTarget = VerificationTarget.None;
+                        if (trustedSignersArgs.Author)
+                        {
+                            if (!trustedSignersArgs.Repository && trustedSignersArgs.Owners != null && trustedSignersArgs.Owners.Any())
+                            {
+                                throw new CommandLineArgumentCombinationException(Strings.Error_CannotTrustOwnersForAuthor);
+                            }
+
+                            trustTarget |= VerificationTarget.Author;
+                        }
+
+                        if (trustedSignersArgs.Repository)
+                        {
+                            trustTarget |= VerificationTarget.Repository;
+                        }
+
+                        if (trustTarget == VerificationTarget.None)
+                        {
+                            trustTarget = VerificationTarget.Unknown;
+                        }
+
+                        var packagesToTrust = LocalFolderUtility.ResolvePackageFromPath(trustedSignersArgs.PackagePath);
+                        LocalFolderUtility.EnsurePackageFileExists(trustedSignersArgs.PackagePath, packagesToTrust);
+
+                        foreach (var package in packagesToTrust)
+                        {
+                            using (var packageReader = new PackageArchiveReader(package))
+                            {
+                                await actionsProvider.AddTrustedSignerAsync(
+                                    trustedSignersArgs.Name,
+                                    packageReader,
+                                    trustTarget,
+                                    trustedSignersArgs.AllowUntrustedRoot,
+                                    trustedSignersArgs.Owners,
+                                    CancellationToken.None);
+                            }
+                        }
+
+                        break;
+
+#else
+                        throw new NotSupportedException();
+#endif
+                    }
+
+                    if (isServiceIndexProvided)
+                    {
+                        if (isFingerprintProvided || isAlgorithmProvided || trustedSignersArgs.Author || trustedSignersArgs.Repository)
+                        {
+                            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_CouldNotAdd, Strings.Error_InvalidCombinationOfArguments));
+                        }
+
+                        var serviceIndex = ValidateAndParseV3ServiceIndexUrl(trustedSignersArgs.ServiceIndex);
+
+                        await actionsProvider.AddTrustedRepositoryAsync(
+                            trustedSignersArgs.Name,
+                            serviceIndex,
+                            trustedSignersArgs.Owners,
+                            CancellationToken.None);
+
+                        break;
+                    }
+
+                    if (isFingerprintProvided)
+                    {
+                        if (trustedSignersArgs.Owners != null && trustedSignersArgs.Owners.Any())
+                        {
+                            throw new ArgumentException(Strings.Error_CannotTrustOwnersForAuthor);
+                        }
+
+                        var hashAlgorithm = ValidateAndParseFingerprintAlgorithm(trustedSignersArgs.FingerprintAlgorithm);
+
+                        actionsProvider.AddOrUpdateTrustedSigner(
+                            trustedSignersArgs.Name,
+                            trustedSignersArgs.CertificateFingerprint,
+                            hashAlgorithm,
+                            trustedSignersArgs.AllowUntrustedRoot);
+
+                        break;
+                    }
+
+                    if (isAlgorithmProvided || trustedSignersArgs.Author || trustedSignersArgs.Repository)
+                    {
+                        throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_CouldNotAdd, Strings.Error_InvalidCombinationOfArguments));
+                    }
+
+                    if (_packageSourceProvider == null)
+                    {
+                        throw new ArgumentException(Strings.Error_NoSourcesInformation);
+                    }
+
+                    var packageSource = _packageSourceProvider.GetPackageSourceByName(trustedSignersArgs.Name);
+                    if (packageSource == null || string.IsNullOrEmpty(packageSource.Source))
+                    {
+                        throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnavailableSource, trustedSignersArgs.Name));
+                    }
+
+                    var sourceServiceIndex = ValidateAndParseV3ServiceIndexUrl(packageSource.Source);
+
+                    await actionsProvider.AddTrustedRepositoryAsync(
+                        trustedSignersArgs.Name,
+                        sourceServiceIndex,
+                        trustedSignersArgs.Owners,
+                        CancellationToken.None);
+
+
+                    break;
+
+                case TrustedSignersAction.Remove:
+                    ValidateRemoveArguments(trustedSignersArgs);
+
+                    await RemoveTrustedSignerAsync(trustedSignersArgs.Name, logger);
+
+                    break;
+
+                case TrustedSignersAction.Sync:
+                    ValidateSyncArguments(trustedSignersArgs);
+
+                    await actionsProvider.SyncTrustedRepositoryAsync(trustedSignersArgs.Name, CancellationToken.None);
+
+                    break;
+            }
+
+            return SuccessCode;
+        }
+
+
+        private async Task ListAllTrustedSignersAsync(ILogger logger)
+        {
+            var trustedSigners = _trustedSignersProvider.GetTrustedSigners();
+            if (!trustedSigners.Any())
+            {
+                await logger.LogAsync(LogLevel.Information, Strings.NoTrustedSigners);
+                return;
+            }
+
+            var trustedSignersLogs = new List<LogMessage>();
+
+            await logger.LogAsync(LogLevel.Information, Strings.RegsiteredTrustedSigners);
+            await logger.LogAsync(LogLevel.Information, Environment.NewLine);
+
+            for (var i = 0; i < trustedSigners.Count; i++)
+            {
+                var item = trustedSigners[i];
+
+                var trustedSignerBuilder = new StringBuilder();
+
+                var index = $" {i+1}.".PadRight(6);
+                var defaultIndentation = string.Empty.PadRight(6);
+
+                trustedSignerBuilder.AppendLine($"{index}{string.Format(CultureInfo.CurrentCulture, Strings.TrustedSignerLogTitle, item.Name, item.ElementName)}");
+
+                if (item is RepositoryItem repoItem)
+                {
+                    trustedSignerBuilder.AppendLine($"{defaultIndentation}{string.Format(CultureInfo.CurrentCulture, Strings.TrustedSignerLogServiceIndex, repoItem.ServiceIndex)}");
+
+                    if (repoItem.Owners != null && repoItem.Owners.Any())
+                    {
+                        trustedSignerBuilder.AppendLine($"{defaultIndentation}{string.Format(CultureInfo.CurrentCulture, Strings.TrustedSignerLogOwners, string.Join("; ", repoItem.Owners))}");
+                    }
+                }
+
+                trustedSignerBuilder.AppendLine($"{defaultIndentation}{Strings.TrustedSignerLogCertificates}");
+
+                foreach (var cert in item.Certificates)
+                {
+                    var extraIndentation = string.Empty.PadRight(2);
+
+                    var summaryAllowUntrustedRoot = (cert.AllowUntrustedRoot) ? Strings.TrustedSignerLogCertificateSummaryAllowUntrustedRoot : Strings.TrustedSignerLogCertificateSummaryUnallowUntrustedRoot;
+                    trustedSignerBuilder.AppendLine($"{defaultIndentation}{extraIndentation}{string.Format(CultureInfo.CurrentCulture, summaryAllowUntrustedRoot, cert.HashAlgorithm.ToString(), cert.Fingerprint)}");
+                }
+
+                trustedSignersLogs.Add(new LogMessage(LogLevel.Information, trustedSignerBuilder.ToString()));
+            }
+
+            await logger.LogMessagesAsync(trustedSignersLogs);
+        }
+
+        private async Task RemoveTrustedSignerAsync(string name, ILogger logger)
+        {
+            var trustedSigners = _trustedSignersProvider.GetTrustedSigners().Where(item => string.Equals(item.Name, name, StringComparison.OrdinalIgnoreCase));
+            if (!trustedSigners.Any())
+            {
+                await logger.LogAsync(LogLevel.Information, string.Format(CultureInfo.CurrentCulture, Strings.NoTrustedSignersMatching, name));
+                return;
+            }
+
+            _trustedSignersProvider.Remove(trustedSigners.ToList());
+
+            await logger.LogAsync(LogLevel.Information, string.Format(CultureInfo.CurrentCulture, Strings.SuccessfullyRemovedTrustedSigner, name));
+        }
+
+        private void ValidateListArguments(TrustedSignersArgs args)
+        {
+            var isNameProvided = !string.IsNullOrEmpty(args.Name);
+            var isPackagePathProvided = !string.IsNullOrEmpty(args.PackagePath);
+            var isServiceIndexProvided = !string.IsNullOrEmpty(args.ServiceIndex);
+            var isFingerprintProvided = !string.IsNullOrEmpty(args.CertificateFingerprint);
+            var isAlgorithmProvided = !string.IsNullOrEmpty(args.FingerprintAlgorithm);
+            var areOwnersProvided = args.Owners != null && args.Owners.Any();
+            var isUntrustedRootProvided = args.AllowUntrustedRoot;
+            var isAuthorProvided = args.Author;
+            var isRepositoryProvided = args.Repository;
+
+            if (isNameProvided || isPackagePathProvided || isServiceIndexProvided ||
+                isFingerprintProvided || isAlgorithmProvided || areOwnersProvided ||
+                isUntrustedRootProvided || isAuthorProvided || isRepositoryProvided)
+            {
+                throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_CouldNotList, Strings.Error_InvalidCombinationOfArguments));
+            }
+        }
+
+        private void ValidateRemoveArguments(TrustedSignersArgs args)
+        {
+            ValidateNameExists(args.Name);
+
+            var isPackagePathProvided = !string.IsNullOrEmpty(args.PackagePath);
+            var isServiceIndexProvided = !string.IsNullOrEmpty(args.ServiceIndex);
+            var isFingerprintProvided = !string.IsNullOrEmpty(args.CertificateFingerprint);
+            var isAlgorithmProvided = !string.IsNullOrEmpty(args.FingerprintAlgorithm);
+            var areOwnersProvided = args.Owners != null && args.Owners.Any();
+            var isUntrustedRootProvided = args.AllowUntrustedRoot;
+            var isAuthorProvided = args.Author;
+            var isRepositoryProvided = args.Repository;
+
+            if (isPackagePathProvided || isServiceIndexProvided ||
+                isFingerprintProvided || isAlgorithmProvided || areOwnersProvided ||
+                isUntrustedRootProvided || isAuthorProvided || isRepositoryProvided)
+            {
+                throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_CouldNotRemove, Strings.Error_InvalidCombinationOfArguments));
+            }
+        }
+
+        private void ValidateSyncArguments(TrustedSignersArgs args)
+        {
+            ValidateNameExists(args.Name);
+
+            var isPackagePathProvided = !string.IsNullOrEmpty(args.PackagePath);
+            var isServiceIndexProvided = !string.IsNullOrEmpty(args.ServiceIndex);
+            var isFingerprintProvided = !string.IsNullOrEmpty(args.CertificateFingerprint);
+            var isAlgorithmProvided = !string.IsNullOrEmpty(args.FingerprintAlgorithm);
+            var areOwnersProvided = args.Owners != null && args.Owners.Any();
+            var isUntrustedRootProvided = args.AllowUntrustedRoot;
+            var isAuthorProvided = args.Author;
+            var isRepositoryProvided = args.Repository;
+
+            if (isPackagePathProvided || isServiceIndexProvided ||
+                isFingerprintProvided || isAlgorithmProvided || areOwnersProvided ||
+                isUntrustedRootProvided || isAuthorProvided || isRepositoryProvided)
+            {
+                throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_CouldNotSync, Strings.Error_InvalidCombinationOfArguments));
+            }
+        }
+
+        private void ValidateNameExists(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_PropertyCannotBeNullOrEmpty, nameof(name)));
+            }
+        }
+
+        private HashAlgorithmName ValidateAndParseFingerprintAlgorithm(string algorithm)
+        {
+            if (string.IsNullOrEmpty(algorithm))
+            {
+                return HashAlgorithmName.SHA256;
+            }
+
+            var hashAlgorithm = CryptoHashUtility.GetHashAlgorithmName(algorithm);
+
+            if (hashAlgorithm == HashAlgorithmName.Unknown || !SigningSpecifications.V1.AllowedHashAlgorithms.Contains(hashAlgorithm))
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_NotSupportedHashAlgorithm, algorithm));
+            }
+
+            return hashAlgorithm;
+        }
+
+        private Uri ValidateAndParseV3ServiceIndexUrl(string serviceIndex)
+        {
+            var validUri = Uri.TryCreate(serviceIndex, UriKind.Absolute, out var serviceIndexUri);
+            if (!validUri || !string.Equals(serviceIndexUri.Scheme, "https", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_ServiceIndexShouldBeHttps, serviceIndex));
+            }
+
+            return serviceIndexUri;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Common/CommandLineArgumentCombinationException.cs
+++ b/src/NuGet.Core/NuGet.Common/CommandLineArgumentCombinationException.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Common
+{
+    public class CommandLineArgumentCombinationException : Exception, ILogMessageException
+    {
+        private readonly ILogMessage _logMessage;
+
+        public CommandLineArgumentCombinationException(string message)
+            : base(message)
+        {
+            _logMessage = LogMessage.CreateError(NuGetLogCode.NU1000, message);
+        }
+
+        public virtual ILogMessage AsLogMessage()
+        {
+            return _logMessage;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/VerificationTarget.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/VerificationTarget.cs
@@ -15,6 +15,11 @@ namespace NuGet.Packaging.Signing
     public enum VerificationTarget
     {
         /// <summary>
+        /// Don't target any signatures.
+        /// </summary>
+        None        = 0,
+
+        /// <summary>
         /// Target unknown primary signatures.
         /// </summary>
         Unknown     = 1 << 1,

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/TrustedSignersCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/TrustedSignersCommandTests.cs
@@ -1,0 +1,455 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NuGet.CommandLine.Commands;
+using NuGet.CommandLine.Test;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Configuration.Test;
+using NuGet.Test.Utility;
+using Test.Utility.Signing;
+using Xunit;
+using static NuGet.Commands.TrustedSignersArgs;
+
+namespace NuGet.CommandLine.FuncTest.Commands
+{
+    /// <summary>
+    /// Tests trusted-signers command
+    /// </summary>
+    [Collection(SignCommandTestCollection.Name)]
+    public class TrustedSignersCommandTests
+    {
+        private readonly string _nugetExePath;
+        private const string _trustedSignersHelpStringFragment = "usage: NuGet trusted-signers <List|Add|Remove|Sync> [options]";
+        private const string _successfulActionTrustedSigner = "Successfully {0} trusted {1} with name: '{2}'.";
+
+        public TrustedSignersCommandTests()
+        {
+            _nugetExePath = Util.GetNuGetExePath();
+        }
+
+        [Fact]
+        public async Task TrustedSignersCommand_NoAction_DefaultsToListAsync()
+        {
+            var commandRunner = new Mock<ITrustedSignersCommandRunner>();
+            var mockConsole = new Mock<IConsole>();
+
+            var command = new TrustedSignersCommand()
+            {
+                TrustedSignersCommandRunner = commandRunner.Object,
+                Console = mockConsole.Object
+            };
+
+            // Act
+            command.Execute();
+            await command.ExecuteCommandAsync();
+
+            commandRunner.Verify(r => r.ExecuteCommandAsync(It.Is<TrustedSignersArgs>(a => a.Action == TrustedSignersAction.List)));
+        }
+
+        [Fact]
+        public async Task TrustedSignersCommand_SendsArgumentsCorrectlyToCommandRunnerAsync()
+        {
+            var commandRunner = new Mock<ITrustedSignersCommandRunner>();
+            var mockConsole = new Mock<IConsole>();
+
+            var expectedName = "signerName";
+            var expectedServiceIndex = @"https://serviceIndex.test";
+            var expectedCertificateFingerprint = "abcdefg";
+            var expectedFingerprintAlgorithm = "SHA256";
+            var expectedAllowUntrustedRoot = true;
+            var expectedAuthor = true;
+            var expectedRepository = true;
+            var expectedAction = TrustedSignersAction.Add;
+            var expectedOwners = new List<string>() { "one", "two", "three" };
+            var expectedPackagePath = @"C:\\package\\path\\test";
+
+            var command = new TrustedSignersCommand()
+            {
+                TrustedSignersCommandRunner = commandRunner.Object,
+                Name = expectedName,
+                ServiceIndex = expectedServiceIndex,
+                CertificateFingerprint = expectedCertificateFingerprint,
+                FingerprintAlgorithm = expectedFingerprintAlgorithm,
+                AllowUntrustedRoot = expectedAllowUntrustedRoot,
+                Author = expectedAuthor,
+                Repository = expectedRepository,
+                Owners = expectedOwners,
+                Console = mockConsole.Object
+            };
+            command.Arguments.Add(expectedAction.ToString());
+            command.Arguments.Add(expectedPackagePath);
+
+            // Act
+            command.Execute();
+            await command.ExecuteCommandAsync();
+
+            commandRunner.Verify(r =>
+                r.ExecuteCommandAsync(It.Is<TrustedSignersArgs>(a =>
+                    a.Action == expectedAction &&
+                    string.Equals(a.Name, expectedName, StringComparison.Ordinal) &&
+                    string.Equals(a.ServiceIndex, expectedServiceIndex, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(a.CertificateFingerprint, expectedCertificateFingerprint, StringComparison.Ordinal) &&
+                    string.Equals(a.FingerprintAlgorithm, expectedFingerprintAlgorithm, StringComparison.Ordinal) &&
+                    a.AllowUntrustedRoot == expectedAllowUntrustedRoot &&
+                    a.Author == expectedAuthor &&
+                    a.Repository == expectedRepository &&
+                    a.Owners.SequenceEqual(expectedOwners) &&
+                    string.Equals(a.PackagePath, expectedPackagePath, StringComparison.Ordinal))));
+        }
+
+        [Theory]
+        [InlineData("list -CertificateFingerprint one -FingerprintAlgorithm SHA256")]
+        [InlineData("add -CertificateFingerprint one -FingerprintAlgorithm SHA256")]
+        [InlineData("add -FingerprintAlgorithm SHA256")]
+        [InlineData("add -Name blah -Repository")]
+        [InlineData("add -Name blah extraArg")]
+        [InlineData("add .\\package -Name blah")]
+        [InlineData("add .\\package -Name blah -Repository -Author")]
+        [InlineData("add .\\package -Name blah -CertificateFingerprint one -FingerprintAlgorithm SHA256")]
+        [InlineData("add .\\package -Name blah -ServiceIndex https://v3.test")]
+        [InlineData("add .\\package -Name blah -Author -Owners one;two")]
+        [InlineData("remove")]
+        [InlineData("remove extraArg")]
+        [InlineData("remove -Name blah -Repository")]
+        [InlineData("remove -Name blah -CertificateFingerprint one")]
+        [InlineData("remove -Name blah -Owners one")]
+        [InlineData("remove -Name blah extraArg")]
+        [InlineData("sync")]
+        [InlineData("sync extraArg")]
+        [InlineData("sync -Name blah -Repository")]
+        [InlineData("sync -Name blah -CertificateFingerprint one")]
+        [InlineData("sync -Name blah -Owners one")]
+        [InlineData("sync -Name blah extraArg")]
+        [InlineData("notSupportedAction")]
+        public void TrustedSignersCommand_Failure_InvalidArguments_HelpMessage(string args)
+        {
+            // Arrange & Act 
+            var result = CommandRunner.Run(
+                _nugetExePath,
+                Directory.GetCurrentDirectory(),
+                $"trusted-signers {args}",
+                waitForExit: true);
+
+            // Assert
+
+            // TODO: Instead of these assertions there should be a call to :
+            //  Util.VerifyResultFailure(result, TrustedSignersHelpStringFragment, checkErrorMsgOnStdErr: false);
+
+            Assert.True(
+                result.Item1 != 0,
+                "nuget.exe DID NOT FAIL: Ouput is " + result.Item2 + ". Error is " + result.Item3);
+
+            Assert.True(
+                result.Item2.Contains(_trustedSignersHelpStringFragment),
+                "Expected error is " + _trustedSignersHelpStringFragment + ". Actual error is " + result.Item3);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TrustedSignersCommand_AddTrustedSigner_WithCertificiateFingerprint_AddsItSuccesfullyToConfig(bool allowUntrustedRoot)
+        {
+            // Arrange
+            var nugetConfigFileName = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>";
+
+            // Arrange
+            using (var dir = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigFileName, dir, config);
+                var nugetConfigPath = Path.Combine(dir, nugetConfigFileName);
+                var allowUntrustedRootArg = allowUntrustedRoot ? "-AllowUntrustedRoot" : string.Empty;
+
+                // Act
+                var commandResult = CommandRunner.Run(
+                    _nugetExePath,
+                    dir,
+                    $"trusted-signers add -Name signer -CertificateFingerprint abcdefg -FingerprintAlgorithm SHA256 {allowUntrustedRootArg} -Config {nugetConfigPath}",
+                    waitForExit: true);
+
+                // Assert
+                commandResult.Success.Should().BeTrue();
+                commandResult.AllOutput.Should().Contain(string.Format(CultureInfo.CurrentCulture, _successfulActionTrustedSigner, "added", "author", "signer"));
+
+                var expectedResult = SettingsTestUtils.RemoveWhitespace($@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <trustedSigners>
+        <author name=""signer"">
+            <certificate fingerprint=""abcdefg"" hashAlgorithm=""SHA256"" allowUntrustedRoot=""{allowUntrustedRoot.ToString().ToLower()}"" />
+        </author>
+    </trustedSigners>
+</configuration>");
+
+                SettingsTestUtils.RemoveWhitespace(File.ReadAllText(nugetConfigPath)).Should().Be(expectedResult);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TrustedSignersCommand_AddTrustedSigner_WithExistingSigner_UpdatesItSuccesfullyInConfig(bool allowUntrustedRoot)
+        {
+            // Arrange
+            var nugetConfigFileName = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <trustedSigners>
+        <author name=""signer"">
+            <certificate fingerprint=""abcdefg"" hashAlgorithm=""SHA256"" allowUntrustedRoot=""false"" />
+        </author>
+    </trustedSigners>
+</configuration>";
+
+            // Arrange
+            using (var dir = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigFileName, dir, config);
+                var nugetConfigPath = Path.Combine(dir, nugetConfigFileName);
+                var allowUntrustedRootArg = allowUntrustedRoot ? "-AllowUntrustedRoot" : string.Empty;
+
+                // Act
+                var commandResult = CommandRunner.Run(
+                    _nugetExePath,
+                    dir,
+                    $"trusted-signers add -Name signer -CertificateFingerprint hijklmn -FingerprintAlgorithm SHA256 {allowUntrustedRootArg} -Config {nugetConfigPath}",
+                    waitForExit: true);
+
+                // Assert
+                commandResult.Success.Should().BeTrue();
+                commandResult.AllOutput.Should().Contain(string.Format(CultureInfo.CurrentCulture, _successfulActionTrustedSigner, "updated", "signer", "signer"));
+
+                var expectedResult = SettingsTestUtils.RemoveWhitespace($@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <trustedSigners>
+        <author name=""signer"">
+            <certificate fingerprint=""abcdefg"" hashAlgorithm=""SHA256"" allowUntrustedRoot=""false"" />
+            <certificate fingerprint=""hijklmn"" hashAlgorithm=""SHA256"" allowUntrustedRoot=""{allowUntrustedRoot.ToString().ToLower()}"" />
+        </author>
+    </trustedSigners>
+</configuration>");
+
+                SettingsTestUtils.RemoveWhitespace(File.ReadAllText(nugetConfigPath)).Should().Be(expectedResult);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TrustedSignersCommand_AddTrustedSigner_WithAuthorSignedPackage_AddsItSuccesfullyToConfigAsync(bool allowUntrustedRoot)
+        {
+            // Arrange
+            var nugetConfigFileName = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>";
+
+            // Arrange
+            var package = new SimpleTestPackageContext();
+            using (var dir = TestDirectory.Create())
+            using (var zipStream = await package.CreateAsStreamAsync())
+            using (var trustedTestCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            {
+                var certFingerprint = SignatureTestUtility.GetFingerprint(trustedTestCert.Source.Cert, HashAlgorithmName.SHA256);
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(trustedTestCert.Source.Cert, package, dir);
+
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigFileName, dir, config);
+                var nugetConfigPath = Path.Combine(dir, nugetConfigFileName);
+                var allowUntrustedRootArg = allowUntrustedRoot ? "-AllowUntrustedRoot" : string.Empty;
+
+                // Act
+                var commandResult = CommandRunner.Run(
+                    _nugetExePath,
+                    dir,
+                    $"trusted-signers add {signedPackagePath} -Name signer -Author {allowUntrustedRootArg} -Config {nugetConfigPath}",
+                    waitForExit: true);
+
+                // Assert
+                commandResult.Success.Should().BeTrue();
+                commandResult.AllOutput.Should().Contain(string.Format(CultureInfo.CurrentCulture, _successfulActionTrustedSigner, "added", "author", "signer"));
+
+                var expectedResult = SettingsTestUtils.RemoveWhitespace($@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+<trustedSigners>
+    <author name=""signer"">
+        <certificate fingerprint=""{certFingerprint}"" hashAlgorithm=""SHA256"" allowUntrustedRoot=""{allowUntrustedRoot.ToString().ToLower()}"" />
+    </author>
+</trustedSigners>
+</configuration>");
+
+                SettingsTestUtils.RemoveWhitespace(File.ReadAllText(nugetConfigPath)).Should().Be(expectedResult);
+            }
+        }
+
+        [Theory]
+        [InlineData(true, null)]
+        [InlineData(true, "one;two;three")]
+        [InlineData(false, null)]
+        [InlineData(false, "one;two;three")]
+        public async Task TrustedSignersCommand_AddTrustedSigner_WithRepositorySignedPackage_AddsItSuccesfullyToConfigAsync(bool allowUntrustedRoot, string owners)
+        {
+            // Arrange
+            var nugetConfigFileName = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>";
+
+            // Arrange
+            var package = new SimpleTestPackageContext();
+            using (var dir = TestDirectory.Create())
+            using (var zipStream = await package.CreateAsStreamAsync())
+            using (var trustedTestCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            {
+                var certFingerprint = SignatureTestUtility.GetFingerprint(trustedTestCert.Source.Cert, HashAlgorithmName.SHA256);
+                var repoServiceIndex = "https://serviceindex.test/v3/index.json";
+                var signedPackagePath = await SignedArchiveTestUtility.RepositorySignPackageAsync(trustedTestCert.Source.Cert, package, dir, new Uri(repoServiceIndex));
+
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigFileName, dir, config);
+                var nugetConfigPath = Path.Combine(dir, nugetConfigFileName);
+                var allowUntrustedRootArg = allowUntrustedRoot ? "-AllowUntrustedRoot" : string.Empty;
+                var ownersArgs = string.Empty;
+                var expectedOwners = string.Empty;
+
+                if (owners != null)
+                {
+                    ownersArgs = $"-Owners {owners}";
+                    expectedOwners = $"<owners>{owners}</owners>";
+                }
+
+                // Act
+                var commandResult = CommandRunner.Run(
+                    _nugetExePath,
+                    dir,
+                    $"trusted-signers add {signedPackagePath} -Name signer -Repository {allowUntrustedRootArg} {ownersArgs} -Config {nugetConfigPath}",
+                    waitForExit: true);
+
+                // Assert
+                commandResult.Success.Should().BeTrue();
+                commandResult.AllOutput.Should().Contain(string.Format(CultureInfo.CurrentCulture, _successfulActionTrustedSigner, "added", "repository", "signer"));
+
+                var expectedResult = SettingsTestUtils.RemoveWhitespace($@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+<trustedSigners>
+    <repository name=""signer"" serviceIndex=""{repoServiceIndex}"">
+        <certificate fingerprint=""{certFingerprint}"" hashAlgorithm=""SHA256"" allowUntrustedRoot=""{allowUntrustedRoot.ToString().ToLower()}"" />
+        {expectedOwners}
+    </repository>
+</trustedSigners>
+</configuration>");
+
+                SettingsTestUtils.RemoveWhitespace(File.ReadAllText(nugetConfigPath)).Should().Be(expectedResult);
+            }
+        }
+
+        [Theory]
+        [InlineData(true, null)]
+        [InlineData(true, "one;two;three")]
+        [InlineData(false, null)]
+        [InlineData(false, "one;two;three")]
+        public async Task TrustedSignersCommand_AddTrustedSigner_WithRepositoryCountersignedPackage_AddsItSuccesfullyToConfigAsync(bool allowUntrustedRoot, string owners)
+        {
+            // Arrange
+            var nugetConfigFileName = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>";
+
+            // Arrange
+            var package = new SimpleTestPackageContext();
+            using (var dir = TestDirectory.Create())
+            using (var zipStream = await package.CreateAsStreamAsync())
+            using (var authorTrustedTestCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            using (var repoTrustedTestCert = SigningTestUtility.GenerateTrustedTestCertificate())
+            {
+                var certFingerprint = SignatureTestUtility.GetFingerprint(repoTrustedTestCert.Source.Cert, HashAlgorithmName.SHA256);
+                var repoServiceIndex = "https://serviceindex.test/v3/index.json";
+                var authorSignedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(authorTrustedTestCert.Source.Cert, package, dir);
+                var signedPackagePath = await SignedArchiveTestUtility.RepositorySignPackageAsync(repoTrustedTestCert.Source.Cert, authorSignedPackagePath, dir, new Uri(repoServiceIndex));
+
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigFileName, dir, config);
+                var nugetConfigPath = Path.Combine(dir, nugetConfigFileName);
+                var allowUntrustedRootArg = allowUntrustedRoot ? "-AllowUntrustedRoot" : string.Empty;
+                var ownersArgs = string.Empty;
+                var expectedOwners = string.Empty;
+
+                if (owners != null)
+                {
+                    ownersArgs = $"-Owners {owners}";
+                    expectedOwners = $"<owners>{owners}</owners>";
+                }
+
+                // Act
+                var commandResult = CommandRunner.Run(
+                    _nugetExePath,
+                    dir,
+                    $"trusted-signers add {signedPackagePath} -Name signer -Repository {allowUntrustedRootArg} {ownersArgs} -Config {nugetConfigPath}",
+                    waitForExit: true);
+
+                // Assert
+                commandResult.Success.Should().BeTrue();
+                commandResult.AllOutput.Should().Contain(string.Format(CultureInfo.CurrentCulture, _successfulActionTrustedSigner, "added", "repository", "signer"));
+
+                var expectedResult = SettingsTestUtils.RemoveWhitespace($@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+<trustedSigners>
+    <repository name=""signer"" serviceIndex=""{repoServiceIndex}"">
+        <certificate fingerprint=""{certFingerprint}"" hashAlgorithm=""SHA256"" allowUntrustedRoot=""{allowUntrustedRoot.ToString().ToLower()}"" />
+        {expectedOwners}
+    </repository>
+</trustedSigners>
+</configuration>");
+
+                SettingsTestUtils.RemoveWhitespace(File.ReadAllText(nugetConfigPath)).Should().Be(expectedResult);
+            }
+        }
+
+        [Fact]
+        public void TrustedSignersCommand_RemoveTrustedSigner_RemovesItSuccessfullyFromConfig()
+        {
+            // Arrange
+            var nugetConfigFileName = "NuGet.Config";
+            var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <trustedSigners>
+        <author name=""signer"">
+            <certificate fingerprint=""abcdefg"" hashAlgorithm=""SHA256"" allowUntrustedRoot=""false"" />
+        </author>
+    </trustedSigners>
+</configuration>";
+
+            // Arrange
+            using (var dir = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigFileName, dir, config);
+                var nugetConfigPath = Path.Combine(dir, nugetConfigFileName);
+
+                // Act
+                var commandResult = CommandRunner.Run(
+                    _nugetExePath,
+                    dir,
+                    $"trusted-signers remove -Name signer -Config {nugetConfigPath}",
+                    waitForExit: true);
+
+                // Assert
+                commandResult.Success.Should().BeTrue();
+                commandResult.AllOutput.Should().Contain(string.Format(CultureInfo.CurrentCulture, _successfulActionTrustedSigner, "removed", "signers", "signer"));
+
+                var expectedResult = SettingsTestUtils.RemoveWhitespace($@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>");
+
+                SettingsTestUtils.RemoveWhitespace(File.ReadAllText(nugetConfigPath)).Should().Be(expectedResult);
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/TrustedSignersCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/TrustedSignersCommandTests.cs
@@ -29,7 +29,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
     {
         private readonly string _nugetExePath;
         private const string _trustedSignersHelpStringFragment = "usage: NuGet trusted-signers <List|Add|Remove|Sync> [options]";
-        private const string _successfulActionTrustedSigner = "Successfully {0} trusted {1} with name: '{2}'.";
+        private const string _successfulActionTrustedSigner = "Successfully {0} the trusted {1} '{2}'.";
+        private const string _successfulAddTrustedSigner = "Successfully added a trusted {0} '{1}'.";
 
         public TrustedSignersCommandTests()
         {
@@ -180,7 +181,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 commandResult.Success.Should().BeTrue();
-                commandResult.AllOutput.Should().Contain(string.Format(CultureInfo.CurrentCulture, _successfulActionTrustedSigner, "added", "author", "signer"));
+                commandResult.AllOutput.Should().Contain(string.Format(CultureInfo.CurrentCulture, _successfulAddTrustedSigner, "author", "signer"));
 
                 var expectedResult = SettingsTestUtils.RemoveWhitespace($@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
@@ -243,7 +244,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        [Theory]
+        [CIOnlyTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task TrustedSignersCommand_AddTrustedSigner_WithAuthorSignedPackage_AddsItSuccesfullyToConfigAsync(bool allowUntrustedRoot)
@@ -276,7 +277,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 commandResult.Success.Should().BeTrue();
-                commandResult.AllOutput.Should().Contain(string.Format(CultureInfo.CurrentCulture, _successfulActionTrustedSigner, "added", "author", "signer"));
+                commandResult.AllOutput.Should().Contain(string.Format(CultureInfo.CurrentCulture, _successfulAddTrustedSigner, "author", "signer"));
 
                 var expectedResult = SettingsTestUtils.RemoveWhitespace($@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
@@ -291,7 +292,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        [Theory]
+        [CIOnlyTheory]
         [InlineData(true, null)]
         [InlineData(true, "one;two;three")]
         [InlineData(false, null)]
@@ -335,7 +336,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 commandResult.Success.Should().BeTrue();
-                commandResult.AllOutput.Should().Contain(string.Format(CultureInfo.CurrentCulture, _successfulActionTrustedSigner, "added", "repository", "signer"));
+                commandResult.AllOutput.Should().Contain(string.Format(CultureInfo.CurrentCulture, _successfulAddTrustedSigner, "repository", "signer"));
 
                 var expectedResult = SettingsTestUtils.RemoveWhitespace($@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
@@ -351,7 +352,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        [Theory]
+        [CIOnlyTheory]
         [InlineData(true, null)]
         [InlineData(true, "one;two;three")]
         [InlineData(false, null)]
@@ -397,7 +398,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 commandResult.Success.Should().BeTrue();
-                commandResult.AllOutput.Should().Contain(string.Format(CultureInfo.CurrentCulture, _successfulActionTrustedSigner, "added", "repository", "signer"));
+                commandResult.AllOutput.Should().Contain(string.Format(CultureInfo.CurrentCulture, _successfulAddTrustedSigner, "repository", "signer"));
 
                 var expectedResult = SettingsTestUtils.RemoveWhitespace($@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
@@ -442,7 +443,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 commandResult.Success.Should().BeTrue();
-                commandResult.AllOutput.Should().Contain(string.Format(CultureInfo.CurrentCulture, _successfulActionTrustedSigner, "removed", "signers", "signer"));
+                commandResult.AllOutput.Should().Contain(string.Format(CultureInfo.CurrentCulture, _successfulActionTrustedSigner, "removed", "signer", "signer"));
 
                 var expectedResult = SettingsTestUtils.RemoveWhitespace($@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/NuGet.CommandLine.FuncTest.csproj
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/NuGet.CommandLine.FuncTest.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
@@ -20,6 +20,8 @@
 
     <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
 
+    <ProjectReference Include="..\..\NuGet.Core.Tests\NuGet.Configuration.Test\NuGet.Configuration.Test.csproj" />
+
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
@@ -34,6 +36,6 @@
     </None>
   </ItemGroup>
   
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
@@ -37,6 +37,15 @@ namespace NuGet.Commands.Test
             Assert.Throws<ArgumentNullException>(() => new TrustedSignerActionsProvider(trustedSignersProvider: null, logger: NullLogger.Instance));
         }
 
+        [Fact]
+        public void TrustedSignerActionsProvider_Constructor_WithNullLogger_Throws()
+        {
+            // Act and Assert
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+
+            Assert.Throws<ArgumentNullException>(() => new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: null));
+        }
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
@@ -34,7 +34,7 @@ namespace NuGet.Commands.Test
         public void TrustedSignerActionsProvider_Constructor_WithNullTrustedSignersProvider_Throws()
         {
             // Act and Assert
-            Assert.Throws<ArgumentNullException>(() => new TrustedSignerActionsProvider(trustedSignersProvider: null));
+            Assert.Throws<ArgumentNullException>(() => new TrustedSignerActionsProvider(trustedSignersProvider: null, logger: NullLogger.Instance));
         }
 
         [Theory]
@@ -44,7 +44,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
 
             // Act and Assert
             var ex = await Assert.ThrowsAsync<ArgumentException>(async () => await actionsProvider.SyncTrustedRepositoryAsync(name, CancellationToken.None));
@@ -66,7 +66,7 @@ namespace NuGet.Commands.Test
                     new RepositoryItem("repo1", "https://serviceIndex.test/api.json", new CertificateItem("abc", HashAlgorithmName.SHA256))
                 });
 
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
 
 
             // Act and Assert
@@ -98,7 +98,7 @@ namespace NuGet.Commands.Test
                     new RepositoryItem("repo1", source, new CertificateItem("abc", HashAlgorithmName.SHA256))
                 });
 
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object)
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance)
             {
                 ServiceIndexSourceRepository = repo
             };
@@ -133,7 +133,7 @@ namespace NuGet.Commands.Test
                     new RepositoryItem("repo1", source, new CertificateItem("abc", HashAlgorithmName.SHA256))
                 });
 
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object)
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance)
             {
                 ServiceIndexSourceRepository = repo
             };
@@ -169,7 +169,7 @@ namespace NuGet.Commands.Test
                     new RepositoryItem("repo1", source, new CertificateItem("abc", HashAlgorithmName.SHA256))
                 });
 
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object)
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance)
             {
                 ServiceIndexSourceRepository = repo
             };
@@ -192,7 +192,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
 
             // Act and Assert
             var ex = await Record.ExceptionAsync(async () =>
@@ -209,7 +209,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
             var packageReader = new Mock<ISignedPackageReader>();
 
             // Act and Assert
@@ -231,7 +231,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
             var packageReader = new Mock<ISignedPackageReader>();
 
             // Act and Assert
@@ -254,7 +254,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
             var packageReader = new Mock<ISignedPackageReader>();
 
             // Act and Assert
@@ -277,7 +277,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
             var packageReader = new Mock<ISignedPackageReader>();
 
             // Act and Assert
@@ -300,7 +300,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
             var packageReader = new Mock<ISignedPackageReader>();
 
             packageReader
@@ -327,7 +327,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
             var packageContext = new SimpleTestPackageContext();
 
             using (var directory = TestDirectory.Create())
@@ -359,7 +359,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
             var packageContext = new SimpleTestPackageContext();
 
             trustedSignersProvider
@@ -398,7 +398,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
             var packageContext = new SimpleTestPackageContext();
             var repoServiceIndex = "https://trustedv3serviceindex.test/api.json";
 
@@ -440,7 +440,7 @@ namespace NuGet.Commands.Test
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
             var packageReader = new Mock<ISignedPackageReader>();
 
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
             var packageContext = new SimpleTestPackageContext();
 
             trustedSignersProvider
@@ -486,7 +486,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
             var packageContext = new SimpleTestPackageContext();
             var repoServiceIndex = "https://trustedV3ServiceIndex.test/api.json";
 
@@ -531,7 +531,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
             var packageContext = new SimpleTestPackageContext();
             var repoServiceIndex = "https://trustedV3ServiceIndex.test/api.json";
 
@@ -577,7 +577,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
             var packageContext = new SimpleTestPackageContext();
             var repoServiceIndex = "https://trustedV3ServiceIndex.test/api.json";
 
@@ -623,7 +623,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
             var packageContext = new SimpleTestPackageContext();
             var repoServiceIndex = "https://trustedV3ServiceIndex.test/api.json";
 
@@ -670,7 +670,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
             var packageContext = new SimpleTestPackageContext();
             var repoServiceIndex = "https://trustedV3ServiceIndex.test/api.json";
 
@@ -718,7 +718,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
             var packageContext = new SimpleTestPackageContext();
             var repoServiceIndex = "https://trustedV3ServiceIndex.test/api.json";
 
@@ -766,7 +766,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
             var packageContext = new SimpleTestPackageContext();
 
             trustedSignersProvider
@@ -808,7 +808,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
             var packageContext = new SimpleTestPackageContext();
 
             trustedSignersProvider
@@ -853,7 +853,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
 
             // Act and Assert
             var ex = Assert.Throws<ArgumentException>(() => actionsProvider.AddOrUpdateTrustedSigner(name, fingerprint: "abc", hashAlgorithm: HashAlgorithmName.SHA256, allowUntrustedRoot: false));
@@ -869,7 +869,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
 
             // Act and Assert
             var ex = Assert.Throws<ArgumentException>(() => actionsProvider.AddOrUpdateTrustedSigner(name: "author1", fingerprint: fingerprint, hashAlgorithm: HashAlgorithmName.SHA256, allowUntrustedRoot: false));
@@ -883,7 +883,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
 
             // Act and Assert
             var ex = Record.Exception(() => actionsProvider.AddOrUpdateTrustedSigner(name: "author1", fingerprint: "abc", hashAlgorithm: HashAlgorithmName.Unknown, allowUntrustedRoot: false));
@@ -899,7 +899,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
 
             // Act and Assert
             var ex = Record.Exception(() => actionsProvider.AddOrUpdateTrustedSigner(name: "author1", fingerprint: "abc", hashAlgorithm: (HashAlgorithmName)99, allowUntrustedRoot: false));
@@ -914,7 +914,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
 
             trustedSignersProvider
                 .Setup(p => p.GetTrustedSigners())
@@ -941,7 +941,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
 
             trustedSignersProvider
                 .Setup(p => p.GetTrustedSigners())
@@ -968,7 +968,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
 
             trustedSignersProvider
                 .Setup(p => p.GetTrustedSigners())
@@ -1000,7 +1000,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
 
             trustedSignersProvider
                 .Setup(p => p.GetTrustedSigners())
@@ -1032,7 +1032,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
 
             trustedSignersProvider
                 .Setup(p => p.GetTrustedSigners())
@@ -1066,7 +1066,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
 
             // Act and Assert
             var ex = await Assert.ThrowsAsync<ArgumentException>(async () => await actionsProvider.AddTrustedRepositoryAsync(name, new Uri("https://serviceIndex.test/v3/api.json"), owners: null, token: CancellationToken.None));
@@ -1080,7 +1080,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
 
             // Act and Assert
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await actionsProvider.AddTrustedRepositoryAsync("repo1", serviceIndex: null, owners: null, token: CancellationToken.None));
@@ -1099,7 +1099,7 @@ namespace NuGet.Commands.Test
                     new RepositoryItem("repo1", "https://serviceIndex.test/api.json", new CertificateItem("abc", HashAlgorithmName.SHA256))
                 });
 
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
 
 
             // Act and Assert
@@ -1123,7 +1123,7 @@ namespace NuGet.Commands.Test
                     new RepositoryItem("repo1", "https://serviceIndex.test/api.json", new CertificateItem("abc", HashAlgorithmName.SHA256))
                 });
 
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object);
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance);
 
 
             // Act and Assert
@@ -1155,7 +1155,7 @@ namespace NuGet.Commands.Test
                     new RepositoryItem("repo1", "https://serviceIndex.test/api.json", new CertificateItem("abc", HashAlgorithmName.SHA256))
                 });
 
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object)
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance)
             {
                 ServiceIndexSourceRepository = repo
             };
@@ -1190,7 +1190,7 @@ namespace NuGet.Commands.Test
                     new RepositoryItem("repo1", "https://serviceIndex.test/api.json", new CertificateItem("abc", HashAlgorithmName.SHA256))
                 });
 
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object)
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance)
             {
                 ServiceIndexSourceRepository = repo
             };
@@ -1225,7 +1225,7 @@ namespace NuGet.Commands.Test
                     new RepositoryItem("repo1", "https://serviceIndex.test/api.json", new CertificateItem("abc", HashAlgorithmName.SHA256))
                 });
 
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object)
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance)
             {
                 ServiceIndexSourceRepository = repo
             };
@@ -1267,7 +1267,7 @@ namespace NuGet.Commands.Test
                     new RepositoryItem("repo1", "https://serviceIndex.test/api.json", new CertificateItem("abc", HashAlgorithmName.SHA256))
                 });
 
-            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object)
+            var actionsProvider = new TrustedSignerActionsProvider(trustedSignersProvider.Object, logger: NullLogger.Instance)
             {
                 ServiceIndexSourceRepository = repo
             };

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignersCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignersCommandRunnerTests.cs
@@ -67,7 +67,7 @@ namespace NuGet.Commands.Test
                 var result = await test.Runner.ExecuteCommandAsync(test.Args);
                 result.Should().Be(0);
 
-                test.Logger.Messages.Should().Contain("No trusted signers with name: 'signer' where found.");
+                test.Logger.Messages.Should().Contain("No trusted signers with the name: 'signer' were found.");
             }
         }
 
@@ -91,7 +91,7 @@ namespace NuGet.Commands.Test
                 var result = await test.Runner.ExecuteCommandAsync(test.Args);
                 result.Should().Be(0);
 
-                test.Logger.Messages.Should().Contain("No trusted signers with name: 'signer' where found.");
+                test.Logger.Messages.Should().Contain("No trusted signers with the name: 'signer' were found.");
             }
         }
 
@@ -116,7 +116,7 @@ namespace NuGet.Commands.Test
                 var result = await test.Runner.ExecuteCommandAsync(test.Args);
                 result.Should().Be(0);
 
-                test.Logger.Messages.Should().Contain("Successfully removed trusted signers with name: 'author'.");
+                test.Logger.Messages.Should().Contain("Successfully removed the trusted signer 'author'.");
 
                 trustedSignersProvider.Verify(p =>
                     p.Remove(It.Is<IReadOnlyList<TrustedSignerItem>>(l =>
@@ -145,7 +145,7 @@ namespace NuGet.Commands.Test
                 var result = await test.Runner.ExecuteCommandAsync(test.Args);
                 result.Should().Be(0);
 
-                test.Logger.Messages.Should().Contain("Successfully added trusted author with name: 'author'.");
+                test.Logger.Messages.Should().Contain("Successfully added a trusted author 'author'.");
 
                 var expectedItem = new AuthorItem("author", new CertificateItem("abc", HashAlgorithmName.SHA256));
                 trustedSignersProvider.Verify(p =>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignersCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignersCommandRunnerTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Configuration.Test;
+using NuGet.Packaging.Signing;
+using NuGet.Test.Utility;
+using Xunit;
+using static NuGet.Commands.TrustedSignersArgs;
+
+namespace NuGet.Commands.Test
+{
+    public class TrustedSignersCommandRunnerTests
+    {
+        [Fact]
+        public async Task ExecuteCommandAsync_ListAction_ShowsListOfTrustedSignersAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    new AuthorItem("author", new CertificateItem("abc", HashAlgorithmName.SHA256, allowUntrustedRoot: true)),
+                    new RepositoryItem("repo", "https://serviceindex.test/v3/index.json", new CertificateItem("def", HashAlgorithmName.SHA384))
+                });
+
+            using (var test = Test.Create(TrustedSignersAction.List, trustedSignersProvider.Object))
+            {
+                // Act
+                var result = await test.Runner.ExecuteCommandAsync(test.Args);
+                result.Should().Be(0);
+
+                var logs = test.Logger.Messages.ToList();
+                logs[0].Should().Contain("Registered trusted signers:");
+                logs[2].Should().Contain("author [author]");
+                logs[2].Should().Contain("[U] SHA256 - abc");
+                logs[3].Should().Contain("repo [repository]");
+                logs[3].Should().Contain("Service Index: https://serviceindex.test/v3/index.json");
+                logs[3].Should().Contain("SHA384 - def");
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteCommandAsync_RemoveAction_WithoutTrustedSigners_LogsAndSucceedsAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                });
+
+            using (var test = Test.Create(TrustedSignersAction.Remove, trustedSignersProvider.Object))
+            {
+                test.Args.Name = "signer";
+
+                // Act
+                var result = await test.Runner.ExecuteCommandAsync(test.Args);
+                result.Should().Be(0);
+
+                test.Logger.Messages.Should().Contain("No trusted signers with name: 'signer' where found.");
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteCommandAsync_RemoveAction_WithTrustedSigners_NonExistantSigner_LogsAndSucceedsAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    new AuthorItem("author", new CertificateItem("abc", HashAlgorithmName.SHA256))
+                });
+
+            using (var test = Test.Create(TrustedSignersAction.Remove, trustedSignersProvider.Object))
+            {
+                test.Args.Name = "signer";
+
+                // Act
+                var result = await test.Runner.ExecuteCommandAsync(test.Args);
+                result.Should().Be(0);
+
+                test.Logger.Messages.Should().Contain("No trusted signers with name: 'signer' where found.");
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteCommandAsync_RemoveAction_WithTrustedSigner_ExistingSigner_RemovesItSuccesfullyAsync()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            var expectedItem = new AuthorItem("author", new CertificateItem("abc", HashAlgorithmName.SHA256));
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                    expectedItem
+                });
+
+            using (var test = Test.Create(TrustedSignersAction.Remove, trustedSignersProvider.Object))
+            {
+                test.Args.Name = "author";
+
+                // Act
+                var result = await test.Runner.ExecuteCommandAsync(test.Args);
+                result.Should().Be(0);
+
+                test.Logger.Messages.Should().Contain("Successfully removed trusted signers with name: 'author'.");
+
+                trustedSignersProvider.Verify(p =>
+                    p.Remove(It.Is<IReadOnlyList<TrustedSignerItem>>(l =>
+                        l.Count == 1 &&
+                        SettingsTestUtils.DeepEquals(l.First(), expectedItem))));
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteCommandAsync_AddAction_WithCertificateFingerprint_WithoutHashAlgorithm_DefaultsToSHA256Async()
+        {
+            // Arrange
+            var trustedSignersProvider = new Mock<ITrustedSignersProvider>();
+            trustedSignersProvider
+                .Setup(p => p.GetTrustedSigners())
+                .Returns(new List<TrustedSignerItem>()
+                {
+                });
+
+            using (var test = Test.Create(TrustedSignersAction.Add, trustedSignersProvider.Object))
+            {
+                test.Args.Name = "author";
+                test.Args.CertificateFingerprint = "abc";
+
+                // Act
+                var result = await test.Runner.ExecuteCommandAsync(test.Args);
+                result.Should().Be(0);
+
+                test.Logger.Messages.Should().Contain("Successfully added trusted author with name: 'author'.");
+
+                var expectedItem = new AuthorItem("author", new CertificateItem("abc", HashAlgorithmName.SHA256));
+                trustedSignersProvider.Verify(p =>
+                    p.AddOrUpdateTrustedSigner(It.Is<TrustedSignerItem>(i =>
+                        SettingsTestUtils.DeepEquals(i, expectedItem))));
+            }
+        }
+
+        private sealed class Test : IDisposable
+        {
+            private bool _isDisposed;
+
+            internal TrustedSignersArgs Args { get; }
+            internal TestDirectory Directory { get; }
+            internal TestLogger Logger { get; }
+            internal TrustedSignersCommandRunner Runner { get; }
+
+            internal Test(
+                ITrustedSignersProvider provider,
+                IPackageSourceProvider sources,
+                TrustedSignersArgs args,
+                TestDirectory directory,
+                TestLogger logger)
+            {
+                Args = args;
+                Directory = directory;
+                Runner = new TrustedSignersCommandRunner(provider, sources);
+                Logger = logger;
+            }
+
+            public void Dispose()
+            {
+                if (!_isDisposed)
+                {
+                    Directory.Dispose();
+
+                    GC.SuppressFinalize(this);
+
+                    _isDisposed = true;
+                }
+            }
+
+            internal static Test Create(
+                TrustedSignersAction action,
+                ITrustedSignersProvider trustedSignersProvider,
+                IPackageSourceProvider sourcesProvider = null)
+            {
+                var directory = TestDirectory.Create();
+                var logger = new TestLogger();
+
+                var args = new TrustedSignersArgs()
+                {
+                    Action = action,
+                    Logger = logger,
+                };
+
+                return new Test(trustedSignersProvider, sourcesProvider, args, directory, logger);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bug
Fixes: Third part of https://github.com/NuGet/Home/issues/7480

## Fix
Exposes the `nuget trusted-signers` command which lets you add, remove, sync and update trusted signers in a config. The different gestures are:

```
> nuget trusted-signers [list]
> nuget trusted-signers add -Name <sourceName> [-AllowUntrustedRoot] [-Owners <o>]
> nuget trusted-signers add -Name <name> -ServiceIndex <https-service-index> [-AllowUntrustedRoot] [-Owners <o>]
> nuget trusted-signers add .\RepoSignedPackage.nupkg -Repository [-AllowUntrustedRoot] [-Owners <o>]
> nuget trusted-signers add .\AuthorSignedPackage.nupkg -Author[-AllowUntrustedRoot]
> nuget trusted-signers add -CertificateFingerprint <f> [-FingerprintAlgorithm <a>]  [-AllowUntrustedRoot]
> nuget trusted-signers remove -Name <signer-name>
> nuget trusted-signers sync -Name <trusted-repository-name>
```

**Note:** This work is on top of https://github.com/NuGet/NuGet.Client/pull/2522, so make sure to review that PR first and skip the first commit which contains the work from that PR.

cc. @rrelyea @rido-min 