### PR TITLE
Properly encode and decode section and credentials element name

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Xml;
 using System.Xml.Linq;
 
 namespace NuGet.Configuration
@@ -16,7 +17,19 @@ namespace NuGet.Configuration
     /// </summary>
     public sealed class CredentialsItem : SettingItem
     {
-        public override string ElementName { get; protected set; }
+        private string _elementName;
+        public override string ElementName {
+            get => XmlConvert.DecodeName(_elementName);
+            protected set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.PropertyCannotBeNullOrEmpty, nameof(ElementName)));
+                }
+
+                _elementName = XmlUtility.GetEncodedXMLName(value);
+            }
+        }
 
         public string Username
         {
@@ -213,7 +226,7 @@ namespace NuGet.Configuration
                 return Node;
             }
 
-            var element = new XElement(ElementName,
+            var element = new XElement(_elementName,
                 _username.AsXNode(),
                 _password.AsXNode());
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingSection.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingSection.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
@@ -11,6 +12,21 @@ namespace NuGet.Configuration
 {
     public abstract class SettingSection : SettingsGroup<SettingItem>
     {
+        private string _elementName;
+        public override string ElementName
+        {
+            get => XmlConvert.DecodeName(_elementName);
+            protected set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.PropertyCannotBeNullOrEmpty, nameof(ElementName)));
+                }
+
+                _elementName = XmlUtility.GetEncodedXMLName(value);
+            }
+        }
+
         public IReadOnlyCollection<SettingItem> Items => Children.ToList();
 
         public T GetFirstItemWithAttribute<T>(string attributeName, string expectedAttributeValue) where T : SettingItem
@@ -28,7 +44,7 @@ namespace NuGet.Configuration
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(name));
             }
 
-            ElementName = XmlConvert.EncodeLocalName(name);
+            ElementName = name;
         }
 
         internal SettingSection(XElement element, SettingsFile origin)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsGroup.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsGroup.cs
@@ -55,7 +55,7 @@ namespace NuGet.Configuration
                 return Node;
             }
 
-            var element = new XElement(ElementName, Children.Select(c => c.AsXNode()));
+            var element = new XElement(XmlUtility.GetEncodedXMLName(ElementName), Children.Select(c => c.AsXNode()));
 
             foreach (var attr in Attributes)
             {

--- a/src/NuGet.Core/NuGet.Configuration/Utility/XmlUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/XmlUtility.cs
@@ -27,6 +27,18 @@ namespace NuGet.Configuration
             return CreateDocument(content, fullPath);
         }
 
