### PR TITLE
Support for Signing using .NET Core 2.1+

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -58,7 +58,7 @@ param (
 
 If (-Not $SkipDelaySigning)
 {
-    & "$PSScriptRoot\scripts\utils\DisableStrongNameVerification.ps1" -skipNoOpMessage
+  #  & "$PSScriptRoot\scripts\utils\DisableStrongNameVerification.ps1" -skipNoOpMessage
 }
 
 if (-not $Configuration) {
@@ -84,6 +84,8 @@ if (-not $VSToolsetInstalled) {
     exit 1
 }
 
+$currentDirectory = split-path $MyInvocation.MyCommand.Definition
+
 $BuildErrors = @()
 
 Invoke-BuildStep 'Cleaning artifacts' {
@@ -106,7 +108,7 @@ Invoke-BuildStep 'Running Restore' {
 
     # Restore
     Trace-Log ". `"$MSBuildExe`" build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /v:m /m:1"
-    & $MSBuildExe build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /v:m /m:1
+    & $MSBuildExe build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /v:m /m:1 /p:MS_PFX_PATH=$currentDirectory\keys\35MSSharedLib1024.snk /p:NUGET_PFX_PATH=$currentDirectory\keys\NuGetKey.snk
 
     if (-not $?)
     {
@@ -119,12 +121,12 @@ Invoke-BuildStep 'Running Restore' {
 
 Invoke-BuildStep $VSMessage {
 
-    $args = 'build\build.proj', "/t:$VSTarget", "/p:Configuration=$Configuration", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", '/v:m', '/m:1'
+    $args = 'build\build.proj', "/t:$VSTarget", "/p:Configuration=$Configuration", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", '/v:m', '/m:1', "/p:MS_PFX_PATH=$currentDirectory\keys\35MSSharedLib1024.snk", "/p:NUGET_PFX_PATH=$currentDirectory\keys\NuGetKey.snk"
 
     If ($SkipDelaySigning)
     {
-        $args += "/p:MS_PFX_PATH="
-        $args += "/p:NUGET_PFX_PATH="
+        #$args += "/p:MS_PFX_PATH="
+        #$args += "/p:NUGET_PFX_PATH="
     }
 
     # Build and (If not $SkipUnitTest) Pack, Core unit tests, and Unit tests for VS
@@ -154,7 +156,7 @@ Invoke-BuildStep 'Running Restore RTM' {
 
     # Restore for VS
     Trace-Log ". `"$MSBuildExe`" build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:BuildRTM=true /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /p:ExcludeTestProjects=true /v:m /m:1 "
-    & $MSBuildExe build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:BuildRTM=true /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /p:ExcludeTestProjects=true /v:m /m:1
+    & $MSBuildExe build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:BuildRTM=true /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /p:ExcludeTestProjects=true /v:m /m:1 /p:MS_PFX_PATH=$currentDirectory\keys\35MSSharedLib1024.snk /p:NUGET_PFX_PATH=$currentDirectory\keys\NuGetKey.snk
 
     if (-not $?)
     {
@@ -170,7 +172,7 @@ Invoke-BuildStep 'Packing RTM' {
 
     # Build and (If not $SkipUnitTest) Pack, Core unit tests, and Unit tests for VS
     Trace-Log ". `"$MSBuildExe`" build\build.proj /t:BuildVS`;Pack /p:Configuration=$Configuration /p:BuildRTM=true /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /p:ExcludeTestProjects=true /v:m /m:1"
-    & $MSBuildExe build\build.proj /t:BuildVS`;Pack /p:Configuration=$Configuration /p:BuildRTM=true  /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /p:ExcludeTestProjects=true /v:m /m:1
+    & $MSBuildExe build\build.proj /t:BuildVS`;Pack /p:Configuration=$Configuration /p:BuildRTM=true  /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /p:ExcludeTestProjects=true /v:m /m:1 /p:MS_PFX_PATH=$currentDirectory\keys\35MSSharedLib1024.snk /p:NUGET_PFX_PATH=$currentDirectory\keys\NuGetKey.snk
 
     if (-not $?)
     {

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -87,14 +87,14 @@
   <!-- DEBUG specific configuration settings -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>embedded</DebugType>
     <Optimize>false</Optimize>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
 
   <!-- RELEASE specific configuration settings -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>embedded</DebugType>
     <Optimize>true</Optimize>
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
@@ -277,7 +277,7 @@
   </ItemGroup>
 
   <!-- source link -->
-  <ItemGroup Condition="'$(Shipping)' == 'true' AND '$(IsXPlat)' != 'true'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>
   </ItemGroup>
 

--- a/build/common.props
+++ b/build/common.props
@@ -2,6 +2,8 @@
 <Project ToolsVersion="15.0">
   <PropertyGroup>
     <IsNetCoreProject>true</IsNetCoreProject>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl> 
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <!-- When building on non-Windows machines, we need the reference assemblies to build full-framework assemblies. -->
@@ -9,7 +11,7 @@
      <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-alpha-5" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup Condition="'$(IsNetCoreProject)' == 'true' AND '$(Shipping)' == 'true' AND '$(IsXPlat)' != 'true'">
-    <DebugType>full</DebugType>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
   <!-- Load config -->
   <Import Project="config.props" />

--- a/build/config.props
+++ b/build/config.props
@@ -68,8 +68,8 @@
     <PackageProjectUrl>https://aka.ms/nugetprj</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/NuGet/NuGet.Client</RepositoryUrl>
+    <!--<RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/NuGet/NuGet.Client</RepositoryUrl>-->
     <PackageTags>nuget</PackageTags>
     <Description>NuGet client library.</Description>
     <Copyright>&#169; Microsoft Corporation. All rights reserved.</Copyright>

--- a/build/sign.targets
+++ b/build/sign.targets
@@ -17,7 +17,8 @@
 
   <PropertyGroup Condition = " Exists($(StrongNameKey)) ">
     <SignAssembly>true</SignAssembly>
-    <DelaySign Condition="'$(IsXplat)' != 'true'">true</DelaySign>
+    <!--<DelaySign Condition="'$(IsXplat)' != 'true'">true</DelaySign>-->
+    <PublicSign Condition="'$(IsXplat)' != 'true'">true</PublicSign>
     <PublicSign Condition="'$(IsXplat)' == 'true'">true</PublicSign>
     <AssemblyOriginatorKeyFile Condition = " '$(AssemblyOriginatorKeyFile)' == '' ">$(StrongNameKey)</AssemblyOriginatorKeyFile>
     <StrongNameCert Condition="'$(StrongNameCert)' == ''">$(DefaultStrongNameCert)</StrongNameCert>

--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -1,10 +1,10 @@
-﻿<Project>
+<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
     <Description>NuGet's implementation for reading nupkg package and nuspec package specification files.</Description>
-    <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksLibrary);netcoreapp2.1</TargetFrameworks>
     <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1574;CS1573;CS1572</NoWarn>
     <NoWarn Condition="'$(TargetFramework)' == '$(NetStandardVersion)'">$(NoWarn);CS0414</NoWarn>
@@ -14,6 +14,13 @@
     <XPLATProject>true</XPLATProject>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <DefineConstants Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)' OR '$(TargetFramework)' == 'netcoreapp2.1'">$(DefineConstants);HAS_SIGNING</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.5.2" />
+  </ItemGroup>
   <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
     <TargetFrameworks />
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
@@ -43,7 +50,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(IsCore)' == 'true' ">
+  <ItemGroup Condition=" '$(IsCore)' == 'true' and '$(TargetFramework)' != 'netcoreapp2.1' ">
     <PackageReference Include="System.Dynamic.Runtime" Version="$(SystemPackagesVersion)" />
   </ItemGroup>
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -271,7 +271,7 @@ namespace NuGet.Packaging
                 using (var reader = new BinaryReader(bufferedStream, new UTF8Encoding(), leaveOpen: true))
                 using (var stream = SignedPackageArchiveUtility.OpenPackageSignatureFileStream(reader))
                 {
-#if IS_DESKTOP
+#if HAS_SIGNING
                     signature = PrimarySignature.Load(stream);
 #endif
                 }
@@ -288,7 +288,7 @@ namespace NuGet.Packaging
 
             var isSigned = false;
 
-#if IS_DESKTOP
+#if HAS_SIGNING
             if (RuntimeEnvironmentHelper.IsWindows)
             {
                 using (var zip = new ZipArchive(ZipReadStream, ZipArchiveMode.Read, leaveOpen: true))
@@ -322,7 +322,7 @@ namespace NuGet.Packaging
                 throw new SignatureException(Strings.SignedPackageNotSignedOnVerify);
             }
 
-#if IS_DESKTOP
+#if HAS_SIGNING
             using (var bufferedStream = new ReadOnlyBufferedStream(ZipReadStream, leaveOpen: true))
             using (var reader = new BinaryReader(bufferedStream, new UTF8Encoding(), leaveOpen: true))
             using (var hashAlgorithm = signatureContent.HashAlgorithm.GetHashProvider())

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveIOUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveIOUtility.cs
@@ -127,7 +127,7 @@ namespace NuGet.Packaging.Signing
             {
                 throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(bytes));
             }
-#if IS_DESKTOP
+#if HAS_SIGNING
             hashAlgorithm.TransformBlock(bytes, 0, bytes.Length, outputBuffer: null, outputOffset: 0);
 #else
             throw new NotImplementedException();

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Archive/SignedPackageArchiveUtility.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography.Pkcs;
 #endif
 using System.Text;
@@ -226,7 +226,7 @@ namespace NuGet.Packaging.Signing
             return false;
         }
 
-#if IS_DESKTOP
+#if HAS_SIGNING
         /// <summary>
         /// Removes repository primary signature (if it exists) or any repository countersignature (if it exists).
         /// </summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/SignPackageRequest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/SignPackageRequest.cs
@@ -41,7 +41,7 @@ namespace NuGet.Packaging.Signing
 
         internal IX509CertificateChain Chain { get; private set; }
 
-#if IS_DESKTOP
+#if HAS_SIGNING && IS_DESKTOP
         /// <summary>
         /// PrivateKey is only used in mssign command.
         /// </summary>
@@ -86,7 +86,7 @@ namespace NuGet.Packaging.Signing
                 Certificate?.Dispose();
                 Chain?.Dispose();
 
-#if IS_DESKTOP
+#if HAS_SIGNING && IS_DESKTOP
                 PrivateKey?.Dispose();
 #endif
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
 #endif
@@ -97,37 +97,42 @@ namespace NuGet.Packaging.Signing
             }
         }
 
-#if IS_DESKTOP
+#if HAS_SIGNING
         private static PrimarySignature CreatePrimarySignature(SignPackageRequest request, SignatureContent signatureContent, ILogger logger)
         {
             var cmsSigner = SigningUtility.CreateCmsSigner(request, logger);
 
+#if IS_DESKTOP
             if (request.PrivateKey != null)
             {
                 return CreatePrimarySignature(cmsSigner, signatureContent.GetBytes(), request.PrivateKey);
             }
-
+#endif
             return CreatePrimarySignature(cmsSigner, request, signatureContent.GetBytes());
         }
 
         private static PrimarySignature CreateRepositoryCountersignature(SignPackageRequest request, PrimarySignature primarySignature, ILogger logger)
         {
             var cmsSigner = SigningUtility.CreateCmsSigner(request, logger);
+#if IS_DESKTOP
 
             if (request.PrivateKey != null)
             {
                 return CreateRepositoryCountersignature(cmsSigner, primarySignature, request.PrivateKey);
             }
+#endif
 
             return CreateRepositoryCountersignature(cmsSigner, request, primarySignature);
         }
 
+#if IS_DESKTOP
         private static PrimarySignature CreatePrimarySignature(CmsSigner cmsSigner, byte[] signingData, CngKey privateKey)
         {
             var cms = NativeUtility.NativeSign(cmsSigner, signingData, privateKey);
 
             return PrimarySignature.Load(cms);
         }
+#endif
 
         private static PrimarySignature CreatePrimarySignature(CmsSigner cmsSigner, SignPackageRequest request, byte[] signingData)
         {
@@ -149,7 +154,7 @@ namespace NuGet.Packaging.Signing
 
             return PrimarySignature.Load(cms);
         }
-
+#if IS_DESKTOP
         private static PrimarySignature CreateRepositoryCountersignature(CmsSigner cmsSigner, PrimarySignature primarySignature, CngKey privateKey)
         {
             using (var primarySignatureNativeCms = NativeCms.Decode(primarySignature.GetBytes()))
@@ -164,6 +169,7 @@ namespace NuGet.Packaging.Signing
                 return PrimarySignature.Load(updatedCms);
             }
         }
