### PR TITLE
ConcurrencyUtilities: Rethrow PathTooLongException to break out of the loop

### DIFF
--- a/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
+++ b/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
@@ -74,19 +74,18 @@ namespace NuGet.Common
 
                         // This can occur when the file is being deleted
                         // Or when an admin user has locked the file
-                        await Task.Delay(SleepDuration);
+                        await Task.Delay(SleepDuration).ConfigureAwait(false);
                         continue;
                     }
                     catch (IOException)
                     {
                         token.ThrowIfCancellationRequested();
 
-                        await Task.Delay(SleepDuration);
+                        await Task.Delay(SleepDuration).ConfigureAwait(false);
                         continue;
                     }
-
                     // Run the action within the lock
-                    return await action(token);
+                    return await action(token).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -99,79 +98,14 @@ namespace NuGet.Common
             }
         }
 
-        public static void ExecuteWithFileLocked(string filePath,
-            Action action)
-        {
-            if (string.IsNullOrEmpty(filePath))
+        public static void ExecuteWithFileLocked(string filePath, Action action) =>
+            ExecuteWithFileLockedAsync(filePath, ct =>
             {
-                throw new ArgumentNullException(nameof(filePath));
-            }
-
-            // limit the number of unauthorized, this should be around 30 seconds.
-            var unauthorizedAttemptsLeft = NumberOfRetries;
-
-            while (true)
-            {
-                FileStream fs = null;
-                var lockPath = string.Empty;
-                try
-                {
-                    try
-                    {
-                        lockPath = FileLockPath(filePath);
-
-                        fs = AcquireFileStream(lockPath);
-                    }
-                    catch (DirectoryNotFoundException)
-                    {
-                        throw;
-                    }
-                    catch(PathTooLongException)
-                    {
-                        throw;
-                    }
-                    catch(UnauthorizedAccessException)
-                    {
-                        if (unauthorizedAttemptsLeft < 1)
-                        {
-                            if (string.IsNullOrEmpty(lockPath))
-                            {
-                                lockPath = BasePath;
-                            }
-
-                            var message = string.Format(
-                                CultureInfo.CurrentCulture,
-                                Strings.UnauthorizedLockFail,
-                                lockPath,
-                                filePath);
-
-                            throw new InvalidOperationException(message);
-                        }
-
-                        unauthorizedAttemptsLeft--;
-
-                        // This can occur when the file is being deleted
-                        // Or when an admin user has locked the file
-                        Thread.Sleep(SleepDuration);
-                        continue;
-                    }
-                    catch (IOException)
-                    {
-                        Thread.Sleep(SleepDuration);
-                        continue;
-                    }
-
-                    // Run the action within the lock
-                    action();
-                    return;
-                }
-                finally
-                {
-                    // Dispose of the stream, this will cause a delete
-                    fs?.Dispose();
-                }
-            }
-        }
+                action();
+                return Task.FromResult(true);
+            }, CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
 
         private static FileStream AcquireFileStream(string lockPath)
         {

--- a/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
+++ b/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
@@ -46,7 +46,11 @@ namespace NuGet.Common
                     {
                         throw;
                     }
-                    catch (UnauthorizedAccessException)
+                    catch(PathTooLongException)
+                    {
+                        throw;
+                    }
+                    catch(UnauthorizedAccessException)
                     {
                         token.ThrowIfCancellationRequested();
 
@@ -122,7 +126,11 @@ namespace NuGet.Common
                     {
                         throw;
                     }
-                    catch (UnauthorizedAccessException)
+                    catch(PathTooLongException)
+                    {
+                        throw;
+                    }
+                    catch(UnauthorizedAccessException)
                     {
                         if (unauthorizedAttemptsLeft < 1)
                         {

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1879,7 +1879,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new TestRestoreRequest(spec, sources, packagesDir + new string('_', 200), cacheContext, logger)
+                var request = new TestRestoreRequest(spec, sources, packagesDir + new string('_', 300), cacheContext, logger)
                 {
                     LockFilePath = Path.Combine(projectDir, "project.lock.json")
                 };

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using NuGet.Commands.Test;
 using NuGet.Configuration;
@@ -1850,6 +1851,46 @@ namespace NuGet.Commands.FuncTest
                 // Don't assert the pre-release tag since it may vary
             }
         }
+
+        [Fact]
+        public async Task RestoreCommand_PathTooLongException()
+        {
+            // Arrange
+            var sources = new List<PackageSource>
+            {
+                new PackageSource("https://www.nuget.org/api/v2/")
+            };
+
+            using(var packagesDir = TestDirectory.Create())
+            using(var projectDir = TestDirectory.Create())
+            using(var cacheContext = new SourceCacheContext())
+            {
+                var configJson = JObject.Parse(@"
+                {
+                    ""dependencies"": {
+                        ""Newtonsoft.Json"": ""7.0.1""
+                    },
+                     ""frameworks"": {
+                        ""net45"": { }
+                    }
+                }");
+
+                var specPath = Path.Combine(projectDir, "TestProject", "project.json");
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(spec, sources, packagesDir + new string('_', 200), cacheContext, logger)
+                {
+                    LockFilePath = Path.Combine(projectDir, "project.lock.json")
+                };
+
+                var command = new RestoreCommand(request);
+
+                // Act
+                new Func<Task>(async () => await command.ExecuteAsync()).ShouldThrow<PathTooLongException>();
+            }
+        }
+
 
         [Fact]
         public async Task RestoreCommand_RestoreExactVersionWithFailingSourceAsync()


### PR DESCRIPTION
Fixes NuGet/Home#7530. The second commit is somewhat beside the point, so if it's problematic I'll just revert it.