### PR TITLE
Add support for reading the PackageDownload items

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestorePackageDownloadsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestorePackageDownloadsTask.cs
@@ -1,0 +1,97 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using NuGet.Shared;
+
+namespace NuGet.Build.Tasks
+{
+    public class GetRestorePackageDownloadsTask : Task
+    {
+        /// <summary>
+        /// Full path to the msbuild project.
+        /// </summary>
+        [Required]
+        public string ProjectUniqueName { get; set; }
+
+        [Required]
+        public ITaskItem[] PackageDownloads { get; set; }
+
+        /// <summary>
+        /// Target frameworks to apply this for. If empty this applies to all.
+        /// </summary>
+        public string TargetFrameworks { get; set; }
+
+        /// <summary>
+        /// Output items
+        /// </summary>
+        [Output]
+        public ITaskItem[] RestoreGraphItems { get; set; }
+
+        public override bool Execute()
+        {
+            var log = new MSBuildLogger(Log);
+            log.LogDebug($"(in) ProjectUniqueName '{ProjectUniqueName}'");
+            log.LogDebug($"(in) TargetFrameworks '{TargetFrameworks}'");
+            log.LogDebug($"(in) PackageDownloads '{string.Join(";", PackageDownloads.Select(p => p.ItemSpec))}'");
+
+            var entries = new List<ITaskItem>();
+            var seenIds = new HashSet<Tuple<string, string>>(new CustomEqualityComparer());
+
+            foreach (var msbuildItem in PackageDownloads)
+            {
+                var packageId = msbuildItem.ItemSpec;
+
+                var properties = new Dictionary<string, string>();
+                properties.Add("ProjectUniqueName", ProjectUniqueName);
+                properties.Add("Type", "DownloadDependency");
+                properties.Add("Id", packageId);
+                BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "Version", "VersionRange");
+
+                properties.TryGetValue("VersionRange", out var versionRange);
+
+                var key = new Tuple<string, string>(packageId, versionRange);
+
+                if (string.IsNullOrEmpty(packageId) || !seenIds.Add(key))
+                {
+                    // Skip duplicate id/version combinations
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(TargetFrameworks))
+                {
+                    properties.Add("TargetFrameworks", TargetFrameworks);
+                }
+
+                entries.Add(new TaskItem(Guid.NewGuid().ToString(), properties));
+            }
+
+            RestoreGraphItems = entries.ToArray();
+
+            return true;
+        }
+
+        private class CustomEqualityComparer : IEqualityComparer<Tuple<string, string>>
+        {
+
+            public bool Equals(Tuple<string, string> lhs, Tuple<string, string> rhs)
+            {
+                return StringComparer.OrdinalIgnoreCase.Equals(lhs.Item1, rhs.Item1)
+               && StringComparer.OrdinalIgnoreCase.Equals(lhs.Item2, rhs.Item2);
+            }
+
+            public int GetHashCode(Tuple<string, string> tuple)
+            {
+                var combiner = new HashCodeCombiner();
+                combiner.AddStringIgnoreCase(tuple.Item1);
+                combiner.AddStringIgnoreCase(tuple.Item2);
+                return combiner.CombinedHash;
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -92,6 +92,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreProjectJsonPathTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreProjectReferencesTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestorePackageReferencesTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
+  <UsingTask TaskName="NuGet.Build.Tasks.GetRestorePackageDownloadsTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreDotnetCliToolsTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetProjectTargetFrameworksTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreSolutionProjectsTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
@@ -162,6 +163,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="CollectPackageReferences" Returns="@(PackageReference)" />
+
+    <!--
+    ============================================================
+    CollectPackageDownloads
+    Gathers all PackageDownload items from the project.
+    This target may be used as an extension point to modify
+    package downloads before NuGet reads them.
+    ============================================================
+  -->
+  <Target Name="CollectPackageDownloads" Returns="@(PackageDownload)" />
 
   <!--
     ============================================================
@@ -772,7 +783,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GenerateProjectRestoreGraphPerFramework"
-    DependsOnTargets="_GetRestoreProjectStyle;CollectPackageReferences"
+    DependsOnTargets="_GetRestoreProjectStyle;CollectPackageReferences;CollectPackageDownloads"
     Returns="@(_RestoreGraphEntry)">
 
     <!-- Write out project references -->
@@ -787,17 +798,31 @@ Copyright (c) .NET Foundation. All rights reserved.
         ItemName="_RestoreGraphEntry" />
     </GetRestoreProjectReferencesTask>
 
-    <!-- Write out package references for NETCore -->
+    <!-- Write out package references-->
     <GetRestorePackageReferencesTask
       Condition=" '$(PackageReferenceCompatibleProjectStyle)' == 'true' "
       ProjectUniqueName="$(MSBuildProjectFullPath)"
       PackageReferences="@(PackageReference)"
-      TargetFrameworks="$(TargetFramework)">
+      TargetFrameworks="$(TargetFramework)"
+      >
 
       <Output
         TaskParameter="RestoreGraphItems"
         ItemName="_RestoreGraphEntry" />
     </GetRestorePackageReferencesTask>
+
+    <!-- Write out package downloads -->
+    <GetRestorePackageDownloadsTask
+      Condition=" '$(PackageReferenceCompatibleProjectStyle)' == 'true' "
+      ProjectUniqueName="$(MSBuildProjectFullPath)"
+      PackageDownloads="@(PackageDownload)"
+      TargetFrameworks="$(TargetFramework)"
+      >
+
+      <Output
+        TaskParameter="RestoreGraphItems"
+        ItemName="_RestoreGraphEntry" />
+    </GetRestorePackageDownloadsTask>
 
     <PropertyGroup>
       <_CombinedFallbacks>$(PackageTargetFallback);$(AssetTargetFallback)</_CombinedFallbacks>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -651,21 +651,13 @@ namespace NuGet.Commands
                     throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_PackageDownload_OnlyExactVersionsAreAllowed, versionRange.OriginalString));
                 }
 
