### PR TITLE
Make CI only test that requires elevation

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
@@ -442,7 +442,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [Fact]
+        [CIOnlyFact]
         public async Task AddTrustedSignersAsync_WithUnknownPrimarySignature_ThrowsAsync()
         {
             // Arrange


### PR DESCRIPTION
## Bug
Fixes test locally that fails because it need to be ran with admin permissions