### PR TITLE
Improve SettingsBase API to be able to subclass it outside NuGet.Configuration

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/AddItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/AddItem.cs
@@ -117,7 +117,7 @@ namespace NuGet.Configuration
 
         public override int GetHashCode() => Key.GetHashCode();
 
-        internal override SettingBase Clone()
+        public override SettingBase Clone()
         {
             var newItem = new AddItem(Key, Value, AdditionalAttributes);
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/AuthorItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/AuthorItem.cs
@@ -24,7 +24,7 @@ namespace NuGet.Configuration
         {
         }
 
-        internal override SettingBase Clone()
+        public override SettingBase Clone()
         {
             var newItem = new AuthorItem(Name, Certificates.Select(c => c.Clone() as CertificateItem).ToArray());
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/CertificateItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/CertificateItem.cs
@@ -90,7 +90,7 @@ namespace NuGet.Configuration
             UpdateAttribute(ConfigurationConstants.AllowUntrustedRoot, AllowUntrustedRoot.ToString().ToLower());
         }
 
-        internal override SettingBase Clone()
+        public override SettingBase Clone()
         {
             var newItem = new CertificateItem(Fingerprint, HashAlgorithm, AllowUntrustedRoot);
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/ClearItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/ClearItem.cs
@@ -10,7 +10,7 @@ namespace NuGet.Configuration
     {
         public override string ElementName => ConfigurationConstants.Clear;
 
-        internal override bool IsEmpty() => false;
+        public override bool IsEmpty() => false;
 
         public ClearItem()
         {
@@ -21,7 +21,7 @@ namespace NuGet.Configuration
         {
         }
 
-        internal override SettingBase Clone()
+        public override SettingBase Clone()
         {
             var newItem = new ClearItem();
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
@@ -75,7 +75,7 @@ namespace NuGet.Configuration
 
         protected override bool CanHaveChildren => true;
 
-        internal override bool IsEmpty() => string.IsNullOrEmpty(Username) && string.IsNullOrEmpty(Password);
+        public override bool IsEmpty() => string.IsNullOrEmpty(Username) && string.IsNullOrEmpty(Password);
 
         internal readonly AddItem _username;
 
@@ -152,7 +152,7 @@ namespace NuGet.Configuration
             }
         }
 
-        internal override SettingBase Clone()
+        public override SettingBase Clone()
         {
             var newSetting = new CredentialsItem(ElementName, Username, Password, IsPasswordClearText);
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/OwnersItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/OwnersItem.cs
@@ -52,7 +52,7 @@ namespace NuGet.Configuration
             Content = _content.Value.Split(OwnersListSeparator).Select(o => o.Trim()).ToList();
         }
 
-        internal override SettingBase Clone()
+        public override SettingBase Clone()
         {
             var newItem = new OwnersItem(_content.Value);
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/RepositoryItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/RepositoryItem.cs
@@ -79,7 +79,7 @@ namespace NuGet.Configuration
             }
         }
 
-        internal override SettingBase Clone()
+        public override SettingBase Clone()
         {
             var newItem = new RepositoryItem(
                 Name,

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
@@ -51,7 +51,7 @@ namespace NuGet.Configuration
         {
         }
 
-        internal override SettingBase Clone()
+        public override SettingBase Clone()
         {
             var newSetting = new SourceItem(Key, Value, ProtocolVersion);
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/UnknownItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/UnknownItem.cs
@@ -17,7 +17,7 @@ namespace NuGet.Configuration
 
         public new IReadOnlyDictionary<string, string> Attributes => base.Attributes;
 
-        internal override bool IsEmpty() => false;
+        public override bool IsEmpty() => false;
 
         protected override bool CanHaveChildren => true;
 
@@ -61,7 +61,7 @@ namespace NuGet.Configuration
             }
         }
 
-        internal override SettingBase Clone()
+        public override SettingBase Clone()
         {
             var newSetting = new UnknownItem(ElementName, Attributes, Children.Select(c => c.Clone()));
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/NuGetConfiguration.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NuGetConfiguration.cs
@@ -139,7 +139,7 @@ namespace NuGet.Configuration
             }
         }
 
-        internal override SettingBase Clone()
+        public override SettingBase Clone()
         {
             return new NuGetConfiguration(Attributes, Sections.Select(s => s.Value.Clone() as SettingSection));
         }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ParsedSettingSection.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ParsedSettingSection.cs
@@ -23,7 +23,7 @@ namespace NuGet.Configuration
             }
         }
 
