### PR TITLE
Embed interop type for PackageReference

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
@@ -20,7 +20,7 @@ namespace NuGet.Build.Tasks.Pack
         string AssemblyName { get; }
         string[] Authors { get; }
         TItem[] BuildOutputInPackage { get; }
-        string BuildOutputFolder { get; }
+        string[] BuildOutputFolder { get; }
         string[] ContentTargetFolders { get; }
         bool ContinuePackingAfterGeneratingNuspec { get; }
         string Copyright { get; }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
@@ -20,7 +20,7 @@ namespace NuGet.Build.Tasks.Pack
         string AssemblyName { get; }
         string[] Authors { get; }
         TItem[] BuildOutputInPackage { get; }
-        string[] BuildOutputFolder { get; }
+        string[] BuildOutputFolders { get; }
         string[] ContentTargetFolders { get; }
         bool ContinuePackingAfterGeneratingNuspec { get; }
         string Copyright { get; }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -236,7 +236,7 @@ Copyright (c) .NET Foundation. All rights reserved.
               ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
               NuspecOutputPath="$(NuspecOutputAbsolutePath)"
               IncludeBuildOutput="$(IncludeBuildOutput)"
-              BuildOutputFolder="$(BuildOutputTargetFolder)"
+              BuildOutputFolders="$(BuildOutputTargetFolder)"
               ContentTargetFolders="$(ContentTargetFolders)"
               RestoreOutputPath="$(RestoreOutputAbsolutePath)"
               NuspecFile="$(NuspecFileAbsolutePath)"

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
@@ -60,7 +60,7 @@ namespace NuGet.Build.Tasks.Pack
         public bool NoDefaultExcludes { get; set; }
         public string NuspecOutputPath { get; set; }
         public bool IncludeBuildOutput { get; set; }
-        public string BuildOutputFolder { get; set; }
+        public string[] BuildOutputFolder { get; set; }
         public string[] ContentTargetFolders { get; set; }
         public string[] NuspecProperties { get; set; }
         public string NuspecBasePath { get; set; }
@@ -159,7 +159,7 @@ namespace NuGet.Build.Tasks.Pack
                 AssemblyName = MSBuildStringUtility.TrimAndGetNullForEmpty(AssemblyName),
                 Authors = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(Authors),
                 BuildOutputInPackage = MSBuildUtility.WrapMSBuildItem(BuildOutputInPackage),
-                BuildOutputFolder = MSBuildStringUtility.TrimAndGetNullForEmpty(BuildOutputFolder),
+                BuildOutputFolder = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(BuildOutputFolder),
                 ContinuePackingAfterGeneratingNuspec = ContinuePackingAfterGeneratingNuspec,
                 ContentTargetFolders = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(ContentTargetFolders),
                 Copyright = MSBuildStringUtility.TrimAndGetNullForEmpty(Copyright),

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
@@ -60,7 +60,7 @@ namespace NuGet.Build.Tasks.Pack
         public bool NoDefaultExcludes { get; set; }
         public string NuspecOutputPath { get; set; }
         public bool IncludeBuildOutput { get; set; }
-        public string[] BuildOutputFolder { get; set; }
+        public string[] BuildOutputFolders { get; set; }
         public string[] ContentTargetFolders { get; set; }
         public string[] NuspecProperties { get; set; }
         public string NuspecBasePath { get; set; }
@@ -159,7 +159,7 @@ namespace NuGet.Build.Tasks.Pack
                 AssemblyName = MSBuildStringUtility.TrimAndGetNullForEmpty(AssemblyName),
                 Authors = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(Authors),
                 BuildOutputInPackage = MSBuildUtility.WrapMSBuildItem(BuildOutputInPackage),
