### PR TITLE
Making sure explicit source parameter with IVS apis is added for restore

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -310,7 +310,7 @@ namespace NuGet.SolutionRestoreManager
                 var dgSpec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(_solutionManager, cacheContext);
 
                 // Avoid restoring solutions with zero potential PackageReference projects.
-                if (DependencyGraphRestoreUtility.IsRestoreRequired(dgSpec))
+                if (dgSpec.Restore.Count > 0)
                 {
                     // NOTE: During restore for build integrated projects,
                     //       We might show the dialog even if there are no packages to restore

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -172,16 +172,6 @@ namespace NuGet.Commands
                 // Create a shared caching provider if one does not exist already
                 CachingSourceProvider = new CachingSourceProvider(packageSourceProvider);
             }
-            else
-            {
-                foreach(var source in CachingSourceProvider.GetRepositories())
-                {
-                    if (!sourceObjects.ContainsKey(source.PackageSource.Source))
-                    {
-                        sourceObjects.Add(source.PackageSource.Source, source.PackageSource);
-                    }
-                }
-            }
 
             return sourceObjects.Select(entry => CachingSourceProvider.CreateRepository(entry.Value)).ToList();
         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -172,6 +172,16 @@ namespace NuGet.Commands
                 // Create a shared caching provider if one does not exist already
                 CachingSourceProvider = new CachingSourceProvider(packageSourceProvider);
             }
+            else
+            {
+                foreach(var source in CachingSourceProvider.GetRepositories())
+                {
+                    if (!sourceObjects.ContainsKey(source.PackageSource.Source))
+                    {
+                        sourceObjects.Add(source.PackageSource.Source, source.PackageSource);
+                    }
+                }
+            }
 
             return sourceObjects.Select(entry => CachingSourceProvider.CreateRepository(entry.Value)).ToList();
         }

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -285,10 +285,6 @@ namespace NuGet.PackageManagement
             bool restoreForceEvaluate)
         {
             var caching = new CachingSourceProvider(new PackageSourceProvider(context.Settings));
-            foreach( var source in sources)
-            {
-                caching.AddSourceRepository(source);
-            }
 
             var dgProvider = new DependencyGraphSpecRequestProvider(providerCache, dgFile);
 
@@ -301,7 +297,8 @@ namespace NuGet.PackageManagement
                 CachingSourceProvider = caching,
                 ParentId = parentId,
                 IsRestoreOriginalAction = isRestoreOriginalAction,
-                RestoreForceEvaluate = restoreForceEvaluate
+                RestoreForceEvaluate = restoreForceEvaluate,
+                Sources = sources.Select(source => source.PackageSource.Source).ToList()
             };
 
             return restoreContext;

--- a/src/NuGet.Core/NuGet.Protocol/CachingSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/CachingSourceProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -67,7 +67,10 @@ namespace NuGet.Protocol
 
         public void AddSourceRepository(SourceRepository source)
         {
-            _cachedSources.TryAdd(source.PackageSource.Source, source);
+            if(_cachedSources.TryAdd(source.PackageSource.Source, source))
+            {
+                _repositories.Add(source);
+            }
         }
 
         public IPackageSourceProvider PackageSourceProvider

--- a/src/NuGet.Core/NuGet.Protocol/CachingSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/CachingSourceProvider.cs
@@ -65,14 +65,6 @@ namespace NuGet.Protocol
             return _cachedSources.GetOrAdd(source.Source, new SourceRepository(source, _resourceProviders, type));
         }
 
-        public void AddSourceRepository(SourceRepository source)
-        {
-            if(_cachedSources.TryAdd(source.PackageSource.Source, source))
-            {
-                _repositories.Add(source);
-            }
-        }
-
         public IPackageSourceProvider PackageSourceProvider
         {
             get { return _packageSourceProvider; }

--- a/test/EndToEnd/tests/ServicesTest.ps1
+++ b/test/EndToEnd/tests/ServicesTest.ps1
@@ -1002,3 +1002,21 @@ function Test-InstallPackageAsyncWithPackageReferenceFormat {
     Assert-AreEqual $packageRefs[0].GetMetadataValue("Identity") 'owin' 
     Assert-AreEqual $packageRefs[0].GetMetadataValue("Version") '1.0.0'
 }
+
+function Test-BuildIntegratedProjectInstallPackage {
+
+    # Arrange
+    $project = New-Project BuildIntegratedClassLibrary Project1
+    $id = 'CustomBuildIntegratedProjectInstallPackage'
+    $version = '1.0.0'
+
+    $solutionFile = Get-SolutionFullName
+	$solutionDir = Split-Path $solutionFile -Parent
+    $source = Join-Path $solutionDir "CustomSource"
+
+    # Act
+    [API.Test.InternalAPITestHook]::InstallPackageApiFromSource($source, $id, $version)
+
+    # Assert
+    Assert-ProjectJsonLockFilePackage $project $id $version
+}


### PR DESCRIPTION
## Bug
Fixes: https://github.com/NuGet/Home/issues/7104
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix
Details: Currently we aren't consuming explicit source provided through IVS `InstallPackage` or NuGet template wizard apis while restoring with `PackageReference`. Which these APIs only works with PR when source is already part of NuGet.config file.

## Testing/Validation
Tests Added: Yes
Reason for not adding tests:  
Validation:  
