### PR TITLE
Avoid unnecessary enumerations over global packages folder to find a exact package

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -209,6 +209,18 @@ namespace NuGet.Commands
             {
                 await EnsureResource();
 
+                // first check if the exact min version exist then simply return that
+                if (await _findPackagesByIdResource.DoesPackageExistAsync(
+                    libraryRange.Name, libraryRange.VersionRange.MinVersion, cacheContext, logger, cancellationToken))
+                {
+                    return new LibraryIdentity
+                    {
+                        Name = libraryRange.Name,
+                        Version = libraryRange.VersionRange.MinVersion,
+                        Type = LibraryType.Package
+                    };
+                }
+
                 // Discover all versions from the feed
                 var packageVersions = await GetAllVersionsAsync(libraryRange.Name, cacheContext, logger, cancellationToken);
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -209,7 +209,7 @@ namespace NuGet.Commands
             {
                 await EnsureResource();
 
-                if (libraryRange.VersionRange?.MinVersion != null)
+                if (libraryRange.VersionRange?.MinVersion != null && libraryRange.VersionRange?.IsFloating != true)
                 {
                     // first check if the exact min version exist then simply return that
                     if (await _findPackagesByIdResource.DoesPackageExistAsync(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -209,16 +209,19 @@ namespace NuGet.Commands
             {
                 await EnsureResource();
 
-                // first check if the exact min version exist then simply return that
-                if (await _findPackagesByIdResource.DoesPackageExistAsync(
-                    libraryRange.Name, libraryRange.VersionRange.MinVersion, cacheContext, logger, cancellationToken))
+                if (libraryRange.VersionRange?.MinVersion != null)
                 {
-                    return new LibraryIdentity
+                    // first check if the exact min version exist then simply return that
+                    if (await _findPackagesByIdResource.DoesPackageExistAsync(
+                        libraryRange.Name, libraryRange.VersionRange.MinVersion, cacheContext, logger, cancellationToken))
                     {
-                        Name = libraryRange.Name,
-                        Version = libraryRange.VersionRange.MinVersion,
-                        Type = LibraryType.Package
-                    };
+                        return new LibraryIdentity
+                        {
+                            Name = libraryRange.Name,
+                            Version = libraryRange.VersionRange.MinVersion,
+                            Type = LibraryType.Package
+                        };
+                    }
                 }
 
                 // Discover all versions from the feed

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV2FindPackageByIdResource.cs
@@ -275,6 +275,56 @@ namespace NuGet.Protocol
             return Task.FromResult(packageDownloader);
         }
 
+        /// <summary>
+        /// Asynchronously check if exact package (id/version) exists at this source.
+        /// </summary>
+        /// <param name="id">A package id.</param>
+        /// <param name="version">A package version.</param>
+        /// <param name="cacheContext">A source cache context.</param>
+        /// <param name="logger">A logger.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result (<see cref="Task{TResult}.Result" />) returns an
+        /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
+        /// is either <c>null</c> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
+        /// is cancelled.</exception>
+        public override Task<bool> DoesPackageExistAsync(
+            string id,
+            NuGetVersion version,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(id));
+            }
+
+            if (version == null)
+            {
+                throw new ArgumentNullException(nameof(version));
+            }
+
+            if (cacheContext == null)
+            {
+                throw new ArgumentNullException(nameof(cacheContext));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return Task.FromResult(GetPackageInfo(id, version, cacheContext, logger) != null);
+        }
+
         private IReadOnlyList<LocalPackageInfo> GetPackageInfos(
             string id,
             SourceCacheContext cacheContext,

--- a/src/NuGet.Core/NuGet.Protocol/PackagesFolder/NuGetv3LocalRepository.cs
+++ b/src/NuGet.Core/NuGet.Protocol/PackagesFolder/NuGetv3LocalRepository.cs
@@ -126,18 +126,11 @@ namespace NuGet.Repositories
 
         private LocalPackageInfo FindPackageImpl(string packageId, NuGetVersion version)
         {
-            var packages = FindPackagesByIdImpl(packageId);
-            var count = packages.Count;
-            for (var i = 0; i < count; i++)
+            var installPath = PathResolver.GetInstallPath(packageId, version);
+            lock (GetLockObj(installPath))
             {
-                var candidatePackage = packages[i];
-                if (candidatePackage.Version == version)
-                {
-                    return candidatePackage;
-                }
+                return GetPackage(packageId, version, installPath);
             }
-
-            return null;
         }
 
         private List<LocalPackageInfo> GetPackages(string id)
@@ -165,34 +158,7 @@ namespace NuGet.Repositories
                         continue;
                     }
 
-                    var nupkgMetadataPath = PathResolver.GetNupkgMetadataPath(id, version);
-                    var hashPath = PathResolver.GetHashPath(id, version);
-                    var zipPath = PathResolver.GetPackageFilePath(id, version);
-                    var installPath = PathResolver.GetInstallPath(id, version);
-
-                    // The nupkg metadata file is written last. If this file does not exist then the package is
-                    // incomplete and should not be used.
-                    if (_packageFileCache.Sha512Exists(nupkgMetadataPath))
-                    {
-                        package = CreateLocalPackageInfo(id, version, fullVersionDir, nupkgMetadataPath, zipPath);
-
-                        // Cache the package, if it is valid it will not change
-                        // for the life of this restore.
-                        // Locking is done at a higher level around the id
-                        _packageCache.TryAdd(fullVersionDir, package);
-                    }
-                    // if hash file exists and it's not a fallback folder then we generate nupkg metadata file
-                    else if(!_isFallbackFolder && _packageFileCache.Sha512Exists(hashPath))
-                    {
-                        LocalFolderUtility.GenerateNupkgMetadataFile(zipPath, installPath, hashPath, nupkgMetadataPath);
-
-                        package = CreateLocalPackageInfo(id, version, fullVersionDir, nupkgMetadataPath, zipPath);
-
-                        // Cache the package, if it is valid it will not change
-                        // for the life of this restore.
-                        // Locking is done at a higher level around the id
-                        _packageCache.TryAdd(fullVersionDir, package);
-                    }
+                    package = GetPackage(id, version, fullVersionDir);
                 }
 
                 // Add the package if it is valid
@@ -203,6 +169,39 @@ namespace NuGet.Repositories
             }
 
             return packages;
+        }
+
+        private LocalPackageInfo GetPackage(string packageId, NuGetVersion version, string path)
+        {
+            var nupkgMetadataPath = PathResolver.GetNupkgMetadataPath(packageId, version);
+            var hashPath = PathResolver.GetHashPath(packageId, version);
+            var zipPath = PathResolver.GetPackageFilePath(packageId, version);
+
+            LocalPackageInfo package = null;
+
+            // The nupkg metadata file is written last. If this file does not exist then the package is
+            // incomplete and should not be used.
+            if (_packageFileCache.Sha512Exists(nupkgMetadataPath))
+            {
+                package = CreateLocalPackageInfo(packageId, version, path, nupkgMetadataPath, zipPath);
+            }
+            // if hash file exists and it's not a fallback folder then we generate nupkg metadata file
+            else if (!_isFallbackFolder && _packageFileCache.Sha512Exists(hashPath))
+            {
+                LocalFolderUtility.GenerateNupkgMetadataFile(zipPath, path, hashPath, nupkgMetadataPath);
+
+                package = CreateLocalPackageInfo(packageId, version, path, nupkgMetadataPath, zipPath);
+            }
+
+            if (package != null)
+            {
+                // Cache the package, if it is valid it will not change
+                // for the life of this restore.
+                // Locking is done at a higher level around the id
+                _packageCache.TryAdd(path, package);
+            }
+
+            return package;
         }
 
         private LocalPackageInfo CreateLocalPackageInfo(string id, NuGetVersion version, string fullVersionDir, string newHashPath, string zipPath)

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
@@ -301,6 +301,58 @@ namespace NuGet.Protocol
             return null;
         }
 
