### PR TITLE
Do not fail verification if owners don't match

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/AllowListVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/AllowListVerificationProvider.cs
@@ -86,10 +86,14 @@ namespace NuGet.Packaging.Signing
                         {
                             if (ShouldVerifyOwners(certificateHashEntry as TrustedSignerAllowListEntry, signature as IRepositorySignature, out var allowedOwners, out var actualOwners))
                             {
-                                return allowedOwners.Intersect(actualOwners).Any();
+                                if (allowedOwners.Intersect(actualOwners).Any())
+                                {
+                                    return true;
+                                }
                             }
-
-                            return true;
+                            else {
+                                return true;
+                            }
                         }
                     }
 
@@ -108,10 +112,15 @@ namespace NuGet.Packaging.Signing
                             {
                                 if (ShouldVerifyOwners(certificateHashEntry as TrustedSignerAllowListEntry, repositoryCountersignature.Value as IRepositorySignature, out var allowedOwners, out var actualOwners))
                                 {
-                                    return allowedOwners.Intersect(actualOwners).Any();
+                                    if (allowedOwners.Intersect(actualOwners).Any())
+                                    {
+                                        return true;
+                                    }
                                 }
-
-                                return true;
+                                else 
+                                {
+                                    return true;
+                                }
                             }
                         }
                     }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/AllowListVerificationProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/AllowListVerificationProvider.cs
@@ -91,7 +91,8 @@ namespace NuGet.Packaging.Signing
                                     return true;
                                 }
                             }
-                            else {
+                            else
+                            {
                                 return true;
                             }
                         }

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
@@ -857,6 +857,61 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
+
+        [CIOnlyFact]
+        public async Task GetTrustResultAsync_RepositoryCountersignedPackage_PackageSignedWithCertFromAllowList_WithOwnerNotInOwnersList_AuthorInList_RequireMode_SuccessAsync()
+        {
+            var nupkg = new SimpleTestPackageContext();
+
+            // Arrange
+            using (var dir = TestDirectory.Create())
+            using (var primaryCertificate = new X509Certificate2(_trustedAuthorTestCert.Source.Cert))
+            using (var counterCertificate = new X509Certificate2(_trustedRepoTestCert.Source.Cert))
+            {
+                var hashAlgorithmName = HashAlgorithmName.SHA256;
+                var authorFingerprint = SignatureTestUtility.GetFingerprint(primaryCertificate, hashAlgorithmName);
+                var repositoryFingerprint = SignatureTestUtility.GetFingerprint(counterCertificate, hashAlgorithmName);
+
+                var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(primaryCertificate, nupkg, dir);
+                var countersignedPackagePath = await SignedArchiveTestUtility.RepositorySignPackageAsync(
+                    counterCertificate,
+                    signedPackagePath,
+                    dir,
+                    v3ServiceIndex: new Uri("https://v3serviceIndex.test/api/index.json"),
+                    timestampService: null,
+                    packageOwners: new List<string>() { "owner4", "owner5" });
+
+                var allowList = new List<CertificateHashAllowListEntry>()
+                {
+                    new TrustedSignerAllowListEntry(VerificationTarget.Repository, SignaturePlacement.Any, repositoryFingerprint, hashAlgorithmName, owners: new List<string>() { "owner1", "owner2", "owner3" }),
+                    new TrustedSignerAllowListEntry(VerificationTarget.Author, SignaturePlacement.PrimarySignature, authorFingerprint, hashAlgorithmName)
+                };
+
+                var signedPackageVerifierSettings = SignedPackageVerifierSettings.GetRequireModeDefaultPolicy();
+                var signedPackageVerifier = new PackageSignatureVerifier(new ISignatureVerificationProvider[]
+                {
+                    new AllowListVerificationProvider(allowList, requireNonEmptyAllowList: true)
+                });
+
+                using (var packageReader = new PackageArchiveReader(countersignedPackagePath))
+                {
+                    // Act
+                    var result = await signedPackageVerifier.VerifySignaturesAsync(packageReader, signedPackageVerifierSettings, CancellationToken.None);
+                    var resultsWithErrors = result.Results.Where(r => r.GetErrorIssues().Any());
+                    var resultsWithWarnings = result.Results.Where(r => r.GetWarningIssues().Any());
+                    var totalErrorIssues = resultsWithErrors.SelectMany(r => r.GetErrorIssues());
+                    var totalWarningIssues = resultsWithWarnings.SelectMany(r => r.GetWarningIssues());
+
+                    // Assert
+                    result.IsValid.Should().BeTrue();
+                    resultsWithErrors.Count().Should().Be(0);
+                    resultsWithWarnings.Count().Should().Be(0);
+                    totalErrorIssues.Count().Should().Be(0);
+                    totalWarningIssues.Count().Should().Be(0);
+                }
+            }
+        }
+
         [CIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_PackageSignedWithCertFromAllowList_WithNoOwnersInPackage_RequireMode_ErrorAsync()
         {


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7572

## Fix
Details: When `AllowListVerificationProvider` matched a signing certificate with a trusted repository entry that has owners, it failed the whole allow list verification if those owners did not match any of the ones that signed the package. This becomes an issue if there's a trusted signer entry later in the list that does match this package (e.g. a trusted author for the author signature).


cc. @rido-min 