### PR TITLE
Make xplat always return false for CanVerifySignedPackages in PackageExtractor.VerifyPackageSignatureAsync

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -381,7 +381,11 @@ namespace NuGet.Packaging
 
         public override bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings)
         {
+#if IS_DESKTOP
             return true;
+#else
+            return false;
+#endif
         }
 
         protected void ThrowIfZipReadStreamIsNull()

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -1157,11 +1157,12 @@ namespace NuGet.Protocol.Plugins
 
         public override bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings)
         {
+#if IS_DESKTOP
             if (!verifierSettings.AllowUnsigned)
             {
                 throw new SignatureException(NuGetLogCode.NU3041, Strings.Plugin_DownloadNotSupportedSinceUnsignedNotAllowed);
             }
-
+#endif
             return false;
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -969,6 +969,7 @@ namespace NuGet.Commands.Test
             }
         }
 
+#if IS_DESKTOP
         [Fact]
         public async Task RestoreCommand_InvalidSignedPackageAsync()
         {
@@ -1108,6 +1109,7 @@ namespace NuGet.Commands.Test
                 Assert.True(result.Success);
             }
         }
+#endif
 
         [Fact]
         public async Task RestoreCommand_PathInPackageLibraryAsync()


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7574

## Fix
PackageExtractor.VerifyPackageSignatureAsync calls CanVerifySignedPackages in the given package reader to make sure it is supported to verify the signature of the package. This PR disables signature verification for every XPLAT scenario.

cc. @rrelyea @rido-min 