### PR TITLE
Added IgnoreLockFileOnRestore option to ignore reading/ writing lock file on a restore

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -407,7 +407,8 @@ namespace NuGet.PackageManagement.VisualStudio
                     RestoreLockProperties = new RestoreLockProperties(
                         await _vsProjectAdapter.GetRestorePackagesWithLockFileAsync(),
                         await _vsProjectAdapter.GetNuGetLockFilePathAsync(),
-                        await _vsProjectAdapter.IsRestoreLockedAsync())
+                        await _vsProjectAdapter.IsRestoreLockedAsync(),
+                        await _vsProjectAdapter.ShouldLockFileBeIgnoredAsync())
                 }
             };
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -388,6 +388,15 @@ namespace NuGet.PackageManagement.VisualStudio
             return MSBuildStringUtility.IsTrue(value);
         }
 
+        public async Task<bool> ShouldLockFileBeIgnoredAsync()
+        {
+            await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            var value = await BuildProperties.GetPropertyValueAsync(ProjectBuildProperties.IgnoreLockFileForRestore);
+
+            return MSBuildStringUtility.IsTrue(value);
+        }
+
         private async Task<string> GetTargetFrameworkStringAsync()
         {
             await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -60,6 +60,7 @@ namespace NuGet.SolutionRestoreManager
         private const string RestorePackagesWithLockFile = nameof(RestorePackagesWithLockFile);
         private const string NuGetLockFilePath = nameof(NuGetLockFilePath);
         private const string RestoreLockedMode = nameof(RestoreLockedMode);
+        private const string IgnoreLockFileForRestore = nameof(IgnoreLockFileForRestore);
 
         private static readonly Version Version20 = new Version(2, 0, 0, 0);
 
@@ -292,7 +293,8 @@ namespace NuGet.SolutionRestoreManager
                     RestoreLockProperties = new RestoreLockProperties(
                         GetRestorePackagesWithLockFile(projectRestoreInfo.TargetFrameworks),
                         GetNuGetLockFilePath(projectRestoreInfo.TargetFrameworks),
-                        IsLockFileFreezeOnRestore(projectRestoreInfo.TargetFrameworks))
+                        IsLockFileFreezeOnRestore(projectRestoreInfo.TargetFrameworks),
+                        ShouldLockFileBeIgnored(projectRestoreInfo.TargetFrameworks))
                 },
                 RuntimeGraph = GetRuntimeGraph(projectRestoreInfo),
                 RestoreSettings = new ProjectRestoreSettings() { HideWarningsAndErrors = true }
@@ -335,6 +337,11 @@ namespace NuGet.SolutionRestoreManager
         private static bool IsLockFileFreezeOnRestore(IVsTargetFrameworks tfms)
         {
             return GetSingleNonEvaluatedPropertyOrNull(tfms, RestoreLockedMode, MSBuildStringUtility.IsTrue);
+        }
+
+        private static bool ShouldLockFileBeIgnored(IVsTargetFrameworks tfms)
+        {
+            return GetSingleNonEvaluatedPropertyOrNull(tfms, IgnoreLockFileForRestore, MSBuildStringUtility.IsTrue);
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
@@ -146,5 +146,7 @@ namespace NuGet.VisualStudio
         /// </summary>
         /// <returns></returns>
         Task<bool> IsRestoreLockedAsync();
+
+        Task<bool> ShouldLockFileBeIgnoredAsync();
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -664,6 +664,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RestorePackagesWithLockFile>$(RestorePackagesWithLockFile)</RestorePackagesWithLockFile>
         <NuGetLockFilePath>$(NuGetLockFilePath)</NuGetLockFilePath>
         <RestoreLockedMode>$(RestoreLockedMode)</RestoreLockedMode>
+        <IgnoreLockFileForRestore>$(IgnoreLockFileForRestore)</IgnoreLockFileForRestore>
       </_RestoreGraphEntry>
     </ItemGroup>
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -309,7 +309,8 @@ namespace NuGet.Commands
                         // clear out the existing lock file so that we don't over-write the same file
                         packagesLockFile = null;
                     }
-                    else if (PackagesLockFileUtilities.IsNuGetLockFileSupported(_request.Project))
+                    else if (PackagesLockFileUtilities.IsNuGetLockFileSupported(_request.Project) &&
+                        !_request.Project.RestoreMetadata.RestoreLockProperties.IgnoreLockFileForRestore)
                     {
                         // generate packages.lock.json file if enabled
                         packagesLockFile = new PackagesLockFileBuilder()
@@ -459,7 +460,8 @@ namespace NuGet.Commands
             }
 
             // read packages.lock.json file if exists and RestoreForceEvaluate flag is not set to true