+        internal static string GetEncodedXMLName(string name)
+        {
+            try
+            {
+                return XmlConvert.VerifyName(name);
+            }
+            catch (XmlException)
+            {
+                return XmlConvert.EncodeName(name);
+            }
+        }
+
         private static XDocument CreateDocument(XDocument content, string fullPath)
         {
             // Add it to the file system

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceCredentialTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceCredentialTests.cs
@@ -176,6 +176,21 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void AsCredentialsItem_WithSpaceOnSourceName_WorksCorrectly()
+        {
+            var credentials = new PackageSourceCredential(
+                "source name",
+                "user",
+                "password",
+                isPasswordClearText: true,
+                validAuthenticationTypesText: null);
+
+            var expectedItem = new CredentialsItem("source name", "user", "password", isPasswordClearText: true, validAuthenticationTypes: null);
+
+            SettingsTestUtils.DeepEquals(credentials.AsCredentialsItem(), expectedItem).Should().BeTrue();
+        }
+
+        [Fact]
         public void AsCredentialsItem_WithAuthenticationTypes_WorksCorrectly()
         {
             var credentials = new PackageSourceCredential(

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -896,6 +896,38 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void LoadPackageSources_WithSpaceInName_ReadsCredentialPairsFromSettings()
+        {
+            // Arrange
+            var encryptedPassword = Guid.NewGuid().ToString();
+
+            var settings = new Mock<ISettings>();
+            settings
+                .Setup(s => s.GetSection("packageSources"))
+                .Returns(new VirtualSettingSection("packageSources",
+                    new SourceItem("one source", "onesource"),
+                    new SourceItem("two source", "twosource"),
+                    new SourceItem("three source", "threesource")
+                ));
+
+            settings
+                .Setup(s => s.GetSection("packageSourceCredentials"))
+                .Returns(new VirtualSettingSection("packageSourceCredentials",
+                    new CredentialsItem("two source", "user1", encryptedPassword, isPasswordClearText: false, validAuthenticationTypes: null)
+                    ));
+
+            var provider = CreatePackageSourceProvider(settings.Object);
+
+            // Act
+            var values = provider.LoadPackageSources().ToList();
+
+            // Assert
+            Assert.Equal(3, values.Count);
+            AssertPackageSource(values[1], "two source", "twosource", true);
+            AssertCredentials(values[1].Credentials, "two source", "user1", encryptedPassword, isPasswordClearText: false);
+        }
+
+        [Fact]
         public void LoadPackageSources_ReadsClearTextCredentialPairsFromSettings()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
@@ -32,6 +32,14 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void CredentialsItem_Constructor_WithSpaceOnName_EncodesItCorrectly()
+        {
+            var item = new CredentialsItem("credentials name", "username", "password", isPasswordClearText: true, validAuthenticationTypes: null);
+
+            item.ElementName.Should().Be("credentials name");
+        }
+
+        [Fact]
         public void CredentialsItem_Parsing_WithoutUsername_Throws()
         {
             // Arrange
@@ -474,6 +482,35 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void CredentialsItem_AsXNode_WithSpaceInName_ReturnsCorrectElement()
+        {
+            // Arrange
+            var credentialsItem = new CredentialsItem("credentials name", "username", "password", isPasswordClearText: false, validAuthenticationTypes: null);
+
+            // Act
+            var xnode = credentialsItem.AsXNode();
+
+            // Assert
+            xnode.Should().BeOfType<XElement>();
+            var xelement = xnode as XElement;
+
+            xelement.Name.LocalName.Should().Be("credentials_x0020_name");
+            var elements = xelement.Elements().ToList();
+            elements.Count.Should().Be(2);
+            elements[0].Name.LocalName.Should().Be("add");
+            var elattr = elements[0].Attributes().ToList();
+            elattr.Count.Should().Be(2);
+            elattr[0].Value.Should().Be("Username");
+            elattr[1].Value.Should().Be("username");
+
+            elements[1].Name.LocalName.Should().Be("add");
+            elattr = elements[1].Attributes().ToList();
+            elattr.Count.Should().Be(2);
+            elattr[0].Value.Should().Be("Password");
+            elattr[1].Value.Should().Be("password");
+        }
+
+        [Fact]
         public void CredentialsItem_AsXNode_WithUsernameAndPassword_ReturnsCorrectElement()
         {
             // Arrange
@@ -569,6 +606,41 @@ namespace NuGet.Configuration.Test
             <add key='Password' value='password' />
             <add key='ValidAuthenticationTypes' value='one,two,three' />
         </NuGet.Org>
+    </packageSourceCredentials>
+</configuration>";
+            var nugetConfigPath = "NuGet.Config";
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
+
+                // Act and Assert
+                var settingsFile = new SettingsFile(mockBaseDirectory);
+                settingsFile.TryGetSection("packageSourceCredentials", out var section).Should().BeTrue();
+                section.Should().NotBeNull();
+
+                section.Items.Count.Should().Be(1);
+                var item = section.Items.First();
+                item.IsCopy().Should().BeFalse();
+                item.Origin.Should().NotBeNull();
+
+                var clone = item.Clone() as CredentialsItem;
+                clone.IsCopy().Should().BeTrue();
+                clone.Origin.Should().NotBeNull();
+                SettingsTestUtils.DeepEquals(clone, item).Should().BeTrue();
+            }
+        }
+
+        [Fact]
+        public void CredentialsItem_Clone_WithSpaceOnName_ReturnsItemClone()
+        {
+            // Arrange
+            var config = @"
+<configuration>
+    <packageSourceCredentials>
+        <nuget_x0020_org>
+            <add key='Username' value='username' />
+            <add key='Password' value='password' />
+        </nuget_x0020_org>
     </packageSourceCredentials>
 </configuration>";
             var nugetConfigPath = "NuGet.Config";

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingSectionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingSectionTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Xml.Linq;
 using FluentAssertions;
 using NuGet.Test.Utility;
 using Xunit;
@@ -429,11 +430,30 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void VirtualSection_AsXNode_WithSpaceOnName_IsCorrect()
+        {
+            var section = new VirtualSettingSection("section name", new AddItem("key1", "val"));
+
+            var xNode = section.AsXNode();
+            xNode.Should().BeOfType<XElement>();
+            var xelement = xNode as XElement;
+            xelement.Name.LocalName.Should().Be("section_x0020_name");
+        }
+
+        [Fact]
         public void VirtualSection_ElementName_IsCorrect()
         {
             var settingSection = new VirtualSettingSection("section", new AddItem("key1", "val"));
 
             settingSection.ElementName.Should().Be("section");
+        }
+
+        [Fact]
+        public void VirtualSection_ElementName_WithSpaceOnName_IsCorrect()
+        {
+            var section = new VirtualSettingSection("section name", new AddItem("key1", "val"));
+
+            section.ElementName.Should().Be("section name");
         }
 
         [Fact]


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7517, https://github.com/NuGet/Home/issues/7516
Regression: Yes  
If Regression then when did it last work:  4.8.1
If Regression then how are we preventing it in future:  added automation test for scenario

## Fix
Details: When setting and getting the element name for elements that don't have hardcoded names (i.e. credentials and sections), xml encode and decode properly the name so we can have all names in the same encoding.

## Testing/Validation
Tests Added: Yes
