### PR TITLE
Fix VS hangs on Solution close by reducing the timeout to cancel existing restore task

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -223,9 +223,8 @@ namespace NuGet.SolutionRestoreManager
                     {
                         // Do not block VS forever
                         // After the specified delay the task will disjoin.
-                        await _backgroundJobRunner.GetValueAsync().WithTimeout(TimeSpan.FromSeconds(60));
-                    },
-                    JoinableTaskCreationOptions.LongRunning);
+                        await _backgroundJobRunner.GetValueAsync().WithTimeout(TimeSpan.FromSeconds(5));
+                    });
             }
 
             _pendingRestore?.Dispose();


### PR DESCRIPTION
## Bug
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/495973 
Regression: Yes/No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: Currently there is a 60 secs timeout to either complete existing BG restore task or cancel it which sometimes hang VS when customer tries to close solution or exit VS. Ideally closing the VS or solution should be very quick. So this PR is going to reduce current timeout from 60 secs to 5 decs just to allow cancellation to be propagated through restore task but doesn't hangs for a long time.

## Testing/Validation
Tests Added: Yes/No  
Reason for not adding tests:  
Validation done:  
