### PR TITLE
Added additional check for version while resolving through packages lock file

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
@@ -211,7 +211,8 @@ namespace NuGet.DependencyResolver
                     // check for the exact library through local repositories
                     var localMatch = await FindLibraryByVersionAsync(library, framework, localProviders, cacheContext, logger, cancellationToken);
 
-                    if (localMatch != null)
+                    if (localMatch != null
+                        && localMatch.Library.Version.Equals(library.Version))
                     {
                         return localMatch;
                     }
@@ -219,9 +220,12 @@ namespace NuGet.DependencyResolver
                     // if not found in local repositories, then check the remote repositories
                     var remoteMatch = await FindLibraryByVersionAsync(library, framework, remoteProviders, cacheContext, logger, cancellationToken);
 
-                    // either found or not, we must return from here since we dont want to resolve to any other version
-                    // then defined in packages.lock.json file
-                    return remoteMatch;
+                    if (remoteMatch != null
+                        && remoteMatch.Library.Version.Equals(library.Version))
+                    {
+                        // Only return the result if the version is same as defined in packages.lock.json file
+                        return remoteMatch;
+                    }
                 }
 
                 // it should never come to this, but as a fail-safe if it ever fails to resolve a package from lock file when

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
@@ -50,9 +50,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     });
 
                 using (var testSolutionManager = new TestSolutionManager(true))
-                using (var randomProjectFolderPath = TestDirectory.Create())
                 {
-                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
                     var deleteOnRestartManager = new TestDeleteOnRestartManager();
                     var nuGetPackageManager = new NuGetPackageManager(
@@ -62,7 +61,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         deleteOnRestartManager);
 
                     var projectTargetFrameworkStr = "net45";
-                    var fullProjectPath = Path.Combine(randomProjectFolderPath, "project1.csproj");
+                    var fullProjectPath = Path.Combine(testSolutionManager.TestDirectory, "project1.csproj");
                     var projectNames = new ProjectNames(
                         fullName: fullProjectPath,
                         uniqueName: Path.GetFileName(fullProjectPath),
@@ -139,9 +138,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     });
 
                 using (var testSolutionManager = new TestSolutionManager(true))
