### PR TITLE
Fix printing stack on signature exception

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureException.cs
@@ -52,10 +52,5 @@ namespace NuGet.Packaging.Signing
         {
             PackageIdentity = package;
         }
-
-        public override string ToString()
-        {
-            return AsLogMessage().FormatWithCode();
-        }
     }
 }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/6455

## Fix
`SignatureException.cs ` had a `ToString()` method that was not being used anywhere and replicated the behavior from `AsLogMessage()`.  `ExceptionUtilities.LogException(…)` relies on `Exception.ToString()` to print the stack of an exception, therefore instead of displaying the error message and the stack, the stack was being printed twice.