### PR TITLE
Snupkgs can only have 1 package type

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -790,6 +790,7 @@ namespace NuGet.Commands
                 symbolsBuilder.HasSnapshotVersion = mainPackageBuilder.HasSnapshotVersion;
                 if(_packArgs.SymbolPackageFormat == SymbolPackageFormat.Snupkg)
                 {
+                    symbolsBuilder.PackageTypes.Clear();
                     symbolsBuilder.PackageTypes.Add(PackageType.SymbolsPackage);
                 }
 
@@ -926,9 +927,9 @@ namespace NuGet.Commands
         private void BuildSymbolsPackage(string path)
         {
             var symbolsBuilder = CreatePackageBuilderFromNuspec(path);
-            if(_packArgs.SymbolPackageFormat == SymbolPackageFormat.Snupkg &&
-                !symbolsBuilder.PackageTypes.Contains(PackageType.SymbolsPackage))
+            if(_packArgs.SymbolPackageFormat == SymbolPackageFormat.Snupkg))
             {
+                symbolsBuilder.PackageTypes.Clear();
                 symbolsBuilder.PackageTypes.Add(PackageType.SymbolsPackage);
             }
 

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -788,7 +788,7 @@ namespace NuGet.Commands
                 var symbolsBuilder = factory.CreateBuilder(_packArgs.BasePath, argsVersion, _packArgs.Suffix, buildIfNeeded: false, builder: mainPackageBuilder);
                 symbolsBuilder.Version = mainPackageBuilder.Version;
                 symbolsBuilder.HasSnapshotVersion = mainPackageBuilder.HasSnapshotVersion;
-                if(_packArgs.SymbolPackageFormat == SymbolPackageFormat.Snupkg)
+                if(_packArgs.SymbolPackageFormat == SymbolPackageFormat.Snupkg) // Snupkgs can only have 1 PackageType. 
                 {
                     symbolsBuilder.PackageTypes.Clear();
                     symbolsBuilder.PackageTypes.Add(PackageType.SymbolsPackage);
@@ -927,7 +927,7 @@ namespace NuGet.Commands
         private void BuildSymbolsPackage(string path)
         {
             var symbolsBuilder = CreatePackageBuilderFromNuspec(path);
-            if(_packArgs.SymbolPackageFormat == SymbolPackageFormat.Snupkg))
+            if(_packArgs.SymbolPackageFormat == SymbolPackageFormat.Snupkg) // Snupkgs can only have 1 PackageType. 
             {
                 symbolsBuilder.PackageTypes.Clear();
                 symbolsBuilder.PackageTypes.Add(PackageType.SymbolsPackage);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -485,6 +485,99 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        public void PackCommand_SymbolPackageWithNuspecFileAndPackageType()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var workingDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "lib", "uap10.0"),
+                    "packageA.dll",
+                    string.Empty);
+
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "lib", "uap10.0"),
+                    "packageA.pdb",
+                    string.Empty);
+
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "contentFiles", "any", "any"),
+                    "image.jpg",
+                    "");
+
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "contentFiles", "cs", "net45"),
+                    "code.cs",
+                    "");
+
+                Util.CreateFile(
+                    workingDirectory,
+                    "packageA.nuspec",
+@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
+  <metadata>
+    <id>packageA</id>
+    <version>1.0.0</version>
+    <title>packageA</title>
+    <authors>test</authors>
+    <owners>test</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Description</description>
+    <copyright>Copyright ©  2013</copyright>
+    <packageTypes>
+        <packageType name=""Dependency""/>
+    </packageTypes>
+  </metadata>
+</package>");
+
+                // Act
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingDirectory,
+                    "pack packageA.nuspec -symbols -SymbolPackageFormat snupkg",
+                    waitForExit: true);
+                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+
+                // Assert
+                var path = Path.Combine(workingDirectory, "packageA.1.0.0.nupkg");
+                var symbolPath = Path.Combine(workingDirectory, "packageA.1.0.0.snupkg");
+
+                using (var package = new PackageArchiveReader(path))
+                using (var symbolPackage = new PackageArchiveReader(symbolPath))
+                {
+                    var files = package.GetFiles()
+                        .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package") && !t.EndsWith("nuspec"))
+                        .ToArray();
+                    var symbolFiles = symbolPackage.GetFiles()
+                        .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package") && !t.EndsWith("nuspec"))
+                        .ToArray();
+                    Array.Sort(files);
+                    Array.Sort(symbolFiles);
+
+                    Assert.Equal(package.GetPackageTypes().Count, 1);
+                    Assert.Equal(package.GetPackageTypes()[0], NuGet.Packaging.Core.PackageType.Dependency);
+                    Assert.Equal(symbolPackage.GetPackageTypes().Count, 1);
+                    Assert.Equal(symbolPackage.GetPackageTypes()[0], NuGet.Packaging.Core.PackageType.SymbolsPackage);
+                    Assert.Equal(
+                        new string[]
+                        {
+                        "contentFiles/any/any/image.jpg",
+                        "contentFiles/cs/net45/code.cs",
+                        Path.Combine("lib", "uap10.0", "packageA.dll").Replace('\\', '/'),
+                        },
+                        files);
+                    Assert.Equal(
+                        new string[]
+                        {
+                        Path.Combine("lib", "uap10.0", "packageA.pdb").Replace('\\','/'),
+                        },
+                        symbolFiles);
+                }
+            }
+        }
+
+        [Fact]
         public void PackCommand_ContentV2PackageFromNuspec()
         {
             var nugetexe = Util.GetNuGetExePath();


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7632  
Regression: Yes/No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
This was a bug where the PackageTypes were not being cleared for the snupkgs. 

The snupkgs can/should only contain 1 package type, which is not combinable with other package types (similar to DotnetTool). 

## Testing/Validation
Tests Added: Yes  
Reason for not adding tests:  
Validation done:  
