### PR TITLE
Check if package exists on disk before package uninstallation

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/MSBuildNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/MSBuildNuGetProjectTests.cs
@@ -486,6 +486,67 @@ namespace ProjectManagement.Test
             }
         }
 
+        [Fact]
+        public async Task TestMSBuildNuGetProject_UninstallPackage_NotExistsInFolder()
+        {
+            // Arrange
+            var packageIdentity = new PackageIdentity("packageA", new NuGetVersion("1.0.0"));
+
+            using (var randomTestPackageSourcePath = TestDirectory.Create())
+            using (var randomPackagesFolderPath = TestDirectory.Create())
+            using (var randomPackagesConfigFolderPath = TestDirectory.Create())
+            {
+                var randomPackagesConfigPath = Path.Combine(randomPackagesConfigFolderPath, "packages.config");
+                var token = CancellationToken.None;
+
+                var projectTargetFramework = NuGetFramework.Parse("net45");
+                var testNuGetProjectContext = new TestNuGetProjectContext();
+                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext);
+                var msBuildNuGetProject = new MSBuildNuGetProject(msBuildNuGetProjectSystem, randomPackagesFolderPath, randomPackagesConfigFolderPath);
+
+                // Pre-Assert
+                // Check that the packages.config file does not exist
+                Assert.False(File.Exists(randomPackagesConfigPath));
+                // Check that there are no packages returned by PackagesConfigProject
+                var packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+                Assert.Equal(0, packagesInPackagesConfig.Count);
+                Assert.Equal(0, msBuildNuGetProjectSystem.References.Count);
+
+                var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackage(randomTestPackageSourcePath,
+                    packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
+                using (var packageStream = GetDownloadResourceResult(randomTestPackageSourcePath, packageFileInfo))
+                {
+                    // Act
+                    await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
+                }
+
+                // Assert
+                // Check that the packages.config file exists after the installation
+                Assert.True(File.Exists(randomPackagesConfigPath));
+                // Check the number of packages and packages returned by PackagesConfigProject after the installation
+                packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+                Assert.Equal(1, packagesInPackagesConfig.Count);
+                Assert.Equal(packageIdentity, packagesInPackagesConfig[0].PackageIdentity);
+                Assert.Equal(projectTargetFramework, packagesInPackagesConfig[0].TargetFramework);
+                // Check that the reference has been added to MSBuildNuGetProjectSystem
+                Assert.Equal(1, msBuildNuGetProjectSystem.References.Count);
+                Assert.Equal("test45.dll", msBuildNuGetProjectSystem.References.First().Key);
+                Assert.Equal(Path.Combine(msBuildNuGetProject.FolderNuGetProject.GetInstalledPath(packageIdentity),
+                    "lib\\net45\\test45.dll"), msBuildNuGetProjectSystem.References.First().Value);
+
+                // Delete Packages folder
+                Directory.Delete(msBuildNuGetProject.FolderNuGetProject.Root, true);
+
+                // Main Act
+                var result = await msBuildNuGetProject.UninstallPackageAsync(packageIdentity, testNuGetProjectContext, token);
+
+                // Assert
+                Assert.False(result);
+                packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+                Assert.Equal(1, packagesInPackagesConfig.Count);
+            }
+        }
+
         #endregion
 
         #region Framework reference tests


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/5936 
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Added a null check before opening a stream for package file path during uninstallation and avoid throwing empty path exception.  

## Testing/Validation

Tests Added: Yes 
Reason for not adding tests:  
Validation:  
