### PR TITLE
Allow installing latest package with InstallPackage IVS api

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
@@ -526,19 +526,10 @@ namespace NuGet.VisualStudio
                 foreach (var package in packages)
                 {
                     // Check if the package is already installed
-                    if (package.Version == null)
+                    if (package.Version != null &&
+                        _packageServices.IsPackageInstalledEx(project, package.Id, package.Version.ToString()))
                     {
-                        if (_packageServices.IsPackageInstalled(project, package.Id))
-                        {
                             continue;
-                        }
-                    }
-                    else
-                    {
-                        if (_packageServices.IsPackageInstalledEx(project, package.Id, package.Version.ToString()))
-                        {
-                            continue;
-                        }
                     }
 
                     // Perform the install

--- a/test/EndToEnd/tests/ServicesTest.ps1
+++ b/test/EndToEnd/tests/ServicesTest.ps1
@@ -1,4 +1,4 @@
-﻿function Test-PackageManagerServicesAreAvailableThroughMEF {
+function Test-PackageManagerServicesAreAvailableThroughMEF {
     # Arrange
     $cm = Get-VsComponentModel
 
@@ -939,4 +939,20 @@ function Test-CreateVsPathContextUsesAssetsFileIfAvailable {
 	# Assert
 	Assert-NotNull $context.UserPackageFolder
 	Assert-NotEqual $userPackageFolder $context.UserPackageFolder
+}
+
+function Test-InstallPackageAPIToLatestVersion
+{
+    param($context)
+
+    # Arrange
+    $p = New-ClassLibrary
+    Install-Package TestPackage.ListedStable -ProjectName $p.Name -version 1.0.0
+    Assert-Package $p TestPackage.ListedStable 1.0.0
+
+    # Act
+    [API.Test.InternalAPITestHook]::InstallPackageApi("TestPackage.ListedStable","")
+
+    # Assert
+    Assert-Package $p TestPackage.ListedStable 2.0.6
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7493
Regression: Yes/No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: When only package id is provided, we'll check for the latest version and if its same as installed version then only we'll return error otherwise it'll allow to update to the latest version.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