+#endif
 
         private static PrimarySignature CreateRepositoryCountersignature(CmsSigner cmsSigner, SignPackageRequest request, PrimarySignature primarySignature)
         {
@@ -218,7 +224,7 @@ namespace NuGet.Packaging.Signing
         }
 
 #else
-        private static PrimarySignature CreatePrimarySignature(SignPackageRequest request, SignatureContent signatureContent, ILogger logger)
+            private static PrimarySignature CreatePrimarySignature(SignPackageRequest request, SignatureContent signatureContent, ILogger logger)
         {
             throw new NotSupportedException();
         }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
@@ -141,7 +141,7 @@ namespace NuGet.Packaging.Signing
 
             try
             {
-                cms.ComputeSignature(cmsSigner);
+                cms.ComputeSignature(cmsSigner, false); // silent is false to ensure PIN prompts appear if CNG/CAPI requires it
             }
             catch (CryptographicException ex) when (ex.HResult == INVALID_PROVIDER_TYPE_HRESULT)
             {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Native/NativeCms.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Native/NativeCms.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 #endif
@@ -260,7 +260,7 @@ namespace NuGet.Packaging.Signing
                 }
             }
         }
-#if IS_DESKTOP
+#if HAS_SIGNING && IS_DESKTOP
         internal unsafe void AddCountersignature(CmsSigner cmsSigner, CngKey privateKey)
         {
             using (var hb = new HeapBlockRetainer())
@@ -278,7 +278,7 @@ namespace NuGet.Packaging.Signing
         }
 #endif
 
