### PR TITLE
Improve LegacyPackageReferenceProject.ShouldReadFromSettings

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -286,7 +286,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private static bool ShouldReadFromSettings(IEnumerable<string> values)
         {
-            return !values.Any() && values.All(e => !StringComparer.OrdinalIgnoreCase.Equals("CLEAR", e));
+            return !values.Any();
         }
 
         private IList<string> GetConfigFilePaths(ISettings settings)


### PR DESCRIPTION
It doesn't make sense to perform the second check.
If (!values.Any() == true), the values is empty and it doesn't contain the CLEAR element.
If (!values.Any() == false), the whole expression is false (regardless of the second value).