### PR TITLE
Fix license link generation

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLicenseUtilities.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLicenseUtilities.cs
@@ -14,8 +14,6 @@ namespace NuGet.PackageManagement.UI
 {
     internal class PackageLicenseUtilities
     {
-        private static string LicenseFormat = "https://licenses.nuget.org/{0}";
-
         internal static IReadOnlyList<IText> GenerateLicenseLinks(DetailedPackageMetadata metadata)
         {
             return GenerateLicenseLinks(metadata.LicenseMetadata, metadata.LicenseUrl, string.Format(CultureInfo.CurrentCulture, Resources.WindowTitle_LicenseFileWindow, metadata.Id), metadata.LoadFileAsText);
@@ -86,7 +84,7 @@ namespace NuGet.PackageManagement.UI
                                 list.Add(new FreeText(licenseToBeProcessed.Substring(0, licenseStart)));
                             }
                             var license = licenseToBeProcessed.Substring(licenseStart, identifier.Length);
-                            list.Add(new LicenseText(license, new Uri(string.Format(LicenseFormat, license))));
+                            list.Add(new LicenseText(license, new Uri(string.Format(LicenseMetadata.LicenseServiceLinkTemplate, license))));
                             licenseToBeProcessed = licenseToBeProcessed.Substring(licenseStart + identifier.Length);
                         }
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/LicenseMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/LicenseMetadata.cs
@@ -101,12 +101,17 @@ namespace NuGet.Packaging
                         return LicenseFileDeprecationUrl;
 
                     case LicenseType.Expression:
-                        return new Uri(string.Format(LicenseServiceLinkTemplate, License));
+                        return new Uri(GenerateLicenseServiceLink(License));
 
                     default:
                         return null;
                 }
             }
+        }
+
+        private string GenerateLicenseServiceLink(string license)
+        {
+            return new Uri(string.Format(LicenseServiceLinkTemplate, License)).AbsoluteUri;
         }
     }
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/LicenseMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/LicenseMetadata.cs
@@ -101,7 +101,7 @@ namespace NuGet.Packaging
                         return LicenseFileDeprecationUrl;
 
                     case LicenseType.Expression:
-                        return new Uri(string.Format(LicenseServiceLinkTemplate, WebUtility.UrlEncode(License)));
+                        return new Uri(string.Format(LicenseServiceLinkTemplate, License));
 
                     default:
                         return null;

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
@@ -45,7 +45,7 @@ namespace NuGet.Packaging.Xml
             {
                 elem.Add(new XElement(ns + "developmentDependency", metadata.DevelopmentDependency));
             }
-            var licenseUrlToWrite = metadata.LicenseUrl;
+            var licenseUrlToWrite = metadata.LicenseUrl?.ToString();
             if (metadata.LicenseMetadata != null)
             {
                 var licenseElement = GetXElementFromLicenseMetadata(ns, metadata.LicenseMetadata);
@@ -53,7 +53,7 @@ namespace NuGet.Packaging.Xml
                 {
                     elem.Add(licenseElement);
                 }
-                licenseUrlToWrite = metadata.LicenseMetadata.LicenseUrl;
+                licenseUrlToWrite = metadata.LicenseMetadata.LicenseUrl.OriginalString;
             }
             AddElementIfNotNull(elem, ns, "licenseUrl", licenseUrlToWrite);
             AddElementIfNotNull(elem, ns, "projectUrl", metadata.ProjectUrl);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -4481,6 +4481,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     var licenseMetadata = nuspecReader.GetLicenseMetadata();
                     Assert.Equal(new Uri(string.Format(LicenseMetadata.LicenseServiceLinkTemplate, licenseExpr)), new Uri(nuspecReader.GetLicenseUrl()));
                     Assert.NotNull(licenseMetadata);
+                    Assert.Equal(licenseMetadata.LicenseUrl.AbsoluteUri, nuspecReader.GetLicenseUrl());
                     Assert.Equal(licenseMetadata.LicenseUrl, new Uri(nuspecReader.GetLicenseUrl()));
                     Assert.Equal(licenseMetadata.Type, LicenseType.Expression);
                     Assert.Equal(licenseMetadata.Version, LicenseMetadata.EmptyVersion);
@@ -5097,6 +5098,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     Assert.Equal(LicenseMetadata.LicenseFileDeprecationUrl, new Uri(nuspecReader.GetLicenseUrl()));
                     var licenseMetadata = nuspecReader.GetLicenseMetadata();
                     Assert.NotNull(licenseMetadata);