-                BuildOutputFolder = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(BuildOutputFolder),
+                BuildOutputFolders = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(BuildOutputFolders),
                 ContinuePackingAfterGeneratingNuspec = ContinuePackingAfterGeneratingNuspec,
                 ContentTargetFolders = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(ContentTargetFolders),
                 Copyright = MSBuildStringUtility.TrimAndGetNullForEmpty(Copyright),

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -436,12 +436,12 @@ namespace NuGet.Build.Tasks.Pack
             {
                 foreach (var packageType in request.PackageTypes)
                 {
-                    string[] packageTypeSplitInPart = packageType.Split(new char[] { ',' });
-                    string packageTypeName = packageTypeSplitInPart[0].Trim();
+                    var packageTypeSplitInPart = packageType.Split(new char[] { ',' });
+                    var packageTypeName = packageTypeSplitInPart[0].Trim();
                     var version = PackageType.EmptyVersion;
                     if (packageTypeSplitInPart.Length > 1)
                     {
-                        string versionString = packageTypeSplitInPart[1];
+                        var versionString = packageTypeSplitInPart[1];
                         Version.TryParse(versionString, out version);
                     }
                     listOfPackageTypes.Add(new PackageType(packageTypeName, version));
@@ -542,7 +542,7 @@ namespace NuGet.Build.Tasks.Pack
 
                 var packagePathString = packageFile.GetProperty("PackagePath");
                 targetPaths = packagePathString == null
-                    ? new string[] { String.Empty }.ToList()
+                    ? new string[] { string.Empty }.ToList()
                     : MSBuildStringUtility.Split(packagePathString)
                     .Distinct()
                     .ToList();
@@ -559,7 +559,7 @@ namespace NuGet.Build.Tasks.Pack
                         newTargetPaths.Add(PathUtility.GetStringComparerBasedOnOS().
                             Compare(Path.GetExtension(fileName),
                             Path.GetExtension(targetPath)) == 0
-                            && !String.IsNullOrEmpty(Path.GetExtension(fileName))
+                            && !string.IsNullOrEmpty(Path.GetExtension(fileName))
                                 ? targetPath
                                 : Path.Combine(targetPath, recursiveDir));
                     }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -80,7 +80,7 @@ namespace NuGet.Build.Tasks.Pack
                 packArgs.PackTargetArgs.TargetPathsToSymbols = InitLibFiles(request.TargetPathsToSymbols);
                 packArgs.PackTargetArgs.AssemblyName = request.AssemblyName;
                 packArgs.PackTargetArgs.IncludeBuildOutput = request.IncludeBuildOutput;
-                packArgs.PackTargetArgs.BuildOutputFolder = request.BuildOutputFolder;
+                packArgs.PackTargetArgs.BuildOutputFolder = request.BuildOutputFolders;
                 packArgs.PackTargetArgs.TargetFrameworks = ParseFrameworks(request);
 
                 if (request.IncludeSource)

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
@@ -14,7 +14,7 @@ namespace NuGet.Build.Tasks.Pack
         public string AssemblyName { get; set; }
         public string[] Authors { get; set; }
         public IMSBuildItem[] BuildOutputInPackage { get; set; }
-        public string BuildOutputFolder { get; set; }
+        public string[] BuildOutputFolder { get; set; }
         public string[] ContentTargetFolders { get; set; }
         public bool ContinuePackingAfterGeneratingNuspec { get; set; }
         public string Copyright { get; set; }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
@@ -14,7 +14,7 @@ namespace NuGet.Build.Tasks.Pack
         public string AssemblyName { get; set; }
         public string[] Authors { get; set; }
         public IMSBuildItem[] BuildOutputInPackage { get; set; }
-        public string[] BuildOutputFolder { get; set; }
+        public string[] BuildOutputFolders { get; set; }
         public string[] ContentTargetFolders { get; set; }
         public bool ContinuePackingAfterGeneratingNuspec { get; set; }
         public string Copyright { get; set; }

--- a/src/NuGet.Core/NuGet.Commands/MSBuildPackTargetArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildPackTargetArgs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -19,7 +19,7 @@ namespace NuGet.Commands
         public ISet<NuGetFramework> TargetFrameworks { get; set; }
         public IDictionary<string, string> SourceFiles { get; set; }
         public bool IncludeBuildOutput { get; set; }
-        public string BuildOutputFolder { get; set; }
+        public string[] BuildOutputFolder { get; set; }
 
 
         public MSBuildPackTargetArgs()

--- a/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
@@ -128,7 +128,7 @@ namespace NuGet.Commands
 
         private void AddOutputLibFiles(IEnumerable<OutputLibFile> libFiles, HashSet<string> allowedExtensions)
         {
-            var targetFolder = PackTargetArgs.BuildOutputFolder;
+            var targetFolders = PackTargetArgs.BuildOutputFolder;
             foreach (var file in libFiles)
             {
                 var extension = Path.GetExtension(file.FinalOutputPath);
@@ -140,13 +140,16 @@ namespace NuGet.Commands
                 }
                 var tfm = NuGetFramework.Parse(file.TargetFramework).GetShortFolderName();
                 var targetPath = file.TargetPath;
-                var packageFile = new ManifestFile()
+                for (var i=0; i<targetFolders.Length; i++)
                 {
-                    Source = file.FinalOutputPath,
-                    Target = IsTool ? Path.Combine(targetFolder, targetPath) : Path.Combine(targetFolder, tfm, targetPath)
-                };
+                    var packageFile = new ManifestFile()
+                    {
+                        Source = file.FinalOutputPath,
+                        Target = IsTool ? Path.Combine(targetFolders[i], targetPath) : Path.Combine(targetFolders[i], tfm, targetPath)
+                    };
 
-                AddFileToBuilder(packageFile);
+                    AddFileToBuilder(packageFile);
+                }
             }
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
@@ -252,6 +252,7 @@ namespace NuGet.Commands
                 graph.Conventions.Patterns.ResourceAssemblies,
                 graph.Conventions.Patterns.CompileRefAssemblies,
                 graph.Conventions.Patterns.RuntimeAssemblies,
