### PR TITLE
Re-enable MacOS signing tests

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
@@ -18,12 +18,14 @@ namespace NuGet.Commands
 
         // OpenSSL:  error:2006D080:BIO routines:BIO_new_file:no such file
         private const int OPENSSL_BIO_R_NO_SUCH_FILE = 0x2006D080;
+        private const int MACOS_FILE_NOT_FOUND = -25257;
 
         // "The specified password is not correct." (ERROR_INVALID_PASSWORD)
         private const int ERROR_INVALID_PASSWORD_HRESULT = unchecked((int)0x80070056);
 
         // OpenSSL:  error:23076071:PKCS12 routines:PKCS12_parse:mac verify failure
         private const int OPENSSL_PKCS12_R_MAC_VERIFY_FAILURE = 0x23076071;
+        private const int MACOS_PKCS12_MAC_VERIFY_FAILURE = -25264;
 
         // "The specified certificate file is not correct." (CRYPT_E_NO_MATCH)
         private const int CRYPT_E_NO_MATCH_HRESULT = unchecked((int)0x80092009);
@@ -56,6 +58,7 @@ namespace NuGet.Commands
                     {
                         case ERROR_INVALID_PASSWORD_HRESULT:
                         case OPENSSL_PKCS12_R_MAC_VERIFY_FAILURE:
+                        case MACOS_PKCS12_MAC_VERIFY_FAILURE:
                             throw new SignCommandException(
                                 LogMessage.CreateError(NuGetLogCode.NU3001,
                                 string.Format(CultureInfo.CurrentCulture,
@@ -65,6 +68,7 @@ namespace NuGet.Commands
 
                         case ERROR_FILE_NOT_FOUND_HRESULT:
                         case OPENSSL_BIO_R_NO_SUCH_FILE:
+                        case MACOS_FILE_NOT_FOUND:
                             throw new SignCommandException(
                                 LogMessage.CreateError(NuGetLogCode.NU3001,
                                 string.Format(CultureInfo.CurrentCulture,

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
@@ -54,53 +54,48 @@ namespace NuGet.Commands
 
                     resultCollection = new X509Certificate2Collection(cert);
                 }
-                catch (Exception ex)
+                catch (CryptographicException ex)
                 {
-                    if (ex is CryptographicException ce)
+                    switch (ex.HResult)
                     {
-                        switch (ce.HResult)
-                        {
-                            case ERROR_INVALID_PASSWORD_HRESULT:
-                            case OPENSSL_PKCS12_R_MAC_VERIFY_FAILURE:
-                            case MACOS_PKCS12_MAC_VERIFY_FAILURE:
-                                throw new SignCommandException(
-                                    LogMessage.CreateError(NuGetLogCode.NU3001,
-                                    string.Format(CultureInfo.CurrentCulture,
-                                    Strings.SignCommandInvalidPasswordException,
-                                    options.CertificatePath,
-                                    nameof(options.CertificatePassword))));
-
-                            case ERROR_FILE_NOT_FOUND_HRESULT:
-                            case OPENSSL_BIO_R_NO_SUCH_FILE:
-                                throw new SignCommandException(
-                                    LogMessage.CreateError(NuGetLogCode.NU3001,
-                                    string.Format(CultureInfo.CurrentCulture,
-                                        Strings.SignCommandCertificateFileNotFound,
-                                        options.CertificatePath)));
-
-                            case CRYPT_E_NO_MATCH_HRESULT:
-                            case OPENSSL_ERR_R_NESTED_ASN1_ERROR:
-                            case MACOS_INVALID_CERT:
-                                throw new SignCommandException(
-                                    LogMessage.CreateError(NuGetLogCode.NU3001,
-                                    string.Format(CultureInfo.CurrentCulture,
-                                        Strings.SignCommandInvalidCertException,
-                                        options.CertificatePath)));
-
-                            default:
-                                throw;
-                        }
-                    }
-                    else if (ex is FileNotFoundException fne)
-                    {
+                        case ERROR_INVALID_PASSWORD_HRESULT:
+                        case OPENSSL_PKCS12_R_MAC_VERIFY_FAILURE:
+                        case MACOS_PKCS12_MAC_VERIFY_FAILURE:
                             throw new SignCommandException(
-                                    LogMessage.CreateError(NuGetLogCode.NU3001,
-                                    string.Format(CultureInfo.CurrentCulture,
-                                        Strings.SignCommandCertificateFileNotFound,
-                                        options.CertificatePath)));
-                    }
+                                LogMessage.CreateError(NuGetLogCode.NU3001,
+                                string.Format(CultureInfo.CurrentCulture,
+                                Strings.SignCommandInvalidPasswordException,
+                                options.CertificatePath,
+                                nameof(options.CertificatePassword))));
 
-                    throw;
+                        case ERROR_FILE_NOT_FOUND_HRESULT:
+                        case OPENSSL_BIO_R_NO_SUCH_FILE:
+                            throw new SignCommandException(
+                                LogMessage.CreateError(NuGetLogCode.NU3001,
+                                string.Format(CultureInfo.CurrentCulture,
+                                    Strings.SignCommandCertificateFileNotFound,
+                                    options.CertificatePath)));
+
+                        case CRYPT_E_NO_MATCH_HRESULT:
+                        case OPENSSL_ERR_R_NESTED_ASN1_ERROR:
+                        case MACOS_INVALID_CERT:
+                            throw new SignCommandException(
+                                LogMessage.CreateError(NuGetLogCode.NU3001,
+                                string.Format(CultureInfo.CurrentCulture,
+                                    Strings.SignCommandInvalidCertException,
+                                    options.CertificatePath)));
+
+                        default:
+                            throw;
+                    }
+                }
+                catch (FileNotFoundException)
+                {
+                        throw new SignCommandException(
+                                LogMessage.CreateError(NuGetLogCode.NU3001,
+                                string.Format(CultureInfo.CurrentCulture,
+                                    Strings.SignCommandCertificateFileNotFound,
+                                    options.CertificatePath)));
                 }
             }
             else

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
@@ -91,11 +91,11 @@ namespace NuGet.Commands
                 }
                 catch (FileNotFoundException)
                 {
-                        throw new SignCommandException(
-                                LogMessage.CreateError(NuGetLogCode.NU3001,
-                                string.Format(CultureInfo.CurrentCulture,
-                                    Strings.SignCommandCertificateFileNotFound,
-                                    options.CertificatePath)));
+                    throw new SignCommandException(
+                            LogMessage.CreateError(NuGetLogCode.NU3001,
+                            string.Format(CultureInfo.CurrentCulture,
+                                Strings.SignCommandCertificateFileNotFound,
+                                options.CertificatePath)));
                 }
             }
             else

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Oids.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Oids.cs
@@ -89,5 +89,13 @@ namespace NuGet.Packaging.Signing
         public const string NuGetV3ServiceIndexUrl = "1.3.6.1.4.1.311.84.2.1.1.1";
 
         public const string NuGetPackageOwners = "1.3.6.1.4.1.311.84.2.1.1.2";
+
+        public const string IdKpClientAuth = "1.3.6.1.5.5.7.3.2";
+
+        public const string IdKpEmailProtection = "1.3.6.1.5.5.7.3.4";
+
+        public const string AnyExtendedKeyUsage = "2.5.29.37.0";
+
+        public const string CrlDistributionPoints = "2.5.29.31";
     }
 }

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/MSSignCommandTestContext.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/MSSignCommandTestContext.cs
@@ -52,7 +52,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest
                 throw new ArgumentNullException(nameof(certificate));
             }
 
