### PR TITLE
Updated validating VS toolset generic for different VS versions

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -2,7 +2,7 @@
 $DefaultConfiguration = 'debug'
 $DefaultReleaseLabel = 'zlocal'
 $DefaultMSBuildVersion = 15
-$DefaultVSVersion = 15.0
+$DefaultVSVersion = "15.0"
 
 # The pack version can be inferred from the .nuspec files on disk. This is only necessary as long
 # as the following issue is open: https://github.com/NuGet/Home/issues/3530
@@ -326,7 +326,7 @@ Function Get-VSVersion() {
 
 Function Get-VSMajorVersion() {
     $vsVersion = Get-VSVersion
-    $vsMajorVersion = $vsVersion.Split('.')[0]
+    $vsMajorVersion = "${vsVersion}".Split('.')[0]
     return $vsMajorVersion
 }
 

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -344,7 +344,8 @@ Function Get-MSBuildRoot {
         $CommonToolsVar = "Env:VS${vsMajorVersion}0COMNTOOLS"
         if (Test-Path $CommonToolsVar) {
             # If VS "15" is installed get msbuild from VS install path
-            $MSBuildRoot = Join-Path $CommonToolsVar '..\..\MSBuild'
+            $CommonToolsValue = gci $CommonToolsVar | select -expand value -ea Ignore
+            $MSBuildRoot = Join-Path $CommonToolsValue '..\..\MSBuild' -Resolve
         } else {
             $VisualStudioRoot = Get-LatestVisualStudioRoot
             if ($VisualStudioRoot -and (Test-Path $VisualStudioRoot)) {

--- a/configure.ps1
+++ b/configure.ps1
@@ -129,20 +129,23 @@ if (-not $ProgramFiles -or -not (Test-Path $ProgramFiles)) {
 $MSBuildDefaultRoot = Get-MSBuildRoot
 $MSBuildRelativePath = 'bin\msbuild.exe'
 
-Invoke-BuildStep 'Validating VS15 toolset installation' {
-    $vs15 = New-BuildToolset 15
+Invoke-BuildStep 'Validating VS toolset installation' {
+
+    $vsMajorVersion = Get-VSMajorVersion
+    $vs15 = New-BuildToolset $vsMajorVersion
     if ($vs15) {
         $ConfigureObject.Toolsets.Add('vs15', $vs15)
-        $script:MSBuildExe = Get-MSBuildExe 15
+        $script:MSBuildExe = Get-MSBuildExe $vsMajorVersion
+        $vsVersion = Get-VSVersion
 
         # Hack VSSDK path
-        $VSToolsPath = Join-Path $MSBuildDefaultRoot 'Microsoft\VisualStudio\v15.0'
+        $VSToolsPath = Join-Path $MSBuildDefaultRoot "Microsoft\VisualStudio\v${vsVersion}"
         $Targets = Join-Path $VSToolsPath 'VSSDK\Microsoft.VsSDK.targets'
         if (-not (Test-Path $Targets)) {
             Warning-Log "VSSDK is not found at default location '$VSToolsPath'. Attempting to override."
             # Attempting to fix VS SDK path for VS15 willow install builds
             # as MSBUILD failes to resolve it correctly
-            $VSToolsPath = Join-Path $vs15.VisualStudioInstallDir '..\..\MSBuild\Microsoft\VisualStudio\v15.0' -Resolve
+            $VSToolsPath = Join-Path $vs15.VisualStudioInstallDir "..\..\MSBuild\Microsoft\VisualStudio\v${vsVersion}" -Resolve
             $ConfigureObject.Add('EnvVars', @{ VSToolsPath = $VSToolsPath })
         }
     }


### PR DESCRIPTION
Currently there are multiple places in our common.ps1 or configure.ps1 which only uses dev15 specific version or env variables which is why it fails for dev16 at some machines. This PR will fix those instances to make it generic for any VS version.