### PR TITLE
Moving MSBuild SDK resolver to use temp project name to restore SDK package

### DIFF
--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
@@ -1,18 +1,18 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Build.Framework;
-using NuGet.Commands;
-using NuGet.Configuration;
-using NuGet.Credentials;
-using NuGet.Packaging;
-using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using NuGet.Commands;
+using NuGet.Configuration;
+using NuGet.Credentials;
+using NuGet.Packaging;
+using NuGet.Versioning;
 
 namespace Microsoft.Build.NuGetSdkResolver
 {
@@ -134,7 +134,6 @@ namespace Microsoft.Build.NuGetSdkResolver
                         // This must be run in its own task because legacy project system evaluates projects on the UI thread which can cause RunWithoutCommit() to deadlock
                         // https://developercommunity.visualstudio.com/content/problem/311379/solution-load-never-completes-when-project-contain.html
                         var restoreTask = Task.Run(() => RestoreRunnerEx.RunWithoutCommit(
-                            context.ProjectFilePath,
                             sdk.Name,
                             parsedSdkVersion.ToFullString(),
                             settings,


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7599
Regression: Yes/No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: MSBuild runs a SDK resolver to resolve SDK packages as part of build evaluation right before restore. This currently uses the associated project file to create `PackageSpec` instance to run restore just to download SDK package without committing anything. But that creates an issue when associated project has `packages.lock.json` feature enabled as described in the bug. 

This PR fixes it by moving msbuild SDK resolver to temp project name instead so that it doesn't consume anything from associated project and just able to download SDK package if needed.

## Testing/Validation
Tests Added: Yes/No  
Reason for not adding tests:  
Validation done:  
