### PR TITLE
Updated warning to info when failed to parse packages.lock.file

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileFormat.cs
@@ -71,7 +71,7 @@ namespace NuGet.ProjectModel
             }
             catch (Exception ex)
             {
-                log.LogWarning(string.Format(CultureInfo.CurrentCulture,
+                log.LogInformation(string.Format(CultureInfo.CurrentCulture,
                     Strings.Log_ErrorReadingLockFile,
                     path, ex.Message));
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
@@ -485,8 +485,14 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         Assert.False(restoreSummary.NoOpRestore);
                     }
 
+                    // Initial asserts
                     Assert.True(File.Exists(projectLockFilePath));
-                    Assert.True(File.Exists(Path.Combine(vsProjectAdapter.MSBuildProjectExtensionsPath, "project.assets.json")));
+                    var assetsFilePath = Path.Combine(vsProjectAdapter.MSBuildProjectExtensionsPath, "project.assets.json");
+                    Assert.True(File.Exists(assetsFilePath));
+
+                    // Assert that there is no warning logged into assets file
+                    var assetsFile = new LockFileFormat().Read(assetsFilePath);
+                    Assert.False(assetsFile.LogMessages.Any());
 
                     // delete existing restore output files
                     File.Delete(Path.Combine(vsProjectAdapter.MSBuildProjectExtensionsPath, "project.assets.json"));
@@ -509,7 +515,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                                 LibraryDependencyTarget.Package)
                         });
 
-                    // update the proeject with new ProjectService instance
+                    // update the project with new ProjectService instance
                     restoreContext.PackageSpecCache.Clear();
                     dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(testSolutionManager, restoreContext);
 


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7428
Regression: No
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: Since we allow creating a blank custom lock file to opt into lock file feature so sometimes it's still valid to have a unparsable file so changing warning into information. We still want to inform user that the current lock file was invalid. Also we don't want to persist this information in lock file otherwise it will keep replaying on every restore.

## Testing/Validation
Tests Added: Yes/No  
Reason for not adding tests:  
Validation done:  
