### PR TITLE
Add hack to build VS15 experimental instance

### DIFF
--- a/build/common.targets
+++ b/build/common.targets
@@ -54,6 +54,15 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
 
+  <!-- These are needed because currently a VSIX project cannot reference a net core project that multi targets.
+  This is a hack for building VS15 VSIX. It's because all these targets are available in the inner build, while the VSIX project
+  is non netcore, and isn't aware of inner/outer builds. -->
+  <Target Name="BuiltProjectOutputGroupDependencies" DependsOnTargets="PrintVSVersionAndNetcore" Condition="false" />
+  <Target Name="BuiltProjectOutputGroup" DependsOnTargets="PrintVSVersionAndNetcore" Condition="false" />
+  <Target Name="GetCopyToOutputDirectoryItems" DependsOnTargets="PrintVSVersionAndNetcore" Condition="false" />
+  <Target Name="SatelliteDllsProjectOutputGroup" DependsOnTargets="PrintVSVersionAndNetcore" Condition="false" />
+  <Target Name="DebugSymbolsProjectOutputGroup" DependsOnTargets="PrintVSVersionAndNetcore" Condition="false" />
+
   <!--
     ============================================================
     TestProject


### PR DESCRIPTION
## Bug
In https://github.com/NuGet/NuGet.Client/commit/1d25f30c3b5978bd3ce04ac107dd7d932fd7aa2f#diff-e3360b39dbc9487df71573c870a8efccL57, a hack for making experimental instance buildable in VS14 was removed, we were not aware that this hack was also helping us build experimental instances in VS15.

If we remove this we get an error when trying to build our VSIX inside VS and run an experimental instance (https://github.com/dotnet/sdk/issues/433)... This PR just adds the hack back to be able to use VS15 with experimental instance until we understand more about the reasons we need this for.
