### PR TITLE
Add list package interactive

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/DeleteCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/DeleteCommand.cs
@@ -53,7 +53,7 @@ namespace NuGet.CommandLine.XPlat
 
                 var interactive = delete.Option(
                     "--interactive",
-                    Strings.PushDeleteCommand_Interactive,
+                    Strings.NuGetXplatCommand_Interactive,
                     CommandOptionType.SingleValue);
 
                 delete.OnExecute(async () =>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.CommandLineUtils;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.Credentials;
 using NuGet.Frameworks;
 
 namespace NuGet.CommandLine.XPlat
@@ -79,6 +80,11 @@ namespace NuGet.CommandLine.XPlat
                     Strings.ListPkg_ConfigDescription,
                     CommandOptionType.SingleValue);
 
+                var interactive = listpkg.Option(
+                    "--interactive",
+                    Strings.NuGetXplatCommand_Interactive,
+                    CommandOptionType.SingleValue);
+
                 listpkg.OnExecute(async () =>
                 {
                     var logger = getLogger();
@@ -103,6 +109,8 @@ namespace NuGet.CommandLine.XPlat
                         logger,
                         CancellationToken.None);
 
+                    DefaultCredentialServiceUtility.SetupDefaultCredentialService(getLogger(), !interactive.HasValue());
+                    
                     var listPackageCommandRunner = getCommandRunner();
                     await listPackageCommandRunner.ExecuteCommandAsync(packageRefArgs);
                     return 0;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
@@ -73,7 +73,7 @@ namespace NuGet.CommandLine.XPlat
 
                 var interactive = push.Option(
                     "--interactive",
-                    Strings.PushDeleteCommand_Interactive,
+                    Strings.NuGetXplatCommand_Interactive,
                     CommandOptionType.SingleValue);
 
                 push.OnExecute(async () =>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace NuGet.CommandLine.XPlat {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -40,7 +39,7 @@ namespace NuGet.CommandLine.XPlat {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.CommandLine.XPlat.Strings", typeof(Strings).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.CommandLine.XPlat.Strings", typeof(Strings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -970,6 +969,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allow the command to block and require manual action for operations like authentication..
+        /// </summary>
+        internal static string NuGetXplatCommand_Interactive {
+            get {
+                return ResourceManager.GetString("NuGetXplatCommand_Interactive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Specifies the directory for the created NuGet package file. If not specified, uses the current directory.
         /// </summary>
         internal static string OutputDirectory_Description {
@@ -1074,15 +1082,6 @@ namespace NuGet.CommandLine.XPlat {
         internal static string Push_Timeout_Error {
             get {
                 return ResourceManager.GetString("Push_Timeout_Error", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Allow the command to block and require manual action for operations like authentication..
-        /// </summary>
-        internal static string PushDeleteCommand_Interactive {
-            get {
-                return ResourceManager.GetString("PushDeleteCommand_Interactive", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -555,7 +555,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="ListPkg_TransitiveHeader" xml:space="preserve">
     <value>Transitive Package</value>
   </data>
-  <data name="PushDeleteCommand_Interactive" xml:space="preserve">
+  <data name="NuGetXplatCommand_Interactive" xml:space="preserve">
     <value>Allow the command to block and require manual action for operations like authentication.</value>
   </data>
   <data name="ListPkg_ErrorFileNotFound" xml:space="preserve">


### PR DESCRIPTION
## Bug
Fixes: P0 of https://github.com/NuGet/Home/issues/7605
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: Setup the credential provider for the list package command. 
In XPLAT, not all the commands inherit from 1 base command like nuget.exe, so there's no place where this can be configured to just "work".   

## Testing/Validation
Tests Added: No  
Reason for not adding tests: Auth integration is not really testable.    
Validation done:  Manual