-        internal override SettingBase Clone()
+        public override SettingBase Clone()
         {
             return new VirtualSettingSection(ElementName, Attributes, Items.Select(s => s.Clone() as SettingItem));
         }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingBase.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingBase.cs
@@ -38,19 +38,19 @@ namespace NuGet.Configuration
         /// <summary>
         /// Specifies if the setting has attributes or values.
         /// </summary>
-        internal abstract bool IsEmpty();
+        public abstract bool IsEmpty();
 
         /// <summary>
         /// Gives the representation of this setting as an XNode object
         /// </summary>
-        internal abstract XNode AsXNode();
+        internal virtual XNode AsXNode() => Node;
 
         /// <summary>
         /// Creates a shallow copy of the setting.
         /// Does not copy any pointer to the original data structure.
         /// Just copies the abstraction.
         /// </summary>
-        internal abstract SettingBase Clone();
+        public abstract SettingBase Clone();
 
         internal void SetNode(XNode node)
         {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingElement.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingElement.cs
@@ -58,7 +58,7 @@ namespace NuGet.Configuration
         /// Each element defines its own definition of empty.
         /// The default definition of empty is an element without attributes.
         /// </summary>
-        internal override bool IsEmpty() => !Attributes.Any();
+        public override bool IsEmpty() => !Attributes.Any();
 
         /// <summary>
         /// Default constructor

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingText.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingText.cs
@@ -54,9 +54,9 @@ namespace NuGet.Configuration
 
         public override int GetHashCode() => Value.GetHashCode();
 
-        internal override bool IsEmpty() => string.IsNullOrEmpty(Value);
+        public override bool IsEmpty() => string.IsNullOrEmpty(Value);
 
-        internal override SettingBase Clone()
+        public override SettingBase Clone()
         {
             var newSetting = new SettingText(Value);
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsGroup.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsGroup.cs
@@ -33,7 +33,7 @@ namespace NuGet.Configuration
             }
         }
 
-        internal override bool IsEmpty() => !Children.Any() || Children.All(c => c.IsEmpty());
+        public override bool IsEmpty() => !Children.Any() || Children.All(c => c.IsEmpty());
 
         internal SettingsGroup(XElement element, SettingsFile origin)
             : base(element, origin)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/VirtualSettingSection.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/VirtualSettingSection.cs
@@ -147,7 +147,7 @@ namespace NuGet.Configuration
             return true;
         }
 
-        internal override SettingBase Clone()
+        public override SettingBase Clone()
         {
             return new VirtualSettingSection(ElementName, Attributes, Items.Select(s => s.Clone() as SettingItem));
         }


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7614

## Fix
Details: 
There were some internal abstract methods in `SettingBase` that made it impossible to subclass it outside `NuGet.Configuration`. This was specifically painful if a user wants to subclass `SettingSection`. This could be useful to mock `ISettings` responses in tests since we do not expose any concrete object to use `SettingSection`.

With this change a user could easily subclass `SettingSection` as follows:

```
    public class SettingSectionCustom : SettingSection
    {
        public SettingSectionCustom(string name, IReadOnlyDictionary<string, string> attributes, IEnumerable<SettingItem> children)
            : base (name, attributes, children)
        {
        }

        public override SettingBase Clone()
        {
            throw new System.NotImplementedException();
        }
    }
```