### PR TITLE
Test:  improve performance testing script further

### DIFF
--- a/scripts/perftests/PerformanceTestRunner.ps1
+++ b/scripts/perftests/PerformanceTestRunner.ps1
@@ -1,67 +1,72 @@
 Param(
     [Parameter(Mandatory = $true)]
-    [string]$resultsDirectoryPath,
-    [string[]]$nugetClients,
-    [string]$testDirectoryPath,
-    [string]$logsDirectoryPath,
-    [switch]$SkipCleanup
+    [string] $resultsFolderPath,
+    [string[]] $nugetClientFilePaths,
+    [string] $testFolderPath,
+    [int] $iterationCount = 3,
+    [switch] $SkipCleanup
 )
 
-    . "$PSScriptRoot\PerformanceTestUtilities.ps1"
+. "$PSScriptRoot\PerformanceTestUtilities.ps1"
 
-    if (![string]::IsNullOrEmpty($testDirectoryPath) -And $(GetAbsolutePath $resultsDirectoryPath).StartsWith($(GetAbsolutePath $testDirectoryPath))) 
-    {
-        Log "$resultsDirectoryPath cannot be a subdirectory of $testDirectoryPath" "red"
-        exit(1)
-    }
-    
-    if ([string]::IsNullOrEmpty($testDirectoryPath)) 
-    {
-        $testDirectoryPath = [System.IO.Path]::Combine($env:TEMP, "np")
-    }
+If ([string]::IsNullOrEmpty($testFolderPath))
+{
+    $testFolderPath = [System.IO.Path]::Combine($env:TEMP, "np")
+}
 
-    Log "Clients: $nugetClients" "green"
+$resultsFolderPath = GetAbsolutePath $resultsFolderPath
+$testFolderPath = GetAbsolutePath $testFolderPath
 
