### PR TITLE
Skip checking suppressParent packages of p2p reference

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NuGet.Common;
+using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Shared;
 
@@ -56,43 +57,90 @@ namespace NuGet.ProjectModel
                 var target = nuGetLockFile.Targets.FirstOrDefault(
                     t => EqualityUtility.EqualsWithNullCheck(t.TargetFramework, framework.FrameworkName));
 
-                if (target != null)
+                if (target == null)
                 {
-                    var directDependencies = target.Dependencies.Where(dep => dep.Type == PackageDependencyType.Direct);
+                    // a new target found in the dgSpec so invalidate existing lock file.
+                    return false;
+                }
 
-                    if (HasProjectDependencyChanged(framework.Dependencies, directDependencies))
-                    {
-                        // lock file is out of sync
-                        return false;
-                    }
+                var directDependencies = target.Dependencies.Where(dep => dep.Type == PackageDependencyType.Direct);
+
+                if (HasProjectDependencyChanged(framework.Dependencies, directDependencies))
+                {
+                    // lock file is out of sync
+                    return false;
                 }
             }
 
             // Validate all P2P references
-            foreach (var p2p in dgSpec.Projects)
+            foreach (var framework in project.RestoreMetadata.TargetFrameworks)
             {
-                if (PathUtility.GetStringComparerBasedOnOS().Equals(p2p.RestoreMetadata.ProjectUniqueName, uniqueName))
-                {
-                    continue;
-                }
-
-                var projectName = Path.GetFileNameWithoutExtension(p2p.RestoreMetadata.ProjectPath);
-
-                foreach (var framework in p2p.TargetFrameworks)
-                {
-                    var target = nuGetLockFile.Targets.FirstOrDefault(
+                var target = nuGetLockFile.Targets.FirstOrDefault(
                     t => EqualityUtility.EqualsWithNullCheck(t.TargetFramework, framework.FrameworkName));
 
-                    if (target != null)
-                    {
-                        var projectDependency = target.Dependencies.FirstOrDefault(
-                            dep => dep.Type == PackageDependencyType.Project &&
-                            PathUtility.GetStringComparerBasedOnOS().Equals(dep.Id, projectName));
+                if (target == null)
+                {
+                    // a new target found in the dgSpec so invalidate existing lock file.
+                    return false;
+                }
 
-                        if (HasP2PDependencyChanged(framework.Dependencies, projectDependency))
+                var queue = new Queue<string>();
+                var visitedP2PReference = new HashSet<string>();
+
+                foreach (var projectReference in framework.ProjectReferences)
+                {
+                    if (visitedP2PReference.Add(projectReference.ProjectUniqueName))
+                    {
+                        queue.Enqueue(projectReference.ProjectUniqueName);
+
+                        while (queue.Count > 0)
                         {
-                            // lock file is out of sync
-                            return false;
+                            var p2pUniqueName = queue.Dequeue();
+                            var p2pProjectName = Path.GetFileNameWithoutExtension(p2pUniqueName);
+
+                            var projectDependency = target.Dependencies.FirstOrDefault(
+                                dep => dep.Type == PackageDependencyType.Project &&
+                                PathUtility.GetStringComparerBasedOnOS().Equals(dep.Id, p2pProjectName));
+
+                            if (projectDependency == null)
+                            {
+                                // project dependency doesn't exist in lock file.
+                                return false;
+                            }
+
+                            var p2pSpec = dgSpec.GetProjectSpec(p2pUniqueName);
+
+                            // ignore if this p2p packageSpec not found in DGSpec, It'll fail restore with different error at later stage
+                            if (p2pSpec != null)
+                            {
+                                var p2pSpecTarget = p2pSpec.TargetFrameworks.FirstOrDefault(
+                                    t => DefaultCompatibilityProvider.Instance.IsCompatible(framework.FrameworkName, t.FrameworkName));
+
+                                // ignore if compatible framework not found for p2p reference which means current project didn't
+                                // get anything transitively from this p2p
+                                if (p2pSpecTarget != null)
+                                {
+                                    if (HasP2PDependencyChanged(p2pSpecTarget.Dependencies, projectDependency))
+                                    {
+                                        // P2P transitive package dependencies has changed
+                                        return false;
+                                    }
+
+                                    var p2pSpecProjectRefTarget = p2pSpec.RestoreMetadata.TargetFrameworks.FirstOrDefault(
+                                        t => PathUtility.GetStringComparerBasedOnOS().Equals(p2pSpecTarget.FrameworkName.GetShortFolderName(), t.FrameworkName.GetShortFolderName()));
+
+                                    if (p2pSpecProjectRefTarget != null)
+                                    {
+                                        foreach (var reference in p2pSpecProjectRefTarget.ProjectReferences)
+                                        {
+                                            if (visitedP2PReference.Add(reference.ProjectUniqueName))
+                                            {
+                                                queue.Enqueue(reference.ProjectUniqueName);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -126,7 +174,8 @@ namespace NuGet.ProjectModel
                 return true;
             }
 
-            foreach (var dependency in newDependencies.Where(dep => dep.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package))
+            foreach (var dependency in newDependencies.Where(
+                dep => (dep.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package && !dep.AutoReferenced)))
             {
                 var matchedP2PLibrary = projectDependency.Dependencies.FirstOrDefault(dep => StringComparer.OrdinalIgnoreCase.Equals(dep.Id, dependency.Name));
 

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -175,7 +175,7 @@ namespace NuGet.ProjectModel
             }
 
             foreach (var dependency in newDependencies.Where(
-                dep => (dep.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package && !dep.AutoReferenced)))
+                dep => (dep.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package && dep.SuppressParent != LibraryIncludeFlags.All)))
             {
                 var matchedP2PLibrary = projectDependency.Dependencies.FirstOrDefault(dep => StringComparer.OrdinalIgnoreCase.Equals(dep.Id, dependency.Name));
 

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -113,8 +113,7 @@ namespace NuGet.ProjectModel
                             // ignore if this p2p packageSpec not found in DGSpec, It'll fail restore with different error at later stage
                             if (p2pSpec != null)
                             {
-                                var p2pSpecTarget = p2pSpec.TargetFrameworks.FirstOrDefault(
-                                    t => DefaultCompatibilityProvider.Instance.IsCompatible(framework.FrameworkName, t.FrameworkName));
+                                var p2pSpecTarget = NuGetFrameworkUtility.GetNearest(p2pSpec.TargetFrameworks, framework.FrameworkName, e => e.FrameworkName);
 
                                 // ignore if compatible framework not found for p2p reference which means current project didn't
                                 // get anything transitively from this p2p

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -6118,5 +6118,67 @@ namespace NuGet.CommandLine.Test
                 }
             }
         }
+
+        [Fact]
+        public async Task RestoreNetCore_MultiTFM_ProjectToProject_PackagesLockFile()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("net46"),
+                    NuGetFramework.Parse("net45"));
+
+                var projectB = SimpleTestProjectContext.CreateNETCore(
+                    "b",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("net45"),
+                    NuGetFramework.Parse("net46"));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net45/x.dll");
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX);
+
+                // A -> B
+                projectA.Properties.Add("RestorePackagesWithLockFile", "true");
+                projectA.Properties.Add("RestoreLockedMode", "true");
+                projectA.AddProjectToAllFrameworks(projectB);
+
+                // B
+                projectB.AddPackageToFramework("net45", packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Projects.Add(projectB);
+                solution.Create(pathContext.SolutionRoot);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath));
+                Assert.True(File.Exists(projectB.AssetsFileOutputPath));
+                Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
+
+                // Second Restore
+                r = Util.RestoreSolution(pathContext);
+
+                // Assert
+                r.Success.Should().BeTrue();
+            }
+        }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
@@ -1499,6 +1499,173 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             }
         }
 
+        [Fact]
+        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_PackagesLockFile_P2PReference()
+        {
+            using (var packageSource = TestDirectory.Create())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var randomProjectFolderPath = TestDirectory.Create())
+                {
+                    var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                    var testNuGetProjectContext = new TestNuGetProjectContext();
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+
+                    // set up projects
+                    var projectTargetFrameworkStr = "net46";
+                    var fullProjectPathB = Path.Combine(randomProjectFolderPath, "ProjectB", "project2.csproj");
+                    var projectNamesB = new ProjectNames(
+                        fullName: fullProjectPathB,
+                        uniqueName: Path.GetFileName(fullProjectPathB),
+                        shortName: Path.GetFileNameWithoutExtension(fullProjectPathB),
+                        customUniqueName: Path.GetFileName(fullProjectPathB));
+                    var vsProjectAdapterB = new TestVSProjectAdapter(
+                        fullProjectPathB,
+                        projectNamesB,
+                        projectTargetFrameworkStr);
+
+                    var projectServicesB = new TestProjectSystemServices();
+                    projectServicesB.SetupInstalledPackages(
+                        NuGetFramework.Parse(projectTargetFrameworkStr),
+                        new LibraryDependency
+                        {
+                            LibraryRange = new LibraryRange(
+                                "packageB",
+                                VersionRange.Parse("1.*"),
+                                LibraryDependencyTarget.Package),
+                            SuppressParent = LibraryIncludeFlags.All
+                        });
+
+                    var legacyPRProjectB = new LegacyPackageReferenceProject(
+                        vsProjectAdapterB,
+                        Guid.NewGuid().ToString(),
+                        projectServicesB,
+                        _threadingService);
+
+                    projectTargetFrameworkStr = "net461";
+                    var projectPathA = Path.Combine(randomProjectFolderPath, "ProjectA");
+                    var fullProjectPathA = Path.Combine(projectPathA, "project1.csproj");
+                    var projectNamesA = new ProjectNames(
+                        fullName: fullProjectPathA,
+                        uniqueName: Path.GetFileName(fullProjectPathA),
+                        shortName: Path.GetFileNameWithoutExtension(fullProjectPathA),
+                        customUniqueName: Path.GetFileName(fullProjectPathA));
+                    var vsProjectAdapterA = new TestVSProjectAdapter(
+                        fullProjectPathA,
+                        projectNamesA,
+                        projectTargetFrameworkStr,
+                        restorePackagesWithLockFile: "true",
+                        restoreLockedMode: true);
+
+                    var projectServicesA = new TestProjectSystemServices();
+                    projectServicesA.SetupInstalledPackages(
+                        NuGetFramework.Parse(projectTargetFrameworkStr),
+                        new LibraryDependency
+                        {
+                            LibraryRange = new LibraryRange(
+                                "packageA",
+                                VersionRange.Parse("1.*"),
+                                LibraryDependencyTarget.Package)
+                        });
+                    projectServicesA.SetupProjectDependencies(
+                        new ProjectRestoreReference
+                        {
+                            ProjectUniqueName = fullProjectPathB,
+                            ProjectPath = fullProjectPathB
+                        });
+
+                    var legacyPRProjectA = new LegacyPackageReferenceProject(
+                        vsProjectAdapterA,
+                        Guid.NewGuid().ToString(),
+                        projectServicesA,
+                        _threadingService);
+                    testSolutionManager.NuGetProjects.Add(legacyPRProjectB);
+                    testSolutionManager.NuGetProjects.Add(legacyPRProjectA);
+
+                    var testLogger = new TestLogger();
+                    var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
+                    var providersCache = new RestoreCommandProvidersCache();
+
+                    var packageContextA = new SimpleTestPackageContext("packageA", "1.0.0");
+                    packageContextA.AddFile("lib/net461/a.dll");
+                    var packageContextB = new SimpleTestPackageContext("packageB", "1.0.0");
+                    packageContextB.AddFile("lib/net45/b.dll");
+                    var packages = new List<SimpleTestPackageContext>() { packageContextA, packageContextB };
+                    SimpleTestPackageUtility.CreateOPCPackages(packages, packageSource);
+
+                    var dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(testSolutionManager, restoreContext);
+
+                    // Set-up Act
+                    var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                        testSolutionManager,
+                        dgSpec,
+                        restoreContext,
+                        providersCache,
+                        (c) => { },
+                        sourceRepositoryProvider.GetRepositories(),
+                        Guid.Empty,
+                        false,
+                        true,
+                        testLogger,
+                        CancellationToken.None);
+
+                    // Assert
+                    foreach (var restoreSummary in restoreSummaries)
+                    {
+                        Assert.True(restoreSummary.Success);
+                        Assert.False(restoreSummary.NoOpRestore);
+                    }
+
+                    Assert.True(File.Exists(Path.Combine(projectPathA, "packages.lock.json")));
+                    var lockFile = PackagesLockFileFormat.Read(Path.Combine(projectPathA, "packages.lock.json"));
+                    Assert.Equal(1, lockFile.Targets.Count);
+
+                    Assert.Equal(".NETFramework,Version=v4.6.1", lockFile.Targets[0].Name);
+                    Assert.Equal(2, lockFile.Targets[0].Dependencies.Count);
+                    Assert.Equal("packageA", lockFile.Targets[0].Dependencies[0].Id);
+                    Assert.Equal(PackageDependencyType.Direct, lockFile.Targets[0].Dependencies[0].Type);
+                    Assert.Equal("project2", lockFile.Targets[0].Dependencies[1].Id);
+                    Assert.Equal(PackageDependencyType.Project, lockFile.Targets[0].Dependencies[1].Type);
+
+                    // Act
+                    File.Delete(Path.Combine(vsProjectAdapterA.MSBuildProjectExtensionsPath, "project1.csproj.nuget.cache"));
+                    File.Delete(Path.Combine(vsProjectAdapterB.MSBuildProjectExtensionsPath, "project2.csproj.nuget.cache"));
+
+                    restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                        testSolutionManager,
+                        dgSpec,
+                        restoreContext,
+                        providersCache,
+                        (c) => { },
+                        sourceRepositoryProvider.GetRepositories(),
+                        Guid.Empty,
+                        false,
+                        true,
+                        testLogger,
+                        CancellationToken.None);
+
+                    // Assert
+                    foreach (var restoreSummary in restoreSummaries)
+                    {
+                        Assert.True(restoreSummary.Success);
+                        Assert.False(restoreSummary.NoOpRestore);
+                    }
+                }
+            }
+        }
+
         private ISettings PopulateSettingsWithSources(SourceRepositoryProvider sourceRepositoryProvider, TestDirectory settingsDirectory)
         {
             var settings = new Settings(settingsDirectory);


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7646 
Regression: Yes/No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: This PR fixes 2 issues:
a. Skipping checking suppressParent packages (`developmentDependency` or `PrivateAssets=all`) of p2p reference which won't be there in lock file so that it doesn't invalidate an existing lock file which should be valid.
b. This PR also fixes the target framework comparison for p2p reference. Currently it just compare the target of p2p reference with the project itself to be same and ignore lock file when it doesn't match. But it would fail for the compatible frameworks like `netstandard2.0` to `net461`. 

## Testing/Validation
Tests Added: Yes
Reason for not adding tests:  
Validation done:  