-                // TODO NK : Check version range. Does it throw here?
                 var downloadDependency = new DownloadDependency(id, versionRange);
                 
                 var frameworks = GetFrameworks(item);
 
-                if (frameworks.Count == 0)
+                foreach (var framework in frameworks)
                 {
-                    AddDownloadDependencyIfNotExist(spec, downloadDependency);
-                }
-                else
-                {
-                    foreach (var framework in frameworks)
-                    {
-                        AddDownloadDependencyIfNotExist(spec, framework, downloadDependency);
-                    }
+                    AddDownloadDependencyIfNotExist(spec, framework, downloadDependency);
                 }
             }
         }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.Commands {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -390,6 +390,15 @@ namespace NuGet.Commands {
         internal static string Error_PackageCommandNoFilesForSymbolsPackage {
             get {
                 return ResourceManager.GetString("Error_PackageCommandNoFilesForSymbolsPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is not an exact version like &apos;[1.0.0]&apos;. Only exact versions are allowed with PackageDownload..
+        /// </summary>
+        internal static string Error_PackageDownload_OnlyExactVersionsAreAllowed {
+            get {
+                return ResourceManager.GetString("Error_PackageDownload_OnlyExactVersionsAreAllowed", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -871,4 +871,8 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>Successfully synchronized the trusted repository '{0}'.</value>
     <comment>0 - name</comment>
   </data>
+  <data name="Error_PackageDownload_OnlyExactVersionsAreAllowed" xml:space="preserve">
+    <value>'{0}' is not an exact version like '[1.0.0]'. Only exact versions are allowed with PackageDownload.</value>
+    <comment>0 - the version string that's not exact</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/ResolverUtility.cs
@@ -83,7 +83,7 @@ namespace NuGet.DependencyResolver
                                                  match.Provider.Source,
                                                 ex.PackageIdentity.ToString());
 
-                    throw new FatalProtocolException(message, ex); // check how this would work in the PackageDownload case. 
+                    throw new FatalProtocolException(message, ex);
                 }
             }
 

--- a/src/NuGet.Core/NuGet.LibraryModel/DownloadDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/DownloadDependency.cs
@@ -73,7 +73,7 @@ namespace NuGet.LibraryModel
         {
             var hashCode = new HashCodeCombiner();
 
-            hashCode.AddObject(Name);
+            hashCode.AddObject(Name.ToLowerInvariant());
             hashCode.AddObject(VersionRange);
 
             return hashCode.CombinedHash;
@@ -96,7 +96,7 @@ namespace NuGet.LibraryModel
                 return true;
             }
 
-            return Name == other.Name &&
+            return Name.Equals(other.Name, StringComparison.OrdinalIgnoreCase) &&
                    EqualityUtility.EqualsWithNullCheck(VersionRange, other.VersionRange);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions;
 using Newtonsoft.Json.Linq;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -6302,6 +6303,374 @@ namespace NuGet.CommandLine.Test
                     Assert.NotNull(library);
                     Assert.False(library.Build.Any(build => build.Path.Equals("buildTransitive/y.targets")));
                 }
+            }
+        }
+        
+        [Fact]
+        public async Task RestoreNetCore_SingleTFM_SimplePackageDownload()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+                var projectFrameworks = "net46";
+                
+                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                            projectName: "a",
+                            solutionRoot: pathContext.SolutionRoot,
+                            frameworks: MSBuildStringUtility.Split(projectFrameworks));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net45/x.dll");
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX);
+
+                projectA.AddPackageDownloadToAllFrameworks(packageX);
+                
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                // Assert
+                Assert.True(r.Success, r.AllOutput);
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.AllOutput);
+
+                var lockFile = LockFileUtilities.GetLockFile(projectA.AssetsFileOutputPath, Common.NullLogger.Instance);
+                Assert.Equal(0, lockFile.Libraries.Count);
+                Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.Count);
+                Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.First().DownloadDependencies.Count);
+                Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().Name);
+                Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX.Identity.Id, packageX.Version)), $"{packageX.ToString()} is not installed");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreNetCore_SingleTFM_SameIdMultiPackageDownload()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+                var projectFrameworks = "net46";
+
+                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                            projectName: "a",
+                            solutionRoot: pathContext.SolutionRoot,
+                            frameworks: MSBuildStringUtility.Split(projectFrameworks));
+
+                var packageX1 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                var packageX2 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "2.0.0"
+                };
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX1,
+                    packageX2);
+
+                projectA.AddPackageDownloadToAllFrameworks(packageX1);
+                projectA.AddPackageDownloadToAllFrameworks(packageX2);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                // Assert
+                Assert.True(r.Success, r.AllOutput);
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.AllOutput);
+
+                var lockFile = LockFileUtilities.GetLockFile(projectA.AssetsFileOutputPath, Common.NullLogger.Instance);
+                Assert.Equal(0, lockFile.Libraries.Count);
+                Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.Count);
+                Assert.Equal(2, lockFile.PackageSpec.TargetFrameworks.First().DownloadDependencies.Count);
+                Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().Name);
+                Assert.Equal($"[{packageX2.Version}, {packageX2.Version}]", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().VersionRange.ToNormalizedString());
+                Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.Last().Name);
+                Assert.Equal($"[{packageX1.Version}, {packageX1.Version}]", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.Last().VersionRange.ToNormalizedString());
+                
+                Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX1.Identity.Id, packageX1.Version)), $"{packageX1.ToString()} is not installed");
+                Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX2.Identity.Id, packageX2.Version)), $"{packageX2.ToString()} is not installed");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreNetCore_SingleTFM_SameIdSameVersionMultiDeclaration_MultiPackageDownload()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+                var projectFrameworks = "net46";
+
+                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                            projectName: "a",
+                            solutionRoot: pathContext.SolutionRoot,
+                            frameworks: MSBuildStringUtility.Split(projectFrameworks));
+
+                var packageX1 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                var packageX2 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "2.0.0"
+                };
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX1,
+                    packageX2);
+
+                projectA.AddPackageDownloadToAllFrameworks(packageX1);
+                projectA.AddPackageDownloadToAllFrameworks(packageX2);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                // Add one more - Adding them through the Test Context adds only exact versions.
+
+                var xml = projectA.GetXML();
+
+                var props = new Dictionary<string, string>();
+                var attributes = new Dictionary<string, string>();
+                attributes.Add("Version", "[1.0.0, 1.0.0]");
+                ProjectFileUtils.AddItem(
+                                    xml,
+                                    "PackageDownload",
+                                    packageX1.Id,
+                                    NuGetFramework.AnyFramework,
+                                    props,
+                                    attributes);
+
+                xml.Save(projectA.ProjectPath);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                // Assert
+                Assert.True(r.Success, r.AllOutput);
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.AllOutput);
+
+                var lockFile = LockFileUtilities.GetLockFile(projectA.AssetsFileOutputPath, Common.NullLogger.Instance);
+                Assert.Equal(0, lockFile.Libraries.Count);
+                Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.Count);
+                Assert.Equal(2, lockFile.PackageSpec.TargetFrameworks.First().DownloadDependencies.Count);
+                Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().Name);
+                Assert.Equal($"[{packageX2.Version}, {packageX2.Version}]", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().VersionRange.ToNormalizedString());
+                Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.Last().Name);
+                Assert.Equal($"[{packageX1.Version}, {packageX1.Version}]", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.Last().VersionRange.ToNormalizedString());
+
+                Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX1.Identity.Id, packageX1.Version)), $"{packageX1.ToString()} is not installed");
+                Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX2.Identity.Id, packageX2.Version)), $"{packageX2.ToString()} is not installed");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreNetCore_MultiTfm_PackageDownloadAndPackageReference()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+                var projectFrameworks = "net45;net46";
+
+                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                            projectName: "a",
+                            solutionRoot: pathContext.SolutionRoot,
+                            frameworks: MSBuildStringUtility.Split(projectFrameworks));
+
+                var packageX1 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                var packageX2 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "2.0.0"
+                };
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX1,
+                    packageX2);
+
+                projectA.AddPackageToFramework("net45", packageX1);
+
+                projectA.AddPackageDownloadToFramework("net46", packageX2);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                // Assert
+                Assert.True(r.Success, r.AllOutput);
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.AllOutput);
+
+                var lockFile = LockFileUtilities.GetLockFile(projectA.AssetsFileOutputPath, Common.NullLogger.Instance);
+
+                Assert.Equal(1, lockFile.Libraries.Count);
+                Assert.Equal(2, lockFile.PackageSpec.TargetFrameworks.Count);
+                Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.First().Dependencies.Count);
+                Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.Count);
+                Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().Name);
+                Assert.Equal($"[{packageX2.Version}, {packageX2.Version}]",
+                    lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().VersionRange.ToNormalizedString());
+                Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks.First().Dependencies.Last().Name);
+                Assert.Equal($"[{packageX1.Version}, )",
+                    lockFile.PackageSpec.TargetFrameworks.First().Dependencies.First().LibraryRange.VersionRange.ToNormalizedString());
+                Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX1.Identity.Id, packageX1.Version)),
+                    $"{packageX1.ToString()} is not installed");
+                Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX2.Identity.Id, packageX2.Version)),
+                    $"{packageX2.ToString()} is not installed");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreNetCore_MultiTfm_MultiPackageDownload()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+                var projectFrameworks = "net45;net46";
+
+                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                            projectName: "a",
+                            solutionRoot: pathContext.SolutionRoot,
+                            frameworks: MSBuildStringUtility.Split(projectFrameworks));
+
+                var packageX1 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                var packageX2 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "2.0.0"
+                };
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX1,
+                    packageX2);
+
+                projectA.AddPackageDownloadToFramework("net45", packageX1);
+
+                projectA.AddPackageDownloadToFramework("net46", packageX2);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                // Assert
+                Assert.True(r.Success, r.AllOutput);
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.AllOutput);
+
+                var lockFile = LockFileUtilities.GetLockFile(projectA.AssetsFileOutputPath, Common.NullLogger.Instance);
+
+                Assert.Equal(0, lockFile.Libraries.Count);
+                Assert.Equal(2, lockFile.PackageSpec.TargetFrameworks.Count);
+                Assert.Equal(0, lockFile.PackageSpec.TargetFrameworks.First().Dependencies.Count);
+                Assert.Equal(0, lockFile.PackageSpec.TargetFrameworks.Last().Dependencies.Count);
+                Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.First().DownloadDependencies.Count);
+                Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.Count);
+
+                Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().Name);
+                Assert.Equal($"[{packageX2.Version}, {packageX2.Version}]",
+                    lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().VersionRange.ToNormalizedString());
+                Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks.First().DownloadDependencies.Last().Name);
+                Assert.Equal($"[{packageX1.Version}, {packageX1.Version}]",
+                    lockFile.PackageSpec.TargetFrameworks.First().DownloadDependencies.First().VersionRange.ToNormalizedString());
+                Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX1.Identity.Id, packageX1.Version)),
+                    $"{packageX1.ToString()} is not installed");
+                Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX2.Identity.Id, packageX2.Version)),
+                    $"{packageX2.ToString()} is not installed");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreNetCore_SingleTFM_PackageDownload_NonExactVersion_Fails()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+                var projectFrameworks = "net46";
+
+                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                            projectName: "a",
+                            solutionRoot: pathContext.SolutionRoot,
+                            frameworks: MSBuildStringUtility.Split(projectFrameworks));
+
+                var packageX1 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX1);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                var xml = projectA.GetXML();
+
+                var props = new Dictionary<string, string>();
+                var attributes = new Dictionary<string, string>();
+                attributes.Add("Version", "1.0.0");
+                ProjectFileUtils.AddItem(
+                                    xml,
+                                    "PackageDownload",
+                                    packageX1.Id,
+                                    NuGetFramework.AnyFramework,
+                                    props,
+                                    attributes);
+
+                xml.Save(projectA.ProjectPath);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
+
+                // Assert
+                Assert.False(r.Success, r.AllOutput);
+                Assert.False(File.Exists(projectA.AssetsFileOutputPath), r.AllOutput);
             }
         }
     }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -147,7 +147,6 @@ namespace NuGet.XPlat.FuncTest
             var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
                     projectName: projectName,
                     solutionRoot: pathContext.SolutionRoot,