-    try 
+If (![string]::IsNullOrEmpty($testFolderPath) -And [System.IO.Path]::GetDirectoryName($resultsFolderPath).StartsWith($testFolderPath))
+{
+    Log "$resultsFolderPath cannot be a subdirectory of $testFolderPath" "red"
+
+    Exit 1
+}
+
+Log "Clients: $nugetClientFilePaths" "green"
+
+Try
+{
+    ForEach ($nugetClientFilePath In $nugetClientFilePaths)
     {
-        foreach($nugetClient in $nugetClients)
+        Try
         {
-            try 
-            {
-                Log "Running tests for $nugetClient" "green"
+            Log "Running tests for $nugetClientFilePath" "green"
 
-                if ([string]::IsNullOrEmpty($nugetClient) -Or !$(Test-Path $nugetClient)) 
+            If ([string]::IsNullOrEmpty($nugetClientFilePath) -Or !$(Test-Path $nugetClientFilePath))
+            {
+                Log "The NuGet client at '$nugetClientFilePath' cannot be resolved." "yellow"
+
+                Exit 1
+            }
+
+            Log "Discovering the test cases."
+            $testFiles = $(Get-ChildItem $PSScriptRoot\testCases "Test-*.ps1" ) | ForEach-Object { $_.FullName }
+            Log "Discovered test cases: $testFiles" "green"
+
+            $testFiles | ForEach-Object {
+                $testCase = $_
+                Try
                 {
-                    Log "The NuGet client at '$nugetClient' cannot be resolved." "yellow"
-                    exit(1)
+                    . $_ -nugetClientFilePath $nugetClientFilePath -sourceRootFolderPath $([System.IO.Path]::Combine($testFolderPath, "source")) -resultsFolderPath $resultsFolderPath -logsFolderPath $([System.IO.Path]::Combine($testFolderPath, "logs")) -iterationCount $iterationCount
                 }
-
-                $testDirectoryPath = GetAbsolutePath $testDirectoryPath
-                $resultsDirectoryPath = GetAbsolutePath $resultsDirectoryPath
-                Log "Discovering the test cases." 
-                $testFiles = $(Get-ChildItem $PSScriptRoot\testCases "Test-*.ps1" ) | ForEach-Object { $_.FullName }
-                Log "Discovered test cases: $testFiles" "green"
-                $testFiles | ForEach-Object {
-                    $testCase = $_
-                    try 
-                    {
-                    . $_ -nugetClient $nugetClient -sourceRootDirectory $([System.IO.Path]::Combine($testDirectoryPath, "source")) -resultsDirectoryPath $resultsDirectoryPath -logsPath $([System.IO.Path]::Combine($testDirectoryPath, "logs")) 
-                    } 
-                    catch 
-                    {
-                        Log "Problem running the test case $testCase with error $_" "red"
-                    }
+                Catch
+                {
+                    Log "Problem running the test case $testCase with error $_" "red"
                 }
-            } 
-            catch 
-            {
-                Log "Problem running the tests with $nugetClient" "red"
             }
         }
-    }
-    finally 
-    {
-        if (!$SkipCleanup) {
-            Remove-Item -r -force $testDirectoryPath -ErrorAction Ignore > $null
+        Catch
+        {
+            Log "Problem running the tests with $nugetClientFilePath" "red"
         }
     }
+}
+Finally
+{
+    If (!$SkipCleanup)
+    {
+        Remove-Item -r -force $testFolderPath -ErrorAction Ignore > $null
+    }
+}

--- a/scripts/perftests/PerformanceTestUtilities.ps1
+++ b/scripts/perftests/PerformanceTestUtilities.ps1
@@ -327,9 +327,16 @@ Function RunRestore(
     [switch] $killMsBuildAndDotnetExeProcesses,
     [switch] $force)
 {
-    Log "Running $nugetClientFilePath restore with cleanGlobalPackagesFolder:$cleanGlobalPackagesFolder cleanHttpCache:$cleanHttpCache cleanPluginsCache:$cleanPluginsCache killMsBuildAndDotnetExeProcesses:$killMsBuildAndDotnetExeProcesses force:$force"
-
     $isClientDotnetExe = IsClientDotnetExe $nugetClientFilePath
+
+    If ($isClientDotnetExe -And $isPackagesConfig)
+    {
+        Log "dotnet.exe does not support packages.config restore." "Red"
+
+        Return
+    }
+
+    Log "Running $nugetClientFilePath restore with cleanGlobalPackagesFolder:$cleanGlobalPackagesFolder cleanHttpCache:$cleanHttpCache cleanPluginsCache:$cleanPluginsCache killMsBuildAndDotnetExeProcesses:$killMsBuildAndDotnetExeProcesses force:$force"
 
     $solutionPackagesFolderPath = $Env:NUGET_SOLUTION_PACKAGES_FOLDER_PATH
 

--- a/scripts/perftests/PerformanceTestUtilities.ps1
+++ b/scripts/perftests/PerformanceTestUtilities.ps1
@@ -1,209 +1,466 @@
 # Contains all the utility methods used by the performance tests.
 
-    # The format of the URL is assumed to be https://github.com/NuGet/NuGet.Client.git. The result would be NuGet-Client-git
-    function GenerateNameFromGitUrl([string]$gitUrl)
+# The format of the URL is assumed to be https://github.com/NuGet/NuGet.Client.git. The result would be NuGet-Client-git
+function GenerateNameFromGitUrl([string]$gitUrl)
+{
+    return $gitUrl.Substring($($gitUrl.LastIndexOf('/') + 1)).Replace('.','-')
+}
+
+# Appends the log time in front of the log statement with the color specified. 
+function Log([string]$logStatement, [string]$color)
+{
+    if([string]::IsNullOrEmpty($color))
     {
-        return $gitUrl.Substring($($gitUrl.LastIndexOf('/') + 1)).Replace('.','-')
+        Write-Host "$($(Get-Date).ToString()): $logStatement"
+    }
+    else
+    { 
+        Write-Host "$($(Get-Date).ToString()): $logStatement" -ForegroundColor $color
+    }
+}
+
+# Given a relative path, gets the absolute path from the current directory
+function GetAbsolutePath([string]$Path)
+{
+    $Path = [System.IO.Path]::Combine((pwd).Path, $Path);
+    $Path = [System.IO.Path]::GetFullPath($Path);
+    return $Path;
+}
+
+# Writes the content to the given path. Creates the folder structure if needed
+function OutFileWithCreateFolders([string]$path, [string]$content)
+{
+    $folder = [System.IO.Path]::GetDirectoryName($path)
+    If(!(Test-Path $folder))
+    {
+        & New-Item -ItemType Directory -Force -Path $folder > $null
+    }
+    Add-Content -Path $path -Value $content
+}
+
+# Gets a list of all the files recursively in the given folder
+Function GetFiles(
+    [Parameter(Mandatory = $True)]
+    [string] $folderPath,
+    [string] $pattern)
+{
+    If (Test-Path $folderPath)
+    {
+        $files = Get-ChildItem -Path $folderPath -Filter $pattern -Recurse -File
+
+        Return $files
     }
 
-    # Appends the log time in front of the log statement with the color specified. 
-    function Log([string]$logStatement, [string]$color)
+    Return $Null
+}
+
+# Gets a list of all the nupkgs recursively in the given folder
+Function GetPackageFiles(
+    [Parameter(Mandatory = $True)]
+    [string] $folderPath)
+{
+    Return GetFiles $folderPath "*.nupkg"
+}
+
+Function GetFilesInfo([System.IO.FileInfo[]] $files)
+{
+    If ($files -eq $Null)
     {
-        if([string]::IsNullOrEmpty($color))
+        $count = 0
+        $totalSizeInMB = 0
+    }
+    Else
+    {
+        $count = $files.Count
+        $totalSizeInMB = ($files | Measure-Object -Property Length -Sum).Sum / 1000000
+    }
+
+    Return @{
+        Count = $count
+        TotalSizeInMB = $totalSizeInMB
+    }
+}
+
+# Determines if the client is dotnet.exe by checking the path.
+function GetClientName([string]$nugetClient)
+{
+    return [System.IO.Path]::GetFileName($nugetClient)
+}
+
+function IsClientDotnetExe([string]$nugetClient)
+{
+    return $nugetClient.EndsWith("dotnet.exe")
+}
+
+# Downloads the repository at the given path.
+Function DownloadRepository([string] $repository, [string] $commitHash, [string] $sourceFolderPath)
+{
+    If (Test-Path $sourceFolderPath)
+    {
+        Log "Skipping the cloning of $repository as $sourceFolderPath is not empty" -color "Yellow"
+    }
+    Else
+    {
+        git clone $repository $sourceFolderPath
+        git -C $sourceFolderPath checkout $commitHash
+    }
+}
+
+# Find the appropriate solution file for the repository. Looks for a solution file matching the repo name, 
+# if not it takes the first available sln file in the repo. 
+Function GetSolutionFilePath([string] $repository, [string] $sourceFolderPath)
+{
+    $gitRepoName = $repository.Substring($($repository.LastIndexOf('/') + 1))
+    $potentialSolutionFilePath = [System.IO.Path]::Combine($sourceFolderPath, "$($gitRepoName.Substring(0, $gitRepoName.Length - 4)).sln")
+
+    If (Test-Path $potentialSolutionFilePath)
+    {
+        $solutionFilePath = $potentialSolutionFilePath
+    }
+    Else
+    {
+        $possibleSln = Get-ChildItem $sourceFolderPath *.sln
+        If ($possibleSln.Length -eq 0)
         {
-            Write-Host "$($(Get-Date).ToString()): $logStatement"
+            Log "No solution files found in $sourceFolderPath" "red"
         }
-        else
-        { 
-            Write-Host "$($(Get-Date).ToString()): $logStatement" -ForegroundColor $color
-        }
-    }
-
-    # Given a relative path, gets the absolute path from the current directory
-    function GetAbsolutePath([string]$Path)
-    {
-        $Path = [System.IO.Path]::Combine((pwd).Path, $Path);
-        $Path = [System.IO.Path]::GetFullPath($Path);
-        return $Path;
-    }
-
-    # Writes the content to the given path. Creates the folder structure if needed
-    function OutFileWithCreateFolders([string]$path, [string]$content){
-        $folder = [System.IO.Path]::GetDirectoryName($path)
-        If(!(Test-Path $folder))
+        Else
         {
-            & New-Item -ItemType Directory -Force -Path $folder > $null
-        }
-        Add-Content -Path $path -Value $content
-    }
-
-    # Gets a list of all the files recursively in the given folder
-    Function GetFiles(
-        [Parameter(Mandatory = $True)]
-        [string] $folderPath,
-        [string] $pattern)
-    {
-        If (Test-Path $folderPath)
-        {
-            $files = Get-ChildItem -Path $folderPath -Filter $pattern -Recurse -File
-
-            Return $files
-        }
-
-        Return $null
-    }
-
-    # Gets a list of all the nupkgs recursively in the given folder
-    Function GetPackageFiles(
-        [Parameter(Mandatory = $True)]
-        [string] $folderPath)
-    {
-        Return GetFiles $folderPath "*.nupkg"
-    }
-
-    # Determines if the client is dotnet.exe by checking the path.
-    function GetClientName([string]$nugetClient)
-    {
-        return [System.IO.Path]::GetFileName($nugetClient)
-    }
-
-    function IsClientDotnetExe([string]$nugetClient)
-    {
-        return $nugetClient.EndsWith("dotnet.exe")
-    }
-
-    # Downloads the repository at the given path.
-    function DownloadRepository([string]$repository, [string]$commitHash, [string]$sourceDirectoryPath)
-    {
-        if(Test-Path $sourceDirectoryPath)
-        {
-            Log "Skipping the cloning of $repository as $sourceDirectoryPath is not empty" -color "Yellow"
-        }
-        else 
-        {
-            git clone $repository $sourceDirectoryPath
-            git -c $sourceDirectoryPath checkout $commitHash
-        }
-    }
-    
-    # Find the appropriate solution file for the repository. Looks for a solution file matching the repo name, 
-    # if not it takes the first available sln file in the repo. 
-    function GetSolutionFile([string]$repository,[string]$sourceDirectoryPath) {
-
-        $gitRepoName = $repository.Substring($($repository.LastIndexOf('/') + 1))
-        $potentialSolutionFile = [System.IO.Path]::Combine($sourceDirectoryPath, "$($gitRepoName.Substring(0, $gitRepoName.Length - 4)).sln")
-
-        if(Test-Path $potentialSolutionFile)
-        {
-            $solutionFile = $potentialSolutionFile
-        } 
-        else 
-        {
-            $possibleSln = Get-ChildItem $sourceDirectoryPath *.sln
-            if($possibleSln.Length -eq 0)
-            {
-                Log "No solution files found in $sourceDirectoryPath" "red"
-            } 
-            else 
-            {
-            $solutionFile = $possibleSln[0] | Select-Object -f 1 | Select-Object -ExpandProperty FullName
-            }
-        }
-        return $solutionFile;
-    }
-
-    # Given a repository and a hash, checks out the revision in the given source directory. The return is a solution file if found. 
-    function SetupGitRepository([string]$repository, [string]$commitHash, [string]$sourceDirectoryPath)
-    {
-        Log "Setting up $repository into $sourceDirectoryPath"
-        DownloadRepository $repository $commitHash $sourceDirectoryPath
-        $solutionFile = GetSolutionFile $repository $sourceDirectoryPath
-        Log "Completed the repository setup. The solution file is $solutionFile" -color "Green"
-        return $solutionFile
-    }
-
-    # runs locals clear all with the given client
-    function LocalsClearAll([string]$nugetClient)
-    {
-        $nugetClient = GetAbsolutePath $nugetClient
-        if($(IsClientDotnetExe $nugetClient))
-        {
-            . $nugetClient nuget locals -c all *>>$null
-        } 
-        else 
-        {
-            . $nugetClient locals -clear all -Verbosity quiet
+            $solutionFilePath = $possibleSln[0] | Select-Object -f 1 | Select-Object -ExpandProperty FullName
         }
     }
 
-    # Gets the client version
-    function GetClientVersion($nugetClient)
+    Return $solutionFilePath
+}
+
+# Given a repository and a hash, checks out the revision in the given source directory. The return is a solution file if found. 
+Function SetupGitRepository([string] $repository, [string] $commitHash, [string] $sourceFolderPath)
+{
+    Log "Setting up $repository into $sourceFolderPath"
+    DownloadRepository $repository $commitHash $sourceFolderPath
+    $solutionFilePath = GetSolutionFilePath $repository $sourceFolderPath
+    Log "Completed the repository setup. The solution file is $solutionFilePath" -color "Green"
+
+    Return $solutionFilePath
+}
+
+# runs locals clear all with the given client
+Function LocalsClearAll([string] $nugetClientFilePath)
+{
+    $nugetClientFilePath = GetAbsolutePath $nugetClientFilePath
+    If ($(IsClientDotnetExe $nugetClientFilePath))
     {
-        $nugetClient = GetAbsolutePath $nugetClient
-        if(IsClientDotnetExe $nugetClient)
+        . $nugetClientFilePath nuget locals -c all *>>$null
+    }
+    Else
+    {
+        . $nugetClientFilePath locals -clear all -Verbosity quiet
+    }
+}
+
+# Gets the client version
+Function GetClientVersion([string] $nugetClientFilePath)
+{
+    $nugetClientFilePath = GetAbsolutePath $nugetClientFilePath
+
+    If (IsClientDotnetExe $nugetClientFilePath)
+    {
+        $version = . $nugetClientFilePath --version
+    }
+    Else
+    {
+        $output = . $nugetClientFilePath
+        $version = $(($output -split '\n')[0]).Substring("NuGet Version: ".Length)
+    }
+
+    Return $version
+}
+
+# Gets the NuGet folders path where all of the discardable data from the tests will be put.
+Function GetNuGetFoldersPath([string] $testRootFolderPath)
+{
+    If ([string]::IsNullOrEmpty($testRootFolderPath))
+    {
+        $testRootFolderPath = $Env:UserProfile
+    }
+
+    $nugetFoldersPath = [System.IO.Path]::Combine($testRootFolderPath, "np")
+
+    Return $nugetFoldersPath
+}
+
+# Sets up the global packages folder, http cache and plugin caches and cleans them before starting.
+# TODO NK - How about temp?
+Function SetupNuGetFolders([string] $nugetClientFilePath, [string] $testRootFolderPath)
+{
+    $nugetFoldersPath = GetNuGetFoldersPath $testRootFolderPath
+
+    $Env:NUGET_PACKAGES = [System.IO.Path]::Combine($nugetFoldersPath, "gpf")
+    $Env:NUGET_HTTP_CACHE_PATH = [System.IO.Path]::Combine($nugetFoldersPath, "hcp")
+    $Env:NUGET_PLUGINS_CACHE_PATH = [System.IO.Path]::Combine($nugetFoldersPath, "pcp")
+
+    # This environment variable is not recognized by any NuGet client.
+    $Env:NUGET_SOLUTION_PACKAGES_FOLDER_PATH = [System.IO.Path]::Combine($nugetFoldersPath, "sp")
+
+    LocalsClearAll $nugetClientFilePath
+}
+
+# Cleanup the nuget folders and delete the nuget folders path.
+# This should only be invoked by the the performance tests
+Function CleanNuGetFolders([string] $nugetClientFilePath, [string] $testRootFolderPath)
+{
+    Log "Cleanup up the NuGet folders - global packages folder, http/plugins caches"
+
+    LocalsClearAll $nugetClientFilePath
+
+    $nugetFoldersPath = GetNuGetFoldersPath $testRootFolderPath
+
+    Remove-Item $nugetFoldersPath -Recurse -Force -ErrorAction Ignore
+
+    [Environment]::SetEnvironmentVariable("NUGET_PACKAGES", $Null)
+    [Environment]::SetEnvironmentVariable("NUGET_HTTP_CACHE_PATH", $Null)
+    [Environment]::SetEnvironmentVariable("NUGET_PLUGINS_CACHE_PATH", $Null)
+    [Environment]::SetEnvironmentVariable("NUGET_SOLUTION_PACKAGES_FOLDER_PATH", $Null)
+}
+
+# Given a repository, a client and directories for the results/logs, runs the configured performance tests.
+Function RunPerformanceTestsOnGitRepository(
+    [string] $nugetClientFilePath,
+    [string] $sourceRootFolderPath,
+    [string] $testCaseName,
+    [string] $repoUrl,
+    [string] $commitHash,
+    [string] $resultsFilePath,
+    [string] $logsFolderPath,
+    [int] $iterationCount)
+{
+    $solutionFilePath = SetupGitRepository -repository $repoUrl -commitHash $commitHash -sourceFolderPath $([System.IO.Path]::Combine($sourceRootFolderPath, $testCaseName))
+    SetupNuGetFolders $nugetClientFilePath
+    . "$PSScriptRoot\RunPerformanceTests.ps1" $nugetClientFilePath $solutionFilePath $resultsFilePath $logsFolderPath -iterationCount $iterationCount
+}
+
+Function GetProcessorInfo()
+{
+    $processorInfo = Get-WmiObject Win32_processor
+
+    Return @{
+        Name = $processorInfo | Select-Object -ExpandProperty Name
+        NumberOfCores = $processorInfo | Select-Object -ExpandProperty NumberOfCores
+        NumberOfLogicalProcessors = $processorInfo | Select-Object -ExpandProperty NumberOfLogicalProcessors
+    }
+}
+
+Function LogDotNetSdkInfo()
+{
+    Try
+    {
+        $currentVersion = dotnet --version
+        $currentSdk = dotnet --list-sdks | Where { $_.StartsWith("$currentVersion ") } | Select -First 1
+
+        Log "Using .NET Core SDK $currentSdk."
+    }
+    Catch [System.Management.Automation.CommandNotFoundException]
+    {
+        Log ".NET Core SDK not found." -Color "Yellow"
+    }
+}
+
+# Note:  System.TimeSpan rounds to the nearest millisecond.
+Function ParseElapsedTime(
+    [Parameter(Mandatory = $True)]
+    [decimal] $value,
+    [Parameter(Mandatory = $True)]
+    [string] $unit)
+{
+    Switch ($unit)
+    {
+        "ms" { Return [System.TimeSpan]::FromMilliseconds($value) }
+        "sec" { Return [System.TimeSpan]::FromSeconds($value) }
+        "min" { Return [System.TimeSpan]::FromMinutes($value) }
+        Default { throw "Unsupported unit of time:  $unit" }
+    }
+}
+
+Function ExtractRestoreElapsedTime(
+    [Parameter(Mandatory = $True)]
+    [string[]] $lines)
+{
+    # All packages listed in packages.config are already installed.
+    $prefix = "Restore completed in "
+
+    $lines = $lines | Where { $_.IndexOf($prefix) -gt -1 }
+
+    ForEach ($line In $lines)
+    {
+        $index = $line.IndexOf($prefix)
+
+        $parts = $line.Substring($index + $prefix.Length).Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)
+
+        $value = [System.Double]::Parse($parts[0])
+        $unit = $parts[1]
+
+        $temp = ParseElapsedTime $value $unit
+
+        If ($elapsedTime -eq $Null -Or $elapsedTime -lt $temp)
         {
-            $version = . $nugetClient --version
-            Log "$version"
-            return $version
-        } 
-        else 
-        {
-            $versionQuery = . $nugetClient
-            $version = $(($versionQuery -split '\n')[0]).Substring("NuGet Version: ".Length)
-            return $version
+            $elapsedTime = $temp
         }
     }
 
-    # Gets the pretermined nuget folders path where all of the throwable data from the tests will be put.
-    function GetNuGetFoldersPath()
+    Return $elapsedTime
+}
+
+# Plugins cache is only available in 4.8+. We need to be careful when using that switch for older clients because it may blow up.
+# The logs location is optional
+Function RunRestore(
+    [string] $solutionFilePath,
+    [string] $nugetClientFilePath,
+    [string] $resultsFile,
+    [string] $logsFolderPath,
+    [string] $scenarioName,
+    [string] $solutionName,
+    [string] $testRunId,
+    [switch] $isPackagesConfig,
+    [switch] $cleanGlobalPackagesFolder,
+    [switch] $cleanHttpCache,
+    [switch] $cleanPluginsCache,
+    [switch] $killMsBuildAndDotnetExeProcesses,
+    [switch] $force)
+{
+    Log "Running $nugetClientFilePath restore with cleanGlobalPackagesFolder:$cleanGlobalPackagesFolder cleanHttpCache:$cleanHttpCache cleanPluginsCache:$cleanPluginsCache killMsBuildAndDotnetExeProcesses:$killMsBuildAndDotnetExeProcesses force:$force"
+
+    $isClientDotnetExe = IsClientDotnetExe $nugetClientFilePath
+
+    $solutionPackagesFolderPath = $Env:NUGET_SOLUTION_PACKAGES_FOLDER_PATH
+
+    # Cleanup if necessary
+    If ($cleanGlobalPackagesFolder -Or $cleanHttpCache -Or $cleanPluginsCache)
     {
-        $nugetFolder = [System.IO.Path]::Combine($env:UserProfile, "np")
-        return $nugetFolder
-    }
+        If ($cleanGlobalPackagesFolder -And $cleanHttpCache -And $cleanPluginsCache)
+        {
+            $localsArguments = "all"
+        }
+        ElseIf ($cleanGlobalPackagesFolder -And $cleanHttpCache)
+        {
+            $localsArguments = "http-cache global-packages"
+        }
+        ElseIf ($cleanGlobalPackagesFolder)
+        {
+            $localsArguments = "global-packages"
+        }
+        ElseIf ($cleanHttpCache)
+        {
+            $localsArguments = "http-cache"
+        }
+        Else
+        {
+            Log "Too risky to invoke a locals clear with the specified parameters." "yellow"
+        }
 
-    # Sets up the global packages folder, http cache and plugin caches and cleans them before starting.
-    # TODO NK - How about temp?
-    function SetupNuGetFolders([string]$nugetClient)
-    {
-        $nugetFolders = GetNuGetFoldersPath
-        $Env:NUGET_PACKAGES = [System.IO.Path]::Combine($nugetFolders, "gpf")
-        $Env:NUGET_HTTP_CACHE_PATH = [System.IO.Path]::Combine($nugetFolders, "hcp")
-        $Env:NUGET_PLUGINS_CACHE_PATH = [System.IO.Path]::Combine($nugetFolders, "pcp")
-        LocalsClearAll $nugetClient
-    }
+        If ($isClientDotnetExe)
+        {
+            . $nugetClientFilePath nuget locals -c $localsArguments *>>$null
+        }
+        Else
+        {
+            . $nugetClientFilePath locals -clear $localsArguments -Verbosity quiet
+        }
 
-    # Cleanup the nuget folders and delete the nuget folders path. 
-    # This should only be invoked by the the performance tests
-    Function CleanNuGetFolders([string] $nugetClient)
-    {
-        Log "Cleanup up the NuGet folders - global packages folder, http/plugins caches"
-
-        LocalsClearAll $nugetClient
-
-        $nugetFolders = GetNuGetFoldersPath
-
-        Remove-Item $nugetFolders -Recurse -Force -ErrorAction Ignore
-
-        [Environment]::SetEnvironmentVariable("NUGET_PACKAGES", $null)
-        [Environment]::SetEnvironmentVariable("NUGET_HTTP_CACHE_PATH", $null)
-        [Environment]::SetEnvironmentVariable("NUGET_PLUGINS_CACHE_PATH", $null)
-    }
-
-    # Given a repository, a client and directories for the results/logs, runs the configured performance tests.
-    function RunPerformanceTestsOnGitRepository([string]$nugetClient, [string]$sourceRootDirectory, [string]$testCaseName, [string]$repoUrl,  [string]$commitHash, [string]$resultsFilePath, [string]$logsPath)
-    {
-        $solutionFilePath = SetupGitRepository -repository $repoUrl -commitHash $commitHash -sourceDirectoryPath  $([System.IO.Path]::Combine($sourceRootDirectory, $testCaseName))
-        SetupNuGetFolders $nugetClient
-        . "$PSScriptRoot\RunPerformanceTests.ps1" $nugetClient $solutionFilePath $resultsFilePath $logsPath
-    }
-
-    Function GetProcessorInfo()
-    {
-        $processorInfo = Get-WmiObject Win32_processor
-
-        Return @{
-            Name = $processorInfo | Select-Object -ExpandProperty Name
-            NumberOfCores = $processorInfo | Select-Object -ExpandProperty NumberOfCores
-            NumberOfLogicalProcessors = $processorInfo | Select-Object -ExpandProperty NumberOfLogicalProcessors
+        If ($isPackagesConfig -And ($cleanGlobalPackagesFolder -Or $cleanHttpCache))
+        {
+            Remove-Item $solutionPackagesFolderPath -Recurse -Force -ErrorAction Ignore > $Null
+            mkdir $solutionPackagesFolderPath > $Null
         }
     }
+
+    if($killMsBuildAndDotnetExeProcesses)
+    {
+        Stop-Process -name msbuild*,dotnet* -Force
+    }
+
+    $arguments = [System.Collections.Generic.List[string]]::new()
+
+    $arguments.Add("restore")
+    $arguments.Add($solutionFilePath)
+
+    If ($isPackagesConfig)
+    {
+        If ($isClientDotnetExe)
+        {
+            $arguments.Add("--packages")
+        }
+        Else
+        {
+            $arguments.Add("-PackagesDirectory")
+        }
+
+        $arguments.Add($Env:NUGET_SOLUTION_PACKAGES_FOLDER_PATH)
+    }
+
+    If ($force)
+    {
+        If ($isClientDotnetExe)
+        {
+            $arguments.Add("--force")
+        }
+        Else
+        {
+            $arguments.Add("-Force")
+        }
+    }
+
+    If (!$isClientDotnetExe)
+    {
+        $arguments.Add("-NonInteractive")
+    }
+
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
+    $logs = . $nugetClientFilePath $arguments | Out-String
+
+    $totalTime = $stopwatch.Elapsed.TotalSeconds
+    $restoreCoreTime = ExtractRestoreElapsedTime $logs
+
+    If ($restoreCoreTime -ne $Null)
+    {
+        $restoreCoreTime = $restoreCoreTime.TotalSeconds
+    }
+
+    if(![string]::IsNullOrEmpty($logsFolderPath))
+    {
+        $logFile = [System.IO.Path]::Combine($logsFolderPath, "restoreLog-$([System.IO.Path]::GetFileNameWithoutExtension($solutionFilePath))-$(get-date -f yyyyMMddTHHmmssffff).txt")
+        OutFileWithCreateFolders $logFile $logs
+    }
+
+    $folderPath = $Env:NUGET_PACKAGES
+    $globalPackagesFolderNupkgFilesInfo = GetFilesInfo(GetPackageFiles $folderPath)
+    $globalPackagesFolderFilesInfo = GetFilesInfo(GetFiles $folderPath)
+
+    $folderPath = $Env:NUGET_HTTP_CACHE_PATH
+    $httpCacheFilesInfo = GetFilesInfo(GetFiles $folderPath)
+
+    $folderPath = $Env:NUGET_PLUGINS_CACHE_PATH
+    $pluginsCacheFilesInfo = GetFilesInfo(GetFiles $folderPath)
+
+    $clientName = GetClientName $nugetClientFilePath
+    $clientVersion = GetClientVersion $nugetClientFilePath
+
+    If (!(Test-Path $resultsFilePath))
+    {
+        $columnHeaders = "Client Name,Client Version,Solution Name,Test Run ID,Scenario Name,Total Time (seconds),Core Restore Time (seconds),Force," + `
+            "Global Packages Folder .nupkg Count,Global Packages Folder .nupkg Size (MB),Global Packages Folder File Count,Global Packages Folder File Size (MB),Clean Global Packages Folder," + `
+            "HTTP Cache File Count,HTTP Cache File Size (MB),Clean HTTP Cache,Plugins Cache File Count,Plugins Cache File Size (MB),Clean Plugins Cache,Kill MSBuild and dotnet Processes," + `
+            "Processor Name,Processor Physical Core Count,Processor Logical Core Count"
+
+        OutFileWithCreateFolders $resultsFilePath $columnHeaders
+    }
+
+    $data = "$clientName,$clientVersion,$solutionName,$testRunId,$scenarioName,$totalTime,$restoreCoreTime,$force," + `
+        "$($globalPackagesFolderNupkgFilesInfo.Count),$($globalPackagesFolderNupkgFilesInfo.TotalSizeInMB),$($globalPackagesFolderFilesInfo.Count),$($globalPackagesFolderFilesInfo.TotalSizeInMB),$cleanGlobalPackagesFolder," + `
+        "$($httpCacheFilesInfo.Count),$($httpCacheFilesInfo.TotalSizeInMB),$cleanHttpCache,$($pluginsCacheFilesInfo.Count),$($pluginsCacheFilesInfo.TotalSizeInMB),$cleanPluginsCache,$killMsBuildAndDotnetExeProcesses," + `
+        "$($processorInfo.Name),$($processorInfo.NumberOfCores),$($processorInfo.NumberOfLogicalProcessors)"
+
+    Add-Content -Path $resultsFilePath -Value $data
+
+    Log "Finished measuring."
+}

--- a/scripts/perftests/RunPerformanceTests.ps1
+++ b/scripts/perftests/RunPerformanceTests.ps1
@@ -68,9 +68,17 @@ Try
     $nugetClientFilePath = GetAbsolutePath $nugetClientFilePath
     $solutionFilePath = GetAbsolutePath $solutionFilePath
     $resultsFilePath = GetAbsolutePath $resultsFilePath
+    $isClientDotnetExe = IsClientDotnetExe $nugetClientFilePath
 
     If ($isPackagesConfig)
     {
+        If ($isClientDotnetExe)
+        {
+            Log "dotnet.exe does not support packages.config restore." "Red"
+
+            Exit 1
+        }
+
         Log "Restores are expected to be packages.config restores."
 
         If (!$skipForceRestores)

--- a/scripts/perftests/RunPerformanceTests.ps1
+++ b/scripts/perftests/RunPerformanceTests.ps1
@@ -1,204 +1,178 @@
 Param(
-    [Parameter(Mandatory=$true)]
-    [string]$nugetClientPath,
-    [Parameter(Mandatory=$true)]
-    [string]$solutionPath,
-    [Parameter(Mandatory=$true)]
-    [string]$resultsFilePath,
-    [string]$logsPath,
-    [int]$iterationCount = 3,
-    [switch]$skipWarmup,
-    [switch]$skipCleanRestores,
-    [switch]$skipColdRestores,
-    [switch]$skipForceRestores,
-    [switch]$skipNoOpRestores
+    [Parameter(Mandatory = $True)]
+    [string] $nugetClientFilePath,
+    [Parameter(Mandatory = $True)]
+    [string] $solutionFilePath,
+    [Parameter(Mandatory = $True)]
+    [string] $resultsFilePath,
+    [string] $logsFolderPath,
+    [string] $testRootFolderPath,
+    [int] $iterationCount = 3,
+    [switch] $isPackagesConfig,
+    [switch] $skipWarmup,
+    [switch] $skipCleanRestores,
+    [switch] $skipColdRestores,
+    [switch] $skipForceRestores,
+    [switch] $skipNoOpRestores
 )
-    . "$PSScriptRoot\PerformanceTestUtilities.ps1"
+
+. "$PSScriptRoot\PerformanceTestUtilities.ps1"
+
+Function CreateNugetClientArguments(
+    [string] $solutionFilePath,
+    [string] $nugetClientFilePath,
+    [string] $resultsFilePath,
+    [string] $logsFolderPath,
+    [string] $solutionName,
+    [string] $testRunId,
+    [string] $scenarioName,
+    [string[]] $enabledSwitches)
+{
+    $arguments = @{
+        solutionFilePath = $solutionFilePath
+        nugetClientFilePath = $nugetClientFilePath
+        resultsFilePath = $resultsFilePath
+        logsFolderPath = $logsFolderPath
+        scenarioName = $scenarioName
+        solutionName = $solutionName
+        testRunId = $testRunId
+    }
+
+    If ($enabledSwitches -ne $Null)
+    {
+        ForEach ($enabledSwitch In $enabledSwitches.GetEnumerator())
+        {
+            $arguments[$enabledSwitch] = $True
+        }
+    }
+
+    Return $arguments
+}
+
+Try
+{
+    ##### Script logic #####
+
+    If (!(Test-Path $solutionFilePath))
+    {
+        Log "$solutionFilePath does not exist!" "Red"
+        Exit 1
+    }
+
+    If (!(Test-Path $nugetClientFilePath))
+    {
+        Log "$nugetClientFilePath does not exist!" "Red"
+        Exit 1
+    }
+
+    $nugetClientFilePath = GetAbsolutePath $nugetClientFilePath
+    $solutionFilePath = GetAbsolutePath $solutionFilePath
+    $resultsFilePath = GetAbsolutePath $resultsFilePath
+
+    If ($isPackagesConfig)
+    {
+        Log "Restores are expected to be packages.config restores."
+
+        If (!$skipForceRestores)
+        {
+            Log "Force restore is not supported with packages.config.  Skipping force restores." "Yellow"
+            $skipForceRestores = $True
+        }
+    }
+
+    If (![string]::IsNullOrEmpty($logsFolderPath))
+    {
+        $logsFolderPath = GetAbsolutePath $logsFolderPath
+
+        If ([System.IO.Path]::GetDirectoryName($resultsFilePath).StartsWith($logsFolderPath))
+        {
+            Log "$resultsFilePath cannot be under $logsFolderPath" "red"
+            Exit 1
+        }
+    }
+
+    LogDotNetSdkInfo
+
+    if(Test-Path $resultsFilePath)
+    {
+        Log "The results file $resultsFilePath already exists. The test results of this run will be appended to the same file." "yellow"
+    }
+
+    # Setup the NuGet folders - This includes global packages folder/http/plugin caches
+    SetupNuGetFolders $nugetClientFilePath $testRootFolderPath
 
     $processorInfo = GetProcessorInfo
 
-    # Plugins cache is only available in 4.8+. We need to be careful when using that switch for older clients because it may blow up.
-    # The logs location is optional
-    function RunRestore([string]$solutionFilePath, [string]$nugetClient, [string]$resultsFile, [string]$logsPath, [string]$restoreName, [string]$testCaseId,
-            [switch]$cleanGlobalPackagesFolder, [switch]$cleanHttpCache, [switch]$cleanPluginsCache, [switch]$killMsBuildAndDotnetExeProcesses, [switch]$force)
+    Log "Measuring restore for $solutionFilePath by $nugetClientFilePath" "Green"
+
+    $solutionName = [System.IO.Path]::GetFileNameWithoutExtension($solutionFilePath)
+    $testRunId = [System.DateTime]::UtcNow.ToString("O")
+
+    If (!$skipWarmup)
     {
-        Log "Running $nugetClient restore with cleanGlobalPackagesFolder:$cleanGlobalPackagesFolder cleanHttpCache:$cleanHttpCache cleanPluginsCache:$cleanPluginsCache killMsBuildAndDotnetExeProcesses:$killMsBuildAndDotnetExeProcesses force:$force"
-
-        # Do the required cleanup if necesarry
-        if($cleanGlobalPackagesFolder -Or $cleanHttpCache -Or $cleanPluginsCache)
+        Log "Running 1x warmup restore"
+        $enabledSwitches = @("cleanGlobalPackagesFolder", "cleanHttpCache", "cleanPluginsCache", "killMSBuildAndDotnetExeProcess")
+        If (!$skipForceRestores)
         {
-            if($cleanGlobalPackagesFolder -And $cleanHttpCache -And $cleanPluginsCache)
-            {
-                $localsArguments = "all"
-            }
-            elseif($cleanGlobalPackagesFolder -And $cleanHttpCache)
-            {
-                $localsArguments =  "http-cache global-packages"
-            }
-            elseif($cleanGlobalPackagesFolder)
-            {
-                $localsArguments =  "global-packages"
-            }
-            elseif($cleanHttpCache)
-            {
-                $localsArguments = "http-cache"
-            } 
-            else 
-            {
-                Log "Too risky to invoke a locals clear with the specified parameters." "yellow"
-            }
-
-            if($(IsClientDotnetExe $nugetClient))
-            {
-                . $nugetClient nuget locals -c $localsArguments *>>$null
-            }
-            else 
-            {
-                . $nugetClient locals -clear $localsArguments -Verbosity quiet
-            }
+            $enabledSwitches += "force"
         }
-
-        if($killMsBuildAndDotnetExeProcesses)
+        If ($isPackagesConfig)
         {
-            Stop-Process -name msbuild*,dotnet* -Force
+            $enabledSwitches += "isPackagesConfig"
         }
-
-        $start=Get-Date
-        if($(IsClientDotnetExe $nugetClient))
-        {
-            $logs = . $nugetClient restore $solutionFilePath $forceArg
-        }
-        else 
-        {
-            $logs = . $nugetClient restore $solutionFilePath -noninteractive $forceArg
-        }
-        $end=Get-Date
-        $totalTime=$end-$start
-
-        if(![string]::IsNullOrEmpty($logsPath))
-        {
-            $logFile = [System.IO.Path]::Combine($logsPath, "restoreLog-$([System.IO.Path]::GetFileNameWithoutExtension($solutionFilePath))-$(get-date -f yyyyMMddTHHmmssffff).txt")
-            OutFileWithCreateFolders $logFile $logs
-        }
-
-        $globalPackagesFolder = $Env:NUGET_PACKAGES
-        if(Test-Path $globalPackagesFolder)
-        {
-            $globalPackagesFolderNupkgFiles = GetPackageFiles $globalPackagesFolder
-            $globalPackagesFolderNupkgsSize = (($globalPackagesFolderNupkgFiles | Measure-Object -property length -sum).Sum/1000000)
-            $globalPackagesFolderFiles = GetFiles $globalPackagesFolder
-            $globalPackagesFolderFilesSize = (($globalPackagesFolderFiles | Measure-Object -property length -sum).Sum/1000000)
-        }
-        else 
-        {
-            Log "The global packages folder $globalPackagesFolder does not exist" "Red"
-        }
-
-        $httpCacheFolder = $Env:NUGET_HTTP_CACHE_PATH
-        if(Test-Path $httpCacheFolder)
-        {
-            $httpCacheFiles = GetFiles $httpCacheFolder
-            $httpCacheFilesSize = (($httpCacheFiles | Measure-Object -property length -sum).Sum/1000000)
-        } 
-        else 
-        {
-            Log "The HTTP cache folder $httpCacheFolder does not exist" "Red"
-        }
-
-        $pluginsCacheFolder = $Env:NUGET_PLUGINS_CACHE_PATH
-        if(Test-Path $pluginsCacheFolder)
-        {
-            $pluginsCacheFiles = GetFiles $pluginsCacheFolder
-            $pluginsCacheFilesSize = (($pluginsCacheFiles | Measure-Object -property length -sum).Sum/1000000)
-        } 
-        else 
-        {
-            Log "The plugins cache folder $pluginsCacheFolder does not exist" "Yellow"
-        }
-
-        $clientName = GetClientName $nugetClient
-        $clientVersion = GetClientVersion $nugetClient
-
-        if(!(Test-Path $resultsFile))
-        {
-            OutFileWithCreateFolders $resultsFile "clientName,clientVersion,testCaseId,name,totalTime,force,globalPackagesFolderNupkgCount,globalPackagesFolderNupkgSize,globalPackagesFolderFilesCount,globalPackagesFolderFilesSize,cleanGlobalPackagesFolder,httpCacheFileCount,httpCacheFilesSize,cleanHttpCache,pluginsCacheFileCount,pluginsCacheFilesSize,cleanPluginsCache,killMsBuildAndDotnetExeProcesses,processorName,cores,logicalCores"
-        }
-
-        Add-Content -Path $resultsFile -Value "$clientName,$clientVersion,$testCaseId,$restoreName,$($totalTime.ToString()),$force,$($globalPackagesFolderNupkgFiles.Count),$globalPackagesFolderNupkgsSize,$($globalPackagesFolderFiles.Count),$globalPackagesFolderFilesSize,$cleanGlobalPackagesFolder,$($httpCacheFiles.Count),$httpCacheFilesSize,$cleanHttpCache,$($pluginsCacheFiles.Count),$pluginsCacheFilesSize,$cleanPluginsCache,$killMsBuildAndDotnetExeProcesses,$($processorInfo.Name),$($processorInfo.NumberOfCores),$($processorInfo.NumberOfLogicalProcessors)"
-
-        Log "Finished measuring."
+        $arguments = CreateNugetClientArguments $solutionFilePath $nugetClientFilePath $resultsFilePath $logsFolderPath $solutionName $testRunId "warmup" -enabledSwitches $enabledSwitches
+        RunRestore @arguments
     }
-    try {
-        ##### Script logic #####
 
-        if(!(Test-Path $solutionPath))
-        {
-            Log "$solutionPath does not exist!" "Red"
-            exit 1;
-        }
-
-        if(!(Test-Path $nugetClientPath))
-        {
-            Log "$nugetClientPath does not exist!" "Red"
-            exit 1;
-        }
-
-        $nugetClientPath = GetAbsolutePath $nugetClientPath
-        $solutionPath = GetAbsolutePath $solutionPath
-        $resultsFilePath = GetAbsolutePath $resultsFilePath
-
-        if(![string]::IsNullOrEmpty($logsPath))
-        {
-            $logsPath = GetAbsolutePath $logsPath
-
-            If($resultsFilePath.StartsWith($logsPath))
-            {
-                Log "$resultsFilePath cannot be under $logsPath" "red"
-                exit(1)
-            }
-        }
-        
-        if(Test-Path $resultsFilePath)
-        {
-            Log "The results file $resultsFilePath already exists. The test results of this run will be appended to the same file." "yellow"
-        }
-
-        # Setup the NuGet folders - This includes global packages folder/http/plugin caches
-        SetupNuGetFolders $nugetClientPath
-
-        Log "Measuring restore for $solutionPath by $nugetClientPath" "Green"
-
-        $uniqueRunID = Get-Date -f d-m-y-h:m:s
-
-        if(!$skipWarmup)
-        {
-            Log "Running 1x warmup restore"
-            RunRestore $solutionPath $nugetClientPath $resultsFilePath $logsPath "warmup" $uniqueRunID -cleanGlobalPackagesFolder -cleanHttpCache -cleanPluginsCache -killMSBuildAndDotnetExeProcess -force
-        }
-        if(!$skipCleanRestores)
-        {
-            Log "Running $($iterationCount)x clean restores"
-            1..$iterationCount | % { RunRestore $solutionPath $nugetClientPath $resultsFilePath $logsPath "arctic" $uniqueRunID -cleanGlobalPackagesFolder -cleanHttpCache -cleanPluginsCache -killMSBuildAndDotnetExeProcess -force }
-        }
-        if(!$skipColdRestores)
-        {
-            Log "Running $($iterationCount)x without a global packages folder"
-            1..$iterationCount | % { RunRestore $solutionPath $nugetClientPath $resultsFilePath $logsPath "cold" $uniqueRunID -cleanGlobalPackagesFolder -killMSBuildAndDotnetExeProcess -force }
-        }
-        if(!$skipForceRestores)
-        {
-            Log "Running $($iterationCount)x force restores"
-            1..$iterationCount | % { RunRestore $solutionPath $nugetClientPath $resultsFilePath $logsPath "force" $uniqueRunID -force }
-        }
-        if(!$skipNoOpRestores){
-            Log "Running $($iterationCount)x no-op restores"
-            1..$iterationCount | % { RunRestore $solutionPath $nugetClientPath $resultsFilePath $logsPath "noop" $uniqueRunID }
-        }
-
-        Log "Completed the performance measurements for $solutionPath, results are in $resultsFilePath" "green"
-    }
-    finally 
+    If (!$skipCleanRestores)
     {
-        # Clean the NuGet folders.
-        CleanNuGetFolders $nugetClientPath
+        Log "Running $($iterationCount)x clean restores"
+        $enabledSwitches = @("cleanGlobalPackagesFolder", "cleanHttpCache", "cleanPluginsCache", "killMSBuildAndDotnetExeProcess")
+        If (!$skipForceRestores)
+        {
+            $enabledSwitches += "force"
+        }
+        If ($isPackagesConfig)
+        {
+            $enabledSwitches += "isPackagesConfig"
+        }
+        $arguments = CreateNugetClientArguments $solutionFilePath $nugetClientFilePath $resultsFilePath $logsFolderPath $solutionName $testRunId "arctic" -enabledSwitches $enabledSwitches
+        1..$iterationCount | % { RunRestore @arguments }
     }
+
+    If (!$skipColdRestores)
+    {
+        Log "Running $($iterationCount)x without a global packages folder"
+        $enabledSwitches = @("cleanGlobalPackagesFolder", "killMSBuildAndDotnetExeProcess")
+        If (!$skipForceRestores)
+        {
+            $enabledSwitches += "force"
+        }
+        If ($isPackagesConfig)
+        {
+            $enabledSwitches += "isPackagesConfig"
+        }
+        $arguments = CreateNugetClientArguments $solutionFilePath $nugetClientFilePath $resultsFilePath $logsFolderPath $solutionName $testRunId "cold" -enabledSwitches $enabledSwitches
+        1..$iterationCount | % { RunRestore @arguments }
+    }
+
+    If (!$skipForceRestores)
+    {
+        Log "Running $($iterationCount)x force restores"
+        $arguments = CreateNugetClientArguments $solutionFilePath $nugetClientFilePath $resultsFilePath $logsFolderPath $solutionName $testRunId "force" -enabledSwitches @("force")
+        1..$iterationCount | % { RunRestore @arguments }
+    }
+
+    If (!$skipNoOpRestores)
+    {
+        Log "Running $($iterationCount)x no-op restores"
+        $arguments = CreateNugetClientArguments $solutionFilePath $nugetClientFilePath $resultsFilePath $logsFolderPath $solutionName $testRunId "noop"
+        1..$iterationCount | % { RunRestore @arguments }
+    }
+
+    Log "Completed the performance measurements for $solutionFilePath.  Results are in $resultsFilePath." "green"
+}
+Finally
+{
+    CleanNuGetFolders $nugetClientFilePath $testRootFolderPath
+}

--- a/scripts/perftests/testCases/Test-NuGetClient.ps1
+++ b/scripts/perftests/testCases/Test-NuGetClient.ps1
@@ -1,33 +1,36 @@
 Param(
-    [Parameter(Mandatory=$true)]
-    [string]$nugetClient,
-    [Parameter(Mandatory=$true)]
-    [string]$sourceRootDirectory,
-    [Parameter(Mandatory=$true)]
-    [string]$resultsDirectoryPath,
-    [Parameter(Mandatory=$true)]
-    [string]$logsPath
+    [Parameter(Mandatory = $True)]
+    [string] $nugetClientFilePath,
+    [Parameter(Mandatory = $True)]
+    [string] $sourceRootFolderPath,
+    [Parameter(Mandatory = $True)]
+    [string] $resultsFolderPath,
+    [Parameter(Mandatory = $True)]
+    [string] $logsFolderPath,
+    [int] $iterationCount
 )
 
-    . "$PSScriptRoot\..\PerformanceTestUtilities.ps1"
+. "$PSScriptRoot\..\PerformanceTestUtilities.ps1"
 
-    $repoUrl = "https://github.com/NuGet/NuGet.Client.git"
-    $commitHash = "203c517a85791243f53ea08d404ee5b8fae36e35"
-    $repoName = GenerateNameFromGitUrl $repoUrl
-    $resultsFilePath = [System.IO.Path]::Combine($resultsDirectoryPath, "$repoName.csv")
-    $sourcePath = $([System.IO.Path]::Combine($sourceRootDirectory, $repoName))
-    $solutionFilePath = SetupGitRepository $repoUrl $commitHash $sourcePath
-    # It's fine if this is run from here. It is run again the performance test script, but it'll set it to the same values.
-    # Additionally, this will cleanup the extras from the bootstrapping which are already in the local folder, allowing us to get more accurate measurements
-    SetupNuGetFolders $nugetClient
-    $currentWorkingDirectory = $pwd
-    try 
-    {
-        Set-Location $sourcePath
-        . "$sourcePath\configure.ps1" *>>$null
-    }
-    finally 
-    {
-        Set-Location $currentWorkingDirectory
-    }
-. "$PSScriptRoot\..\RunPerformanceTests.ps1" $nugetClient $solutionFilePath $resultsFilePath $logsPath
+$repoUrl = "https://github.com/NuGet/NuGet.Client.git"
+$commitHash = "203c517a85791243f53ea08d404ee5b8fae36e35"
+$repoName = GenerateNameFromGitUrl $repoUrl
+$resultsFilePath = [System.IO.Path]::Combine($resultsFolderPath, "$repoName.csv")
+$sourcePath = $([System.IO.Path]::Combine($sourceRootFolderPath, $repoName))
+$solutionFilePath = SetupGitRepository $repoUrl $commitHash $sourcePath
+# It's fine if this is run from here. It is run again the performance test script, but it'll set it to the same values.
+# Additionally, this will cleanup the extras from the bootstrapping which are already in the local folder, allowing us to get more accurate measurements
+SetupNuGetFolders $nugetClientFilePath
+$currentWorkingDirectory = $pwd
+
+Try
+{
+    Set-Location $sourcePath
+    . "$sourcePath\configure.ps1" *>>$null
+}
+Finally
+{
+    Set-Location $currentWorkingDirectory
+}
+
+. "$PSScriptRoot\..\RunPerformanceTests.ps1" $nugetClientFilePath $solutionFilePath $resultsFilePath $logsFolderPath -iterationCount $iterationCount

--- a/scripts/perftests/testCases/Test-OrchardCore.ps1
+++ b/scripts/perftests/testCases/Test-OrchardCore.ps1
@@ -1,18 +1,19 @@
 Param(
-    [Parameter(Mandatory=$true)]
-    [string]$nugetClient,
-    [Parameter(Mandatory=$true)]
-    [string]$sourceRootDirectory,
-    [Parameter(Mandatory=$true)]
-    [string]$resultsDirectoryPath,
-    [Parameter(Mandatory=$true)]
-    [string]$logsPath
+    [Parameter(Mandatory = $True)]
+    [string] $nugetClientFilePath,
+    [Parameter(Mandatory = $True)]
+    [string] $sourceRootFolderPath,
+    [Parameter(Mandatory = $True)]
+    [string] $resultsFolderPath,
+    [Parameter(Mandatory = $True)]
+    [string] $logsFolderPath,
+    [int] $iterationCount
 )
 
+. "$PSScriptRoot\..\PerformanceTestUtilities.ps1"
 
-    . "$PSScriptRoot\..\PerformanceTestUtilities.ps1"
-    
-    $repoUrl = "https://github.com/OrchardCMS/OrchardCore.git"
-    $testCaseName = GenerateNameFromGitUrl $repoUrl
-    $resultsFilePath = [System.IO.Path]::Combine($resultsDirectoryPath, "$testCaseName.csv")
-    RunPerformanceTestsOnGitRepository -nugetClient $nugetClient -sourceRootDirectory $sourceRootDirectory -testCaseName $testCaseName -repoUrl $repoUrl -commitHash "991ff7b536811c8ff2c603e30d754b858d009fa2" -resultsFilePath $resultsFilePath -logsPath $logsPath
+$repoUrl = "https://github.com/OrchardCMS/OrchardCore.git"
+$testCaseName = GenerateNameFromGitUrl $repoUrl
+$resultsFilePath = [System.IO.Path]::Combine($resultsFolderPath, "$testCaseName.csv")
+
+RunPerformanceTestsOnGitRepository -nugetClientFilePath $nugetClientFilePath -sourceRootFolderPath $sourceRootFolderPath -testCaseName $testCaseName -repoUrl $repoUrl -commitHash "991ff7b536811c8ff2c603e30d754b858d009fa2" -resultsFilePath $resultsFilePath -logsFolderPath $logsFolderPath -iterationCount $iterationCount

--- a/scripts/perftests/testCases/Test-Orleans.ps1
+++ b/scripts/perftests/testCases/Test-Orleans.ps1
@@ -1,17 +1,19 @@
 Param(
-    [Parameter(Mandatory=$true)]
-    [string]$nugetClient,
-    [Parameter(Mandatory=$true)]
-    [string]$sourceRootDirectory,
-    [Parameter(Mandatory=$true)]
-    [string]$resultsDirectoryPath,
-    [Parameter(Mandatory=$true)]
-    [string]$logsPath
+    [Parameter(Mandatory = $True)]
+    [string] $nugetClientFilePath,
+    [Parameter(Mandatory = $True)]
+    [string] $sourceRootFolderPath,
+    [Parameter(Mandatory = $True)]
+    [string] $resultsFolderPath,
+    [Parameter(Mandatory = $True)]
+    [string] $logsFolderPath,
+    [int] $iterationCount
 )
 
-    . "$PSScriptRoot\..\PerformanceTestUtilities.ps1"
+. "$PSScriptRoot\..\PerformanceTestUtilities.ps1"
 
-    $repoUrl = "https://github.com/dotnet/orleans.git" 
-    $testCaseName = GenerateNameFromGitUrl $repoUrl
-    $resultsFilePath = [System.IO.Path]::Combine($resultsDirectoryPath, "$testCaseName.csv")
-    RunPerformanceTestsOnGitRepository -nugetClient $nugetClient -sourceRootDirectory $sourceRootDirectory -testCaseName $testCaseName -repoUrl $repoUrl -commitHash "00fe587cc9d18db3bb238f1e78abf46835b97457" -resultsFilePath $resultsFilePath -logsPath $logsPath
+$repoUrl = "https://github.com/dotnet/orleans.git"
+$testCaseName = GenerateNameFromGitUrl $repoUrl
+$resultsFilePath = [System.IO.Path]::Combine($resultsFolderPath, "$testCaseName.csv")
+
+RunPerformanceTestsOnGitRepository -nugetClientFilePath $nugetClientFilePath -sourceRootFolderPath $sourceRootFolderPath -testCaseName $testCaseName -repoUrl $repoUrl -commitHash "00fe587cc9d18db3bb238f1e78abf46835b97457" -resultsFilePath $resultsFilePath -logsFolderPath $logsFolderPath -iterationCount $iterationCount


### PR DESCRIPTION
Progress on https://github.com/NuGet/Home/issues/7695.

* Deduplicate code.
* Log .NET SDK information.  (This is important.  I found that NuGet used the .NET SDK installed under \git\NuGet.Client instead of under \Program Files (x86)\Microsoft SDKs\NuGetPackages when executing the performance testing script from the same PowerShell window where I initialized and built the NuGet.Client repo.)
* Remove unnecessary error (red) and warning (yellow) log messages.  For example, if a restore scenario uses fallback folders and not the global package folder, the script should not log an error stating that the global package folder does not exist.
* Format NuGet CLI output such that newlines are preserved in log files.  This improves log file readability significantly.
* Enable moving the NuGet test folder, so as to enable testing on different drives.
* Report restore core elapsed time, which is what is reported in NuGet output.  "Restore completed in …"
* Report times with decimals instead of TimeSpan format.  (Excel PivotTables do some unexpected rounding with the TimeSpan format.)
* Add support for packages.config-based projects.

CC @nkolev92