### PR TITLE
Add flag to skip MSBuild step during restore

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -56,8 +56,8 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "ForceRestoreCommand")]
         public bool Force { get; set; }
 
-        [Option(typeof(NuGetCommand), "RestoreCommandSkipMSBuild")]
-        public bool SkipMSBuild { get; set; }
+        [Option(typeof(NuGetCommand), "RestoreCommandPackagesConfigOnly")]
+        public bool PackagesConfigOnly { get; set; }
 
         [ImportingConstructor]
         public RestoreCommand()
@@ -503,7 +503,7 @@ namespace NuGet.CommandLine
 
                 try
                 {
-                    if (SkipMSBuild)
+                    if (PackagesConfigOnly)
                     {
                         // We still need a (blank) DependencyGraphSpec or AddInputsFromDependencyGraphSpec below
                         // won't run, and that does important processing on packageRestoreInputs even if there's

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -10360,6 +10360,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Do not analyze projects for ProjectReference-style package references with MSBuild. This is significantly faster if all of your packages are found in old-style packages.config files..
+        /// </summary>
+        internal static string RestoreCommandSkipMSBuild {
+            get {
+                return ResourceManager.GetString("RestoreCommandSkipMSBuild", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Specifies the solution directory. Not valid when restoring packages for a solution..
         /// </summary>
         internal static string RestoreCommandSolutionDirectory {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -10099,6 +10099,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Do not analyze projects for ProjectReference-style package references with MSBuild. This is significantly faster if all of your packages are found in old-style packages.config files..
+        /// </summary>
+        internal static string RestoreCommandPackagesConfigOnly {
+            get {
+                return ResourceManager.GetString("RestoreCommandPackagesConfigOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Specifies the packages folder..
         /// </summary>
         internal static string RestoreCommandPackagesDirectory {
@@ -10356,15 +10365,6 @@ namespace NuGet.CommandLine {
         internal static string RestoreCommandRequireConsent_trk {
             get {
                 return ResourceManager.GetString("RestoreCommandRequireConsent_trk", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Do not analyze projects for ProjectReference-style package references with MSBuild. This is significantly faster if all of your packages are found in old-style packages.config files..
-        /// </summary>
-        internal static string RestoreCommandSkipMSBuild {
-            get {
-                return ResourceManager.GetString("RestoreCommandSkipMSBuild", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5526,4 +5526,7 @@ nuget-trusted-signers Remove -Name TrustedRepo</value>
   <data name="TrustedSignersCommandServiceIndexDescription" xml:space="preserve">
     <value>Service index for a repository to be trusted.</value>
   </data>
+  <data name="RestoreCommandSkipMSBuild" xml:space="preserve">
+    <value>Do not analyze projects for ProjectReference-style package references with MSBuild. This is significantly faster if all of your packages are found in old-style packages.config files.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5526,7 +5526,7 @@ nuget-trusted-signers Remove -Name TrustedRepo</value>
   <data name="TrustedSignersCommandServiceIndexDescription" xml:space="preserve">
     <value>Service index for a repository to be trusted.</value>
   </data>
-  <data name="RestoreCommandSkipMSBuild" xml:space="preserve">
+  <data name="RestoreCommandPackagesConfigOnly" xml:space="preserve">
     <value>Do not analyze projects for ProjectReference-style package references with MSBuild. This is significantly faster if all of your packages are found in old-style packages.config files.</value>
   </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -2313,7 +2313,7 @@ EndProject";
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void RestoreCommand_HonorsSkipMSBuildFlag(bool skipMSBuild)
+        public void RestoreCommand_HonorsPackagesConfigOnlyFlag(bool packagesConfigOnly)
         {
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
@@ -2332,14 +2332,14 @@ EndProject";
                 var r = CommandRunner.Run(
                     nugetexe,
                     workingPath,
-                    "restore -Source " + repositoryPath + (skipMSBuild ? " -SkipMSBuild" : ""),
+                    "restore -Source " + repositoryPath + (packagesConfigOnly ? " -PackagesConfigOnly" : ""),
                     waitForExit: true);
 
                 Assert.True(_successCode == r.Item1, r.Item2 + " " + r.Item3);
                 var packageFileA = Path.Combine(workingPath, @"GlobalPackages", "packageA", "1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, @"GlobalPackages", "packageB", "2.2.0", "packageB.2.2.0.nupkg");
                 var packageFileC = Path.Combine(workingPath, @"packages", "packageC.3.3.0", "packageC.3.3.0.nupkg");
-                if (skipMSBuild)
+                if (packagesConfigOnly)
                 {
                     Assert.False(File.Exists(packageFileA));
                     Assert.False(File.Exists(packageFileB));


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#7690
Regression: Yes
* Last working version: 3.5.0 (as tested)
* How are we preventing it in future: optional flag with unit test

## Fix

Details: The MSBuild analysis of the projects is expensive on large projects (17 seconds on our 400-project solution). For legacy solutions (like ours) where all package references are handled in the old-style packages.config files, the MSBuild analysis is unnecessary and just wastes time on every package restore, even those that should be no-ops. Allow callers to pass a flag that skips this step.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  N/A
Validation:  Ran all tests in NuGetRestoreCommandTests class and the three RestoreCommandTests classes. Observed 3 failures (RestoreCommand_LongPathPackage, Restore_LegacyPackageReference_WithNuGetLockFile, and Restore_LegacyPackageReference_WithNuGetLockFilePath) also observed in current unmodified dev. Added additional test for this specific case to confirm intended behavior with and without new flag, both cases pass.
