### PR TITLE
Use a static verison of nuget.build.tasks.pack, use licenseexpression

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -18,5 +18,6 @@
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" />
   <package id="NuGetValidator" version="2.0.1" targetFramework="net461" />
   <package id="XunitXml.TestLogger" version="2.0.0" />
+  <package id="NuGet.Build.Tasks.Pack" version="4.9.2" />
   <package id="Microsoft.DotNet.Build.Tasks.Feed" version="2.1.0-prerelease-02419-02" />   <!-- For the .NET Core orchestrated build.-->
 </packages>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -31,6 +31,7 @@
     <XunitConsoleExePath>$(SolutionPackagesFolder)xunit.runner.console.2.3.1\tools\net452\xunit.console.x86.exe</XunitConsoleExePath>
     <ILMergeExePath>$(SolutionPackagesFolder)ILMerge.2.14.1208\tools\ILMerge.exe</ILMergeExePath>
     <XunitXmlLoggerDirectory>$(SolutionPackagesFolder)XunitXml.TestLogger.2.0.0\build\_common</XunitXmlLoggerDirectory>
+    <NuGetBuildTasksPackTargets>$(SolutionPackagesFolder)NuGet.Build.Tasks.Pack.4.9.2\build\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
     <EnlistmentRoot>$(RepositoryRootDirectory)</EnlistmentRoot>
     <EnlistmentRootSrc>$(RepositoryRootDirectory)src</EnlistmentRootSrc>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(RepositoryRootDirectory)</SolutionDir>

--- a/build/common.targets
+++ b/build/common.targets
@@ -37,6 +37,10 @@
     <DocumentationFile Condition=" '$(DocumentationFile)' == '' AND '$(GenerateDocumentationFile)' == 'true' AND '$(IsNetCoreProject)' != 'true' ">$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
+  <ImportGroup Condition=" '$(PackProject)' == 'true' ">
+      <Import Project="$(NuGetBuildTasksPackTargets)" />
+  </ImportGroup>
+
   <!-- Test Projects -->
   <ImportGroup Condition=" '$(TestProject)' == 'true' ">
     <Import Project="test.targets" />

--- a/build/config.props
+++ b/build/config.props
@@ -42,7 +42,7 @@
   <PropertyGroup>
     <Authors>Microsoft</Authors>
     <PackageProjectUrl>https://aka.ms/nugetprj</PackageProjectUrl>
-    <PackageLicenseUrl>https://aka.ms/nugetlicense</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/NuGet/NuGet.Client</RepositoryUrl>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -536,9 +536,6 @@
       <SubType>Designer</SubType>
     </Content>
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="NuGet.Build.Tasks.Pack" Version="4.8.0" PrivateAssets="all" />
-  </ItemGroup>
   <PropertyGroup>
     <IncludeContentInPack>false</IncludeContentInPack>
   </PropertyGroup>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -296,7 +296,6 @@
     <PackageReference Include="VSLangProj110" Version="11.0.61030" />
     <PackageReference Include="VSLangProj2" Version="7.0.5000" />
     <PackageReference Include="VSLangProj157" Version="15.7.0" />
-    <PackageReference Include="NuGet.Build.Tasks.Pack" Version="4.8.0" PrivateAssets="all" />
   </ItemGroup>
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="$(BuildCommonDirectory)fixinterop.targets" />

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/NuGet.SolutionRestoreManager.Interop.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/NuGet.SolutionRestoreManager.Interop.csproj
@@ -9,12 +9,9 @@
     <PackProject>true</PackProject>
     <IncludeInVsix>true</IncludeInVsix>
     <authors>Microsoft</authors>
-    <PackageLicenseUrl>https://aka.ms/nugetlicense</PackageLicenseUrl>
-    <PackageProjectUrl>https://aka.ms/nugetprj</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <AssemblyDescription>APIs for invoking NuGet Restore Manager in Visual Studio.</AssemblyDescription>
     <Description>APIs for invoking NuGet Restore Manager in Visual Studio.</Description>
-    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
@@ -17,10 +17,7 @@
     <Guid>228F7591-2777-47D7-B81D-FEADFC71CEB5</Guid>
     <ComVisible>false</ComVisible>
     <authors>Microsoft</authors>
-    <PackageLicenseUrl>https://aka.ms/nugetlicense</PackageLicenseUrl>
-    <PackageProjectUrl>https://aka.ms/nugetprj</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Bug
Fixes: First part of https://github.com/NuGet/Home/issues/7629. 
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
Use a repeatable version of the pack target, don't depend on the machine dotnet sdk for packing. 
Use LicenseExpression instead of license url. 

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  
Validation done:  Verified with a script that the packages generated are the same. 
I will add a tool that does some validation of the packages after the fact. 

fyi @karann-msft @anangaur @rrelyea 