-            var key = certificate.PrivateKey as ICspAsymmetricAlgorithm;
+            var key = certificate.GetRSAPrivateKey() as ICspAsymmetricAlgorithm;
             if (key != null)
             {
                 var keyContainer = key.CspKeyContainerInfo;

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using NuGet.Packaging.Signing;
@@ -103,19 +104,21 @@ namespace NuGet.Packaging.FuncTest
             {
                 if (_trustedTestCertificateWithReissuedCertificate == null)
                 {
-                    var keyPair = SigningTestUtility.GenerateKeyPair(publicKeyLength: 2048);
-                    var certificateName = TestCertificate.GenerateCertificateName();
-                    var certificate1 = SigningTestUtility.GenerateCertificate(certificateName, keyPair);
-                    var certificate2 = SigningTestUtility.GenerateCertificate(certificateName, keyPair);
-
-                    var testCertificate1 = new TestCertificate() { Cert = certificate1 }.WithTrust(StoreName.Root, StoreLocation.LocalMachine);
-                    var testCertificate2 = new TestCertificate() { Cert = certificate2 }.WithTrust(StoreName.Root, StoreLocation.LocalMachine);
-
-                    _trustedTestCertificateWithReissuedCertificate = new[]
+                    using (var rsa = RSA.Create(keySizeInBits: 2048))
                     {
-                        testCertificate1,
-                        testCertificate2
-                    };
+                        var certificateName = TestCertificate.GenerateCertificateName();
+                        var certificate1 = SigningTestUtility.GenerateCertificate(certificateName, rsa);
+                        var certificate2 = SigningTestUtility.GenerateCertificate(certificateName, rsa);
+
+                        var testCertificate1 = new TestCertificate() { Cert = certificate1 }.WithTrust(StoreName.Root, StoreLocation.LocalMachine);
+                        var testCertificate2 = new TestCertificate() { Cert = certificate2 }.WithTrust(StoreName.Root, StoreLocation.LocalMachine);
+
+                        _trustedTestCertificateWithReissuedCertificate = new[]
+                        {
+                            testCertificate1,
+                            testCertificate2
+                        };
+                    }
                 }
 
                 return _trustedTestCertificateWithReissuedCertificate;

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -139,7 +139,6 @@ namespace NuGet.Packaging.FuncTest
 
             Action<TestCertificateGenerator> modifyGenerator = delegate (TestCertificateGenerator gen)
             {
-                gen.NotBefore = DateTime.MinValue;
                 gen.NotBefore = DateTime.UtcNow.Subtract(TimeSpan.FromDays(1)); // cert has expired
             };
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
@@ -17,7 +16,6 @@ using FluentAssertions;
 using NuGet.Common;
 using NuGet.Packaging.Signing;
 using NuGet.Test.Utility;
-using Org.BouncyCastle.X509;
 using Test.Utility.Signing;
 using Xunit;
 
@@ -139,10 +137,10 @@ namespace NuGet.Packaging.FuncTest
             var authorCertName = "author@nuget.func.test";
             var content = new SignatureContent(SigningSpecifications.V1, Common.HashAlgorithmName.SHA256, "Test data to be signed and timestamped");
 
-            Action<X509V3CertificateGenerator> modifyGenerator = delegate (X509V3CertificateGenerator gen)
+            Action<TestCertificateGenerator> modifyGenerator = delegate (TestCertificateGenerator gen)
             {
-                gen.SetNotBefore(DateTime.MinValue);
-                gen.SetNotBefore(DateTime.UtcNow.Subtract(TimeSpan.FromDays(1))); // cert has expired
+                gen.NotBefore = DateTime.MinValue;
+                gen.NotBefore = DateTime.UtcNow.Subtract(TimeSpan.FromDays(1)); // cert has expired
             };
 
             using (var authorCert = SigningTestUtility.GenerateCertificate(authorCertName, modifyGenerator: modifyGenerator))

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
@@ -21,7 +21,7 @@ namespace NuGet.Commands.Test
             _fixture = fixture;
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public async Task ExecuteCommandAsync_WithCertificateFileNotFound_ThrowsAsync()
         {
             using (var test = await Test.CreateAsync(_fixture.GetDefaultCertificate()))
@@ -38,7 +38,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public async Task ExecuteCommandAsync_WithEmptyPkcs7File_ThrowsAsync()
         {
             using (var test = await Test.CreateAsync(_fixture.GetDefaultCertificate()))
@@ -80,7 +80,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public async Task ExecuteCommandAsync_WithIncorrectPassword_ThrowsAsync()
         {
             const string password = "password";
@@ -119,7 +119,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public async Task ExecuteCommandAsync_WithMultiplePackagesAndInvalidCertificate_RaisesErrorsOnceAsync()
         {
             const string password = "password";

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/AuthorSignPackageRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/AuthorSignPackageRequestTests.cs
@@ -32,7 +32,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal("certificate", exception.ParamName);
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Constructor_CertificateHashAlgorithm_WhenHashAlgorithmInvalid_Throws()
         {
             using (var certificate = _fixture.GetDefaultCertificate())
@@ -44,7 +44,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Constructor_CertificateHashAlgorithm_WithValidInput_InitializesProperties()
         {
             using (var certificate = _fixture.GetDefaultCertificate())
@@ -70,7 +70,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal("certificate", exception.ParamName);
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Constructor_CertificateSignatureHashAlgorithmTimestampHashAlgorithm_WhenSignatureHashAlgorithmInvalid_Throws()
         {
             using (var certificate = _fixture.GetDefaultCertificate())
@@ -86,7 +86,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Constructor_CertificateSignatureHashAlgorithmTimestampHashAlgorithm_WhenTimestampHashAlgorithmInvalid_Throws()
         {
             using (var certificate = _fixture.GetDefaultCertificate())
@@ -102,7 +102,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Constructor_CertificateSignatureHashAlgorithmTimestampHashAlgorithm_WithValidInput_InitializesProperties()
         {
             using (var certificate = _fixture.GetDefaultCertificate())

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
@@ -73,7 +73,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal("certificateType", exception.ParamName);
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void GetCertificateChain_WithUntrustedRoot_Throws()
         {
             using (var chainHolder = new X509ChainHolder())
@@ -108,7 +108,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void GetCertificateChain_WithUntrustedSelfIssuedCertificate_ReturnsChain()
         {
             using (var certificate = _fixture.GetDefaultCertificate())

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
@@ -96,14 +96,18 @@ namespace NuGet.Packaging.Test
                 Assert.Equal("Certificate chain validation failed.", exception.Message);
 
                 Assert.Equal(1, logger.Errors);
-                Assert.Equal(RuntimeEnvironmentHelper.IsWindows ? 2 : 1, logger.Warnings);
-
                 SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Error);
-                SigningTestUtility.AssertOfflineRevocation(logger.LogMessages, LogLevel.Warning);
 
-                if (RuntimeEnvironmentHelper.IsWindows)
+                if (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsLinux)
                 {
-                    SigningTestUtility.AssertRevocationStatusUnknown(logger.LogMessages, LogLevel.Warning);
+                    Assert.Equal(RuntimeEnvironmentHelper.IsWindows ? 2 : 1, logger.Warnings);
+
+                    SigningTestUtility.AssertOfflineRevocation(logger.LogMessages, LogLevel.Warning);
+
+                    if (RuntimeEnvironmentHelper.IsWindows)
+                    {
+                        SigningTestUtility.AssertRevocationStatusUnknown(logger.LogMessages, LogLevel.Warning);
+                    }
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
@@ -127,11 +127,11 @@ namespace NuGet.Packaging.Test
                 }
 
                 Assert.Equal(0, logger.Errors);
-                Assert.Equal(RuntimeEnvironmentHelper.IsWindows ? 1 : 2, logger.Warnings);
+                Assert.Equal(RuntimeEnvironmentHelper.IsLinux ? 2 : 1, logger.Warnings);
 
                 SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Warning);
 
-                if (!RuntimeEnvironmentHelper.IsWindows)
+                if (RuntimeEnvironmentHelper.IsLinux)
                 {
                     SigningTestUtility.AssertOfflineRevocation(logger.LogMessages, LogLevel.Warning);
                 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
@@ -28,16 +28,16 @@ namespace NuGet.Packaging.Test
         }
 
         [Theory]
-        [InlineData(Common.HashAlgorithmName.SHA256, RSASignaturePaddingMode.Pkcs1, Oids.Sha256WithRSAEncryption)]
-        [InlineData(Common.HashAlgorithmName.SHA384, RSASignaturePaddingMode.Pkcs1, Oids.Sha384WithRSAEncryption)]
-        [InlineData(Common.HashAlgorithmName.SHA512, RSASignaturePaddingMode.Pkcs1, Oids.Sha512WithRSAEncryption)]
-        public void IsSignatureAlgorithmSupported_WhenSupported_ReturnsTrue(Common.HashAlgorithmName algorithm, RSASignaturePaddingMode paddingMode, string expectedSignatureAlgorithmOid)
+        [InlineData(Common.HashAlgorithmName.SHA256, Oids.Sha256WithRSAEncryption)]
+        [InlineData(Common.HashAlgorithmName.SHA384, Oids.Sha384WithRSAEncryption)]
+        [InlineData(Common.HashAlgorithmName.SHA512, Oids.Sha512WithRSAEncryption)]
+        public void IsSignatureAlgorithmSupported_WhenSupported_ReturnsTrue(Common.HashAlgorithmName algorithm, string expectedSignatureAlgorithmOid)
         {
             using (var certificate = SigningTestUtility.GenerateCertificate(
                 "test",
                 generator => { },
                 algorithm,
-                paddingMode))
+                RSASignaturePaddingMode.Pkcs1))
             {
                 Assert.Equal(expectedSignatureAlgorithmOid, certificate.SignatureAlgorithm.Value);
                 Assert.True(CertificateUtility.IsSignatureAlgorithmSupported(certificate));
@@ -166,12 +166,12 @@ namespace NuGet.Packaging.Test
             using (var certificate = SigningTestUtility.GenerateCertificate("test",
                 generator =>
                 {
-                    var usages = new OidCollection { TestCertificateGenerator.IdKPCodeSigning };
+                    var usages = new OidCollection { new Oid(Oids.CodeSigningEku) };
 
                     generator.Extensions.Add(
                         new X509EnhancedKeyUsageExtension(
                               usages,
-                              critical: true));
+                              critical: false));
                 }))
             {
                 Assert.Equal(1, GetExtendedKeyUsageCount(certificate));
@@ -195,12 +195,12 @@ namespace NuGet.Packaging.Test
             using (var certificate = SigningTestUtility.GenerateCertificate("test",
                 generator =>
                 {
-                    var usages = new OidCollection { TestCertificateGenerator.IdKPCodeSigning };
+                    var usages = new OidCollection { new Oid(Oids.CodeSigningEku) };
 
                     generator.Extensions.Add(
                         new X509EnhancedKeyUsageExtension(
                               usages,
-                              critical: true));
+                              critical: false));
                 }))
             {
                 Assert.Equal(1, GetExtendedKeyUsageCount(certificate));
@@ -214,12 +214,12 @@ namespace NuGet.Packaging.Test
             using (var certificate = SigningTestUtility.GenerateCertificate("test",
                 generator =>
                 {
-                    var usages = new OidCollection { TestCertificateGenerator.IdKPEmailProtection };
+                    var usages = new OidCollection { new Oid(Oids.IdKpEmailProtection) };
 
                     generator.Extensions.Add(
                         new X509EnhancedKeyUsageExtension(
                               usages,
-                              critical: true));
+                              critical: false));
                 }))
             {
                 Assert.Equal(1, GetExtendedKeyUsageCount(certificate));
@@ -233,12 +233,12 @@ namespace NuGet.Packaging.Test
             using (var certificate = SigningTestUtility.GenerateCertificate("test",
                 generator =>
                 {
-                    var usages = new OidCollection { TestCertificateGenerator.IdKPEmailProtection, TestCertificateGenerator.AnyExtendedKeyUsage };
+                    var usages = new OidCollection { new Oid(Oids.IdKpEmailProtection), new Oid(Oids.AnyExtendedKeyUsage) };
 
                     generator.Extensions.Add(
                         new X509EnhancedKeyUsageExtension(
                               usages,
-                              critical: true));
+                              critical: false));
                 }))
             {
                 Assert.Equal(2, GetExtendedKeyUsageCount(certificate));

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
@@ -41,7 +41,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void IsSignatureAlgorithmSupported_WhenUnsupported_ReturnsFalse()
         {
             using (var certificate = _fixture.GetRsaSsaPssCertificate())
@@ -136,7 +136,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void HasLifetimeSigningEku_WithLifetimeSignerEku_ReturnsTrue()
         {
             using (var certificate = _fixture.GetLifetimeSigningCertificate())
@@ -262,7 +262,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void IsSelfIssued_WithNonSelfSignedCertificate_ReturnsFalse()
         {
             using (var certificate = _fixture.GetNonSelfSignedCertificate())
@@ -271,7 +271,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void IsSelfIssued_WithSelfSignedCertificate_ReturnsTrue()
         {
             using (var certificate = _fixture.GetDefaultCertificate())
@@ -280,7 +280,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void IsSelfIssued_WithSelfIssuedCertificate_ReturnsTrue()
         {
             using (var certificate = _fixture.GetSelfIssuedCertificate())
@@ -289,7 +289,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void IsSelfIssued_WithRootCertificate_ReturnsTrue()
         {
             using (var certificate = _fixture.GetRootCertificate())
@@ -313,7 +313,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void GetHashString_UnknownHashAlgorithm_Throws()
         {
             using (var certificate = _fixture.GetDefaultCertificate())
@@ -323,7 +323,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void GetHashString_UnsupportedHashAlgorithm_Throws()
         {
             using (var certificate = _fixture.GetDefaultCertificate())

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/EssCertIdV2Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/EssCertIdV2Tests.cs
@@ -43,7 +43,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal("certificate", exception.ParamName);
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Create_WithUnknownHashAlgorithmName_Throws()
         {
             using (var certificate = _fixture.GetDefaultCertificate())
@@ -55,7 +55,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Create_WithSha256_ReturnsEssCertIdV2()
         {
             var hashAlgorithmName = HashAlgorithmName.SHA256;
@@ -72,7 +72,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Create_WithSha384_ReturnsEssCertIdV2()
         {
             var hashAlgorithmName = HashAlgorithmName.SHA384;
@@ -89,7 +89,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Create_WithSha512_ReturnsEssCertIdV2()
         {
             var hashAlgorithmName = HashAlgorithmName.SHA512;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/IssuerSerialTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/IssuerSerialTests.cs
@@ -38,7 +38,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal("certificate", exception.ParamName);
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Create_WithCertificate_InitializesFields()
         {
             using (var certificate = _fixture.GetDefaultCertificate())

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/IssuerSerialTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/IssuerSerialTests.cs
@@ -56,7 +56,9 @@ namespace NuGet.Packaging.Test
         {
             using (var certificate = SigningTestUtility.GenerateCertificate("test", generator =>
                 {
-                    generator.SetSerialNumber(BigInteger.One);
+                    var bytes = BitConverter.GetBytes(1);
+                    Array.Reverse(bytes);
+                    generator.SetSerialNumber(bytes);
                 }))
             {
                 var issuerSerial = IssuerSerial.Create(certificate);
@@ -70,7 +72,9 @@ namespace NuGet.Packaging.Test
         {
             using (var certificate = SigningTestUtility.GenerateCertificate("test", generator =>
                 {
-                    generator.SetSerialNumber(BigInteger.ValueOf(long.MaxValue));
+                    var bytes = BitConverter.GetBytes(long.MaxValue);
+                    Array.Reverse(bytes);
+                    generator.SetSerialNumber(bytes);
                 }))
             {
                 var issuerSerial = IssuerSerial.Create(certificate);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/RepositorySignPackageRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/RepositorySignPackageRequestTests.cs
@@ -82,7 +82,7 @@ namespace NuGet.Packaging.Test
         }
 
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Constructor_WhenV3ServiceIndexUrlNull_Throws()
         {
             using (var certificate = _fixture.GetDefaultCertificate())
@@ -99,7 +99,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Constructor_WhenV3ServiceIndexUrlNotAbsolute_Throws()
         {
             using (var certificate = _fixture.GetDefaultCertificate())
@@ -117,7 +117,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Constructor_WhenV3ServiceIndexUrlNotHttps_Throws()
         {
             using (var certificate = _fixture.GetDefaultCertificate())
@@ -135,7 +135,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformTheory(Platform.Windows, Platform.Linux)]
+        [Theory]
         [InlineData(null)]
         [InlineData("")]
         [InlineData(" ")]

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageArchiveUtilityTests.cs
@@ -22,12 +22,7 @@ namespace NuGet.Packaging.Test
 
         public SignedPackageArchiveUtilityTests(CertificatesFixture fixture)
         {
-            if (fixture == null)
-            {
-                throw new ArgumentNullException(nameof(fixture));
-            }
-
-            _fixture = fixture;
+            _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningCertificateV2Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningCertificateV2Tests.cs
@@ -40,7 +40,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal("certificate", exception.ParamName);
         }
 
-        [PlatformTheory(Platform.Windows, Platform.Linux)]
+        [Theory]
         [InlineData(HashAlgorithmName.SHA256)]
         [InlineData(HashAlgorithmName.SHA384)]
         [InlineData(HashAlgorithmName.SHA512)]
@@ -70,7 +70,7 @@ namespace NuGet.Packaging.Test
                 () => SigningCertificateV2.Read(new byte[] { 0x30, 0x0b }));
         }
 
-        [PlatformTheory(Platform.Windows, Platform.Linux)]
+        [Theory]
         [InlineData(HashAlgorithmName.SHA256)]
         [InlineData(HashAlgorithmName.SHA384)]
         [InlineData(HashAlgorithmName.SHA512)]

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
@@ -39,7 +39,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal("request", exception.ParamName);
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Verify_WhenLoggerNull_Throws()
         {
             using (var certificate = _fixture.GetDefaultCertificate())
@@ -52,7 +52,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Verify_WithCertificateWithUnsupportedSignatureAlgorithm_Throws()
         {
             using (var certificate = _fixture.GetRsaSsaPssCertificate())
@@ -66,7 +66,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Verify_WithCertificateWithLifetimeSigningEku_Throws()
         {
             using (var certificate = _fixture.GetLifetimeSigningCertificate())
@@ -80,7 +80,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Verify_WithNotYetValidCertificate_Throws()
         {
             using (var certificate = _fixture.GetNotYetValidCertificate())
@@ -94,7 +94,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Verify_WhenChainBuildingFails_Throws()
         {
             using (var certificate = _fixture.GetExpiredCertificate())
@@ -125,7 +125,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void Verify_WithUntrustedSelfSignedCertificate_Succeeds()
         {
             using (var certificate = _fixture.GetDefaultCertificate())
@@ -307,7 +307,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal("request", exception.ParamName);
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public void CreateCmsSigner_WhenLoggerNull_Throws()
         {
             using (var request = new AuthorSignPackageRequest(new X509Certificate2(), Common.HashAlgorithmName.SHA256))
@@ -537,7 +537,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [Fact]
         public async Task SignAsync_WithUntrustedSelfSignedCertificate_SucceedsAsync()
         {
             var package = new SimpleTestPackageContext();

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
@@ -463,7 +463,8 @@ namespace NuGet.Packaging.Test
             using (var certificate = SigningTestUtility.GenerateCertificate(
                 "test",
                 generator => { },
-                "SHA256WITHRSAANDMGF1"))
+                Common.HashAlgorithmName.SHA256,
+                System.Security.Cryptography.RSASignaturePaddingMode.Pss))
             using (var test = SignTest.Create(certificate, HashAlgorithmName.SHA256))
             {
                 var exception = await Assert.ThrowsAsync<SignatureException>(

--- a/test/TestUtilities/Test.Utility/Signing/CertificateRevocationList.cs
+++ b/test/TestUtilities/Test.Utility/Signing/CertificateRevocationList.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using Org.BouncyCastle.Asn1.X509;
@@ -60,8 +61,10 @@ namespace Test.Utility.Signing
                 crlGen.AddCrlEntry(bcRevokedCert.SerialNumber, DateTime.Now, CrlReason.PrivilegeWithdrawn);
             }
 
+            Debugger.Launch();
+
             var random = new SecureRandom();
-            var issuerPrivateKey = DotNetUtilities.GetKeyPair(issuerCert.PrivateKey).Private;
+            var issuerPrivateKey = DotNetUtilities.GetKeyPair(issuerCert.GetRSAPrivateKey()).Private;
             var signatureFactory = new Asn1SignatureFactory(bcIssuerCert.SigAlgOid, issuerPrivateKey, random);
             var crl = crlGen.Generate(signatureFactory);
             return crl;

--- a/test/TestUtilities/Test.Utility/Signing/ChainCertificateRequest.cs
+++ b/test/TestUtilities/Test.Utility/Signing/ChainCertificateRequest.cs
@@ -17,7 +17,5 @@ namespace Test.Utility.Signing
         public bool ConfigureCrl { get; set; } = true;
 
         public X509Certificate2 Issuer { get; set; }
-
-        public string IssuerDN => Issuer?.Subject;
     }
 }

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -266,7 +266,7 @@ namespace Test.Utility.Signing
             var rsa = RSA.Create(rsaParams);
             using (var export = certResult.CopyWithPrivateKey(rsa))
             {
-                return new X509Certificate2(export.Export(X509ContentType.Pkcs12));
+                return new X509Certificate2(export.Export(X509ContentType.Pkcs12), password: (string) null, keyStorageFlags: X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
             }
         }
 
@@ -315,9 +315,10 @@ namespace Test.Utility.Signing
             var rsaParams = DotNetUtilities.ToRSAParameters(keyPair.Private as RsaPrivateCrtKeyParameters);
 
             var rsa = RSA.Create(rsaParams);
+            //rsa.
             using (var export = certResult.CopyWithPrivateKey(rsa))
             {
-                return new X509Certificate2(export.Export(X509ContentType.Pkcs12));
+                return new X509Certificate2(export.Export(X509ContentType.Pkcs12), password: (string)null, keyStorageFlags: X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
             }
         }
 
@@ -361,7 +362,7 @@ namespace Test.Utility.Signing
             var rsa = RSA.Create(rsaParams);
             using (var export = certResult.CopyWithPrivateKey(rsa))
             {
-                return new X509Certificate2(export.Export(X509ContentType.Pkcs12));
+                return new X509Certificate2(export.Export(X509ContentType.Pkcs12), password: (string)null, keyStorageFlags: X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
             }
         }
 
@@ -412,7 +413,7 @@ namespace Test.Utility.Signing
             var rsa = RSA.Create(rsaParams);
             using (var export = certResult.CopyWithPrivateKey(rsa))
             {
-                return new X509Certificate2(export.Export(X509ContentType.Pkcs12));
+                return new X509Certificate2(export.Export(X509ContentType.Pkcs12), password: (string)null, keyStorageFlags: X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
             }
         }
 

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -680,7 +680,7 @@ namespace Test.Utility.Signing
             }
             else if (RuntimeEnvironmentHelper.IsMacOSX)
             {
-                untrustedRoot = "The certificate was not trusted.";
+                untrustedRoot = "The trust policy was not trusted.";
             }
             else
             {

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -268,12 +268,18 @@ namespace Test.Utility.Signing
                     request.CertificateExtensions.Add(extension);
                 }
 
+                X509Certificate2 certResult;
+
                 if (isSelfSigned)
                 {
-                    return request.CreateSelfSigned(certGen.NotBefore, certGen.NotAfter);
+                    certResult = request.CreateSelfSigned(certGen.NotBefore, certGen.NotAfter);
+                }
+                else
+                {
+                    certResult = request.Create(issuer, certGen.NotBefore, certGen.NotAfter, certGen.SerialNumber);
                 }
 
-                return request.Create(issuer, certGen.NotBefore, certGen.NotAfter, certGen.SerialNumber);
+                return new X509Certificate2(certResult.Export(X509ContentType.Pkcs12), password: (string)null, keyStorageFlags: X509KeyStorageFlags.Exportable);
             }
         }
 
@@ -313,7 +319,9 @@ namespace Test.Utility.Signing
             request.CertificateExtensions.Add(
                 new X509EnhancedKeyUsageExtension(new OidCollection { TestCertificateGenerator.IdKPCodeSigning }, critical: true));
 
-            return request.CreateSelfSigned(notBefore: DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)), notAfter: DateTime.UtcNow.Add(TimeSpan.FromHours(1)));
+            var certResult = request.CreateSelfSigned(notBefore: DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)), notAfter: DateTime.UtcNow.Add(TimeSpan.FromHours(1)));
+
+            return new X509Certificate2(certResult.Export(X509ContentType.Pkcs12), password: (string)null, keyStorageFlags: X509KeyStorageFlags.Exportable);
         }
 
         public static X509Certificate2 GenerateCertificate(
@@ -345,8 +353,10 @@ namespace Test.Utility.Signing
             request.CertificateExtensions.Add(
                 new X509EnhancedKeyUsageExtension(new OidCollection { TestCertificateGenerator.IdKPCodeSigning }, critical: true));
 
-           var generator = X509SignatureGenerator.CreateForRSA(issuerAlgorithm, RSASignaturePadding.Pkcs1);
-           return request.Create(issuerDN, generator, notBefore, notAfter, serialNumber);
+            var generator = X509SignatureGenerator.CreateForRSA(issuerAlgorithm, RSASignaturePadding.Pkcs1);
+            var certResult = request.Create(issuerDN, generator, notBefore, notAfter, serialNumber);
+
+            return new X509Certificate2(certResult.Export(X509ContentType.Pkcs12), password: (string)null, keyStorageFlags: X509KeyStorageFlags.Exportable);
         }
 
         public static X509Certificate2 GenerateSelfIssuedCertificate(bool isCa)
@@ -380,7 +390,9 @@ namespace Test.Utility.Signing
                     new X509KeyUsageExtension(keyUsages, critical: true));
 
                 var now = DateTime.UtcNow;
-                return request.CreateSelfSigned(notBefore: now, notAfter: now.AddHours(1));
+                var certResult = request.CreateSelfSigned(notBefore: now, notAfter: now.AddHours(1));
+
+                return new X509Certificate2(certResult.Export(X509ContentType.Pkcs12), password: (string)null, keyStorageFlags: X509KeyStorageFlags.Exportable);
             }
         }
 

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -224,6 +224,7 @@ namespace Test.Utility.Signing
 
             var isSelfSigned = true;
             X509Certificate2 issuer = null;
+            DateTimeOffset? notAfter = null;
 
             var keyUsage = X509KeyUsageFlags.DigitalSignature;
 
@@ -235,6 +236,7 @@ namespace Test.Utility.Signing
                     // for a certificate with an issuer assign Authority Key Identifier
                     issuer = chainCertificateRequest?.Issuer;
 
+                    notAfter = issuer.NotAfter.Subtract(TimeSpan.FromMinutes(5));
                     var publicKey = DotNetUtilities.GetRsaPublicKey(issuer.GetRSAPublicKey());
 
                     certGen.Extensions.Add(
@@ -270,7 +272,7 @@ namespace Test.Utility.Signing
             var padding = paddingMode.ToPadding();
             var request = new CertificateRequest(subjectDN, rsa, hashAlgorithm.ConvertToSystemSecurityHashAlgorithmName(), padding);
 
-            certGen.NotAfter = DateTime.UtcNow.Add(TimeSpan.FromMinutes(30));
+            certGen.NotAfter = notAfter ?? DateTime.UtcNow.Add(TimeSpan.FromMinutes(30));
             certGen.NotBefore = DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(30));
 
             var random = new Random();

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -264,7 +264,10 @@ namespace Test.Utility.Signing
             var rsaParams = DotNetUtilities.ToRSAParameters(keyPair.Private as RsaPrivateCrtKeyParameters);
 
             var rsa = RSA.Create(rsaParams);
-            return certResult.CopyWithPrivateKey(rsa);
+            using (var export = certResult.CopyWithPrivateKey(rsa))
+            {
+                return new X509Certificate2(export.Export(X509ContentType.Pkcs12));
+            }
         }
 
         /// <summary>
@@ -312,7 +315,10 @@ namespace Test.Utility.Signing
             var rsaParams = DotNetUtilities.ToRSAParameters(keyPair.Private as RsaPrivateCrtKeyParameters);
 
             var rsa = RSA.Create(rsaParams);
-            return certResult.CopyWithPrivateKey(rsa);
+            using (var export = certResult.CopyWithPrivateKey(rsa))
+            {
+                return new X509Certificate2(export.Export(X509ContentType.Pkcs12));
+            }
         }
 
         public static X509Certificate2 GenerateCertificate(
@@ -353,7 +359,10 @@ namespace Test.Utility.Signing
             var rsaParams = DotNetUtilities.ToRSAParameters(keyPair.Private as RsaPrivateCrtKeyParameters);
 
             var rsa = RSA.Create(rsaParams);
-            return certResult.CopyWithPrivateKey(rsa);
+            using (var export = certResult.CopyWithPrivateKey(rsa))
+            {
+                return new X509Certificate2(export.Export(X509ContentType.Pkcs12));
+            }
         }
 
         public static X509Certificate2 GenerateSelfIssuedCertificate(bool isCa)
@@ -401,7 +410,10 @@ namespace Test.Utility.Signing
             var rsaParams = DotNetUtilities.ToRSAParameters(keyPair.Private as RsaPrivateCrtKeyParameters);
 
             var rsa = RSA.Create(rsaParams);
-            return certResult.CopyWithPrivateKey(rsa);
+            using (var export = certResult.CopyWithPrivateKey(rsa))
+            {
+                return new X509Certificate2(export.Export(X509ContentType.Pkcs12));
+            }
         }
 
         private static X509SubjectKeyIdentifierExtension GetSubjectKeyIdentifier(X509Certificate2 issuer)

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -34,7 +34,7 @@ namespace Test.Utility.Signing
         public static Action<TestCertificateGenerator> CertificateModificationGeneratorForInvalidEkuCert = delegate (TestCertificateGenerator gen)
         {
             // any EKU besides CodeSigning
-            var usages = new OidCollection { TestCertificateGenerator.IdKPClientAuth };
+            var usages = new OidCollection { new Oid(Oids.IdKpClientAuth) };
 
             gen.Extensions.Add(
                  new X509EnhancedKeyUsageExtension(
@@ -48,7 +48,7 @@ namespace Test.Utility.Signing
         /// </summary>
         public static Action<TestCertificateGenerator> CertificateModificationGeneratorForCodeSigningEkuCert = delegate (TestCertificateGenerator gen)
         {
-            var usages = new OidCollection { TestCertificateGenerator.IdKPCodeSigning };
+            var usages = new OidCollection { new Oid(Oids.CodeSigningEku) };
 
             gen.Extensions.Add(
                   new X509EnhancedKeyUsageExtension(
@@ -62,7 +62,7 @@ namespace Test.Utility.Signing
         /// </summary>
         public static Action<TestCertificateGenerator> CertificateModificationGeneratorExpiredCert = delegate (TestCertificateGenerator gen)
         {
-            var usages = new OidCollection { TestCertificateGenerator.IdKPCodeSigning };
+            var usages = new OidCollection { new Oid(Oids.CodeSigningEku) };
 
             gen.Extensions.Add(
                   new X509EnhancedKeyUsageExtension(
@@ -79,7 +79,7 @@ namespace Test.Utility.Signing
         /// </summary>
         public static Action<TestCertificateGenerator> CertificateModificationGeneratorNotYetValidCert = delegate (TestCertificateGenerator gen)
         {
-            var usages = new OidCollection { TestCertificateGenerator.IdKPCodeSigning };
+            var usages = new OidCollection { new Oid(Oids.CodeSigningEku) };
 
             gen.Extensions.Add(
              new X509EnhancedKeyUsageExtension(
@@ -98,7 +98,7 @@ namespace Test.Utility.Signing
         /// </summary>
         public static Action<TestCertificateGenerator> CertificateModificationGeneratorExpireIn10Seconds = delegate (TestCertificateGenerator gen)
         {
-            var usages = new OidCollection { TestCertificateGenerator.IdKPCodeSigning };
+            var usages = new OidCollection { new Oid(Oids.CodeSigningEku) };
 
             gen.Extensions.Add(
                 new X509EnhancedKeyUsageExtension(
@@ -241,7 +241,7 @@ namespace Test.Utility.Signing
 
                     certGen.Extensions.Add(
                         new X509Extension(
-                            TestCertificateGenerator.AuthorityKeyIdentifier,
+                            Oids.AuthorityKeyIdentifier,
                             new AuthorityKeyIdentifierStructure(publicKey).GetEncoded(),
                             critical: false));
                 }
@@ -257,7 +257,7 @@ namespace Test.Utility.Signing
 
                     certGen.Extensions.Add(
                         new X509Extension(
-                            TestCertificateGenerator.CrlDistributionPoints,
+                            Oids.CrlDistributionPoints,
                             new DerSequence(distPoint).GetDerEncoded(),
                             critical: false));
                 }
@@ -347,7 +347,7 @@ namespace Test.Utility.Signing
             request.CertificateExtensions.Add(
                 new X509KeyUsageExtension(X509KeyUsageFlags.KeyCertSign, critical: true));
             request.CertificateExtensions.Add(
-                new X509EnhancedKeyUsageExtension(new OidCollection { TestCertificateGenerator.IdKPCodeSigning }, critical: true));
+                new X509EnhancedKeyUsageExtension(new OidCollection { new Oid(Oids.CodeSigningEku) }, critical: true));
 
             var certResult = request.CreateSelfSigned(notBefore: DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)), notAfter: DateTime.UtcNow.Add(TimeSpan.FromHours(1)));
 
@@ -381,7 +381,7 @@ namespace Test.Utility.Signing
             request.CertificateExtensions.Add(
                 new X509KeyUsageExtension(X509KeyUsageFlags.KeyCertSign, critical: true));
             request.CertificateExtensions.Add(
-                new X509EnhancedKeyUsageExtension(new OidCollection { TestCertificateGenerator.IdKPCodeSigning }, critical: true));
+                new X509EnhancedKeyUsageExtension(new OidCollection { new Oid(Oids.CodeSigningEku) }, critical: true));
 
             var generator = X509SignatureGenerator.CreateForRSA(issuerAlgorithm, RSASignaturePadding.Pkcs1);
 
@@ -414,7 +414,7 @@ namespace Test.Utility.Signing
 
                 request.CertificateExtensions.Add(
                     new X509Extension(
-                        TestCertificateGenerator.AuthorityKeyIdentifier,
+                        Oids.AuthorityKeyIdentifier,
                         new AuthorityKeyIdentifierStructure(publicKey).GetEncoded(),
                         critical: false));
                 request.CertificateExtensions.Add(

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -369,7 +369,7 @@ namespace Test.Utility.Signing
         {
             using (var rsa = RSA.Create(keySizeInBits: 2048))
             {
-                var subjectName = new X500DistinguishedName($"CN=NuGet Test Self Issued Certificate ({Guid.NewGuid().ToString()})");
+                var subjectName = new X500DistinguishedName($"C=US,S=WA,L=Redmond,O=NuGet,CN=NuGet Test Self-Issued Certificate ({Guid.NewGuid().ToString()})");
                 var hashAlgorithm = System.Security.Cryptography.HashAlgorithmName.SHA256;
                 var request = new CertificateRequest(subjectName, rsa, hashAlgorithm, RSASignaturePadding.Pkcs1);
 

--- a/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Security.Cryptography.X509Certificates;
-using Org.BouncyCastle.X509;
 
 namespace Test.Utility.Signing
 {
@@ -56,7 +55,7 @@ namespace Test.Utility.Signing
             return "NuGetTest-" + Guid.NewGuid().ToString();
         }
 
-        public static TestCertificate Generate(Action<X509V3CertificateGenerator> modifyGenerator = null, ChainCertificateRequest chainCertificateRequest = null)
+        public static TestCertificate Generate(Action<TestCertificateGenerator> modifyGenerator = null, ChainCertificateRequest chainCertificateRequest = null)
         {
             var certName = GenerateCertificateName();
             var cert = SigningTestUtility.GenerateCertificate(certName, modifyGenerator, chainCertificateRequest: chainCertificateRequest);

--- a/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
@@ -58,7 +58,7 @@ namespace Test.Utility.Signing
         public static TestCertificate Generate(Action<TestCertificateGenerator> modifyGenerator = null, ChainCertificateRequest chainCertificateRequest = null)
         {
             var certName = GenerateCertificateName();
-            var cert = SigningTestUtility.GenerateCertificate(certName, modifyGenerator, chainCertificateRequest: chainCertificateRequest);
+            var cert = SigningTestUtility.GenerateCertificateWithKeyInfo(certName, modifyGenerator, chainCertificateRequest: chainCertificateRequest);
             CertificateRevocationList crl = null;
 
             // create a crl only if the certificate is part of a chain and it is a CA
@@ -69,7 +69,7 @@ namespace Test.Utility.Signing
 
             var testCertificate = new TestCertificate
             {
-                Cert = cert,
+                Cert = cert.Certificate,
                 Crl = crl
             };
 

--- a/test/TestUtilities/Test.Utility/Signing/TestCertificateGenerator.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TestCertificateGenerator.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Test.Utility.Signing
+{
+    public class TestCertificateGenerator
+    {
+        public static readonly Oid IdKPCodeSigning = new Oid("1.3.6.1.5.5.7.3.3");
+        public static readonly Oid IdKPClientAuth = new Oid("1.3.6.1.5.5.7.3.2");
+        public static readonly Oid IdKPEmailProtection = new Oid("1.3.6.1.5.5.7.3.4");
+        public static readonly Oid AnyExtendedKeyUsage = new Oid("2.5.29.37");
+        public static readonly Oid AuthorityKeyIdentifier = new Oid("2.5.29.35");
+        public static readonly Oid CrlDistributionPoints = new Oid("2.5.29.31");
+
+        public DateTimeOffset NotBefore { get; set; }
+
+        public DateTimeOffset NotAfter { get; set; }
+
+        public byte[] SerialNumber { get; private set; }
+
+        public Collection<X509Extension> Extensions { get; }
+
+        public TestCertificateGenerator()
+        {
+            Extensions = new Collection<X509Extension>();
+        }
+
+        public void SetSerialNumber(byte[] serialNumber)
+        {
+            SerialNumber = serialNumber ?? throw new ArgumentNullException(nameof(serialNumber));
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/TestCertificateGenerator.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TestCertificateGenerator.cs
@@ -3,20 +3,12 @@
 
 using System;
 using System.Collections.ObjectModel;
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Test.Utility.Signing
 {
-    public class TestCertificateGenerator
+    public sealed class TestCertificateGenerator
     {
-        public static readonly Oid IdKPCodeSigning = new Oid("1.3.6.1.5.5.7.3.3");
-        public static readonly Oid IdKPClientAuth = new Oid("1.3.6.1.5.5.7.3.2");
-        public static readonly Oid IdKPEmailProtection = new Oid("1.3.6.1.5.5.7.3.4");
-        public static readonly Oid AnyExtendedKeyUsage = new Oid("2.5.29.37");
-        public static readonly Oid AuthorityKeyIdentifier = new Oid("2.5.29.35");
-        public static readonly Oid CrlDistributionPoints = new Oid("2.5.29.31");
-
         public DateTimeOffset NotBefore { get; set; }
 
         public DateTimeOffset NotAfter { get; set; }

--- a/test/TestUtilities/Test.Utility/Signing/X509CertificateWithKeyInfo.cs
+++ b/test/TestUtilities/Test.Utility/Signing/X509CertificateWithKeyInfo.cs
@@ -8,14 +8,14 @@ using System.Security.Cryptography.X509Certificates;
 namespace Test.Utility.Signing
 {
     /// <summary>
-    /// Utility to store a certificate and the RSA key that it was build with.
+    /// Utility to store a certificate and the RSA key that it was built with.
     /// </summary>
     /// <remarks>
-    /// This is useful because CGN certs import the key as Exportable, but bouncy castle needs it as ExportablePlainText.
+    /// This is useful because CNG certs import the key as Exportable, but bouncy castle needs it as ExportablePlainText.
     /// By having the RSA key stored, you can use it with bouncy castle. If we update our test infrastructure to not use bouncy castle
     /// this class won't be needed anymore.
     /// </remarks>
-    public class X509CertificateWithKeyInfo : IDisposable
+    public sealed class X509CertificateWithKeyInfo : IDisposable
     {
         public X509Certificate2 Certificate { get; private set; }
 

--- a/test/TestUtilities/Test.Utility/Signing/X509CertificateWithKeyInfo.cs
+++ b/test/TestUtilities/Test.Utility/Signing/X509CertificateWithKeyInfo.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Test.Utility.Signing
+{
+    public class X509CertificateWithKeyInfo : IDisposable
+    {
+        public X509Certificate2 Certificate { get; private set; }
+
+        public RSA KeyPair { get; private set; }
+
+        private bool _isDisposed;
+
+        public X509CertificateWithKeyInfo(X509Certificate2 cert, RSA keyPair)
+        {
+            Certificate = cert;
+            KeyPair = keyPair;
+        }
+
+        public void Dispose()
+        {
+            if (!_isDisposed)
+            {
+                Certificate?.Dispose();
+                KeyPair?.Dispose();
+            }
+
+            _isDisposed = true;
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/Signing/X509CertificateWithKeyInfo.cs
+++ b/test/TestUtilities/Test.Utility/Signing/X509CertificateWithKeyInfo.cs
@@ -7,6 +7,14 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace Test.Utility.Signing
 {
+    /// <summary>
+    /// Utility to store a certificate and the RSA key that it was build with.
+    /// </summary>
+    /// <remarks>
+    /// This is useful because CGN certs import the key as Exportable, but bouncy castle needs it as ExportablePlainText.
+    /// By having the RSA key stored, you can use it with bouncy castle. If we update our test infrastructure to not use bouncy castle
+    /// this class won't be needed anymore.
+    /// </remarks>
     public class X509CertificateWithKeyInfo : IDisposable
     {
         public X509Certificate2 Certificate { get; private set; }

--- a/test/TestUtilities/Test.Utility/Test.Utility.csproj
+++ b/test/TestUtilities/Test.Utility/Test.Utility.csproj
@@ -1,11 +1,11 @@
-﻿<Project>
+<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksExe)</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <NoWarn Condition="'$(TargetFramework)' == '$(NetStandardVersion)'">$(NoWarn);CS1998</NoWarn>
+    <NoWarn Condition="'$(TargetFramework)' == '$(NETCoreTargetFramework)'">$(NoWarn);CS1998</NoWarn>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
     <IsPackable>true</IsPackable>
@@ -65,13 +65,14 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardVersion)' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == '$(NETCoreTargetFramework)' ">
     <PackageReference Include="System.Diagnostics.Process" Version="$(SystemPackagesVersion)" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="$(SystemPackagesVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.5.2" />
   </ItemGroup>
 
-  <!-- Remove files that do not support netstandard -->
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardVersion)' ">
+  <!-- Remove files that do not support netcore -->
+  <ItemGroup Condition=" '$(TargetFramework)' == '$(NETCoreTargetFramework)' ">
     <Compile Remove="PackageManagement\*.cs" />
     <Compile Remove="ProjectManagement\*.cs" />
     <Compile Remove="Threading\*.cs" />


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7608
## Fix

Re-enabled and made pass mac tests. This change involves changing some utilities to be able to create certificates with private keys cross platform. Test utility had to be moved to netcoreapp2.1 since netstandard2.0 doesn't have support for the methods needed. Once netstandard2.1 is out test.utility should be able to return to target netstandard instead of netcore.