+                graph.Conventions.Patterns.LinkAssemblies,
                 graph.Conventions.Patterns.ContentFiles
             };
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
@@ -252,7 +252,7 @@ namespace NuGet.Commands
                 graph.Conventions.Patterns.ResourceAssemblies,
                 graph.Conventions.Patterns.CompileRefAssemblies,
                 graph.Conventions.Patterns.RuntimeAssemblies,
-                graph.Conventions.Patterns.LinkAssemblies,
+                graph.Conventions.Patterns.EmbedAssemblies,
                 graph.Conventions.Patterns.ContentFiles
             };
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -174,6 +174,14 @@ namespace NuGet.Commands
 
             lockFileLib.RuntimeAssemblies.AddRange(runtimeGroup);
 
+            // Link
+            var linkGroup = GetLockFileItems(
+                orderedCriteria,
+                contentItems,
+                targetGraph.Conventions.Patterns.LinkAssemblies);
+
+            lockFileLib.LinkAssemblies.AddRange(linkGroup);
+
             // Resources
             var resourceGroup = GetLockFileItems(
                 orderedCriteria,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -174,13 +174,13 @@ namespace NuGet.Commands
 
             lockFileLib.RuntimeAssemblies.AddRange(runtimeGroup);
 
-            // Link
-            var linkGroup = GetLockFileItems(
+            // Embed
+            var embedGroup = GetLockFileItems(
                 orderedCriteria,
                 contentItems,
-                targetGraph.Conventions.Patterns.LinkAssemblies);
+                targetGraph.Conventions.Patterns.EmbedAssemblies);
 
-            lockFileLib.LinkAssemblies.AddRange(linkGroup);
+            lockFileLib.EmbedAssemblies.AddRange(embedGroup);
 
             // Resources
             var resourceGroup = GetLockFileItems(
@@ -940,6 +940,7 @@ namespace NuGet.Commands
             if ((dependencyType & LibraryIncludeFlags.Compile) == LibraryIncludeFlags.None)
             {
                 ClearIfExists(lockFileLib.CompileTimeAssemblies);
+                ClearIfExists(lockFileLib.EmbedAssemblies);
             }
 
             if ((dependencyType & LibraryIncludeFlags.Native) == LibraryIncludeFlags.None)

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
@@ -395,6 +395,11 @@ namespace NuGet.Client
             /// </summary>
             public PatternSet ToolsAssemblies { get; }
 
+            /// <summary>
+            /// Pattern used to locate embed interop types assemblies
+            /// </summary>
+            public PatternSet LinkAssemblies { get; }
+
             internal ManagedCodePatterns(ManagedCodeConventions conventions)
             {
                 AnyTargettedFile = new PatternSet(
@@ -526,6 +531,17 @@ namespace NuGet.Client
                         {
                             new PatternDefinition("tools/{tfm}/{rid}/{any?}", table: AnyTable),
                     });
+
+                LinkAssemblies = new PatternSet(
+                    conventions.Properties,
+                    groupPatterns: new PatternDefinition[]
+                        {
+                            new PatternDefinition("link/{tfm}/{any?}", table: DotnetAnyTable),
+                        },
+                    pathPatterns: new PatternDefinition[]
+                        {
+                            new PatternDefinition("link/{tfm}/{assembly}", table: DotnetAnyTable),
+                        });
             }
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
@@ -398,7 +398,7 @@ namespace NuGet.Client
             /// <summary>
             /// Pattern used to locate embed interop types assemblies
             /// </summary>
-            public PatternSet LinkAssemblies { get; }
+            public PatternSet EmbedAssemblies { get; }
 
             internal ManagedCodePatterns(ManagedCodeConventions conventions)
             {
@@ -532,15 +532,15 @@ namespace NuGet.Client
                             new PatternDefinition("tools/{tfm}/{rid}/{any?}", table: AnyTable),
                     });
 
-                LinkAssemblies = new PatternSet(
+                EmbedAssemblies = new PatternSet(
                     conventions.Properties,
                     groupPatterns: new PatternDefinition[]
                         {
-                            new PatternDefinition("link/{tfm}/{any?}", table: DotnetAnyTable),
+                            new PatternDefinition("embed/{tfm}/{any?}", table: DotnetAnyTable),
                         },
                     pathPatterns: new PatternDefinition[]
                         {
-                            new PatternDefinition("link/{tfm}/{assembly}", table: DotnetAnyTable),
+                            new PatternDefinition("embed/{tfm}/{assembly}", table: DotnetAnyTable),
                         });
             }
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -50,6 +50,7 @@ namespace NuGet.ProjectModel
         private const string PackageFoldersProperty = "packageFolders";
         private const string PackageSpecProperty = "project";
         private const string LogsProperty = "logs";
+        private const string LinkProperty = "link";
 
         // Legacy property names
         private const string RuntimeAssembliesProperty = "runtimeAssemblies";
@@ -485,6 +486,7 @@ namespace NuGet.ProjectModel
             library.ContentFiles = JsonUtility.ReadObject(json[ContentFilesProperty] as JObject, ReadContentFile);
             library.RuntimeTargets = JsonUtility.ReadObject(json[RuntimeTargetsProperty] as JObject, ReadRuntimeTarget);
             library.ToolsAssemblies = JsonUtility.ReadObject(json[ToolsProperty] as JObject, ReadFileItem);
+            library.LinkAssemblies = JsonUtility.ReadObject(json[LinkProperty] as JObject, ReadFileItem);
 
             return library;
         }