-#if IS_DESKTOP
+#if HAS_SIGNING
         internal unsafe void AddTimestampToRepositoryCountersignature(SignedCms timestamp)
         {
             using (var hb = new HeapBlockRetainer())

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Native/NativeUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Native/NativeUtility.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 #endif
@@ -28,7 +28,7 @@ namespace NuGet.Packaging.Signing
             }
         }
 
-#if IS_DESKTOP
+#if HAS_SIGNING && IS_DESKTOP
         internal static SignedCms NativeSign(CmsSigner cmsSigner, byte[] data, CngKey privateKey)
         {
             using (var hb = new HeapBlockRetainer())

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageWriter.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Package/ISignedPackageWriter.cs
@@ -14,7 +14,7 @@ namespace NuGet.Packaging.Signing
     /// </summary>
     public interface ISignedPackageWriter
     {
-#if IS_DESKTOP
+#if HAS_SIGNING
         /// <summary>
         /// Removes a signature if it exists.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/AuthorPrimarySignature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/AuthorPrimarySignature.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
 #endif
@@ -14,7 +14,7 @@ namespace NuGet.Packaging.Signing
 {
     public sealed class AuthorPrimarySignature : PrimarySignature
     {
-#if IS_DESKTOP
+#if HAS_SIGNING
 
         public AuthorPrimarySignature(SignedCms signedCms)
             : base(signedCms, SignatureType.Author)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/IRepositorySignature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/IRepositorySignature.cs
@@ -8,7 +8,7 @@ namespace NuGet.Packaging.Signing
 {
     public interface IRepositorySignature : ISignature
     {
-#if IS_DESKTOP
+#if HAS_SIGNING
         Uri V3ServiceIndexUrl { get; }
 
         IReadOnlyList<string> PackageOwners { get; }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/PrimarySignature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/PrimarySignature.cs
@@ -4,7 +4,7 @@
 using System;
 using System.IO;
 using System.Security.Cryptography;
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography.Pkcs;
 #endif
 using NuGet.Common;
@@ -13,7 +13,7 @@ namespace NuGet.Packaging.Signing
 {
     public abstract class PrimarySignature : Signature
     {
-#if IS_DESKTOP
+#if HAS_SIGNING
         /// <summary>
         /// A SignedCms object holding the signature and SignerInfo.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/PrimarySignatureFactory.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/PrimarySignatureFactory.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography.Pkcs;
 using NuGet.Common;
 #endif
@@ -10,7 +10,7 @@ namespace NuGet.Packaging.Signing
 {
     public static class PrimarySignatureFactory
     {
-#if IS_DESKTOP
+#if HAS_SIGNING
         public static PrimarySignature CreateSignature(SignedCms signedCms)
         {
             var signatureType = AttributeUtility.GetSignatureType(signedCms.SignerInfos[0].SignedAttributes);

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/RepositoryCountersignature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/RepositoryCountersignature.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
 #endif
@@ -15,7 +15,7 @@ namespace NuGet.Packaging.Signing
 {
     public sealed class RepositoryCountersignature : Signature, IRepositorySignature
     {
-#if IS_DESKTOP
+#if HAS_SIGNING
         private readonly PrimarySignature _primarySignature;
 
         public Uri V3ServiceIndexUrl { get; }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/RepositoryPrimarySignature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/RepositoryPrimarySignature.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
 #endif
@@ -15,7 +15,7 @@ namespace NuGet.Packaging.Signing
 {
     public sealed class RepositoryPrimarySignature : PrimarySignature, IRepositorySignature
     {
-#if IS_DESKTOP
+#if HAS_SIGNING
         public Uri V3ServiceIndexUrl { get; }
         public IReadOnlyList<string> PackageOwners { get; }
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/Signature.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
@@ -20,7 +20,7 @@ namespace NuGet.Packaging.Signing
     /// </summary>
     public abstract class Signature : ISignature
     {
-#if IS_DESKTOP
+#if HAS_SIGNING
         private readonly Lazy<IReadOnlyList<Timestamp>> _timestamps;
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/UnknownPrimarySignature.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Signatures/UnknownPrimarySignature.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography.Pkcs;
 #endif
 
@@ -9,7 +9,7 @@ namespace NuGet.Packaging.Signing
 {
     public sealed class UnknownPrimarySignature : PrimarySignature
     {
-#if IS_DESKTOP
+#if HAS_SIGNING
         public UnknownPrimarySignature(SignedCms signedCms)
             : base(signedCms, SignatureType.Unknown)
         {

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampProvider.cs
@@ -7,7 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
 
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography.Pkcs;
 #endif
 
@@ -30,7 +30,7 @@ namespace NuGet.Packaging.Signing
 
         public Rfc3161TimestampProvider(Uri timeStampServerUrl)
         {
-#if IS_DESKTOP
+#if HAS_SIGNING
             // Uri.UriSchemeHttp and Uri.UriSchemeHttps are not available in netstandard 1.3
             if (!string.Equals(timeStampServerUrl.Scheme, Uri.UriSchemeHttp, StringComparison.Ordinal) &&
                 !string.Equals(timeStampServerUrl.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal))
@@ -46,7 +46,7 @@ namespace NuGet.Packaging.Signing
             _timestamperUrl = timeStampServerUrl ?? throw new ArgumentNullException(nameof(timeStampServerUrl));
         }
 
-#if IS_DESKTOP
+#if HAS_SIGNING
 
         /// <summary>
         /// Timestamps data present in the TimestampRequest.

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampRequest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampRequest.cs
@@ -19,7 +19,7 @@ namespace NuGet.Packaging.Signing
     internal sealed class Rfc3161TimestampRequest : AsnEncodedData
     {
 
-#if IS_DESKTOP
+#if HAS_SIGNING
         private class DataType
         {
             internal int _version;

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampToken.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampToken.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography.Pkcs;
 #endif
 
@@ -22,7 +22,7 @@ namespace NuGet.Packaging.Signing
     internal sealed class Rfc3161TimestampToken
     {
 
-#if IS_DESKTOP
+#if HAS_SIGNING
 
         private readonly byte[] _encoded;
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampTokenInfo.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampTokenInfo.cs
@@ -6,7 +6,7 @@ using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography.Pkcs;
 #endif
 using System.Security.Cryptography.X509Certificates;
@@ -19,7 +19,7 @@ namespace NuGet.Packaging.Signing
     /// </summary>
     public sealed class Rfc3161TimestampTokenInfo : AsnEncodedData
     {
-#if IS_DESKTOP
+#if HAS_SIGNING
         public const string TimestampTokenInfoId = "1.2.840.113549.1.9.16.1.4";
 
         private TstInfo _decoded;

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampUtils.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampUtils.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography.Pkcs;
 #endif
 
@@ -74,7 +74,7 @@ namespace NuGet.Packaging.Signing
             return allowPeriod;
         }
 
-#if IS_DESKTOP
+#if HAS_SIGNING
         public static byte[] GetSignature(this SignerInfo signerInfo)
         {
             var field = typeof(SignerInfo).GetField("m_pbCmsgSignerInfo", BindingFlags.Instance | BindingFlags.NonPublic);

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampVerificationUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Rfc3161TimestampVerificationUtility.cs
@@ -4,7 +4,7 @@
 using System;
 using System.IO;
 
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography.Pkcs;
 #endif
 
@@ -19,7 +19,7 @@ namespace NuGet.Packaging.Signing
     {
         private const double _millisecondsPerMicrosecond = 0.001;
 
-#if IS_DESKTOP
+#if HAS_SIGNING
 
         internal static bool ValidateSignerCertificateAgainstTimestamp(
             X509Certificate2 signerCertificate,

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Timestamp.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Timestamp/Timestamp.cs
@@ -8,7 +8,7 @@ using System.Globalization;
 using System.Security.Cryptography.X509Certificates;
 using System.Linq;
 
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography.Pkcs;
 #endif
 
@@ -16,7 +16,7 @@ namespace NuGet.Packaging.Signing
 {
     public sealed class Timestamp
     {
-#if IS_DESKTOP
+#if HAS_SIGNING
 
         /// <summary>
         /// Upper limit of Timestamp.

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/AttributeUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/AttributeUtility.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography.Pkcs;
 #endif
 using System.Security.Cryptography.X509Certificates;
@@ -15,7 +15,7 @@ namespace NuGet.Packaging.Signing
 {
     public static class AttributeUtility
     {
-#if IS_DESKTOP
+#if HAS_SIGNING
         /// <summary>
         /// Create a CommitmentTypeIndication attribute.
         /// https://tools.ietf.org/html/rfc5126.html#section-5.11.1

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SignatureUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SignatureUtility.cs
@@ -5,7 +5,7 @@ using System;
 using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography.Pkcs;
 #endif
 using System.Security.Cryptography.X509Certificates;
@@ -23,7 +23,7 @@ namespace NuGet.Packaging.Signing
             EitherOrBoth
         }
 
-#if IS_DESKTOP
+#if HAS_SIGNING
         /// <summary>
         /// Gets certificates in the certificate chain for the primary signature.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SigningUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/SigningUtility.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Security.Cryptography;
-#if IS_DESKTOP
+#if HAS_SIGNING
 using System.Security.Cryptography.Pkcs;
 #endif
 using System.Security.Cryptography.X509Certificates;
@@ -56,7 +56,7 @@ namespace NuGet.Packaging.Signing
             request.BuildSigningCertificateChainOnce(logger);
         }
 
-#if IS_DESKTOP
+#if HAS_SIGNING
         public static CryptographicAttributeObjectCollection CreateSignedAttributes(
             SignPackageRequest request,
             IReadOnlyList<X509Certificate2> chainList)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/VerificationUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/VerificationUtility.cs
@@ -95,7 +95,7 @@ namespace NuGet.Packaging.Signing
             return validationFlags;
         }
 
-#if IS_DESKTOP
+#if HAS_SIGNING
         internal static SignatureVerificationStatusFlags ValidateTimestamp(Timestamp timestamp, Signature signature, bool treatIssuesAsErrors, List<SignatureLog> issues, SigningSpecifications spec)
         {
             if (timestamp == null)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/AllowListVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/AllowListVerificationProvider.cs
@@ -31,7 +31,7 @@ namespace NuGet.Packaging.Signing
             return Task.FromResult(VerifyAllowList(package, signature, settings));
         }
 
-#if IS_DESKTOP
+#if HAS_SIGNING
         private PackageVerificationResult VerifyAllowList(ISignedPackageReader package, PrimarySignature signature, SignedPackageVerifierSettings settings)
         {
             var treatIssuesAsErrors = !settings.AllowUntrusted;

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/IntegrityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/IntegrityVerificationProvider.cs
@@ -18,7 +18,7 @@ namespace NuGet.Packaging.Signing
             return VerifyPackageIntegrityAsync(package, signature, settings);
         }
 
-#if IS_DESKTOP
+#if HAS_SIGNING
         private async Task<PackageVerificationResult> VerifyPackageIntegrityAsync(ISignedPackageReader package, PrimarySignature signature, SignedPackageVerifierSettings settings)
         {
             var status = SignatureVerificationStatus.Unknown;

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureTrustAndValidityVerificationProvider.cs
@@ -51,7 +51,7 @@ namespace NuGet.Packaging.Signing
             return Task.FromResult(result);
         }
 
-#if IS_DESKTOP
+#if HAS_SIGNING
         private PackageVerificationResult Verify(
             PrimarySignature signature,
             SignedPackageVerifierSettings settings)

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
@@ -44,6 +44,7 @@ namespace NuGet.Protocol
             var clientHandler = new HttpClientHandler
             {
                 Proxy = proxy,
+                DefaultProxyCredentials = CredentialCache.DefaultCredentials,
                 AutomaticDecompression = (DecompressionMethods.GZip | DecompressionMethods.Deflate)
             };
 

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/NuGet.Common.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/NuGet.Common.Test.csproj
@@ -29,5 +29,11 @@
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets"/>
+
+  <PropertyGroup>
+    <PublicSign>false</PublicSign>
+    <DelaySign>true</DelaySign>
+  </PropertyGroup>
+
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>


### PR DESCRIPTION
cc @dtivel 

This PR has the changes necessary to enable signing using .NET Core 2.1 and higher. 

Mostly for reference when you're ready.