### PR TITLE
Using PATH env to get the right MSBuild version for NuGet.exe

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -196,6 +196,40 @@ namespace NuGet.CommandLine.Test
             }
         }
 
+        [Fact]
+        public void TestGetMsbuildDirectoryFromPATHENV()
+        {
+            using (var vsPath = TestDirectory.Create())
+            {
+                var msBuild159BinPath = Directory.CreateDirectory(Path.Combine(vsPath, "MSBuild", "15.9", "Bin")).FullName;
+
+                var msBuild159ExePath = Path.Combine(msBuild159BinPath, "msbuild.exe").ToString();
+
+                if (RuntimeEnvironmentHelper.IsMono)
+                {
+                    msBuild159ExePath = Path.Combine(msBuild159BinPath, "msbuild").ToString();
+                }
+
+                using (var fs15 = File.CreateText(msBuild159ExePath))
+                {
+                    fs15.Write("foo 15.9");
+                }
+
+                var pathValue = Environment.GetEnvironmentVariable("PATH");
+                var newPathValue = msBuild159BinPath + ";" + pathValue;
+
+                Environment.SetEnvironmentVariable("PATH", newPathValue);
+
+                // Act;
+                var toolset = MsBuildUtility.GetMsBuildToolset(userVersion: null, console: null);
+                Environment.SetEnvironmentVariable("PATH", pathValue);
+
+                // Assert
+                Assert.NotNull(toolset);
+                Assert.Equal(msBuild159BinPath, toolset.Path);
+            }
+        }
+
         public static class ToolsetDataSource
         {
             // Legacy toolsets


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7621
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: If msbuild is set in $PATH environment variable then use that with NuGet.exe instead of always failing back to the latest msbuild on the machine

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