@@ -578,6 +580,13 @@ namespace NuGet.ProjectModel
                 var ordered = library.ToolsAssemblies.OrderBy(assembly => assembly.Path, StringComparer.Ordinal);
 
                 json[ToolsProperty] = JsonUtility.WriteObject(ordered, WriteFileItem);
+            }
+
+            if (library.LinkAssemblies.Count > 0)
+            {
+                var ordered = library.LinkAssemblies.OrderBy(assemby => assemby.Path, StringComparer.Ordinal);
+
+                json[LinkProperty] = JsonUtility.WriteObject(ordered, WriteFileItem);
             }
 
             return new JProperty(library.Name + "/" + library.Version.ToNormalizedString(), json);

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -50,7 +50,7 @@ namespace NuGet.ProjectModel
         private const string PackageFoldersProperty = "packageFolders";
         private const string PackageSpecProperty = "project";
         private const string LogsProperty = "logs";
-        private const string LinkProperty = "link";
+        private const string EmbedProperty = "embed";
 
         // Legacy property names
         private const string RuntimeAssembliesProperty = "runtimeAssemblies";
@@ -486,7 +486,7 @@ namespace NuGet.ProjectModel
             library.ContentFiles = JsonUtility.ReadObject(json[ContentFilesProperty] as JObject, ReadContentFile);
             library.RuntimeTargets = JsonUtility.ReadObject(json[RuntimeTargetsProperty] as JObject, ReadRuntimeTarget);
             library.ToolsAssemblies = JsonUtility.ReadObject(json[ToolsProperty] as JObject, ReadFileItem);