-                using (var randomProjectFolderPath = TestDirectory.Create())
                 {
-                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
                     var deleteOnRestartManager = new TestDeleteOnRestartManager();
                     var nuGetPackageManager = new NuGetPackageManager(
@@ -152,7 +150,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     // set up projects
                     var projectTargetFrameworkStr = "net45";
-                    var fullProjectPathB = Path.Combine(randomProjectFolderPath, "ProjectB", "project2.csproj");
+                    var fullProjectPathB = Path.Combine(testSolutionManager.TestDirectory, "ProjectB", "project2.csproj");
                     var projectNamesB = new ProjectNames(
                         fullName: fullProjectPathB,
                         uniqueName: Path.GetFileName(fullProjectPathB),
@@ -180,7 +178,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         projectServicesB,
                         _threadingService);
 
-                    var projectPathA = Path.Combine(randomProjectFolderPath, "ProjectA");
+                    var projectPathA = Path.Combine(testSolutionManager.TestDirectory, "ProjectA");
                     var fullProjectPathA = Path.Combine(projectPathA, "project1.csproj");
                     var projectNamesA = new ProjectNames(
                         fullName: fullProjectPathA,
@@ -281,9 +279,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     });
 
                 using (var testSolutionManager = new TestSolutionManager(true))
-                using (var randomProjectFolderPath = TestDirectory.Create())
                 {
-                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
                     var deleteOnRestartManager = new TestDeleteOnRestartManager();
                     var nuGetPackageManager = new NuGetPackageManager(
@@ -293,7 +290,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         deleteOnRestartManager);
 
                     var projectTargetFrameworkStr = "net45";
-                    var fullProjectPath = Path.Combine(randomProjectFolderPath, "project1.csproj");
+                    var fullProjectPath = Path.Combine(testSolutionManager.TestDirectory, "project1.csproj");
                     var projectNames = new ProjectNames(
                         fullName: fullProjectPath,
                         uniqueName: Path.GetFileName(fullProjectPath),
@@ -331,7 +328,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     var dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(testSolutionManager, restoreContext);
 
-                    var projectLockFilePath = Path.Combine(randomProjectFolderPath, "packages.project1.lock.json");
+                    var projectLockFilePath = Path.Combine(testSolutionManager.TestDirectory, "packages.project1.lock.json");
                     File.Create(projectLockFilePath).Close();
 
                     var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
@@ -408,9 +405,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     });
 
                 using (var testSolutionManager = new TestSolutionManager(true))
-                using (var randomProjectFolderPath = TestDirectory.Create())
                 {
-                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
                     var deleteOnRestartManager = new TestDeleteOnRestartManager();
                     var nuGetPackageManager = new NuGetPackageManager(
@@ -420,8 +416,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         deleteOnRestartManager);
 
                     var projectTargetFrameworkStr = "net45";
-                    var fullProjectPath = Path.Combine(randomProjectFolderPath, "project1.csproj");
-                    var projectLockFilePath = Path.Combine(randomProjectFolderPath, "packages.custom.lock.json");
+                    var fullProjectPath = Path.Combine(testSolutionManager.TestDirectory, "project1.csproj");
+                    var projectLockFilePath = Path.Combine(testSolutionManager.TestDirectory, "packages.custom.lock.json");
                     File.Create(projectLockFilePath).Close();
 
                     var projectNames = new ProjectNames(
@@ -561,9 +557,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     });
 
                 using (var testSolutionManager = new TestSolutionManager(true))
-                using (var randomProjectFolderPath = TestDirectory.Create())
                 {
-                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
                     var deleteOnRestartManager = new TestDeleteOnRestartManager();
                     var nuGetPackageManager = new NuGetPackageManager(
@@ -573,8 +568,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         deleteOnRestartManager);
 
                     var projectTargetFrameworkStr = "net45";
-                    var fullProjectPath = Path.Combine(randomProjectFolderPath, "project1.csproj");
-                    var projectLockFilePath = Path.Combine(randomProjectFolderPath, "packages.lock.json");
+                    var fullProjectPath = Path.Combine(testSolutionManager.TestDirectory, "project1.csproj");
+                    var projectLockFilePath = Path.Combine(testSolutionManager.TestDirectory, "packages.lock.json");
                     File.Create(projectLockFilePath).Close();
 
                     var projectNames = new ProjectNames(
@@ -652,9 +647,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     });
 
                 using (var testSolutionManager = new TestSolutionManager(true))
-                using (var randomProjectFolderPath = TestDirectory.Create())
                 {
-                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
                     var deleteOnRestartManager = new TestDeleteOnRestartManager();
                     var nuGetPackageManager = new NuGetPackageManager(
@@ -664,7 +658,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         deleteOnRestartManager);
 
                     var projectTargetFrameworkStr = "net45";
-                    var fullProjectPath = Path.Combine(randomProjectFolderPath, "project1.csproj");
+                    var fullProjectPath = Path.Combine(testSolutionManager.TestDirectory, "project1.csproj");
 
                     var projectNames = new ProjectNames(
                         fullName: fullProjectPath,
@@ -727,7 +721,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         Assert.False(restoreSummary.NoOpRestore);
                     }
 
-                    Assert.True(File.Exists(Path.Combine(randomProjectFolderPath, "packages.lock.json")));
+                    Assert.True(File.Exists(Path.Combine(testSolutionManager.TestDirectory, "packages.lock.json")));
 
                     // install a new package
                     projectServices.SetupInstalledPackages(
@@ -787,9 +781,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     });
 
                 using (var testSolutionManager = new TestSolutionManager(true))
-                using (var randomProjectFolderPath = TestDirectory.Create())
                 {
-                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
                     var deleteOnRestartManager = new TestDeleteOnRestartManager();
                     var nuGetPackageManager = new NuGetPackageManager(
@@ -799,7 +792,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         deleteOnRestartManager);
 
                     var projectTargetFrameworkStr = "net45";
-                    var fullProjectPath = Path.Combine(randomProjectFolderPath, "project1.csproj");
+                    var fullProjectPath = Path.Combine(testSolutionManager.TestDirectory, "project1.csproj");
                     var projectNames = new ProjectNames(
                         fullName: fullProjectPath,
                         uniqueName: Path.GetFileName(fullProjectPath),
@@ -837,7 +830,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     var dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(testSolutionManager, restoreContext);
 
-                    var projectLockFilePath = Path.Combine(randomProjectFolderPath, "packages.project1.lock.json");
+                    var projectLockFilePath = Path.Combine(testSolutionManager.TestDirectory, "packages.project1.lock.json");
                     File.Create(projectLockFilePath).Close();
 
                     var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
@@ -866,9 +859,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     File.Delete(Path.Combine(vsProjectAdapter.MSBuildProjectExtensionsPath, "project1.csproj.nuget.cache"));
 
                     // clean packages folder
-                    var packagesFolder = Path.Combine(randomProjectFolderPath, "packages");
-                    Directory.Delete(packagesFolder, true);
-                    Directory.CreateDirectory(packagesFolder);
+                    Directory.Delete(testSolutionManager.GlobalPackagesFolder, true);
+                    Directory.CreateDirectory(testSolutionManager.GlobalPackagesFolder);
 
                     // add a new package
                     var newPackageContext = new SimpleTestPackageContext("packageA", "1.0.0");
@@ -913,9 +905,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     });
 
                 using (var testSolutionManager = new TestSolutionManager(true))
-                using (var randomProjectFolderPath = TestDirectory.Create())
                 {
-                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
                     var deleteOnRestartManager = new TestDeleteOnRestartManager();
                     var nuGetPackageManager = new NuGetPackageManager(
@@ -926,7 +917,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     // set up projects
                     var projectTargetFrameworkStr = "net45";
-                    var fullProjectPathB = Path.Combine(randomProjectFolderPath, "ProjectB", "ProjectB.csproj");
+                    var fullProjectPathB = Path.Combine(testSolutionManager.TestDirectory, "ProjectB", "ProjectB.csproj");
                     var projectNamesB = new ProjectNames(
                         fullName: fullProjectPathB,
                         uniqueName: Path.GetFileName(fullProjectPathB),
@@ -945,7 +936,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         projectServicesB,
                         _threadingService);
 
-                    var projectPathA = Path.Combine(randomProjectFolderPath, "ProjectA");
+                    var projectPathA = Path.Combine(testSolutionManager.TestDirectory, "ProjectA");
                     var fullProjectPathA = Path.Combine(projectPathA, "project1.csproj");
                     var projectNamesA = new ProjectNames(
                         fullName: fullProjectPathA,
@@ -1012,9 +1003,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     });
 
                 using (var testSolutionManager = new TestSolutionManager(true))
-                using (var randomProjectFolderPath = TestDirectory.Create())
                 {
-                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
                     var deleteOnRestartManager = new TestDeleteOnRestartManager();
                     var nuGetPackageManager = new NuGetPackageManager(
@@ -1025,7 +1015,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     // set up projects
                     var projectTargetFrameworkStr = "net45";
-                    var projectPathA = Path.Combine(randomProjectFolderPath, "ProjectA");
+                    var projectPathA = Path.Combine(testSolutionManager.TestDirectory, "ProjectA");
                     var fullProjectPathA = Path.Combine(projectPathA, "project1.csproj");
                     var projectNamesA = new ProjectNames(
                         fullName: fullProjectPathA,
@@ -1107,9 +1097,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     });
 
                 using (var testSolutionManager = new TestSolutionManager(true))
-                using (var randomProjectFolderPath = TestDirectory.Create())
                 {
-                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
                     var deleteOnRestartManager = new TestDeleteOnRestartManager();
                     var nuGetPackageManager = new NuGetPackageManager(
@@ -1120,7 +1109,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     // set up projects
                     var projectTargetFrameworkStr = "net45";
-                    var projectPathA = Path.Combine(randomProjectFolderPath, "ProjectA");
+                    var projectPathA = Path.Combine(testSolutionManager.TestDirectory, "ProjectA");
                     var fullProjectPathA = Path.Combine(projectPathA, "project1.csproj");
                     var projectNamesA = new ProjectNames(
                         fullName: fullProjectPathA,
@@ -1214,9 +1203,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     });
 
                 using (var testSolutionManager = new TestSolutionManager(true))
-                using (var randomProjectFolderPath = TestDirectory.Create())
                 {
-                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
                     var deleteOnRestartManager = new TestDeleteOnRestartManager();
                     var nuGetPackageManager = new NuGetPackageManager(
@@ -1227,7 +1215,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     // set up projects
                     var projectTargetFrameworkStr = "net45";
-                    var fullProjectPathB = Path.Combine(randomProjectFolderPath, "ProjectB", "project2.csproj");
+                    var fullProjectPathB = Path.Combine(testSolutionManager.TestDirectory, "ProjectB", "project2.csproj");
                     var projectNamesB = new ProjectNames(
                         fullName: fullProjectPathB,
                         uniqueName: Path.GetFileName(fullProjectPathB),
@@ -1255,7 +1243,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         projectServicesB,
                         _threadingService);
 
-                    var projectPathA = Path.Combine(randomProjectFolderPath, "ProjectA");
+                    var projectPathA = Path.Combine(testSolutionManager.TestDirectory, "ProjectA");
                     var fullProjectPathA = Path.Combine(projectPathA, "project1.csproj");
                     var projectNamesA = new ProjectNames(
                         fullName: fullProjectPathA,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/TestVSProjectAdapter.cs
@@ -134,7 +134,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             get
             {
-                return Path.Combine(ProjectDirectory, "packages");
+                return null;
             }
         }
 

--- a/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
+++ b/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
@@ -31,7 +31,7 @@ namespace Test.Utility
 
         public string SolutionDirectory { get; }
 
-        public TestDirectory TestDirectory;
+        public TestDirectory TestDirectory { get; private set; }
 
         private readonly string _configContent = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>

--- a/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
+++ b/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
@@ -31,8 +31,7 @@ namespace Test.Utility
 
         public string SolutionDirectory { get; }
 
-
-        private TestDirectory _testDirectory;
+        public TestDirectory TestDirectory;
 
         private readonly string _configContent = @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
@@ -46,8 +45,8 @@ namespace Test.Utility
 
         public TestSolutionManager(bool foo)
         {
-            _testDirectory = TestDirectory.Create();
-            SolutionDirectory = _testDirectory;
+            TestDirectory = TestDirectory.Create();
+            SolutionDirectory = TestDirectory;
             NuGetConfigPath = Path.Combine(SolutionDirectory, "NuGet.Config");
             PackagesFolder = Path.Combine(SolutionDirectory, "packages");
             GlobalPackagesFolder = Path.Combine(SolutionDirectory, "globalpackages");
@@ -209,11 +208,11 @@ namespace Test.Utility
 
         public void Dispose()
         {
-            var testDirectory = _testDirectory;
+            var testDirectory = TestDirectory;
             if (testDirectory != null)
             {
                 testDirectory.Dispose();
-                _testDirectory = null;
+                TestDirectory = null;
             }
 
             // reset environment variable


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7667 
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: While resolving a version from packages lock file, this PR adds an additional check to make sure that it has resolved the exact same version otherwise fails restore.

## Testing/Validation
Tests Added: Yes
Reason for not adding tests:  
Validation done:  