+                    Assert.Equal(licenseMetadata.LicenseUrl.AbsoluteUri, nuspecReader.GetLicenseUrl());
                     Assert.Equal(licenseMetadata.Type, LicenseType.File);
                     Assert.Equal(licenseMetadata.Version, LicenseMetadata.EmptyVersion);
                     Assert.Equal(licenseMetadata.License, licenseFileName);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -4481,7 +4481,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     var licenseMetadata = nuspecReader.GetLicenseMetadata();
                     Assert.Equal(new Uri(string.Format(LicenseMetadata.LicenseServiceLinkTemplate, licenseExpr)), new Uri(nuspecReader.GetLicenseUrl()));
                     Assert.NotNull(licenseMetadata);
-                    Assert.Equal(licenseMetadata.LicenseUrl.AbsoluteUri, nuspecReader.GetLicenseUrl());
+                    Assert.Equal(licenseMetadata.LicenseUrl.OriginalString, nuspecReader.GetLicenseUrl());
                     Assert.Equal(licenseMetadata.LicenseUrl, new Uri(nuspecReader.GetLicenseUrl()));
                     Assert.Equal(licenseMetadata.Type, LicenseType.Expression);
                     Assert.Equal(licenseMetadata.Version, LicenseMetadata.EmptyVersion);
@@ -5098,7 +5098,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     Assert.Equal(LicenseMetadata.LicenseFileDeprecationUrl, new Uri(nuspecReader.GetLicenseUrl()));
                     var licenseMetadata = nuspecReader.GetLicenseMetadata();
                     Assert.NotNull(licenseMetadata);
-                    Assert.Equal(licenseMetadata.LicenseUrl.AbsoluteUri, nuspecReader.GetLicenseUrl());
+                    Assert.Equal(licenseMetadata.LicenseUrl.OriginalString, nuspecReader.GetLicenseUrl());
                     Assert.Equal(licenseMetadata.Type, LicenseType.File);
                     Assert.Equal(licenseMetadata.Version, LicenseMetadata.EmptyVersion);
                     Assert.Equal(licenseMetadata.License, licenseFileName);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -4542,9 +4542,10 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     Assert.Equal(packageName, nuspecReader.GetId());
                     Assert.Equal(version, nuspecReader.GetVersion().ToFullString());
                     Assert.Equal(requireLicenseAcceptance, nuspecReader.GetRequireLicenseAcceptance());
+                    Assert.Equal(new Uri(string.Format(LicenseMetadata.LicenseServiceLinkTemplate, licenseExpr)), new Uri(nuspecReader.GetLicenseUrl()));
                     var licenseMetadata = nuspecReader.GetLicenseMetadata();
-                    Assert.Equal(new Uri(string.Format(LicenseMetadata.LicenseServiceLinkTemplate, WebUtility.UrlEncode(licenseExpr))), new Uri(nuspecReader.GetLicenseUrl()));
                     Assert.NotNull(licenseMetadata);
+                    Assert.Equal(licenseMetadata.LicenseUrl.OriginalString, nuspecReader.GetLicenseUrl());
                     Assert.Equal(licenseMetadata.LicenseUrl, new Uri(nuspecReader.GetLicenseUrl()));
                     Assert.Equal(licenseMetadata.Type, LicenseType.Expression);
                     Assert.Equal(licenseMetadata.Version, LicenseMetadata.EmptyVersion);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -4431,6 +4431,7 @@ namespace Proj1
         [Theory]
         [InlineData("MIT", true)]
         [InlineData("MIT OR Apache-2.0", false)]
+        [InlineData("MIT+ OR Apache-2.0", false)]
         public void PackCommand_PackLicense_SimpleExpression_StandardLicense(string licenseExpr, bool requireLicenseAcceptance)
         {
             var nugetexe = Util.GetNuGetExePath();
@@ -4478,7 +4479,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     Assert.Equal(version, nuspecReader.GetVersion().ToFullString());
                     Assert.Equal(requireLicenseAcceptance, nuspecReader.GetRequireLicenseAcceptance());
                     var licenseMetadata = nuspecReader.GetLicenseMetadata();
-                    Assert.Equal(new Uri(string.Format(LicenseMetadata.LicenseServiceLinkTemplate, WebUtility.UrlEncode(licenseExpr))), new Uri(nuspecReader.GetLicenseUrl()));
+                    Assert.Equal(new Uri(string.Format(LicenseMetadata.LicenseServiceLinkTemplate, licenseExpr)), new Uri(nuspecReader.GetLicenseUrl()));
                     Assert.NotNull(licenseMetadata);
                     Assert.Equal(licenseMetadata.LicenseUrl, new Uri(nuspecReader.GetLicenseUrl()));
                     Assert.Equal(licenseMetadata.Type, LicenseType.Expression);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageLicenseUtilitiesTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageLicenseUtilitiesTests.cs
@@ -167,5 +167,24 @@ namespace NuGet.PackageManagement.UI.Test
             Assert.Equal(Resources.Text_ViewLicense, licenseFileText.Text);
             Assert.Equal(Resources.LicenseFile_Loading, ((Run)((Paragraph)licenseFileText.LicenseText.Blocks.AsEnumerable().First()).Inlines.First()).Text);
         }