-            library.LinkAssemblies = JsonUtility.ReadObject(json[LinkProperty] as JObject, ReadFileItem);
+            library.EmbedAssemblies = JsonUtility.ReadObject(json[EmbedProperty] as JObject, ReadFileItem);
 
             return library;
         }
@@ -582,11 +582,11 @@ namespace NuGet.ProjectModel
                 json[ToolsProperty] = JsonUtility.WriteObject(ordered, WriteFileItem);
             }
 
-            if (library.LinkAssemblies.Count > 0)
+            if (library.EmbedAssemblies.Count > 0)
             {
-                var ordered = library.LinkAssemblies.OrderBy(assemby => assemby.Path, StringComparer.Ordinal);
+                var ordered = library.EmbedAssemblies.OrderBy(assemby => assemby.Path, StringComparer.Ordinal);
 
-                json[LinkProperty] = JsonUtility.WriteObject(ordered, WriteFileItem);
+                json[EmbedProperty] = JsonUtility.WriteObject(ordered, WriteFileItem);
             }
 
             return new JProperty(library.Name + "/" + library.Version.ToNormalizedString(), json);

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileTargetLibrary.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileTargetLibrary.cs
@@ -42,6 +42,8 @@ namespace NuGet.ProjectModel
 
         public IList<LockFileItem> ToolsAssemblies { get; set; } = new List<LockFileItem>();
 
+        public IList<LockFileItem> LinkAssemblies { get; set; } = new List<LockFileItem>();
+
         // Package Type does not belong in Equals and HashCode, since it's only used for compatibility checking post restore.
         public IList<PackageType> PackageType { get; set; } = new List<PackageType>();
 
@@ -72,7 +74,8 @@ namespace NuGet.ProjectModel
                 && RuntimeTargets.OrderedEquals(other.RuntimeTargets, item => item.Path, StringComparer.OrdinalIgnoreCase)
                 && Build.OrderedEquals(other.Build, item => item.Path, StringComparer.OrdinalIgnoreCase)
                 && BuildMultiTargeting.OrderedEquals(other.BuildMultiTargeting, item => item.Path, StringComparer.OrdinalIgnoreCase)
-                && ToolsAssemblies.OrderedEquals(other.ToolsAssemblies, item => item.Path, StringComparer.OrdinalIgnoreCase);
+                && ToolsAssemblies.OrderedEquals(other.ToolsAssemblies, item => item.Path, StringComparer.OrdinalIgnoreCase)
+                && LinkAssemblies.OrderedEquals(other.LinkAssemblies, item => item.Path, StringComparer.OrdinalIgnoreCase);
         }
 
         public override bool Equals(object obj)
@@ -140,6 +143,11 @@ namespace NuGet.ProjectModel
             }
 
             foreach (var item in ToolsAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
+            {
+                combiner.AddObject(item);
+            }
+
+            foreach (var item in LinkAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
             {
                 combiner.AddObject(item);
             }

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileTargetLibrary.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileTargetLibrary.cs
@@ -42,7 +42,7 @@ namespace NuGet.ProjectModel
 
         public IList<LockFileItem> ToolsAssemblies { get; set; } = new List<LockFileItem>();
 
-        public IList<LockFileItem> LinkAssemblies { get; set; } = new List<LockFileItem>();
+        public IList<LockFileItem> EmbedAssemblies { get; set; } = new List<LockFileItem>();
 
         // Package Type does not belong in Equals and HashCode, since it's only used for compatibility checking post restore.
         public IList<PackageType> PackageType { get; set; } = new List<PackageType>();
@@ -75,7 +75,7 @@ namespace NuGet.ProjectModel
                 && Build.OrderedEquals(other.Build, item => item.Path, StringComparer.OrdinalIgnoreCase)
                 && BuildMultiTargeting.OrderedEquals(other.BuildMultiTargeting, item => item.Path, StringComparer.OrdinalIgnoreCase)
                 && ToolsAssemblies.OrderedEquals(other.ToolsAssemblies, item => item.Path, StringComparer.OrdinalIgnoreCase)
-                && LinkAssemblies.OrderedEquals(other.LinkAssemblies, item => item.Path, StringComparer.OrdinalIgnoreCase);
+                && EmbedAssemblies.OrderedEquals(other.EmbedAssemblies, item => item.Path, StringComparer.OrdinalIgnoreCase);
         }
 
         public override bool Equals(object obj)
@@ -147,7 +147,7 @@ namespace NuGet.ProjectModel
                 combiner.AddObject(item);
             }
 
