### PR TITLE
Fix xplat build from source: don't assume ILMerge was used

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -164,6 +164,9 @@
       <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)**\NuGet*.resources.dll">
         <PackagePath>CoreCLR/</PackagePath>
       </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)**\*.dll" Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">
+        <PackagePath>CoreCLR/</PackagePath>
+      </TfmSpecificPackageFile>
     </ItemGroup>    
   </Target>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -141,7 +141,7 @@
   <Target Name="CreatePackNupkg">
     <PropertyGroup>
       <!-- Build from source can't use ILMerge. -->
-      <ILMergeSubpath Condition="'$(DotNetBuildFromSource)' != 'true'">ilmerge\</ILMergeSubpath>
+      <ILMergeSubpath Condition="'$(IsBuildOnlyXPLATProjects)' != 'true'">ilmerge\</ILMergeSubpath>
     </PropertyGroup>
     <ItemGroup Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)' AND '$(IsBuildOnlyXPLATProjects)' != 'true'">
       <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)NuGet.Build.Tasks.Pack.dll">

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -139,25 +139,29 @@
   </Target>
 
   <Target Name="CreatePackNupkg">
+    <PropertyGroup>
+      <!-- Build from source can't use ILMerge. -->
+      <ILMergeSubpath Condition="'$(DotNetBuildFromSource)' != 'true'">ilmerge\</ILMergeSubpath>
+    </PropertyGroup>
     <ItemGroup Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)' AND '$(IsBuildOnlyXPLATProjects)' != 'true'">
-      <TfmSpecificPackageFile Include="$(OutputPath)\ilmerge\NuGet.Build.Tasks.Pack.dll">
+      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)NuGet.Build.Tasks.Pack.dll">
         <PackagePath>Desktop/</PackagePath>
       </TfmSpecificPackageFile>
-      <TfmSpecificPackageFile Include="$(OutputPath)\ilmerge\NuGet.Build.Tasks.Pack.xml">
+      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)NuGet.Build.Tasks.Pack.xml">
         <PackagePath>Desktop/</PackagePath>
       </TfmSpecificPackageFile>
-      <TfmSpecificPackageFile Include="$(OutputPath)\ilmerge\**\NuGet*.resources.dll">
+      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)**\NuGet*.resources.dll">
         <PackagePath>Desktop/</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == '$(NetStandardVersion)'">
-      <TfmSpecificPackageFile Include="$(OutputPath)\ilmerge\NuGet.Build.Tasks.Pack.dll">
+      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)NuGet.Build.Tasks.Pack.dll">
         <PackagePath>CoreCLR/</PackagePath>
       </TfmSpecificPackageFile>
-      <TfmSpecificPackageFile Include="$(OutputPath)\ilmerge\NuGet.Build.Tasks.Pack.xml">
+      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)NuGet.Build.Tasks.Pack.xml">
         <PackagePath>CoreCLR/</PackagePath>
       </TfmSpecificPackageFile>
-      <TfmSpecificPackageFile Include="$(OutputPath)\ilmerge\**\NuGet*.resources.dll">
+      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)**\NuGet*.resources.dll">
         <PackagePath>CoreCLR/</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>    


### PR DESCRIPTION
## Bug
Fixes: N/A
Regression: Yes
If Regression then when did it last work: 25225bb1b55bc17e52cb6fa02335d559c12ccd18
If Regression then how are we preventing it in future: Not feasible yet, but source-build CI leg described in https://github.com/dotnet/source-build/issues/379 will probably do it.

The issue is that PR https://github.com/NuGet/NuGet.Client/pull/2405 didn't carry over the right xplat build behavior. Build from source can't use ILMerge, but the paths in `NuGet.Build.Tasks.Pack.csproj` assume the output is ILMerged. When xplat pack happens, the build fails.

Encountered when I tried to update the source-build nuget-client submodule to the commit used in the .NET Core 3.0 preview build.

## Fix
Only use ILMerge paths when `DotNetBuildFromSource != true`. It would also be fine to use `IsBuildOnlyXPLATProjects`. `DotNetBuildFromSource` seems more precise (in theory someone could build only xplat projects but still use ILMerge?), but let me know.

This fix is going in a source-build patch to make this repo work at the specific commit used for .NET Core 3.0 preview. But as usual, removing patches is a priority for us. @rrelyea as the NuGet source-build champion can you make sure this PR gets traction?

## Testing/Validation
Tests Added: No
Reason for not adding tests: Don't know if this is testable.
Validation done: Ran in source-build context. I haven't checked non-source-build behavior.