### PR TITLE
Avoid using Thread boundary APIs in MEF constructor

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/InteractiveLoginProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/InteractiveLoginProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.Services.Client;
 using Microsoft.VisualStudio.Services.Client.AccountManagement;
 using Microsoft.VisualStudio.Services.DelegatedAuthorization.Client;
 using Microsoft.VisualStudio.Services.WebApi;
+using NuGet.Common;
 using NuGet.VisualStudio;
 
 namespace NuGet.PackageManagement.VisualStudio
@@ -24,11 +25,14 @@ namespace NuGet.PackageManagement.VisualStudio
         private const string MsaOnlyTenantId = "00000000-0000-0000-0000-000000000000";
         private const string SessionTokenScope = "vso.packaging_write";
 
-        private readonly DTE _dte;
+        private readonly AsyncLazy<DTE> _dte;
 
         public InteractiveLoginProvider()
         {
-            _dte = ServiceLocator.GetInstance<DTE>();
+            _dte = new AsyncLazy<DTE>(async () =>
+            {
+                return await ServiceLocator.GetInstanceAsync<DTE>();
+            });
         }
 
         // Logic shows UI and interacts with all mocked methods.  Mocking this as well.
@@ -53,7 +57,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 var parent = IntPtr.Zero;
                 if (_dte != null)
                 {
-                    parent = new IntPtr(_dte.MainWindow.HWnd);
+                    parent = new IntPtr((await _dte).MainWindow.HWnd);
                 }
 
                 account = await provider.CreateAccountWithUIAsync(parent, cancellationToken);
@@ -94,7 +98,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 var parent = IntPtr.Zero;
                 if (_dte != null)
                 {
-                    parent = new IntPtr(_dte.MainWindow.HWnd);
+                    parent = new IntPtr((await _dte).MainWindow.HWnd);
                 }
 
                 try

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/InteractiveLoginProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/InteractiveLoginProvider.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.Services.Client;
 using Microsoft.VisualStudio.Services.Client.AccountManagement;
 using Microsoft.VisualStudio.Services.DelegatedAuthorization.Client;
 using Microsoft.VisualStudio.Services.WebApi;
-using NuGet.Common;
+using Microsoft.VisualStudio.Threading;
 using NuGet.VisualStudio;
 
 namespace NuGet.PackageManagement.VisualStudio
@@ -29,10 +29,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public InteractiveLoginProvider()
         {
-            _dte = new AsyncLazy<DTE>(async () =>
-            {
-                return await ServiceLocator.GetInstanceAsync<DTE>();
-            });
+            _dte = new AsyncLazy<DTE>(() => ServiceLocator.GetInstanceAsync<DTE>(), NuGetUIThreadHelper.JoinableTaskFactory);
         }
 
         // Logic shows UI and interacts with all mocked methods.  Mocking this as well.
@@ -57,7 +54,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 var parent = IntPtr.Zero;
                 if (_dte != null)
                 {
-                    parent = new IntPtr((await _dte).MainWindow.HWnd);
+                    parent = new IntPtr((await _dte.GetValueAsync()).MainWindow.HWnd);
                 }
 
                 account = await provider.CreateAccountWithUIAsync(parent, cancellationToken);
@@ -98,7 +95,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 var parent = IntPtr.Zero;
                 if (_dte != null)
                 {
-                    parent = new IntPtr((await _dte).MainWindow.HWnd);
+                    parent = new IntPtr((await _dte.GetValueAsync()).MainWindow.HWnd);
                 }
 
                 try

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
@@ -50,7 +50,7 @@ namespace NuGet.VisualStudio
             return NuGetUIThreadHelper.JoinableTaskFactory.Run(GetInstanceAsync<TService>);
         }
 
-        private static async Task<TService> GetInstanceAsync<TService>() where TService : class
+        public static async Task<TService> GetInstanceAsync<TService>() where TService : class
         {
             // VS Threading Rule #1
             // Access to ServiceProvider and a lot of casts are performed in this method,
@@ -88,7 +88,7 @@ namespace NuGet.VisualStudio
             return NuGetUIThreadHelper.JoinableTaskFactory.Run(GetGlobalServiceAsync<TService, TInterface>);
         }
 
-        private static async Task<TInterface> GetGlobalServiceAsync<TService, TInterface>() where TInterface : class
+        public static async Task<TInterface> GetGlobalServiceAsync<TService, TInterface>() where TInterface : class
         {
             // VS Threading Rule #1
             // Access to ServiceProvider and a lot of casts are performed in this method,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VisualStudioAccountProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VisualStudioAccountProviderTests.cs
@@ -1,17 +1,17 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.Services.Client.AccountManagement;
-using Moq;
 using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Services.Client.AccountManagement;
+using Microsoft.VisualStudio.Threading;
+using Moq;
+using NuGet.Configuration;
 using NuGet.Credentials;
 using Xunit;
-using NuGet.Configuration;
-using NuGet.Common;
 
 namespace NuGet.PackageManagement.VisualStudio.Test
 {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VisualStudioAccountProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VisualStudioAccountProviderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.VisualStudio.Services.Client.AccountManagement;
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using NuGet.Credentials;
 using Xunit;
 using NuGet.Configuration;
+using NuGet.Common;
 
 namespace NuGet.PackageManagement.VisualStudio.Test
 {
@@ -55,7 +56,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 x => x.FindTenantInAccount(It.IsAny<Account>(), It.IsAny<string>(), It.IsAny<VSAccountProvider>()))
                 .Returns(new TenantInformation("uid", TestTenantId, "name", true, true));
 
-            _provider = new VisualStudioAccountProvider(_mockAccountManager.Object, _mockLoginProvider.Object);
+            _provider = new VisualStudioAccountProvider(new AsyncLazy<IAccountManager>(() => Task.FromResult(_mockAccountManager.Object)), _mockLoginProvider.Object);
         }
 
         private Account GetTestAccount()


### PR DESCRIPTION
## Bug
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/723777 
Regression: Yes
If Regression then when did it last work: 15.8
If Regression then how are we preventing it in future: 

## Fix
Details: While initializing default VSTS credential service, it's trying to consume Thread boundary APIs like GetService in MEF initialization which tries to complete a COM call where as at another async task msbuild evaluation was blocked for this MEF initialization hence deadlock. This PR avoids COM calls from MEF constructor instead make them `AsyncLazy` so that MEF initialization is minimalistic. 

## Testing/Validation
Tests Added: No
Reason for not adding tests:  Visual Studio threading related changes, where we don't have adequate test infrastructure to add func tests. Will try to get the repro solution so that we can ask test vendors to complete manual testing.

Validation done:  


@lifengl