### PR TITLE
Moved test oids to their own class

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Oids.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Oids.cs
@@ -89,13 +89,5 @@ namespace NuGet.Packaging.Signing
         public const string NuGetV3ServiceIndexUrl = "1.3.6.1.4.1.311.84.2.1.1.1";
 
         public const string NuGetPackageOwners = "1.3.6.1.4.1.311.84.2.1.1.2";
-
-        public const string IdKpClientAuth = "1.3.6.1.5.5.7.3.2";
-
-        public const string IdKpEmailProtection = "1.3.6.1.5.5.7.3.4";
-
-        public const string AnyExtendedKeyUsage = "2.5.29.37.0";
-
-        public const string CrlDistributionPoints = "2.5.29.31";
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
@@ -214,7 +214,7 @@ namespace NuGet.Packaging.Test
             using (var certificate = SigningTestUtility.GenerateCertificate("test",
                 generator =>
                 {
-                    var usages = new OidCollection { new Oid(Oids.IdKpEmailProtection) };
+                    var usages = new OidCollection { new Oid(TestOids.IdKpEmailProtection) };
 
                     generator.Extensions.Add(
                         new X509EnhancedKeyUsageExtension(
@@ -233,7 +233,7 @@ namespace NuGet.Packaging.Test
             using (var certificate = SigningTestUtility.GenerateCertificate("test",
                 generator =>
                 {
-                    var usages = new OidCollection { new Oid(Oids.IdKpEmailProtection), new Oid(Oids.AnyExtendedKeyUsage) };
+                    var usages = new OidCollection { new Oid(TestOids.IdKpEmailProtection), new Oid(TestOids.AnyExtendedKeyUsage) };
 
                     generator.Extensions.Add(
                         new X509EnhancedKeyUsageExtension(

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -34,7 +34,7 @@ namespace Test.Utility.Signing
         public static Action<TestCertificateGenerator> CertificateModificationGeneratorForInvalidEkuCert = delegate (TestCertificateGenerator gen)
         {
             // any EKU besides CodeSigning
-            var usages = new OidCollection { new Oid(Oids.IdKpClientAuth) };
+            var usages = new OidCollection { new Oid(TestOids.IdKpClientAuth) };
 
             gen.Extensions.Add(
                  new X509EnhancedKeyUsageExtension(
@@ -257,7 +257,7 @@ namespace Test.Utility.Signing
 
                     certGen.Extensions.Add(
                         new X509Extension(
-                            Oids.CrlDistributionPoints,
+                            TestOids.CrlDistributionPoints,
                             new DerSequence(distPoint).GetDerEncoded(),
                             critical: false));
                 }

--- a/test/TestUtilities/Test.Utility/Signing/TestOids.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TestOids.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Test.Utility.Signing
+{
+    public static class TestOids
+    {
+        public const string IdKpClientAuth = "1.3.6.1.5.5.7.3.2";
+
+        public const string IdKpEmailProtection = "1.3.6.1.5.5.7.3.4";
+
+        public const string AnyExtendedKeyUsage = "2.5.29.37.0";
+
+        public const string CrlDistributionPoints = "2.5.29.31";
+    }
+}


### PR DESCRIPTION
## Bug

As part of https://github.com/NuGet/NuGet.Client/pull/2685 some OIDs were added to the Signing/Oids class. This OIDs are only used on tests and should not be in product code.

This PR moves them to their own static class on tests.