+        /// <summary>
+        /// Asynchronously check if exact package (id/version) exists at this source.
+        /// </summary>
+        /// <param name="id">A package id.</param>
+        /// <param name="version">A package version.</param>
+        /// <param name="cacheContext">A source cache context.</param>
+        /// <param name="logger">A logger.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result (<see cref="Task{TResult}.Result" />) returns an
+        /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
+        /// is either <c>null</c> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
+        /// is cancelled.</exception>
+        public override async Task<bool> DoesPackageExistAsync(
+            string id,
+            NuGetVersion version,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(id));
+            }
+
+            if (version == null)
+            {
+                throw new ArgumentNullException(nameof(version));
+            }
+
+            if (cacheContext == null)
+            {
+                throw new ArgumentNullException(nameof(cacheContext));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var packageInfos = await EnsurePackagesAsync(id, cacheContext, logger, cancellationToken);
+
+            return packageInfos.TryGetValue(version, out var packageInfo);
+        }
+
         private async Task<SortedDictionary<NuGetVersion, PackageInfo>> EnsurePackagesAsync(
             string id,
             SourceCacheContext cacheContext,

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/PluginFindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/PluginFindPackageByIdResource.cs
@@ -266,6 +266,58 @@ namespace NuGet.Protocol.Core.Types
             return null;
         }
 
