### PR TITLE
Fixed unreadable Yellow Tabs in Blue Theme

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -12,9 +12,10 @@ using Microsoft.VisualStudio.Shell;
 namespace NuGet.PackageManagement.UI
 {
     /// <summary>
-    /// Color Brushes for multiple elements of the NuGet Package Manger UI
+    /// Color Brushes for multiple elements of the NuGet Package Manager UI
     ///
-    /// Initially, the properties are initialized with System Colors but, later, proper colors are assigned
+    /// Initially, the properties are initialized with SystemColors brushes but, later, proper colors are assigned in
+    /// another method.
     /// <seealso cref="Brushes.LoadVsBrushes"/>
     /// </summary>
     public static class Brushes
@@ -157,11 +158,17 @@ namespace NuGet.PackageManagement.UI
  
         public static object ButtonFocusedStyleBrushKey { get; private set; } = SystemColors.HighlightTextBrushKey;
 
+        public static object TabInactiveBrushKey { get; private set; } = SystemColors.InactiveCaptionBrushKey;
+
+        public static object TabInactiveTextBrushKey { get; private set; } = SystemColors.InactiveCaptionTextBrushKey;
+
         public static object TabSelectedBrushKey { get; private set; } = SystemColors.ActiveCaptionTextColor;
 
         public static object TabSelectedTextBrushKey { get; private set; } = SystemColors.ActiveCaptionTextColorKey;
 
-        public static object TabPopupTextBrushKey { get; private set; } = SystemColors.HighlightBrushKey;
+        public static object TabPopupBrushKey { get; private set; } = SystemColors.ActiveCaptionTextColor;
+
+        public static object TabPopupTextBrushKey { get; private set; } = SystemColors.HighlightTextBrush;
 
         public static void LoadVsBrushes()
         {
@@ -229,9 +236,9 @@ namespace NuGet.PackageManagement.UI
             CheckBoxBorderPressedBrushKey = CommonControlsColors.CheckBoxBorderPressedBrushKey;
 
             BackgroundBrushKey = EnvironmentColors.ToolWindowBackgroundBrushKey;
+
             ContentMouseOverBrushKey = EnvironmentColors.ToolboxContentMouseOverBrushKey;
             ContentMouseOverTextBrushKey = EnvironmentColors.ToolboxContentMouseOverTextBrushKey;
-
             ContentInactiveSelectedBrushKey = TreeViewColors.SelectedItemInactiveBrushKey;
             ContentInactiveSelectedTextBrushKey = TreeViewColors.SelectedItemInactiveTextBrushKey;
             ContentSelectedBrushKey = TreeViewColors.SelectedItemActiveBrushKey;
@@ -239,7 +246,9 @@ namespace NuGet.PackageManagement.UI
 
             TabSelectedBrushKey = CommonDocumentColors.InnerTabTextFocusedBrushKey;
             TabSelectedTextBrushKey = CommonDocumentColors.InnerTabTextFocusedBrushKey;
-            TabPopupTextBrushKey = ContentSelectedTextBrushKey;
+
+            TabPopupBrushKey = CommonControlsColors.ButtonPressedBrushKey;
+            TabPopupTextBrushKey = CommonControlsColors.ButtonPressedTextBrushKey;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -240,21 +240,19 @@ namespace NuGet.PackageManagement.UI
             BackgroundBrushKey = EnvironmentColors.ToolWindowBackgroundBrushKey;
 
             // Brushes/Colors for InfiniteScrollList
-            ContentMouseOverBrushKey = ThemedDialogColors.ListItemMouseOverBrushKey;
-            ContentMouseOverTextBrushKey = ThemedDialogColors.ListItemMouseOverTextBrushKey;
-            ContentInactiveSelectedBrushKey = ThemedDialogColors.SelectedItemInactiveBrushKey;
-            ContentInactiveSelectedTextBrushKey = ThemedDialogColors.SelectedItemInactiveTextBrushKey;
-            ContentSelectedBrushKey = ThemedDialogColors.SelectedItemActiveBrushKey;
-            ContentSelectedTextBrushKey = ThemedDialogColors.SelectedItemActiveTextBrushKey;
+            ContentMouseOverBrushKey = CommonDocumentColors.ListItemBackgroundHoverBrushKey;
+            ContentMouseOverTextBrushKey = CommonDocumentColors.ListItemTextHoverBrushKey;
+            ContentInactiveSelectedBrushKey = CommonDocumentColors.ListItemBackgroundUnfocusedBrushKey;
+            ContentInactiveSelectedTextBrushKey = CommonDocumentColors.ListItemTextUnfocusedBrushKey;
+            ContentSelectedBrushKey = CommonDocumentColors.ListItemBackgroundFocusedBrushKey;
+            ContentSelectedTextBrushKey = CommonDocumentColors.ListItemTextFocusedBrushKey;
 
             // Brushes/Colors for FilterLabel (Top Tabs)
             TabSelectedBrushKey = CommonDocumentColors.InnerTabTextFocusedBrushKey;
             TabSelectedTextBrushKey = CommonDocumentColors.InnerTabTextFocusedBrushKey;
-
+            TabHoverBrushKey = CommonDocumentColors.InnerTabInactiveHoverTextBrushKey;
             TabPopupBrushKey = CommonControlsColors.ButtonPressedBrushKey;
             TabPopupTextBrushKey = CommonControlsColors.ButtonPressedTextBrushKey;
-
-            TabHoverBrushKey = CommonDocumentColors.InnerTabInactiveHoverTextBrushKey;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -11,6 +11,12 @@ using Microsoft.VisualStudio.Shell;
 
 namespace NuGet.PackageManagement.UI
 {
+    /// <summary>
+    /// Color Brushes for multiple elements of the NuGet Package Manger UI
+    ///
+    /// Initially, the properties are initialized with System Colors but, later, proper colors are assigned
+    /// <seealso cref="Brushes.LoadVsBrushes"/>
+    /// </summary>
     public static class Brushes
     {
         public static object ActiveBorderKey { get; private set; } = SystemColors.ActiveBorderBrushKey;
@@ -149,7 +155,11 @@ namespace NuGet.PackageManagement.UI
  
         public static object ButtonBorderFocusedStyleBrushKey { get; private set; } = SystemColors.HighlightTextBrushKey; 
  
-        public static object ButtonFocusedStyleBrushKey { get; private set; } = SystemColors.HighlightTextBrushKey; 
+        public static object ButtonFocusedStyleBrushKey { get; private set; } = SystemColors.HighlightTextBrushKey;
+
+        public static object TabSelectedBrushKey { get; private set; } = SystemColors.ActiveCaptionTextColor;
+
+        public static object TabSelectedTextBrushKey { get; private set; } = SystemColors.ActiveCaptionTextColorKey;
 
         public static void LoadVsBrushes()
         {
@@ -224,6 +234,9 @@ namespace NuGet.PackageManagement.UI
             ContentInactiveSelectedTextBrushKey = TreeViewColors.SelectedItemInactiveTextBrushKey;
             ContentSelectedBrushKey = TreeViewColors.SelectedItemActiveBrushKey;
             ContentSelectedTextBrushKey = TreeViewColors.SelectedItemActiveTextBrushKey;
+
+            TabSelectedBrushKey = CommonDocumentColors.InnerTabTextFocusedBrushKey;
+            TabSelectedTextBrushKey = CommonDocumentColors.InnerTabTextFocusedBrushKey;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -158,10 +158,6 @@ namespace NuGet.PackageManagement.UI
  
         public static object ButtonFocusedStyleBrushKey { get; private set; } = SystemColors.HighlightTextBrushKey;
 
-        public static object TabInactiveBrushKey { get; private set; } = SystemColors.InactiveCaptionBrushKey;
-
-        public static object TabInactiveTextBrushKey { get; private set; } = SystemColors.InactiveCaptionTextBrushKey;
-
         public static object TabSelectedBrushKey { get; private set; } = SystemColors.ActiveCaptionTextColor;
 
         public static object TabSelectedTextBrushKey { get; private set; } = SystemColors.ActiveCaptionTextColorKey;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -170,6 +170,8 @@ namespace NuGet.PackageManagement.UI
 
         public static object TabPopupTextBrushKey { get; private set; } = SystemColors.HighlightTextBrush;
 
+        public static object TabHoverBrushKey { get; private set; } = SystemColors.HotTrackBrushKey;
+
         public static void LoadVsBrushes()
         {
             FocusVisualStyleBrushKey = VsBrushes.ToolWindowTextKey; 
@@ -249,6 +251,8 @@ namespace NuGet.PackageManagement.UI
 
             TabPopupBrushKey = CommonControlsColors.ButtonPressedBrushKey;
             TabPopupTextBrushKey = CommonControlsColors.ButtonPressedTextBrushKey;
+
+            TabHoverBrushKey = CommonDocumentColors.InnerTabInactiveHoverTextBrushKey;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -239,13 +239,15 @@ namespace NuGet.PackageManagement.UI
 
             BackgroundBrushKey = EnvironmentColors.ToolWindowBackgroundBrushKey;
 
-            ContentMouseOverBrushKey = EnvironmentColors.ToolboxContentMouseOverBrushKey;
-            ContentMouseOverTextBrushKey = EnvironmentColors.ToolboxContentMouseOverTextBrushKey;
-            ContentInactiveSelectedBrushKey = TreeViewColors.SelectedItemInactiveBrushKey;
-            ContentInactiveSelectedTextBrushKey = TreeViewColors.SelectedItemInactiveTextBrushKey;
-            ContentSelectedBrushKey = TreeViewColors.SelectedItemActiveBrushKey;
-            ContentSelectedTextBrushKey = TreeViewColors.SelectedItemActiveTextBrushKey;
+            // Brushes/Colors for InfiniteScrollList
+            ContentMouseOverBrushKey = ThemedDialogColors.ListItemMouseOverBrushKey;
+            ContentMouseOverTextBrushKey = ThemedDialogColors.ListItemMouseOverTextBrushKey;
+            ContentInactiveSelectedBrushKey = ThemedDialogColors.SelectedItemInactiveBrushKey;
+            ContentInactiveSelectedTextBrushKey = ThemedDialogColors.SelectedItemInactiveTextBrushKey;
+            ContentSelectedBrushKey = ThemedDialogColors.SelectedItemActiveBrushKey;
+            ContentSelectedTextBrushKey = ThemedDialogColors.SelectedItemActiveTextBrushKey;
 
+            // Brushes/Colors for FilterLabel (Top Tabs)
             TabSelectedBrushKey = CommonDocumentColors.InnerTabTextFocusedBrushKey;
             TabSelectedTextBrushKey = CommonDocumentColors.InnerTabTextFocusedBrushKey;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Brushes.cs
@@ -161,6 +161,8 @@ namespace NuGet.PackageManagement.UI
 
         public static object TabSelectedTextBrushKey { get; private set; } = SystemColors.ActiveCaptionTextColorKey;
 
+        public static object TabPopupTextBrushKey { get; private set; } = SystemColors.HighlightBrushKey;
+
         public static void LoadVsBrushes()
         {
             FocusVisualStyleBrushKey = VsBrushes.ToolWindowTextKey; 
@@ -237,6 +239,7 @@ namespace NuGet.PackageManagement.UI
 
             TabSelectedBrushKey = CommonDocumentColors.InnerTabTextFocusedBrushKey;
             TabSelectedTextBrushKey = CommonDocumentColors.InnerTabTextFocusedBrushKey;
+            TabPopupTextBrushKey = ContentSelectedTextBrushKey;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FilterLabel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FilterLabel.xaml
@@ -55,7 +55,7 @@
           Visibility="Collapsed"
           HorizontalAlignment="Center"
           VerticalAlignment="Center"
-          Background="{DynamicResource {x:Static nuget:Brushes.TabSelectedBrushKey}}">
+          Background="{DynamicResource {x:Static nuget:Brushes.TabPopupBrushKey}}">
           <TextBlock
             x:Name="_textBlockCount"
             HorizontalAlignment="Right"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FilterLabel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FilterLabel.xaml
@@ -55,7 +55,7 @@
           Visibility="Collapsed"
           HorizontalAlignment="Center"
           VerticalAlignment="Center"
-          Background="{DynamicResource {x:Static nuget:Brushes.ContentSelectedBrushKey}}">
+          Background="{DynamicResource {x:Static nuget:Brushes.TabSelectedBrushKey}}">
           <TextBlock
             x:Name="_textBlockCount"
             HorizontalAlignment="Right"
@@ -72,6 +72,6 @@
       Margin="0"
       Height="3"
       Visibility="{Binding Selected ,Converter={StaticResource BooleanToVisibilityConverter}}"
-      Fill="{DynamicResource {x:Static nuget:Brushes.ContentSelectedBrushKey}}"/>
+      Fill="{DynamicResource {x:Static nuget:Brushes.TabSelectedBrushKey}}"/>
   </Grid>
 </UserControl>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FilterLabel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FilterLabel.xaml
@@ -60,7 +60,7 @@
             x:Name="_textBlockCount"
             HorizontalAlignment="Right"
             VerticalAlignment="Top"
-            Foreground="{DynamicResource {x:Static nuget:Brushes.ContentSelectedTextBrushKey}}"/>
+            Foreground="{DynamicResource {x:Static nuget:Brushes.TabPopupTextBrushKey}}"/>
         </Border>
       </StackPanel>
     </nuget:TabItemButton>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FilterLabel.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FilterLabel.xaml.cs
@@ -57,7 +57,7 @@ namespace NuGet.PackageManagement.UI
                 {
                     _labelText.SetResourceReference(
                         TextBlock.ForegroundProperty,
-                        Brushes.ContentSelectedBrushKey);
+                        Brushes.TabSelectedTextBrushKey);
                     _underline.Visibility = Visibility.Visible;
 
                     if (ControlSelected != null)
@@ -114,7 +114,7 @@ namespace NuGet.PackageManagement.UI
         {
             _labelText.SetResourceReference(
                 TextBlock.ForegroundProperty,
-                Brushes.ContentSelectedBrushKey);
+                Brushes.TabSelectedTextBrushKey);
         }
 
         private void _labelText_MouseLeave(object sender, MouseEventArgs e)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FilterLabel.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FilterLabel.xaml.cs
@@ -112,9 +112,18 @@ namespace NuGet.PackageManagement.UI
 
         private void _labelText_MouseEnter(object sender, MouseEventArgs e)
         {
-            _labelText.SetResourceReference(
-                TextBlock.ForegroundProperty,
-                Brushes.TabSelectedTextBrushKey);
+            if(_selected)
+            {
+                _labelText.SetResourceReference(
+                    TextBlock.ForegroundProperty,
+                    Brushes.TabSelectedTextBrushKey);
+            }
+            else // for simulating hover state
+            {
+                _labelText.SetResourceReference(
+                    TextBlock.ForegroundProperty,
+                    Brushes.TabHoverBrushKey);
+            }
         }
 
         private void _labelText_MouseLeave(object sender, MouseEventArgs e)


### PR DESCRIPTION
## Bug
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/737441, 
https://developercommunity.visualstudio.com/content/problem/395098/tabs-in-nuget-package-ui-with-new-blue-theme-are-u.html
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: New color brushes for the tabs.

## Testing/Validation
Tests Added: No  
Reason for not adding tests: Need more info for creating tests for UI issues.
Validation done:  Graphic demo. See image below:

### Before:

#### VS 2017 Before

2017 Blue Theme (High contrast):
![image](https://user-images.githubusercontent.com/1192347/50530340-5dc21380-0ab1-11e9-84f1-a5451e90bb36.png)

2017 Light Theme:
![image](https://user-images.githubusercontent.com/1192347/50530322-38350a00-0ab1-11e9-9cc4-eacedd320793.png)

2017 Dark Theme:
![image](https://user-images.githubusercontent.com/1192347/50530309-176cb480-0ab1-11e9-8f5f-aca7ff6ffd29.png)

2017 Blue Theme:
![image](https://user-images.githubusercontent.com/1192347/50530279-bf35b280-0ab0-11e9-9b1d-f5d0d20ec3d0.png)


#### VS 2019 Before
2019 Light Theme
![image](https://user-images.githubusercontent.com/1192347/50530407-ef318580-0ab1-11e9-80fb-836e27661ef7.png)

2019 Blue Theme:
![image](https://user-images.githubusercontent.com/1192347/50527026-7d9a0d00-0a9a-11e9-8f93-9c2f92308df0.png)

2019 Dark Theme:
![image](https://user-images.githubusercontent.com/1192347/50530379-b2fe2500-0ab1-11e9-8c85-6faa595c02f1.png)

2019 Blue Theme (High contrast):
![image](https://user-images.githubusercontent.com/1192347/50530432-361f7b00-0ab2-11e9-8249-5ca7e26c3367.png)


### VS 2019 After:
2019 Blue Theme:
![image](https://user-images.githubusercontent.com/1192347/50940117-7e388900-1434-11e9-8e8b-8d17ce4e52d7.png)

2019 Light Theme:
![image](https://user-images.githubusercontent.com/1192347/50941433-bd1d0d80-1439-11e9-94a2-d40d77eb4bc4.png)

2019 Dark Theme:
![image](https://user-images.githubusercontent.com/1192347/50940812-3ff09900-1437-11e9-875f-6331ac8cd221.png)

2019 Blue Theme (High contrast):
![image](https://user-images.githubusercontent.com/1192347/50940361-73322880-1435-11e9-838a-fa07692ea805.png)
