### PR TITLE
Avoid DateTime.Parse crash in DateTimeConverter

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/DateTimeConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/DateTimeConverter.cs
@@ -24,7 +24,24 @@ namespace NuGet.PackageManagement.UI
                 return null;
             }
 
-            var dateTime = DateTime.Parse(value.ToString());
+            DateTimeOffset dateTime;
+            if (value is DateTimeOffset dto)
+            {
+                dateTime = dto;
+            }
+            else if (value is DateTime dt)
+            {
+                dateTime = dt;
+            }
+            else
+            {
+                if (!DateTime.TryParse(value.ToString(), out dt))
+                {
+                    return null;
+                }
+                dateTime = dt;
+            }
+
             if (string.Equals(culture.Name, "ja-JP"))
             {
                 return $"{dateTime.ToString("D", culture)} {dateTime.ToString("dddd", culture)} ({ dateTime.ToString("d", culture)})";

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/DateTimeConverterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/DateTimeConverterTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using Xunit;
+
+namespace NuGet.PackageManagement.UI.Test.Converters
+{
+    public class DateTimeConverterTests
+    {
+        [Fact]
+        public void Convert_NullValue()
+        {
+            var converter = new DateTimeConverter();
+
+            var converted = converter.Convert(
+                null,
+                typeof(string),
+                null,
+                new CultureInfo("en-US"));
+
+            Assert.Null(converted);
+        }
+
+        // Only test languages that have a Visual Studio language pack
+        [Theory]
+        [InlineData("cs-CZ", "úterý 20. listopadu 2018 (20.11.2018)")]
+        [InlineData("de-DE", "Dienstag, 20. November 2018 (20.11.2018)")]
+        [InlineData("en-US", "Tuesday, November 20, 2018 (11/20/2018)")]
+        [InlineData("es-ES", "martes, 20 de noviembre de 2018 (20/11/2018)")]
+        [InlineData("fr-FR", "mardi 20 novembre 2018 (20/11/2018)")]
+        [InlineData("it-IT", "martedì 20 novembre 2018 (20/11/2018)")]
+        [InlineData("ja-JP", "2018年11月20日 火曜日 (2018/11/20)")]
+        [InlineData("ko-KR", "2018년 11월 20일 화요일 (2018-11-20)")]
+        [InlineData("pl-PL", "wtorek, 20 listopada 2018 (20.11.2018)")]
+        [InlineData("pt-BR", "terça-feira, 20 de novembro de 2018 (20/11/2018)")]
+        [InlineData("ru-RU", "20 ноября 2018 г. (20.11.2018)")]
+        [InlineData("tr-TR", "20 Kasım 2018 Salı (20.11.2018)")]
+        [InlineData("zh-CN", "2018年11月20日 (2018/11/20)")]
+        [InlineData("zh-TW", "2018年11月20日 (2018/11/20)")]
+        public void Convert_WithConverterParameter_UsesVersionFormatter(string locale, string expected)
+        {
+            var culture = CultureInfo.GetCultureInfoByIetfLanguageTag(locale);
+            var value = new DateTimeOffset(2018, 11, 20, 13, 44, 31, TimeSpan.FromHours(-8));
+            
+            var converter = new DateTimeConverter();
+
+            var converted = converter.Convert(
+                value,
+                typeof(string),
+                null,
+                culture);
+
+            Assert.Equal(expected, converted);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/DateTimeConverterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Converters/DateTimeConverterTests.cs
@@ -54,5 +54,45 @@ namespace NuGet.PackageManagement.UI.Test.Converters
 
             Assert.Equal(expected, converted);
         }
+
+        [Fact]
+        public void Convert_DateTime()
+        {
+            var converter = new DateTimeConverter();
+
+            var converted = converter.Convert(new DateTime(2018, 11, 20),
+                typeof(string),
+                null,
+                CultureInfo.GetCultureInfo("en-US"));
+
+            Assert.Equal("Tuesday, November 20, 2018 (11/20/2018)", converted);
+        }
+
+        [Fact]
+        public void Convert_DateTimeParsableObject()
+        {
+            var converter = new DateTimeConverter();
+
+            var converted = converter.Convert("2018-11-20",
+                typeof(string),
+                null,
+                CultureInfo.GetCultureInfo("en-US"));
+
+            Assert.Equal("Tuesday, November 20, 2018 (11/20/2018)", converted);
+        }
+
+        [Fact]
+        public void Convert_ObjectDateTimeCanNotParse()
+        {
+            var converter = new DateTimeConverter();
+
+            var converted = converter.Convert(Guid.Empty,
+                typeof(string),
+                null,
+                CultureInfo.GetCultureInfo("en-US"));
+
+            Assert.Null(converted);
+        }
+
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Converters\IconUrlToImageCacheConverterTests.cs" />
+    <Compile Include="Converters\DateTimeConverterTests.cs" />
     <Compile Include="Converters\VersionToStringConverterTests.cs" />
     <Compile Include="ConverterTests.cs" />
     <Compile Include="GlobalSuppressions.cs" />


### PR DESCRIPTION
## Bug
Fixes: NuGet/Home#7539
Regression: Yes
If Regression then when did it last work:   VSS15.8
If Regression then how are we preventing it in future: Raise awareness within the team that `DateTime[Offset].ToString()` uses machine formatting settings, which may have been modified and therefore cannot be parsed. If a machine-parsable string is required, use ISO formatting or custom formatting, which also avoid MM/dd vs dd/MM ordering issues. Unfortunately since XAML converters use `object` instead of strong types, we can't write a Roslyn analyzer to prevent calling dangerous `ToString` formats on DateTime types.

## Fix
Details: Changed `DateTimeConverter` to cast the `object` back to a `DateTimeOffset` instead of formatting to a string and then parsing it. Since the could be used in the future by other components using other data types, it also tries to cast & convert `DateTime`, and falls back to `ToString()` and `TryParse()` for other datatypes.

## Testing/Validation
Tests Added: Yes
Reason for not adding tests:  
Validation done:  