+        /// <summary>
+        /// Asynchronously check if exact package (id/version) exists at this source.
+        /// </summary>
+        /// <param name="id">A package id.</param>
+        /// <param name="version">A package version.</param>
+        /// <param name="cacheContext">A source cache context.</param>
+        /// <param name="logger">A logger.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result (<see cref="Task{TResult}.Result" />) returns an
+        /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
+        /// is either <c>null</c> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
+        /// is cancelled.</exception>
+        public override async Task<bool> DoesPackageExistAsync(
+            string id,
+            NuGetVersion version,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(id));
+            }
+
+            if (version == null)
+            {
+                throw new ArgumentNullException(nameof(version));
+            }
+
+            if (cacheContext == null)
+            {
+                throw new ArgumentNullException(nameof(cacheContext));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var packageInfos = await EnsurePackagesAsync(id, cacheContext, logger, cancellationToken);
+
+            return packageInfos.TryGetValue(version, out var packageInfo);
+        }
+
         private async Task<SortedDictionary<NuGetVersion, PackageInfo>> EnsurePackagesAsync(
             string id,
             SourceCacheContext cacheContext,

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -305,6 +305,58 @@ namespace NuGet.Protocol
             return new RemotePackageArchiveDownloader(PackageSource.Source, this, packageInfo.Identity, cacheContext, logger);
         }
 
+        /// <summary>
+        /// Asynchronously check if exact package (id/version) exists at this source.
+        /// </summary>
+        /// <param name="id">A package id.</param>
+        /// <param name="version">A package version.</param>
+        /// <param name="cacheContext">A source cache context.</param>
+        /// <param name="logger">A logger.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result (<see cref="Task{TResult}.Result" />) returns an
+        /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
+        /// is either <c>null</c> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
+        /// is cancelled.</exception>
+        public override async Task<bool> DoesPackageExistAsync(
+            string id,
+            NuGetVersion version,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(id));
+            }
+
+            if (version == null)
+            {
+                throw new ArgumentNullException(nameof(version));
+            }
+
+            if (cacheContext == null)
+            {
+                throw new ArgumentNullException(nameof(cacheContext));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var packageInfo = await GetPackageInfoAsync(id, version, cacheContext, logger, cancellationToken);
+
+            return packageInfo != null;
+        }
+
         private async Task<PackageInfo> GetPackageInfoAsync(
             string id,
             NuGetVersion version,

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
@@ -290,6 +290,58 @@ namespace NuGet.Protocol
             return new RemotePackageArchiveDownloader(SourceRepository.PackageSource.Source, this, packageInfo.Identity, cacheContext, logger);
         }
 
+        /// <summary>
+        /// Asynchronously check if exact package (id/version) exists at this source.
+        /// </summary>
+        /// <param name="id">A package id.</param>
+        /// <param name="version">A package version.</param>
+        /// <param name="cacheContext">A source cache context.</param>
+        /// <param name="logger">A logger.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result (<see cref="Task{TResult}.Result" />) returns an
+        /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
+        /// is either <c>null</c> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
+        /// is cancelled.</exception>
+        public override async Task<bool> DoesPackageExistAsync(
+            string id,
+            NuGetVersion version,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(id));
+            }
+
+            if (version == null)
+            {
+                throw new ArgumentNullException(nameof(version));
+            }
+
+            if (cacheContext == null)
+            {
+                throw new ArgumentNullException(nameof(cacheContext));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var packageInfo = await GetPackageInfoAsync(id, version, cacheContext, logger, cancellationToken);
+
+            return packageInfo != null;
+        }
+
         private async Task<RemoteSourceDependencyInfo> GetPackageInfoAsync(
             string id,
             NuGetVersion version,

--- a/src/NuGet.Core/NuGet.Protocol/Resources/FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/FindPackageByIdResource.cs
@@ -114,6 +114,31 @@ namespace NuGet.Protocol.Core.Types
             CancellationToken cancellationToken);
 
         /// <summary>
+        /// Asynchronously check if exact package (id/version) exists at this source.
+        /// </summary>
+        /// <param name="id">A package id.</param>
+        /// <param name="version">A package version.</param>
+        /// <param name="cacheContext">A source cache context.</param>
+        /// <param name="logger">A logger.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result (<see cref="Task{TResult}.Result" />) returns an
+        /// <see cref="IEnumerable{NuGetVersion}" />.</returns>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="id" />
+        /// is either <c>null</c> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="version" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> <c>null</c>.</exception>
+        /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
+        /// is cancelled.</exception>
+        public abstract Task<bool> DoesPackageExistAsync(
+            string id,
+            NuGetVersion version,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Read dependency info from a nuspec.
         /// </summary>
         /// <remarks>This also verifies minClientVersion.</remarks>


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7639
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: While resolving package through global packages folder (%userprofile%/.nuget/packages) or fallback folder,  we always create a list of all the versions of a specific package id and then find the best matching version for the requested version. This adds an unnecessary perf overhead when the requested version is available at either of the source.

This PR optimize this code path to first look for the exact package (id/ version) to only read that, otherwise fallback to get the best matching version. This should not impact any existing functionality in any manner, this is only a perf optimization. Although this might not look like a significant perf improvement but it's important for Domino since they've a fixed input/ output requirements.

## Testing/Validation
Tests Added: Yes/No  
Reason for not adding tests:  
Validation done:  