-            if (!_request.RestoreForceEvaluate && File.Exists(packagesLockFilePath))
+            if (!_request.RestoreForceEvaluate && File.Exists(packagesLockFilePath) &&
+                _request.Project.RestoreMetadata?.RestoreLockProperties.IgnoreLockFileForRestore != true )
             {
                 lockFileTelemetry.StartIntervalMeasure();
                 packagesLockFile = PackagesLockFileFormat.Read(packagesLockFilePath, _logger);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -835,7 +835,8 @@ namespace NuGet.Commands
             return new RestoreLockProperties(
                 specItem.GetProperty("RestorePackagesWithLockFile"),
                 specItem.GetProperty("NuGetLockFilePath"),
-                IsPropertyTrue(specItem, "RestoreLockedMode"));
+                IsPropertyTrue(specItem, "RestoreLockedMode"),
+                IsPropertyTrue(specItem, "IgnoreLockFileForRestore"));
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
@@ -37,5 +37,6 @@ namespace NuGet.ProjectManagement
         public const string RestorePackagesWithLockFile = nameof(RestorePackagesWithLockFile);
         public const string NuGetLockFilePath = nameof(NuGetLockFilePath);
         public const string RestoreLockedMode = nameof(RestoreLockedMode);
+        public const string IgnoreLockFileForRestore = nameof(IgnoreLockFileForRestore);
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -337,7 +337,8 @@ namespace NuGet.ProjectModel
                 msbuildMetadata.RestoreLockProperties = new RestoreLockProperties(
                     restoreLockProperties.GetValue<string>("restorePackagesWithLockFile"),
                     restoreLockProperties.GetValue<string>("nuGetLockFilePath"),
-                    GetBoolOrFalse(restoreLockProperties, "restoreLockedMode", packageSpec.FilePath));
+                    GetBoolOrFalse(restoreLockProperties, "restoreLockedMode", packageSpec.FilePath),
+                    GetBoolOrFalse(restoreLockProperties, "ignoreLockFileForRestore", packageSpec.FilePath));
             }
 
             return msbuildMetadata;

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -176,13 +176,15 @@ namespace NuGet.ProjectModel
             if (msbuildMetadata.RestoreLockProperties != null &&
                 (!string.IsNullOrEmpty(msbuildMetadata.RestoreLockProperties.RestorePackagesWithLockFile) ||
                  !string.IsNullOrEmpty(msbuildMetadata.RestoreLockProperties.NuGetLockFilePath) ||
-                 msbuildMetadata.RestoreLockProperties.RestoreLockedMode))
+                 msbuildMetadata.RestoreLockProperties.RestoreLockedMode ||
+                 msbuildMetadata.RestoreLockProperties.IgnoreLockFileForRestore))
             {
                 writer.WriteObjectStart("restoreLockProperties");
 
                 SetValue(writer, "restorePackagesWithLockFile", msbuildMetadata.RestoreLockProperties.RestorePackagesWithLockFile);
                 SetValue(writer, "nuGetLockFilePath", msbuildMetadata.RestoreLockProperties.NuGetLockFilePath);
                 SetValueIfTrue(writer, "restoreLockedMode", msbuildMetadata.RestoreLockProperties.RestoreLockedMode);
+                SetValueIfTrue(writer, "ignoreLockFileForRestore", msbuildMetadata.RestoreLockProperties.IgnoreLockFileForRestore);
 
                 writer.WriteObjectEnd();
             }

--- a/src/NuGet.Core/NuGet.ProjectModel/RestoreLockProperties.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/RestoreLockProperties.cs
@@ -24,6 +24,11 @@ namespace NuGet.ProjectModel
         /// </summary>
         public bool RestoreLockedMode { get; }
 
+        /// <summary>
+        /// True, if lock file should be ignored for restore.
+        /// </summary>
+        public bool IgnoreLockFileForRestore { get; }
+
         public RestoreLockProperties()
         {
         }
@@ -31,11 +36,13 @@ namespace NuGet.ProjectModel
         public RestoreLockProperties(
             string restorePackagesWithLockFile,
             string nuGetLockFilePath,
-            bool restoreLockedMode)
+            bool restoreLockedMode,
+            bool ignoreLockFileForRestore)
         {
             RestorePackagesWithLockFile = restorePackagesWithLockFile;
             NuGetLockFilePath = nuGetLockFilePath;
             RestoreLockedMode = restoreLockedMode;
+            IgnoreLockFileForRestore = ignoreLockFileForRestore;
         }
 
         public override int GetHashCode()
@@ -45,6 +52,7 @@ namespace NuGet.ProjectModel
             hashCode.AddObject(RestorePackagesWithLockFile);
             hashCode.AddObject(NuGetLockFilePath);
             hashCode.AddObject(RestoreLockedMode);
