### PR TITLE
Don't recompute already-known FeedTypes

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Utility/FeedTypeUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/FeedTypeUtility.cs
@@ -16,6 +16,12 @@ namespace NuGet.Protocol
         /// </summary>
         public static FeedType GetFeedType(PackageSource packageSource)
         {
+            // If the feed type is already specified, use that value
+            if (packageSource is FeedTypePackageSource feedTypePackageSource)
+            {
+                return feedTypePackageSource.FeedType;
+            }
+
             // Default to unknown file system
             var type = FeedType.FileSystemUnknown;
 


### PR DESCRIPTION
Don't recompute already-known FeedTypes. This has the known affect of avoiding unnecessary enumerations in the global packages cache during restore operations and likely provides minor perf boosts in other scenarios as well.

## Bug
Fixes: [#7596](https://github.com/NuGet/Home/issues/7596)
Regression: ¯\_(ツ)_/¯  

## Fix
Details: In GetFeedType, check if the FeedType is already known before looking at the file system

## Testing/Validation
Tests Added: No
Reason for not adding tests:  Existing test coverage suffices
Validation done:  Ran existing UTs, validated simple Restore scenarios work as expected