-            foreach (var item in LinkAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
+            foreach (var item in EmbedAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
             {
                 combiner.AddObject(item);
             }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
@@ -617,7 +617,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                         { "Extension", Path.GetExtension(fullPath) },
                         { "FullPath", fullPath }
                     }),
-                    BuildOutputFolder = "lib",
+                    BuildOutputFolder = new string[] { "lib" },
                     NuspecOutputPath = "obj",
                     IncludeBuildOutput = true,
                     RestoreOutputPath = Path.Combine(testDir, "obj"),

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
@@ -617,7 +617,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                         { "Extension", Path.GetExtension(fullPath) },
                         { "FullPath", fullPath }
                     }),
-                    BuildOutputFolder = new string[] { "lib" },
+                    BuildOutputFolders = new string[] { "lib" },
                     NuspecOutputPath = "obj",
                     IncludeBuildOutput = true,
                     RestoreOutputPath = Path.Combine(testDir, "obj"),

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
@@ -581,6 +581,36 @@ namespace NuGet.Build.Tasks.Pack.Test
             }
         }
 
+        [Fact]
+        public void PackTaskLogic_EmbedInteropAssembly()
+        {
+            // Arrange
+            using (var testDir = TestDirectory.Create())
+            {
+                var tc = new TestContext(testDir);
+                tc.Request.BuildOutputFolders = new[]
+                {
+                    "lib",
+                    "embed"
+                };
+
+                // Act
+                tc.BuildPackage();
+
+                // Assert
+                using (var nupkgReader = new PackageArchiveReader(tc.NupkgPath))
+                {
+                    // Validate the content items
+                    foreach (var buildTargetFolder in tc.Request.BuildOutputFolders)
+                    {
+                        var compileItems = nupkgReader.GetFiles(buildTargetFolder).ToList();
+                        Assert.Equal(1, compileItems.Count);
+                        Assert.Equal(new[] { buildTargetFolder + "/net45/a.dll" }, compileItems);
+                    }
+                }
+            }
+        }
+
         private class TestContext
         {
             public TestContext(TestDirectory testDir)

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -107,7 +107,7 @@ namespace NuGet.Build.Tasks.Pack.Test
             var target = new PackTask
             {
                 AssemblyName = " AssemblyName \t ",
-                BuildOutputFolder = " BuildOutputFolder \t ",
+                BuildOutputFolder = new string[] { " BuildOutputFolder \t " },
                 Copyright = " Copyright \t ",
                 Description = " Description \t ",
                 IconUrl = " IconUrl \t ",
@@ -130,7 +130,7 @@ namespace NuGet.Build.Tasks.Pack.Test
 
             // Assert
             Assert.Equal("AssemblyName", actual.AssemblyName);
-            Assert.Equal("BuildOutputFolder", actual.BuildOutputFolder);
+            Assert.Equal("BuildOutputFolder", actual.BuildOutputFolder[0]);
             Assert.Equal("Copyright", actual.Copyright);
             Assert.Equal("Description", actual.Description);
             Assert.Equal("IconUrl", actual.IconUrl);
@@ -155,7 +155,7 @@ namespace NuGet.Build.Tasks.Pack.Test
             var target = new PackTask
             {
                 AssemblyName = " \t ",
-                BuildOutputFolder = " \t ",
+                BuildOutputFolder = Array.Empty<string>(),
                 Copyright = " \t ",
                 Description = " \t ",
                 IconUrl = " \t ",
@@ -178,7 +178,7 @@ namespace NuGet.Build.Tasks.Pack.Test
 
             // Assert
             Assert.Null(actual.AssemblyName);
-            Assert.Null(actual.BuildOutputFolder);
+            Assert.Empty(actual.BuildOutputFolder);
             Assert.Null(actual.Copyright);
             Assert.Null(actual.Description);
             Assert.Null(actual.IconUrl);
@@ -325,7 +325,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                 Authors = Array.Empty<string>(),
                 AllowedOutputExtensionsInPackageBuildOutputFolder = Array.Empty<string>(),
                 AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder = Array.Empty<string>(),
-                BuildOutputFolder = "BuildOutputFolder",
+                BuildOutputFolder = new string[] { "BuildOutputFolder" },
                 ContentTargetFolders = new string[] { "ContentTargetFolders" } ,
                 ContinuePackingAfterGeneratingNuspec = true,
                 Copyright = "Copyright",

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -107,7 +107,7 @@ namespace NuGet.Build.Tasks.Pack.Test
             var target = new PackTask
             {
                 AssemblyName = " AssemblyName \t ",
-                BuildOutputFolder = new string[] { " BuildOutputFolder \t " },
+                BuildOutputFolders = new string[] { " BuildOutputFolder \t " },
                 Copyright = " Copyright \t ",
                 Description = " Description \t ",
                 IconUrl = " IconUrl \t ",
@@ -130,7 +130,7 @@ namespace NuGet.Build.Tasks.Pack.Test
 
             // Assert
             Assert.Equal("AssemblyName", actual.AssemblyName);
-            Assert.Equal("BuildOutputFolder", actual.BuildOutputFolder[0]);
+            Assert.Equal("BuildOutputFolder", actual.BuildOutputFolders[0]);
             Assert.Equal("Copyright", actual.Copyright);
             Assert.Equal("Description", actual.Description);
             Assert.Equal("IconUrl", actual.IconUrl);
@@ -155,7 +155,7 @@ namespace NuGet.Build.Tasks.Pack.Test
             var target = new PackTask
             {
                 AssemblyName = " \t ",
-                BuildOutputFolder = Array.Empty<string>(),
+                BuildOutputFolders = Array.Empty<string>(),
                 Copyright = " \t ",
                 Description = " \t ",
                 IconUrl = " \t ",
@@ -178,7 +178,7 @@ namespace NuGet.Build.Tasks.Pack.Test
 
             // Assert
             Assert.Null(actual.AssemblyName);
-            Assert.Empty(actual.BuildOutputFolder);
+            Assert.Empty(actual.BuildOutputFolders);
             Assert.Null(actual.Copyright);
             Assert.Null(actual.Description);
             Assert.Null(actual.IconUrl);
@@ -325,7 +325,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                 Authors = Array.Empty<string>(),
                 AllowedOutputExtensionsInPackageBuildOutputFolder = Array.Empty<string>(),
                 AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder = Array.Empty<string>(),
-                BuildOutputFolder = new string[] { "BuildOutputFolder" },
+                BuildOutputFolders = new string[] { "BuildOutputFolder" },
                 ContentTargetFolders = new string[] { "ContentTargetFolders" } ,
                 ContinuePackingAfterGeneratingNuspec = true,
                 Copyright = "Copyright",

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -325,7 +325,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                 Authors = Array.Empty<string>(),
                 AllowedOutputExtensionsInPackageBuildOutputFolder = Array.Empty<string>(),
                 AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder = Array.Empty<string>(),
-                BuildOutputFolders = new string[] { "BuildOutputFolder" },
+                BuildOutputFolders = new string[] { "lib", "embed" },
                 ContentTargetFolders = new string[] { "ContentTargetFolders" } ,
                 ContinuePackingAfterGeneratingNuspec = true,
                 Copyright = "Copyright",


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/2365
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: This PR is the implementation of supporting interop type assemblies with PackageReference. More details about the solution can be found in the [Spec doc](https://github.com/NuGet/Home/wiki/Embed-Interop-Types-with-PackageReference)

## Testing/Validation
Tests Added: Working on adding tests
Reason for not adding tests:  
Validation done:  