+            hashCode.AddObject(IgnoreLockFileForRestore);
 
             return hashCode.CombinedHash;
         }
@@ -68,12 +76,13 @@ namespace NuGet.ProjectModel
 
             return StringComparer.OrdinalIgnoreCase.Equals(RestorePackagesWithLockFile, other.RestorePackagesWithLockFile) &&
                 PathUtility.GetStringComparerBasedOnOS().Equals(NuGetLockFilePath, other.NuGetLockFilePath) &&
-                RestoreLockedMode == other.RestoreLockedMode;
+                RestoreLockedMode == other.RestoreLockedMode &&
+                IgnoreLockFileForRestore == other.IgnoreLockFileForRestore;
         }
 
         public RestoreLockProperties Clone()
         {
-            return new RestoreLockProperties(RestorePackagesWithLockFile, NuGetLockFilePath, RestoreLockedMode);
+            return new RestoreLockProperties(RestorePackagesWithLockFile, NuGetLockFilePath, RestoreLockedMode, IgnoreLockFileForRestore);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
@@ -24,6 +24,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         private readonly string _nuGetLockFilePath;
         private readonly bool _restoreLockedMode;
 
+        public bool IgnoreLockFileForRestore;
+
         public TestVSProjectAdapter(
             string fullProjectPath,
             ProjectNames projectNames,
@@ -213,7 +215,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
         public Task<bool> ShouldLockFileBeIgnoredAsync()
         {
-            return Task.FromResult(false);
+            return Task.FromResult(IgnoreLockFileForRestore);
         }
 
         public Task<bool> IsRestoreLockedAsync()

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
@@ -211,6 +211,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             return Task.FromResult(NuGetFramework.Parse(_targetFrameworkString));
         }
 
+        public Task<bool> ShouldLockFileBeIgnoredAsync()
+        {
+            return Task.FromResult(false);
+        }
+
         public Task<bool> IsRestoreLockedAsync()
         {
             return Task.FromResult(_restoreLockedMode);

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -990,6 +990,66 @@ namespace NuGet.ProjectModel.Test
 
             Assert.NotNull(metadata);
             Assert.NotNull(warningProperties);
+        }
+
+        [Fact]
+        public void PackageSpecReader_ReadsRestoreMetadataWithLockFileProperties()
+        {
+            // Arrange
+            var json = @"{  
+                ""restore"": {
+                    ""projectUniqueName"": ""projectUniqueName"",
+                    ""projectName"": ""projectName"",
+                    ""projectPath"": ""projectPath"",
+                    ""projectJsonPath"": ""projectJsonPath"",
+                    ""packagesPath"": ""packagesPath"",
+                    ""outputPath"": ""outputPath"",
+                    ""projectStyle"": ""PackageReference"",
+                    ""crossTargeting"": true,
+                    ""configFilePaths"": [
+                      ""b"",
+                      ""a"",
+                      ""c""
+                    ],
+                    ""fallbackFolders"": [
+                      ""b"",
+                      ""a"",
+                      ""c""
+                    ],
+                    ""originalTargetFrameworks"": [
+                      ""b"",
+                      ""a"",
+                      ""c""
+                    ],
+                    ""sources"": {
+                      ""source"": {}
+                    },
+                    ""frameworks"": {
+                      ""frameworkidentifier123-frameworkprofile"": {
+                        ""projectReferences"": {}
+                      }
+                    },
+                    ""restoreLockProperties"": {
+                        ""restorePackagesWithLockFile"" : ""true"",
+                        ""nuGetLockFilePath"" : ""nuGetLockFilePath"",
+                        ""restoreLockedMode"" : true,
+                        ""ignoreLockFileForRestore"" : true
+                    }
+                  }
+                }";
+
+            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+
+            // Assert
+            var metadata = actual.RestoreMetadata;
+            var lockProperties = actual.RestoreMetadata.RestoreLockProperties;
+
+            Assert.NotNull(metadata);
+            Assert.NotNull(lockProperties);
+            Assert.Equal("true", lockProperties.RestorePackagesWithLockFile);
+            Assert.Equal("nuGetLockFilePath", lockProperties.NuGetLockFilePath);
+            Assert.True(lockProperties.RestoreLockedMode);
+            Assert.True(lockProperties.IgnoreLockFileForRestore);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -445,6 +445,27 @@ namespace NuGet.ProjectModel.Test
             VerifyPackageSpecWrite(json, expectedJson);
         }
 
