### PR TITLE
Add cli1.0.4 to git ignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ artifacts/
 **/.vscode/
 
 cli/
+cli1.0.4/
 **/nupkgs/*.nupkg
 packages/
 .nuget/nuget.exe


### PR DESCRIPTION
## Bug
Fixes: 
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
When the migration to netstandard2.0 was completed, the .gitignore file was updated to not included cli1.0.4. 

Now if you switch between branches that do and don't have the need for cli1.0.4 you get unnecesary changes shown in git. As this is not harmful at all, it doesn't hurt to add it back. 

## Testing/Validation
Tests Added: Yes/No  
Reason for not adding tests:  
Validation done:  