-                    isToolingVersion15: true,
                     frameworks: MSBuildStringUtility.Split(projectFrameworks));
 
             if (packageFramework == null)
@@ -170,7 +169,6 @@ namespace NuGet.XPlat.FuncTest
             var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
                     projectName: projectName,
                     solutionRoot: pathContext.SolutionRoot,
-                    isToolingVersion15: true,
                     frameworks: MSBuildStringUtility.Split(projectFrameworks));
 
             project.FallbackFolders = (IList<string>) SettingsUtility.GetFallbackPackageFolders(settings);

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectFrameworkContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectFrameworkContext.cs
@@ -24,6 +24,12 @@ namespace NuGet.Test.Utility
         public List<SimpleTestPackageContext> PackageReferences { get; set; } = new List<SimpleTestPackageContext>();
 
         /// <summary>
+        /// Package downloads. All the packages are added as exact versions.
+        /// </summary>
+        public List<SimpleTestPackageContext> PackageDownloads { get; set; } = new List<SimpleTestPackageContext>();
+
+
+        /// <summary>
         /// Project dependencies.
         /// </summary>
         public List<SimpleTestProjectContext> ProjectReferences { get; set; } = new List<SimpleTestProjectContext>();


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7721
Part of https://github.com/NuGet/Home/issues/7720 (The commandline tool side)
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Note that this is building on top of https://github.com/NuGet/NuGet.Client/pull/2688, so please review that before looking into this. Only the commit with targets change(obvious name) is relevant for this PR.

This change allows the commandline tools (all of them, nuget.exe, msbuild and obviously dotnet.exe) to read PackageDownload items and use them during restore. 

There is a bunch of deduping happening there. 

```
<PackageDownload Include="x" Version="[1.0.0]" />
<PackageDownload Include="x" Version="[1.0.0, 1.0.0]" />
<PackageDownload Include="x" Version="[2.0.0]" />
```

translates to only 2 Download Dependencies as the first and second are semantically equivalent. 

fyi @nguerrera @dsplaisted @davkean

This change also adds the CollectPackageDownloads target. 
## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  Manual, Automation
