### PR TITLE
handle the temp directory generation with under mono correctly

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -986,10 +986,9 @@ namespace NuGet.CommandLine
                 {
                     throw new ArgumentNullException(nameof(extension));
                 }
-
                 var tempDirectory = NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp);
 
-                Directory.CreateDirectory(tempDirectory);
+                DirectoryUtility.CreateSharedDirectory(tempDirectory);
 
                 var count = 0;
                 do


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7793

One of the potential root causes to https://github.com/NuGet/Home/issues/7341  
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

There is a code path that potentially created a bad temp folder in the nuget.exe under mono scenario. 

fyi @rrelyea 

## Testing/Validation

Tests Added: No  
Reason for not adding tests: It's difficult to test this. 
The existing tests should catch any other potential issues. 
Validation:  