+
+        [Fact]
+        public void PackageLicenseUtility_GenerateCorrectLink()
+        {
+            // Setup
+            var license = "MIT";
+            var expression = NuGetLicenseExpression.Parse(license);
+            var licenseData = new LicenseMetadata(LicenseType.Expression, license, expression, null, LicenseMetadata.EmptyVersion);
+
+            // Act
+            var links = PackageLicenseUtilities.GenerateLicenseLinks(licenseData, null, null);
+
+            // Assert
+            Assert.Equal(1, links.Count);
+            var licenseText = links[0] as LicenseText;
+            Assert.NotNull(licenseText);
+            Assert.Equal(license, licenseText.Text);
+            Assert.Equal("https://licenses.nuget.org/MIT", licenseText.Link.AbsoluteUri);
+        }
     }
 }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -3084,9 +3084,10 @@ namespace ClassLibrary
                     Assert.Equal("ClassLibrary1", nuspecReader.GetId());
                     Assert.Equal("1.0.0", nuspecReader.GetVersion().ToFullString());
                     Assert.False(nuspecReader.GetRequireLicenseAcceptance());
+                    Assert.Equal(new Uri(string.Format(LicenseMetadata.LicenseServiceLinkTemplate, licenseExpr)), new Uri(nuspecReader.GetLicenseUrl()));
                     var licenseMetadata = nuspecReader.GetLicenseMetadata();
-                    Assert.Equal(new Uri(string.Format(LicenseMetadata.LicenseServiceLinkTemplate, WebUtility.UrlEncode(licenseExpr))), new Uri(nuspecReader.GetLicenseUrl()));
                     Assert.NotNull(licenseMetadata);
+                    Assert.Equal(licenseMetadata.LicenseUrl.OriginalString, nuspecReader.GetLicenseUrl());
                     Assert.Equal(licenseMetadata.LicenseUrl, new Uri(nuspecReader.GetLicenseUrl()));
                     Assert.Equal(licenseMetadata.Type, LicenseType.Expression);
                     Assert.Equal(licenseMetadata.Version, LicenseMetadata.EmptyVersion);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -3136,9 +3136,10 @@ namespace ClassLibrary
                     Assert.Equal("ClassLibrary1", nuspecReader.GetId());
                     Assert.Equal("1.0.0", nuspecReader.GetVersion().ToFullString());
                     Assert.False(nuspecReader.GetRequireLicenseAcceptance());
-                    Assert.Equal(new Uri(string.Format(LicenseMetadata.LicenseServiceLinkTemplate, WebUtility.UrlEncode(licenseExpr))), new Uri(nuspecReader.GetLicenseUrl()));
+                    Assert.Equal(new Uri(string.Format(LicenseMetadata.LicenseServiceLinkTemplate, licenseExpr)), new Uri(nuspecReader.GetLicenseUrl()));
                     var licenseMetadata = nuspecReader.GetLicenseMetadata();
                     Assert.NotNull(licenseMetadata);
+                    Assert.Equal(licenseMetadata.LicenseUrl.OriginalString, nuspecReader.GetLicenseUrl());
                     Assert.Equal(licenseMetadata.LicenseUrl, new Uri(nuspecReader.GetLicenseUrl()));
                     Assert.Equal(licenseMetadata.Type, LicenseType.Expression);
                     Assert.Equal(licenseMetadata.Version, LicenseMetadata.EmptyVersion);


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7515
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
The url was being incorrectly encoded when a plus was in question. 
The encoding strategy by the client was inconsistent with the decoding strategy by IIS, leading to where `MIT` and `MIT+` were indistinguishable.

@agr I'll provide you with a build for you to test. 

## Testing/Validation
Tests Added: Yes
Reason for not adding tests: It's not an "expectation change" and the test were already covering that.
Validation done:  
