### PR TITLE
Logging packages lock file related errors in output window and error window

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -450,7 +450,10 @@ namespace NuGet.Commands
 
                 // invalid input since packages.lock.json file exists along with RestorePackagesWithLockFile is set to false.
                 var message = string.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidLockFileInput, packagesLockFilePath);
-                await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1005, message));
+
+                // directly log to the request logger when we're not going to rewrite the assets file otherwise this log will
+                // be skipped for netcore projects.
+                await _request.Log.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1005, message));
 
                 return Tuple.Create(success, Tuple.Create(isLockFileValid, packagesLockFile));
             }
@@ -488,7 +491,9 @@ namespace NuGet.Commands
                         success = false;
 
                         // bail restore since it's the locked mode but required to update the lock file.
-                        await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1004, Strings.Error_RestoreInLockedMode));
+                        // directly log to the request logger when we're not going to rewrite the assets file otherwise this log will
+                        // be skipped for netcore projects.
+                        await _request.Log.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1004, Strings.Error_RestoreInLockedMode));
                     }
                 }
             }


### PR DESCRIPTION
## Bug
Fixes: Link_to_issue  https://github.com/NuGet/Home/issues/7429
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: For netcore projects, project system handles showing errors/warnings in output and error window. But since `packages.lock.json` file related errors are not written in lock file (since these errors are generated before running the actual restore) so they were not being shown in output or error window. Fix is to log these errors in inner logger so that we ourselves handle them.

## Testing/Validation
Tests Added: Yes
Reason for not adding tests:  
Validation done:  
