### PR TITLE
NuGetInteractive should default to MSBuildInteractive

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -53,6 +53,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <RestoreBuildInParallel Condition=" '$(RestoreBuildInParallel)' == '' ">true</RestoreBuildInParallel>
     <!-- Check if the restore target was executed on a sln file -->
     <_RestoreSolutionFileUsed Condition=" '$(_RestoreSolutionFileUsed)' == '' AND '$(SolutionDir)' != '' AND $(MSBuildProjectFullPath.EndsWith('.metaproj')) == 'true' " >true</_RestoreSolutionFileUsed>
+    <!-- We default to MSBuildInteractive. -->
+    <NuGetInteractive Condition="'$(NuGetInteractive)' == ''">$(MSBuildInteractive)</NuGetInteractive>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -54,7 +54,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Check if the restore target was executed on a sln file -->
     <_RestoreSolutionFileUsed Condition=" '$(_RestoreSolutionFileUsed)' == '' AND '$(SolutionDir)' != '' AND $(MSBuildProjectFullPath.EndsWith('.metaproj')) == 'true' " >true</_RestoreSolutionFileUsed>
     <!-- We default to MSBuildInteractive. -->
-    <NuGetInteractive Condition="'$(NuGetInteractive)' == ''">$(MSBuildInteractive)</NuGetInteractive>
+    <NuGetInteractive Condition=" '$(NuGetInteractive)' == '' ">$(MSBuildInteractive)</NuGetInteractive>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Bug
Fixes: NuGet side of https://github.com/Microsoft/msbuild/issues/4036
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 

This allows the /interactive flag to be implemented in msbuild in a way in that it is communicated to NuGet. 
The alternative would have been for /interactive to set potentially an open ended list of property which is error prone.

//cc @rainersigwald  @wli3 @rrelyea 
## Testing/Validation
Tests Added: No  
Reason for not adding tests:  Not really testable on our end. 
Validation done:  
