### PR TITLE
fix bug in dotnet list package & add test

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -375,6 +375,11 @@ namespace NuGet.CommandLine.XPlat
                 requestedTargets = filteredTargets;
             }
 
+            // In 2.2.100 of CLI. DotNet list package would show a section for each TFM and for each TFM/RID.
+            // Filtering the Targets to ignore TargetFramework + RID combination, only keep TargetFramework in requestedTargets.
+            // So that only one section will be shown for each TFM.
+            requestedTargets = requestedTargets.Where(target => target.RuntimeIdentifier == null).ToList();
+
             foreach (var target in requestedTargets)
             {
                 // Find the tfminformation corresponding to the target to

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -375,7 +375,6 @@ namespace NuGet.CommandLine.XPlat
                 requestedTargets = filteredTargets;
             }
 
-            // In 2.2.100 of CLI. DotNet list package would show a section for each TFM and for each TFM/RID.
             // Filtering the Targets to ignore TargetFramework + RID combination, only keep TargetFramework in requestedTargets.
             // So that only one section will be shown for each TFM.
             requestedTargets = requestedTargets.Where(target => target.RuntimeIdentifier == null).ToList();

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using NuGet.Packaging;

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -232,15 +232,6 @@ namespace Dotnet.Integration.Test
 
                 //the assets file should generate 4 sections in Targets: 1 for TFM only , and 3 for TFM + RID combinations 
                 var assetsFile = projectA.AssetsFile;
-                //add for testing the assetsFile
-                var targets = assetsFile.Targets.GetEnumerator();
-                var i = 0;
-                while (targets.MoveNext()) {
-                    var currTarget = targets.Current;
-                    Console.WriteLine(i + "  Name : " + currTarget.Name + " RID : " + currTarget.RuntimeIdentifier);
-                    i++;
-                }
-                
                 Assert.Equal(4, assetsFile.Targets.Count);
 
                 var listResult = _fixture.RunDotnet(Directory.GetParent(projectA.ProjectPath).FullName,

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -196,6 +196,54 @@ namespace Dotnet.Integration.Test
             }
         }
 
+
+        // In 2.2.100 of CLI. DotNet list package would show a section for each TFM and for each TFM/RID.
+        // This is testing to ensure that it only shows one section for each TFM.
+        [PlatformFact(Platform.Windows)]
+        public async void DotnetListPackage_ShowFrameworksOnly_SDK()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net461");
+
+                projectA.Properties.Add("RuntimeIdentifiers", "win;win-x86;win-x64");
+
+                var packageX = XPlatTestUtils.CreatePackage();
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                projectA.Save();
+
+                // Generate Package
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var addResult = _fixture.RunDotnet(Directory.GetParent(projectA.ProjectPath).FullName,
+                    $"add {projectA.ProjectPath} package packageX --no-restore");
+                Assert.True(addResult.Success);
+
+                var restoreResult = _fixture.RunDotnet(Directory.GetParent(projectA.ProjectPath).FullName,
+                    $"restore {projectA.ProjectName}.csproj");
+                Assert.True(restoreResult.Success);
+
+                //the assets file should generate 4 sections in Targets: 1 for TFM only , and 3 for TFM + RID combinations 
+                var assetsFile = projectA.AssetsFile;
+                Assert.Equal(4, assetsFile.Targets.Count);
+
+                var listResult = _fixture.RunDotnet(Directory.GetParent(projectA.ProjectPath).FullName,
+                    $"list {projectA.ProjectPath} package",
+                    true);
+
+                //make sure there is no duplicate in output
+                Assert.True(NoDuplicateSection(listResult.AllOutput));
+
+            }
+        }
+        
+
         [PlatformTheory(Platform.Windows)]
         [InlineData("1.0.0", "", "2.1.0")]
         [InlineData("1.0.0", "--include-prerelease", "2.2.0-beta")]
@@ -243,6 +291,26 @@ namespace Dotnet.Integration.Test
             var commandResultNoSpaces = output.Replace(" ", "");
 
             return commandResultNoSpaces.ToLowerInvariant().Contains(pattern.ToLowerInvariant());
+        }
+
+        private static bool NoDuplicateSection(string output)
+        {
+            var sections = output.Replace(" ", "").Replace("\r", "").Replace("\n", "").Split("[");
+            if (sections.Length == 1)
+            {
+                return false;
+            }
+            for (var i = 1; i <= sections.Length - 2; i++)
+            {
+                for (var j = i + 1; j <= sections.Length - 1; j++)
+                {
+                    if (sections[i].Equals(sections[j]))
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -232,6 +232,15 @@ namespace Dotnet.Integration.Test
 
                 //the assets file should generate 4 sections in Targets: 1 for TFM only , and 3 for TFM + RID combinations 
                 var assetsFile = projectA.AssetsFile;
+                //add for testing the assetsFile
+                var targets = assetsFile.Targets.GetEnumerator();
+                var i = 0;
+                while (targets.MoveNext()) {
+                    var currTarget = targets.Current;
+                    Console.WriteLine(i + "  Name : " + currTarget.Name + " RID : " + currTarget.RuntimeIdentifier);
+                    i++;
+                }
+                
                 Assert.Equal(4, assetsFile.Targets.Count);
 
                 var listResult = _fixture.RunDotnet(Directory.GetParent(projectA.ProjectPath).FullName,
@@ -239,8 +248,8 @@ namespace Dotnet.Integration.Test
                     true);
 
                 //make sure there is no duplicate in output
-                Assert.True(NoDuplicateSection(listResult.AllOutput));
-
+                Assert.True(NoDuplicateSection(listResult.AllOutput), listResult.AllOutput);
+               
             }
         }
         
@@ -300,10 +309,6 @@ namespace Dotnet.Integration.Test
             if (sections.Length == 1)
             {
                 return false;
-            }
-            //add to see the actual ouput msg in devdiv
-            for (var i = 0; i <= sections.Length - 1; i++) {
-                Console.WriteLine(sections[i]);
             }
             
             for (var i = 1; i <= sections.Length - 2; i++)

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using NuGet.Packaging;
@@ -300,6 +301,11 @@ namespace Dotnet.Integration.Test
             {
                 return false;
             }
+            //add to see the actual ouput msg in devdiv
+            for (var i = 0; i <= sections.Length - 1; i++) {
+                Console.WriteLine(sections[i]);
+            }
+            
             for (var i = 1; i <= sections.Length - 2; i++)
             {
                 for (var j = i + 1; j <= sections.Length - 1; j++)

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -260,6 +260,7 @@ namespace Dotnet.Integration.Test
                 {
                     var files = nupkg.GetFiles()
                     .Where(fileName => fileName.StartsWith("lib/netstandard")
+                                    || fileName.StartsWith("lib/netcoreapp")
                                     || fileName.Contains("NuGet.targets"));
 
                     CopyFlatlistOfFilesToTarget(nupkg, pathToSdkInCli, files);


### PR DESCRIPTION
## Bug

Fixes: [#7607](https://github.com/NuGet/Home/issues/7607)  
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: add filter to ignore the TFM + RID records when get resolved versions

## Testing/Validation

Tests Added: Yes
Validation:  Assets file created correctly with TFM & TFM+RID, only one section per TFM is shown when running dotnet list package command.
