### PR TITLE
Fixing dev build for dev16

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -272,14 +272,14 @@
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' " />
   <Import Project="$(VSSDKRoot)\build\Microsoft.VSSDK.BuildTools.targets" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' " />
   <Target Name="FindSourceVsixManifest">
-    <ItemGroup Condition="'$(VisualStudioVersion)' == '15.0'">
+    <ItemGroup>
       <SourceVsixManifest Include="source.extension.vs15.vsixmanifest" />
     </ItemGroup>
   </Target>
   <ItemGroup>
     <VsixIncludeFile Include=".vsixinclude" />
   </ItemGroup>
-  <ItemGroup Condition="'$(VisualStudioVersion)' == '15.0'">
+  <ItemGroup>
     <VsixIgnoreFile Include=".vsixignore.vs15" />
     <None Include="source.extension.vs15.vsixmanifest">
       <SubType>Designer</SubType>
@@ -291,7 +291,7 @@
     </PackageReference>
   </ItemGroup>
   <Target Name="AfterBuild" DependsOnTargets="PublishVS15" />
-  <Target Name="PublishVS15" Condition="'$(VisualStudioVersion)' == '15.0'">
+  <Target Name="PublishVS15">
     <ItemGroup>
       <PackageManifest Include="$(OutputPath)Microsoft.VisualStudio.NuGet.Core.json" />
     </ItemGroup>

--- a/test/TestExtensions/API.Test/API.Test.csproj
+++ b/test/TestExtensions/API.Test/API.Test.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.PowerShell.3.ReferenceAssemblies" Version="1.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(VisualStudioVersion)' == '15.0'">
+  <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime">
       <HintPath>$(SolutionPackagesFolder)Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime.15.0.26201\lib\Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>


### PR DESCRIPTION
This is the minimum set of changes to fix dev build for dev16 developer command prompt. This PR removes VS 14.0 or 15.0 specific conditions from project files. There is another [wip] PR to remove all dev14 specific code which will also remove lot of source code conditioned on different VS versions.