### PR TITLE
implement V2 search metadata versions

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -122,9 +123,7 @@ namespace NuGet.Protocol
 
         public NuGetVersion Version { get; private set; }
 
-        public Lazy<VersionInfo[]> OnDemandParsedVersions { get; private set; }
-
-        public Task<IEnumerable<VersionInfo>> GetVersionsAsync() => Task.FromResult<IEnumerable<VersionInfo>>(OnDemandParsedVersions.Value);
+        public Task<IEnumerable<VersionInfo>> GetVersionsAsync() => Task.FromResult(Enumerable.Empty<VersionInfo>());
 
         private static Uri GetUriSafe(string url)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
@@ -14,6 +14,33 @@ namespace NuGet.Protocol
 {
     public class PackageSearchMetadataV2Feed : IPackageSearchMetadata
     {
+        public PackageSearchMetadataV2Feed(V2FeedPackageInfo package)
+        {
+            Authors = string.Join(", ", package.Authors);
+            DependencySets = package.DependencySets;
+            Description = package.Description;
+            IconUrl = GetUriSafe(package.IconUrl);
+            LicenseUrl = GetUriSafe(package.LicenseUrl);
+            Owners = string.Join(", ", package.Owners);
+            PackageId = package.Id;
+            ProjectUrl = GetUriSafe(package.ProjectUrl);
+            Created = package.Created;
+            LastEdited = package.LastEdited;
+            Published = package.Published;
+            ReportAbuseUrl = GetUriSafe(package.ReportAbuseUrl);
+            RequireLicenseAcceptance = package.RequireLicenseAcceptance;
+            Summary = package.Summary;
+            Tags = package.Tags;
+            Title = package.Title;
+            Version = package.Version;
+            IsListed = package.IsListed;
+
+            long count;
+            if (long.TryParse(package.DownloadCount, out count))
+            {
+                DownloadCount = count;
+            }
+        }
         public PackageSearchMetadataV2Feed(V2FeedPackageInfo package, MetadataReferenceCache metadataCache)
         {
             Authors = metadataCache.GetString(string.Join(", ", package.Authors));

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
@@ -14,33 +14,6 @@ namespace NuGet.Protocol
 {
     public class PackageSearchMetadataV2Feed : IPackageSearchMetadata
     {
-        public PackageSearchMetadataV2Feed(V2FeedPackageInfo package)
-        {
-            Authors = string.Join(", ", package.Authors);
-            DependencySets = package.DependencySets;
-            Description = package.Description;
-            IconUrl = GetUriSafe(package.IconUrl);
-            LicenseUrl = GetUriSafe(package.LicenseUrl);
-            Owners = string.Join(", ", package.Owners);
-            PackageId = package.Id;
-            ProjectUrl = GetUriSafe(package.ProjectUrl);
-            Created = package.Created;
-            LastEdited = package.LastEdited;
-            Published = package.Published;
-            ReportAbuseUrl = GetUriSafe(package.ReportAbuseUrl);
-            RequireLicenseAcceptance = package.RequireLicenseAcceptance;
-            Summary = package.Summary;
-            Tags = package.Tags;
-            Title = package.Title;
-            Version = package.Version;
-            IsListed = package.IsListed;
-
-            long count;
-            if (long.TryParse(package.DownloadCount, out count))
-            {
-                DownloadCount = count;
-            }
-        }
         public PackageSearchMetadataV2Feed(V2FeedPackageInfo package, MetadataReferenceCache metadataCache)
         {
             Authors = metadataCache.GetString(string.Join(", ", package.Authors));


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7523
Regression: No  

## Fix
Details:
`PackageSearchMetadataV2Feed.GetVersionsAsync` throwed a NRE because `OnDemandParsedVersions` was always `null`.
The first commit fixes this by just returning an empty enumerable as done in other `IPackageSearchMetadata` implementations.

The second commit implements the `PackageSearchMetadataV2Feed.GetVersionsAsync` by using the `V2FeedUtilities.CreatePackageSearchResult`. Which is now the only place where  `PackageSearchMetadataV2Feed` objects are initialized.

## Testing/Validation
Tests Added: Yes