+        [Fact]
+        public void Write_SerializesMembersAsJsonWithRestoreLockProperties()
+        {
+            // Arrange && Act
+            var expectedRestoreLockPropertiesJson = @"{
+  ""restorePackagesWithLockFile"": ""true"",
+  ""nuGetLockFilePath"": ""nuGetLockFilePath"",
+  ""restoreLockedMode"": true,
+  ""ignoreLockFileForRestore"": true
+}";
+
+            var restoreLockProperties = new RestoreLockProperties("true", "nuGetLockFilePath", true, true);
+            var packageSpec = CreatePackageSpec(withRestoreSettings: true, restoreLockProperties: restoreLockProperties);
+            var actualJson = GetJsonObject(packageSpec);
+            var actualWarningPropertiesJson = actualJson["restore"]["restoreLockProperties"].ToString();
+
+            // Assert
+            Assert.NotNull(actualWarningPropertiesJson);
+            Assert.Equal(expectedRestoreLockPropertiesJson, actualWarningPropertiesJson);
+        }
+
         private static string GetJsonString(PackageSpec packageSpec)
         {
             var writer = new JsonObjectWriter();
@@ -463,7 +484,7 @@ namespace NuGet.ProjectModel.Test
             return writer.GetJObject();
         }
 
-        private static PackageSpec CreatePackageSpec(bool withRestoreSettings, WarningProperties warningProperties = null)
+        private static PackageSpec CreatePackageSpec(bool withRestoreSettings, WarningProperties warningProperties = null, RestoreLockProperties restoreLockProperties = null)
         {
             var unsortedArray = new[] { "b", "a", "c" };
             var unsortedReadOnlyList = new List<string>(unsortedArray).AsReadOnly();
@@ -559,6 +580,11 @@ namespace NuGet.ProjectModel.Test
             if (warningProperties != null)
             {
                 packageSpec.RestoreMetadata.ProjectWideWarningProperties = warningProperties;
+            }
+
+            if (restoreLockProperties != null)
+            {
+                packageSpec.RestoreMetadata.RestoreLockProperties = restoreLockProperties;
             }
 
             packageSpec.PackInclude.Add("b", "d");

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
@@ -103,9 +103,9 @@ namespace NuGet.ProjectModel.Test
             var metadata3 = metadata1.Clone();
             var metadata4 = metadata1.Clone();
 
-            metadata2.RestoreLockProperties = new RestoreLockProperties("false", null, false);
-            metadata3.RestoreLockProperties = new RestoreLockProperties("true", "tempPath", false);
-            metadata4.RestoreLockProperties = new RestoreLockProperties("true", null, true);
+            metadata2.RestoreLockProperties = new RestoreLockProperties("false", null, false, false);
+            metadata3.RestoreLockProperties = new RestoreLockProperties("true", "tempPath", false, false);
+            metadata4.RestoreLockProperties = new RestoreLockProperties("true", null, true, true);
 
             // Act & Assert
             metadata1.Equals(metadata2).Should().BeFalse();
@@ -135,7 +135,7 @@ namespace NuGet.ProjectModel.Test
             var noWarn = new HashSet<NuGetLogCode>() { NuGetLogCode.NU1000, NuGetLogCode.NU1500 };
             var warningsAsErrors = new HashSet<NuGetLogCode>() { NuGetLogCode.NU1001, NuGetLogCode.NU1501 };
             var warningProperties = new WarningProperties(allWarningsAsErrors: allWarningsAsErrors, warningsAsErrors: warningsAsErrors, noWarn: noWarn);
-            var restoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile: "true", nuGetLockFilePath: null, restoreLockedMode: false);
+            var restoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile: "true", nuGetLockFilePath: null, restoreLockedMode: false, ignoreLockFileForRestore: false);
             var originalProjectRestoreMetadata = new ProjectRestoreMetadata
             {
                 ProjectStyle = ProjectStyle.PackageReference,


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7599
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: If lock file feature is enabled, and msbuild SDK resolver calls into restore api to restore SDK package, it will also try to use lock file but since SDK packages are not part of lock file (since they are not part of actual restore) so the SHA validation as part of lock file feature fails which fails the SDK resolver which ultimately fails the restore. But this will only happens when first time SDK package is not on disk, all subsequent times it will always pass because SHA validation only happens first time when we extract the package on disk.

This PR is to add a new option with restore metadata called `IgnoreLockFileOnRestore` from our existing [design spec](https://github.com/NuGet/Home/wiki/Enable-repeatable-package-restore-using-lock-file) which will allow a specific restore to skip reading/writing lock file even though the lock file feature is enabled. So the msbuild SDK resolver task will set this option while calling into restore api so that NuGet doesn't tries to validate SHA for SDK packages. In dev16, when we have `NuGet download only APIs` then we can think of switching msbuild SDK resolver task to those apis which will be more appropriate solution.

## Testing/Validation
Tests Added: Yes
Reason for not adding tests:  
Validation done:  
