### PR TITLE
Enabled packages.lock.json for NuGet sln

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -155,6 +155,7 @@
     <BaseOutputPath>$(ArtifactsDirectory)$(MSBuildProjectName)\$(BuildVariationFolder)\bin\</BaseOutputPath>
     <OutputPath>$(BaseOutputPath)$(Configuration)\</OutputPath>
     <AppxPackageDir>$(OutputPath)</AppxPackageDir>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 
   <!-- Generate AssemblyFileVersion and AssemblyVersion attributes. -->

--- a/src/NuGet.Clients/NuGet.CommandLine/packages.lock.json
+++ b/src/NuGet.Clients/NuGet.CommandLine/packages.lock.json
@@ -1,0 +1,108 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Microsoft.Web.Xdt": {
+        "type": "Transitive",
+        "resolved": "2.1.2",
+        "contentHash": "YIaNTOOtGzjF8CkQBOx3aUBWi0dD+g/nOjbpsVslx9G0/uldtpmoKLmyldmKdMv/gHs3qg40rBT3+wvEWoY5gg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "NuGet.Build.Tasks": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Commands": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.2",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/NuGet.Clients/NuGet.Console/packages.lock.json
+++ b/src/NuGet.Clients/NuGet.Console/packages.lock.json
@@ -1,0 +1,811 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "Microsoft.VisualStudio.TextManager.Interop": {
+        "type": "Direct",
+        "requested": "[7.10.6071, )",
+        "resolved": "7.10.6071",
+        "contentHash": "+xdOtk+Hxdt4Bewl4kCA7KQsI7IZa58uZdnkTcNV9CEtT6Om6VxApAMPIBNvt7sZQoA6SOYubX4uAzEADHX55g==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.10.0": {
+        "type": "Direct",
+        "requested": "[10.0.30319, )",
+        "resolved": "10.0.30319",
+        "contentHash": "NXkMxLGqJqHBUrCYi7EHyhrzWQNf5Pb1IFiJJW0JIW4BWzC5sT4PHVZYy0Ew8nRBrn3ZjMLUWOR50sFhYMDbAA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50727"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "EnvDTE": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "ppW2nOaaMCOy1HNdUWvTM+btoXVbvntTL4RxVvEWBaHFk+Aj/r7vrS3t9x1QrHB4Y9Rrd2n7UAmjzet3Ps63XA==",
+        "dependencies": {
+          "stdole": "7.0.3301"
+        }
+      },
+      "EnvDTE80": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "3CBF4ileGBzGDPvNePcI3611sRVP5xMHXMZGGgQtcFV5nUu5L5QAZkkrgnBdM0oD9ZXc6dReVwo+tXOSR91z4Q==",
+        "dependencies": {
+          "EnvDTE": "8.0.1",
+          "stdole": "7.0.3301"
+        }
+      },
+      "Lucene.Net": {
+        "type": "Transitive",
+        "resolved": "3.0.3",
+        "contentHash": "A/70q4eDcuuafQeDB9eaiDP9FQG7X29T4VIYRphS7Wk8kAM9gNcfVqYyd0H8BJ1BTpA5C1ORm9RzFn4BiNavrw==",
+        "dependencies": {
+          "SharpZipLib": "0.86.0"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "iAzPAX/guSnBXJxM+PZ+dVXF+vmE8hxcxJ9fOFrvHUv5cY/ILD1icf2sKjJLltJD0Na8r9oGF5PjNiTMxK8EYw==",
+        "dependencies": {
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.ApplicationInsights.PersistenceChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "V7peE2ssNCCfOqzk1kOJfr3zZLDDPs+M88N34e98L+YPpAoL11wQkLpPxWmztjipTD+DBxJO6PNaVsM9q5bM/A==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "0.17.2-build00169"
+        }
+      },
+      "Microsoft.ApplicationInsights.UniversalTelemetryChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "8sg18/b63fhYjpr0kZ2v/NEjOEJ3gwpzXaaKZTth04AUPuOKjWvS3/pyVIRQ1mUEhrV3Xn3S2/TkLiWLCTpo7A==",
+        "dependencies": {
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Client": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "w5w8GVLMmo+JzizmcuV01tgYn2OsaVhxGAO0ryKXkO5sob6EVjzcoJv8NHL3Xm98vywSh7kRgeLqbA/lxZuTXg==",
+        "dependencies": {
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Core": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "bP+PAx17AVQJ19aU9N7yMnz8yST1U9cekbYHRyIUvQzFLqqzrthEs/gLdyZiLJPmL4ZABuvwGBOXG/ukqmsbDg==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3"
+        }
+      },
+      "Microsoft.Bcl": {
+        "type": "Transitive",
+        "resolved": "1.1.8",
+        "contentHash": "gM+PUzd8ONxJpcPJeNppCJPklDhDuPUMVQkxvK4fe0rd9WyqBNPh4+UFx3Uv8zuG4C1Gapu1c25sfotE7TQtig==",
+        "dependencies": {
+          "Microsoft.Bcl.Build": "1.0.14"
+        }
+      },
+      "Microsoft.Bcl.Async": {
+        "type": "Transitive",
+        "resolved": "1.0.168",
+        "contentHash": "tUNC02eBwDKpGre0BcNIvblLv1q0Q3DnS/vtkRHj2FE1sXwt386HAudztyl5C0U88hllrqHDvtlz8bK0Y8cHDA==",
+        "dependencies": {
+          "Microsoft.Bcl": "1.1.8"
+        }
+      },
+      "Microsoft.Bcl.Build": {
+        "type": "Transitive",
+        "resolved": "1.0.14",
+        "contentHash": "cDLKSvNvRa519hplsbSoYqO69TjdDIhfjtKUM0g20/nVROoWsGav9KCI9HtnGjLmdV1+TcUUDhbotcllibjPEA=="
+      },
+      "Microsoft.Diagnostics.Tracing.EventSource.Redist": {
+        "type": "Transitive",
+        "resolved": "1.1.16-beta",
+        "contentHash": "o1gsKlGjLAnSHRyWBygKnO55Kp0bRXB3AO9e8OeAnqQH7HA5MAW6YAPEEy5e3aRE//7AlkdPtq28F19NqOLZQQ=="
+      },
+      "Microsoft.IdentityModel.Clients.ActiveDirectory": {
+        "type": "Transitive",
+        "resolved": "3.17.2",
+        "contentHash": "zvDoWJlrKg1TQeJScq+5znAZtduyJHlT7M9gEquUjm2PQCIR4C5PqJ0E8xYQsV3eF4bY8cW54uyr0FyhiN0MtQ=="
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "kbmvhMYu5OZXWN3toFXhrj3bSN7B+ZzNWzAZQ4Ofp5x2srk9ZCYFljETGS5faxzPwGd5+7W4WZlAfOI7QvzhlA=="
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "wVWYpXfE6gpkSrIRNo5TDVC7ss6KPTTrmT6x8ysHiZRIMSRAZ8TyHEAmpdATBBPNRmnlevyAs4CK6nPfDpCTqw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "dsDJhsL2zJyL5az5D3LhILIQRt+nXFQ64Bclj6vspIwD96sYRK/fPKTP8xLcLyw0fcosiFUgmWOXRLkWcAm1Pw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]"
+        }
+      },
+      "Microsoft.TeamFoundationServer.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "UBwF/VUULHHy5WHpShIW0ZdcG10N3jADUlW+KEgA7qiKCDB8VYbv7FR0miwutTtyuYFh/lE+G6q4IF0ugDyX6A==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3"
+        }
+      },
+      "Microsoft.TeamFoundationServer.ExtendedClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "g3G19/HJEOeYR8xFnNWSegBqRcMZRUyPLBmf5JF24pqhVqrY31fSA7ZBUX9r6nHHdSBkmZbRQisR/IvwrfDGqQ==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.AspNet.WebApi.Core": "5.2.3",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.TeamFoundationServer.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.ComponentModelHost": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "79WnMNn2T4xDqNVCAR9u3r2OXrA4QPOHYy36MMDjfIKvhL5mQ5Osgc+e+3wVVfeyD4EUdAYs/hC74+w4k/6ktg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319"
+        }
+      },
+      "Microsoft.VisualStudio.CoreUtility": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "eiepEOoyUJ+5K+7qitTMzXBJB6GcOMp5LdcedFa30dLxGPwgKY+XdVjiqcrxyQps4i7+hHNlYWvZCR6SKnWLRA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.23",
+          "System.ValueTuple": "4.3.0"
+        }
+      },
+      "Microsoft.VisualStudio.Editor": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "EnlJfSZABDJP36kg5td5A4HXqR2TWQrCgjXvDyBTF3peyDFQR6R6XZ63Wul+BY6Yract+UHP6E/8I+LlZ2BvRw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50727",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.ImageCatalog": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "X3nCoei2FTkh1m8tDDL8zEi9nFLVxjyRzMgL5HzPzio4uDCsKW1Oa/F/BkfICwx3cEPuwsyT7MlJjTgVqIbXgQ=="
+      },
+      "Microsoft.VisualStudio.Imaging": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "pDNYWW/w1hZF7Xk1SVhCMQxpxz5jFbaEkqrmSVRp7B8o6uei2fDrAscbMJmTxGcVA4rzV02ABytSCrc3jr1LvA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26930",
+        "contentHash": "gbmcUTMhYF/9oDUHI6b6Ki1PBaEkiqDhYNIdkYrrGy7XN0LhYew/BggDCJORUiEbzc5zJ8Hlc40jYGmqx4qfLg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16"
+        }
+      },
+      "Microsoft.VisualStudio.Language": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "BWRDlPth8bLOqUH7j6ClkBFPwjJ83aApHcr1GtJNPZfSj4Nw32pYRLIxCuBs2NLS2f9AF80yl0AYrzVlO6YRWg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Newtonsoft.Json": "9.0.1",
+          "StreamJsonRpc": "1.3.23",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Language.Intellisense": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "GShi/VaASPpvPLnF+rbJcfjbOlxAgpgtxc+PuQLruStw/9DVsL1LF/dB4dvdzRbkci8Ux0TvkI+Csd0/KeIOAg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Language.StandardClassification": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "fU1175eTKfdg4XRVwrl08wPNT4/KDuHKxgKrQ/aGaFzA93NMqtxsgyw6PB/zTA16j1eeIvqCOZpZOWigkuQGGg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.OLE.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "6W3YMtSGt+hHRvAqbktXHLWZgEbEpuFZxuC1XiKCX4Th3fGv+7SeKGGH7Gmeu9fp/8kNqq7uovqWaHfhni13Hw=="
+      },
+      "Microsoft.VisualStudio.RemoteControl": {
+        "type": "Transitive",
+        "resolved": "14.0.249-master2E2DC10C",
+        "contentHash": "bqmdFTlPzEH0VkncJBTq3bXmvW0SKM/pCQcKBgYZfCn/othfLnjChUKCyHvwQyJcjcy8JRnFXRejBQ0pqPXpqQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1"
+        }
+      },
+      "Microsoft.VisualStudio.SDK.EmbedInteropTypes": {
+        "type": "Transitive",
+        "resolved": "15.0.16",
+        "contentHash": "iI+b/DL6AaN/D8vHXcLorZJIjY0MvQehT6xfI3mx+AD2w1f/mEGtuXQE5mFfYu425FSDrPtoBIDRf+tKtLDA5g=="
+      },
+      "Microsoft.VisualStudio.Services.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "bdqdkWc2yWnsOD2yVeKNc/u/M2Lq6xs6C2tqcvuMnq7HT0nu7tYq72ymnk4iQQBJGMGZfJFPOrI8r/7tDhJ0KA==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Services.InteractiveClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "5fvdv0vPMcW+ANVv7HLXeVMKaDST1ydI3y10WMTP+tKDNp1Se4r8XzAuhdG9m+uh5Wozxj5cA9CK3wPfX+BQEA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.15.0": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "QurLa40g6/qehW75Qpi5LR7EE9vSW/mZuc5QwlTcBcW9k/H7jzBPwxcmAzZ5teswJPkD0+VvOQecTEIguOvnVQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging": "15.8.28010",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Framework": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": "14.3.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": "15.0.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": "15.6.27413",
+          "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30730",
+          "Microsoft.VisualStudio.Text.Data": "15.6.27740",
+          "Microsoft.VisualStudio.Threading": "15.6.31"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Framework": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "BRqUcfXNZ17aiuTTr1jawd/WHpt/A70WmDFUwgDS+vwGd0fp8fendG4ANLY5a4KI7+Yhyhz5DO/jsL3UBujNcQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "15.6.27740",
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6072",
+        "contentHash": "hoaT0t8DMA5YwPQEeiRD7UJpndgJDyK00uYcQl3I2+KvgQroo7lAZfkPNbGIhy2OGW4nOEqlvr0i5OE71hgT1w==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.10.0": {
+        "type": "Transitive",
+        "resolved": "10.0.30320",
+        "contentHash": "RKmdy0EgbXFtzjM2Kcdv9w9XdMJS81QykYUb1D/5SnvUYn28ElVt3criqGlvcC1syLJLmk9DdHomOhX6R50e1A==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.11.0": {
+        "type": "Transitive",
+        "resolved": "11.0.61031",
+        "contentHash": "N8il5VcZNr4GZeAvItmpWE4A5DKwSpFelQQ+I1VoUm1kVj+6dPieZXlhdbFC3bJVyCs1gl0uUzOH7FDVGfdDCw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30320"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.12.0": {
+        "type": "Transitive",
+        "resolved": "12.0.30111",
+        "contentHash": "ToNByCRLH875yHd1G43EmGuQz16bAV0PKICvzArpjuNugx/Cl4Djg15NHu7XUdPHm+UpAfH4W7nYh0u8NxqWHw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26929",
+        "contentHash": "J1WemvOhywfve6BbN91azp2nflhc68bpeGFFazoNnYl4MqEjRM0IUe3eNuieoeRw7a+UsHDubne/7K7XJ8yVdA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.26930",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.0.26929",
+        "contentHash": "hHAmrLBvxnmZDPPIOw6zQjsYenbqAcJfcIHSHDl5n/FyBC0VYleDwG2XcEOx1OkXWXReDMGY9lfeHyRv5SSJJQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.12",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.6.27413",
+        "contentHash": "Cb0fRe0ek16fLkE0Buea8zU55zu2WyzBp+8HhK1j3azndHBx0FZAfcDj3xnSum8kllcwQKhEerqEfxdpmwt1mw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "gGhUi9HaXGFC48HxZPV4nYcjygT/vcYYUow5iNocHp/EfwCCnDTUqe5AisH/o1pqB+iakw64g73KSDFsRNAXcA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.9.0": {
+        "type": "Transitive",
+        "resolved": "9.0.30730",
+        "contentHash": "AjBQfZ3HYtpRLFkLjClhR1vWffeEQXScMkhssKxnDnXFc59zOY3RToYxmIS6ZmjD5MS5ICwJDWy7hPOpKbh3Qg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Telemetry": {
+        "type": "Transitive",
+        "resolved": "15.0.691-master31907920",
+        "contentHash": "nTDxnBLOEY+NsjvnGpEeUHmzJrKtUOJjbgxkYd3UdblGlQrLjceIvkpr9c5v1yWwv8byAa2R6itlutjNjb53dA==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.PersistenceChannel": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.UniversalTelemetryChannel": "[0.17.2-build00169]",
+          "Microsoft.Bcl": "1.1.8",
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Bcl.Build": "1.0.14",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta",
+          "Microsoft.VisualStudio.RemoteControl": "[14.0.249-master2E2DC10C]",
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1",
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Data": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "e4OUFLIJ+roHfIeG++y6GZK1S6E0D91iB6LTDQLTz7cC4BvOE3yU3/Eki6Xdy/6inTUKsdqsYUFYEBTWeeF5vA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Logic": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "OG+pya+vxVGjDBp98mBjOWKRj295vwe5HtUmns1w/h727uhO4Y6KxYE4wRs7nOd7JMzB/WSAx2cgdBLtjBOoUg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "k8uKuTcTdOeZEtjrKXQAquWlEKswH2x0A/Ycqjinj7NJ6ykajccNCKiGb6jAJzVBkepSn81pWIO2QLpXKzcHuw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI.Wpf": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "Oa7/4XzATSR683uEK027pkQaV8yoebHABIRWuKZANe2cKWbInAMeoWibGUFW6T58W+8koX7zOIprTwYe02q4Og==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "AicV/XF3LkQhplsacUr1sUyVL+7kuTk/RczvvYAFUr1PGpNtoHh17DqQYfI3zs/8lQIB+RCmpi6ZU7t0SmY0mg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072"
+        }
+      },
+      "Microsoft.VisualStudio.Threading": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "KLjgM7NPjNg0FNv4z8qx8rpiAOnI5ZB6jrZWfJ4ho2YHtxT2dhWi8e94q9+BR4GBOks9ynL90LAnZX2CE3n4/Q==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Validation": "15.3.15"
+        }
+      },
+      "Microsoft.VisualStudio.Threading.Analyzers": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "SCFubDweTsyzzmXOmQOFedpSnUsN7Rrvh/ZD2phYRkOVBZtz3dX3LVen6IhcePZuDEQMtl4gNW9kzVpjTLlZ0A=="
+      },
+      "Microsoft.VisualStudio.Utilities": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "A36/u2YlW0Fs2H2WJSyTO9xW1FMGzKD+Oqtvfmgff+LyhlO8ZcSzR8waD7DKh2gZCyCR4M89m1VHvHn0Z/s5xg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.6.31",
+          "StreamJsonRpc": "1.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Utilities.Internal": {
+        "type": "Transitive",
+        "resolved": "14.0.54-masterD06D5CD1",
+        "contentHash": "vX0Ka1y7dEUs9HGTCw5BNTPREKJXy04OCy/GaDAgken2bSsjPZON8IkiTDFvkN0JtGuGIHCn9AU12lJU/4HLnw=="
+      },
+      "Microsoft.VisualStudio.Validation": {
+        "type": "Transitive",
+        "resolved": "15.3.15",
+        "contentHash": "bvJIwuCLqu7YKXcZqY85VJy0ljtm9QSRkq4CD2bpO/GHynsm72uZxjBDa050VY7kElXS8mb7VW5JNUfg4D/UBA=="
+      },
+      "Microsoft.VisualStudio.Workspace.VSIntegration": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "eSm+OpRg2C7L+h9UXvbzhwwBPdEk/8VAciEVdgtip5yZvhN2JrnzZxl1gPQdmQT8kVSn+B492fHOlDRa/ljcmA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspaces": "15.0.198-pre"
+        }
+      },
+      "Microsoft.VisualStudio.Workspaces": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "Bk83t69Kmo+9t60N5/rUqDy3HC/4IxsXdcV52m4KZVaYo1eTwuiQRhvjQ56013G23RBMTgeId3LYXWj/vWIaLg=="
+      },
+      "Microsoft.Web.Xdt": {
+        "type": "Transitive",
+        "resolved": "2.1.2",
+        "contentHash": "YIaNTOOtGzjF8CkQBOx3aUBWi0dD+g/nOjbpsVslx9G0/uldtpmoKLmyldmKdMv/gHs3qg40rBT3+wvEWoY5gg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "hSXaFmh7hNCuEoC4XNY5DrRkLDzYHqPx/Ik23R4J86Z7PE/Y6YidhG602dFVdLBRSdG6xp9NabH3dXpcoxWvww=="
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "0.86.0",
+        "contentHash": "5DbS1SlKLMi+WG00Cm0ueYf2oyXJrowETQk8nx96rmdjTuHsA3laPykGV7Sxi0R5Xxfx0Kh/EfacAZ1f6M7y/g=="
+      },
+      "stdole": {
+        "type": "Transitive",
+        "resolved": "7.0.3301",
+        "contentHash": "qQW62tF9+Naie3mQ3wAIY5SU8dqNRaiLUPwQ5v2sQRfzhY8h0M1arECSb68M4smTR89RAvuvXRgxBOiJOblkyA=="
+      },
+      "StreamJsonRpc": {
+        "type": "Transitive",
+        "resolved": "1.3.23",
+        "contentHash": "xJU19tAWEgmXn79SdwgUYPWXjXLxXX+xGHw9R1Ody4YCnRde51NqXk/fQyFbSWlQek1AI0m9f9OXqMIDwNxayw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.20",
+          "Newtonsoft.Json": "6.0.6"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "D3eEHg9hnGHTYsKBHiD/bT8pkBt2tS9BTTCRv2Wx+86FqWTzvsCjuB+I1j0gYIjKQiI5+NSrPtnxWmNHz4CCQw=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "QwALOmIQnwYXO7SZuzHvp+aF9+E8kouJl2JDHe9hyV/Mqzl2KhOwZMlN+mhyIYo5ggHcIVa/LN7E46WD26OEEg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "91UTX0e+S3j5pTVl7V9r8qjBElGhEFp+TBXNT64K68Ecy8DXtM66pFKWQktGBL4GYQRBuZXQdIxX2XuBb77gJA=="
+      },
+      "VSLangProj": {
+        "type": "Transitive",
+        "resolved": "7.0.3300",
+        "contentHash": "/0bb3ssO3rsPUZnVPFNAva2uBQLYNdT4hVLTx0XgxI8+/7acZVuMum18YOaOaE7hnLHMY00o4ypGL/L7JssEww==",
+        "dependencies": {
+          "EnvDTE": "8.0.1"
+        }
+      },
+      "VSLangProj110": {
+        "type": "Transitive",
+        "resolved": "11.0.61030",
+        "contentHash": "ZD0/JubfPji1tUTI7d1fOxEZqC23eHU7PIzoeR0LSY/dmDwEKa32xujNsgx6TT58ZRaSVFY27nUaiVaFdBz5Og==",
+        "dependencies": {
+          "VSLangProj80": "8.0.50727",
+          "VSLangProj90": "9.0.30729"
+        }
+      },
+      "VSLangProj157": {
+        "type": "Transitive",
+        "resolved": "15.7.0",
+        "contentHash": "PjFMHShxIYuZlwqa3feX3MpmCb0RsfCTExjgaJseODGJDXsjApJ5CWolJhlm956W1RHwALQXPiH786H3vZ8upw=="
+      },
+      "VSLangProj2": {
+        "type": "Transitive",
+        "resolved": "7.0.5000",
+        "contentHash": "A286CbJJxrKW4tpVyVaJit5rgVEmTJod/reZ8epekhZWiNoKv2YWkPGaCi0+gQXq4YepqPngE6UpQp5iAXyYDg==",
+        "dependencies": {
+          "VSLangProj": "7.0.3300"
+        }
+      },
+      "VSLangProj80": {
+        "type": "Transitive",
+        "resolved": "8.0.50727",
+        "contentHash": "I2xOMyQcbBXMXKE8zmHljkV1XLAltQ4/T5QRk8Q1mWz7fdd7x1OMp+2VqxZVAJ89Ebfs4wclkcACyvc4FY4wcQ==",
+        "dependencies": {
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "VSLangProj90": {
+        "type": "Transitive",
+        "resolved": "9.0.30729",
+        "contentHash": "xCG2hloStE4TCToHlBai7n/s33sfw/UiEkwqozRPt0AtW9JMr+0hXgGjlOyvPT2rgY6jjKywU55qoTXY2M8f6g=="
+      },
+      "VSSDK.DTE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "uUEaT0sCVnJR54vxfsf5xHpJVWgTrCbl10oKkFuCvJb3I6M5WW4cu9zCTqtYP1i1mYYySGGqooNYiO45kLUkiQ==",
+        "dependencies": {
+          "VSSDK.IDE": "[7.0.4, 8.0.0)"
+        }
+      },
+      "VSSDK.IDE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "KPXgpya93UDz/JZVegRr+AAewTGw46+8Aq7Dl22jWaqjH2KaH/5ycCLG0LET2OX4VBpp15IjhNw08Y5H0vJMKQ=="
+      },
+      "VSSDK.IDE.12": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "XYcSrKW9369JO1tOAuNxzZ6OOlx2QujDuboey4eYpp9GgA3Bd3mo0Fy2ZJd86sZqX27roBRzJfM1Ue/peyWOIg=="
+      },
+      "VSSDK.TemplateWizardInterface": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "stTXrh4h/mftHaQWKZn043WCgP7cmv3QVPB8M3bbBp99kktLdJBTXygPctpgeOYfsBi1TqKJIiNZjG3hCoHNMw==",
+        "dependencies": {
+          "VSSDK.DTE": "[7.0.4, 8.0.0)",
+          "VSSDK.IDE.12": "[12.0.4, 13.0.0)"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Indexing": {
+        "type": "Project",
+        "dependencies": {
+          "Lucene.Net": "3.0.3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.2",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement.UI": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "NuGet.Indexing": "5.0.0-preview3",
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.PackageManagement.VisualStudio": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "NuGet.Indexing": "5.0.0-preview3",
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3",
+          "VSLangProj110": "11.0.61030",
+          "VSLangProj157": "15.7.0",
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      },
+      "NuGet.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "VSSDK.TemplateWizardInterface": "12.0.4"
+        }
+      },
+      "NuGet.VisualStudio.Common": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.TeamFoundationServer.ExtendedClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.ComponentModelHost": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Editor": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Language.Intellisense": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language.StandardClassification": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Services.Client": "16.144.1-preview",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.Shell.15.0": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "Microsoft.VisualStudio.Telemetry": "15.0.691-master31907920",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.8.132",
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "VSLangProj": "7.0.3300"
+        }
+      }
+    },
+    ".NETFramework,Version=v4.7.2/win": {},
+    ".NETFramework,Version=v4.7.2/win-x64": {},
+    ".NETFramework,Version=v4.7.2/win-x86": {}
+  }
+}

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/packages.lock.json
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/packages.lock.json
@@ -1,0 +1,115 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Microsoft.Web.Xdt": {
+        "type": "Transitive",
+        "resolved": "2.1.2",
+        "contentHash": "YIaNTOOtGzjF8CkQBOx3aUBWi0dD+g/nOjbpsVslx9G0/uldtpmoKLmyldmKdMv/gHs3qg40rBT3+wvEWoY5gg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "NuGet.Build.Tasks": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Commands": "5.0.0-preview3"
+        }
+      },
+      "NuGet.CommandLine": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Build.Tasks": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.2",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/packages.lock.json
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/packages.lock.json
@@ -1,0 +1,780 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "EnvDTE": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "ppW2nOaaMCOy1HNdUWvTM+btoXVbvntTL4RxVvEWBaHFk+Aj/r7vrS3t9x1QrHB4Y9Rrd2n7UAmjzet3Ps63XA==",
+        "dependencies": {
+          "stdole": "7.0.3301"
+        }
+      },
+      "EnvDTE80": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "3CBF4ileGBzGDPvNePcI3611sRVP5xMHXMZGGgQtcFV5nUu5L5QAZkkrgnBdM0oD9ZXc6dReVwo+tXOSR91z4Q==",
+        "dependencies": {
+          "EnvDTE": "8.0.1",
+          "stdole": "7.0.3301"
+        }
+      },
+      "Lucene.Net": {
+        "type": "Transitive",
+        "resolved": "3.0.3",
+        "contentHash": "A/70q4eDcuuafQeDB9eaiDP9FQG7X29T4VIYRphS7Wk8kAM9gNcfVqYyd0H8BJ1BTpA5C1ORm9RzFn4BiNavrw==",
+        "dependencies": {
+          "SharpZipLib": "0.86.0"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "iAzPAX/guSnBXJxM+PZ+dVXF+vmE8hxcxJ9fOFrvHUv5cY/ILD1icf2sKjJLltJD0Na8r9oGF5PjNiTMxK8EYw==",
+        "dependencies": {
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.ApplicationInsights.PersistenceChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "V7peE2ssNCCfOqzk1kOJfr3zZLDDPs+M88N34e98L+YPpAoL11wQkLpPxWmztjipTD+DBxJO6PNaVsM9q5bM/A==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "0.17.2-build00169"
+        }
+      },
+      "Microsoft.ApplicationInsights.UniversalTelemetryChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "8sg18/b63fhYjpr0kZ2v/NEjOEJ3gwpzXaaKZTth04AUPuOKjWvS3/pyVIRQ1mUEhrV3Xn3S2/TkLiWLCTpo7A==",
+        "dependencies": {
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Client": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "w5w8GVLMmo+JzizmcuV01tgYn2OsaVhxGAO0ryKXkO5sob6EVjzcoJv8NHL3Xm98vywSh7kRgeLqbA/lxZuTXg==",
+        "dependencies": {
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Core": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "bP+PAx17AVQJ19aU9N7yMnz8yST1U9cekbYHRyIUvQzFLqqzrthEs/gLdyZiLJPmL4ZABuvwGBOXG/ukqmsbDg==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3"
+        }
+      },
+      "Microsoft.Bcl": {
+        "type": "Transitive",
+        "resolved": "1.1.8",
+        "contentHash": "gM+PUzd8ONxJpcPJeNppCJPklDhDuPUMVQkxvK4fe0rd9WyqBNPh4+UFx3Uv8zuG4C1Gapu1c25sfotE7TQtig==",
+        "dependencies": {
+          "Microsoft.Bcl.Build": "1.0.14"
+        }
+      },
+      "Microsoft.Bcl.Async": {
+        "type": "Transitive",
+        "resolved": "1.0.168",
+        "contentHash": "tUNC02eBwDKpGre0BcNIvblLv1q0Q3DnS/vtkRHj2FE1sXwt386HAudztyl5C0U88hllrqHDvtlz8bK0Y8cHDA==",
+        "dependencies": {
+          "Microsoft.Bcl": "1.1.8"
+        }
+      },
+      "Microsoft.Bcl.Build": {
+        "type": "Transitive",
+        "resolved": "1.0.14",
+        "contentHash": "cDLKSvNvRa519hplsbSoYqO69TjdDIhfjtKUM0g20/nVROoWsGav9KCI9HtnGjLmdV1+TcUUDhbotcllibjPEA=="
+      },
+      "Microsoft.Diagnostics.Tracing.EventSource.Redist": {
+        "type": "Transitive",
+        "resolved": "1.1.16-beta",
+        "contentHash": "o1gsKlGjLAnSHRyWBygKnO55Kp0bRXB3AO9e8OeAnqQH7HA5MAW6YAPEEy5e3aRE//7AlkdPtq28F19NqOLZQQ=="
+      },
+      "Microsoft.IdentityModel.Clients.ActiveDirectory": {
+        "type": "Transitive",
+        "resolved": "3.17.2",
+        "contentHash": "zvDoWJlrKg1TQeJScq+5znAZtduyJHlT7M9gEquUjm2PQCIR4C5PqJ0E8xYQsV3eF4bY8cW54uyr0FyhiN0MtQ=="
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "kbmvhMYu5OZXWN3toFXhrj3bSN7B+ZzNWzAZQ4Ofp5x2srk9ZCYFljETGS5faxzPwGd5+7W4WZlAfOI7QvzhlA=="
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "wVWYpXfE6gpkSrIRNo5TDVC7ss6KPTTrmT6x8ysHiZRIMSRAZ8TyHEAmpdATBBPNRmnlevyAs4CK6nPfDpCTqw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "dsDJhsL2zJyL5az5D3LhILIQRt+nXFQ64Bclj6vspIwD96sYRK/fPKTP8xLcLyw0fcosiFUgmWOXRLkWcAm1Pw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]"
+        }
+      },
+      "Microsoft.TeamFoundationServer.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "UBwF/VUULHHy5WHpShIW0ZdcG10N3jADUlW+KEgA7qiKCDB8VYbv7FR0miwutTtyuYFh/lE+G6q4IF0ugDyX6A==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3"
+        }
+      },
+      "Microsoft.TeamFoundationServer.ExtendedClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "g3G19/HJEOeYR8xFnNWSegBqRcMZRUyPLBmf5JF24pqhVqrY31fSA7ZBUX9r6nHHdSBkmZbRQisR/IvwrfDGqQ==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.AspNet.WebApi.Core": "5.2.3",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.TeamFoundationServer.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.ComponentModelHost": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "79WnMNn2T4xDqNVCAR9u3r2OXrA4QPOHYy36MMDjfIKvhL5mQ5Osgc+e+3wVVfeyD4EUdAYs/hC74+w4k/6ktg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319"
+        }
+      },
+      "Microsoft.VisualStudio.CoreUtility": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "eiepEOoyUJ+5K+7qitTMzXBJB6GcOMp5LdcedFa30dLxGPwgKY+XdVjiqcrxyQps4i7+hHNlYWvZCR6SKnWLRA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.23",
+          "System.ValueTuple": "4.3.0"
+        }
+      },
+      "Microsoft.VisualStudio.Editor": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "EnlJfSZABDJP36kg5td5A4HXqR2TWQrCgjXvDyBTF3peyDFQR6R6XZ63Wul+BY6Yract+UHP6E/8I+LlZ2BvRw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50727",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.ImageCatalog": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "X3nCoei2FTkh1m8tDDL8zEi9nFLVxjyRzMgL5HzPzio4uDCsKW1Oa/F/BkfICwx3cEPuwsyT7MlJjTgVqIbXgQ=="
+      },
+      "Microsoft.VisualStudio.Imaging": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "pDNYWW/w1hZF7Xk1SVhCMQxpxz5jFbaEkqrmSVRp7B8o6uei2fDrAscbMJmTxGcVA4rzV02ABytSCrc3jr1LvA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26930",
+        "contentHash": "gbmcUTMhYF/9oDUHI6b6Ki1PBaEkiqDhYNIdkYrrGy7XN0LhYew/BggDCJORUiEbzc5zJ8Hlc40jYGmqx4qfLg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16"
+        }
+      },
+      "Microsoft.VisualStudio.Language": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "BWRDlPth8bLOqUH7j6ClkBFPwjJ83aApHcr1GtJNPZfSj4Nw32pYRLIxCuBs2NLS2f9AF80yl0AYrzVlO6YRWg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Newtonsoft.Json": "9.0.1",
+          "StreamJsonRpc": "1.3.23",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Language.Intellisense": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "GShi/VaASPpvPLnF+rbJcfjbOlxAgpgtxc+PuQLruStw/9DVsL1LF/dB4dvdzRbkci8Ux0TvkI+Csd0/KeIOAg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Language.StandardClassification": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "fU1175eTKfdg4XRVwrl08wPNT4/KDuHKxgKrQ/aGaFzA93NMqtxsgyw6PB/zTA16j1eeIvqCOZpZOWigkuQGGg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.OLE.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "6W3YMtSGt+hHRvAqbktXHLWZgEbEpuFZxuC1XiKCX4Th3fGv+7SeKGGH7Gmeu9fp/8kNqq7uovqWaHfhni13Hw=="
+      },
+      "Microsoft.VisualStudio.RemoteControl": {
+        "type": "Transitive",
+        "resolved": "14.0.249-master2E2DC10C",
+        "contentHash": "bqmdFTlPzEH0VkncJBTq3bXmvW0SKM/pCQcKBgYZfCn/othfLnjChUKCyHvwQyJcjcy8JRnFXRejBQ0pqPXpqQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1"
+        }
+      },
+      "Microsoft.VisualStudio.SDK.EmbedInteropTypes": {
+        "type": "Transitive",
+        "resolved": "15.0.16",
+        "contentHash": "iI+b/DL6AaN/D8vHXcLorZJIjY0MvQehT6xfI3mx+AD2w1f/mEGtuXQE5mFfYu425FSDrPtoBIDRf+tKtLDA5g=="
+      },
+      "Microsoft.VisualStudio.Services.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "bdqdkWc2yWnsOD2yVeKNc/u/M2Lq6xs6C2tqcvuMnq7HT0nu7tYq72ymnk4iQQBJGMGZfJFPOrI8r/7tDhJ0KA==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Services.InteractiveClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "5fvdv0vPMcW+ANVv7HLXeVMKaDST1ydI3y10WMTP+tKDNp1Se4r8XzAuhdG9m+uh5Wozxj5cA9CK3wPfX+BQEA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.15.0": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "QurLa40g6/qehW75Qpi5LR7EE9vSW/mZuc5QwlTcBcW9k/H7jzBPwxcmAzZ5teswJPkD0+VvOQecTEIguOvnVQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging": "15.8.28010",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Framework": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": "14.3.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": "15.0.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": "15.6.27413",
+          "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30730",
+          "Microsoft.VisualStudio.Text.Data": "15.6.27740",
+          "Microsoft.VisualStudio.Threading": "15.6.31"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Framework": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "BRqUcfXNZ17aiuTTr1jawd/WHpt/A70WmDFUwgDS+vwGd0fp8fendG4ANLY5a4KI7+Yhyhz5DO/jsL3UBujNcQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "15.6.27740",
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6072",
+        "contentHash": "hoaT0t8DMA5YwPQEeiRD7UJpndgJDyK00uYcQl3I2+KvgQroo7lAZfkPNbGIhy2OGW4nOEqlvr0i5OE71hgT1w==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.10.0": {
+        "type": "Transitive",
+        "resolved": "10.0.30320",
+        "contentHash": "RKmdy0EgbXFtzjM2Kcdv9w9XdMJS81QykYUb1D/5SnvUYn28ElVt3criqGlvcC1syLJLmk9DdHomOhX6R50e1A==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.11.0": {
+        "type": "Transitive",
+        "resolved": "11.0.61031",
+        "contentHash": "N8il5VcZNr4GZeAvItmpWE4A5DKwSpFelQQ+I1VoUm1kVj+6dPieZXlhdbFC3bJVyCs1gl0uUzOH7FDVGfdDCw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30320"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.12.0": {
+        "type": "Transitive",
+        "resolved": "12.0.30111",
+        "contentHash": "ToNByCRLH875yHd1G43EmGuQz16bAV0PKICvzArpjuNugx/Cl4Djg15NHu7XUdPHm+UpAfH4W7nYh0u8NxqWHw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26929",
+        "contentHash": "J1WemvOhywfve6BbN91azp2nflhc68bpeGFFazoNnYl4MqEjRM0IUe3eNuieoeRw7a+UsHDubne/7K7XJ8yVdA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.26930",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.0.26929",
+        "contentHash": "hHAmrLBvxnmZDPPIOw6zQjsYenbqAcJfcIHSHDl5n/FyBC0VYleDwG2XcEOx1OkXWXReDMGY9lfeHyRv5SSJJQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.12",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.6.27413",
+        "contentHash": "Cb0fRe0ek16fLkE0Buea8zU55zu2WyzBp+8HhK1j3azndHBx0FZAfcDj3xnSum8kllcwQKhEerqEfxdpmwt1mw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "gGhUi9HaXGFC48HxZPV4nYcjygT/vcYYUow5iNocHp/EfwCCnDTUqe5AisH/o1pqB+iakw64g73KSDFsRNAXcA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.9.0": {
+        "type": "Transitive",
+        "resolved": "9.0.30730",
+        "contentHash": "AjBQfZ3HYtpRLFkLjClhR1vWffeEQXScMkhssKxnDnXFc59zOY3RToYxmIS6ZmjD5MS5ICwJDWy7hPOpKbh3Qg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Telemetry": {
+        "type": "Transitive",
+        "resolved": "15.0.691-master31907920",
+        "contentHash": "nTDxnBLOEY+NsjvnGpEeUHmzJrKtUOJjbgxkYd3UdblGlQrLjceIvkpr9c5v1yWwv8byAa2R6itlutjNjb53dA==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.PersistenceChannel": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.UniversalTelemetryChannel": "[0.17.2-build00169]",
+          "Microsoft.Bcl": "1.1.8",
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Bcl.Build": "1.0.14",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta",
+          "Microsoft.VisualStudio.RemoteControl": "[14.0.249-master2E2DC10C]",
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1",
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Data": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "e4OUFLIJ+roHfIeG++y6GZK1S6E0D91iB6LTDQLTz7cC4BvOE3yU3/Eki6Xdy/6inTUKsdqsYUFYEBTWeeF5vA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Logic": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "OG+pya+vxVGjDBp98mBjOWKRj295vwe5HtUmns1w/h727uhO4Y6KxYE4wRs7nOd7JMzB/WSAx2cgdBLtjBOoUg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "k8uKuTcTdOeZEtjrKXQAquWlEKswH2x0A/Ycqjinj7NJ6ykajccNCKiGb6jAJzVBkepSn81pWIO2QLpXKzcHuw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI.Wpf": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "Oa7/4XzATSR683uEK027pkQaV8yoebHABIRWuKZANe2cKWbInAMeoWibGUFW6T58W+8koX7zOIprTwYe02q4Og==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "+xdOtk+Hxdt4Bewl4kCA7KQsI7IZa58uZdnkTcNV9CEtT6Om6VxApAMPIBNvt7sZQoA6SOYubX4uAzEADHX55g==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "AicV/XF3LkQhplsacUr1sUyVL+7kuTk/RczvvYAFUr1PGpNtoHh17DqQYfI3zs/8lQIB+RCmpi6ZU7t0SmY0mg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072"
+        }
+      },
+      "Microsoft.VisualStudio.Threading": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "KLjgM7NPjNg0FNv4z8qx8rpiAOnI5ZB6jrZWfJ4ho2YHtxT2dhWi8e94q9+BR4GBOks9ynL90LAnZX2CE3n4/Q==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Validation": "15.3.15"
+        }
+      },
+      "Microsoft.VisualStudio.Threading.Analyzers": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "SCFubDweTsyzzmXOmQOFedpSnUsN7Rrvh/ZD2phYRkOVBZtz3dX3LVen6IhcePZuDEQMtl4gNW9kzVpjTLlZ0A=="
+      },
+      "Microsoft.VisualStudio.Utilities": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "A36/u2YlW0Fs2H2WJSyTO9xW1FMGzKD+Oqtvfmgff+LyhlO8ZcSzR8waD7DKh2gZCyCR4M89m1VHvHn0Z/s5xg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.6.31",
+          "StreamJsonRpc": "1.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Utilities.Internal": {
+        "type": "Transitive",
+        "resolved": "14.0.54-masterD06D5CD1",
+        "contentHash": "vX0Ka1y7dEUs9HGTCw5BNTPREKJXy04OCy/GaDAgken2bSsjPZON8IkiTDFvkN0JtGuGIHCn9AU12lJU/4HLnw=="
+      },
+      "Microsoft.VisualStudio.Validation": {
+        "type": "Transitive",
+        "resolved": "15.3.15",
+        "contentHash": "bvJIwuCLqu7YKXcZqY85VJy0ljtm9QSRkq4CD2bpO/GHynsm72uZxjBDa050VY7kElXS8mb7VW5JNUfg4D/UBA=="
+      },
+      "Microsoft.VisualStudio.Workspace.VSIntegration": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "eSm+OpRg2C7L+h9UXvbzhwwBPdEk/8VAciEVdgtip5yZvhN2JrnzZxl1gPQdmQT8kVSn+B492fHOlDRa/ljcmA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspaces": "15.0.198-pre"
+        }
+      },
+      "Microsoft.VisualStudio.Workspaces": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "Bk83t69Kmo+9t60N5/rUqDy3HC/4IxsXdcV52m4KZVaYo1eTwuiQRhvjQ56013G23RBMTgeId3LYXWj/vWIaLg=="
+      },
+      "Microsoft.Web.Xdt": {
+        "type": "Transitive",
+        "resolved": "2.1.2",
+        "contentHash": "YIaNTOOtGzjF8CkQBOx3aUBWi0dD+g/nOjbpsVslx9G0/uldtpmoKLmyldmKdMv/gHs3qg40rBT3+wvEWoY5gg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "hSXaFmh7hNCuEoC4XNY5DrRkLDzYHqPx/Ik23R4J86Z7PE/Y6YidhG602dFVdLBRSdG6xp9NabH3dXpcoxWvww=="
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "0.86.0",
+        "contentHash": "5DbS1SlKLMi+WG00Cm0ueYf2oyXJrowETQk8nx96rmdjTuHsA3laPykGV7Sxi0R5Xxfx0Kh/EfacAZ1f6M7y/g=="
+      },
+      "stdole": {
+        "type": "Transitive",
+        "resolved": "7.0.3301",
+        "contentHash": "qQW62tF9+Naie3mQ3wAIY5SU8dqNRaiLUPwQ5v2sQRfzhY8h0M1arECSb68M4smTR89RAvuvXRgxBOiJOblkyA=="
+      },
+      "StreamJsonRpc": {
+        "type": "Transitive",
+        "resolved": "1.3.23",
+        "contentHash": "xJU19tAWEgmXn79SdwgUYPWXjXLxXX+xGHw9R1Ody4YCnRde51NqXk/fQyFbSWlQek1AI0m9f9OXqMIDwNxayw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.20",
+          "Newtonsoft.Json": "6.0.6"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "D3eEHg9hnGHTYsKBHiD/bT8pkBt2tS9BTTCRv2Wx+86FqWTzvsCjuB+I1j0gYIjKQiI5+NSrPtnxWmNHz4CCQw=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "QwALOmIQnwYXO7SZuzHvp+aF9+E8kouJl2JDHe9hyV/Mqzl2KhOwZMlN+mhyIYo5ggHcIVa/LN7E46WD26OEEg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "91UTX0e+S3j5pTVl7V9r8qjBElGhEFp+TBXNT64K68Ecy8DXtM66pFKWQktGBL4GYQRBuZXQdIxX2XuBb77gJA=="
+      },
+      "VSLangProj": {
+        "type": "Transitive",
+        "resolved": "7.0.3300",
+        "contentHash": "/0bb3ssO3rsPUZnVPFNAva2uBQLYNdT4hVLTx0XgxI8+/7acZVuMum18YOaOaE7hnLHMY00o4ypGL/L7JssEww==",
+        "dependencies": {
+          "EnvDTE": "8.0.1"
+        }
+      },
+      "VSLangProj110": {
+        "type": "Transitive",
+        "resolved": "11.0.61030",
+        "contentHash": "ZD0/JubfPji1tUTI7d1fOxEZqC23eHU7PIzoeR0LSY/dmDwEKa32xujNsgx6TT58ZRaSVFY27nUaiVaFdBz5Og==",
+        "dependencies": {
+          "VSLangProj80": "8.0.50727",
+          "VSLangProj90": "9.0.30729"
+        }
+      },
+      "VSLangProj157": {
+        "type": "Transitive",
+        "resolved": "15.7.0",
+        "contentHash": "PjFMHShxIYuZlwqa3feX3MpmCb0RsfCTExjgaJseODGJDXsjApJ5CWolJhlm956W1RHwALQXPiH786H3vZ8upw=="
+      },
+      "VSLangProj2": {
+        "type": "Transitive",
+        "resolved": "7.0.5000",
+        "contentHash": "A286CbJJxrKW4tpVyVaJit5rgVEmTJod/reZ8epekhZWiNoKv2YWkPGaCi0+gQXq4YepqPngE6UpQp5iAXyYDg==",
+        "dependencies": {
+          "VSLangProj": "7.0.3300"
+        }
+      },
+      "VSLangProj80": {
+        "type": "Transitive",
+        "resolved": "8.0.50727",
+        "contentHash": "I2xOMyQcbBXMXKE8zmHljkV1XLAltQ4/T5QRk8Q1mWz7fdd7x1OMp+2VqxZVAJ89Ebfs4wclkcACyvc4FY4wcQ==",
+        "dependencies": {
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "VSLangProj90": {
+        "type": "Transitive",
+        "resolved": "9.0.30729",
+        "contentHash": "xCG2hloStE4TCToHlBai7n/s33sfw/UiEkwqozRPt0AtW9JMr+0hXgGjlOyvPT2rgY6jjKywU55qoTXY2M8f6g=="
+      },
+      "VSSDK.DTE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "uUEaT0sCVnJR54vxfsf5xHpJVWgTrCbl10oKkFuCvJb3I6M5WW4cu9zCTqtYP1i1mYYySGGqooNYiO45kLUkiQ==",
+        "dependencies": {
+          "VSSDK.IDE": "[7.0.4, 8.0.0)"
+        }
+      },
+      "VSSDK.IDE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "KPXgpya93UDz/JZVegRr+AAewTGw46+8Aq7Dl22jWaqjH2KaH/5ycCLG0LET2OX4VBpp15IjhNw08Y5H0vJMKQ=="
+      },
+      "VSSDK.IDE.12": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "XYcSrKW9369JO1tOAuNxzZ6OOlx2QujDuboey4eYpp9GgA3Bd3mo0Fy2ZJd86sZqX27roBRzJfM1Ue/peyWOIg=="
+      },
+      "VSSDK.TemplateWizardInterface": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "stTXrh4h/mftHaQWKZn043WCgP7cmv3QVPB8M3bbBp99kktLdJBTXygPctpgeOYfsBi1TqKJIiNZjG3hCoHNMw==",
+        "dependencies": {
+          "VSSDK.DTE": "[7.0.4, 8.0.0)",
+          "VSSDK.IDE.12": "[12.0.4, 13.0.0)"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Indexing": {
+        "type": "Project",
+        "dependencies": {
+          "Lucene.Net": "3.0.3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.2",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "NuGet.Indexing": "5.0.0-preview3",
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3",
+          "VSLangProj110": "11.0.61030",
+          "VSLangProj157": "15.7.0",
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      },
+      "NuGet.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "VSSDK.TemplateWizardInterface": "12.0.4"
+        }
+      },
+      "NuGet.VisualStudio.Common": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.TeamFoundationServer.ExtendedClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.ComponentModelHost": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Editor": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Language.Intellisense": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language.StandardClassification": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Services.Client": "16.144.1-preview",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.Shell.15.0": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "Microsoft.VisualStudio.Telemetry": "15.0.691-master31907920",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.8.132",
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "VSLangProj": "7.0.3300"
+        }
+      }
+    },
+    ".NETFramework,Version=v4.7.2/win": {},
+    ".NETFramework,Version=v4.7.2/win-x64": {},
+    ".NETFramework,Version=v4.7.2/win-x86": {}
+  }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/packages.lock.json
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/packages.lock.json
@@ -1,0 +1,780 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "EnvDTE": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "ppW2nOaaMCOy1HNdUWvTM+btoXVbvntTL4RxVvEWBaHFk+Aj/r7vrS3t9x1QrHB4Y9Rrd2n7UAmjzet3Ps63XA==",
+        "dependencies": {
+          "stdole": "7.0.3301"
+        }
+      },
+      "EnvDTE80": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "3CBF4ileGBzGDPvNePcI3611sRVP5xMHXMZGGgQtcFV5nUu5L5QAZkkrgnBdM0oD9ZXc6dReVwo+tXOSR91z4Q==",
+        "dependencies": {
+          "EnvDTE": "8.0.1",
+          "stdole": "7.0.3301"
+        }
+      },
+      "Lucene.Net": {
+        "type": "Transitive",
+        "resolved": "3.0.3",
+        "contentHash": "A/70q4eDcuuafQeDB9eaiDP9FQG7X29T4VIYRphS7Wk8kAM9gNcfVqYyd0H8BJ1BTpA5C1ORm9RzFn4BiNavrw==",
+        "dependencies": {
+          "SharpZipLib": "0.86.0"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "iAzPAX/guSnBXJxM+PZ+dVXF+vmE8hxcxJ9fOFrvHUv5cY/ILD1icf2sKjJLltJD0Na8r9oGF5PjNiTMxK8EYw==",
+        "dependencies": {
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.ApplicationInsights.PersistenceChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "V7peE2ssNCCfOqzk1kOJfr3zZLDDPs+M88N34e98L+YPpAoL11wQkLpPxWmztjipTD+DBxJO6PNaVsM9q5bM/A==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "0.17.2-build00169"
+        }
+      },
+      "Microsoft.ApplicationInsights.UniversalTelemetryChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "8sg18/b63fhYjpr0kZ2v/NEjOEJ3gwpzXaaKZTth04AUPuOKjWvS3/pyVIRQ1mUEhrV3Xn3S2/TkLiWLCTpo7A==",
+        "dependencies": {
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Client": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "w5w8GVLMmo+JzizmcuV01tgYn2OsaVhxGAO0ryKXkO5sob6EVjzcoJv8NHL3Xm98vywSh7kRgeLqbA/lxZuTXg==",
+        "dependencies": {
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Core": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "bP+PAx17AVQJ19aU9N7yMnz8yST1U9cekbYHRyIUvQzFLqqzrthEs/gLdyZiLJPmL4ZABuvwGBOXG/ukqmsbDg==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3"
+        }
+      },
+      "Microsoft.Bcl": {
+        "type": "Transitive",
+        "resolved": "1.1.8",
+        "contentHash": "gM+PUzd8ONxJpcPJeNppCJPklDhDuPUMVQkxvK4fe0rd9WyqBNPh4+UFx3Uv8zuG4C1Gapu1c25sfotE7TQtig==",
+        "dependencies": {
+          "Microsoft.Bcl.Build": "1.0.14"
+        }
+      },
+      "Microsoft.Bcl.Async": {
+        "type": "Transitive",
+        "resolved": "1.0.168",
+        "contentHash": "tUNC02eBwDKpGre0BcNIvblLv1q0Q3DnS/vtkRHj2FE1sXwt386HAudztyl5C0U88hllrqHDvtlz8bK0Y8cHDA==",
+        "dependencies": {
+          "Microsoft.Bcl": "1.1.8"
+        }
+      },
+      "Microsoft.Bcl.Build": {
+        "type": "Transitive",
+        "resolved": "1.0.14",
+        "contentHash": "cDLKSvNvRa519hplsbSoYqO69TjdDIhfjtKUM0g20/nVROoWsGav9KCI9HtnGjLmdV1+TcUUDhbotcllibjPEA=="
+      },
+      "Microsoft.Diagnostics.Tracing.EventSource.Redist": {
+        "type": "Transitive",
+        "resolved": "1.1.16-beta",
+        "contentHash": "o1gsKlGjLAnSHRyWBygKnO55Kp0bRXB3AO9e8OeAnqQH7HA5MAW6YAPEEy5e3aRE//7AlkdPtq28F19NqOLZQQ=="
+      },
+      "Microsoft.IdentityModel.Clients.ActiveDirectory": {
+        "type": "Transitive",
+        "resolved": "3.17.2",
+        "contentHash": "zvDoWJlrKg1TQeJScq+5znAZtduyJHlT7M9gEquUjm2PQCIR4C5PqJ0E8xYQsV3eF4bY8cW54uyr0FyhiN0MtQ=="
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "kbmvhMYu5OZXWN3toFXhrj3bSN7B+ZzNWzAZQ4Ofp5x2srk9ZCYFljETGS5faxzPwGd5+7W4WZlAfOI7QvzhlA=="
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "wVWYpXfE6gpkSrIRNo5TDVC7ss6KPTTrmT6x8ysHiZRIMSRAZ8TyHEAmpdATBBPNRmnlevyAs4CK6nPfDpCTqw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "dsDJhsL2zJyL5az5D3LhILIQRt+nXFQ64Bclj6vspIwD96sYRK/fPKTP8xLcLyw0fcosiFUgmWOXRLkWcAm1Pw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]"
+        }
+      },
+      "Microsoft.TeamFoundationServer.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "UBwF/VUULHHy5WHpShIW0ZdcG10N3jADUlW+KEgA7qiKCDB8VYbv7FR0miwutTtyuYFh/lE+G6q4IF0ugDyX6A==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3"
+        }
+      },
+      "Microsoft.TeamFoundationServer.ExtendedClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "g3G19/HJEOeYR8xFnNWSegBqRcMZRUyPLBmf5JF24pqhVqrY31fSA7ZBUX9r6nHHdSBkmZbRQisR/IvwrfDGqQ==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.AspNet.WebApi.Core": "5.2.3",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.TeamFoundationServer.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.ComponentModelHost": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "79WnMNn2T4xDqNVCAR9u3r2OXrA4QPOHYy36MMDjfIKvhL5mQ5Osgc+e+3wVVfeyD4EUdAYs/hC74+w4k/6ktg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319"
+        }
+      },
+      "Microsoft.VisualStudio.CoreUtility": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "eiepEOoyUJ+5K+7qitTMzXBJB6GcOMp5LdcedFa30dLxGPwgKY+XdVjiqcrxyQps4i7+hHNlYWvZCR6SKnWLRA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.23",
+          "System.ValueTuple": "4.3.0"
+        }
+      },
+      "Microsoft.VisualStudio.Editor": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "EnlJfSZABDJP36kg5td5A4HXqR2TWQrCgjXvDyBTF3peyDFQR6R6XZ63Wul+BY6Yract+UHP6E/8I+LlZ2BvRw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50727",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.ImageCatalog": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "X3nCoei2FTkh1m8tDDL8zEi9nFLVxjyRzMgL5HzPzio4uDCsKW1Oa/F/BkfICwx3cEPuwsyT7MlJjTgVqIbXgQ=="
+      },
+      "Microsoft.VisualStudio.Imaging": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "pDNYWW/w1hZF7Xk1SVhCMQxpxz5jFbaEkqrmSVRp7B8o6uei2fDrAscbMJmTxGcVA4rzV02ABytSCrc3jr1LvA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26930",
+        "contentHash": "gbmcUTMhYF/9oDUHI6b6Ki1PBaEkiqDhYNIdkYrrGy7XN0LhYew/BggDCJORUiEbzc5zJ8Hlc40jYGmqx4qfLg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16"
+        }
+      },
+      "Microsoft.VisualStudio.Language": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "BWRDlPth8bLOqUH7j6ClkBFPwjJ83aApHcr1GtJNPZfSj4Nw32pYRLIxCuBs2NLS2f9AF80yl0AYrzVlO6YRWg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Newtonsoft.Json": "9.0.1",
+          "StreamJsonRpc": "1.3.23",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Language.Intellisense": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "GShi/VaASPpvPLnF+rbJcfjbOlxAgpgtxc+PuQLruStw/9DVsL1LF/dB4dvdzRbkci8Ux0TvkI+Csd0/KeIOAg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Language.StandardClassification": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "fU1175eTKfdg4XRVwrl08wPNT4/KDuHKxgKrQ/aGaFzA93NMqtxsgyw6PB/zTA16j1eeIvqCOZpZOWigkuQGGg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.OLE.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "6W3YMtSGt+hHRvAqbktXHLWZgEbEpuFZxuC1XiKCX4Th3fGv+7SeKGGH7Gmeu9fp/8kNqq7uovqWaHfhni13Hw=="
+      },
+      "Microsoft.VisualStudio.RemoteControl": {
+        "type": "Transitive",
+        "resolved": "14.0.249-master2E2DC10C",
+        "contentHash": "bqmdFTlPzEH0VkncJBTq3bXmvW0SKM/pCQcKBgYZfCn/othfLnjChUKCyHvwQyJcjcy8JRnFXRejBQ0pqPXpqQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1"
+        }
+      },
+      "Microsoft.VisualStudio.SDK.EmbedInteropTypes": {
+        "type": "Transitive",
+        "resolved": "15.0.16",
+        "contentHash": "iI+b/DL6AaN/D8vHXcLorZJIjY0MvQehT6xfI3mx+AD2w1f/mEGtuXQE5mFfYu425FSDrPtoBIDRf+tKtLDA5g=="
+      },
+      "Microsoft.VisualStudio.Services.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "bdqdkWc2yWnsOD2yVeKNc/u/M2Lq6xs6C2tqcvuMnq7HT0nu7tYq72ymnk4iQQBJGMGZfJFPOrI8r/7tDhJ0KA==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Services.InteractiveClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "5fvdv0vPMcW+ANVv7HLXeVMKaDST1ydI3y10WMTP+tKDNp1Se4r8XzAuhdG9m+uh5Wozxj5cA9CK3wPfX+BQEA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.15.0": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "QurLa40g6/qehW75Qpi5LR7EE9vSW/mZuc5QwlTcBcW9k/H7jzBPwxcmAzZ5teswJPkD0+VvOQecTEIguOvnVQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging": "15.8.28010",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Framework": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": "14.3.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": "15.0.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": "15.6.27413",
+          "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30730",
+          "Microsoft.VisualStudio.Text.Data": "15.6.27740",
+          "Microsoft.VisualStudio.Threading": "15.6.31"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Framework": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "BRqUcfXNZ17aiuTTr1jawd/WHpt/A70WmDFUwgDS+vwGd0fp8fendG4ANLY5a4KI7+Yhyhz5DO/jsL3UBujNcQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "15.6.27740",
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6072",
+        "contentHash": "hoaT0t8DMA5YwPQEeiRD7UJpndgJDyK00uYcQl3I2+KvgQroo7lAZfkPNbGIhy2OGW4nOEqlvr0i5OE71hgT1w==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.10.0": {
+        "type": "Transitive",
+        "resolved": "10.0.30320",
+        "contentHash": "RKmdy0EgbXFtzjM2Kcdv9w9XdMJS81QykYUb1D/5SnvUYn28ElVt3criqGlvcC1syLJLmk9DdHomOhX6R50e1A==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.11.0": {
+        "type": "Transitive",
+        "resolved": "11.0.61031",
+        "contentHash": "N8il5VcZNr4GZeAvItmpWE4A5DKwSpFelQQ+I1VoUm1kVj+6dPieZXlhdbFC3bJVyCs1gl0uUzOH7FDVGfdDCw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30320"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.12.0": {
+        "type": "Transitive",
+        "resolved": "12.0.30111",
+        "contentHash": "ToNByCRLH875yHd1G43EmGuQz16bAV0PKICvzArpjuNugx/Cl4Djg15NHu7XUdPHm+UpAfH4W7nYh0u8NxqWHw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26929",
+        "contentHash": "J1WemvOhywfve6BbN91azp2nflhc68bpeGFFazoNnYl4MqEjRM0IUe3eNuieoeRw7a+UsHDubne/7K7XJ8yVdA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.26930",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.0.26929",
+        "contentHash": "hHAmrLBvxnmZDPPIOw6zQjsYenbqAcJfcIHSHDl5n/FyBC0VYleDwG2XcEOx1OkXWXReDMGY9lfeHyRv5SSJJQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.12",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.6.27413",
+        "contentHash": "Cb0fRe0ek16fLkE0Buea8zU55zu2WyzBp+8HhK1j3azndHBx0FZAfcDj3xnSum8kllcwQKhEerqEfxdpmwt1mw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "gGhUi9HaXGFC48HxZPV4nYcjygT/vcYYUow5iNocHp/EfwCCnDTUqe5AisH/o1pqB+iakw64g73KSDFsRNAXcA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.9.0": {
+        "type": "Transitive",
+        "resolved": "9.0.30730",
+        "contentHash": "AjBQfZ3HYtpRLFkLjClhR1vWffeEQXScMkhssKxnDnXFc59zOY3RToYxmIS6ZmjD5MS5ICwJDWy7hPOpKbh3Qg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Telemetry": {
+        "type": "Transitive",
+        "resolved": "15.0.691-master31907920",
+        "contentHash": "nTDxnBLOEY+NsjvnGpEeUHmzJrKtUOJjbgxkYd3UdblGlQrLjceIvkpr9c5v1yWwv8byAa2R6itlutjNjb53dA==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.PersistenceChannel": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.UniversalTelemetryChannel": "[0.17.2-build00169]",
+          "Microsoft.Bcl": "1.1.8",
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Bcl.Build": "1.0.14",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta",
+          "Microsoft.VisualStudio.RemoteControl": "[14.0.249-master2E2DC10C]",
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1",
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Data": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "e4OUFLIJ+roHfIeG++y6GZK1S6E0D91iB6LTDQLTz7cC4BvOE3yU3/Eki6Xdy/6inTUKsdqsYUFYEBTWeeF5vA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Logic": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "OG+pya+vxVGjDBp98mBjOWKRj295vwe5HtUmns1w/h727uhO4Y6KxYE4wRs7nOd7JMzB/WSAx2cgdBLtjBOoUg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "k8uKuTcTdOeZEtjrKXQAquWlEKswH2x0A/Ycqjinj7NJ6ykajccNCKiGb6jAJzVBkepSn81pWIO2QLpXKzcHuw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI.Wpf": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "Oa7/4XzATSR683uEK027pkQaV8yoebHABIRWuKZANe2cKWbInAMeoWibGUFW6T58W+8koX7zOIprTwYe02q4Og==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "+xdOtk+Hxdt4Bewl4kCA7KQsI7IZa58uZdnkTcNV9CEtT6Om6VxApAMPIBNvt7sZQoA6SOYubX4uAzEADHX55g==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "AicV/XF3LkQhplsacUr1sUyVL+7kuTk/RczvvYAFUr1PGpNtoHh17DqQYfI3zs/8lQIB+RCmpi6ZU7t0SmY0mg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072"
+        }
+      },
+      "Microsoft.VisualStudio.Threading": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "KLjgM7NPjNg0FNv4z8qx8rpiAOnI5ZB6jrZWfJ4ho2YHtxT2dhWi8e94q9+BR4GBOks9ynL90LAnZX2CE3n4/Q==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Validation": "15.3.15"
+        }
+      },
+      "Microsoft.VisualStudio.Threading.Analyzers": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "SCFubDweTsyzzmXOmQOFedpSnUsN7Rrvh/ZD2phYRkOVBZtz3dX3LVen6IhcePZuDEQMtl4gNW9kzVpjTLlZ0A=="
+      },
+      "Microsoft.VisualStudio.Utilities": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "A36/u2YlW0Fs2H2WJSyTO9xW1FMGzKD+Oqtvfmgff+LyhlO8ZcSzR8waD7DKh2gZCyCR4M89m1VHvHn0Z/s5xg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.6.31",
+          "StreamJsonRpc": "1.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Utilities.Internal": {
+        "type": "Transitive",
+        "resolved": "14.0.54-masterD06D5CD1",
+        "contentHash": "vX0Ka1y7dEUs9HGTCw5BNTPREKJXy04OCy/GaDAgken2bSsjPZON8IkiTDFvkN0JtGuGIHCn9AU12lJU/4HLnw=="
+      },
+      "Microsoft.VisualStudio.Validation": {
+        "type": "Transitive",
+        "resolved": "15.3.15",
+        "contentHash": "bvJIwuCLqu7YKXcZqY85VJy0ljtm9QSRkq4CD2bpO/GHynsm72uZxjBDa050VY7kElXS8mb7VW5JNUfg4D/UBA=="
+      },
+      "Microsoft.VisualStudio.Workspace.VSIntegration": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "eSm+OpRg2C7L+h9UXvbzhwwBPdEk/8VAciEVdgtip5yZvhN2JrnzZxl1gPQdmQT8kVSn+B492fHOlDRa/ljcmA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspaces": "15.0.198-pre"
+        }
+      },
+      "Microsoft.VisualStudio.Workspaces": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "Bk83t69Kmo+9t60N5/rUqDy3HC/4IxsXdcV52m4KZVaYo1eTwuiQRhvjQ56013G23RBMTgeId3LYXWj/vWIaLg=="
+      },
+      "Microsoft.Web.Xdt": {
+        "type": "Transitive",
+        "resolved": "2.1.2",
+        "contentHash": "YIaNTOOtGzjF8CkQBOx3aUBWi0dD+g/nOjbpsVslx9G0/uldtpmoKLmyldmKdMv/gHs3qg40rBT3+wvEWoY5gg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "hSXaFmh7hNCuEoC4XNY5DrRkLDzYHqPx/Ik23R4J86Z7PE/Y6YidhG602dFVdLBRSdG6xp9NabH3dXpcoxWvww=="
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "0.86.0",
+        "contentHash": "5DbS1SlKLMi+WG00Cm0ueYf2oyXJrowETQk8nx96rmdjTuHsA3laPykGV7Sxi0R5Xxfx0Kh/EfacAZ1f6M7y/g=="
+      },
+      "stdole": {
+        "type": "Transitive",
+        "resolved": "7.0.3301",
+        "contentHash": "qQW62tF9+Naie3mQ3wAIY5SU8dqNRaiLUPwQ5v2sQRfzhY8h0M1arECSb68M4smTR89RAvuvXRgxBOiJOblkyA=="
+      },
+      "StreamJsonRpc": {
+        "type": "Transitive",
+        "resolved": "1.3.23",
+        "contentHash": "xJU19tAWEgmXn79SdwgUYPWXjXLxXX+xGHw9R1Ody4YCnRde51NqXk/fQyFbSWlQek1AI0m9f9OXqMIDwNxayw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.20",
+          "Newtonsoft.Json": "6.0.6"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "D3eEHg9hnGHTYsKBHiD/bT8pkBt2tS9BTTCRv2Wx+86FqWTzvsCjuB+I1j0gYIjKQiI5+NSrPtnxWmNHz4CCQw=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "QwALOmIQnwYXO7SZuzHvp+aF9+E8kouJl2JDHe9hyV/Mqzl2KhOwZMlN+mhyIYo5ggHcIVa/LN7E46WD26OEEg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "91UTX0e+S3j5pTVl7V9r8qjBElGhEFp+TBXNT64K68Ecy8DXtM66pFKWQktGBL4GYQRBuZXQdIxX2XuBb77gJA=="
+      },
+      "VSLangProj": {
+        "type": "Transitive",
+        "resolved": "7.0.3300",
+        "contentHash": "/0bb3ssO3rsPUZnVPFNAva2uBQLYNdT4hVLTx0XgxI8+/7acZVuMum18YOaOaE7hnLHMY00o4ypGL/L7JssEww==",
+        "dependencies": {
+          "EnvDTE": "8.0.1"
+        }
+      },
+      "VSLangProj110": {
+        "type": "Transitive",
+        "resolved": "11.0.61030",
+        "contentHash": "ZD0/JubfPji1tUTI7d1fOxEZqC23eHU7PIzoeR0LSY/dmDwEKa32xujNsgx6TT58ZRaSVFY27nUaiVaFdBz5Og==",
+        "dependencies": {
+          "VSLangProj80": "8.0.50727",
+          "VSLangProj90": "9.0.30729"
+        }
+      },
+      "VSLangProj157": {
+        "type": "Transitive",
+        "resolved": "15.7.0",
+        "contentHash": "PjFMHShxIYuZlwqa3feX3MpmCb0RsfCTExjgaJseODGJDXsjApJ5CWolJhlm956W1RHwALQXPiH786H3vZ8upw=="
+      },
+      "VSLangProj2": {
+        "type": "Transitive",
+        "resolved": "7.0.5000",
+        "contentHash": "A286CbJJxrKW4tpVyVaJit5rgVEmTJod/reZ8epekhZWiNoKv2YWkPGaCi0+gQXq4YepqPngE6UpQp5iAXyYDg==",
+        "dependencies": {
+          "VSLangProj": "7.0.3300"
+        }
+      },
+      "VSLangProj80": {
+        "type": "Transitive",
+        "resolved": "8.0.50727",
+        "contentHash": "I2xOMyQcbBXMXKE8zmHljkV1XLAltQ4/T5QRk8Q1mWz7fdd7x1OMp+2VqxZVAJ89Ebfs4wclkcACyvc4FY4wcQ==",
+        "dependencies": {
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "VSLangProj90": {
+        "type": "Transitive",
+        "resolved": "9.0.30729",
+        "contentHash": "xCG2hloStE4TCToHlBai7n/s33sfw/UiEkwqozRPt0AtW9JMr+0hXgGjlOyvPT2rgY6jjKywU55qoTXY2M8f6g=="
+      },
+      "VSSDK.DTE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "uUEaT0sCVnJR54vxfsf5xHpJVWgTrCbl10oKkFuCvJb3I6M5WW4cu9zCTqtYP1i1mYYySGGqooNYiO45kLUkiQ==",
+        "dependencies": {
+          "VSSDK.IDE": "[7.0.4, 8.0.0)"
+        }
+      },
+      "VSSDK.IDE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "KPXgpya93UDz/JZVegRr+AAewTGw46+8Aq7Dl22jWaqjH2KaH/5ycCLG0LET2OX4VBpp15IjhNw08Y5H0vJMKQ=="
+      },
+      "VSSDK.IDE.12": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "XYcSrKW9369JO1tOAuNxzZ6OOlx2QujDuboey4eYpp9GgA3Bd3mo0Fy2ZJd86sZqX27roBRzJfM1Ue/peyWOIg=="
+      },
+      "VSSDK.TemplateWizardInterface": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "stTXrh4h/mftHaQWKZn043WCgP7cmv3QVPB8M3bbBp99kktLdJBTXygPctpgeOYfsBi1TqKJIiNZjG3hCoHNMw==",
+        "dependencies": {
+          "VSSDK.DTE": "[7.0.4, 8.0.0)",
+          "VSSDK.IDE.12": "[12.0.4, 13.0.0)"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Indexing": {
+        "type": "Project",
+        "dependencies": {
+          "Lucene.Net": "3.0.3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.2",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "NuGet.Indexing": "5.0.0-preview3",
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3",
+          "VSLangProj110": "11.0.61030",
+          "VSLangProj157": "15.7.0",
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      },
+      "NuGet.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "VSSDK.TemplateWizardInterface": "12.0.4"
+        }
+      },
+      "NuGet.VisualStudio.Common": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.TeamFoundationServer.ExtendedClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.ComponentModelHost": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Editor": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Language.Intellisense": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language.StandardClassification": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Services.Client": "16.144.1-preview",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.Shell.15.0": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "Microsoft.VisualStudio.Telemetry": "15.0.691-master31907920",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.8.132",
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "VSLangProj": "7.0.3300"
+        }
+      }
+    },
+    ".NETFramework,Version=v4.7.2/win": {},
+    ".NETFramework,Version=v4.7.2/win-x64": {},
+    ".NETFramework,Version=v4.7.2/win-x86": {}
+  }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/packages.lock.json
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/packages.lock.json
@@ -1,0 +1,761 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "Microsoft.VisualStudio.Workspace.VSIntegration": {
+        "type": "Direct",
+        "requested": "[15.0.198-pre, )",
+        "resolved": "15.0.198-pre",
+        "contentHash": "eSm+OpRg2C7L+h9UXvbzhwwBPdEk/8VAciEVdgtip5yZvhN2JrnzZxl1gPQdmQT8kVSn+B492fHOlDRa/ljcmA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspaces": "15.0.198-pre"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "VSLangProj110": {
+        "type": "Direct",
+        "requested": "[11.0.61030, )",
+        "resolved": "11.0.61030",
+        "contentHash": "ZD0/JubfPji1tUTI7d1fOxEZqC23eHU7PIzoeR0LSY/dmDwEKa32xujNsgx6TT58ZRaSVFY27nUaiVaFdBz5Og==",
+        "dependencies": {
+          "VSLangProj80": "8.0.50727",
+          "VSLangProj90": "9.0.30729"
+        }
+      },
+      "VSLangProj157": {
+        "type": "Direct",
+        "requested": "[15.7.0, )",
+        "resolved": "15.7.0",
+        "contentHash": "PjFMHShxIYuZlwqa3feX3MpmCb0RsfCTExjgaJseODGJDXsjApJ5CWolJhlm956W1RHwALQXPiH786H3vZ8upw=="
+      },
+      "VSLangProj2": {
+        "type": "Direct",
+        "requested": "[7.0.5000, )",
+        "resolved": "7.0.5000",
+        "contentHash": "A286CbJJxrKW4tpVyVaJit5rgVEmTJod/reZ8epekhZWiNoKv2YWkPGaCi0+gQXq4YepqPngE6UpQp5iAXyYDg==",
+        "dependencies": {
+          "VSLangProj": "7.0.3300"
+        }
+      },
+      "EnvDTE": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "ppW2nOaaMCOy1HNdUWvTM+btoXVbvntTL4RxVvEWBaHFk+Aj/r7vrS3t9x1QrHB4Y9Rrd2n7UAmjzet3Ps63XA==",
+        "dependencies": {
+          "stdole": "7.0.3301"
+        }
+      },
+      "EnvDTE80": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "3CBF4ileGBzGDPvNePcI3611sRVP5xMHXMZGGgQtcFV5nUu5L5QAZkkrgnBdM0oD9ZXc6dReVwo+tXOSR91z4Q==",
+        "dependencies": {
+          "EnvDTE": "8.0.1",
+          "stdole": "7.0.3301"
+        }
+      },
+      "Lucene.Net": {
+        "type": "Transitive",
+        "resolved": "3.0.3",
+        "contentHash": "A/70q4eDcuuafQeDB9eaiDP9FQG7X29T4VIYRphS7Wk8kAM9gNcfVqYyd0H8BJ1BTpA5C1ORm9RzFn4BiNavrw==",
+        "dependencies": {
+          "SharpZipLib": "0.86.0"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "iAzPAX/guSnBXJxM+PZ+dVXF+vmE8hxcxJ9fOFrvHUv5cY/ILD1icf2sKjJLltJD0Na8r9oGF5PjNiTMxK8EYw==",
+        "dependencies": {
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.ApplicationInsights.PersistenceChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "V7peE2ssNCCfOqzk1kOJfr3zZLDDPs+M88N34e98L+YPpAoL11wQkLpPxWmztjipTD+DBxJO6PNaVsM9q5bM/A==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "0.17.2-build00169"
+        }
+      },
+      "Microsoft.ApplicationInsights.UniversalTelemetryChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "8sg18/b63fhYjpr0kZ2v/NEjOEJ3gwpzXaaKZTth04AUPuOKjWvS3/pyVIRQ1mUEhrV3Xn3S2/TkLiWLCTpo7A==",
+        "dependencies": {
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Client": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "w5w8GVLMmo+JzizmcuV01tgYn2OsaVhxGAO0ryKXkO5sob6EVjzcoJv8NHL3Xm98vywSh7kRgeLqbA/lxZuTXg==",
+        "dependencies": {
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Core": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "bP+PAx17AVQJ19aU9N7yMnz8yST1U9cekbYHRyIUvQzFLqqzrthEs/gLdyZiLJPmL4ZABuvwGBOXG/ukqmsbDg==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3"
+        }
+      },
+      "Microsoft.Bcl": {
+        "type": "Transitive",
+        "resolved": "1.1.8",
+        "contentHash": "gM+PUzd8ONxJpcPJeNppCJPklDhDuPUMVQkxvK4fe0rd9WyqBNPh4+UFx3Uv8zuG4C1Gapu1c25sfotE7TQtig==",
+        "dependencies": {
+          "Microsoft.Bcl.Build": "1.0.14"
+        }
+      },
+      "Microsoft.Bcl.Async": {
+        "type": "Transitive",
+        "resolved": "1.0.168",
+        "contentHash": "tUNC02eBwDKpGre0BcNIvblLv1q0Q3DnS/vtkRHj2FE1sXwt386HAudztyl5C0U88hllrqHDvtlz8bK0Y8cHDA==",
+        "dependencies": {
+          "Microsoft.Bcl": "1.1.8"
+        }
+      },
+      "Microsoft.Bcl.Build": {
+        "type": "Transitive",
+        "resolved": "1.0.14",
+        "contentHash": "cDLKSvNvRa519hplsbSoYqO69TjdDIhfjtKUM0g20/nVROoWsGav9KCI9HtnGjLmdV1+TcUUDhbotcllibjPEA=="
+      },
+      "Microsoft.Diagnostics.Tracing.EventSource.Redist": {
+        "type": "Transitive",
+        "resolved": "1.1.16-beta",
+        "contentHash": "o1gsKlGjLAnSHRyWBygKnO55Kp0bRXB3AO9e8OeAnqQH7HA5MAW6YAPEEy5e3aRE//7AlkdPtq28F19NqOLZQQ=="
+      },
+      "Microsoft.IdentityModel.Clients.ActiveDirectory": {
+        "type": "Transitive",
+        "resolved": "3.17.2",
+        "contentHash": "zvDoWJlrKg1TQeJScq+5znAZtduyJHlT7M9gEquUjm2PQCIR4C5PqJ0E8xYQsV3eF4bY8cW54uyr0FyhiN0MtQ=="
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "kbmvhMYu5OZXWN3toFXhrj3bSN7B+ZzNWzAZQ4Ofp5x2srk9ZCYFljETGS5faxzPwGd5+7W4WZlAfOI7QvzhlA=="
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "wVWYpXfE6gpkSrIRNo5TDVC7ss6KPTTrmT6x8ysHiZRIMSRAZ8TyHEAmpdATBBPNRmnlevyAs4CK6nPfDpCTqw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "dsDJhsL2zJyL5az5D3LhILIQRt+nXFQ64Bclj6vspIwD96sYRK/fPKTP8xLcLyw0fcosiFUgmWOXRLkWcAm1Pw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]"
+        }
+      },
+      "Microsoft.TeamFoundationServer.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "UBwF/VUULHHy5WHpShIW0ZdcG10N3jADUlW+KEgA7qiKCDB8VYbv7FR0miwutTtyuYFh/lE+G6q4IF0ugDyX6A==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3"
+        }
+      },
+      "Microsoft.TeamFoundationServer.ExtendedClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "g3G19/HJEOeYR8xFnNWSegBqRcMZRUyPLBmf5JF24pqhVqrY31fSA7ZBUX9r6nHHdSBkmZbRQisR/IvwrfDGqQ==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.AspNet.WebApi.Core": "5.2.3",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.TeamFoundationServer.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.ComponentModelHost": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "79WnMNn2T4xDqNVCAR9u3r2OXrA4QPOHYy36MMDjfIKvhL5mQ5Osgc+e+3wVVfeyD4EUdAYs/hC74+w4k/6ktg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319"
+        }
+      },
+      "Microsoft.VisualStudio.CoreUtility": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "eiepEOoyUJ+5K+7qitTMzXBJB6GcOMp5LdcedFa30dLxGPwgKY+XdVjiqcrxyQps4i7+hHNlYWvZCR6SKnWLRA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.23",
+          "System.ValueTuple": "4.3.0"
+        }
+      },
+      "Microsoft.VisualStudio.Editor": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "EnlJfSZABDJP36kg5td5A4HXqR2TWQrCgjXvDyBTF3peyDFQR6R6XZ63Wul+BY6Yract+UHP6E/8I+LlZ2BvRw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50727",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.ImageCatalog": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "X3nCoei2FTkh1m8tDDL8zEi9nFLVxjyRzMgL5HzPzio4uDCsKW1Oa/F/BkfICwx3cEPuwsyT7MlJjTgVqIbXgQ=="
+      },
+      "Microsoft.VisualStudio.Imaging": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "pDNYWW/w1hZF7Xk1SVhCMQxpxz5jFbaEkqrmSVRp7B8o6uei2fDrAscbMJmTxGcVA4rzV02ABytSCrc3jr1LvA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26930",
+        "contentHash": "gbmcUTMhYF/9oDUHI6b6Ki1PBaEkiqDhYNIdkYrrGy7XN0LhYew/BggDCJORUiEbzc5zJ8Hlc40jYGmqx4qfLg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16"
+        }
+      },
+      "Microsoft.VisualStudio.Language": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "BWRDlPth8bLOqUH7j6ClkBFPwjJ83aApHcr1GtJNPZfSj4Nw32pYRLIxCuBs2NLS2f9AF80yl0AYrzVlO6YRWg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Newtonsoft.Json": "9.0.1",
+          "StreamJsonRpc": "1.3.23",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Language.Intellisense": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "GShi/VaASPpvPLnF+rbJcfjbOlxAgpgtxc+PuQLruStw/9DVsL1LF/dB4dvdzRbkci8Ux0TvkI+Csd0/KeIOAg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Language.StandardClassification": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "fU1175eTKfdg4XRVwrl08wPNT4/KDuHKxgKrQ/aGaFzA93NMqtxsgyw6PB/zTA16j1eeIvqCOZpZOWigkuQGGg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.OLE.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "6W3YMtSGt+hHRvAqbktXHLWZgEbEpuFZxuC1XiKCX4Th3fGv+7SeKGGH7Gmeu9fp/8kNqq7uovqWaHfhni13Hw=="
+      },
+      "Microsoft.VisualStudio.RemoteControl": {
+        "type": "Transitive",
+        "resolved": "14.0.249-master2E2DC10C",
+        "contentHash": "bqmdFTlPzEH0VkncJBTq3bXmvW0SKM/pCQcKBgYZfCn/othfLnjChUKCyHvwQyJcjcy8JRnFXRejBQ0pqPXpqQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1"
+        }
+      },
+      "Microsoft.VisualStudio.SDK.EmbedInteropTypes": {
+        "type": "Transitive",
+        "resolved": "15.0.16",
+        "contentHash": "iI+b/DL6AaN/D8vHXcLorZJIjY0MvQehT6xfI3mx+AD2w1f/mEGtuXQE5mFfYu425FSDrPtoBIDRf+tKtLDA5g=="
+      },
+      "Microsoft.VisualStudio.Services.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "bdqdkWc2yWnsOD2yVeKNc/u/M2Lq6xs6C2tqcvuMnq7HT0nu7tYq72ymnk4iQQBJGMGZfJFPOrI8r/7tDhJ0KA==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Services.InteractiveClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "5fvdv0vPMcW+ANVv7HLXeVMKaDST1ydI3y10WMTP+tKDNp1Se4r8XzAuhdG9m+uh5Wozxj5cA9CK3wPfX+BQEA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.15.0": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "QurLa40g6/qehW75Qpi5LR7EE9vSW/mZuc5QwlTcBcW9k/H7jzBPwxcmAzZ5teswJPkD0+VvOQecTEIguOvnVQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging": "15.8.28010",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Framework": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": "14.3.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": "15.0.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": "15.6.27413",
+          "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30730",
+          "Microsoft.VisualStudio.Text.Data": "15.6.27740",
+          "Microsoft.VisualStudio.Threading": "15.6.31"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Framework": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "BRqUcfXNZ17aiuTTr1jawd/WHpt/A70WmDFUwgDS+vwGd0fp8fendG4ANLY5a4KI7+Yhyhz5DO/jsL3UBujNcQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "15.6.27740",
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6072",
+        "contentHash": "hoaT0t8DMA5YwPQEeiRD7UJpndgJDyK00uYcQl3I2+KvgQroo7lAZfkPNbGIhy2OGW4nOEqlvr0i5OE71hgT1w==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.10.0": {
+        "type": "Transitive",
+        "resolved": "10.0.30320",
+        "contentHash": "RKmdy0EgbXFtzjM2Kcdv9w9XdMJS81QykYUb1D/5SnvUYn28ElVt3criqGlvcC1syLJLmk9DdHomOhX6R50e1A==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.11.0": {
+        "type": "Transitive",
+        "resolved": "11.0.61031",
+        "contentHash": "N8il5VcZNr4GZeAvItmpWE4A5DKwSpFelQQ+I1VoUm1kVj+6dPieZXlhdbFC3bJVyCs1gl0uUzOH7FDVGfdDCw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30320"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.12.0": {
+        "type": "Transitive",
+        "resolved": "12.0.30111",
+        "contentHash": "ToNByCRLH875yHd1G43EmGuQz16bAV0PKICvzArpjuNugx/Cl4Djg15NHu7XUdPHm+UpAfH4W7nYh0u8NxqWHw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26929",
+        "contentHash": "J1WemvOhywfve6BbN91azp2nflhc68bpeGFFazoNnYl4MqEjRM0IUe3eNuieoeRw7a+UsHDubne/7K7XJ8yVdA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.26930",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.0.26929",
+        "contentHash": "hHAmrLBvxnmZDPPIOw6zQjsYenbqAcJfcIHSHDl5n/FyBC0VYleDwG2XcEOx1OkXWXReDMGY9lfeHyRv5SSJJQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.12",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.6.27413",
+        "contentHash": "Cb0fRe0ek16fLkE0Buea8zU55zu2WyzBp+8HhK1j3azndHBx0FZAfcDj3xnSum8kllcwQKhEerqEfxdpmwt1mw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "gGhUi9HaXGFC48HxZPV4nYcjygT/vcYYUow5iNocHp/EfwCCnDTUqe5AisH/o1pqB+iakw64g73KSDFsRNAXcA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.9.0": {
+        "type": "Transitive",
+        "resolved": "9.0.30730",
+        "contentHash": "AjBQfZ3HYtpRLFkLjClhR1vWffeEQXScMkhssKxnDnXFc59zOY3RToYxmIS6ZmjD5MS5ICwJDWy7hPOpKbh3Qg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Telemetry": {
+        "type": "Transitive",
+        "resolved": "15.0.691-master31907920",
+        "contentHash": "nTDxnBLOEY+NsjvnGpEeUHmzJrKtUOJjbgxkYd3UdblGlQrLjceIvkpr9c5v1yWwv8byAa2R6itlutjNjb53dA==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.PersistenceChannel": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.UniversalTelemetryChannel": "[0.17.2-build00169]",
+          "Microsoft.Bcl": "1.1.8",
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Bcl.Build": "1.0.14",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta",
+          "Microsoft.VisualStudio.RemoteControl": "[14.0.249-master2E2DC10C]",
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1",
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Data": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "e4OUFLIJ+roHfIeG++y6GZK1S6E0D91iB6LTDQLTz7cC4BvOE3yU3/Eki6Xdy/6inTUKsdqsYUFYEBTWeeF5vA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Logic": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "OG+pya+vxVGjDBp98mBjOWKRj295vwe5HtUmns1w/h727uhO4Y6KxYE4wRs7nOd7JMzB/WSAx2cgdBLtjBOoUg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "k8uKuTcTdOeZEtjrKXQAquWlEKswH2x0A/Ycqjinj7NJ6ykajccNCKiGb6jAJzVBkepSn81pWIO2QLpXKzcHuw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI.Wpf": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "Oa7/4XzATSR683uEK027pkQaV8yoebHABIRWuKZANe2cKWbInAMeoWibGUFW6T58W+8koX7zOIprTwYe02q4Og==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "+xdOtk+Hxdt4Bewl4kCA7KQsI7IZa58uZdnkTcNV9CEtT6Om6VxApAMPIBNvt7sZQoA6SOYubX4uAzEADHX55g==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "AicV/XF3LkQhplsacUr1sUyVL+7kuTk/RczvvYAFUr1PGpNtoHh17DqQYfI3zs/8lQIB+RCmpi6ZU7t0SmY0mg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072"
+        }
+      },
+      "Microsoft.VisualStudio.Threading": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "KLjgM7NPjNg0FNv4z8qx8rpiAOnI5ZB6jrZWfJ4ho2YHtxT2dhWi8e94q9+BR4GBOks9ynL90LAnZX2CE3n4/Q==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Validation": "15.3.15"
+        }
+      },
+      "Microsoft.VisualStudio.Threading.Analyzers": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "SCFubDweTsyzzmXOmQOFedpSnUsN7Rrvh/ZD2phYRkOVBZtz3dX3LVen6IhcePZuDEQMtl4gNW9kzVpjTLlZ0A=="
+      },
+      "Microsoft.VisualStudio.Utilities": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "A36/u2YlW0Fs2H2WJSyTO9xW1FMGzKD+Oqtvfmgff+LyhlO8ZcSzR8waD7DKh2gZCyCR4M89m1VHvHn0Z/s5xg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.6.31",
+          "StreamJsonRpc": "1.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Utilities.Internal": {
+        "type": "Transitive",
+        "resolved": "14.0.54-masterD06D5CD1",
+        "contentHash": "vX0Ka1y7dEUs9HGTCw5BNTPREKJXy04OCy/GaDAgken2bSsjPZON8IkiTDFvkN0JtGuGIHCn9AU12lJU/4HLnw=="
+      },
+      "Microsoft.VisualStudio.Validation": {
+        "type": "Transitive",
+        "resolved": "15.3.15",
+        "contentHash": "bvJIwuCLqu7YKXcZqY85VJy0ljtm9QSRkq4CD2bpO/GHynsm72uZxjBDa050VY7kElXS8mb7VW5JNUfg4D/UBA=="
+      },
+      "Microsoft.VisualStudio.Workspaces": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "Bk83t69Kmo+9t60N5/rUqDy3HC/4IxsXdcV52m4KZVaYo1eTwuiQRhvjQ56013G23RBMTgeId3LYXWj/vWIaLg=="
+      },
+      "Microsoft.Web.Xdt": {
+        "type": "Transitive",
+        "resolved": "2.1.2",
+        "contentHash": "YIaNTOOtGzjF8CkQBOx3aUBWi0dD+g/nOjbpsVslx9G0/uldtpmoKLmyldmKdMv/gHs3qg40rBT3+wvEWoY5gg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "hSXaFmh7hNCuEoC4XNY5DrRkLDzYHqPx/Ik23R4J86Z7PE/Y6YidhG602dFVdLBRSdG6xp9NabH3dXpcoxWvww=="
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "0.86.0",
+        "contentHash": "5DbS1SlKLMi+WG00Cm0ueYf2oyXJrowETQk8nx96rmdjTuHsA3laPykGV7Sxi0R5Xxfx0Kh/EfacAZ1f6M7y/g=="
+      },
+      "stdole": {
+        "type": "Transitive",
+        "resolved": "7.0.3301",
+        "contentHash": "qQW62tF9+Naie3mQ3wAIY5SU8dqNRaiLUPwQ5v2sQRfzhY8h0M1arECSb68M4smTR89RAvuvXRgxBOiJOblkyA=="
+      },
+      "StreamJsonRpc": {
+        "type": "Transitive",
+        "resolved": "1.3.23",
+        "contentHash": "xJU19tAWEgmXn79SdwgUYPWXjXLxXX+xGHw9R1Ody4YCnRde51NqXk/fQyFbSWlQek1AI0m9f9OXqMIDwNxayw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.20",
+          "Newtonsoft.Json": "6.0.6"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "D3eEHg9hnGHTYsKBHiD/bT8pkBt2tS9BTTCRv2Wx+86FqWTzvsCjuB+I1j0gYIjKQiI5+NSrPtnxWmNHz4CCQw=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "QwALOmIQnwYXO7SZuzHvp+aF9+E8kouJl2JDHe9hyV/Mqzl2KhOwZMlN+mhyIYo5ggHcIVa/LN7E46WD26OEEg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "91UTX0e+S3j5pTVl7V9r8qjBElGhEFp+TBXNT64K68Ecy8DXtM66pFKWQktGBL4GYQRBuZXQdIxX2XuBb77gJA=="
+      },
+      "VSLangProj": {
+        "type": "Transitive",
+        "resolved": "7.0.3300",
+        "contentHash": "/0bb3ssO3rsPUZnVPFNAva2uBQLYNdT4hVLTx0XgxI8+/7acZVuMum18YOaOaE7hnLHMY00o4ypGL/L7JssEww==",
+        "dependencies": {
+          "EnvDTE": "8.0.1"
+        }
+      },
+      "VSLangProj80": {
+        "type": "Transitive",
+        "resolved": "8.0.50727",
+        "contentHash": "I2xOMyQcbBXMXKE8zmHljkV1XLAltQ4/T5QRk8Q1mWz7fdd7x1OMp+2VqxZVAJ89Ebfs4wclkcACyvc4FY4wcQ==",
+        "dependencies": {
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "VSLangProj90": {
+        "type": "Transitive",
+        "resolved": "9.0.30729",
+        "contentHash": "xCG2hloStE4TCToHlBai7n/s33sfw/UiEkwqozRPt0AtW9JMr+0hXgGjlOyvPT2rgY6jjKywU55qoTXY2M8f6g=="
+      },
+      "VSSDK.DTE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "uUEaT0sCVnJR54vxfsf5xHpJVWgTrCbl10oKkFuCvJb3I6M5WW4cu9zCTqtYP1i1mYYySGGqooNYiO45kLUkiQ==",
+        "dependencies": {
+          "VSSDK.IDE": "[7.0.4, 8.0.0)"
+        }
+      },
+      "VSSDK.IDE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "KPXgpya93UDz/JZVegRr+AAewTGw46+8Aq7Dl22jWaqjH2KaH/5ycCLG0LET2OX4VBpp15IjhNw08Y5H0vJMKQ=="
+      },
+      "VSSDK.IDE.12": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "XYcSrKW9369JO1tOAuNxzZ6OOlx2QujDuboey4eYpp9GgA3Bd3mo0Fy2ZJd86sZqX27roBRzJfM1Ue/peyWOIg=="
+      },
+      "VSSDK.TemplateWizardInterface": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "stTXrh4h/mftHaQWKZn043WCgP7cmv3QVPB8M3bbBp99kktLdJBTXygPctpgeOYfsBi1TqKJIiNZjG3hCoHNMw==",
+        "dependencies": {
+          "VSSDK.DTE": "[7.0.4, 8.0.0)",
+          "VSSDK.IDE.12": "[12.0.4, 13.0.0)"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Indexing": {
+        "type": "Project",
+        "dependencies": {
+          "Lucene.Net": "3.0.3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.2",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      },
+      "NuGet.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "VSSDK.TemplateWizardInterface": "12.0.4"
+        }
+      },
+      "NuGet.VisualStudio.Common": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.TeamFoundationServer.ExtendedClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.ComponentModelHost": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Editor": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Language.Intellisense": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language.StandardClassification": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Services.Client": "16.144.1-preview",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.Shell.15.0": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "Microsoft.VisualStudio.Telemetry": "15.0.691-master31907920",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.8.132",
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "VSLangProj": "7.0.3300"
+        }
+      }
+    },
+    ".NETFramework,Version=v4.7.2/win": {},
+    ".NETFramework,Version=v4.7.2/win-x64": {},
+    ".NETFramework,Version=v4.7.2/win-x86": {}
+  }
+}

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/packages.lock.json
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/packages.lock.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      }
+    }
+  }
+}

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/packages.lock.json
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/packages.lock.json
@@ -1,0 +1,783 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "EnvDTE": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "ppW2nOaaMCOy1HNdUWvTM+btoXVbvntTL4RxVvEWBaHFk+Aj/r7vrS3t9x1QrHB4Y9Rrd2n7UAmjzet3Ps63XA==",
+        "dependencies": {
+          "stdole": "7.0.3301"
+        }
+      },
+      "EnvDTE80": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "3CBF4ileGBzGDPvNePcI3611sRVP5xMHXMZGGgQtcFV5nUu5L5QAZkkrgnBdM0oD9ZXc6dReVwo+tXOSR91z4Q==",
+        "dependencies": {
+          "EnvDTE": "8.0.1",
+          "stdole": "7.0.3301"
+        }
+      },
+      "Lucene.Net": {
+        "type": "Transitive",
+        "resolved": "3.0.3",
+        "contentHash": "A/70q4eDcuuafQeDB9eaiDP9FQG7X29T4VIYRphS7Wk8kAM9gNcfVqYyd0H8BJ1BTpA5C1ORm9RzFn4BiNavrw==",
+        "dependencies": {
+          "SharpZipLib": "0.86.0"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "iAzPAX/guSnBXJxM+PZ+dVXF+vmE8hxcxJ9fOFrvHUv5cY/ILD1icf2sKjJLltJD0Na8r9oGF5PjNiTMxK8EYw==",
+        "dependencies": {
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.ApplicationInsights.PersistenceChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "V7peE2ssNCCfOqzk1kOJfr3zZLDDPs+M88N34e98L+YPpAoL11wQkLpPxWmztjipTD+DBxJO6PNaVsM9q5bM/A==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "0.17.2-build00169"
+        }
+      },
+      "Microsoft.ApplicationInsights.UniversalTelemetryChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "8sg18/b63fhYjpr0kZ2v/NEjOEJ3gwpzXaaKZTth04AUPuOKjWvS3/pyVIRQ1mUEhrV3Xn3S2/TkLiWLCTpo7A==",
+        "dependencies": {
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Client": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "w5w8GVLMmo+JzizmcuV01tgYn2OsaVhxGAO0ryKXkO5sob6EVjzcoJv8NHL3Xm98vywSh7kRgeLqbA/lxZuTXg==",
+        "dependencies": {
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Core": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "bP+PAx17AVQJ19aU9N7yMnz8yST1U9cekbYHRyIUvQzFLqqzrthEs/gLdyZiLJPmL4ZABuvwGBOXG/ukqmsbDg==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3"
+        }
+      },
+      "Microsoft.Bcl": {
+        "type": "Transitive",
+        "resolved": "1.1.8",
+        "contentHash": "gM+PUzd8ONxJpcPJeNppCJPklDhDuPUMVQkxvK4fe0rd9WyqBNPh4+UFx3Uv8zuG4C1Gapu1c25sfotE7TQtig==",
+        "dependencies": {
+          "Microsoft.Bcl.Build": "1.0.14"
+        }
+      },
+      "Microsoft.Bcl.Async": {
+        "type": "Transitive",
+        "resolved": "1.0.168",
+        "contentHash": "tUNC02eBwDKpGre0BcNIvblLv1q0Q3DnS/vtkRHj2FE1sXwt386HAudztyl5C0U88hllrqHDvtlz8bK0Y8cHDA==",
+        "dependencies": {
+          "Microsoft.Bcl": "1.1.8"
+        }
+      },
+      "Microsoft.Bcl.Build": {
+        "type": "Transitive",
+        "resolved": "1.0.14",
+        "contentHash": "cDLKSvNvRa519hplsbSoYqO69TjdDIhfjtKUM0g20/nVROoWsGav9KCI9HtnGjLmdV1+TcUUDhbotcllibjPEA=="
+      },
+      "Microsoft.Diagnostics.Tracing.EventSource.Redist": {
+        "type": "Transitive",
+        "resolved": "1.1.16-beta",
+        "contentHash": "o1gsKlGjLAnSHRyWBygKnO55Kp0bRXB3AO9e8OeAnqQH7HA5MAW6YAPEEy5e3aRE//7AlkdPtq28F19NqOLZQQ=="
+      },
+      "Microsoft.IdentityModel.Clients.ActiveDirectory": {
+        "type": "Transitive",
+        "resolved": "3.17.2",
+        "contentHash": "zvDoWJlrKg1TQeJScq+5znAZtduyJHlT7M9gEquUjm2PQCIR4C5PqJ0E8xYQsV3eF4bY8cW54uyr0FyhiN0MtQ=="
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "kbmvhMYu5OZXWN3toFXhrj3bSN7B+ZzNWzAZQ4Ofp5x2srk9ZCYFljETGS5faxzPwGd5+7W4WZlAfOI7QvzhlA=="
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "wVWYpXfE6gpkSrIRNo5TDVC7ss6KPTTrmT6x8ysHiZRIMSRAZ8TyHEAmpdATBBPNRmnlevyAs4CK6nPfDpCTqw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "dsDJhsL2zJyL5az5D3LhILIQRt+nXFQ64Bclj6vspIwD96sYRK/fPKTP8xLcLyw0fcosiFUgmWOXRLkWcAm1Pw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]"
+        }
+      },
+      "Microsoft.TeamFoundationServer.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "UBwF/VUULHHy5WHpShIW0ZdcG10N3jADUlW+KEgA7qiKCDB8VYbv7FR0miwutTtyuYFh/lE+G6q4IF0ugDyX6A==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3"
+        }
+      },
+      "Microsoft.TeamFoundationServer.ExtendedClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "g3G19/HJEOeYR8xFnNWSegBqRcMZRUyPLBmf5JF24pqhVqrY31fSA7ZBUX9r6nHHdSBkmZbRQisR/IvwrfDGqQ==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.AspNet.WebApi.Core": "5.2.3",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.TeamFoundationServer.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.ComponentModelHost": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "79WnMNn2T4xDqNVCAR9u3r2OXrA4QPOHYy36MMDjfIKvhL5mQ5Osgc+e+3wVVfeyD4EUdAYs/hC74+w4k/6ktg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319"
+        }
+      },
+      "Microsoft.VisualStudio.CoreUtility": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "eiepEOoyUJ+5K+7qitTMzXBJB6GcOMp5LdcedFa30dLxGPwgKY+XdVjiqcrxyQps4i7+hHNlYWvZCR6SKnWLRA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.23",
+          "System.ValueTuple": "4.3.0"
+        }
+      },
+      "Microsoft.VisualStudio.Editor": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "EnlJfSZABDJP36kg5td5A4HXqR2TWQrCgjXvDyBTF3peyDFQR6R6XZ63Wul+BY6Yract+UHP6E/8I+LlZ2BvRw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50727",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.ImageCatalog": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "X3nCoei2FTkh1m8tDDL8zEi9nFLVxjyRzMgL5HzPzio4uDCsKW1Oa/F/BkfICwx3cEPuwsyT7MlJjTgVqIbXgQ=="
+      },
+      "Microsoft.VisualStudio.Imaging": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "pDNYWW/w1hZF7Xk1SVhCMQxpxz5jFbaEkqrmSVRp7B8o6uei2fDrAscbMJmTxGcVA4rzV02ABytSCrc3jr1LvA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26930",
+        "contentHash": "gbmcUTMhYF/9oDUHI6b6Ki1PBaEkiqDhYNIdkYrrGy7XN0LhYew/BggDCJORUiEbzc5zJ8Hlc40jYGmqx4qfLg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16"
+        }
+      },
+      "Microsoft.VisualStudio.Language": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "BWRDlPth8bLOqUH7j6ClkBFPwjJ83aApHcr1GtJNPZfSj4Nw32pYRLIxCuBs2NLS2f9AF80yl0AYrzVlO6YRWg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Newtonsoft.Json": "9.0.1",
+          "StreamJsonRpc": "1.3.23",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Language.Intellisense": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "GShi/VaASPpvPLnF+rbJcfjbOlxAgpgtxc+PuQLruStw/9DVsL1LF/dB4dvdzRbkci8Ux0TvkI+Csd0/KeIOAg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Language.StandardClassification": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "fU1175eTKfdg4XRVwrl08wPNT4/KDuHKxgKrQ/aGaFzA93NMqtxsgyw6PB/zTA16j1eeIvqCOZpZOWigkuQGGg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.OLE.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "6W3YMtSGt+hHRvAqbktXHLWZgEbEpuFZxuC1XiKCX4Th3fGv+7SeKGGH7Gmeu9fp/8kNqq7uovqWaHfhni13Hw=="
+      },
+      "Microsoft.VisualStudio.RemoteControl": {
+        "type": "Transitive",
+        "resolved": "14.0.249-master2E2DC10C",
+        "contentHash": "bqmdFTlPzEH0VkncJBTq3bXmvW0SKM/pCQcKBgYZfCn/othfLnjChUKCyHvwQyJcjcy8JRnFXRejBQ0pqPXpqQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1"
+        }
+      },
+      "Microsoft.VisualStudio.SDK.EmbedInteropTypes": {
+        "type": "Transitive",
+        "resolved": "15.0.16",
+        "contentHash": "iI+b/DL6AaN/D8vHXcLorZJIjY0MvQehT6xfI3mx+AD2w1f/mEGtuXQE5mFfYu425FSDrPtoBIDRf+tKtLDA5g=="
+      },
+      "Microsoft.VisualStudio.Services.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "bdqdkWc2yWnsOD2yVeKNc/u/M2Lq6xs6C2tqcvuMnq7HT0nu7tYq72ymnk4iQQBJGMGZfJFPOrI8r/7tDhJ0KA==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Services.InteractiveClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "5fvdv0vPMcW+ANVv7HLXeVMKaDST1ydI3y10WMTP+tKDNp1Se4r8XzAuhdG9m+uh5Wozxj5cA9CK3wPfX+BQEA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.15.0": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "QurLa40g6/qehW75Qpi5LR7EE9vSW/mZuc5QwlTcBcW9k/H7jzBPwxcmAzZ5teswJPkD0+VvOQecTEIguOvnVQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging": "15.8.28010",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Framework": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": "14.3.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": "15.0.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": "15.6.27413",
+          "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30730",
+          "Microsoft.VisualStudio.Text.Data": "15.6.27740",
+          "Microsoft.VisualStudio.Threading": "15.6.31"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Framework": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "BRqUcfXNZ17aiuTTr1jawd/WHpt/A70WmDFUwgDS+vwGd0fp8fendG4ANLY5a4KI7+Yhyhz5DO/jsL3UBujNcQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "15.6.27740",
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6072",
+        "contentHash": "hoaT0t8DMA5YwPQEeiRD7UJpndgJDyK00uYcQl3I2+KvgQroo7lAZfkPNbGIhy2OGW4nOEqlvr0i5OE71hgT1w==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.10.0": {
+        "type": "Transitive",
+        "resolved": "10.0.30320",
+        "contentHash": "RKmdy0EgbXFtzjM2Kcdv9w9XdMJS81QykYUb1D/5SnvUYn28ElVt3criqGlvcC1syLJLmk9DdHomOhX6R50e1A==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.11.0": {
+        "type": "Transitive",
+        "resolved": "11.0.61031",
+        "contentHash": "N8il5VcZNr4GZeAvItmpWE4A5DKwSpFelQQ+I1VoUm1kVj+6dPieZXlhdbFC3bJVyCs1gl0uUzOH7FDVGfdDCw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30320"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.12.0": {
+        "type": "Transitive",
+        "resolved": "12.0.30111",
+        "contentHash": "ToNByCRLH875yHd1G43EmGuQz16bAV0PKICvzArpjuNugx/Cl4Djg15NHu7XUdPHm+UpAfH4W7nYh0u8NxqWHw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26929",
+        "contentHash": "J1WemvOhywfve6BbN91azp2nflhc68bpeGFFazoNnYl4MqEjRM0IUe3eNuieoeRw7a+UsHDubne/7K7XJ8yVdA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.26930",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.0.26929",
+        "contentHash": "hHAmrLBvxnmZDPPIOw6zQjsYenbqAcJfcIHSHDl5n/FyBC0VYleDwG2XcEOx1OkXWXReDMGY9lfeHyRv5SSJJQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.12",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.6.27413",
+        "contentHash": "Cb0fRe0ek16fLkE0Buea8zU55zu2WyzBp+8HhK1j3azndHBx0FZAfcDj3xnSum8kllcwQKhEerqEfxdpmwt1mw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "gGhUi9HaXGFC48HxZPV4nYcjygT/vcYYUow5iNocHp/EfwCCnDTUqe5AisH/o1pqB+iakw64g73KSDFsRNAXcA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.9.0": {
+        "type": "Transitive",
+        "resolved": "9.0.30730",
+        "contentHash": "AjBQfZ3HYtpRLFkLjClhR1vWffeEQXScMkhssKxnDnXFc59zOY3RToYxmIS6ZmjD5MS5ICwJDWy7hPOpKbh3Qg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Telemetry": {
+        "type": "Transitive",
+        "resolved": "15.0.691-master31907920",
+        "contentHash": "nTDxnBLOEY+NsjvnGpEeUHmzJrKtUOJjbgxkYd3UdblGlQrLjceIvkpr9c5v1yWwv8byAa2R6itlutjNjb53dA==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.PersistenceChannel": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.UniversalTelemetryChannel": "[0.17.2-build00169]",
+          "Microsoft.Bcl": "1.1.8",
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Bcl.Build": "1.0.14",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta",
+          "Microsoft.VisualStudio.RemoteControl": "[14.0.249-master2E2DC10C]",
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1",
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Data": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "e4OUFLIJ+roHfIeG++y6GZK1S6E0D91iB6LTDQLTz7cC4BvOE3yU3/Eki6Xdy/6inTUKsdqsYUFYEBTWeeF5vA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Logic": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "OG+pya+vxVGjDBp98mBjOWKRj295vwe5HtUmns1w/h727uhO4Y6KxYE4wRs7nOd7JMzB/WSAx2cgdBLtjBOoUg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "k8uKuTcTdOeZEtjrKXQAquWlEKswH2x0A/Ycqjinj7NJ6ykajccNCKiGb6jAJzVBkepSn81pWIO2QLpXKzcHuw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI.Wpf": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "Oa7/4XzATSR683uEK027pkQaV8yoebHABIRWuKZANe2cKWbInAMeoWibGUFW6T58W+8koX7zOIprTwYe02q4Og==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "+xdOtk+Hxdt4Bewl4kCA7KQsI7IZa58uZdnkTcNV9CEtT6Om6VxApAMPIBNvt7sZQoA6SOYubX4uAzEADHX55g==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "AicV/XF3LkQhplsacUr1sUyVL+7kuTk/RczvvYAFUr1PGpNtoHh17DqQYfI3zs/8lQIB+RCmpi6ZU7t0SmY0mg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072"
+        }
+      },
+      "Microsoft.VisualStudio.Threading": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "KLjgM7NPjNg0FNv4z8qx8rpiAOnI5ZB6jrZWfJ4ho2YHtxT2dhWi8e94q9+BR4GBOks9ynL90LAnZX2CE3n4/Q==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Validation": "15.3.15"
+        }
+      },
+      "Microsoft.VisualStudio.Threading.Analyzers": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "SCFubDweTsyzzmXOmQOFedpSnUsN7Rrvh/ZD2phYRkOVBZtz3dX3LVen6IhcePZuDEQMtl4gNW9kzVpjTLlZ0A=="
+      },
+      "Microsoft.VisualStudio.Utilities": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "A36/u2YlW0Fs2H2WJSyTO9xW1FMGzKD+Oqtvfmgff+LyhlO8ZcSzR8waD7DKh2gZCyCR4M89m1VHvHn0Z/s5xg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.6.31",
+          "StreamJsonRpc": "1.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Utilities.Internal": {
+        "type": "Transitive",
+        "resolved": "14.0.54-masterD06D5CD1",
+        "contentHash": "vX0Ka1y7dEUs9HGTCw5BNTPREKJXy04OCy/GaDAgken2bSsjPZON8IkiTDFvkN0JtGuGIHCn9AU12lJU/4HLnw=="
+      },
+      "Microsoft.VisualStudio.Validation": {
+        "type": "Transitive",
+        "resolved": "15.3.15",
+        "contentHash": "bvJIwuCLqu7YKXcZqY85VJy0ljtm9QSRkq4CD2bpO/GHynsm72uZxjBDa050VY7kElXS8mb7VW5JNUfg4D/UBA=="
+      },
+      "Microsoft.VisualStudio.Workspace.VSIntegration": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "eSm+OpRg2C7L+h9UXvbzhwwBPdEk/8VAciEVdgtip5yZvhN2JrnzZxl1gPQdmQT8kVSn+B492fHOlDRa/ljcmA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspaces": "15.0.198-pre"
+        }
+      },
+      "Microsoft.VisualStudio.Workspaces": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "Bk83t69Kmo+9t60N5/rUqDy3HC/4IxsXdcV52m4KZVaYo1eTwuiQRhvjQ56013G23RBMTgeId3LYXWj/vWIaLg=="
+      },
+      "Microsoft.Web.Xdt": {
+        "type": "Transitive",
+        "resolved": "2.1.2",
+        "contentHash": "YIaNTOOtGzjF8CkQBOx3aUBWi0dD+g/nOjbpsVslx9G0/uldtpmoKLmyldmKdMv/gHs3qg40rBT3+wvEWoY5gg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "hSXaFmh7hNCuEoC4XNY5DrRkLDzYHqPx/Ik23R4J86Z7PE/Y6YidhG602dFVdLBRSdG6xp9NabH3dXpcoxWvww=="
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "0.86.0",
+        "contentHash": "5DbS1SlKLMi+WG00Cm0ueYf2oyXJrowETQk8nx96rmdjTuHsA3laPykGV7Sxi0R5Xxfx0Kh/EfacAZ1f6M7y/g=="
+      },
+      "stdole": {
+        "type": "Transitive",
+        "resolved": "7.0.3301",
+        "contentHash": "qQW62tF9+Naie3mQ3wAIY5SU8dqNRaiLUPwQ5v2sQRfzhY8h0M1arECSb68M4smTR89RAvuvXRgxBOiJOblkyA=="
+      },
+      "StreamJsonRpc": {
+        "type": "Transitive",
+        "resolved": "1.3.23",
+        "contentHash": "xJU19tAWEgmXn79SdwgUYPWXjXLxXX+xGHw9R1Ody4YCnRde51NqXk/fQyFbSWlQek1AI0m9f9OXqMIDwNxayw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.20",
+          "Newtonsoft.Json": "6.0.6"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "D3eEHg9hnGHTYsKBHiD/bT8pkBt2tS9BTTCRv2Wx+86FqWTzvsCjuB+I1j0gYIjKQiI5+NSrPtnxWmNHz4CCQw=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "QwALOmIQnwYXO7SZuzHvp+aF9+E8kouJl2JDHe9hyV/Mqzl2KhOwZMlN+mhyIYo5ggHcIVa/LN7E46WD26OEEg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "91UTX0e+S3j5pTVl7V9r8qjBElGhEFp+TBXNT64K68Ecy8DXtM66pFKWQktGBL4GYQRBuZXQdIxX2XuBb77gJA=="
+      },
+      "VSLangProj": {
+        "type": "Transitive",
+        "resolved": "7.0.3300",
+        "contentHash": "/0bb3ssO3rsPUZnVPFNAva2uBQLYNdT4hVLTx0XgxI8+/7acZVuMum18YOaOaE7hnLHMY00o4ypGL/L7JssEww==",
+        "dependencies": {
+          "EnvDTE": "8.0.1"
+        }
+      },
+      "VSLangProj110": {
+        "type": "Transitive",
+        "resolved": "11.0.61030",
+        "contentHash": "ZD0/JubfPji1tUTI7d1fOxEZqC23eHU7PIzoeR0LSY/dmDwEKa32xujNsgx6TT58ZRaSVFY27nUaiVaFdBz5Og==",
+        "dependencies": {
+          "VSLangProj80": "8.0.50727",
+          "VSLangProj90": "9.0.30729"
+        }
+      },
+      "VSLangProj157": {
+        "type": "Transitive",
+        "resolved": "15.7.0",
+        "contentHash": "PjFMHShxIYuZlwqa3feX3MpmCb0RsfCTExjgaJseODGJDXsjApJ5CWolJhlm956W1RHwALQXPiH786H3vZ8upw=="
+      },
+      "VSLangProj2": {
+        "type": "Transitive",
+        "resolved": "7.0.5000",
+        "contentHash": "A286CbJJxrKW4tpVyVaJit5rgVEmTJod/reZ8epekhZWiNoKv2YWkPGaCi0+gQXq4YepqPngE6UpQp5iAXyYDg==",
+        "dependencies": {
+          "VSLangProj": "7.0.3300"
+        }
+      },
+      "VSLangProj80": {
+        "type": "Transitive",
+        "resolved": "8.0.50727",
+        "contentHash": "I2xOMyQcbBXMXKE8zmHljkV1XLAltQ4/T5QRk8Q1mWz7fdd7x1OMp+2VqxZVAJ89Ebfs4wclkcACyvc4FY4wcQ==",
+        "dependencies": {
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "VSLangProj90": {
+        "type": "Transitive",
+        "resolved": "9.0.30729",
+        "contentHash": "xCG2hloStE4TCToHlBai7n/s33sfw/UiEkwqozRPt0AtW9JMr+0hXgGjlOyvPT2rgY6jjKywU55qoTXY2M8f6g=="
+      },
+      "VSSDK.DTE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "uUEaT0sCVnJR54vxfsf5xHpJVWgTrCbl10oKkFuCvJb3I6M5WW4cu9zCTqtYP1i1mYYySGGqooNYiO45kLUkiQ==",
+        "dependencies": {
+          "VSSDK.IDE": "[7.0.4, 8.0.0)"
+        }
+      },
+      "VSSDK.IDE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "KPXgpya93UDz/JZVegRr+AAewTGw46+8Aq7Dl22jWaqjH2KaH/5ycCLG0LET2OX4VBpp15IjhNw08Y5H0vJMKQ=="
+      },
+      "VSSDK.IDE.12": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "XYcSrKW9369JO1tOAuNxzZ6OOlx2QujDuboey4eYpp9GgA3Bd3mo0Fy2ZJd86sZqX27roBRzJfM1Ue/peyWOIg=="
+      },
+      "VSSDK.TemplateWizardInterface": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "stTXrh4h/mftHaQWKZn043WCgP7cmv3QVPB8M3bbBp99kktLdJBTXygPctpgeOYfsBi1TqKJIiNZjG3hCoHNMw==",
+        "dependencies": {
+          "VSSDK.DTE": "[7.0.4, 8.0.0)",
+          "VSSDK.IDE.12": "[12.0.4, 13.0.0)"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Indexing": {
+        "type": "Project",
+        "dependencies": {
+          "Lucene.Net": "3.0.3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.2",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "NuGet.Indexing": "5.0.0-preview3",
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3",
+          "VSLangProj110": "11.0.61030",
+          "VSLangProj157": "15.7.0",
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.SolutionRestoreManager.Interop": {
+        "type": "Project"
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      },
+      "NuGet.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "VSSDK.TemplateWizardInterface": "12.0.4"
+        }
+      },
+      "NuGet.VisualStudio.Common": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.TeamFoundationServer.ExtendedClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.ComponentModelHost": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Editor": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Language.Intellisense": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language.StandardClassification": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Services.Client": "16.144.1-preview",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.Shell.15.0": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "Microsoft.VisualStudio.Telemetry": "15.0.691-master31907920",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.8.132",
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "VSLangProj": "7.0.3300"
+        }
+      }
+    },
+    ".NETFramework,Version=v4.7.2/win": {},
+    ".NETFramework,Version=v4.7.2/win-x64": {},
+    ".NETFramework,Version=v4.7.2/win-x86": {}
+  }
+}

--- a/src/NuGet.Clients/NuGet.Tools/packages.lock.json
+++ b/src/NuGet.Clients/NuGet.Tools/packages.lock.json
@@ -1,0 +1,824 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "EnvDTE": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "ppW2nOaaMCOy1HNdUWvTM+btoXVbvntTL4RxVvEWBaHFk+Aj/r7vrS3t9x1QrHB4Y9Rrd2n7UAmjzet3Ps63XA==",
+        "dependencies": {
+          "stdole": "7.0.3301"
+        }
+      },
+      "EnvDTE80": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "3CBF4ileGBzGDPvNePcI3611sRVP5xMHXMZGGgQtcFV5nUu5L5QAZkkrgnBdM0oD9ZXc6dReVwo+tXOSR91z4Q==",
+        "dependencies": {
+          "EnvDTE": "8.0.1",
+          "stdole": "7.0.3301"
+        }
+      },
+      "Lucene.Net": {
+        "type": "Transitive",
+        "resolved": "3.0.3",
+        "contentHash": "A/70q4eDcuuafQeDB9eaiDP9FQG7X29T4VIYRphS7Wk8kAM9gNcfVqYyd0H8BJ1BTpA5C1ORm9RzFn4BiNavrw==",
+        "dependencies": {
+          "SharpZipLib": "0.86.0"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "iAzPAX/guSnBXJxM+PZ+dVXF+vmE8hxcxJ9fOFrvHUv5cY/ILD1icf2sKjJLltJD0Na8r9oGF5PjNiTMxK8EYw==",
+        "dependencies": {
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.ApplicationInsights.PersistenceChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "V7peE2ssNCCfOqzk1kOJfr3zZLDDPs+M88N34e98L+YPpAoL11wQkLpPxWmztjipTD+DBxJO6PNaVsM9q5bM/A==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "0.17.2-build00169"
+        }
+      },
+      "Microsoft.ApplicationInsights.UniversalTelemetryChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "8sg18/b63fhYjpr0kZ2v/NEjOEJ3gwpzXaaKZTth04AUPuOKjWvS3/pyVIRQ1mUEhrV3Xn3S2/TkLiWLCTpo7A==",
+        "dependencies": {
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Client": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "w5w8GVLMmo+JzizmcuV01tgYn2OsaVhxGAO0ryKXkO5sob6EVjzcoJv8NHL3Xm98vywSh7kRgeLqbA/lxZuTXg==",
+        "dependencies": {
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Core": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "bP+PAx17AVQJ19aU9N7yMnz8yST1U9cekbYHRyIUvQzFLqqzrthEs/gLdyZiLJPmL4ZABuvwGBOXG/ukqmsbDg==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3"
+        }
+      },
+      "Microsoft.Bcl": {
+        "type": "Transitive",
+        "resolved": "1.1.8",
+        "contentHash": "gM+PUzd8ONxJpcPJeNppCJPklDhDuPUMVQkxvK4fe0rd9WyqBNPh4+UFx3Uv8zuG4C1Gapu1c25sfotE7TQtig==",
+        "dependencies": {
+          "Microsoft.Bcl.Build": "1.0.14"
+        }
+      },
+      "Microsoft.Bcl.Async": {
+        "type": "Transitive",
+        "resolved": "1.0.168",
+        "contentHash": "tUNC02eBwDKpGre0BcNIvblLv1q0Q3DnS/vtkRHj2FE1sXwt386HAudztyl5C0U88hllrqHDvtlz8bK0Y8cHDA==",
+        "dependencies": {
+          "Microsoft.Bcl": "1.1.8"
+        }
+      },
+      "Microsoft.Bcl.Build": {
+        "type": "Transitive",
+        "resolved": "1.0.14",
+        "contentHash": "cDLKSvNvRa519hplsbSoYqO69TjdDIhfjtKUM0g20/nVROoWsGav9KCI9HtnGjLmdV1+TcUUDhbotcllibjPEA=="
+      },
+      "Microsoft.Diagnostics.Tracing.EventSource.Redist": {
+        "type": "Transitive",
+        "resolved": "1.1.16-beta",
+        "contentHash": "o1gsKlGjLAnSHRyWBygKnO55Kp0bRXB3AO9e8OeAnqQH7HA5MAW6YAPEEy5e3aRE//7AlkdPtq28F19NqOLZQQ=="
+      },
+      "Microsoft.IdentityModel.Clients.ActiveDirectory": {
+        "type": "Transitive",
+        "resolved": "3.17.2",
+        "contentHash": "zvDoWJlrKg1TQeJScq+5znAZtduyJHlT7M9gEquUjm2PQCIR4C5PqJ0E8xYQsV3eF4bY8cW54uyr0FyhiN0MtQ=="
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "kbmvhMYu5OZXWN3toFXhrj3bSN7B+ZzNWzAZQ4Ofp5x2srk9ZCYFljETGS5faxzPwGd5+7W4WZlAfOI7QvzhlA=="
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "wVWYpXfE6gpkSrIRNo5TDVC7ss6KPTTrmT6x8ysHiZRIMSRAZ8TyHEAmpdATBBPNRmnlevyAs4CK6nPfDpCTqw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "dsDJhsL2zJyL5az5D3LhILIQRt+nXFQ64Bclj6vspIwD96sYRK/fPKTP8xLcLyw0fcosiFUgmWOXRLkWcAm1Pw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]"
+        }
+      },
+      "Microsoft.TeamFoundationServer.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "UBwF/VUULHHy5WHpShIW0ZdcG10N3jADUlW+KEgA7qiKCDB8VYbv7FR0miwutTtyuYFh/lE+G6q4IF0ugDyX6A==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3"
+        }
+      },
+      "Microsoft.TeamFoundationServer.ExtendedClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "g3G19/HJEOeYR8xFnNWSegBqRcMZRUyPLBmf5JF24pqhVqrY31fSA7ZBUX9r6nHHdSBkmZbRQisR/IvwrfDGqQ==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.AspNet.WebApi.Core": "5.2.3",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.TeamFoundationServer.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.ComponentModelHost": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "79WnMNn2T4xDqNVCAR9u3r2OXrA4QPOHYy36MMDjfIKvhL5mQ5Osgc+e+3wVVfeyD4EUdAYs/hC74+w4k/6ktg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319"
+        }
+      },
+      "Microsoft.VisualStudio.CoreUtility": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "eiepEOoyUJ+5K+7qitTMzXBJB6GcOMp5LdcedFa30dLxGPwgKY+XdVjiqcrxyQps4i7+hHNlYWvZCR6SKnWLRA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.23",
+          "System.ValueTuple": "4.3.0"
+        }
+      },
+      "Microsoft.VisualStudio.Editor": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "EnlJfSZABDJP36kg5td5A4HXqR2TWQrCgjXvDyBTF3peyDFQR6R6XZ63Wul+BY6Yract+UHP6E/8I+LlZ2BvRw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50727",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.ImageCatalog": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "X3nCoei2FTkh1m8tDDL8zEi9nFLVxjyRzMgL5HzPzio4uDCsKW1Oa/F/BkfICwx3cEPuwsyT7MlJjTgVqIbXgQ=="
+      },
+      "Microsoft.VisualStudio.Imaging": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "pDNYWW/w1hZF7Xk1SVhCMQxpxz5jFbaEkqrmSVRp7B8o6uei2fDrAscbMJmTxGcVA4rzV02ABytSCrc3jr1LvA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26930",
+        "contentHash": "gbmcUTMhYF/9oDUHI6b6Ki1PBaEkiqDhYNIdkYrrGy7XN0LhYew/BggDCJORUiEbzc5zJ8Hlc40jYGmqx4qfLg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16"
+        }
+      },
+      "Microsoft.VisualStudio.Language": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "BWRDlPth8bLOqUH7j6ClkBFPwjJ83aApHcr1GtJNPZfSj4Nw32pYRLIxCuBs2NLS2f9AF80yl0AYrzVlO6YRWg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Newtonsoft.Json": "9.0.1",
+          "StreamJsonRpc": "1.3.23",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Language.Intellisense": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "GShi/VaASPpvPLnF+rbJcfjbOlxAgpgtxc+PuQLruStw/9DVsL1LF/dB4dvdzRbkci8Ux0TvkI+Csd0/KeIOAg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Language.StandardClassification": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "fU1175eTKfdg4XRVwrl08wPNT4/KDuHKxgKrQ/aGaFzA93NMqtxsgyw6PB/zTA16j1eeIvqCOZpZOWigkuQGGg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.OLE.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "6W3YMtSGt+hHRvAqbktXHLWZgEbEpuFZxuC1XiKCX4Th3fGv+7SeKGGH7Gmeu9fp/8kNqq7uovqWaHfhni13Hw=="
+      },
+      "Microsoft.VisualStudio.RemoteControl": {
+        "type": "Transitive",
+        "resolved": "14.0.249-master2E2DC10C",
+        "contentHash": "bqmdFTlPzEH0VkncJBTq3bXmvW0SKM/pCQcKBgYZfCn/othfLnjChUKCyHvwQyJcjcy8JRnFXRejBQ0pqPXpqQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1"
+        }
+      },
+      "Microsoft.VisualStudio.SDK.EmbedInteropTypes": {
+        "type": "Transitive",
+        "resolved": "15.0.16",
+        "contentHash": "iI+b/DL6AaN/D8vHXcLorZJIjY0MvQehT6xfI3mx+AD2w1f/mEGtuXQE5mFfYu425FSDrPtoBIDRf+tKtLDA5g=="
+      },
+      "Microsoft.VisualStudio.Services.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "bdqdkWc2yWnsOD2yVeKNc/u/M2Lq6xs6C2tqcvuMnq7HT0nu7tYq72ymnk4iQQBJGMGZfJFPOrI8r/7tDhJ0KA==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Services.InteractiveClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "5fvdv0vPMcW+ANVv7HLXeVMKaDST1ydI3y10WMTP+tKDNp1Se4r8XzAuhdG9m+uh5Wozxj5cA9CK3wPfX+BQEA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.15.0": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "QurLa40g6/qehW75Qpi5LR7EE9vSW/mZuc5QwlTcBcW9k/H7jzBPwxcmAzZ5teswJPkD0+VvOQecTEIguOvnVQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging": "15.8.28010",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Framework": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": "14.3.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": "15.0.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": "15.6.27413",
+          "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30730",
+          "Microsoft.VisualStudio.Text.Data": "15.6.27740",
+          "Microsoft.VisualStudio.Threading": "15.6.31"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Framework": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "BRqUcfXNZ17aiuTTr1jawd/WHpt/A70WmDFUwgDS+vwGd0fp8fendG4ANLY5a4KI7+Yhyhz5DO/jsL3UBujNcQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "15.6.27740",
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6072",
+        "contentHash": "hoaT0t8DMA5YwPQEeiRD7UJpndgJDyK00uYcQl3I2+KvgQroo7lAZfkPNbGIhy2OGW4nOEqlvr0i5OE71hgT1w==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.10.0": {
+        "type": "Transitive",
+        "resolved": "10.0.30320",
+        "contentHash": "RKmdy0EgbXFtzjM2Kcdv9w9XdMJS81QykYUb1D/5SnvUYn28ElVt3criqGlvcC1syLJLmk9DdHomOhX6R50e1A==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.11.0": {
+        "type": "Transitive",
+        "resolved": "11.0.61031",
+        "contentHash": "N8il5VcZNr4GZeAvItmpWE4A5DKwSpFelQQ+I1VoUm1kVj+6dPieZXlhdbFC3bJVyCs1gl0uUzOH7FDVGfdDCw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30320"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.12.0": {
+        "type": "Transitive",
+        "resolved": "12.0.30111",
+        "contentHash": "ToNByCRLH875yHd1G43EmGuQz16bAV0PKICvzArpjuNugx/Cl4Djg15NHu7XUdPHm+UpAfH4W7nYh0u8NxqWHw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26929",
+        "contentHash": "J1WemvOhywfve6BbN91azp2nflhc68bpeGFFazoNnYl4MqEjRM0IUe3eNuieoeRw7a+UsHDubne/7K7XJ8yVdA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.26930",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.0.26929",
+        "contentHash": "hHAmrLBvxnmZDPPIOw6zQjsYenbqAcJfcIHSHDl5n/FyBC0VYleDwG2XcEOx1OkXWXReDMGY9lfeHyRv5SSJJQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.12",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.6.27413",
+        "contentHash": "Cb0fRe0ek16fLkE0Buea8zU55zu2WyzBp+8HhK1j3azndHBx0FZAfcDj3xnSum8kllcwQKhEerqEfxdpmwt1mw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "gGhUi9HaXGFC48HxZPV4nYcjygT/vcYYUow5iNocHp/EfwCCnDTUqe5AisH/o1pqB+iakw64g73KSDFsRNAXcA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.9.0": {
+        "type": "Transitive",
+        "resolved": "9.0.30730",
+        "contentHash": "AjBQfZ3HYtpRLFkLjClhR1vWffeEQXScMkhssKxnDnXFc59zOY3RToYxmIS6ZmjD5MS5ICwJDWy7hPOpKbh3Qg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Telemetry": {
+        "type": "Transitive",
+        "resolved": "15.0.691-master31907920",
+        "contentHash": "nTDxnBLOEY+NsjvnGpEeUHmzJrKtUOJjbgxkYd3UdblGlQrLjceIvkpr9c5v1yWwv8byAa2R6itlutjNjb53dA==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.PersistenceChannel": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.UniversalTelemetryChannel": "[0.17.2-build00169]",
+          "Microsoft.Bcl": "1.1.8",
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Bcl.Build": "1.0.14",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta",
+          "Microsoft.VisualStudio.RemoteControl": "[14.0.249-master2E2DC10C]",
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1",
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Data": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "e4OUFLIJ+roHfIeG++y6GZK1S6E0D91iB6LTDQLTz7cC4BvOE3yU3/Eki6Xdy/6inTUKsdqsYUFYEBTWeeF5vA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Logic": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "OG+pya+vxVGjDBp98mBjOWKRj295vwe5HtUmns1w/h727uhO4Y6KxYE4wRs7nOd7JMzB/WSAx2cgdBLtjBOoUg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "k8uKuTcTdOeZEtjrKXQAquWlEKswH2x0A/Ycqjinj7NJ6ykajccNCKiGb6jAJzVBkepSn81pWIO2QLpXKzcHuw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI.Wpf": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "Oa7/4XzATSR683uEK027pkQaV8yoebHABIRWuKZANe2cKWbInAMeoWibGUFW6T58W+8koX7zOIprTwYe02q4Og==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "+xdOtk+Hxdt4Bewl4kCA7KQsI7IZa58uZdnkTcNV9CEtT6Om6VxApAMPIBNvt7sZQoA6SOYubX4uAzEADHX55g==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.10.0": {
+        "type": "Transitive",
+        "resolved": "10.0.30319",
+        "contentHash": "NXkMxLGqJqHBUrCYi7EHyhrzWQNf5Pb1IFiJJW0JIW4BWzC5sT4PHVZYy0Ew8nRBrn3ZjMLUWOR50sFhYMDbAA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50727"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "AicV/XF3LkQhplsacUr1sUyVL+7kuTk/RczvvYAFUr1PGpNtoHh17DqQYfI3zs/8lQIB+RCmpi6ZU7t0SmY0mg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072"
+        }
+      },
+      "Microsoft.VisualStudio.Threading": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "KLjgM7NPjNg0FNv4z8qx8rpiAOnI5ZB6jrZWfJ4ho2YHtxT2dhWi8e94q9+BR4GBOks9ynL90LAnZX2CE3n4/Q==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Validation": "15.3.15"
+        }
+      },
+      "Microsoft.VisualStudio.Threading.Analyzers": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "SCFubDweTsyzzmXOmQOFedpSnUsN7Rrvh/ZD2phYRkOVBZtz3dX3LVen6IhcePZuDEQMtl4gNW9kzVpjTLlZ0A=="
+      },
+      "Microsoft.VisualStudio.Utilities": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "A36/u2YlW0Fs2H2WJSyTO9xW1FMGzKD+Oqtvfmgff+LyhlO8ZcSzR8waD7DKh2gZCyCR4M89m1VHvHn0Z/s5xg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.6.31",
+          "StreamJsonRpc": "1.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Utilities.Internal": {
+        "type": "Transitive",
+        "resolved": "14.0.54-masterD06D5CD1",
+        "contentHash": "vX0Ka1y7dEUs9HGTCw5BNTPREKJXy04OCy/GaDAgken2bSsjPZON8IkiTDFvkN0JtGuGIHCn9AU12lJU/4HLnw=="
+      },
+      "Microsoft.VisualStudio.Validation": {
+        "type": "Transitive",
+        "resolved": "15.3.15",
+        "contentHash": "bvJIwuCLqu7YKXcZqY85VJy0ljtm9QSRkq4CD2bpO/GHynsm72uZxjBDa050VY7kElXS8mb7VW5JNUfg4D/UBA=="
+      },
+      "Microsoft.VisualStudio.Workspace.VSIntegration": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "eSm+OpRg2C7L+h9UXvbzhwwBPdEk/8VAciEVdgtip5yZvhN2JrnzZxl1gPQdmQT8kVSn+B492fHOlDRa/ljcmA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspaces": "15.0.198-pre"
+        }
+      },
+      "Microsoft.VisualStudio.Workspaces": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "Bk83t69Kmo+9t60N5/rUqDy3HC/4IxsXdcV52m4KZVaYo1eTwuiQRhvjQ56013G23RBMTgeId3LYXWj/vWIaLg=="
+      },
+      "Microsoft.Web.Xdt": {
+        "type": "Transitive",
+        "resolved": "2.1.2",
+        "contentHash": "YIaNTOOtGzjF8CkQBOx3aUBWi0dD+g/nOjbpsVslx9G0/uldtpmoKLmyldmKdMv/gHs3qg40rBT3+wvEWoY5gg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "hSXaFmh7hNCuEoC4XNY5DrRkLDzYHqPx/Ik23R4J86Z7PE/Y6YidhG602dFVdLBRSdG6xp9NabH3dXpcoxWvww=="
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "0.86.0",
+        "contentHash": "5DbS1SlKLMi+WG00Cm0ueYf2oyXJrowETQk8nx96rmdjTuHsA3laPykGV7Sxi0R5Xxfx0Kh/EfacAZ1f6M7y/g=="
+      },
+      "stdole": {
+        "type": "Transitive",
+        "resolved": "7.0.3301",
+        "contentHash": "qQW62tF9+Naie3mQ3wAIY5SU8dqNRaiLUPwQ5v2sQRfzhY8h0M1arECSb68M4smTR89RAvuvXRgxBOiJOblkyA=="
+      },
+      "StreamJsonRpc": {
+        "type": "Transitive",
+        "resolved": "1.3.23",
+        "contentHash": "xJU19tAWEgmXn79SdwgUYPWXjXLxXX+xGHw9R1Ody4YCnRde51NqXk/fQyFbSWlQek1AI0m9f9OXqMIDwNxayw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.20",
+          "Newtonsoft.Json": "6.0.6"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "D3eEHg9hnGHTYsKBHiD/bT8pkBt2tS9BTTCRv2Wx+86FqWTzvsCjuB+I1j0gYIjKQiI5+NSrPtnxWmNHz4CCQw=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "QwALOmIQnwYXO7SZuzHvp+aF9+E8kouJl2JDHe9hyV/Mqzl2KhOwZMlN+mhyIYo5ggHcIVa/LN7E46WD26OEEg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "91UTX0e+S3j5pTVl7V9r8qjBElGhEFp+TBXNT64K68Ecy8DXtM66pFKWQktGBL4GYQRBuZXQdIxX2XuBb77gJA=="
+      },
+      "VSLangProj": {
+        "type": "Transitive",
+        "resolved": "7.0.3300",
+        "contentHash": "/0bb3ssO3rsPUZnVPFNAva2uBQLYNdT4hVLTx0XgxI8+/7acZVuMum18YOaOaE7hnLHMY00o4ypGL/L7JssEww==",
+        "dependencies": {
+          "EnvDTE": "8.0.1"
+        }
+      },
+      "VSLangProj110": {
+        "type": "Transitive",
+        "resolved": "11.0.61030",
+        "contentHash": "ZD0/JubfPji1tUTI7d1fOxEZqC23eHU7PIzoeR0LSY/dmDwEKa32xujNsgx6TT58ZRaSVFY27nUaiVaFdBz5Og==",
+        "dependencies": {
+          "VSLangProj80": "8.0.50727",
+          "VSLangProj90": "9.0.30729"
+        }
+      },
+      "VSLangProj157": {
+        "type": "Transitive",
+        "resolved": "15.7.0",
+        "contentHash": "PjFMHShxIYuZlwqa3feX3MpmCb0RsfCTExjgaJseODGJDXsjApJ5CWolJhlm956W1RHwALQXPiH786H3vZ8upw=="
+      },
+      "VSLangProj2": {
+        "type": "Transitive",
+        "resolved": "7.0.5000",
+        "contentHash": "A286CbJJxrKW4tpVyVaJit5rgVEmTJod/reZ8epekhZWiNoKv2YWkPGaCi0+gQXq4YepqPngE6UpQp5iAXyYDg==",
+        "dependencies": {
+          "VSLangProj": "7.0.3300"
+        }
+      },
+      "VSLangProj80": {
+        "type": "Transitive",
+        "resolved": "8.0.50727",
+        "contentHash": "I2xOMyQcbBXMXKE8zmHljkV1XLAltQ4/T5QRk8Q1mWz7fdd7x1OMp+2VqxZVAJ89Ebfs4wclkcACyvc4FY4wcQ==",
+        "dependencies": {
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "VSLangProj90": {
+        "type": "Transitive",
+        "resolved": "9.0.30729",
+        "contentHash": "xCG2hloStE4TCToHlBai7n/s33sfw/UiEkwqozRPt0AtW9JMr+0hXgGjlOyvPT2rgY6jjKywU55qoTXY2M8f6g=="
+      },
+      "VSSDK.DTE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "uUEaT0sCVnJR54vxfsf5xHpJVWgTrCbl10oKkFuCvJb3I6M5WW4cu9zCTqtYP1i1mYYySGGqooNYiO45kLUkiQ==",
+        "dependencies": {
+          "VSSDK.IDE": "[7.0.4, 8.0.0)"
+        }
+      },
+      "VSSDK.IDE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "KPXgpya93UDz/JZVegRr+AAewTGw46+8Aq7Dl22jWaqjH2KaH/5ycCLG0LET2OX4VBpp15IjhNw08Y5H0vJMKQ=="
+      },
+      "VSSDK.IDE.12": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "XYcSrKW9369JO1tOAuNxzZ6OOlx2QujDuboey4eYpp9GgA3Bd3mo0Fy2ZJd86sZqX27roBRzJfM1Ue/peyWOIg=="
+      },
+      "VSSDK.TemplateWizardInterface": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "stTXrh4h/mftHaQWKZn043WCgP7cmv3QVPB8M3bbBp99kktLdJBTXygPctpgeOYfsBi1TqKJIiNZjG3hCoHNMw==",
+        "dependencies": {
+          "VSSDK.DTE": "[7.0.4, 8.0.0)",
+          "VSSDK.IDE.12": "[12.0.4, 13.0.0)"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Console": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.TextManager.Interop.10.0": "10.0.30319",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.PackageManagement.UI": "5.0.0-preview3",
+          "NuGet.PackageManagement.VisualStudio": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Indexing": {
+        "type": "Project",
+        "dependencies": {
+          "Lucene.Net": "3.0.3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.2",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement.UI": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "NuGet.Indexing": "5.0.0-preview3",
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.PackageManagement.VisualStudio": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "NuGet.Indexing": "5.0.0-preview3",
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3",
+          "VSLangProj110": "11.0.61030",
+          "VSLangProj157": "15.7.0",
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      },
+      "NuGet.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "VSSDK.TemplateWizardInterface": "12.0.4"
+        }
+      },
+      "NuGet.VisualStudio.Common": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.TeamFoundationServer.ExtendedClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.ComponentModelHost": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Editor": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Language.Intellisense": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language.StandardClassification": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Services.Client": "16.144.1-preview",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.Shell.15.0": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "Microsoft.VisualStudio.Telemetry": "15.0.691-master31907920",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.8.132",
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "VSLangProj": "7.0.3300"
+        }
+      }
+    },
+    ".NETFramework,Version=v4.7.2/win": {},
+    ".NETFramework,Version=v4.7.2/win-x64": {},
+    ".NETFramework,Version=v4.7.2/win-x86": {}
+  }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/packages.lock.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/packages.lock.json
@@ -1,0 +1,1032 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "Lucene.Net": {
+        "type": "Direct",
+        "requested": "[3.0.3, )",
+        "resolved": "3.0.3",
+        "contentHash": "A/70q4eDcuuafQeDB9eaiDP9FQG7X29T4VIYRphS7Wk8kAM9gNcfVqYyd0H8BJ1BTpA5C1ORm9RzFn4BiNavrw==",
+        "dependencies": {
+          "SharpZipLib": "0.86.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "EnvDTE": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "ppW2nOaaMCOy1HNdUWvTM+btoXVbvntTL4RxVvEWBaHFk+Aj/r7vrS3t9x1QrHB4Y9Rrd2n7UAmjzet3Ps63XA==",
+        "dependencies": {
+          "stdole": "7.0.3301"
+        }
+      },
+      "EnvDTE80": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "3CBF4ileGBzGDPvNePcI3611sRVP5xMHXMZGGgQtcFV5nUu5L5QAZkkrgnBdM0oD9ZXc6dReVwo+tXOSR91z4Q==",
+        "dependencies": {
+          "EnvDTE": "8.0.1",
+          "stdole": "7.0.3301"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "iAzPAX/guSnBXJxM+PZ+dVXF+vmE8hxcxJ9fOFrvHUv5cY/ILD1icf2sKjJLltJD0Na8r9oGF5PjNiTMxK8EYw==",
+        "dependencies": {
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.ApplicationInsights.PersistenceChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "V7peE2ssNCCfOqzk1kOJfr3zZLDDPs+M88N34e98L+YPpAoL11wQkLpPxWmztjipTD+DBxJO6PNaVsM9q5bM/A==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "0.17.2-build00169"
+        }
+      },
+      "Microsoft.ApplicationInsights.UniversalTelemetryChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "8sg18/b63fhYjpr0kZ2v/NEjOEJ3gwpzXaaKZTth04AUPuOKjWvS3/pyVIRQ1mUEhrV3Xn3S2/TkLiWLCTpo7A==",
+        "dependencies": {
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Client": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "w5w8GVLMmo+JzizmcuV01tgYn2OsaVhxGAO0ryKXkO5sob6EVjzcoJv8NHL3Xm98vywSh7kRgeLqbA/lxZuTXg==",
+        "dependencies": {
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Core": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "bP+PAx17AVQJ19aU9N7yMnz8yST1U9cekbYHRyIUvQzFLqqzrthEs/gLdyZiLJPmL4ZABuvwGBOXG/ukqmsbDg==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3"
+        }
+      },
+      "Microsoft.Bcl": {
+        "type": "Transitive",
+        "resolved": "1.1.8",
+        "contentHash": "gM+PUzd8ONxJpcPJeNppCJPklDhDuPUMVQkxvK4fe0rd9WyqBNPh4+UFx3Uv8zuG4C1Gapu1c25sfotE7TQtig==",
+        "dependencies": {
+          "Microsoft.Bcl.Build": "1.0.14"
+        }
+      },
+      "Microsoft.Bcl.Async": {
+        "type": "Transitive",
+        "resolved": "1.0.168",
+        "contentHash": "tUNC02eBwDKpGre0BcNIvblLv1q0Q3DnS/vtkRHj2FE1sXwt386HAudztyl5C0U88hllrqHDvtlz8bK0Y8cHDA==",
+        "dependencies": {
+          "Microsoft.Bcl": "1.1.8"
+        }
+      },
+      "Microsoft.Bcl.Build": {
+        "type": "Transitive",
+        "resolved": "1.0.14",
+        "contentHash": "cDLKSvNvRa519hplsbSoYqO69TjdDIhfjtKUM0g20/nVROoWsGav9KCI9HtnGjLmdV1+TcUUDhbotcllibjPEA=="
+      },
+      "Microsoft.Build.Framework": {
+        "type": "Transitive",
+        "resolved": "15.6.85",
+        "contentHash": "hwigmviEq8nOOd973M7jVXhuFXHT9rupUxeJ0sdbsNi6mgiXayUvVkj2k3mKXOusMTkuiYqcYrajr/rM2BJjUA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Process": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks.Parallel": "4.0.1",
+          "System.Threading.Thread": "4.0.0"
+        }
+      },
+      "Microsoft.Diagnostics.Tracing.EventSource.Redist": {
+        "type": "Transitive",
+        "resolved": "1.1.16-beta",
+        "contentHash": "o1gsKlGjLAnSHRyWBygKnO55Kp0bRXB3AO9e8OeAnqQH7HA5MAW6YAPEEy5e3aRE//7AlkdPtq28F19NqOLZQQ=="
+      },
+      "Microsoft.IdentityModel.Clients.ActiveDirectory": {
+        "type": "Transitive",
+        "resolved": "3.17.2",
+        "contentHash": "zvDoWJlrKg1TQeJScq+5znAZtduyJHlT7M9gEquUjm2PQCIR4C5PqJ0E8xYQsV3eF4bY8cW54uyr0FyhiN0MtQ=="
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "kbmvhMYu5OZXWN3toFXhrj3bSN7B+ZzNWzAZQ4Ofp5x2srk9ZCYFljETGS5faxzPwGd5+7W4WZlAfOI7QvzhlA=="
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "wVWYpXfE6gpkSrIRNo5TDVC7ss6KPTTrmT6x8ysHiZRIMSRAZ8TyHEAmpdATBBPNRmnlevyAs4CK6nPfDpCTqw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "dsDJhsL2zJyL5az5D3LhILIQRt+nXFQ64Bclj6vspIwD96sYRK/fPKTP8xLcLyw0fcosiFUgmWOXRLkWcAm1Pw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]"
+        }
+      },
+      "Microsoft.TeamFoundationServer.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "UBwF/VUULHHy5WHpShIW0ZdcG10N3jADUlW+KEgA7qiKCDB8VYbv7FR0miwutTtyuYFh/lE+G6q4IF0ugDyX6A==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3"
+        }
+      },
+      "Microsoft.TeamFoundationServer.ExtendedClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "g3G19/HJEOeYR8xFnNWSegBqRcMZRUyPLBmf5JF24pqhVqrY31fSA7ZBUX9r6nHHdSBkmZbRQisR/IvwrfDGqQ==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.AspNet.WebApi.Core": "5.2.3",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.TeamFoundationServer.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.ComponentModelHost": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "79WnMNn2T4xDqNVCAR9u3r2OXrA4QPOHYy36MMDjfIKvhL5mQ5Osgc+e+3wVVfeyD4EUdAYs/hC74+w4k/6ktg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319"
+        }
+      },
+      "Microsoft.VisualStudio.CoreUtility": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "eiepEOoyUJ+5K+7qitTMzXBJB6GcOMp5LdcedFa30dLxGPwgKY+XdVjiqcrxyQps4i7+hHNlYWvZCR6SKnWLRA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.23",
+          "System.ValueTuple": "4.3.0"
+        }
+      },
+      "Microsoft.VisualStudio.Editor": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "EnlJfSZABDJP36kg5td5A4HXqR2TWQrCgjXvDyBTF3peyDFQR6R6XZ63Wul+BY6Yract+UHP6E/8I+LlZ2BvRw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50727",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.ImageCatalog": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "X3nCoei2FTkh1m8tDDL8zEi9nFLVxjyRzMgL5HzPzio4uDCsKW1Oa/F/BkfICwx3cEPuwsyT7MlJjTgVqIbXgQ=="
+      },
+      "Microsoft.VisualStudio.Imaging": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "pDNYWW/w1hZF7Xk1SVhCMQxpxz5jFbaEkqrmSVRp7B8o6uei2fDrAscbMJmTxGcVA4rzV02ABytSCrc3jr1LvA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26930",
+        "contentHash": "gbmcUTMhYF/9oDUHI6b6Ki1PBaEkiqDhYNIdkYrrGy7XN0LhYew/BggDCJORUiEbzc5zJ8Hlc40jYGmqx4qfLg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16"
+        }
+      },
+      "Microsoft.VisualStudio.Language": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "BWRDlPth8bLOqUH7j6ClkBFPwjJ83aApHcr1GtJNPZfSj4Nw32pYRLIxCuBs2NLS2f9AF80yl0AYrzVlO6YRWg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Newtonsoft.Json": "9.0.1",
+          "StreamJsonRpc": "1.3.23",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Language.Intellisense": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "GShi/VaASPpvPLnF+rbJcfjbOlxAgpgtxc+PuQLruStw/9DVsL1LF/dB4dvdzRbkci8Ux0TvkI+Csd0/KeIOAg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Language.StandardClassification": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "fU1175eTKfdg4XRVwrl08wPNT4/KDuHKxgKrQ/aGaFzA93NMqtxsgyw6PB/zTA16j1eeIvqCOZpZOWigkuQGGg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.OLE.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "6W3YMtSGt+hHRvAqbktXHLWZgEbEpuFZxuC1XiKCX4Th3fGv+7SeKGGH7Gmeu9fp/8kNqq7uovqWaHfhni13Hw=="
+      },
+      "Microsoft.VisualStudio.RemoteControl": {
+        "type": "Transitive",
+        "resolved": "14.0.249-master2E2DC10C",
+        "contentHash": "bqmdFTlPzEH0VkncJBTq3bXmvW0SKM/pCQcKBgYZfCn/othfLnjChUKCyHvwQyJcjcy8JRnFXRejBQ0pqPXpqQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1"
+        }
+      },
+      "Microsoft.VisualStudio.SDK.EmbedInteropTypes": {
+        "type": "Transitive",
+        "resolved": "15.0.16",
+        "contentHash": "iI+b/DL6AaN/D8vHXcLorZJIjY0MvQehT6xfI3mx+AD2w1f/mEGtuXQE5mFfYu425FSDrPtoBIDRf+tKtLDA5g=="
+      },
+      "Microsoft.VisualStudio.Services.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "bdqdkWc2yWnsOD2yVeKNc/u/M2Lq6xs6C2tqcvuMnq7HT0nu7tYq72ymnk4iQQBJGMGZfJFPOrI8r/7tDhJ0KA==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Services.InteractiveClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "5fvdv0vPMcW+ANVv7HLXeVMKaDST1ydI3y10WMTP+tKDNp1Se4r8XzAuhdG9m+uh5Wozxj5cA9CK3wPfX+BQEA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.15.0": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "QurLa40g6/qehW75Qpi5LR7EE9vSW/mZuc5QwlTcBcW9k/H7jzBPwxcmAzZ5teswJPkD0+VvOQecTEIguOvnVQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging": "15.8.28010",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Framework": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": "14.3.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": "15.0.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": "15.6.27413",
+          "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30730",
+          "Microsoft.VisualStudio.Text.Data": "15.6.27740",
+          "Microsoft.VisualStudio.Threading": "15.6.31"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Framework": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "BRqUcfXNZ17aiuTTr1jawd/WHpt/A70WmDFUwgDS+vwGd0fp8fendG4ANLY5a4KI7+Yhyhz5DO/jsL3UBujNcQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "15.6.27740",
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6072",
+        "contentHash": "hoaT0t8DMA5YwPQEeiRD7UJpndgJDyK00uYcQl3I2+KvgQroo7lAZfkPNbGIhy2OGW4nOEqlvr0i5OE71hgT1w==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.10.0": {
+        "type": "Transitive",
+        "resolved": "10.0.30320",
+        "contentHash": "RKmdy0EgbXFtzjM2Kcdv9w9XdMJS81QykYUb1D/5SnvUYn28ElVt3criqGlvcC1syLJLmk9DdHomOhX6R50e1A==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.11.0": {
+        "type": "Transitive",
+        "resolved": "11.0.61031",
+        "contentHash": "N8il5VcZNr4GZeAvItmpWE4A5DKwSpFelQQ+I1VoUm1kVj+6dPieZXlhdbFC3bJVyCs1gl0uUzOH7FDVGfdDCw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30320"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.12.0": {
+        "type": "Transitive",
+        "resolved": "12.0.30111",
+        "contentHash": "ToNByCRLH875yHd1G43EmGuQz16bAV0PKICvzArpjuNugx/Cl4Djg15NHu7XUdPHm+UpAfH4W7nYh0u8NxqWHw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26929",
+        "contentHash": "J1WemvOhywfve6BbN91azp2nflhc68bpeGFFazoNnYl4MqEjRM0IUe3eNuieoeRw7a+UsHDubne/7K7XJ8yVdA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.26930",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.0.26929",
+        "contentHash": "hHAmrLBvxnmZDPPIOw6zQjsYenbqAcJfcIHSHDl5n/FyBC0VYleDwG2XcEOx1OkXWXReDMGY9lfeHyRv5SSJJQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.12",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.6.27413",
+        "contentHash": "Cb0fRe0ek16fLkE0Buea8zU55zu2WyzBp+8HhK1j3azndHBx0FZAfcDj3xnSum8kllcwQKhEerqEfxdpmwt1mw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "gGhUi9HaXGFC48HxZPV4nYcjygT/vcYYUow5iNocHp/EfwCCnDTUqe5AisH/o1pqB+iakw64g73KSDFsRNAXcA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.9.0": {
+        "type": "Transitive",
+        "resolved": "9.0.30730",
+        "contentHash": "AjBQfZ3HYtpRLFkLjClhR1vWffeEQXScMkhssKxnDnXFc59zOY3RToYxmIS6ZmjD5MS5ICwJDWy7hPOpKbh3Qg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Telemetry": {
+        "type": "Transitive",
+        "resolved": "15.0.691-master31907920",
+        "contentHash": "nTDxnBLOEY+NsjvnGpEeUHmzJrKtUOJjbgxkYd3UdblGlQrLjceIvkpr9c5v1yWwv8byAa2R6itlutjNjb53dA==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.PersistenceChannel": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.UniversalTelemetryChannel": "[0.17.2-build00169]",
+          "Microsoft.Bcl": "1.1.8",
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Bcl.Build": "1.0.14",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta",
+          "Microsoft.VisualStudio.RemoteControl": "[14.0.249-master2E2DC10C]",
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1",
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Data": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "e4OUFLIJ+roHfIeG++y6GZK1S6E0D91iB6LTDQLTz7cC4BvOE3yU3/Eki6Xdy/6inTUKsdqsYUFYEBTWeeF5vA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Logic": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "OG+pya+vxVGjDBp98mBjOWKRj295vwe5HtUmns1w/h727uhO4Y6KxYE4wRs7nOd7JMzB/WSAx2cgdBLtjBOoUg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "k8uKuTcTdOeZEtjrKXQAquWlEKswH2x0A/Ycqjinj7NJ6ykajccNCKiGb6jAJzVBkepSn81pWIO2QLpXKzcHuw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI.Wpf": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "Oa7/4XzATSR683uEK027pkQaV8yoebHABIRWuKZANe2cKWbInAMeoWibGUFW6T58W+8koX7zOIprTwYe02q4Og==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "+xdOtk+Hxdt4Bewl4kCA7KQsI7IZa58uZdnkTcNV9CEtT6Om6VxApAMPIBNvt7sZQoA6SOYubX4uAzEADHX55g==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.10.0": {
+        "type": "Transitive",
+        "resolved": "10.0.30319",
+        "contentHash": "NXkMxLGqJqHBUrCYi7EHyhrzWQNf5Pb1IFiJJW0JIW4BWzC5sT4PHVZYy0Ew8nRBrn3ZjMLUWOR50sFhYMDbAA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50727"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "AicV/XF3LkQhplsacUr1sUyVL+7kuTk/RczvvYAFUr1PGpNtoHh17DqQYfI3zs/8lQIB+RCmpi6ZU7t0SmY0mg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072"
+        }
+      },
+      "Microsoft.VisualStudio.Threading": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "KLjgM7NPjNg0FNv4z8qx8rpiAOnI5ZB6jrZWfJ4ho2YHtxT2dhWi8e94q9+BR4GBOks9ynL90LAnZX2CE3n4/Q==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Validation": "15.3.15"
+        }
+      },
+      "Microsoft.VisualStudio.Threading.Analyzers": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "SCFubDweTsyzzmXOmQOFedpSnUsN7Rrvh/ZD2phYRkOVBZtz3dX3LVen6IhcePZuDEQMtl4gNW9kzVpjTLlZ0A=="
+      },
+      "Microsoft.VisualStudio.Utilities": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "A36/u2YlW0Fs2H2WJSyTO9xW1FMGzKD+Oqtvfmgff+LyhlO8ZcSzR8waD7DKh2gZCyCR4M89m1VHvHn0Z/s5xg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.6.31",
+          "StreamJsonRpc": "1.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Utilities.Internal": {
+        "type": "Transitive",
+        "resolved": "14.0.54-masterD06D5CD1",
+        "contentHash": "vX0Ka1y7dEUs9HGTCw5BNTPREKJXy04OCy/GaDAgken2bSsjPZON8IkiTDFvkN0JtGuGIHCn9AU12lJU/4HLnw=="
+      },
+      "Microsoft.VisualStudio.Validation": {
+        "type": "Transitive",
+        "resolved": "15.3.15",
+        "contentHash": "bvJIwuCLqu7YKXcZqY85VJy0ljtm9QSRkq4CD2bpO/GHynsm72uZxjBDa050VY7kElXS8mb7VW5JNUfg4D/UBA=="
+      },
+      "Microsoft.VisualStudio.Workspace.VSIntegration": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "eSm+OpRg2C7L+h9UXvbzhwwBPdEk/8VAciEVdgtip5yZvhN2JrnzZxl1gPQdmQT8kVSn+B492fHOlDRa/ljcmA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspaces": "15.0.198-pre"
+        }
+      },
+      "Microsoft.VisualStudio.Workspaces": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "Bk83t69Kmo+9t60N5/rUqDy3HC/4IxsXdcV52m4KZVaYo1eTwuiQRhvjQ56013G23RBMTgeId3LYXWj/vWIaLg=="
+      },
+      "Microsoft.Web.Xdt": {
+        "type": "Transitive",
+        "resolved": "2.1.2",
+        "contentHash": "YIaNTOOtGzjF8CkQBOx3aUBWi0dD+g/nOjbpsVslx9G0/uldtpmoKLmyldmKdMv/gHs3qg40rBT3+wvEWoY5gg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "hSXaFmh7hNCuEoC4XNY5DrRkLDzYHqPx/Ik23R4J86Z7PE/Y6YidhG602dFVdLBRSdG6xp9NabH3dXpcoxWvww=="
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "0.86.0",
+        "contentHash": "5DbS1SlKLMi+WG00Cm0ueYf2oyXJrowETQk8nx96rmdjTuHsA3laPykGV7Sxi0R5Xxfx0Kh/EfacAZ1f6M7y/g=="
+      },
+      "stdole": {
+        "type": "Transitive",
+        "resolved": "7.0.3301",
+        "contentHash": "qQW62tF9+Naie3mQ3wAIY5SU8dqNRaiLUPwQ5v2sQRfzhY8h0M1arECSb68M4smTR89RAvuvXRgxBOiJOblkyA=="
+      },
+      "StreamJsonRpc": {
+        "type": "Transitive",
+        "resolved": "1.3.23",
+        "contentHash": "xJU19tAWEgmXn79SdwgUYPWXjXLxXX+xGHw9R1Ody4YCnRde51NqXk/fQyFbSWlQek1AI0m9f9OXqMIDwNxayw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.20",
+          "Newtonsoft.Json": "6.0.6"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "YUJGz6eFKqS0V//mLt25vFGrrCvOnsXjlvFQs+KimpwNxug9x0Pzy4PlFMU3Q2IzqAa9G2L4LsK3+9vCBK7oTg=="
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "D3eEHg9hnGHTYsKBHiD/bT8pkBt2tS9BTTCRv2Wx+86FqWTzvsCjuB+I1j0gYIjKQiI5+NSrPtnxWmNHz4CCQw=="
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "w5U95fVKHY4G8ASs/K5iK3J5LY+/dLFd4vKejsnI/ZhBsWS9hQakfx3Zr7lRWKg4tAw9r4iktyvsTagWkqYCiw=="
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "mpVZ5bnlSs3tTeJ6jYyDJEIa6tavhAd88lxq1zbYhkkCu0Pno2+gHXcvZcoygq2d8JxW3gojXqNJMTAshduqZA=="
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "B95h0YLEL2oSnwF/XjqSWKnwKOy/01VWkNlsCeMTFJLLabflpGV26nK164eRs5GiaRSBGpOxQ3pKoSnnyZN5pg=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "QwALOmIQnwYXO7SZuzHvp+aF9+E8kouJl2JDHe9hyV/Mqzl2KhOwZMlN+mhyIYo5ggHcIVa/LN7E46WD26OEEg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "bQ0iYFOQI0nuTnt+NQADns6ucV4DUvMdwN6CbkB1yj8i7arTGiTN5eok1kQwdnnNWSDZfIUySQY+J3d5KjWn0g=="
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.0.12",
+        "contentHash": "tAgJM1xt3ytyMoW4qn4wIqgJYm7L7TShRZG4+Q4Qsi2PCcj96pXN7nRywS9KkB3p/xDUjc2HSwP9SROyPYDYKQ=="
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "TxwVeUNoTgUOdQ09gfTjvW411MF+w9MBYL7AtNVc+HtBCFlutPLhUCdZjNkjbhj3bNQWMdHboF0KIWEOjJssbA=="
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "v6c/4Yaa9uWsq+JMhnOFewrYkgdNHNG2eMKuNqRn8P733rNXeRCGvV5FkkjBXn2dbVkPXOsO0xjsEeM1q2zC0g=="
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "CUOHjTT/vgP0qGW22U4/hDlOqXmcPq5YicBaXdUR2UiUoLwBT+olO6we4DVbq57jeX5uXH2uerVZhf0qGj+sVQ=="
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "16eu3kjHS633yYdkjwShDHZLRNMKVi/s0bY8ODiqJ2RfMhDMAwxZaUaWVnZ2P71kr/or+X9o/xFWtNqz8ivieQ==",
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "N+3xqIcg3VDKyjwwCGaZ9HawG9aC6cSDI+s7ROma310GQo8vilFZa86hqKppwTHleR/G0sfOzhvgnUxWCR/DrQ=="
+      },
+      "System.Threading.Tasks.Parallel": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "7Pc9t25bcynT9FpMvkUw4ZjYwUiGup/5cJFW72/5MgCG+np2cfVUMdh29u8d7onxX7d8PS3J+wL73zQRqkdrSA=="
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "gIdJqDXlOr5W9zeqFErLw3dsOsiShSCYtF9SEHitACycmvNvY8odf9kiKvp6V7aibc8C4HzzNBkWXjyfn7plbQ=="
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "91UTX0e+S3j5pTVl7V9r8qjBElGhEFp+TBXNT64K68Ecy8DXtM66pFKWQktGBL4GYQRBuZXQdIxX2XuBb77gJA=="
+      },
+      "VSLangProj": {
+        "type": "Transitive",
+        "resolved": "7.0.3300",
+        "contentHash": "/0bb3ssO3rsPUZnVPFNAva2uBQLYNdT4hVLTx0XgxI8+/7acZVuMum18YOaOaE7hnLHMY00o4ypGL/L7JssEww==",
+        "dependencies": {
+          "EnvDTE": "8.0.1"
+        }
+      },
+      "VSLangProj110": {
+        "type": "Transitive",
+        "resolved": "11.0.61030",
+        "contentHash": "ZD0/JubfPji1tUTI7d1fOxEZqC23eHU7PIzoeR0LSY/dmDwEKa32xujNsgx6TT58ZRaSVFY27nUaiVaFdBz5Og==",
+        "dependencies": {
+          "VSLangProj80": "8.0.50727",
+          "VSLangProj90": "9.0.30729"
+        }
+      },
+      "VSLangProj157": {
+        "type": "Transitive",
+        "resolved": "15.7.0",
+        "contentHash": "PjFMHShxIYuZlwqa3feX3MpmCb0RsfCTExjgaJseODGJDXsjApJ5CWolJhlm956W1RHwALQXPiH786H3vZ8upw=="
+      },
+      "VSLangProj2": {
+        "type": "Transitive",
+        "resolved": "7.0.5000",
+        "contentHash": "A286CbJJxrKW4tpVyVaJit5rgVEmTJod/reZ8epekhZWiNoKv2YWkPGaCi0+gQXq4YepqPngE6UpQp5iAXyYDg==",
+        "dependencies": {
+          "VSLangProj": "7.0.3300"
+        }
+      },
+      "VSLangProj80": {
+        "type": "Transitive",
+        "resolved": "8.0.50727",
+        "contentHash": "I2xOMyQcbBXMXKE8zmHljkV1XLAltQ4/T5QRk8Q1mWz7fdd7x1OMp+2VqxZVAJ89Ebfs4wclkcACyvc4FY4wcQ==",
+        "dependencies": {
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "VSLangProj90": {
+        "type": "Transitive",
+        "resolved": "9.0.30729",
+        "contentHash": "xCG2hloStE4TCToHlBai7n/s33sfw/UiEkwqozRPt0AtW9JMr+0hXgGjlOyvPT2rgY6jjKywU55qoTXY2M8f6g=="
+      },
+      "VSSDK.DTE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "uUEaT0sCVnJR54vxfsf5xHpJVWgTrCbl10oKkFuCvJb3I6M5WW4cu9zCTqtYP1i1mYYySGGqooNYiO45kLUkiQ==",
+        "dependencies": {
+          "VSSDK.IDE": "[7.0.4, 8.0.0)"
+        }
+      },
+      "VSSDK.IDE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "KPXgpya93UDz/JZVegRr+AAewTGw46+8Aq7Dl22jWaqjH2KaH/5ycCLG0LET2OX4VBpp15IjhNw08Y5H0vJMKQ=="
+      },
+      "VSSDK.IDE.12": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "XYcSrKW9369JO1tOAuNxzZ6OOlx2QujDuboey4eYpp9GgA3Bd3mo0Fy2ZJd86sZqX27roBRzJfM1Ue/peyWOIg=="
+      },
+      "VSSDK.TemplateWizardInterface": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "stTXrh4h/mftHaQWKZn043WCgP7cmv3QVPB8M3bbBp99kktLdJBTXygPctpgeOYfsBi1TqKJIiNZjG3hCoHNMw==",
+        "dependencies": {
+          "VSSDK.DTE": "[7.0.4, 8.0.0)",
+          "VSSDK.IDE.12": "[12.0.4, 13.0.0)"
+        }
+      },
+      "Microsoft.Build.NuGetSdkResolver": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Build.Framework": "15.6.85",
+          "NuGet.Commands": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Build.Tasks": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Commands": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Console": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.TextManager.Interop.10.0": "10.0.30319",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.PackageManagement.UI": "5.0.0-preview3",
+          "NuGet.PackageManagement.VisualStudio": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Indexing": {
+        "type": "Project",
+        "dependencies": {
+          "Lucene.Net": "3.0.3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.2",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement.PowerShellCmdlets": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.PackageManagement.VisualStudio": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement.UI": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "NuGet.Indexing": "5.0.0-preview3",
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.PackageManagement.VisualStudio": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "NuGet.Indexing": "5.0.0-preview3",
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3",
+          "VSLangProj110": "11.0.61030",
+          "VSLangProj157": "15.7.0",
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.SolutionRestoreManager": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.PackageManagement.VisualStudio": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3",
+          "NuGet.SolutionRestoreManager.Interop": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.SolutionRestoreManager.Interop": {
+        "type": "Project"
+      },
+      "NuGet.Tools": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Console": "5.0.0-preview3",
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.PackageManagement.UI": "5.0.0-preview3",
+          "NuGet.PackageManagement.VisualStudio": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3",
+          "NuGet.VisualStudio": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      },
+      "NuGet.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "VSSDK.TemplateWizardInterface": "12.0.4"
+        }
+      },
+      "NuGet.VisualStudio.Common": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.TeamFoundationServer.ExtendedClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.ComponentModelHost": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Editor": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Language.Intellisense": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language.StandardClassification": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Services.Client": "16.144.1-preview",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.Shell.15.0": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "Microsoft.VisualStudio.Telemetry": "15.0.691-master31907920",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.8.132",
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "VSLangProj": "7.0.3300"
+        }
+      },
+      "NuGet.VisualStudio.Implementation": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.PackageManagement.VisualStudio": "5.0.0-preview3",
+          "NuGet.VisualStudio": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.VisualStudio.Interop": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.VisualStudio.ComponentModelHost": "15.0.26201",
+          "Microsoft.VisualStudio.Shell.15.0": "15.0.26201",
+          "NuGet.VisualStudio": "5.0.0-preview3"
+        }
+      },
+      "NuGetConsole.Host.PowerShell": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Console": "5.0.0-preview3",
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3"
+        }
+      }
+    },
+    ".NETFramework,Version=v4.7.2/win": {
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "mpVZ5bnlSs3tTeJ6jYyDJEIa6tavhAd88lxq1zbYhkkCu0Pno2+gHXcvZcoygq2d8JxW3gojXqNJMTAshduqZA=="
+      }
+    },
+    ".NETFramework,Version=v4.7.2/win-x64": {
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "mpVZ5bnlSs3tTeJ6jYyDJEIa6tavhAd88lxq1zbYhkkCu0Pno2+gHXcvZcoygq2d8JxW3gojXqNJMTAshduqZA=="
+      }
+    },
+    ".NETFramework,Version=v4.7.2/win-x86": {
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "mpVZ5bnlSs3tTeJ6jYyDJEIa6tavhAd88lxq1zbYhkkCu0Pno2+gHXcvZcoygq2d8JxW3gojXqNJMTAshduqZA=="
+      }
+    }
+  }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/packages.lock.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/packages.lock.json
@@ -1,0 +1,682 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "EnvDTE80": {
+        "type": "Direct",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "3CBF4ileGBzGDPvNePcI3611sRVP5xMHXMZGGgQtcFV5nUu5L5QAZkkrgnBdM0oD9ZXc6dReVwo+tXOSR91z4Q==",
+        "dependencies": {
+          "EnvDTE": "8.0.1",
+          "stdole": "7.0.3301"
+        }
+      },
+      "Microsoft.TeamFoundationServer.ExtendedClient": {
+        "type": "Direct",
+        "requested": "[16.144.1-preview, )",
+        "resolved": "16.144.1-preview",
+        "contentHash": "g3G19/HJEOeYR8xFnNWSegBqRcMZRUyPLBmf5JF24pqhVqrY31fSA7ZBUX9r6nHHdSBkmZbRQisR/IvwrfDGqQ==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.AspNet.WebApi.Core": "5.2.3",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.TeamFoundationServer.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.ComponentModelHost": {
+        "type": "Direct",
+        "requested": "[16.0.189-g83e7c53a57, )",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "79WnMNn2T4xDqNVCAR9u3r2OXrA4QPOHYy36MMDjfIKvhL5mQ5Osgc+e+3wVVfeyD4EUdAYs/hC74+w4k/6ktg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319"
+        }
+      },
+      "Microsoft.VisualStudio.CoreUtility": {
+        "type": "Direct",
+        "requested": "[16.0.189-g83e7c53a57, )",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "eiepEOoyUJ+5K+7qitTMzXBJB6GcOMp5LdcedFa30dLxGPwgKY+XdVjiqcrxyQps4i7+hHNlYWvZCR6SKnWLRA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.23",
+          "System.ValueTuple": "4.3.0"
+        }
+      },
+      "Microsoft.VisualStudio.Editor": {
+        "type": "Direct",
+        "requested": "[16.0.189-g83e7c53a57, )",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "EnlJfSZABDJP36kg5td5A4HXqR2TWQrCgjXvDyBTF3peyDFQR6R6XZ63Wul+BY6Yract+UHP6E/8I+LlZ2BvRw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50727",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.ImageCatalog": {
+        "type": "Direct",
+        "requested": "[15.8.28010, )",
+        "resolved": "15.8.28010",
+        "contentHash": "X3nCoei2FTkh1m8tDDL8zEi9nFLVxjyRzMgL5HzPzio4uDCsKW1Oa/F/BkfICwx3cEPuwsyT7MlJjTgVqIbXgQ=="
+      },
+      "Microsoft.VisualStudio.Language.Intellisense": {
+        "type": "Direct",
+        "requested": "[16.0.189-g83e7c53a57, )",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "GShi/VaASPpvPLnF+rbJcfjbOlxAgpgtxc+PuQLruStw/9DVsL1LF/dB4dvdzRbkci8Ux0TvkI+Csd0/KeIOAg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Language.StandardClassification": {
+        "type": "Direct",
+        "requested": "[16.0.189-g83e7c53a57, )",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "fU1175eTKfdg4XRVwrl08wPNT4/KDuHKxgKrQ/aGaFzA93NMqtxsgyw6PB/zTA16j1eeIvqCOZpZOWigkuQGGg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Services.Client": {
+        "type": "Direct",
+        "requested": "[16.144.1-preview, )",
+        "resolved": "16.144.1-preview",
+        "contentHash": "bdqdkWc2yWnsOD2yVeKNc/u/M2Lq6xs6C2tqcvuMnq7HT0nu7tYq72ymnk4iQQBJGMGZfJFPOrI8r/7tDhJ0KA==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Services.InteractiveClient": {
+        "type": "Direct",
+        "requested": "[16.144.1-preview, )",
+        "resolved": "16.144.1-preview",
+        "contentHash": "5fvdv0vPMcW+ANVv7HLXeVMKaDST1ydI3y10WMTP+tKDNp1Se4r8XzAuhdG9m+uh5Wozxj5cA9CK3wPfX+BQEA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.15.0": {
+        "type": "Direct",
+        "requested": "[15.8.28010, )",
+        "resolved": "15.8.28010",
+        "contentHash": "QurLa40g6/qehW75Qpi5LR7EE9vSW/mZuc5QwlTcBcW9k/H7jzBPwxcmAzZ5teswJPkD0+VvOQecTEIguOvnVQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging": "15.8.28010",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Framework": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": "14.3.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": "15.0.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": "15.6.27413",
+          "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30730",
+          "Microsoft.VisualStudio.Text.Data": "15.6.27740",
+          "Microsoft.VisualStudio.Threading": "15.6.31"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Immutable.15.0": {
+        "type": "Direct",
+        "requested": "[15.0.25123-Dev15Preview, )",
+        "resolved": "15.0.25123-Dev15Preview",
+        "contentHash": "40tG5zbJwRgejzozySX5SuEo/3llSa4B461Bi5PdmTqC16AR3Uje50ThCgUmTx0GVq2qMypnaTiSRYaY+3x9NQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Immutable.11.0": "11.0.50727",
+          "Microsoft.VisualStudio.Shell.Immutable.12.0": "12.0.21003"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.12.0": {
+        "type": "Direct",
+        "requested": "[12.0.30111, )",
+        "resolved": "12.0.30111",
+        "contentHash": "ToNByCRLH875yHd1G43EmGuQz16bAV0PKICvzArpjuNugx/Cl4Djg15NHu7XUdPHm+UpAfH4W7nYh0u8NxqWHw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Telemetry": {
+        "type": "Direct",
+        "requested": "[15.0.691-master31907920, )",
+        "resolved": "15.0.691-master31907920",
+        "contentHash": "nTDxnBLOEY+NsjvnGpEeUHmzJrKtUOJjbgxkYd3UdblGlQrLjceIvkpr9c5v1yWwv8byAa2R6itlutjNjb53dA==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.PersistenceChannel": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.UniversalTelemetryChannel": "[0.17.2-build00169]",
+          "Microsoft.Bcl": "1.1.8",
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Bcl.Build": "1.0.14",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta",
+          "Microsoft.VisualStudio.RemoteControl": "[14.0.249-master2E2DC10C]",
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1",
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Data": {
+        "type": "Direct",
+        "requested": "[16.0.189-g83e7c53a57, )",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "e4OUFLIJ+roHfIeG++y6GZK1S6E0D91iB6LTDQLTz7cC4BvOE3yU3/Eki6Xdy/6inTUKsdqsYUFYEBTWeeF5vA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Logic": {
+        "type": "Direct",
+        "requested": "[16.0.189-g83e7c53a57, )",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "OG+pya+vxVGjDBp98mBjOWKRj295vwe5HtUmns1w/h727uhO4Y6KxYE4wRs7nOd7JMzB/WSAx2cgdBLtjBOoUg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI": {
+        "type": "Direct",
+        "requested": "[16.0.189-g83e7c53a57, )",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "k8uKuTcTdOeZEtjrKXQAquWlEKswH2x0A/Ycqjinj7NJ6ykajccNCKiGb6jAJzVBkepSn81pWIO2QLpXKzcHuw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI.Wpf": {
+        "type": "Direct",
+        "requested": "[16.0.189-g83e7c53a57, )",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "Oa7/4XzATSR683uEK027pkQaV8yoebHABIRWuKZANe2cKWbInAMeoWibGUFW6T58W+8koX7zOIprTwYe02q4Og==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Threading": {
+        "type": "Direct",
+        "requested": "[15.8.132, )",
+        "resolved": "15.8.132",
+        "contentHash": "KLjgM7NPjNg0FNv4z8qx8rpiAOnI5ZB6jrZWfJ4ho2YHtxT2dhWi8e94q9+BR4GBOks9ynL90LAnZX2CE3n4/Q==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Validation": "15.3.15"
+        }
+      },
+      "Microsoft.VisualStudio.Threading.Analyzers": {
+        "type": "Direct",
+        "requested": "[15.8.132, )",
+        "resolved": "15.8.132",
+        "contentHash": "SCFubDweTsyzzmXOmQOFedpSnUsN7Rrvh/ZD2phYRkOVBZtz3dX3LVen6IhcePZuDEQMtl4gNW9kzVpjTLlZ0A=="
+      },
+      "Microsoft.VisualStudio.Workspace.VSIntegration": {
+        "type": "Direct",
+        "requested": "[15.0.198-pre, )",
+        "resolved": "15.0.198-pre",
+        "contentHash": "eSm+OpRg2C7L+h9UXvbzhwwBPdEk/8VAciEVdgtip5yZvhN2JrnzZxl1gPQdmQT8kVSn+B492fHOlDRa/ljcmA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspaces": "15.0.198-pre"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "VSLangProj": {
+        "type": "Direct",
+        "requested": "[7.0.3300, )",
+        "resolved": "7.0.3300",
+        "contentHash": "/0bb3ssO3rsPUZnVPFNAva2uBQLYNdT4hVLTx0XgxI8+/7acZVuMum18YOaOaE7hnLHMY00o4ypGL/L7JssEww==",
+        "dependencies": {
+          "EnvDTE": "8.0.1"
+        }
+      },
+      "EnvDTE": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "ppW2nOaaMCOy1HNdUWvTM+btoXVbvntTL4RxVvEWBaHFk+Aj/r7vrS3t9x1QrHB4Y9Rrd2n7UAmjzet3Ps63XA==",
+        "dependencies": {
+          "stdole": "7.0.3301"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "iAzPAX/guSnBXJxM+PZ+dVXF+vmE8hxcxJ9fOFrvHUv5cY/ILD1icf2sKjJLltJD0Na8r9oGF5PjNiTMxK8EYw==",
+        "dependencies": {
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.ApplicationInsights.PersistenceChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "V7peE2ssNCCfOqzk1kOJfr3zZLDDPs+M88N34e98L+YPpAoL11wQkLpPxWmztjipTD+DBxJO6PNaVsM9q5bM/A==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "0.17.2-build00169"
+        }
+      },
+      "Microsoft.ApplicationInsights.UniversalTelemetryChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "8sg18/b63fhYjpr0kZ2v/NEjOEJ3gwpzXaaKZTth04AUPuOKjWvS3/pyVIRQ1mUEhrV3Xn3S2/TkLiWLCTpo7A==",
+        "dependencies": {
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Client": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "w5w8GVLMmo+JzizmcuV01tgYn2OsaVhxGAO0ryKXkO5sob6EVjzcoJv8NHL3Xm98vywSh7kRgeLqbA/lxZuTXg==",
+        "dependencies": {
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Core": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "bP+PAx17AVQJ19aU9N7yMnz8yST1U9cekbYHRyIUvQzFLqqzrthEs/gLdyZiLJPmL4ZABuvwGBOXG/ukqmsbDg==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3"
+        }
+      },
+      "Microsoft.Bcl": {
+        "type": "Transitive",
+        "resolved": "1.1.8",
+        "contentHash": "gM+PUzd8ONxJpcPJeNppCJPklDhDuPUMVQkxvK4fe0rd9WyqBNPh4+UFx3Uv8zuG4C1Gapu1c25sfotE7TQtig==",
+        "dependencies": {
+          "Microsoft.Bcl.Build": "1.0.14"
+        }
+      },
+      "Microsoft.Bcl.Async": {
+        "type": "Transitive",
+        "resolved": "1.0.168",
+        "contentHash": "tUNC02eBwDKpGre0BcNIvblLv1q0Q3DnS/vtkRHj2FE1sXwt386HAudztyl5C0U88hllrqHDvtlz8bK0Y8cHDA==",
+        "dependencies": {
+          "Microsoft.Bcl": "1.1.8"
+        }
+      },
+      "Microsoft.Bcl.Build": {
+        "type": "Transitive",
+        "resolved": "1.0.14",
+        "contentHash": "cDLKSvNvRa519hplsbSoYqO69TjdDIhfjtKUM0g20/nVROoWsGav9KCI9HtnGjLmdV1+TcUUDhbotcllibjPEA=="
+      },
+      "Microsoft.Diagnostics.Tracing.EventSource.Redist": {
+        "type": "Transitive",
+        "resolved": "1.1.16-beta",
+        "contentHash": "o1gsKlGjLAnSHRyWBygKnO55Kp0bRXB3AO9e8OeAnqQH7HA5MAW6YAPEEy5e3aRE//7AlkdPtq28F19NqOLZQQ=="
+      },
+      "Microsoft.IdentityModel.Clients.ActiveDirectory": {
+        "type": "Transitive",
+        "resolved": "3.17.2",
+        "contentHash": "zvDoWJlrKg1TQeJScq+5znAZtduyJHlT7M9gEquUjm2PQCIR4C5PqJ0E8xYQsV3eF4bY8cW54uyr0FyhiN0MtQ=="
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "kbmvhMYu5OZXWN3toFXhrj3bSN7B+ZzNWzAZQ4Ofp5x2srk9ZCYFljETGS5faxzPwGd5+7W4WZlAfOI7QvzhlA=="
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "wVWYpXfE6gpkSrIRNo5TDVC7ss6KPTTrmT6x8ysHiZRIMSRAZ8TyHEAmpdATBBPNRmnlevyAs4CK6nPfDpCTqw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "dsDJhsL2zJyL5az5D3LhILIQRt+nXFQ64Bclj6vspIwD96sYRK/fPKTP8xLcLyw0fcosiFUgmWOXRLkWcAm1Pw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]"
+        }
+      },
+      "Microsoft.TeamFoundationServer.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "UBwF/VUULHHy5WHpShIW0ZdcG10N3jADUlW+KEgA7qiKCDB8VYbv7FR0miwutTtyuYFh/lE+G6q4IF0ugDyX6A==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3"
+        }
+      },
+      "Microsoft.VisualStudio.Imaging": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "pDNYWW/w1hZF7Xk1SVhCMQxpxz5jFbaEkqrmSVRp7B8o6uei2fDrAscbMJmTxGcVA4rzV02ABytSCrc3jr1LvA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26930",
+        "contentHash": "gbmcUTMhYF/9oDUHI6b6Ki1PBaEkiqDhYNIdkYrrGy7XN0LhYew/BggDCJORUiEbzc5zJ8Hlc40jYGmqx4qfLg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16"
+        }
+      },
+      "Microsoft.VisualStudio.Language": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "BWRDlPth8bLOqUH7j6ClkBFPwjJ83aApHcr1GtJNPZfSj4Nw32pYRLIxCuBs2NLS2f9AF80yl0AYrzVlO6YRWg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Newtonsoft.Json": "9.0.1",
+          "StreamJsonRpc": "1.3.23",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.OLE.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "6W3YMtSGt+hHRvAqbktXHLWZgEbEpuFZxuC1XiKCX4Th3fGv+7SeKGGH7Gmeu9fp/8kNqq7uovqWaHfhni13Hw=="
+      },
+      "Microsoft.VisualStudio.RemoteControl": {
+        "type": "Transitive",
+        "resolved": "14.0.249-master2E2DC10C",
+        "contentHash": "bqmdFTlPzEH0VkncJBTq3bXmvW0SKM/pCQcKBgYZfCn/othfLnjChUKCyHvwQyJcjcy8JRnFXRejBQ0pqPXpqQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1"
+        }
+      },
+      "Microsoft.VisualStudio.SDK.EmbedInteropTypes": {
+        "type": "Transitive",
+        "resolved": "15.0.16",
+        "contentHash": "iI+b/DL6AaN/D8vHXcLorZJIjY0MvQehT6xfI3mx+AD2w1f/mEGtuXQE5mFfYu425FSDrPtoBIDRf+tKtLDA5g=="
+      },
+      "Microsoft.VisualStudio.Shell.Framework": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "BRqUcfXNZ17aiuTTr1jawd/WHpt/A70WmDFUwgDS+vwGd0fp8fendG4ANLY5a4KI7+Yhyhz5DO/jsL3UBujNcQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "15.6.27740",
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Immutable.11.0": {
+        "type": "Transitive",
+        "resolved": "11.0.50727",
+        "contentHash": "WNKEdjQZ5AWFrYITqvpbrRhe6uCMhU5eU1zZLbSfyYIJ4JimpUFU8HFGJXepfek2KqA/3vM8DIHMtx0+tEWeCA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Immutable.12.0": {
+        "type": "Transitive",
+        "resolved": "12.0.21003",
+        "contentHash": "R3N/n9v8wkG/Um3lh0GMwG0anSszaIYDMUTrrje+wYNkezGCvCt4EJsQ7qs5hvAsszE1GhVcpMYNtQ9Bfk3Rdw=="
+      },
+      "Microsoft.VisualStudio.Shell.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6072",
+        "contentHash": "hoaT0t8DMA5YwPQEeiRD7UJpndgJDyK00uYcQl3I2+KvgQroo7lAZfkPNbGIhy2OGW4nOEqlvr0i5OE71hgT1w==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.10.0": {
+        "type": "Transitive",
+        "resolved": "10.0.30320",
+        "contentHash": "RKmdy0EgbXFtzjM2Kcdv9w9XdMJS81QykYUb1D/5SnvUYn28ElVt3criqGlvcC1syLJLmk9DdHomOhX6R50e1A==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.11.0": {
+        "type": "Transitive",
+        "resolved": "11.0.61031",
+        "contentHash": "N8il5VcZNr4GZeAvItmpWE4A5DKwSpFelQQ+I1VoUm1kVj+6dPieZXlhdbFC3bJVyCs1gl0uUzOH7FDVGfdDCw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30320"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26929",
+        "contentHash": "J1WemvOhywfve6BbN91azp2nflhc68bpeGFFazoNnYl4MqEjRM0IUe3eNuieoeRw7a+UsHDubne/7K7XJ8yVdA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.26930",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.0.26929",
+        "contentHash": "hHAmrLBvxnmZDPPIOw6zQjsYenbqAcJfcIHSHDl5n/FyBC0VYleDwG2XcEOx1OkXWXReDMGY9lfeHyRv5SSJJQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.12",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.6.27413",
+        "contentHash": "Cb0fRe0ek16fLkE0Buea8zU55zu2WyzBp+8HhK1j3azndHBx0FZAfcDj3xnSum8kllcwQKhEerqEfxdpmwt1mw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "gGhUi9HaXGFC48HxZPV4nYcjygT/vcYYUow5iNocHp/EfwCCnDTUqe5AisH/o1pqB+iakw64g73KSDFsRNAXcA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.9.0": {
+        "type": "Transitive",
+        "resolved": "9.0.30730",
+        "contentHash": "AjBQfZ3HYtpRLFkLjClhR1vWffeEQXScMkhssKxnDnXFc59zOY3RToYxmIS6ZmjD5MS5ICwJDWy7hPOpKbh3Qg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "+xdOtk+Hxdt4Bewl4kCA7KQsI7IZa58uZdnkTcNV9CEtT6Om6VxApAMPIBNvt7sZQoA6SOYubX4uAzEADHX55g==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "AicV/XF3LkQhplsacUr1sUyVL+7kuTk/RczvvYAFUr1PGpNtoHh17DqQYfI3zs/8lQIB+RCmpi6ZU7t0SmY0mg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072"
+        }
+      },
+      "Microsoft.VisualStudio.Utilities": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "A36/u2YlW0Fs2H2WJSyTO9xW1FMGzKD+Oqtvfmgff+LyhlO8ZcSzR8waD7DKh2gZCyCR4M89m1VHvHn0Z/s5xg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.6.31",
+          "StreamJsonRpc": "1.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Utilities.Internal": {
+        "type": "Transitive",
+        "resolved": "14.0.54-masterD06D5CD1",
+        "contentHash": "vX0Ka1y7dEUs9HGTCw5BNTPREKJXy04OCy/GaDAgken2bSsjPZON8IkiTDFvkN0JtGuGIHCn9AU12lJU/4HLnw=="
+      },
+      "Microsoft.VisualStudio.Validation": {
+        "type": "Transitive",
+        "resolved": "15.3.15",
+        "contentHash": "bvJIwuCLqu7YKXcZqY85VJy0ljtm9QSRkq4CD2bpO/GHynsm72uZxjBDa050VY7kElXS8mb7VW5JNUfg4D/UBA=="
+      },
+      "Microsoft.VisualStudio.Workspaces": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "Bk83t69Kmo+9t60N5/rUqDy3HC/4IxsXdcV52m4KZVaYo1eTwuiQRhvjQ56013G23RBMTgeId3LYXWj/vWIaLg=="
+      },
+      "Microsoft.Web.Xdt": {
+        "type": "Transitive",
+        "resolved": "2.1.2",
+        "contentHash": "YIaNTOOtGzjF8CkQBOx3aUBWi0dD+g/nOjbpsVslx9G0/uldtpmoKLmyldmKdMv/gHs3qg40rBT3+wvEWoY5gg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "hSXaFmh7hNCuEoC4XNY5DrRkLDzYHqPx/Ik23R4J86Z7PE/Y6YidhG602dFVdLBRSdG6xp9NabH3dXpcoxWvww=="
+      },
+      "stdole": {
+        "type": "Transitive",
+        "resolved": "7.0.3301",
+        "contentHash": "qQW62tF9+Naie3mQ3wAIY5SU8dqNRaiLUPwQ5v2sQRfzhY8h0M1arECSb68M4smTR89RAvuvXRgxBOiJOblkyA=="
+      },
+      "StreamJsonRpc": {
+        "type": "Transitive",
+        "resolved": "1.3.23",
+        "contentHash": "xJU19tAWEgmXn79SdwgUYPWXjXLxXX+xGHw9R1Ody4YCnRde51NqXk/fQyFbSWlQek1AI0m9f9OXqMIDwNxayw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.20",
+          "Newtonsoft.Json": "6.0.6"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "D3eEHg9hnGHTYsKBHiD/bT8pkBt2tS9BTTCRv2Wx+86FqWTzvsCjuB+I1j0gYIjKQiI5+NSrPtnxWmNHz4CCQw=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "QwALOmIQnwYXO7SZuzHvp+aF9+E8kouJl2JDHe9hyV/Mqzl2KhOwZMlN+mhyIYo5ggHcIVa/LN7E46WD26OEEg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "91UTX0e+S3j5pTVl7V9r8qjBElGhEFp+TBXNT64K68Ecy8DXtM66pFKWQktGBL4GYQRBuZXQdIxX2XuBb77gJA=="
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.2",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/packages.lock.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/packages.lock.json
@@ -1,0 +1,777 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "EnvDTE": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "ppW2nOaaMCOy1HNdUWvTM+btoXVbvntTL4RxVvEWBaHFk+Aj/r7vrS3t9x1QrHB4Y9Rrd2n7UAmjzet3Ps63XA==",
+        "dependencies": {
+          "stdole": "7.0.3301"
+        }
+      },
+      "EnvDTE80": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "3CBF4ileGBzGDPvNePcI3611sRVP5xMHXMZGGgQtcFV5nUu5L5QAZkkrgnBdM0oD9ZXc6dReVwo+tXOSR91z4Q==",
+        "dependencies": {
+          "EnvDTE": "8.0.1",
+          "stdole": "7.0.3301"
+        }
+      },
+      "Lucene.Net": {
+        "type": "Transitive",
+        "resolved": "3.0.3",
+        "contentHash": "A/70q4eDcuuafQeDB9eaiDP9FQG7X29T4VIYRphS7Wk8kAM9gNcfVqYyd0H8BJ1BTpA5C1ORm9RzFn4BiNavrw==",
+        "dependencies": {
+          "SharpZipLib": "0.86.0"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "iAzPAX/guSnBXJxM+PZ+dVXF+vmE8hxcxJ9fOFrvHUv5cY/ILD1icf2sKjJLltJD0Na8r9oGF5PjNiTMxK8EYw==",
+        "dependencies": {
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.ApplicationInsights.PersistenceChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "V7peE2ssNCCfOqzk1kOJfr3zZLDDPs+M88N34e98L+YPpAoL11wQkLpPxWmztjipTD+DBxJO6PNaVsM9q5bM/A==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "0.17.2-build00169"
+        }
+      },
+      "Microsoft.ApplicationInsights.UniversalTelemetryChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "8sg18/b63fhYjpr0kZ2v/NEjOEJ3gwpzXaaKZTth04AUPuOKjWvS3/pyVIRQ1mUEhrV3Xn3S2/TkLiWLCTpo7A==",
+        "dependencies": {
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Client": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "w5w8GVLMmo+JzizmcuV01tgYn2OsaVhxGAO0ryKXkO5sob6EVjzcoJv8NHL3Xm98vywSh7kRgeLqbA/lxZuTXg==",
+        "dependencies": {
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Core": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "bP+PAx17AVQJ19aU9N7yMnz8yST1U9cekbYHRyIUvQzFLqqzrthEs/gLdyZiLJPmL4ZABuvwGBOXG/ukqmsbDg==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3"
+        }
+      },
+      "Microsoft.Bcl": {
+        "type": "Transitive",
+        "resolved": "1.1.8",
+        "contentHash": "gM+PUzd8ONxJpcPJeNppCJPklDhDuPUMVQkxvK4fe0rd9WyqBNPh4+UFx3Uv8zuG4C1Gapu1c25sfotE7TQtig==",
+        "dependencies": {
+          "Microsoft.Bcl.Build": "1.0.14"
+        }
+      },
+      "Microsoft.Bcl.Async": {
+        "type": "Transitive",
+        "resolved": "1.0.168",
+        "contentHash": "tUNC02eBwDKpGre0BcNIvblLv1q0Q3DnS/vtkRHj2FE1sXwt386HAudztyl5C0U88hllrqHDvtlz8bK0Y8cHDA==",
+        "dependencies": {
+          "Microsoft.Bcl": "1.1.8"
+        }
+      },
+      "Microsoft.Bcl.Build": {
+        "type": "Transitive",
+        "resolved": "1.0.14",
+        "contentHash": "cDLKSvNvRa519hplsbSoYqO69TjdDIhfjtKUM0g20/nVROoWsGav9KCI9HtnGjLmdV1+TcUUDhbotcllibjPEA=="
+      },
+      "Microsoft.Diagnostics.Tracing.EventSource.Redist": {
+        "type": "Transitive",
+        "resolved": "1.1.16-beta",
+        "contentHash": "o1gsKlGjLAnSHRyWBygKnO55Kp0bRXB3AO9e8OeAnqQH7HA5MAW6YAPEEy5e3aRE//7AlkdPtq28F19NqOLZQQ=="
+      },
+      "Microsoft.IdentityModel.Clients.ActiveDirectory": {
+        "type": "Transitive",
+        "resolved": "3.17.2",
+        "contentHash": "zvDoWJlrKg1TQeJScq+5znAZtduyJHlT7M9gEquUjm2PQCIR4C5PqJ0E8xYQsV3eF4bY8cW54uyr0FyhiN0MtQ=="
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "kbmvhMYu5OZXWN3toFXhrj3bSN7B+ZzNWzAZQ4Ofp5x2srk9ZCYFljETGS5faxzPwGd5+7W4WZlAfOI7QvzhlA=="
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "wVWYpXfE6gpkSrIRNo5TDVC7ss6KPTTrmT6x8ysHiZRIMSRAZ8TyHEAmpdATBBPNRmnlevyAs4CK6nPfDpCTqw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "dsDJhsL2zJyL5az5D3LhILIQRt+nXFQ64Bclj6vspIwD96sYRK/fPKTP8xLcLyw0fcosiFUgmWOXRLkWcAm1Pw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]"
+        }
+      },
+      "Microsoft.TeamFoundationServer.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "UBwF/VUULHHy5WHpShIW0ZdcG10N3jADUlW+KEgA7qiKCDB8VYbv7FR0miwutTtyuYFh/lE+G6q4IF0ugDyX6A==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3"
+        }
+      },
+      "Microsoft.TeamFoundationServer.ExtendedClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "g3G19/HJEOeYR8xFnNWSegBqRcMZRUyPLBmf5JF24pqhVqrY31fSA7ZBUX9r6nHHdSBkmZbRQisR/IvwrfDGqQ==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.AspNet.WebApi.Core": "5.2.3",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.TeamFoundationServer.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.ComponentModelHost": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "79WnMNn2T4xDqNVCAR9u3r2OXrA4QPOHYy36MMDjfIKvhL5mQ5Osgc+e+3wVVfeyD4EUdAYs/hC74+w4k/6ktg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319"
+        }
+      },
+      "Microsoft.VisualStudio.CoreUtility": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "eiepEOoyUJ+5K+7qitTMzXBJB6GcOMp5LdcedFa30dLxGPwgKY+XdVjiqcrxyQps4i7+hHNlYWvZCR6SKnWLRA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.23",
+          "System.ValueTuple": "4.3.0"
+        }
+      },
+      "Microsoft.VisualStudio.Editor": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "EnlJfSZABDJP36kg5td5A4HXqR2TWQrCgjXvDyBTF3peyDFQR6R6XZ63Wul+BY6Yract+UHP6E/8I+LlZ2BvRw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50727",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.ImageCatalog": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "X3nCoei2FTkh1m8tDDL8zEi9nFLVxjyRzMgL5HzPzio4uDCsKW1Oa/F/BkfICwx3cEPuwsyT7MlJjTgVqIbXgQ=="
+      },
+      "Microsoft.VisualStudio.Imaging": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "pDNYWW/w1hZF7Xk1SVhCMQxpxz5jFbaEkqrmSVRp7B8o6uei2fDrAscbMJmTxGcVA4rzV02ABytSCrc3jr1LvA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26930",
+        "contentHash": "gbmcUTMhYF/9oDUHI6b6Ki1PBaEkiqDhYNIdkYrrGy7XN0LhYew/BggDCJORUiEbzc5zJ8Hlc40jYGmqx4qfLg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16"
+        }
+      },
+      "Microsoft.VisualStudio.Language": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "BWRDlPth8bLOqUH7j6ClkBFPwjJ83aApHcr1GtJNPZfSj4Nw32pYRLIxCuBs2NLS2f9AF80yl0AYrzVlO6YRWg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Newtonsoft.Json": "9.0.1",
+          "StreamJsonRpc": "1.3.23",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Language.Intellisense": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "GShi/VaASPpvPLnF+rbJcfjbOlxAgpgtxc+PuQLruStw/9DVsL1LF/dB4dvdzRbkci8Ux0TvkI+Csd0/KeIOAg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Language.StandardClassification": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "fU1175eTKfdg4XRVwrl08wPNT4/KDuHKxgKrQ/aGaFzA93NMqtxsgyw6PB/zTA16j1eeIvqCOZpZOWigkuQGGg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.OLE.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "6W3YMtSGt+hHRvAqbktXHLWZgEbEpuFZxuC1XiKCX4Th3fGv+7SeKGGH7Gmeu9fp/8kNqq7uovqWaHfhni13Hw=="
+      },
+      "Microsoft.VisualStudio.RemoteControl": {
+        "type": "Transitive",
+        "resolved": "14.0.249-master2E2DC10C",
+        "contentHash": "bqmdFTlPzEH0VkncJBTq3bXmvW0SKM/pCQcKBgYZfCn/othfLnjChUKCyHvwQyJcjcy8JRnFXRejBQ0pqPXpqQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1"
+        }
+      },
+      "Microsoft.VisualStudio.SDK.EmbedInteropTypes": {
+        "type": "Transitive",
+        "resolved": "15.0.16",
+        "contentHash": "iI+b/DL6AaN/D8vHXcLorZJIjY0MvQehT6xfI3mx+AD2w1f/mEGtuXQE5mFfYu425FSDrPtoBIDRf+tKtLDA5g=="
+      },
+      "Microsoft.VisualStudio.Services.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "bdqdkWc2yWnsOD2yVeKNc/u/M2Lq6xs6C2tqcvuMnq7HT0nu7tYq72ymnk4iQQBJGMGZfJFPOrI8r/7tDhJ0KA==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Services.InteractiveClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "5fvdv0vPMcW+ANVv7HLXeVMKaDST1ydI3y10WMTP+tKDNp1Se4r8XzAuhdG9m+uh5Wozxj5cA9CK3wPfX+BQEA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.15.0": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "QurLa40g6/qehW75Qpi5LR7EE9vSW/mZuc5QwlTcBcW9k/H7jzBPwxcmAzZ5teswJPkD0+VvOQecTEIguOvnVQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging": "15.8.28010",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Framework": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": "14.3.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": "15.0.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": "15.6.27413",
+          "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30730",
+          "Microsoft.VisualStudio.Text.Data": "15.6.27740",
+          "Microsoft.VisualStudio.Threading": "15.6.31"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Framework": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "BRqUcfXNZ17aiuTTr1jawd/WHpt/A70WmDFUwgDS+vwGd0fp8fendG4ANLY5a4KI7+Yhyhz5DO/jsL3UBujNcQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "15.6.27740",
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6072",
+        "contentHash": "hoaT0t8DMA5YwPQEeiRD7UJpndgJDyK00uYcQl3I2+KvgQroo7lAZfkPNbGIhy2OGW4nOEqlvr0i5OE71hgT1w==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.10.0": {
+        "type": "Transitive",
+        "resolved": "10.0.30320",
+        "contentHash": "RKmdy0EgbXFtzjM2Kcdv9w9XdMJS81QykYUb1D/5SnvUYn28ElVt3criqGlvcC1syLJLmk9DdHomOhX6R50e1A==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.11.0": {
+        "type": "Transitive",
+        "resolved": "11.0.61031",
+        "contentHash": "N8il5VcZNr4GZeAvItmpWE4A5DKwSpFelQQ+I1VoUm1kVj+6dPieZXlhdbFC3bJVyCs1gl0uUzOH7FDVGfdDCw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30320"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.12.0": {
+        "type": "Transitive",
+        "resolved": "12.0.30111",
+        "contentHash": "ToNByCRLH875yHd1G43EmGuQz16bAV0PKICvzArpjuNugx/Cl4Djg15NHu7XUdPHm+UpAfH4W7nYh0u8NxqWHw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26929",
+        "contentHash": "J1WemvOhywfve6BbN91azp2nflhc68bpeGFFazoNnYl4MqEjRM0IUe3eNuieoeRw7a+UsHDubne/7K7XJ8yVdA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.26930",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.0.26929",
+        "contentHash": "hHAmrLBvxnmZDPPIOw6zQjsYenbqAcJfcIHSHDl5n/FyBC0VYleDwG2XcEOx1OkXWXReDMGY9lfeHyRv5SSJJQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.12",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.6.27413",
+        "contentHash": "Cb0fRe0ek16fLkE0Buea8zU55zu2WyzBp+8HhK1j3azndHBx0FZAfcDj3xnSum8kllcwQKhEerqEfxdpmwt1mw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "gGhUi9HaXGFC48HxZPV4nYcjygT/vcYYUow5iNocHp/EfwCCnDTUqe5AisH/o1pqB+iakw64g73KSDFsRNAXcA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.9.0": {
+        "type": "Transitive",
+        "resolved": "9.0.30730",
+        "contentHash": "AjBQfZ3HYtpRLFkLjClhR1vWffeEQXScMkhssKxnDnXFc59zOY3RToYxmIS6ZmjD5MS5ICwJDWy7hPOpKbh3Qg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Telemetry": {
+        "type": "Transitive",
+        "resolved": "15.0.691-master31907920",
+        "contentHash": "nTDxnBLOEY+NsjvnGpEeUHmzJrKtUOJjbgxkYd3UdblGlQrLjceIvkpr9c5v1yWwv8byAa2R6itlutjNjb53dA==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.PersistenceChannel": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.UniversalTelemetryChannel": "[0.17.2-build00169]",
+          "Microsoft.Bcl": "1.1.8",
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Bcl.Build": "1.0.14",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta",
+          "Microsoft.VisualStudio.RemoteControl": "[14.0.249-master2E2DC10C]",
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1",
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Data": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "e4OUFLIJ+roHfIeG++y6GZK1S6E0D91iB6LTDQLTz7cC4BvOE3yU3/Eki6Xdy/6inTUKsdqsYUFYEBTWeeF5vA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Logic": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "OG+pya+vxVGjDBp98mBjOWKRj295vwe5HtUmns1w/h727uhO4Y6KxYE4wRs7nOd7JMzB/WSAx2cgdBLtjBOoUg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "k8uKuTcTdOeZEtjrKXQAquWlEKswH2x0A/Ycqjinj7NJ6ykajccNCKiGb6jAJzVBkepSn81pWIO2QLpXKzcHuw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI.Wpf": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "Oa7/4XzATSR683uEK027pkQaV8yoebHABIRWuKZANe2cKWbInAMeoWibGUFW6T58W+8koX7zOIprTwYe02q4Og==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "+xdOtk+Hxdt4Bewl4kCA7KQsI7IZa58uZdnkTcNV9CEtT6Om6VxApAMPIBNvt7sZQoA6SOYubX4uAzEADHX55g==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "AicV/XF3LkQhplsacUr1sUyVL+7kuTk/RczvvYAFUr1PGpNtoHh17DqQYfI3zs/8lQIB+RCmpi6ZU7t0SmY0mg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072"
+        }
+      },
+      "Microsoft.VisualStudio.Threading": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "KLjgM7NPjNg0FNv4z8qx8rpiAOnI5ZB6jrZWfJ4ho2YHtxT2dhWi8e94q9+BR4GBOks9ynL90LAnZX2CE3n4/Q==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Validation": "15.3.15"
+        }
+      },
+      "Microsoft.VisualStudio.Threading.Analyzers": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "SCFubDweTsyzzmXOmQOFedpSnUsN7Rrvh/ZD2phYRkOVBZtz3dX3LVen6IhcePZuDEQMtl4gNW9kzVpjTLlZ0A=="
+      },
+      "Microsoft.VisualStudio.Utilities": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "A36/u2YlW0Fs2H2WJSyTO9xW1FMGzKD+Oqtvfmgff+LyhlO8ZcSzR8waD7DKh2gZCyCR4M89m1VHvHn0Z/s5xg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.6.31",
+          "StreamJsonRpc": "1.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Utilities.Internal": {
+        "type": "Transitive",
+        "resolved": "14.0.54-masterD06D5CD1",
+        "contentHash": "vX0Ka1y7dEUs9HGTCw5BNTPREKJXy04OCy/GaDAgken2bSsjPZON8IkiTDFvkN0JtGuGIHCn9AU12lJU/4HLnw=="
+      },
+      "Microsoft.VisualStudio.Validation": {
+        "type": "Transitive",
+        "resolved": "15.3.15",
+        "contentHash": "bvJIwuCLqu7YKXcZqY85VJy0ljtm9QSRkq4CD2bpO/GHynsm72uZxjBDa050VY7kElXS8mb7VW5JNUfg4D/UBA=="
+      },
+      "Microsoft.VisualStudio.Workspace.VSIntegration": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "eSm+OpRg2C7L+h9UXvbzhwwBPdEk/8VAciEVdgtip5yZvhN2JrnzZxl1gPQdmQT8kVSn+B492fHOlDRa/ljcmA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspaces": "15.0.198-pre"
+        }
+      },
+      "Microsoft.VisualStudio.Workspaces": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "Bk83t69Kmo+9t60N5/rUqDy3HC/4IxsXdcV52m4KZVaYo1eTwuiQRhvjQ56013G23RBMTgeId3LYXWj/vWIaLg=="
+      },
+      "Microsoft.Web.Xdt": {
+        "type": "Transitive",
+        "resolved": "2.1.2",
+        "contentHash": "YIaNTOOtGzjF8CkQBOx3aUBWi0dD+g/nOjbpsVslx9G0/uldtpmoKLmyldmKdMv/gHs3qg40rBT3+wvEWoY5gg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "hSXaFmh7hNCuEoC4XNY5DrRkLDzYHqPx/Ik23R4J86Z7PE/Y6YidhG602dFVdLBRSdG6xp9NabH3dXpcoxWvww=="
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "0.86.0",
+        "contentHash": "5DbS1SlKLMi+WG00Cm0ueYf2oyXJrowETQk8nx96rmdjTuHsA3laPykGV7Sxi0R5Xxfx0Kh/EfacAZ1f6M7y/g=="
+      },
+      "stdole": {
+        "type": "Transitive",
+        "resolved": "7.0.3301",
+        "contentHash": "qQW62tF9+Naie3mQ3wAIY5SU8dqNRaiLUPwQ5v2sQRfzhY8h0M1arECSb68M4smTR89RAvuvXRgxBOiJOblkyA=="
+      },
+      "StreamJsonRpc": {
+        "type": "Transitive",
+        "resolved": "1.3.23",
+        "contentHash": "xJU19tAWEgmXn79SdwgUYPWXjXLxXX+xGHw9R1Ody4YCnRde51NqXk/fQyFbSWlQek1AI0m9f9OXqMIDwNxayw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.20",
+          "Newtonsoft.Json": "6.0.6"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "D3eEHg9hnGHTYsKBHiD/bT8pkBt2tS9BTTCRv2Wx+86FqWTzvsCjuB+I1j0gYIjKQiI5+NSrPtnxWmNHz4CCQw=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "QwALOmIQnwYXO7SZuzHvp+aF9+E8kouJl2JDHe9hyV/Mqzl2KhOwZMlN+mhyIYo5ggHcIVa/LN7E46WD26OEEg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "91UTX0e+S3j5pTVl7V9r8qjBElGhEFp+TBXNT64K68Ecy8DXtM66pFKWQktGBL4GYQRBuZXQdIxX2XuBb77gJA=="
+      },
+      "VSLangProj": {
+        "type": "Transitive",
+        "resolved": "7.0.3300",
+        "contentHash": "/0bb3ssO3rsPUZnVPFNAva2uBQLYNdT4hVLTx0XgxI8+/7acZVuMum18YOaOaE7hnLHMY00o4ypGL/L7JssEww==",
+        "dependencies": {
+          "EnvDTE": "8.0.1"
+        }
+      },
+      "VSLangProj110": {
+        "type": "Transitive",
+        "resolved": "11.0.61030",
+        "contentHash": "ZD0/JubfPji1tUTI7d1fOxEZqC23eHU7PIzoeR0LSY/dmDwEKa32xujNsgx6TT58ZRaSVFY27nUaiVaFdBz5Og==",
+        "dependencies": {
+          "VSLangProj80": "8.0.50727",
+          "VSLangProj90": "9.0.30729"
+        }
+      },
+      "VSLangProj157": {
+        "type": "Transitive",
+        "resolved": "15.7.0",
+        "contentHash": "PjFMHShxIYuZlwqa3feX3MpmCb0RsfCTExjgaJseODGJDXsjApJ5CWolJhlm956W1RHwALQXPiH786H3vZ8upw=="
+      },
+      "VSLangProj2": {
+        "type": "Transitive",
+        "resolved": "7.0.5000",
+        "contentHash": "A286CbJJxrKW4tpVyVaJit5rgVEmTJod/reZ8epekhZWiNoKv2YWkPGaCi0+gQXq4YepqPngE6UpQp5iAXyYDg==",
+        "dependencies": {
+          "VSLangProj": "7.0.3300"
+        }
+      },
+      "VSLangProj80": {
+        "type": "Transitive",
+        "resolved": "8.0.50727",
+        "contentHash": "I2xOMyQcbBXMXKE8zmHljkV1XLAltQ4/T5QRk8Q1mWz7fdd7x1OMp+2VqxZVAJ89Ebfs4wclkcACyvc4FY4wcQ==",
+        "dependencies": {
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "VSLangProj90": {
+        "type": "Transitive",
+        "resolved": "9.0.30729",
+        "contentHash": "xCG2hloStE4TCToHlBai7n/s33sfw/UiEkwqozRPt0AtW9JMr+0hXgGjlOyvPT2rgY6jjKywU55qoTXY2M8f6g=="
+      },
+      "VSSDK.DTE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "uUEaT0sCVnJR54vxfsf5xHpJVWgTrCbl10oKkFuCvJb3I6M5WW4cu9zCTqtYP1i1mYYySGGqooNYiO45kLUkiQ==",
+        "dependencies": {
+          "VSSDK.IDE": "[7.0.4, 8.0.0)"
+        }
+      },
+      "VSSDK.IDE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "KPXgpya93UDz/JZVegRr+AAewTGw46+8Aq7Dl22jWaqjH2KaH/5ycCLG0LET2OX4VBpp15IjhNw08Y5H0vJMKQ=="
+      },
+      "VSSDK.IDE.12": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "XYcSrKW9369JO1tOAuNxzZ6OOlx2QujDuboey4eYpp9GgA3Bd3mo0Fy2ZJd86sZqX27roBRzJfM1Ue/peyWOIg=="
+      },
+      "VSSDK.TemplateWizardInterface": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "stTXrh4h/mftHaQWKZn043WCgP7cmv3QVPB8M3bbBp99kktLdJBTXygPctpgeOYfsBi1TqKJIiNZjG3hCoHNMw==",
+        "dependencies": {
+          "VSSDK.DTE": "[7.0.4, 8.0.0)",
+          "VSSDK.IDE.12": "[12.0.4, 13.0.0)"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Indexing": {
+        "type": "Project",
+        "dependencies": {
+          "Lucene.Net": "3.0.3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.2",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "NuGet.Indexing": "5.0.0-preview3",
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3",
+          "VSLangProj110": "11.0.61030",
+          "VSLangProj157": "15.7.0",
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      },
+      "NuGet.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "VSSDK.TemplateWizardInterface": "12.0.4"
+        }
+      },
+      "NuGet.VisualStudio.Common": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.TeamFoundationServer.ExtendedClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.ComponentModelHost": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Editor": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Language.Intellisense": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language.StandardClassification": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Services.Client": "16.144.1-preview",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.Shell.15.0": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "Microsoft.VisualStudio.Telemetry": "15.0.691-master31907920",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.8.132",
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "VSLangProj": "7.0.3300"
+        }
+      }
+    }
+  }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Interop/packages.lock.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Interop/packages.lock.json
@@ -1,0 +1,207 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "Microsoft.VisualStudio.ComponentModelHost": {
+        "type": "Direct",
+        "requested": "[15.0.26201, )",
+        "resolved": "15.0.26201",
+        "contentHash": "9eaojnnd56aUnuMP9gnwH5W255paUQCyazEVfo3JOFrnao6HVpsqJkBkwbj7EwNoQipI81qpiQxISXpzb5auFA=="
+      },
+      "Microsoft.VisualStudio.Shell.15.0": {
+        "type": "Direct",
+        "requested": "[15.0.26201, )",
+        "resolved": "15.0.26201",
+        "contentHash": "2lKlpJFXy3VXVM6vCDV+abH/BhC/aAD60fJGf8WYm3Cak98GiV3euW+vDRdH+Txj6BElDr2lMNubGdFoG0RxNQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging": "15.0.26201",
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.Shell.Framework": "15.0.26201",
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50727",
+          "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30729",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.Threading": "15.0.240",
+          "Microsoft.VisualStudio.Utilities": "15.0.26201"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "EnvDTE": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "ppW2nOaaMCOy1HNdUWvTM+btoXVbvntTL4RxVvEWBaHFk+Aj/r7vrS3t9x1QrHB4Y9Rrd2n7UAmjzet3Ps63XA==",
+        "dependencies": {
+          "stdole": "7.0.3301"
+        }
+      },
+      "EnvDTE80": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "3CBF4ileGBzGDPvNePcI3611sRVP5xMHXMZGGgQtcFV5nUu5L5QAZkkrgnBdM0oD9ZXc6dReVwo+tXOSR91z4Q==",
+        "dependencies": {
+          "EnvDTE": "8.0.1",
+          "stdole": "7.0.3301"
+        }
+      },
+      "Microsoft.VisualStudio.CoreUtility": {
+        "type": "Transitive",
+        "resolved": "15.0.26201",
+        "contentHash": "Fqo/QUJZC86gzYevfo+D1UPeoB77SCsK/8fDM4RLWq5M3CYveq0xwMZKvEEbbRq+e1fKlh0faA7yFitmp8RMdA=="
+      },
+      "Microsoft.VisualStudio.Imaging": {
+        "type": "Transitive",
+        "resolved": "15.0.26201",
+        "contentHash": "+zfcm4ytyHza2hbbZ7ew3/lLSd3rBGykK7VqOFy0C7yPf17IJ2bUVG5BXhB/3pwTsFVrXXU00w4G1arBQ+oLoA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Utilities": "15.0.26201"
+        }
+      },
+      "Microsoft.VisualStudio.OLE.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "6W3YMtSGt+hHRvAqbktXHLWZgEbEpuFZxuC1XiKCX4Th3fGv+7SeKGGH7Gmeu9fp/8kNqq7uovqWaHfhni13Hw=="
+      },
+      "Microsoft.VisualStudio.Shell.Framework": {
+        "type": "Transitive",
+        "resolved": "15.0.26201",
+        "contentHash": "g9yJ+5m0oasafO/VhRFF860lO51qjQp/E5R+oZC747eGhRTzB2iGtdhb521U99KYPB4C3UF/WpnatwGRHnfmzg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "15.0.26201",
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.Utilities": "15.0.26201"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6072",
+        "contentHash": "hoaT0t8DMA5YwPQEeiRD7UJpndgJDyK00uYcQl3I2+KvgQroo7lAZfkPNbGIhy2OGW4nOEqlvr0i5OE71hgT1w==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.10.0": {
+        "type": "Transitive",
+        "resolved": "10.0.30320",
+        "contentHash": "RKmdy0EgbXFtzjM2Kcdv9w9XdMJS81QykYUb1D/5SnvUYn28ElVt3criqGlvcC1syLJLmk9DdHomOhX6R50e1A==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.11.0": {
+        "type": "Transitive",
+        "resolved": "11.0.61031",
+        "contentHash": "N8il5VcZNr4GZeAvItmpWE4A5DKwSpFelQQ+I1VoUm1kVj+6dPieZXlhdbFC3bJVyCs1gl0uUzOH7FDVGfdDCw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30320"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.12.0": {
+        "type": "Transitive",
+        "resolved": "12.0.30111",
+        "contentHash": "ToNByCRLH875yHd1G43EmGuQz16bAV0PKICvzArpjuNugx/Cl4Djg15NHu7XUdPHm+UpAfH4W7nYh0u8NxqWHw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "gGhUi9HaXGFC48HxZPV4nYcjygT/vcYYUow5iNocHp/EfwCCnDTUqe5AisH/o1pqB+iakw64g73KSDFsRNAXcA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.9.0": {
+        "type": "Transitive",
+        "resolved": "9.0.30729",
+        "contentHash": "Qolo2V47CYOwS44mlfCpC7ie+juK44MLBNtBxDSeImolTjvLdY8INv8PtQM1WX51XRcgQBV+g3QiSdScJTtOSQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50727",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "+xdOtk+Hxdt4Bewl4kCA7KQsI7IZa58uZdnkTcNV9CEtT6Om6VxApAMPIBNvt7sZQoA6SOYubX4uAzEADHX55g==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "AicV/XF3LkQhplsacUr1sUyVL+7kuTk/RczvvYAFUr1PGpNtoHh17DqQYfI3zs/8lQIB+RCmpi6ZU7t0SmY0mg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072"
+        }
+      },
+      "Microsoft.VisualStudio.Threading": {
+        "type": "Transitive",
+        "resolved": "15.0.240",
+        "contentHash": "s73wFNWfQKAYZr6IhR7VIPDAHWuAGIpUeFTfSyDxtUIH7FOgGRvJZTe8hHQDvIT3OYYu50mKGUATdAuCKirr2Q==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Validation": "15.0.82"
+        }
+      },
+      "Microsoft.VisualStudio.Utilities": {
+        "type": "Transitive",
+        "resolved": "15.0.26201",
+        "contentHash": "Df6Pbn1wIXnZXF9cCzeLt8gbLURR8OTWnrIJ+hV+b3Gyi8ztaXdVun+Pdoqt84Ynjanntps5jj9lvgSFjozk0g=="
+      },
+      "Microsoft.VisualStudio.Validation": {
+        "type": "Transitive",
+        "resolved": "15.0.82",
+        "contentHash": "XwZyVCsHuEtnd6nYScJnA8XkXPzy4Ok0DV5/hqqAe5ccgOhJ6yap7Qh/sU/i6QxEzuYyECPYDQ7IOyEQ3yRQgQ=="
+      },
+      "stdole": {
+        "type": "Transitive",
+        "resolved": "7.0.3301",
+        "contentHash": "qQW62tF9+Naie3mQ3wAIY5SU8dqNRaiLUPwQ5v2sQRfzhY8h0M1arECSb68M4smTR89RAvuvXRgxBOiJOblkyA=="
+      },
+      "VSSDK.DTE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "uUEaT0sCVnJR54vxfsf5xHpJVWgTrCbl10oKkFuCvJb3I6M5WW4cu9zCTqtYP1i1mYYySGGqooNYiO45kLUkiQ==",
+        "dependencies": {
+          "VSSDK.IDE": "[7.0.4, 8.0.0)"
+        }
+      },
+      "VSSDK.IDE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "KPXgpya93UDz/JZVegRr+AAewTGw46+8Aq7Dl22jWaqjH2KaH/5ycCLG0LET2OX4VBpp15IjhNw08Y5H0vJMKQ=="
+      },
+      "VSSDK.IDE.12": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "XYcSrKW9369JO1tOAuNxzZ6OOlx2QujDuboey4eYpp9GgA3Bd3mo0Fy2ZJd86sZqX27roBRzJfM1Ue/peyWOIg=="
+      },
+      "VSSDK.TemplateWizardInterface": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "stTXrh4h/mftHaQWKZn043WCgP7cmv3QVPB8M3bbBp99kktLdJBTXygPctpgeOYfsBi1TqKJIiNZjG3hCoHNMw==",
+        "dependencies": {
+          "VSSDK.DTE": "[7.0.4, 8.0.0)",
+          "VSSDK.IDE.12": "[12.0.4, 13.0.0)"
+        }
+      },
+      "NuGet.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "VSSDK.TemplateWizardInterface": "12.0.4"
+        }
+      }
+    }
+  }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio/packages.lock.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio/packages.lock.json
@@ -1,0 +1,127 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "EnvDTE80": {
+        "type": "Direct",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "3CBF4ileGBzGDPvNePcI3611sRVP5xMHXMZGGgQtcFV5nUu5L5QAZkkrgnBdM0oD9ZXc6dReVwo+tXOSR91z4Q==",
+        "dependencies": {
+          "EnvDTE": "8.0.1",
+          "stdole": "7.0.3301"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.12.0": {
+        "type": "Direct",
+        "requested": "[12.0.30111, )",
+        "resolved": "12.0.30111",
+        "contentHash": "ToNByCRLH875yHd1G43EmGuQz16bAV0PKICvzArpjuNugx/Cl4Djg15NHu7XUdPHm+UpAfH4W7nYh0u8NxqWHw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "VSSDK.TemplateWizardInterface": {
+        "type": "Direct",
+        "requested": "[12.0.4, )",
+        "resolved": "12.0.4",
+        "contentHash": "stTXrh4h/mftHaQWKZn043WCgP7cmv3QVPB8M3bbBp99kktLdJBTXygPctpgeOYfsBi1TqKJIiNZjG3hCoHNMw==",
+        "dependencies": {
+          "VSSDK.DTE": "[7.0.4, 8.0.0)",
+          "VSSDK.IDE.12": "[12.0.4, 13.0.0)"
+        }
+      },
+      "EnvDTE": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "ppW2nOaaMCOy1HNdUWvTM+btoXVbvntTL4RxVvEWBaHFk+Aj/r7vrS3t9x1QrHB4Y9Rrd2n7UAmjzet3Ps63XA==",
+        "dependencies": {
+          "stdole": "7.0.3301"
+        }
+      },
+      "Microsoft.VisualStudio.OLE.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "6W3YMtSGt+hHRvAqbktXHLWZgEbEpuFZxuC1XiKCX4Th3fGv+7SeKGGH7Gmeu9fp/8kNqq7uovqWaHfhni13Hw=="
+      },
+      "Microsoft.VisualStudio.Shell.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6072",
+        "contentHash": "hoaT0t8DMA5YwPQEeiRD7UJpndgJDyK00uYcQl3I2+KvgQroo7lAZfkPNbGIhy2OGW4nOEqlvr0i5OE71hgT1w==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.10.0": {
+        "type": "Transitive",
+        "resolved": "10.0.30320",
+        "contentHash": "RKmdy0EgbXFtzjM2Kcdv9w9XdMJS81QykYUb1D/5SnvUYn28ElVt3criqGlvcC1syLJLmk9DdHomOhX6R50e1A==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.11.0": {
+        "type": "Transitive",
+        "resolved": "11.0.61031",
+        "contentHash": "N8il5VcZNr4GZeAvItmpWE4A5DKwSpFelQQ+I1VoUm1kVj+6dPieZXlhdbFC3bJVyCs1gl0uUzOH7FDVGfdDCw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30320"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "gGhUi9HaXGFC48HxZPV4nYcjygT/vcYYUow5iNocHp/EfwCCnDTUqe5AisH/o1pqB+iakw64g73KSDFsRNAXcA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "+xdOtk+Hxdt4Bewl4kCA7KQsI7IZa58uZdnkTcNV9CEtT6Om6VxApAMPIBNvt7sZQoA6SOYubX4uAzEADHX55g==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "AicV/XF3LkQhplsacUr1sUyVL+7kuTk/RczvvYAFUr1PGpNtoHh17DqQYfI3zs/8lQIB+RCmpi6ZU7t0SmY0mg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072"
+        }
+      },
+      "stdole": {
+        "type": "Transitive",
+        "resolved": "7.0.3301",
+        "contentHash": "qQW62tF9+Naie3mQ3wAIY5SU8dqNRaiLUPwQ5v2sQRfzhY8h0M1arECSb68M4smTR89RAvuvXRgxBOiJOblkyA=="
+      },
+      "VSSDK.DTE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "uUEaT0sCVnJR54vxfsf5xHpJVWgTrCbl10oKkFuCvJb3I6M5WW4cu9zCTqtYP1i1mYYySGGqooNYiO45kLUkiQ==",
+        "dependencies": {
+          "VSSDK.IDE": "[7.0.4, 8.0.0)"
+        }
+      },
+      "VSSDK.IDE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "KPXgpya93UDz/JZVegRr+AAewTGw46+8Aq7Dl22jWaqjH2KaH/5ycCLG0LET2OX4VBpp15IjhNw08Y5H0vJMKQ=="
+      },
+      "VSSDK.IDE.12": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "XYcSrKW9369JO1tOAuNxzZ6OOlx2QujDuboey4eYpp9GgA3Bd3mo0Fy2ZJd86sZqX27roBRzJfM1Ue/peyWOIg=="
+      }
+    }
+  }
+}

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/packages.lock.json
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/packages.lock.json
@@ -1,0 +1,824 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "EnvDTE": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "ppW2nOaaMCOy1HNdUWvTM+btoXVbvntTL4RxVvEWBaHFk+Aj/r7vrS3t9x1QrHB4Y9Rrd2n7UAmjzet3Ps63XA==",
+        "dependencies": {
+          "stdole": "7.0.3301"
+        }
+      },
+      "EnvDTE80": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "3CBF4ileGBzGDPvNePcI3611sRVP5xMHXMZGGgQtcFV5nUu5L5QAZkkrgnBdM0oD9ZXc6dReVwo+tXOSR91z4Q==",
+        "dependencies": {
+          "EnvDTE": "8.0.1",
+          "stdole": "7.0.3301"
+        }
+      },
+      "Lucene.Net": {
+        "type": "Transitive",
+        "resolved": "3.0.3",
+        "contentHash": "A/70q4eDcuuafQeDB9eaiDP9FQG7X29T4VIYRphS7Wk8kAM9gNcfVqYyd0H8BJ1BTpA5C1ORm9RzFn4BiNavrw==",
+        "dependencies": {
+          "SharpZipLib": "0.86.0"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "iAzPAX/guSnBXJxM+PZ+dVXF+vmE8hxcxJ9fOFrvHUv5cY/ILD1icf2sKjJLltJD0Na8r9oGF5PjNiTMxK8EYw==",
+        "dependencies": {
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.ApplicationInsights.PersistenceChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "V7peE2ssNCCfOqzk1kOJfr3zZLDDPs+M88N34e98L+YPpAoL11wQkLpPxWmztjipTD+DBxJO6PNaVsM9q5bM/A==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "0.17.2-build00169"
+        }
+      },
+      "Microsoft.ApplicationInsights.UniversalTelemetryChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "8sg18/b63fhYjpr0kZ2v/NEjOEJ3gwpzXaaKZTth04AUPuOKjWvS3/pyVIRQ1mUEhrV3Xn3S2/TkLiWLCTpo7A==",
+        "dependencies": {
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Client": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "w5w8GVLMmo+JzizmcuV01tgYn2OsaVhxGAO0ryKXkO5sob6EVjzcoJv8NHL3Xm98vywSh7kRgeLqbA/lxZuTXg==",
+        "dependencies": {
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Core": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "bP+PAx17AVQJ19aU9N7yMnz8yST1U9cekbYHRyIUvQzFLqqzrthEs/gLdyZiLJPmL4ZABuvwGBOXG/ukqmsbDg==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3"
+        }
+      },
+      "Microsoft.Bcl": {
+        "type": "Transitive",
+        "resolved": "1.1.8",
+        "contentHash": "gM+PUzd8ONxJpcPJeNppCJPklDhDuPUMVQkxvK4fe0rd9WyqBNPh4+UFx3Uv8zuG4C1Gapu1c25sfotE7TQtig==",
+        "dependencies": {
+          "Microsoft.Bcl.Build": "1.0.14"
+        }
+      },
+      "Microsoft.Bcl.Async": {
+        "type": "Transitive",
+        "resolved": "1.0.168",
+        "contentHash": "tUNC02eBwDKpGre0BcNIvblLv1q0Q3DnS/vtkRHj2FE1sXwt386HAudztyl5C0U88hllrqHDvtlz8bK0Y8cHDA==",
+        "dependencies": {
+          "Microsoft.Bcl": "1.1.8"
+        }
+      },
+      "Microsoft.Bcl.Build": {
+        "type": "Transitive",
+        "resolved": "1.0.14",
+        "contentHash": "cDLKSvNvRa519hplsbSoYqO69TjdDIhfjtKUM0g20/nVROoWsGav9KCI9HtnGjLmdV1+TcUUDhbotcllibjPEA=="
+      },
+      "Microsoft.Diagnostics.Tracing.EventSource.Redist": {
+        "type": "Transitive",
+        "resolved": "1.1.16-beta",
+        "contentHash": "o1gsKlGjLAnSHRyWBygKnO55Kp0bRXB3AO9e8OeAnqQH7HA5MAW6YAPEEy5e3aRE//7AlkdPtq28F19NqOLZQQ=="
+      },
+      "Microsoft.IdentityModel.Clients.ActiveDirectory": {
+        "type": "Transitive",
+        "resolved": "3.17.2",
+        "contentHash": "zvDoWJlrKg1TQeJScq+5znAZtduyJHlT7M9gEquUjm2PQCIR4C5PqJ0E8xYQsV3eF4bY8cW54uyr0FyhiN0MtQ=="
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "kbmvhMYu5OZXWN3toFXhrj3bSN7B+ZzNWzAZQ4Ofp5x2srk9ZCYFljETGS5faxzPwGd5+7W4WZlAfOI7QvzhlA=="
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "wVWYpXfE6gpkSrIRNo5TDVC7ss6KPTTrmT6x8ysHiZRIMSRAZ8TyHEAmpdATBBPNRmnlevyAs4CK6nPfDpCTqw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "dsDJhsL2zJyL5az5D3LhILIQRt+nXFQ64Bclj6vspIwD96sYRK/fPKTP8xLcLyw0fcosiFUgmWOXRLkWcAm1Pw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]"
+        }
+      },
+      "Microsoft.TeamFoundationServer.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "UBwF/VUULHHy5WHpShIW0ZdcG10N3jADUlW+KEgA7qiKCDB8VYbv7FR0miwutTtyuYFh/lE+G6q4IF0ugDyX6A==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3"
+        }
+      },
+      "Microsoft.TeamFoundationServer.ExtendedClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "g3G19/HJEOeYR8xFnNWSegBqRcMZRUyPLBmf5JF24pqhVqrY31fSA7ZBUX9r6nHHdSBkmZbRQisR/IvwrfDGqQ==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.AspNet.WebApi.Core": "5.2.3",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.TeamFoundationServer.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.ComponentModelHost": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "79WnMNn2T4xDqNVCAR9u3r2OXrA4QPOHYy36MMDjfIKvhL5mQ5Osgc+e+3wVVfeyD4EUdAYs/hC74+w4k/6ktg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319"
+        }
+      },
+      "Microsoft.VisualStudio.CoreUtility": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "eiepEOoyUJ+5K+7qitTMzXBJB6GcOMp5LdcedFa30dLxGPwgKY+XdVjiqcrxyQps4i7+hHNlYWvZCR6SKnWLRA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.23",
+          "System.ValueTuple": "4.3.0"
+        }
+      },
+      "Microsoft.VisualStudio.Editor": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "EnlJfSZABDJP36kg5td5A4HXqR2TWQrCgjXvDyBTF3peyDFQR6R6XZ63Wul+BY6Yract+UHP6E/8I+LlZ2BvRw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50727",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.ImageCatalog": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "X3nCoei2FTkh1m8tDDL8zEi9nFLVxjyRzMgL5HzPzio4uDCsKW1Oa/F/BkfICwx3cEPuwsyT7MlJjTgVqIbXgQ=="
+      },
+      "Microsoft.VisualStudio.Imaging": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "pDNYWW/w1hZF7Xk1SVhCMQxpxz5jFbaEkqrmSVRp7B8o6uei2fDrAscbMJmTxGcVA4rzV02ABytSCrc3jr1LvA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26930",
+        "contentHash": "gbmcUTMhYF/9oDUHI6b6Ki1PBaEkiqDhYNIdkYrrGy7XN0LhYew/BggDCJORUiEbzc5zJ8Hlc40jYGmqx4qfLg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16"
+        }
+      },
+      "Microsoft.VisualStudio.Language": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "BWRDlPth8bLOqUH7j6ClkBFPwjJ83aApHcr1GtJNPZfSj4Nw32pYRLIxCuBs2NLS2f9AF80yl0AYrzVlO6YRWg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Newtonsoft.Json": "9.0.1",
+          "StreamJsonRpc": "1.3.23",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Language.Intellisense": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "GShi/VaASPpvPLnF+rbJcfjbOlxAgpgtxc+PuQLruStw/9DVsL1LF/dB4dvdzRbkci8Ux0TvkI+Csd0/KeIOAg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Language.StandardClassification": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "fU1175eTKfdg4XRVwrl08wPNT4/KDuHKxgKrQ/aGaFzA93NMqtxsgyw6PB/zTA16j1eeIvqCOZpZOWigkuQGGg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.OLE.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "6W3YMtSGt+hHRvAqbktXHLWZgEbEpuFZxuC1XiKCX4Th3fGv+7SeKGGH7Gmeu9fp/8kNqq7uovqWaHfhni13Hw=="
+      },
+      "Microsoft.VisualStudio.RemoteControl": {
+        "type": "Transitive",
+        "resolved": "14.0.249-master2E2DC10C",
+        "contentHash": "bqmdFTlPzEH0VkncJBTq3bXmvW0SKM/pCQcKBgYZfCn/othfLnjChUKCyHvwQyJcjcy8JRnFXRejBQ0pqPXpqQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1"
+        }
+      },
+      "Microsoft.VisualStudio.SDK.EmbedInteropTypes": {
+        "type": "Transitive",
+        "resolved": "15.0.16",
+        "contentHash": "iI+b/DL6AaN/D8vHXcLorZJIjY0MvQehT6xfI3mx+AD2w1f/mEGtuXQE5mFfYu425FSDrPtoBIDRf+tKtLDA5g=="
+      },
+      "Microsoft.VisualStudio.Services.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "bdqdkWc2yWnsOD2yVeKNc/u/M2Lq6xs6C2tqcvuMnq7HT0nu7tYq72ymnk4iQQBJGMGZfJFPOrI8r/7tDhJ0KA==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Services.InteractiveClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "5fvdv0vPMcW+ANVv7HLXeVMKaDST1ydI3y10WMTP+tKDNp1Se4r8XzAuhdG9m+uh5Wozxj5cA9CK3wPfX+BQEA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.15.0": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "QurLa40g6/qehW75Qpi5LR7EE9vSW/mZuc5QwlTcBcW9k/H7jzBPwxcmAzZ5teswJPkD0+VvOQecTEIguOvnVQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging": "15.8.28010",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Framework": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": "14.3.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": "15.0.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": "15.6.27413",
+          "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30730",
+          "Microsoft.VisualStudio.Text.Data": "15.6.27740",
+          "Microsoft.VisualStudio.Threading": "15.6.31"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Framework": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "BRqUcfXNZ17aiuTTr1jawd/WHpt/A70WmDFUwgDS+vwGd0fp8fendG4ANLY5a4KI7+Yhyhz5DO/jsL3UBujNcQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "15.6.27740",
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6072",
+        "contentHash": "hoaT0t8DMA5YwPQEeiRD7UJpndgJDyK00uYcQl3I2+KvgQroo7lAZfkPNbGIhy2OGW4nOEqlvr0i5OE71hgT1w==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.10.0": {
+        "type": "Transitive",
+        "resolved": "10.0.30320",
+        "contentHash": "RKmdy0EgbXFtzjM2Kcdv9w9XdMJS81QykYUb1D/5SnvUYn28ElVt3criqGlvcC1syLJLmk9DdHomOhX6R50e1A==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.11.0": {
+        "type": "Transitive",
+        "resolved": "11.0.61031",
+        "contentHash": "N8il5VcZNr4GZeAvItmpWE4A5DKwSpFelQQ+I1VoUm1kVj+6dPieZXlhdbFC3bJVyCs1gl0uUzOH7FDVGfdDCw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30320"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.12.0": {
+        "type": "Transitive",
+        "resolved": "12.0.30111",
+        "contentHash": "ToNByCRLH875yHd1G43EmGuQz16bAV0PKICvzArpjuNugx/Cl4Djg15NHu7XUdPHm+UpAfH4W7nYh0u8NxqWHw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26929",
+        "contentHash": "J1WemvOhywfve6BbN91azp2nflhc68bpeGFFazoNnYl4MqEjRM0IUe3eNuieoeRw7a+UsHDubne/7K7XJ8yVdA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.26930",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.0.26929",
+        "contentHash": "hHAmrLBvxnmZDPPIOw6zQjsYenbqAcJfcIHSHDl5n/FyBC0VYleDwG2XcEOx1OkXWXReDMGY9lfeHyRv5SSJJQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.12",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.6.27413",
+        "contentHash": "Cb0fRe0ek16fLkE0Buea8zU55zu2WyzBp+8HhK1j3azndHBx0FZAfcDj3xnSum8kllcwQKhEerqEfxdpmwt1mw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "gGhUi9HaXGFC48HxZPV4nYcjygT/vcYYUow5iNocHp/EfwCCnDTUqe5AisH/o1pqB+iakw64g73KSDFsRNAXcA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.9.0": {
+        "type": "Transitive",
+        "resolved": "9.0.30730",
+        "contentHash": "AjBQfZ3HYtpRLFkLjClhR1vWffeEQXScMkhssKxnDnXFc59zOY3RToYxmIS6ZmjD5MS5ICwJDWy7hPOpKbh3Qg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Telemetry": {
+        "type": "Transitive",
+        "resolved": "15.0.691-master31907920",
+        "contentHash": "nTDxnBLOEY+NsjvnGpEeUHmzJrKtUOJjbgxkYd3UdblGlQrLjceIvkpr9c5v1yWwv8byAa2R6itlutjNjb53dA==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.PersistenceChannel": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.UniversalTelemetryChannel": "[0.17.2-build00169]",
+          "Microsoft.Bcl": "1.1.8",
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Bcl.Build": "1.0.14",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta",
+          "Microsoft.VisualStudio.RemoteControl": "[14.0.249-master2E2DC10C]",
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1",
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Data": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "e4OUFLIJ+roHfIeG++y6GZK1S6E0D91iB6LTDQLTz7cC4BvOE3yU3/Eki6Xdy/6inTUKsdqsYUFYEBTWeeF5vA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Logic": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "OG+pya+vxVGjDBp98mBjOWKRj295vwe5HtUmns1w/h727uhO4Y6KxYE4wRs7nOd7JMzB/WSAx2cgdBLtjBOoUg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "k8uKuTcTdOeZEtjrKXQAquWlEKswH2x0A/Ycqjinj7NJ6ykajccNCKiGb6jAJzVBkepSn81pWIO2QLpXKzcHuw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI.Wpf": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "Oa7/4XzATSR683uEK027pkQaV8yoebHABIRWuKZANe2cKWbInAMeoWibGUFW6T58W+8koX7zOIprTwYe02q4Og==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "+xdOtk+Hxdt4Bewl4kCA7KQsI7IZa58uZdnkTcNV9CEtT6Om6VxApAMPIBNvt7sZQoA6SOYubX4uAzEADHX55g==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.10.0": {
+        "type": "Transitive",
+        "resolved": "10.0.30319",
+        "contentHash": "NXkMxLGqJqHBUrCYi7EHyhrzWQNf5Pb1IFiJJW0JIW4BWzC5sT4PHVZYy0Ew8nRBrn3ZjMLUWOR50sFhYMDbAA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50727"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "AicV/XF3LkQhplsacUr1sUyVL+7kuTk/RczvvYAFUr1PGpNtoHh17DqQYfI3zs/8lQIB+RCmpi6ZU7t0SmY0mg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072"
+        }
+      },
+      "Microsoft.VisualStudio.Threading": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "KLjgM7NPjNg0FNv4z8qx8rpiAOnI5ZB6jrZWfJ4ho2YHtxT2dhWi8e94q9+BR4GBOks9ynL90LAnZX2CE3n4/Q==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Validation": "15.3.15"
+        }
+      },
+      "Microsoft.VisualStudio.Threading.Analyzers": {
+        "type": "Transitive",
+        "resolved": "15.8.132",
+        "contentHash": "SCFubDweTsyzzmXOmQOFedpSnUsN7Rrvh/ZD2phYRkOVBZtz3dX3LVen6IhcePZuDEQMtl4gNW9kzVpjTLlZ0A=="
+      },
+      "Microsoft.VisualStudio.Utilities": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "A36/u2YlW0Fs2H2WJSyTO9xW1FMGzKD+Oqtvfmgff+LyhlO8ZcSzR8waD7DKh2gZCyCR4M89m1VHvHn0Z/s5xg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.6.31",
+          "StreamJsonRpc": "1.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Utilities.Internal": {
+        "type": "Transitive",
+        "resolved": "14.0.54-masterD06D5CD1",
+        "contentHash": "vX0Ka1y7dEUs9HGTCw5BNTPREKJXy04OCy/GaDAgken2bSsjPZON8IkiTDFvkN0JtGuGIHCn9AU12lJU/4HLnw=="
+      },
+      "Microsoft.VisualStudio.Validation": {
+        "type": "Transitive",
+        "resolved": "15.3.15",
+        "contentHash": "bvJIwuCLqu7YKXcZqY85VJy0ljtm9QSRkq4CD2bpO/GHynsm72uZxjBDa050VY7kElXS8mb7VW5JNUfg4D/UBA=="
+      },
+      "Microsoft.VisualStudio.Workspace.VSIntegration": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "eSm+OpRg2C7L+h9UXvbzhwwBPdEk/8VAciEVdgtip5yZvhN2JrnzZxl1gPQdmQT8kVSn+B492fHOlDRa/ljcmA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspaces": "15.0.198-pre"
+        }
+      },
+      "Microsoft.VisualStudio.Workspaces": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "Bk83t69Kmo+9t60N5/rUqDy3HC/4IxsXdcV52m4KZVaYo1eTwuiQRhvjQ56013G23RBMTgeId3LYXWj/vWIaLg=="
+      },
+      "Microsoft.Web.Xdt": {
+        "type": "Transitive",
+        "resolved": "2.1.2",
+        "contentHash": "YIaNTOOtGzjF8CkQBOx3aUBWi0dD+g/nOjbpsVslx9G0/uldtpmoKLmyldmKdMv/gHs3qg40rBT3+wvEWoY5gg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "hSXaFmh7hNCuEoC4XNY5DrRkLDzYHqPx/Ik23R4J86Z7PE/Y6YidhG602dFVdLBRSdG6xp9NabH3dXpcoxWvww=="
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "0.86.0",
+        "contentHash": "5DbS1SlKLMi+WG00Cm0ueYf2oyXJrowETQk8nx96rmdjTuHsA3laPykGV7Sxi0R5Xxfx0Kh/EfacAZ1f6M7y/g=="
+      },
+      "stdole": {
+        "type": "Transitive",
+        "resolved": "7.0.3301",
+        "contentHash": "qQW62tF9+Naie3mQ3wAIY5SU8dqNRaiLUPwQ5v2sQRfzhY8h0M1arECSb68M4smTR89RAvuvXRgxBOiJOblkyA=="
+      },
+      "StreamJsonRpc": {
+        "type": "Transitive",
+        "resolved": "1.3.23",
+        "contentHash": "xJU19tAWEgmXn79SdwgUYPWXjXLxXX+xGHw9R1Ody4YCnRde51NqXk/fQyFbSWlQek1AI0m9f9OXqMIDwNxayw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.20",
+          "Newtonsoft.Json": "6.0.6"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "D3eEHg9hnGHTYsKBHiD/bT8pkBt2tS9BTTCRv2Wx+86FqWTzvsCjuB+I1j0gYIjKQiI5+NSrPtnxWmNHz4CCQw=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "QwALOmIQnwYXO7SZuzHvp+aF9+E8kouJl2JDHe9hyV/Mqzl2KhOwZMlN+mhyIYo5ggHcIVa/LN7E46WD26OEEg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "91UTX0e+S3j5pTVl7V9r8qjBElGhEFp+TBXNT64K68Ecy8DXtM66pFKWQktGBL4GYQRBuZXQdIxX2XuBb77gJA=="
+      },
+      "VSLangProj": {
+        "type": "Transitive",
+        "resolved": "7.0.3300",
+        "contentHash": "/0bb3ssO3rsPUZnVPFNAva2uBQLYNdT4hVLTx0XgxI8+/7acZVuMum18YOaOaE7hnLHMY00o4ypGL/L7JssEww==",
+        "dependencies": {
+          "EnvDTE": "8.0.1"
+        }
+      },
+      "VSLangProj110": {
+        "type": "Transitive",
+        "resolved": "11.0.61030",
+        "contentHash": "ZD0/JubfPji1tUTI7d1fOxEZqC23eHU7PIzoeR0LSY/dmDwEKa32xujNsgx6TT58ZRaSVFY27nUaiVaFdBz5Og==",
+        "dependencies": {
+          "VSLangProj80": "8.0.50727",
+          "VSLangProj90": "9.0.30729"
+        }
+      },
+      "VSLangProj157": {
+        "type": "Transitive",
+        "resolved": "15.7.0",
+        "contentHash": "PjFMHShxIYuZlwqa3feX3MpmCb0RsfCTExjgaJseODGJDXsjApJ5CWolJhlm956W1RHwALQXPiH786H3vZ8upw=="
+      },
+      "VSLangProj2": {
+        "type": "Transitive",
+        "resolved": "7.0.5000",
+        "contentHash": "A286CbJJxrKW4tpVyVaJit5rgVEmTJod/reZ8epekhZWiNoKv2YWkPGaCi0+gQXq4YepqPngE6UpQp5iAXyYDg==",
+        "dependencies": {
+          "VSLangProj": "7.0.3300"
+        }
+      },
+      "VSLangProj80": {
+        "type": "Transitive",
+        "resolved": "8.0.50727",
+        "contentHash": "I2xOMyQcbBXMXKE8zmHljkV1XLAltQ4/T5QRk8Q1mWz7fdd7x1OMp+2VqxZVAJ89Ebfs4wclkcACyvc4FY4wcQ==",
+        "dependencies": {
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "VSLangProj90": {
+        "type": "Transitive",
+        "resolved": "9.0.30729",
+        "contentHash": "xCG2hloStE4TCToHlBai7n/s33sfw/UiEkwqozRPt0AtW9JMr+0hXgGjlOyvPT2rgY6jjKywU55qoTXY2M8f6g=="
+      },
+      "VSSDK.DTE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "uUEaT0sCVnJR54vxfsf5xHpJVWgTrCbl10oKkFuCvJb3I6M5WW4cu9zCTqtYP1i1mYYySGGqooNYiO45kLUkiQ==",
+        "dependencies": {
+          "VSSDK.IDE": "[7.0.4, 8.0.0)"
+        }
+      },
+      "VSSDK.IDE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "KPXgpya93UDz/JZVegRr+AAewTGw46+8Aq7Dl22jWaqjH2KaH/5ycCLG0LET2OX4VBpp15IjhNw08Y5H0vJMKQ=="
+      },
+      "VSSDK.IDE.12": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "XYcSrKW9369JO1tOAuNxzZ6OOlx2QujDuboey4eYpp9GgA3Bd3mo0Fy2ZJd86sZqX27roBRzJfM1Ue/peyWOIg=="
+      },
+      "VSSDK.TemplateWizardInterface": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "stTXrh4h/mftHaQWKZn043WCgP7cmv3QVPB8M3bbBp99kktLdJBTXygPctpgeOYfsBi1TqKJIiNZjG3hCoHNMw==",
+        "dependencies": {
+          "VSSDK.DTE": "[7.0.4, 8.0.0)",
+          "VSSDK.IDE.12": "[12.0.4, 13.0.0)"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Console": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.TextManager.Interop.10.0": "10.0.30319",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.PackageManagement.UI": "5.0.0-preview3",
+          "NuGet.PackageManagement.VisualStudio": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Indexing": {
+        "type": "Project",
+        "dependencies": {
+          "Lucene.Net": "3.0.3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.2",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement.UI": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "NuGet.Indexing": "5.0.0-preview3",
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.PackageManagement.VisualStudio": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "NuGet.Indexing": "5.0.0-preview3",
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3",
+          "VSLangProj110": "11.0.61030",
+          "VSLangProj157": "15.7.0",
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      },
+      "NuGet.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "VSSDK.TemplateWizardInterface": "12.0.4"
+        }
+      },
+      "NuGet.VisualStudio.Common": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.TeamFoundationServer.ExtendedClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.ComponentModelHost": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Editor": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Language.Intellisense": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language.StandardClassification": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Services.Client": "16.144.1-preview",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.Shell.15.0": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "Microsoft.VisualStudio.Telemetry": "15.0.691-master31907920",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.8.132",
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "VSLangProj": "7.0.3300"
+        }
+      }
+    },
+    ".NETFramework,Version=v4.7.2/win": {},
+    ".NETFramework,Version=v4.7.2/win-x64": {},
+    ".NETFramework,Version=v4.7.2/win-x86": {}
+  }
+}

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/packages.lock.json
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/packages.lock.json
@@ -1,0 +1,890 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "Microsoft.Build.Framework": {
+        "type": "Direct",
+        "requested": "[15.6.85, )",
+        "resolved": "15.6.85",
+        "contentHash": "hwigmviEq8nOOd973M7jVXhuFXHT9rupUxeJ0sdbsNi6mgiXayUvVkj2k3mKXOusMTkuiYqcYrajr/rM2BJjUA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Process": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks.Parallel": "4.0.1",
+          "System.Threading.Thread": "4.0.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "YUJGz6eFKqS0V//mLt25vFGrrCvOnsXjlvFQs+KimpwNxug9x0Pzy4PlFMU3Q2IzqAa9G2L4LsK3+9vCBK7oTg=="
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "w5U95fVKHY4G8ASs/K5iK3J5LY+/dLFd4vKejsnI/ZhBsWS9hQakfx3Zr7lRWKg4tAw9r4iktyvsTagWkqYCiw=="
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "mpVZ5bnlSs3tTeJ6jYyDJEIa6tavhAd88lxq1zbYhkkCu0Pno2+gHXcvZcoygq2d8JxW3gojXqNJMTAshduqZA=="
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "B95h0YLEL2oSnwF/XjqSWKnwKOy/01VWkNlsCeMTFJLLabflpGV26nK164eRs5GiaRSBGpOxQ3pKoSnnyZN5pg=="
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "bQ0iYFOQI0nuTnt+NQADns6ucV4DUvMdwN6CbkB1yj8i7arTGiTN5eok1kQwdnnNWSDZfIUySQY+J3d5KjWn0g=="
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.0.12",
+        "contentHash": "tAgJM1xt3ytyMoW4qn4wIqgJYm7L7TShRZG4+Q4Qsi2PCcj96pXN7nRywS9KkB3p/xDUjc2HSwP9SROyPYDYKQ=="
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "TxwVeUNoTgUOdQ09gfTjvW411MF+w9MBYL7AtNVc+HtBCFlutPLhUCdZjNkjbhj3bNQWMdHboF0KIWEOjJssbA=="
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "v6c/4Yaa9uWsq+JMhnOFewrYkgdNHNG2eMKuNqRn8P733rNXeRCGvV5FkkjBXn2dbVkPXOsO0xjsEeM1q2zC0g=="
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "CUOHjTT/vgP0qGW22U4/hDlOqXmcPq5YicBaXdUR2UiUoLwBT+olO6we4DVbq57jeX5uXH2uerVZhf0qGj+sVQ=="
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "16eu3kjHS633yYdkjwShDHZLRNMKVi/s0bY8ODiqJ2RfMhDMAwxZaUaWVnZ2P71kr/or+X9o/xFWtNqz8ivieQ==",
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "N+3xqIcg3VDKyjwwCGaZ9HawG9aC6cSDI+s7ROma310GQo8vilFZa86hqKppwTHleR/G0sfOzhvgnUxWCR/DrQ=="
+      },
+      "System.Threading.Tasks.Parallel": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "7Pc9t25bcynT9FpMvkUw4ZjYwUiGup/5cJFW72/5MgCG+np2cfVUMdh29u8d7onxX7d8PS3J+wL73zQRqkdrSA=="
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "gIdJqDXlOr5W9zeqFErLw3dsOsiShSCYtF9SEHitACycmvNvY8odf9kiKvp6V7aibc8C4HzzNBkWXjyfn7plbQ=="
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    },
+    ".NETStandard,Version=v2.0": {
+      "Microsoft.Build.Framework": {
+        "type": "Direct",
+        "requested": "[15.6.85, )",
+        "resolved": "15.6.85",
+        "contentHash": "hwigmviEq8nOOd973M7jVXhuFXHT9rupUxeJ0sdbsNi6mgiXayUvVkj2k3mKXOusMTkuiYqcYrajr/rM2BJjUA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Process": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks.Parallel": "4.0.1",
+          "System.Threading.Thread": "4.0.0"
+        }
+      },
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "lJSTbsIVqnziQ1ZLPw+NZKyVHw9oABRwWer5dQesnt4kk7V8iLFtW8PhuAxEBlzii/z39FL/p+Kl+GptrRoRmA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "tI5H6Zg4DPqLcJNB232JMLACfX7UGawjTfMYdH8t6z5mXpDpHQVcFRzugqE6gG/EWrpQfAVJJzOVXeLJZ6ZZ+g=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "JFoFlE+s92bQksXVDwfQPBCf/eGLLIBcxEwuUva82KN079lG0KTQiWRTSKaCaXLThMohP9IXgy22eZCkOkwNIA=="
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cFEQkQFLOADfBo4k6zrDqhyg4bffeoFQsD1S1kzrrO06rSl5VeVn747esouUgH1xWNujphM9r6/AN85fxCIBTA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        }
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OJt7kV0xjgrGIO9dmygcZTzr8wFMpr8t17okLvtFEhSL+Hy9gvg8uGPUZH/IR+vjU7LSdg/lKweDNCrHEKHYXw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Collections.Concurrent": {
+        "type": "Transitive",
+        "resolved": "4.0.12",
+        "contentHash": "dXASCMmlhLiBcjjsdaMS4hPRCCkNHmIEYdJUlUDVfMSFqSpnVNZgrjSZxqVX3LsjwZSQmdl72ZWxzhYgUF5Z+Q==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "A3aDinDgWcac4zUmardLoisyp2aSF+OFy2/1GZEHqKrYlFObrYHx5Oa69YHALUhEBtCjc8UYgAFjpPZCw9fdiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Diagnostics.Tracing": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "3krIWb0PiXbD+Kd6TnEPJ050BjcTdRQJx0aF8BhdrML4m2WGt8DaxdZeuMck9c/Q8sUaS27a9syTfQ1NwdbLSg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Dynamic.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "M/4NKf2BW3OgjEEIY5zIICntbpzqG7mf6QW5/Sc8/jq6J1juU+r6Dd7Zy8BQc//BsgLN/ilp+jsidnNLvsvPlQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "wPQxHRTOQjHSTCoeRhcaNgUiN6+XLClZ4cF0Vxtx1cNLT6R1h8dkQ6OI86hJ5U0k6xlACnZZK2uPPKyCxHT9hg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "geg256WzQ6sWriZcgPAesEyvxEeQA4bChtNS0oXIHPNcXUli+h57SgF8oAG82YYIWFkw1WtJY8Ipswoj1lIV0w==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Expressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "pUhwb1gZm4nYs1vWOSBEtgFL2sba471wBK56vD+E9QXQPMCotyNoUlXDQU6JKP3iiXcZAYiLph74yDhK9LJn0A==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SN0ezyl68hX6MqubPw+9H/eYd66vXcYcPkGbcIlG2LAbRtLOjunoEFu4zwxbinKOYdIh7CBTCU1yLUFNXtqEcA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "N/L1zj+UTlLogL84AUE3fsJ0qjxlbHN9OxWxbkAlxNC+t47PQU8VssyXu0TjzH1QAclJOiEFTPa/V+My3P60dw==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ewhNB2sVnRTbEIkmOr0bjpn/3QAb6adt5VLjRLM3xYYHBmDotoVcYWOCtzXQoELX3EPhbo9tTt1COmHbOmtBaA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "s/qCR1/wIzV0EbusqDf13kez/m7ovN4qGy/YYgcKso98R+xJxbAtT0tK1e0UCHEHWZ0O0p3X9LraQpSl4Hs6qw==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "AxxXMPKP0sZp7eBBF7HMp8cj4w4vuaoVXHshS8F4qdvPy/nm5DCWOf7f0JX1xmwpsZEQiHj908cbVnNrRk1PzA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rsg/2b0JRcKznNmMJDljYlfHpUQ6LHmKdeKOvMz5DI0XKhY1DttFMNs0cdAjr/rSu4RjKMSjrsh1vWm1gEKutA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Formatters": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "giE1EDm3wyZjKOxNQpsg7cmPvlPcUDTevUpUeclRbWBbv8PCg245cFg8A3ihb0jETo2Uzgi4kXWRNIKuVLMDIA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Serialization.Primitives": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "JmkqsVmd/4ZAItnNtQdjPPLdMmsUIXtix/dI6eq2g4edEnqHJnI5naBXLcP49xmnuNo4JLEuSurtUefsp3LfAg==",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZLmOFqjQ8iOxQDHGOcxvIZ0LV8hOD8hFEJmfI3ugWpQfbiVXKuLspFgosbDuSPuxeZL6sBN6oUKa+qNFLF2y2g==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qBUHUk7IqrPHY96THHTa1akCxw0GsNFpsk3XFHbi0A0tMUDBpQprtY1Tbl6yaS1x4c96ilcXU8PocYtmSmkaQQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "zyxULthU5BUBw4RiTuO4zecYbVBIgoq0CrPfonNgWOd5Cl11xxIESMq+Q2TWTsAFkfsD3A6Kp6UTuhnroV6e0w==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Gj7tzvn7Q5lNaXz88jrohC7if2jqHKQpq8pw/yhgpIO9s/Y/nTMUSoeuxAODSO0UzaBh6M3c/F1y1olrpY1lng==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "PGbJReQ7spxIZuCb8nYjVNnNWWQn5Loey6sC8MvGBnHN9oJAetXW/Va9UvDmlB4+nZhY3uW2nbKEOsz6gFf88A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Threading.Tasks.Parallel": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "7Pc9t25bcynT9FpMvkUw4ZjYwUiGup/5cJFW72/5MgCG+np2cfVUMdh29u8d7onxX7d8PS3J+wL73zQRqkdrSA==",
+        "dependencies": {
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kCgI/sTE4fxnz1Fs0aScBCC+cYFIIR7I0IG1JPWDPjOSQxYs5Qdzi4Gf3eeAIevdE03n3PeCh2JVCKv0/11yrA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1WaMGI7TLOynUVjVzFmgVvxvho/yl2l7lkTc2EdgA0jtLDX9pHpEZkgG7KaY+9G2WMO1GVmuSEBzucbgmsFW2w==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "lvA/29NjaGEYADSOy+fJp6dtZ9NMSMX1cbePx9FHX5w66EwnceLVtggzWv1StQPAULtUrbjicjA7I2eAtvNgOQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Extensions": "4.0.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "Y0igaOCZs653g0Z+zeFiu9vTR/CPhpUmaee+BK4QUixVk2winYIZfGqKGQ9Jn8TBn+CX98adj1Q6OB1/XZXanw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "System.Diagnostics.Process": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "System.Security.Cryptography.ProtectedData": "4.3.0"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3",
+          "System.Runtime.Serialization.Formatters": "4.3.0"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/packages.lock.json
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/packages.lock.json
@@ -1,0 +1,1947 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    },
+    ".NETFramework,Version=v4.7.2/win10-x64": {},
+    ".NETStandard,Version=v2.0": {
+      "Microsoft.Build.Framework": {
+        "type": "Direct",
+        "requested": "[15.1.1012, )",
+        "resolved": "15.1.1012",
+        "contentHash": "ZunLrX0LtzXfnFM7va7WqsOWFQ63jufIapUIpE/Y+nGZtOgQSJcprwp92Fyad3F0NhY3yJMwDXqZ6xzi/1pHcA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Thread": "4.0.0"
+        }
+      },
+      "Microsoft.Build.Tasks.Core": {
+        "type": "Direct",
+        "requested": "[15.1.1012, )",
+        "resolved": "15.1.1012",
+        "contentHash": "a7WZR94HfvX+AuLoAl5p+wTdYrcCW+8Y0BTjXCEqqP4uXWWQlmT2wH4sepirurwXT1I/BYZqMVVvcgktd0qwJg==",
+        "dependencies": {
+          "Microsoft.Build.Framework": "[15.1.1012]",
+          "Microsoft.Build.Utilities.Core": "[15.1.1012]",
+          "Microsoft.Win32.Primitives": "4.0.1",
+          "System.AppContext": "4.1.0",
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Collections.Immutable": "1.2.0",
+          "System.Collections.NonGeneric": "4.0.1",
+          "System.Console": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Process": "4.1.0",
+          "System.Diagnostics.TraceSource": "4.0.0",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Linq": "4.1.0",
+          "System.Linq.Parallel": "4.0.1",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Metadata": "1.3.0",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.Reader": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Resources.Writer": "4.0.0",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Runtime.Serialization.Xml": "4.1.1",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Thread": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11",
+          "System.Xml.XmlDocument": "4.0.1"
+        }
+      },
+      "Microsoft.Build.Utilities.Core": {
+        "type": "Direct",
+        "requested": "[15.1.1012, )",
+        "resolved": "15.1.1012",
+        "contentHash": "JeD4Rc0P3tqVhxhaaqOGrSqYgT7MA1GqhUaGwM09w/bFfiHdGw9qCGcIrVTTm3AMHXzGPhWiOaCxrq1KbjtMHQ==",
+        "dependencies": {
+          "Microsoft.Build.Framework": "[15.1.1012]",
+          "Microsoft.Win32.Primitives": "4.0.1",
+          "System.AppContext": "4.1.0",
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Collections.NonGeneric": "4.0.1",
+          "System.Console": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Process": "4.1.0",
+          "System.Diagnostics.TraceSource": "4.0.0",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Linq": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.Reader": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Runtime.Serialization.Xml": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Thread": "4.0.0",
+          "System.Threading.Timer": "4.0.1",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XmlDocument": "4.0.1"
+        }
+      },
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "lJSTbsIVqnziQ1ZLPw+NZKyVHw9oABRwWer5dQesnt4kk7V8iLFtW8PhuAxEBlzii/z39FL/p+Kl+GptrRoRmA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "tI5H6Zg4DPqLcJNB232JMLACfX7UGawjTfMYdH8t6z5mXpDpHQVcFRzugqE6gG/EWrpQfAVJJzOVXeLJZ6ZZ+g=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "JFoFlE+s92bQksXVDwfQPBCf/eGLLIBcxEwuUva82KN079lG0KTQiWRTSKaCaXLThMohP9IXgy22eZCkOkwNIA=="
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cFEQkQFLOADfBo4k6zrDqhyg4bffeoFQsD1S1kzrrO06rSl5VeVn747esouUgH1xWNujphM9r6/AN85fxCIBTA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        }
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OJt7kV0xjgrGIO9dmygcZTzr8wFMpr8t17okLvtFEhSL+Hy9gvg8uGPUZH/IR+vjU7LSdg/lKweDNCrHEKHYXw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "runtime.native.System.Net.Http": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "53MjJLkfCgFku4pWahmKxK4fjxL48HXFw0vAs/gDRMW0rdrk/YxrbcAxtWIYt1g74aM30wprJHnADzlMWQLPDA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1"
+        }
+      },
+      "runtime.native.System.Security.Cryptography": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "jS4PpSyxGlG3to9V8Gk4jDHwS+hGgzXZH/wG4IlcjfbTB7HasxQocEd6kxUvV9agq8y8mnPSoj9Vm9tKOtGvyg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1"
+        }
+      },
+      "System.AppContext": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "aFK/Xsrb9Z4fqycvQn4CZ0dmaxEtJ4uA5tBX+TEW0AZIiRMeltD2N4R7sE5CxnQuJw4V4xW/tjRri6Flxn9CSQ==",
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Collections.Concurrent": {
+        "type": "Transitive",
+        "resolved": "4.0.12",
+        "contentHash": "dXASCMmlhLiBcjjsdaMS4hPRCCkNHmIEYdJUlUDVfMSFqSpnVNZgrjSZxqVX3LsjwZSQmdl72ZWxzhYgUF5Z+Q==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.2.0",
+        "contentHash": "hAMRmOgMrVvLHwz1ihGzBK9FVLo1Xx2zR9CloCaXcGxlXK3G8oiGjWZkCXsnd4nogg0VSVlSUgULsZ0jSl270Q==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Collections.NonGeneric": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "wagd87BNhA4dLXzJU4PRYrcTTzVqPtgH+kYrCjVvBEarJ56xbsZvJ7jJiG77EN5ek+y2/4jkLDLfLwsoBkue5g==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Console": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "lr8aZR1MUEJSV5ciX1rBAGZITMDYNSPVQBFPc42MpeiQLCygcrJcvD+FdLFF+8h+x/vxYJMHE4keeJSSyW5/Eg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Runtime": "4.1.0",
+          "System.Text.Encoding": "4.0.11"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "A3aDinDgWcac4zUmardLoisyp2aSF+OFy2/1GZEHqKrYlFObrYHx5Oa69YHALUhEBtCjc8UYgAFjpPZCw9fdiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Diagnostics.TraceSource": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "N2TnkNmV5CXwvcl3IUNhrD/zp9Kz4BeKucwuDbFff/mjH0G5yW/PFHYDc0UQfj9+l3XZzoR134ukYp2FpdiOqg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "runtime.native.System": "4.0.0"
+        }
+      },
+      "System.Diagnostics.Tracing": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "3krIWb0PiXbD+Kd6TnEPJ050BjcTdRQJx0aF8BhdrML4m2WGt8DaxdZeuMck9c/Q8sUaS27a9syTfQ1NwdbLSg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Dynamic.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "M/4NKf2BW3OgjEEIY5zIICntbpzqG7mf6QW5/Sc8/jq6J1juU+r6Dd7Zy8BQc//BsgLN/ilp+jsidnNLvsvPlQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Globalization.Calendars": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "06/EeQC76MAFreNlSeXs7WI32t7yVvUYB0qnW8nEPX7FAJDxl/fx4Il/wHHnUNGrLHp2On5aUq0X4xOWnG/u3A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Globalization": "4.0.11",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "wPQxHRTOQjHSTCoeRhcaNgUiN6+XLClZ4cF0Vxtx1cNLT6R1h8dkQ6OI86hJ5U0k6xlACnZZK2uPPKyCxHT9hg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "geg256WzQ6sWriZcgPAesEyvxEeQA4bChtNS0oXIHPNcXUli+h57SgF8oAG82YYIWFkw1WtJY8Ipswoj1lIV0w==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Expressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "pUhwb1gZm4nYs1vWOSBEtgFL2sba471wBK56vD+E9QXQPMCotyNoUlXDQU6JKP3iiXcZAYiLph74yDhK9LJn0A==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Linq.Parallel": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "Kgjp5qHYVWwzMaHz/uhRUFQFsHGPQ361iAzMD1SWpYU5Wj78zU5KqD0MhgyW+p1yXBUCMiuCSlzNmGVbNP0l4A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SN0ezyl68hX6MqubPw+9H/eYd66vXcYcPkGbcIlG2LAbRtLOjunoEFu4zwxbinKOYdIh7CBTCU1yLUFNXtqEcA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Private.DataContractSerialization": {
+        "type": "Transitive",
+        "resolved": "4.1.1",
+        "contentHash": "Q/sTcU1WM4Ol1PY5ES7hvSivYAq7K89i9FxnGmv0abRlrFI+ou09a4vvIsOl1g9snM12x2RU1+ZIdUj9BHTG/Q==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Emit.Lightweight": "4.0.1",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XmlDocument": "4.0.1",
+          "System.Xml.XmlSerializer": "4.0.11"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "N/L1zj+UTlLogL84AUE3fsJ0qjxlbHN9OxWxbkAlxNC+t47PQU8VssyXu0TjzH1QAclJOiEFTPa/V+My3P60dw==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ewhNB2sVnRTbEIkmOr0bjpn/3QAb6adt5VLjRLM3xYYHBmDotoVcYWOCtzXQoELX3EPhbo9tTt1COmHbOmtBaA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "s/qCR1/wIzV0EbusqDf13kez/m7ovN4qGy/YYgcKso98R+xJxbAtT0tK1e0UCHEHWZ0O0p3X9LraQpSl4Hs6qw==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "AxxXMPKP0sZp7eBBF7HMp8cj4w4vuaoVXHshS8F4qdvPy/nm5DCWOf7f0JX1xmwpsZEQiHj908cbVnNrRk1PzA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "1.3.0",
+        "contentHash": "mYYlGzXDyQXdHdG1nGzZQl3slFw6c5qQvuVVEwxw2RgVleXbd5wMbcQAxMjaiSHEZal+9cyfdvpAGYdccKxddA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Collections.Immutable": "1.2.0",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rsg/2b0JRcKznNmMJDljYlfHpUQ6LHmKdeKOvMz5DI0XKhY1DttFMNs0cdAjr/rSu4RjKMSjrsh1vWm1gEKutA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.Reader": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "RFMcsDn+LnHP7m6aCeAL+7x34tjNcKZKXF6Pwp8ff6cST7Yq11kK2zSJcJnumiWbq2xFmYC2BnnPanr2hxFYaQ==",
+        "dependencies": {
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.Writer": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "rjUPqh9wKHTVmh4i+4eyY0TfRQpyEJbeqp7z38zQ9rZY0Lf7XECReocX18PqozRK7eJCH1M31z0P9HATLRX9Lw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "/zHD0V2SwwuUUIpNHFqMAF612isHYhm/j3zJ310wChKFsyPDh3YJGy1ZpJQvmdUQPmiLsO6bh86DcY0L4Ogwgw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11",
+          "runtime.native.System": "4.0.0"
+        }
+      },
+      "System.Runtime.Numerics": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "S+ceQBaAoJahQfLF+by68BMp/GwTQh9k6Vbr961sH7r3dquq9588y4R1qxu84H48bsbA1p4BujLSdcXC1vwyRQ==",
+        "dependencies": {
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0"
+        }
+      },
+      "System.Runtime.Serialization.Formatters": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "giE1EDm3wyZjKOxNQpsg7cmPvlPcUDTevUpUeclRbWBbv8PCg245cFg8A3ihb0jETo2Uzgi4kXWRNIKuVLMDIA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Serialization.Primitives": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "JmkqsVmd/4ZAItnNtQdjPPLdMmsUIXtix/dI6eq2g4edEnqHJnI5naBXLcP49xmnuNo4JLEuSurtUefsp3LfAg==",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Xml": {
+        "type": "Transitive",
+        "resolved": "4.1.1",
+        "contentHash": "bg593KWxsTLllUHFg30net6x3p/+59+xDO5+WapE26d/mIh6YgV0o0Eyc4Q6/uuqowtTiIUd0dvbw+6fqlPkjQ==",
+        "dependencies": {
+          "System.IO": "4.1.0",
+          "System.Private.DataContractSerialization": "4.1.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
+      "System.Security.Cryptography.Algorithms": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "e3htH7AZi1CSHTWmfZTG6iQ6BGTQI3rWL88EGU+B+YqVDZn9qYKFiSvPxi1c1G6Itg7AbgO2gTgikOpw0cxdrQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        }
+      },
+      "System.Security.Cryptography.Cng": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "ly8bJk0z2hwypxXzKyPRm9tDJaB1bJ0O6TVF/whKttfusAk/WDeqkT06J+LbpAIoZIDkGMecH8bLJxhJA120Mg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11"
+        }
+      },
+      "System.Security.Cryptography.Csp": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "XjRqot97O7biTpDngIX3294+AdOfGTC4Hdo4WsajYriy0jb8gu03GeUlIuLlS7ycUNw1N1lGYntGGhHkkee6ew==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Security.Cryptography.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "j3BYjHDj3u94ZNq1KwQONCYJrU6uqT7ho/rwPosDW5GL+RvPH9UQ5cwotYkfdbdNipXN9nBzpMBuSRXIMAV9KQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        }
+      },
+      "System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "0WsJ0bWTr+7humusjg5C0xYkjZpsme7goXX31JMKzGdRYeSwExnB7mVZ/lNrB+i5Jw+qdYflN2dW/xCdl2K6Eg==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        }
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZLmOFqjQ8iOxQDHGOcxvIZ0LV8hOD8hFEJmfI3ugWpQfbiVXKuLspFgosbDuSPuxeZL6sBN6oUKa+qNFLF2y2g==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qBUHUk7IqrPHY96THHTa1akCxw0GsNFpsk3XFHbi0A0tMUDBpQprtY1Tbl6yaS1x4c96ilcXU8PocYtmSmkaQQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.X509Certificates": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "NCcNKz3NHHAU/eqvCzYePh6zF1flcb2sptJvm4/qE68GI5NAmQKqw7Siohx0OFF57rPpl7ewT1FT9plCJrga8g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Globalization.Calendars": "4.0.1",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Cng": "4.2.0",
+          "System.Security.Cryptography.Csp": "4.0.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.OpenSsl": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "runtime.native.System": "4.0.0",
+          "runtime.native.System.Net.Http": "4.0.1",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "zyxULthU5BUBw4RiTuO4zecYbVBIgoq0CrPfonNgWOd5Cl11xxIESMq+Q2TWTsAFkfsD3A6Kp6UTuhnroV6e0w==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Gj7tzvn7Q5lNaXz88jrohC7if2jqHKQpq8pw/yhgpIO9s/Y/nTMUSoeuxAODSO0UzaBh6M3c/F1y1olrpY1lng==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "PGbJReQ7spxIZuCb8nYjVNnNWWQn5Loey6sC8MvGBnHN9oJAetXW/Va9UvDmlB4+nZhY3uW2nbKEOsz6gFf88A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kCgI/sTE4fxnz1Fs0aScBCC+cYFIIR7I0IG1JPWDPjOSQxYs5Qdzi4Gf3eeAIevdE03n3PeCh2JVCKv0/11yrA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1WaMGI7TLOynUVjVzFmgVvxvho/yl2l7lkTc2EdgA0jtLDX9pHpEZkgG7KaY+9G2WMO1GVmuSEBzucbgmsFW2w==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Threading.Timer": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "vFBe4Y3UCSKVm7K3BxloF/06VQVrhoOPTjicln1H7TSQeAhyriPLbJu72kCMJzjRfblve36EHk894sjAHzBL/w==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "lvA/29NjaGEYADSOy+fJp6dtZ9NMSMX1cbePx9FHX5w66EwnceLVtggzWv1StQPAULtUrbjicjA7I2eAtvNgOQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Extensions": "4.0.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "Y0igaOCZs653g0Z+zeFiu9vTR/CPhpUmaee+BK4QUixVk2winYIZfGqKGQ9Jn8TBn+CX98adj1Q6OB1/XZXanw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
+      "System.Xml.XmlDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "oq+vEDFjPI+NDGZG8oFBa+SU7imXDgN0VAjkQTWhQLukklLOAtf1tvZRxMCOJfCVDHnmIFsGjoN27Dc5DzmZlg==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
+      "System.Xml.XmlSerializer": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "N77vYjK/LMLryOnhq4qBM0kLjp8Egb5Yeow6qnUI+50Itpo2o8uSJwQ4kUxkrF+VdbUiUU6txCuWaj95IJ+KTg==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit": "4.0.1",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XmlDocument": "4.0.1"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "System.Diagnostics.Process": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "System.Security.Cryptography.ProtectedData": "4.3.0"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3",
+          "System.Runtime.Serialization.Formatters": "4.3.0"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    },
+    ".NETStandard,Version=v2.0/win10-x64": {
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cFEQkQFLOADfBo4k6zrDqhyg4bffeoFQsD1S1kzrrO06rSl5VeVn747esouUgH1xWNujphM9r6/AN85fxCIBTA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "runtime.win.Microsoft.Win32.Primitives": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "runtime.any.System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "23g6rqftKmovn2cLeGsuHUYm0FD7pdutb0uQMJpZ3qTvq+zHkgmt6J65VtRry4WDGYlmkMa4xDACtaQ94alNag==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "runtime.any.System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "S/GPBmfPBB48ZghLxdDR7kDAJVAqgAuThyDJho3OLP5OS4tWD2ydyL8LKm8lhiBxce10OKe9X2zZ6DUjAqEbPg=="
+      },
+      "runtime.any.System.Diagnostics.Tracing": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lpifymjGDzoYIaam6/Hyqf8GhBI3xXYLK2TgEvTtuZMorG3Kb9QnMTIKhLjJYXIiu1JvxjngHvtVFQQlpQ3HQ=="
+      },
+      "runtime.any.System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "sMDBnad4rp4t7GY442Jux0MCUuKL4otn5BK6Ni0ARTXTSpRNBzZ7hpMfKSvnVSED5kYJm96YOWsqV0JH0d2uuw=="
+      },
+      "runtime.any.System.Globalization.Calendars": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "M1r+760j1CNA6M/ZaW6KX8gOS8nxPRqloqDcJYVidRG566Ykwcs29AweZs2JF+nMOCgWDiMfPSTMfvwOI9F77w=="
+      },
+      "runtime.any.System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SDZ5AD1DtyRoxYtEcqQ3HDlcrorMYXZeCt7ZhG9US9I5Vva+gpIWDGMkcwa5XiKL0ceQKRZIX2x0XEjLX7PDzQ=="
+      },
+      "runtime.any.System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hLC3A3rI8jipR5d9k7+f0MgRCW6texsAp0MWkN/ci18FMtQ9KH7E2vDn/DH2LkxsszlpJpOn9qy6Z6/69rH6eQ=="
+      },
+      "runtime.any.System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cPhT+Vqu52+cQQrDai/V91gubXUnDKNRvlBnH+hOgtGyHdC17aQIU64EaehwAQymd7kJA5rSrVRNfDYrbhnzyA=="
+      },
+      "runtime.any.System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Nrm1p3armp6TTf2xuvaa+jGTTmncALWFq22CpmwRvhDf6dE9ZmH40EbOswD4GnFLrMRS0Ki6Kx5aUPmKK/hZBg=="
+      },
+      "runtime.any.System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Lxb89SMvf8w9p9+keBLyL6H6x/TEmc6QVsIIA0T36IuyOY3kNvIdyGddA2qt35cRamzxF8K5p0Opq4G4HjNbhQ=="
+      },
+      "runtime.any.System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fRS7zJgaG9NkifaAxGGclDDoRn9HC7hXACl52Or06a/fxdzDajWb5wov3c6a+gVSlekRoexfjwQSK9sh5um5LQ==",
+        "dependencies": {
+          "System.Private.Uri": "4.3.0"
+        }
+      },
+      "runtime.any.System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "GG84X6vufoEzqx8PbeBKheE4srOhimv+yLtGb/JkR3Y2FmoqmueLNFU4Xx8Y67plFpltQSdK74x0qlEhIpv/CQ=="
+      },
+      "runtime.any.System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "lBoFeQfxe/4eqjPi46E0LU/YaCMdNkQ8B4MZu/mkzdIAZh8RQ1NYZSj0egrQKdgdvlPFtP4STtob40r4o2DBAw=="
+      },
+      "runtime.any.System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "+ihI5VaXFCMVPJNstG4O4eo1CfbrByLxRrQQTqOTp1ttK0kUKDqOdBSTaCB2IBk/QtjDrs6+x4xuezyMXdm0HQ=="
+      },
+      "runtime.any.System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "NLrxmLsfRrOuVqPWG+2lrQZnE53MLVeo+w9c54EV+TUo4c8rILpsDXfY8pPiOy9kHpUHHP07ugKmtsU3vVW5Jg=="
+      },
+      "runtime.any.System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OhBAVBQG5kFj1S+hCEQ3TUHBAEtZ3fbEMgZMRNdN8A0Pj4x+5nTELEqL59DU0TjKVE6II3dqKw4Dklb3szT65w=="
+      },
+      "runtime.any.System.Threading.Timer": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "w4ehZJ+AwXYmGwYu+rMvym6RvMaRiUEQR1u6dwcyuKHxz8Heu/mO9AG1MquEgTyucnhv3M43X0iKpDOoN17C0w=="
+      },
+      "runtime.win.Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "NU51SEt/ZaD2MF48sJ17BIqx7rjeNNLXUevfMOjqQIetdndXwYjZfZsT6jD+rSWp/FYxjesdK4xUSl4OTEI0jw==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "runtime.win.System.Console": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "RRACWygml5dnmfgC1SW6tLGsFgwsUAKFtvhdyHnIEz4EhWyrd7pacDdY95CacQJy7BMXRDRCejC9aCRC0Y1sQA==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "runtime.win.System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hHHP0WCStene2jjeYcuDkETozUYF/3sHVRHAEOgS3L15hlip24ssqCTnJC28Z03Wpo078oMcJd0H4egD2aJI8g=="
+      },
+      "runtime.win.System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Z37zcSCpXuGCYtFbqYO0TwOVXxS2d+BXgSoDFZmRg8BC4Cuy54edjyIvhhcfCrDQA9nl+EPFTgHN54dRAK7mNA==",
+        "dependencies": {
+          "System.Buffers": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Overlapped": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "runtime.win.System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "RkgHVhUPvzZxuUubiZe8yr/6CypRVXj0VBzaR8hsqQ8f+rUo7e4PWrHTLOCjd8fBMGWCrY//fi7Ku3qXD7oHRw==",
+        "dependencies": {
+          "System.Private.Uri": "4.3.0"
+        }
+      },
+      "runtime.win7.System.Private.Uri": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Q+IBgaPYicSQs2tBlmXqbS25c/JLIthWrgrpMwxKSOobW/OqIMVFruUGfuaz4QABVzV8iKdCAbN7APY7Tclbnw=="
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "eQAvCk2CKY8IiO/mDwttFqgdmW30yiuIi/SCx+rofGirYGqjjK9j7uVnIUs8P9o5R1flCOKY4MFd2GGh1d4oyA==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "runtime.any.System.Collections": "4.3.0"
+        }
+      },
+      "System.Console": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "lr8aZR1MUEJSV5ciX1rBAGZITMDYNSPVQBFPc42MpeiQLCygcrJcvD+FdLFF+8h+x/vxYJMHE4keeJSSyW5/Eg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Runtime": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "runtime.win.System.Console": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "runtime.win.System.Diagnostics.Debug": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "A3aDinDgWcac4zUmardLoisyp2aSF+OFy2/1GZEHqKrYlFObrYHx5Oa69YHALUhEBtCjc8UYgAFjpPZCw9fdiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "runtime.any.System.Diagnostics.Tools": "4.3.0"
+        }
+      },
+      "System.Diagnostics.TraceSource": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "N2TnkNmV5CXwvcl3IUNhrD/zp9Kz4BeKucwuDbFff/mjH0G5yW/PFHYDc0UQfj9+l3XZzoR134ukYp2FpdiOqg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "runtime.native.System": "4.0.0"
+        }
+      },
+      "System.Diagnostics.Tracing": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Krwavn7yTVK68eEzsmXF8ES7xA2vUcgAVASfsGNoRyFyfAcRLH/tEWhSpXx/ILCLkGxbZc47Y1gCfQmAudpRAw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "runtime.any.System.Diagnostics.Tracing": "4.3.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "runtime.any.System.Globalization": "4.3.0"
+        }
+      },
+      "System.Globalization.Calendars": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "06/EeQC76MAFreNlSeXs7WI32t7yVvUYB0qnW8nEPX7FAJDxl/fx4Il/wHHnUNGrLHp2On5aUq0X4xOWnG/u3A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Globalization": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "runtime.any.System.Globalization.Calendars": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.any.System.IO": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.win.System.IO.FileSystem": "4.3.0"
+        }
+      },
+      "System.Private.Uri": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "I4SwANiUGho1esj4V4oSlPllXjzCZDE+5XXso2P03LW2vOda2Enzh8DWOxwN6hnrJyp314c7KuVu31QYhRzOGg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "runtime.win7.System.Private.Uri": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "runtime.any.System.Reflection": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "AxxXMPKP0sZp7eBBF7HMp8cj4w4vuaoVXHshS8F4qdvPy/nm5DCWOf7f0JX1xmwpsZEQiHj908cbVnNrRk1PzA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "runtime.any.System.Reflection.Extensions": "4.3.0"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "runtime.any.System.Reflection.Primitives": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "runtime.any.System.Resources.ResourceManager": "4.3.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "runtime.any.System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "runtime.win.System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "runtime.any.System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "runtime.any.System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "/zHD0V2SwwuUUIpNHFqMAF612isHYhm/j3zJ310wChKFsyPDh3YJGy1ZpJQvmdUQPmiLsO6bh86DcY0L4Ogwgw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11",
+          "runtime.native.System": "4.0.0"
+        }
+      },
+      "System.Security.Cryptography.Algorithms": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "e3htH7AZi1CSHTWmfZTG6iQ6BGTQI3rWL88EGU+B+YqVDZn9qYKFiSvPxi1c1G6Itg7AbgO2gTgikOpw0cxdrQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        }
+      },
+      "System.Security.Cryptography.Cng": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "ly8bJk0z2hwypxXzKyPRm9tDJaB1bJ0O6TVF/whKttfusAk/WDeqkT06J+LbpAIoZIDkGMecH8bLJxhJA120Mg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11"
+        }
+      },
+      "System.Security.Cryptography.Csp": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "XjRqot97O7biTpDngIX3294+AdOfGTC4Hdo4WsajYriy0jb8gu03GeUlIuLlS7ycUNw1N1lGYntGGhHkkee6ew==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Security.Cryptography.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "j3BYjHDj3u94ZNq1KwQONCYJrU6uqT7ho/rwPosDW5GL+RvPH9UQ5cwotYkfdbdNipXN9nBzpMBuSRXIMAV9KQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        }
+      },
+      "System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "0WsJ0bWTr+7humusjg5C0xYkjZpsme7goXX31JMKzGdRYeSwExnB7mVZ/lNrB+i5Jw+qdYflN2dW/xCdl2K6Eg==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qBUHUk7IqrPHY96THHTa1akCxw0GsNFpsk3XFHbi0A0tMUDBpQprtY1Tbl6yaS1x4c96ilcXU8PocYtmSmkaQQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.X509Certificates": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "NCcNKz3NHHAU/eqvCzYePh6zF1flcb2sptJvm4/qE68GI5NAmQKqw7Siohx0OFF57rPpl7ewT1FT9plCJrga8g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Globalization.Calendars": "4.0.1",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Cng": "4.2.0",
+          "System.Security.Cryptography.Csp": "4.0.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.OpenSsl": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "runtime.native.System": "4.0.0",
+          "runtime.native.System.Net.Http": "4.0.1",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "runtime.any.System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.any.System.Text.Encoding.Extensions": "4.3.0"
+        }
+      },
+      "System.Threading.Overlapped": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "m3HQ2dPiX/DSTpf+yJt8B0c+SRvzfqAJKx+QDWi+VLhz8svLT23MVjEOHPF/KiSLeArKU/iHescrbLd3yVgyNg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "runtime.any.System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Timer": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "vFBe4Y3UCSKVm7K3BxloF/06VQVrhoOPTjicln1H7TSQeAhyriPLbJu72kCMJzjRfblve36EHk894sjAHzBL/w==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "runtime.any.System.Threading.Timer": "4.3.0"
+        }
+      }
+    }
+  }
+}

--- a/src/NuGet.Core/NuGet.Build.Tasks/packages.lock.json
+++ b/src/NuGet.Core/NuGet.Build.Tasks/packages.lock.json
@@ -1,0 +1,1281 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    },
+    ".NETStandard,Version=v2.0": {
+      "Microsoft.Build.Framework": {
+        "type": "Direct",
+        "requested": "[15.1.1012, )",
+        "resolved": "15.1.1012",
+        "contentHash": "ZunLrX0LtzXfnFM7va7WqsOWFQ63jufIapUIpE/Y+nGZtOgQSJcprwp92Fyad3F0NhY3yJMwDXqZ6xzi/1pHcA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Thread": "4.0.0"
+        }
+      },
+      "Microsoft.Build.Tasks.Core": {
+        "type": "Direct",
+        "requested": "[15.1.1012, )",
+        "resolved": "15.1.1012",
+        "contentHash": "a7WZR94HfvX+AuLoAl5p+wTdYrcCW+8Y0BTjXCEqqP4uXWWQlmT2wH4sepirurwXT1I/BYZqMVVvcgktd0qwJg==",
+        "dependencies": {
+          "Microsoft.Build.Framework": "[15.1.1012]",
+          "Microsoft.Build.Utilities.Core": "[15.1.1012]",
+          "Microsoft.Win32.Primitives": "4.0.1",
+          "System.AppContext": "4.1.0",
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Collections.Immutable": "1.2.0",
+          "System.Collections.NonGeneric": "4.0.1",
+          "System.Console": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Process": "4.1.0",
+          "System.Diagnostics.TraceSource": "4.0.0",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Linq": "4.1.0",
+          "System.Linq.Parallel": "4.0.1",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Metadata": "1.3.0",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.Reader": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Resources.Writer": "4.0.0",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Runtime.Serialization.Xml": "4.1.1",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Thread": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11",
+          "System.Xml.XmlDocument": "4.0.1"
+        }
+      },
+      "Microsoft.Build.Utilities.Core": {
+        "type": "Direct",
+        "requested": "[15.1.1012, )",
+        "resolved": "15.1.1012",
+        "contentHash": "JeD4Rc0P3tqVhxhaaqOGrSqYgT7MA1GqhUaGwM09w/bFfiHdGw9qCGcIrVTTm3AMHXzGPhWiOaCxrq1KbjtMHQ==",
+        "dependencies": {
+          "Microsoft.Build.Framework": "[15.1.1012]",
+          "Microsoft.Win32.Primitives": "4.0.1",
+          "System.AppContext": "4.1.0",
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Collections.NonGeneric": "4.0.1",
+          "System.Console": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Process": "4.1.0",
+          "System.Diagnostics.TraceSource": "4.0.0",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Linq": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.Reader": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Runtime.Serialization.Xml": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Thread": "4.0.0",
+          "System.Threading.Timer": "4.0.1",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XmlDocument": "4.0.1"
+        }
+      },
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "lJSTbsIVqnziQ1ZLPw+NZKyVHw9oABRwWer5dQesnt4kk7V8iLFtW8PhuAxEBlzii/z39FL/p+Kl+GptrRoRmA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "tI5H6Zg4DPqLcJNB232JMLACfX7UGawjTfMYdH8t6z5mXpDpHQVcFRzugqE6gG/EWrpQfAVJJzOVXeLJZ6ZZ+g=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "JFoFlE+s92bQksXVDwfQPBCf/eGLLIBcxEwuUva82KN079lG0KTQiWRTSKaCaXLThMohP9IXgy22eZCkOkwNIA=="
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cFEQkQFLOADfBo4k6zrDqhyg4bffeoFQsD1S1kzrrO06rSl5VeVn747esouUgH1xWNujphM9r6/AN85fxCIBTA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        }
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OJt7kV0xjgrGIO9dmygcZTzr8wFMpr8t17okLvtFEhSL+Hy9gvg8uGPUZH/IR+vjU7LSdg/lKweDNCrHEKHYXw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "runtime.native.System.Net.Http": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "53MjJLkfCgFku4pWahmKxK4fjxL48HXFw0vAs/gDRMW0rdrk/YxrbcAxtWIYt1g74aM30wprJHnADzlMWQLPDA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1"
+        }
+      },
+      "runtime.native.System.Security.Cryptography": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "jS4PpSyxGlG3to9V8Gk4jDHwS+hGgzXZH/wG4IlcjfbTB7HasxQocEd6kxUvV9agq8y8mnPSoj9Vm9tKOtGvyg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1"
+        }
+      },
+      "System.AppContext": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "aFK/Xsrb9Z4fqycvQn4CZ0dmaxEtJ4uA5tBX+TEW0AZIiRMeltD2N4R7sE5CxnQuJw4V4xW/tjRri6Flxn9CSQ==",
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Collections.Concurrent": {
+        "type": "Transitive",
+        "resolved": "4.0.12",
+        "contentHash": "dXASCMmlhLiBcjjsdaMS4hPRCCkNHmIEYdJUlUDVfMSFqSpnVNZgrjSZxqVX3LsjwZSQmdl72ZWxzhYgUF5Z+Q==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.2.0",
+        "contentHash": "hAMRmOgMrVvLHwz1ihGzBK9FVLo1Xx2zR9CloCaXcGxlXK3G8oiGjWZkCXsnd4nogg0VSVlSUgULsZ0jSl270Q==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Collections.NonGeneric": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "wagd87BNhA4dLXzJU4PRYrcTTzVqPtgH+kYrCjVvBEarJ56xbsZvJ7jJiG77EN5ek+y2/4jkLDLfLwsoBkue5g==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Console": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "lr8aZR1MUEJSV5ciX1rBAGZITMDYNSPVQBFPc42MpeiQLCygcrJcvD+FdLFF+8h+x/vxYJMHE4keeJSSyW5/Eg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Runtime": "4.1.0",
+          "System.Text.Encoding": "4.0.11"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "A3aDinDgWcac4zUmardLoisyp2aSF+OFy2/1GZEHqKrYlFObrYHx5Oa69YHALUhEBtCjc8UYgAFjpPZCw9fdiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Diagnostics.TraceSource": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "N2TnkNmV5CXwvcl3IUNhrD/zp9Kz4BeKucwuDbFff/mjH0G5yW/PFHYDc0UQfj9+l3XZzoR134ukYp2FpdiOqg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "runtime.native.System": "4.0.0"
+        }
+      },
+      "System.Diagnostics.Tracing": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "3krIWb0PiXbD+Kd6TnEPJ050BjcTdRQJx0aF8BhdrML4m2WGt8DaxdZeuMck9c/Q8sUaS27a9syTfQ1NwdbLSg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Dynamic.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "M/4NKf2BW3OgjEEIY5zIICntbpzqG7mf6QW5/Sc8/jq6J1juU+r6Dd7Zy8BQc//BsgLN/ilp+jsidnNLvsvPlQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Globalization.Calendars": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "06/EeQC76MAFreNlSeXs7WI32t7yVvUYB0qnW8nEPX7FAJDxl/fx4Il/wHHnUNGrLHp2On5aUq0X4xOWnG/u3A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Globalization": "4.0.11",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "wPQxHRTOQjHSTCoeRhcaNgUiN6+XLClZ4cF0Vxtx1cNLT6R1h8dkQ6OI86hJ5U0k6xlACnZZK2uPPKyCxHT9hg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "geg256WzQ6sWriZcgPAesEyvxEeQA4bChtNS0oXIHPNcXUli+h57SgF8oAG82YYIWFkw1WtJY8Ipswoj1lIV0w==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Expressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "pUhwb1gZm4nYs1vWOSBEtgFL2sba471wBK56vD+E9QXQPMCotyNoUlXDQU6JKP3iiXcZAYiLph74yDhK9LJn0A==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Linq.Parallel": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "Kgjp5qHYVWwzMaHz/uhRUFQFsHGPQ361iAzMD1SWpYU5Wj78zU5KqD0MhgyW+p1yXBUCMiuCSlzNmGVbNP0l4A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SN0ezyl68hX6MqubPw+9H/eYd66vXcYcPkGbcIlG2LAbRtLOjunoEFu4zwxbinKOYdIh7CBTCU1yLUFNXtqEcA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Private.DataContractSerialization": {
+        "type": "Transitive",
+        "resolved": "4.1.1",
+        "contentHash": "Q/sTcU1WM4Ol1PY5ES7hvSivYAq7K89i9FxnGmv0abRlrFI+ou09a4vvIsOl1g9snM12x2RU1+ZIdUj9BHTG/Q==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Emit.Lightweight": "4.0.1",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XmlDocument": "4.0.1",
+          "System.Xml.XmlSerializer": "4.0.11"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "N/L1zj+UTlLogL84AUE3fsJ0qjxlbHN9OxWxbkAlxNC+t47PQU8VssyXu0TjzH1QAclJOiEFTPa/V+My3P60dw==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ewhNB2sVnRTbEIkmOr0bjpn/3QAb6adt5VLjRLM3xYYHBmDotoVcYWOCtzXQoELX3EPhbo9tTt1COmHbOmtBaA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "s/qCR1/wIzV0EbusqDf13kez/m7ovN4qGy/YYgcKso98R+xJxbAtT0tK1e0UCHEHWZ0O0p3X9LraQpSl4Hs6qw==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "AxxXMPKP0sZp7eBBF7HMp8cj4w4vuaoVXHshS8F4qdvPy/nm5DCWOf7f0JX1xmwpsZEQiHj908cbVnNrRk1PzA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "1.3.0",
+        "contentHash": "mYYlGzXDyQXdHdG1nGzZQl3slFw6c5qQvuVVEwxw2RgVleXbd5wMbcQAxMjaiSHEZal+9cyfdvpAGYdccKxddA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Collections.Immutable": "1.2.0",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rsg/2b0JRcKznNmMJDljYlfHpUQ6LHmKdeKOvMz5DI0XKhY1DttFMNs0cdAjr/rSu4RjKMSjrsh1vWm1gEKutA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.Reader": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "RFMcsDn+LnHP7m6aCeAL+7x34tjNcKZKXF6Pwp8ff6cST7Yq11kK2zSJcJnumiWbq2xFmYC2BnnPanr2hxFYaQ==",
+        "dependencies": {
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.Writer": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "rjUPqh9wKHTVmh4i+4eyY0TfRQpyEJbeqp7z38zQ9rZY0Lf7XECReocX18PqozRK7eJCH1M31z0P9HATLRX9Lw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "/zHD0V2SwwuUUIpNHFqMAF612isHYhm/j3zJ310wChKFsyPDh3YJGy1ZpJQvmdUQPmiLsO6bh86DcY0L4Ogwgw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11",
+          "runtime.native.System": "4.0.0"
+        }
+      },
+      "System.Runtime.Numerics": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "S+ceQBaAoJahQfLF+by68BMp/GwTQh9k6Vbr961sH7r3dquq9588y4R1qxu84H48bsbA1p4BujLSdcXC1vwyRQ==",
+        "dependencies": {
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0"
+        }
+      },
+      "System.Runtime.Serialization.Formatters": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "giE1EDm3wyZjKOxNQpsg7cmPvlPcUDTevUpUeclRbWBbv8PCg245cFg8A3ihb0jETo2Uzgi4kXWRNIKuVLMDIA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Serialization.Primitives": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "JmkqsVmd/4ZAItnNtQdjPPLdMmsUIXtix/dI6eq2g4edEnqHJnI5naBXLcP49xmnuNo4JLEuSurtUefsp3LfAg==",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Xml": {
+        "type": "Transitive",
+        "resolved": "4.1.1",
+        "contentHash": "bg593KWxsTLllUHFg30net6x3p/+59+xDO5+WapE26d/mIh6YgV0o0Eyc4Q6/uuqowtTiIUd0dvbw+6fqlPkjQ==",
+        "dependencies": {
+          "System.IO": "4.1.0",
+          "System.Private.DataContractSerialization": "4.1.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
+      "System.Security.Cryptography.Algorithms": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "e3htH7AZi1CSHTWmfZTG6iQ6BGTQI3rWL88EGU+B+YqVDZn9qYKFiSvPxi1c1G6Itg7AbgO2gTgikOpw0cxdrQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        }
+      },
+      "System.Security.Cryptography.Cng": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "ly8bJk0z2hwypxXzKyPRm9tDJaB1bJ0O6TVF/whKttfusAk/WDeqkT06J+LbpAIoZIDkGMecH8bLJxhJA120Mg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11"
+        }
+      },
+      "System.Security.Cryptography.Csp": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "XjRqot97O7biTpDngIX3294+AdOfGTC4Hdo4WsajYriy0jb8gu03GeUlIuLlS7ycUNw1N1lGYntGGhHkkee6ew==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Security.Cryptography.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "j3BYjHDj3u94ZNq1KwQONCYJrU6uqT7ho/rwPosDW5GL+RvPH9UQ5cwotYkfdbdNipXN9nBzpMBuSRXIMAV9KQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        }
+      },
+      "System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "0WsJ0bWTr+7humusjg5C0xYkjZpsme7goXX31JMKzGdRYeSwExnB7mVZ/lNrB+i5Jw+qdYflN2dW/xCdl2K6Eg==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        }
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZLmOFqjQ8iOxQDHGOcxvIZ0LV8hOD8hFEJmfI3ugWpQfbiVXKuLspFgosbDuSPuxeZL6sBN6oUKa+qNFLF2y2g==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qBUHUk7IqrPHY96THHTa1akCxw0GsNFpsk3XFHbi0A0tMUDBpQprtY1Tbl6yaS1x4c96ilcXU8PocYtmSmkaQQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.X509Certificates": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "NCcNKz3NHHAU/eqvCzYePh6zF1flcb2sptJvm4/qE68GI5NAmQKqw7Siohx0OFF57rPpl7ewT1FT9plCJrga8g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Globalization.Calendars": "4.0.1",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Cng": "4.2.0",
+          "System.Security.Cryptography.Csp": "4.0.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.OpenSsl": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "runtime.native.System": "4.0.0",
+          "runtime.native.System.Net.Http": "4.0.1",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "zyxULthU5BUBw4RiTuO4zecYbVBIgoq0CrPfonNgWOd5Cl11xxIESMq+Q2TWTsAFkfsD3A6Kp6UTuhnroV6e0w==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Gj7tzvn7Q5lNaXz88jrohC7if2jqHKQpq8pw/yhgpIO9s/Y/nTMUSoeuxAODSO0UzaBh6M3c/F1y1olrpY1lng==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "PGbJReQ7spxIZuCb8nYjVNnNWWQn5Loey6sC8MvGBnHN9oJAetXW/Va9UvDmlB4+nZhY3uW2nbKEOsz6gFf88A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kCgI/sTE4fxnz1Fs0aScBCC+cYFIIR7I0IG1JPWDPjOSQxYs5Qdzi4Gf3eeAIevdE03n3PeCh2JVCKv0/11yrA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1WaMGI7TLOynUVjVzFmgVvxvho/yl2l7lkTc2EdgA0jtLDX9pHpEZkgG7KaY+9G2WMO1GVmuSEBzucbgmsFW2w==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Threading.Timer": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "vFBe4Y3UCSKVm7K3BxloF/06VQVrhoOPTjicln1H7TSQeAhyriPLbJu72kCMJzjRfblve36EHk894sjAHzBL/w==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "lvA/29NjaGEYADSOy+fJp6dtZ9NMSMX1cbePx9FHX5w66EwnceLVtggzWv1StQPAULtUrbjicjA7I2eAtvNgOQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Extensions": "4.0.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "Y0igaOCZs653g0Z+zeFiu9vTR/CPhpUmaee+BK4QUixVk2winYIZfGqKGQ9Jn8TBn+CX98adj1Q6OB1/XZXanw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
+      "System.Xml.XmlDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "oq+vEDFjPI+NDGZG8oFBa+SU7imXDgN0VAjkQTWhQLukklLOAtf1tvZRxMCOJfCVDHnmIFsGjoN27Dc5DzmZlg==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
+      "System.Xml.XmlSerializer": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "N77vYjK/LMLryOnhq4qBM0kLjp8Egb5Yeow6qnUI+50Itpo2o8uSJwQ4kUxkrF+VdbUiUU6txCuWaj95IJ+KTg==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit": "4.0.1",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XmlDocument": "4.0.1"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "System.Diagnostics.Process": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "System.Security.Cryptography.ProtectedData": "4.3.0"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3",
+          "System.Runtime.Serialization.Formatters": "4.3.0"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/packages.lock.json
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/packages.lock.json
@@ -1,0 +1,1903 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETCoreApp,Version=v2.1": {
+      "Microsoft.Build.Runtime": {
+        "type": "Direct",
+        "requested": "[16.0.0-preview.256, )",
+        "resolved": "16.0.0-preview.256",
+        "contentHash": "5yq7PGU0e6WbhDQMzHYRWSjYdPnmElXGvfuCCohwRqfflqa5PlmOfYuUTe3vNePv1wv75EJqpCV9LGwMltKMsg==",
+        "dependencies": {
+          "Microsoft.Build": "16.0.0-preview.256",
+          "Microsoft.Build.Tasks.Core": "16.0.0-preview.256",
+          "Microsoft.Win32.Registry": "4.3.0"
+        }
+      },
+      "Microsoft.Extensions.CommandLineUtils": {
+        "type": "Direct",
+        "requested": "[1.0.1, )",
+        "resolved": "1.0.1",
+        "contentHash": "wTk8JFNIBF94m8gzbkjinkgdtD2SfZe8yu8847x8YsqDYYsHOT4siGZeFot3/061RfMm2W2QopRKyNkzz16V2A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Console": "4.0.0",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1"
+        }
+      },
+      "Microsoft.NETCore.App": {
+        "type": "Direct",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "mVxL8khUMyl0L+MkyY0SLhZU13Z+KoUCcCTDC1MZKaegUVbAuaEzqX0VyGJ5U1lyo8fh6ryJPbsBPJww6qcKpw==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetHostPolicy": "2.1.0",
+          "Microsoft.NETCore.Platforms": "2.1.0",
+          "Microsoft.NETCore.Targets": "2.1.0",
+          "NETStandard.Library": "2.0.3"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "System.Runtime.Serialization.Primitives": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "JmkqsVmd/4ZAItnNtQdjPPLdMmsUIXtix/dI6eq2g4edEnqHJnI5naBXLcP49xmnuNo4JLEuSurtUefsp3LfAg==",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Build": {
+        "type": "Transitive",
+        "resolved": "16.0.0-preview.256",
+        "contentHash": "I6kBUcktsSWyJVa7+x+ya7U1eZxWZ0pWcyYgBIGgkF1C37hIZ9uruVHS+A+Z5bNvcvDvMZ8Yuu7gzZQewH5gBA==",
+        "dependencies": {
+          "Microsoft.Build.Framework": "16.0.0-preview.256",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections.Immutable": "1.5.0",
+          "System.Diagnostics.TraceSource": "4.0.0",
+          "System.Reflection.Metadata": "1.6.0",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Runtime.Loader": "4.0.0",
+          "System.Security.Principal.Windows": "4.3.0",
+          "System.Text.Encoding.CodePages": "4.0.1",
+          "System.Threading.Tasks.Dataflow": "4.6.0"
+        }
+      },
+      "Microsoft.Build.Framework": {
+        "type": "Transitive",
+        "resolved": "16.0.0-preview.256",
+        "contentHash": "ylCm2gQM8QYg9ONato2Ee/E7oxS9a4YNrh7TgqiwibxfCBvh8R6d2MZyzPUSg6i5BhDDCH6hoty8P1GNthHySg==",
+        "dependencies": {
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Threading.Thread": "4.0.0"
+        }
+      },
+      "Microsoft.Build.Tasks.Core": {
+        "type": "Transitive",
+        "resolved": "16.0.0-preview.256",
+        "contentHash": "tMfPm4OC+YXlUW2FTE+ZHLRYNx7LIJVw2Whj8uHjy3zu9OJLI40r03sxZ7023uFCEecGHyHQaX1ss1QXqwvHlw==",
+        "dependencies": {
+          "Microsoft.Build.Framework": "16.0.0-preview.256",
+          "Microsoft.Build.Utilities.Core": "16.0.0-preview.256",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.CodeDom": "4.4.0",
+          "System.Collections.Immutable": "1.5.0",
+          "System.Linq.Parallel": "4.0.1",
+          "System.Net.Http": "4.3.0",
+          "System.Reflection.Metadata": "1.6.0",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.Writer": "4.0.0",
+          "System.Threading.Tasks.Dataflow": "4.6.0"
+        }
+      },
+      "Microsoft.Build.Utilities.Core": {
+        "type": "Transitive",
+        "resolved": "16.0.0-preview.256",
+        "contentHash": "UJNG3JYTvjyzoUebumGe5UYl09A3pN7qI5C7Jm6xrWYUQ+bL+rhonwb6jqgtc7EqeLQzsygJ4y/n5JFKhMZH8g==",
+        "dependencies": {
+          "Microsoft.Build.Framework": "16.0.0-preview.256",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections.Immutable": "1.5.0",
+          "System.Text.Encoding.CodePages": "4.0.1"
+        }
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "lJSTbsIVqnziQ1ZLPw+NZKyVHw9oABRwWer5dQesnt4kk7V8iLFtW8PhuAxEBlzii/z39FL/p+Kl+GptrRoRmA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "Microsoft.NETCore.DotNetAppHost": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "cZiASE81rksPJsGJ04hd/uEn6guNGAoqNsrzE/DP6AaNRPCHwTe6nZvHd4uAPj3MaVRQ3U0c6cRycMaHCYLPUQ=="
+      },
+      "Microsoft.NETCore.DotNetHostPolicy": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "JHyN4ibWkJy/2HlqHnUXBmcpzZfIhCFw7uGqWU5fyL7mzGq5E5vjCHChpFqPzRugM2QS3q31re6CAVzFBzTMqw==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetHostResolver": "2.1.0"
+        }
+      },
+      "Microsoft.NETCore.DotNetHostResolver": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "d+V3yHIMimz3m4MkecBtIrf1NI1oPUez5eaAXbVSWqNyFUuTeBeolYwA3yCYeKCS0zDkV0QjXEOaHd0pjujOZA==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetAppHost": "2.1.0"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "aSTPL94NloSiQVL5Len8wbjFKOnoAX/vOh3s3DF6g3c7GUUMLCDvnBhmA72M2iN2AedyA8hpr7m89kzSAKUnJQ=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "R+z1NrmXptbA6maCVVPcJ9xrCjUZFGEW1CHQeCqOyRni6PFxANYjiEjDBAK7wQUdmdZFy3xKJYUY0qhpb+hSLQ=="
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cFEQkQFLOADfBo4k6zrDqhyg4bffeoFQsD1S1kzrrO06rSl5VeVn747esouUgH1xWNujphM9r6/AN85fxCIBTA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "NETStandard.Library": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        }
+      },
+      "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OC4N/9/h5o82cVZT5xDYLweAt/DvGfvxRA+LxtAVgIck9UXqZVBPddeUH/uSE9ANGlhE7ar77+kjtOdJpsghyw=="
+      },
+      "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "5hnkCG1lDYlcmcds11NyDLGxfi97dZmStdsY/I2iH0/cBKHrqno9jVlGrFLI8eQWEsxCLop0vj3f4YWGfJxi8w=="
+      },
+      "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "10lC2+5ImKZ3U+WPyYI+Idk+BWVLKSUoCmeZIEtE6UHYq7eiZJBOjCT2A8ivKNX/AALKt5S66RDTWgawVY7guA=="
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OJt7kV0xjgrGIO9dmygcZTzr8wFMpr8t17okLvtFEhSL+Hy9gvg8uGPUZH/IR+vjU7LSdg/lKweDNCrHEKHYXw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "runtime.native.System.Net.Http": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "byd0WJYdKNXFThd70nBpqPUmk5x6Le1YO9iTDJM6vHszz2iFwxNnz5PljhTBBJgwaSjyOkJOdk7C61FLyoUlLQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "runtime.native.System.Security.Cryptography.Apple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "m8177a64R05Tze41qLz7dPtLnvQll4yYgEDYZERVOlEZ+b4ucDmWM0VoSxaGVlWCEr1Dls1Ty9pD7BsWPbSiEQ==",
+        "dependencies": {
+          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": "4.3.0"
+        }
+      },
+      "runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cf5sB00QnqejVbbt5URL548Bs+BAHlXmElWFQASszzKqzR72mw7YwLSaeoAyQ9FqahVp+IIzhJxuqVCXkaM9gA==",
+        "dependencies": {
+          "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fSExnM1euZtjZpymvSd/Wg8njOlk49hAPnmrFokV68c+6LzKy6v2tgJq2LSmATR0Wb7FDejfWkck8fjR46e4tw=="
+      },
+      "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "+FbXEqsv9GOHYGl2QnNQvG2/BZsQVXB+j9NL6nO62lNozdxDHhNFHp04tpOvkKsdVPvSCx5StZSkeAir1VmIbA=="
+      },
+      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "U6DFEEJqW66ctBqfu0Uh1WutOb3QEymGii5jFE8L9/50GbyF6wNLPNx7rTOdjapeOUvFx4J6zET+zwyajN5Efw=="
+      },
+      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cECKTL4dDrFSOixmbBxc7/GSCfabHrPZ6FDahI7he01I0XvQiLAbIJsZgobdMLeBtlFapvvNgSrseLxG9x0tCg=="
+      },
+      "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "oIxC5EeW+6seQtZQjhRJoj3+Mb7t6Ssfar4eTmga/2y+kKob7x03Aey41fzZLq1HPzIScJtE3ItnMm1VSoCszQ=="
+      },
+      "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "GXaC5CPHg/tEJWnGu/RbOxsVYMgN3/XSVh91zNrIZ/nHAeTM0ncPDn297jJWAoGT++JdjQN2FF1g8fFCPd1F8g=="
+      },
+      "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "b8+D5EKHYP0QrjeDwt3/QSmirRPNWZnAb6Wc/opqeCPoO5SfpOZ2u+8DAji3LFU+VHwz0V+GRca8vkACHsMcUQ=="
+      },
+      "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "8PpbWQszEd5vgPDCILpsq1gKgQ1wjl9ObefAU5w0q5WCx54lPl+MPV0lpi50A7yeV93a+sxyuBwi0OZte4h8sA=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "2sCCb7doXEwtYAbqzbF/8UAeDRMNmPaQbU2q50Psg1J9KzumyVVCgKQY8s53WIPTufNT0DpSe9QRvVjOzfDWBA=="
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Collections.Concurrent": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "s8UqYVK3GEhuuLdl39eo2rXAK4+JpcmpjT45C97x+745VhkkgX4PSts0ilBSKalQG9U7JBIRlicEU7ogawubQA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.5.0",
+        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+      },
+      "System.Console": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "lr8aZR1MUEJSV5ciX1rBAGZITMDYNSPVQBFPc42MpeiQLCygcrJcvD+FdLFF+8h+x/vxYJMHE4keeJSSyW5/Eg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Runtime": "4.1.0",
+          "System.Text.Encoding": "4.0.11"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PAvxOdarjpNwWnxhF33D99g4ayi3lHycTMzk2V0oRZw9b0mybgzRxpON7ns8wGIwOnDOPkDEiMD73LR91peBUw==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "A3aDinDgWcac4zUmardLoisyp2aSF+OFy2/1GZEHqKrYlFObrYHx5Oa69YHALUhEBtCjc8UYgAFjpPZCw9fdiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Diagnostics.TraceSource": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "N2TnkNmV5CXwvcl3IUNhrD/zp9Kz4BeKucwuDbFff/mjH0G5yW/PFHYDc0UQfj9+l3XZzoR134ukYp2FpdiOqg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "runtime.native.System": "4.0.0"
+        }
+      },
+      "System.Diagnostics.Tracing": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Krwavn7yTVK68eEzsmXF8ES7xA2vUcgAVASfsGNoRyFyfAcRLH/tEWhSpXx/ILCLkGxbZc47Y1gCfQmAudpRAw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Dynamic.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "M/4NKf2BW3OgjEEIY5zIICntbpzqG7mf6QW5/Sc8/jq6J1juU+r6Dd7Zy8BQc//BsgLN/ilp+jsidnNLvsvPlQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Globalization.Calendars": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "L3YesDrnr9kUjp1Wp3BFd1WR5I8M8afWq+E4vEMMdNSvUi1uBW3TlgPDJQ0rpUuh7xyLgfY3nbmtCNgz5W9Vbw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Globalization.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "0+kk6M3ojv2QmP0/ghfgl87f0rMIlCGk1ypozsbPKvIpPPe4/sAlS72dmX8qhEHzBgnpo8CuS19DRUkvUcZGhA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "wPQxHRTOQjHSTCoeRhcaNgUiN6+XLClZ4cF0Vxtx1cNLT6R1h8dkQ6OI86hJ5U0k6xlACnZZK2uPPKyCxHT9hg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "geg256WzQ6sWriZcgPAesEyvxEeQA4bChtNS0oXIHPNcXUli+h57SgF8oAG82YYIWFkw1WtJY8Ipswoj1lIV0w==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Expressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "pUhwb1gZm4nYs1vWOSBEtgFL2sba471wBK56vD+E9QXQPMCotyNoUlXDQU6JKP3iiXcZAYiLph74yDhK9LJn0A==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Linq.Parallel": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "Kgjp5qHYVWwzMaHz/uhRUFQFsHGPQ361iAzMD1SWpYU5Wj78zU5KqD0MhgyW+p1yXBUCMiuCSlzNmGVbNP0l4A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Net.Http": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "D3E1jKDFIqwDqAxvUWdC3UJ6xhrbXi+pA3pkQv9ccMJlbtW6HrQeotM+9GpjwzN3jPkQ9toJCR5HHDfOkj/GBA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.DiagnosticSource": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Extensions": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.Net.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.OpenSsl": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.Net.Http": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Net.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "2WGKfyPn3STBJLoP57cGSHmB1iyGVmbmu6S+86P63y3+ahsgNTEBq9rtOzowwSM9N8rBR/qVKcGMHChg6nhzrg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SN0ezyl68hX6MqubPw+9H/eYd66vXcYcPkGbcIlG2LAbRtLOjunoEFu4zwxbinKOYdIh7CBTCU1yLUFNXtqEcA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "N/L1zj+UTlLogL84AUE3fsJ0qjxlbHN9OxWxbkAlxNC+t47PQU8VssyXu0TjzH1QAclJOiEFTPa/V+My3P60dw==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ewhNB2sVnRTbEIkmOr0bjpn/3QAb6adt5VLjRLM3xYYHBmDotoVcYWOCtzXQoELX3EPhbo9tTt1COmHbOmtBaA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "s/qCR1/wIzV0EbusqDf13kez/m7ovN4qGy/YYgcKso98R+xJxbAtT0tK1e0UCHEHWZ0O0p3X9LraQpSl4Hs6qw==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "AxxXMPKP0sZp7eBBF7HMp8cj4w4vuaoVXHshS8F4qdvPy/nm5DCWOf7f0JX1xmwpsZEQiHj908cbVnNrRk1PzA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rsg/2b0JRcKznNmMJDljYlfHpUQ6LHmKdeKOvMz5DI0XKhY1DttFMNs0cdAjr/rSu4RjKMSjrsh1vWm1gEKutA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.Writer": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "rjUPqh9wKHTVmh4i+4eyY0TfRQpyEJbeqp7z38zQ9rZY0Lf7XECReocX18PqozRK7eJCH1M31z0P9HATLRX9Lw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.Loader": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "0nbumjdgKR+Na/8PTd0GqrnGTwayw2e7LuLgPu/07eZ+P1WNjuIY9OnekMx+L2uCJQly+965RFibZTaNqrsy9w==",
+        "dependencies": {
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Runtime.Numerics": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "57eQH3a3rjAif8bRm5dToYGliFUKUKp5zyVrMW03RBQCwM9Rc9E4LjCNlYE3mCeMBmWaSm4GcLGEB9itUGqSqw==",
+        "dependencies": {
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Formatters": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "giE1EDm3wyZjKOxNQpsg7cmPvlPcUDTevUpUeclRbWBbv8PCg245cFg8A3ihb0jETo2Uzgi4kXWRNIKuVLMDIA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Serialization.Primitives": "4.3.0"
+        }
+      },
+      "System.Security.Claims": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hBfBqH7wkyLcngQJQ5ubZwMTTA46buFk1j0vrU/63QfuywoMiN47Rugavls5+YHrynXCLHJdQ6z4hCVKmfnGdQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Security.Principal": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Algorithms": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "l4dRimDHzWA/6dQ5NcMIbuHRp2nxfHO+ejq5+AmZcMR8dLJA1RK0Y/yIBuwKNX4gIYw2FIWWhgjOwFVZsK3gQg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.Apple": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Cng": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "oA7CLLSH//E5UjBY3zXrXUaALfHdgFiEKDUKJWQYqeu2LJ/JVPIJ/19k2CjyFHSJgp3rqUEP7HLC5zys9+JWcA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Csp": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bAlbofGk6IwmUprrVxpxe68TNapZs6iLvifJVNrvTI1AHZfCRcw9OF/fIW0nEQ8c8SY5K/tEmMakQnMSVL+R5g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "lw23IDVvQHGepzfAP9nVN9cBa1IeajAgdxcv6PvdCDj2atuRATWGvHauzALVwAVNu4jkhd7XD0CE1cz3VmCQPA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Wh3QYL3P6popkYpUlPi7YukI8F3M+0fVBFkquPYI4QfziJnHH+3GYk+mHjFM06NaIGwTO3PqIhn0+T0PoF9CPA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZLmOFqjQ8iOxQDHGOcxvIZ0LV8hOD8hFEJmfI3ugWpQfbiVXKuLspFgosbDuSPuxeZL6sBN6oUKa+qNFLF2y2g==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qBUHUk7IqrPHY96THHTa1akCxw0GsNFpsk3XFHbi0A0tMUDBpQprtY1Tbl6yaS1x4c96ilcXU8PocYtmSmkaQQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.X509Certificates": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "znewiGtuNlvOtocECc879Ed/wOOc4sLqyZrsMUewVdRGVbxa/WOs4jBxRDQ6EsGz2QZ2gOiDUAmcj+JOzI628Q==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Calendars": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Cng": "4.3.0",
+          "System.Security.Cryptography.Csp": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.OpenSsl": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.Net.Http": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Principal": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cT2urREXTsGnjWBP0G6N42EelZc0RZnfqU7tDFGJ5SDUi4QXafTDGYjVRKQEFcVlAf8RWRS/YSgRh7+VLeA0Dg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Security.Principal.Windows": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "9Wj4Yl5McaxrjHggOnClgXJ/p+srNLBP0SzTrp8EosI9NGEGrKu4dvbwiUXlnLzZMJO/9ptNsP8L7g16xdcR0g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Claims": "4.3.0",
+          "System.Security.Principal": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.CodePages": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "x/cY+8iefjx83eq3cwLNS+pg/VMnDThvgL03+3Wcua1ErvrfayGLRzOiig6Ug/lnlX+fLOgpZtcqB21b6rTbnw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "zyxULthU5BUBw4RiTuO4zecYbVBIgoq0CrPfonNgWOd5Cl11xxIESMq+Q2TWTsAFkfsD3A6Kp6UTuhnroV6e0w==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Gj7tzvn7Q5lNaXz88jrohC7if2jqHKQpq8pw/yhgpIO9s/Y/nTMUSoeuxAODSO0UzaBh6M3c/F1y1olrpY1lng==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Dataflow": {
+        "type": "Transitive",
+        "resolved": "4.6.0",
+        "contentHash": "hFcbI8fzWzyi8GaFLgK7eQKFQhUFTjA0AD+LZquje2NgBaP35dHN4/qJHYy+X9LzZ6IMEj7z3VdHt/Izd+DTRQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "PGbJReQ7spxIZuCb8nYjVNnNWWQn5Loey6sC8MvGBnHN9oJAetXW/Va9UvDmlB4+nZhY3uW2nbKEOsz6gFf88A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kCgI/sTE4fxnz1Fs0aScBCC+cYFIIR7I0IG1JPWDPjOSQxYs5Qdzi4Gf3eeAIevdE03n3PeCh2JVCKv0/11yrA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1WaMGI7TLOynUVjVzFmgVvxvho/yl2l7lkTc2EdgA0jtLDX9pHpEZkgG7KaY+9G2WMO1GVmuSEBzucbgmsFW2w==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "lvA/29NjaGEYADSOy+fJp6dtZ9NMSMX1cbePx9FHX5w66EwnceLVtggzWv1StQPAULtUrbjicjA7I2eAtvNgOQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Extensions": "4.0.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "Y0igaOCZs653g0Z+zeFiu9vTR/CPhpUmaee+BK4QUixVk2winYIZfGqKGQ9Jn8TBn+CX98adj1Q6OB1/XZXanw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "System.Diagnostics.Process": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "System.Security.Cryptography.ProtectedData": "4.3.0"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3",
+          "System.Runtime.Serialization.Formatters": "4.3.0"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    },
+    ".NETCoreApp,Version=v2.1/win7-x86": {
+      "Microsoft.NETCore.App": {
+        "type": "Direct",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "mVxL8khUMyl0L+MkyY0SLhZU13Z+KoUCcCTDC1MZKaegUVbAuaEzqX0VyGJ5U1lyo8fh6ryJPbsBPJww6qcKpw==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetHostPolicy": "2.1.0",
+          "Microsoft.NETCore.Platforms": "2.1.0",
+          "Microsoft.NETCore.Targets": "2.1.0",
+          "NETStandard.Library": "2.0.3",
+          "runtime.win-x86.Microsoft.NETCore.App": "2.1.0"
+        }
+      },
+      "Microsoft.NETCore.DotNetAppHost": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "cZiASE81rksPJsGJ04hd/uEn6guNGAoqNsrzE/DP6AaNRPCHwTe6nZvHd4uAPj3MaVRQ3U0c6cRycMaHCYLPUQ==",
+        "dependencies": {
+          "runtime.win-x86.Microsoft.NETCore.DotNetAppHost": "2.1.0"
+        }
+      },
+      "Microsoft.NETCore.DotNetHostPolicy": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "JHyN4ibWkJy/2HlqHnUXBmcpzZfIhCFw7uGqWU5fyL7mzGq5E5vjCHChpFqPzRugM2QS3q31re6CAVzFBzTMqw==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetHostResolver": "2.1.0",
+          "runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy": "2.1.0"
+        }
+      },
+      "Microsoft.NETCore.DotNetHostResolver": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "d+V3yHIMimz3m4MkecBtIrf1NI1oPUez5eaAXbVSWqNyFUuTeBeolYwA3yCYeKCS0zDkV0QjXEOaHd0pjujOZA==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetAppHost": "2.1.0",
+          "runtime.win-x86.Microsoft.NETCore.DotNetHostResolver": "2.1.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OC4N/9/h5o82cVZT5xDYLweAt/DvGfvxRA+LxtAVgIck9UXqZVBPddeUH/uSE9ANGlhE7ar77+kjtOdJpsghyw=="
+      },
+      "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "5hnkCG1lDYlcmcds11NyDLGxfi97dZmStdsY/I2iH0/cBKHrqno9jVlGrFLI8eQWEsxCLop0vj3f4YWGfJxi8w=="
+      },
+      "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "10lC2+5ImKZ3U+WPyYI+Idk+BWVLKSUoCmeZIEtE6UHYq7eiZJBOjCT2A8ivKNX/AALKt5S66RDTWgawVY7guA=="
+      },
+      "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fSExnM1euZtjZpymvSd/Wg8njOlk49hAPnmrFokV68c+6LzKy6v2tgJq2LSmATR0Wb7FDejfWkck8fjR46e4tw=="
+      },
+      "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "+FbXEqsv9GOHYGl2QnNQvG2/BZsQVXB+j9NL6nO62lNozdxDHhNFHp04tpOvkKsdVPvSCx5StZSkeAir1VmIbA=="
+      },
+      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "U6DFEEJqW66ctBqfu0Uh1WutOb3QEymGii5jFE8L9/50GbyF6wNLPNx7rTOdjapeOUvFx4J6zET+zwyajN5Efw=="
+      },
+      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cECKTL4dDrFSOixmbBxc7/GSCfabHrPZ6FDahI7he01I0XvQiLAbIJsZgobdMLeBtlFapvvNgSrseLxG9x0tCg=="
+      },
+      "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "oIxC5EeW+6seQtZQjhRJoj3+Mb7t6Ssfar4eTmga/2y+kKob7x03Aey41fzZLq1HPzIScJtE3ItnMm1VSoCszQ=="
+      },
+      "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "GXaC5CPHg/tEJWnGu/RbOxsVYMgN3/XSVh91zNrIZ/nHAeTM0ncPDn297jJWAoGT++JdjQN2FF1g8fFCPd1F8g=="
+      },
+      "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "b8+D5EKHYP0QrjeDwt3/QSmirRPNWZnAb6Wc/opqeCPoO5SfpOZ2u+8DAji3LFU+VHwz0V+GRca8vkACHsMcUQ=="
+      },
+      "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "8PpbWQszEd5vgPDCILpsq1gKgQ1wjl9ObefAU5w0q5WCx54lPl+MPV0lpi50A7yeV93a+sxyuBwi0OZte4h8sA=="
+      },
+      "runtime.win-x86.Microsoft.NETCore.App": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "FzifzUza//+Ycepg0ajNxkER0wDQ+8Pxd6oF5+kKuCD2c0rRVfkgxK7435JwnkyDVxfmBCqQiNbAdnzQXUfy9g=="
+      },
+      "runtime.win-x86.Microsoft.NETCore.DotNetAppHost": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "EoYojMSBbAdYUqLwnByFTLyqqtPmFDmDjpVgnKcBZFECvpS3GiRvQVWIvOpVEBMnlXIDYhoPmby/M6sxPeNehg=="
+      },
+      "runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "jZ6VW5ZQGNxDOFfrRjLizu8TyxA7xrxkSYyGegOKnunvbGtZVonfgNNErVHnb8rOkf1be8GubTVj6TN6oHgwdQ==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetHostResolver": "2.1.0"
+        }
+      },
+      "runtime.win-x86.Microsoft.NETCore.DotNetHostResolver": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "tMCZx7SYGvoJXJD6619UlVlPlOFgHOR7qkQaLIzTix93bd4Fqa6Ga/Kav9ihAW8V/gIYqWVPk21j80REBucFCQ==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetAppHost": "2.1.0"
+        }
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Diagnostics.TraceSource": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "N2TnkNmV5CXwvcl3IUNhrD/zp9Kz4BeKucwuDbFff/mjH0G5yW/PFHYDc0UQfj9+l3XZzoR134ukYp2FpdiOqg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "runtime.native.System": "4.0.0"
+        }
+      },
+      "System.Globalization.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "0+kk6M3ojv2QmP0/ghfgl87f0rMIlCGk1ypozsbPKvIpPPe4/sAlS72dmX8qhEHzBgnpo8CuS19DRUkvUcZGhA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "System.Net.Http": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "D3E1jKDFIqwDqAxvUWdC3UJ6xhrbXi+pA3pkQv9ccMJlbtW6HrQeotM+9GpjwzN3jPkQ9toJCR5HHDfOkj/GBA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.DiagnosticSource": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Extensions": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.Net.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.OpenSsl": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.Net.Http": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Algorithms": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "l4dRimDHzWA/6dQ5NcMIbuHRp2nxfHO+ejq5+AmZcMR8dLJA1RK0Y/yIBuwKNX4gIYw2FIWWhgjOwFVZsK3gQg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.Apple": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Cng": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "oA7CLLSH//E5UjBY3zXrXUaALfHdgFiEKDUKJWQYqeu2LJ/JVPIJ/19k2CjyFHSJgp3rqUEP7HLC5zys9+JWcA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Csp": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bAlbofGk6IwmUprrVxpxe68TNapZs6iLvifJVNrvTI1AHZfCRcw9OF/fIW0nEQ8c8SY5K/tEmMakQnMSVL+R5g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "lw23IDVvQHGepzfAP9nVN9cBa1IeajAgdxcv6PvdCDj2atuRATWGvHauzALVwAVNu4jkhd7XD0CE1cz3VmCQPA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Wh3QYL3P6popkYpUlPi7YukI8F3M+0fVBFkquPYI4QfziJnHH+3GYk+mHjFM06NaIGwTO3PqIhn0+T0PoF9CPA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qBUHUk7IqrPHY96THHTa1akCxw0GsNFpsk3XFHbi0A0tMUDBpQprtY1Tbl6yaS1x4c96ilcXU8PocYtmSmkaQQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.X509Certificates": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "znewiGtuNlvOtocECc879Ed/wOOc4sLqyZrsMUewVdRGVbxa/WOs4jBxRDQ6EsGz2QZ2gOiDUAmcj+JOzI628Q==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Calendars": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Cng": "4.3.0",
+          "System.Security.Cryptography.Csp": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.OpenSsl": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.Net.Http": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Principal.Windows": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "9Wj4Yl5McaxrjHggOnClgXJ/p+srNLBP0SzTrp8EosI9NGEGrKu4dvbwiUXlnLzZMJO/9ptNsP8L7g16xdcR0g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Claims": "4.3.0",
+          "System.Security.Principal": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.CodePages": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "x/cY+8iefjx83eq3cwLNS+pg/VMnDThvgL03+3Wcua1ErvrfayGLRzOiig6Ug/lnlX+fLOgpZtcqB21b6rTbnw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11"
+        }
+      }
+    },
+    ".NETFramework,Version=v4.7.2": {
+      "Microsoft.Build.Runtime": {
+        "type": "Direct",
+        "requested": "[16.0.0-preview.256, )",
+        "resolved": "16.0.0-preview.256",
+        "contentHash": "5yq7PGU0e6WbhDQMzHYRWSjYdPnmElXGvfuCCohwRqfflqa5PlmOfYuUTe3vNePv1wv75EJqpCV9LGwMltKMsg==",
+        "dependencies": {
+          "Microsoft.Build": "16.0.0-preview.256",
+          "Microsoft.Build.Tasks.Core": "16.0.0-preview.256"
+        }
+      },
+      "Microsoft.Extensions.CommandLineUtils": {
+        "type": "Direct",
+        "requested": "[1.0.1, )",
+        "resolved": "1.0.1",
+        "contentHash": "wTk8JFNIBF94m8gzbkjinkgdtD2SfZe8yu8847x8YsqDYYsHOT4siGZeFot3/061RfMm2W2QopRKyNkzz16V2A=="
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "System.Runtime.Serialization.Primitives": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "JmkqsVmd/4ZAItnNtQdjPPLdMmsUIXtix/dI6eq2g4edEnqHJnI5naBXLcP49xmnuNo4JLEuSurtUefsp3LfAg=="
+      },
+      "Microsoft.Build": {
+        "type": "Transitive",
+        "resolved": "16.0.0-preview.256",
+        "contentHash": "I6kBUcktsSWyJVa7+x+ya7U1eZxWZ0pWcyYgBIGgkF1C37hIZ9uruVHS+A+Z5bNvcvDvMZ8Yuu7gzZQewH5gBA==",
+        "dependencies": {
+          "Microsoft.Build.Framework": "16.0.0-preview.256",
+          "Microsoft.VisualStudio.Setup.Configuration.Interop": "1.16.30",
+          "System.Collections.Immutable": "1.5.0",
+          "System.Threading.Tasks.Dataflow": "4.5.24"
+        }
+      },
+      "Microsoft.Build.Framework": {
+        "type": "Transitive",
+        "resolved": "16.0.0-preview.256",
+        "contentHash": "ylCm2gQM8QYg9ONato2Ee/E7oxS9a4YNrh7TgqiwibxfCBvh8R6d2MZyzPUSg6i5BhDDCH6hoty8P1GNthHySg=="
+      },
+      "Microsoft.Build.Tasks.Core": {
+        "type": "Transitive",
+        "resolved": "16.0.0-preview.256",
+        "contentHash": "tMfPm4OC+YXlUW2FTE+ZHLRYNx7LIJVw2Whj8uHjy3zu9OJLI40r03sxZ7023uFCEecGHyHQaX1ss1QXqwvHlw==",
+        "dependencies": {
+          "Microsoft.Build.Framework": "16.0.0-preview.256",
+          "Microsoft.Build.Utilities.Core": "16.0.0-preview.256",
+          "Microsoft.VisualStudio.Setup.Configuration.Interop": "1.16.30",
+          "System.Collections.Immutable": "1.5.0",
+          "System.Threading.Tasks.Dataflow": "4.5.24"
+        }
+      },
+      "Microsoft.Build.Utilities.Core": {
+        "type": "Transitive",
+        "resolved": "16.0.0-preview.256",
+        "contentHash": "UJNG3JYTvjyzoUebumGe5UYl09A3pN7qI5C7Jm6xrWYUQ+bL+rhonwb6jqgtc7EqeLQzsygJ4y/n5JFKhMZH8g==",
+        "dependencies": {
+          "Microsoft.Build.Framework": "16.0.0-preview.256",
+          "Microsoft.VisualStudio.Setup.Configuration.Interop": "1.16.30",
+          "System.Collections.Immutable": "1.5.0"
+        }
+      },
+      "Microsoft.VisualStudio.Setup.Configuration.Interop": {
+        "type": "Transitive",
+        "resolved": "1.16.30",
+        "contentHash": "YQ98WZeF3IlJu++LL0Y9GickgfHcwBv6BAsdb1YIaYN9IU6dBJk3BdvfPkrRK2ajJENlmJrGrES844zvSXLWGw=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "Os1VVCpZSpvd07BQ9vWAZKGLmGSaxMvnG6N4skdEQafWIR5a91Oz9eqZkeEU4DosGeorMeBhsqCT+v4Pt4kw1g=="
+      },
+      "System.Collections.Concurrent": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "/wloGAZnNcW9qOeav7Rv65DrwJ6ePDSPLZV6szPEsnwxfsfS+bgT6X8ExH2IKFWK38AQizhtDEvQj32G0RT79A=="
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.5.0",
+        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "9XZ/I69kRpsqepPHRjL4RUgyhaGnorHbd2zgq1FpNSLgxbWRvjdzxUSyRATrYfLtwZ6sAakXmiGDQtdzA+DKog=="
+      },
+      "System.Diagnostics.Tracing": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "3A2rjgqedbfs+UAhiO6gUsXt6sb627UsWXDdfjSz+9c7z8LfMyK4FjaL3L7KrBYpXRP5NjgvkH164WhWKv3FxA=="
+      },
+      "System.Dynamic.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "MgddWRjtJ23Seb5bDWCQR6tLkJX8vzG+AcoZMROLzIILbF84rxYA0iTZ3VuSlDi2IztGnids7OLbf7TNPSy9JQ=="
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg=="
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "77X5uRDBRtt6snpiwYwiaPT7hg3q6xjzeRP2wW7xFT+nMY5iXUa/kXv065y2EISQY1Vb7tfKXSORoTbVzjmX7w=="
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "Uq9epame8hEqJlj4KaWb67dDJvj4IM37jRFGVeFbugRdPz48bR0voyBhrbf3iSa2tAmlkg4lsa6BUOL9iwlMew=="
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "zPzwoJcA7qar/b5Ihhzfcdr3vBOR8FIg7u//Qc5mqyAriasXuMFVraBZ5vOQq5asfun9ryNEL8Z2BOlUK5QRqA=="
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "H6O/9gUrjPDNYanh/7OFGAZHjVXvEuITD0RcnjfvIV04HOGrOPqUBU0kmz9RIX/7YGgCQn1o1S2DX6Cuv8kVGQ=="
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "2AsUMxNvqBh1K3eTING7vPWn89/96DefivH9IWEUjEoYOyfNTgfRzBNVFivmUPVMA8/2pEOpVR5r2fwezrOw1w=="
+      },
+      "System.Threading.Tasks.Dataflow": {
+        "type": "Transitive",
+        "resolved": "4.5.24",
+        "contentHash": "5rxjiabaug+brvFB+zb15JHa+FEgkTAMZOkG0JczklX5vxqSBhWB4g2P8MdJZ6OPuE4bqnuUpml5wfm2sSoBXw==",
+        "dependencies": {
+          "System.Collections": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.0",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    },
+    ".NETFramework,Version=v4.7.2/win7-x86": {}
+  }
+}

--- a/src/NuGet.Core/NuGet.Commands/packages.lock.json
+++ b/src/NuGet.Core/NuGet.Commands/packages.lock.json
@@ -1,0 +1,724 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    },
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "lJSTbsIVqnziQ1ZLPw+NZKyVHw9oABRwWer5dQesnt4kk7V8iLFtW8PhuAxEBlzii/z39FL/p+Kl+GptrRoRmA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "tI5H6Zg4DPqLcJNB232JMLACfX7UGawjTfMYdH8t6z5mXpDpHQVcFRzugqE6gG/EWrpQfAVJJzOVXeLJZ6ZZ+g=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "JFoFlE+s92bQksXVDwfQPBCf/eGLLIBcxEwuUva82KN079lG0KTQiWRTSKaCaXLThMohP9IXgy22eZCkOkwNIA=="
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cFEQkQFLOADfBo4k6zrDqhyg4bffeoFQsD1S1kzrrO06rSl5VeVn747esouUgH1xWNujphM9r6/AN85fxCIBTA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        }
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OJt7kV0xjgrGIO9dmygcZTzr8wFMpr8t17okLvtFEhSL+Hy9gvg8uGPUZH/IR+vjU7LSdg/lKweDNCrHEKHYXw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "A3aDinDgWcac4zUmardLoisyp2aSF+OFy2/1GZEHqKrYlFObrYHx5Oa69YHALUhEBtCjc8UYgAFjpPZCw9fdiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Dynamic.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "M/4NKf2BW3OgjEEIY5zIICntbpzqG7mf6QW5/Sc8/jq6J1juU+r6Dd7Zy8BQc//BsgLN/ilp+jsidnNLvsvPlQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "wPQxHRTOQjHSTCoeRhcaNgUiN6+XLClZ4cF0Vxtx1cNLT6R1h8dkQ6OI86hJ5U0k6xlACnZZK2uPPKyCxHT9hg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "geg256WzQ6sWriZcgPAesEyvxEeQA4bChtNS0oXIHPNcXUli+h57SgF8oAG82YYIWFkw1WtJY8Ipswoj1lIV0w==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Expressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "pUhwb1gZm4nYs1vWOSBEtgFL2sba471wBK56vD+E9QXQPMCotyNoUlXDQU6JKP3iiXcZAYiLph74yDhK9LJn0A==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SN0ezyl68hX6MqubPw+9H/eYd66vXcYcPkGbcIlG2LAbRtLOjunoEFu4zwxbinKOYdIh7CBTCU1yLUFNXtqEcA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "N/L1zj+UTlLogL84AUE3fsJ0qjxlbHN9OxWxbkAlxNC+t47PQU8VssyXu0TjzH1QAclJOiEFTPa/V+My3P60dw==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ewhNB2sVnRTbEIkmOr0bjpn/3QAb6adt5VLjRLM3xYYHBmDotoVcYWOCtzXQoELX3EPhbo9tTt1COmHbOmtBaA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "s/qCR1/wIzV0EbusqDf13kez/m7ovN4qGy/YYgcKso98R+xJxbAtT0tK1e0UCHEHWZ0O0p3X9LraQpSl4Hs6qw==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "AxxXMPKP0sZp7eBBF7HMp8cj4w4vuaoVXHshS8F4qdvPy/nm5DCWOf7f0JX1xmwpsZEQiHj908cbVnNrRk1PzA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rsg/2b0JRcKznNmMJDljYlfHpUQ6LHmKdeKOvMz5DI0XKhY1DttFMNs0cdAjr/rSu4RjKMSjrsh1vWm1gEKutA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Formatters": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "giE1EDm3wyZjKOxNQpsg7cmPvlPcUDTevUpUeclRbWBbv8PCg245cFg8A3ihb0jETo2Uzgi4kXWRNIKuVLMDIA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Serialization.Primitives": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "JmkqsVmd/4ZAItnNtQdjPPLdMmsUIXtix/dI6eq2g4edEnqHJnI5naBXLcP49xmnuNo4JLEuSurtUefsp3LfAg==",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZLmOFqjQ8iOxQDHGOcxvIZ0LV8hOD8hFEJmfI3ugWpQfbiVXKuLspFgosbDuSPuxeZL6sBN6oUKa+qNFLF2y2g==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qBUHUk7IqrPHY96THHTa1akCxw0GsNFpsk3XFHbi0A0tMUDBpQprtY1Tbl6yaS1x4c96ilcXU8PocYtmSmkaQQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "zyxULthU5BUBw4RiTuO4zecYbVBIgoq0CrPfonNgWOd5Cl11xxIESMq+Q2TWTsAFkfsD3A6Kp6UTuhnroV6e0w==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Gj7tzvn7Q5lNaXz88jrohC7if2jqHKQpq8pw/yhgpIO9s/Y/nTMUSoeuxAODSO0UzaBh6M3c/F1y1olrpY1lng==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "PGbJReQ7spxIZuCb8nYjVNnNWWQn5Loey6sC8MvGBnHN9oJAetXW/Va9UvDmlB4+nZhY3uW2nbKEOsz6gFf88A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kCgI/sTE4fxnz1Fs0aScBCC+cYFIIR7I0IG1JPWDPjOSQxYs5Qdzi4Gf3eeAIevdE03n3PeCh2JVCKv0/11yrA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1WaMGI7TLOynUVjVzFmgVvxvho/yl2l7lkTc2EdgA0jtLDX9pHpEZkgG7KaY+9G2WMO1GVmuSEBzucbgmsFW2w==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "lvA/29NjaGEYADSOy+fJp6dtZ9NMSMX1cbePx9FHX5w66EwnceLVtggzWv1StQPAULtUrbjicjA7I2eAtvNgOQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Extensions": "4.0.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "Y0igaOCZs653g0Z+zeFiu9vTR/CPhpUmaee+BK4QUixVk2winYIZfGqKGQ9Jn8TBn+CX98adj1Q6OB1/XZXanw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "System.Diagnostics.Process": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "System.Security.Cryptography.ProtectedData": "4.3.0"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3",
+          "System.Runtime.Serialization.Formatters": "4.3.0"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/NuGet.Core/NuGet.Common/packages.lock.json
+++ b/src/NuGet.Core/NuGet.Common/packages.lock.json
@@ -1,0 +1,308 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      }
+    },
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "System.Diagnostics.Process": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "kCgI/sTE4fxnz1Fs0aScBCC+cYFIIR7I0IG1JPWDPjOSQxYs5Qdzi4Gf3eeAIevdE03n3PeCh2JVCKv0/11yrA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "tI5H6Zg4DPqLcJNB232JMLACfX7UGawjTfMYdH8t6z5mXpDpHQVcFRzugqE6gG/EWrpQfAVJJzOVXeLJZ6ZZ+g=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "JFoFlE+s92bQksXVDwfQPBCf/eGLLIBcxEwuUva82KN079lG0KTQiWRTSKaCaXLThMohP9IXgy22eZCkOkwNIA=="
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cFEQkQFLOADfBo4k6zrDqhyg4bffeoFQsD1S1kzrrO06rSl5VeVn747esouUgH1xWNujphM9r6/AN85fxCIBTA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OJt7kV0xjgrGIO9dmygcZTzr8wFMpr8t17okLvtFEhSL+Hy9gvg8uGPUZH/IR+vjU7LSdg/lKweDNCrHEKHYXw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "wPQxHRTOQjHSTCoeRhcaNgUiN6+XLClZ4cF0Vxtx1cNLT6R1h8dkQ6OI86hJ5U0k6xlACnZZK2uPPKyCxHT9hg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Gj7tzvn7Q5lNaXz88jrohC7if2jqHKQpq8pw/yhgpIO9s/Y/nTMUSoeuxAODSO0UzaBh6M3c/F1y1olrpY1lng==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1WaMGI7TLOynUVjVzFmgVvxvho/yl2l7lkTc2EdgA0jtLDX9pHpEZkgG7KaY+9G2WMO1GVmuSEBzucbgmsFW2w==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/NuGet.Core/NuGet.Configuration/packages.lock.json
+++ b/src/NuGet.Core/NuGet.Configuration/packages.lock.json
@@ -1,0 +1,347 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      }
+    },
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "qBUHUk7IqrPHY96THHTa1akCxw0GsNFpsk3XFHbi0A0tMUDBpQprtY1Tbl6yaS1x4c96ilcXU8PocYtmSmkaQQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "tI5H6Zg4DPqLcJNB232JMLACfX7UGawjTfMYdH8t6z5mXpDpHQVcFRzugqE6gG/EWrpQfAVJJzOVXeLJZ6ZZ+g=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "JFoFlE+s92bQksXVDwfQPBCf/eGLLIBcxEwuUva82KN079lG0KTQiWRTSKaCaXLThMohP9IXgy22eZCkOkwNIA=="
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cFEQkQFLOADfBo4k6zrDqhyg4bffeoFQsD1S1kzrrO06rSl5VeVn747esouUgH1xWNujphM9r6/AN85fxCIBTA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OJt7kV0xjgrGIO9dmygcZTzr8wFMpr8t17okLvtFEhSL+Hy9gvg8uGPUZH/IR+vjU7LSdg/lKweDNCrHEKHYXw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "wPQxHRTOQjHSTCoeRhcaNgUiN6+XLClZ4cF0Vxtx1cNLT6R1h8dkQ6OI86hJ5U0k6xlACnZZK2uPPKyCxHT9hg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZLmOFqjQ8iOxQDHGOcxvIZ0LV8hOD8hFEJmfI3ugWpQfbiVXKuLspFgosbDuSPuxeZL6sBN6oUKa+qNFLF2y2g==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Gj7tzvn7Q5lNaXz88jrohC7if2jqHKQpq8pw/yhgpIO9s/Y/nTMUSoeuxAODSO0UzaBh6M3c/F1y1olrpY1lng==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kCgI/sTE4fxnz1Fs0aScBCC+cYFIIR7I0IG1JPWDPjOSQxYs5Qdzi4Gf3eeAIevdE03n3PeCh2JVCKv0/11yrA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1WaMGI7TLOynUVjVzFmgVvxvho/yl2l7lkTc2EdgA0jtLDX9pHpEZkgG7KaY+9G2WMO1GVmuSEBzucbgmsFW2w==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "System.Diagnostics.Process": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/NuGet.Core/NuGet.Credentials/packages.lock.json
+++ b/src/NuGet.Core/NuGet.Credentials/packages.lock.json
@@ -1,0 +1,670 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    },
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "System.Runtime.Serialization.Formatters": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "giE1EDm3wyZjKOxNQpsg7cmPvlPcUDTevUpUeclRbWBbv8PCg245cFg8A3ihb0jETo2Uzgi4kXWRNIKuVLMDIA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Serialization.Primitives": "4.3.0"
+        }
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "lJSTbsIVqnziQ1ZLPw+NZKyVHw9oABRwWer5dQesnt4kk7V8iLFtW8PhuAxEBlzii/z39FL/p+Kl+GptrRoRmA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "tI5H6Zg4DPqLcJNB232JMLACfX7UGawjTfMYdH8t6z5mXpDpHQVcFRzugqE6gG/EWrpQfAVJJzOVXeLJZ6ZZ+g=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "JFoFlE+s92bQksXVDwfQPBCf/eGLLIBcxEwuUva82KN079lG0KTQiWRTSKaCaXLThMohP9IXgy22eZCkOkwNIA=="
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cFEQkQFLOADfBo4k6zrDqhyg4bffeoFQsD1S1kzrrO06rSl5VeVn747esouUgH1xWNujphM9r6/AN85fxCIBTA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        }
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OJt7kV0xjgrGIO9dmygcZTzr8wFMpr8t17okLvtFEhSL+Hy9gvg8uGPUZH/IR+vjU7LSdg/lKweDNCrHEKHYXw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "A3aDinDgWcac4zUmardLoisyp2aSF+OFy2/1GZEHqKrYlFObrYHx5Oa69YHALUhEBtCjc8UYgAFjpPZCw9fdiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Dynamic.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "M/4NKf2BW3OgjEEIY5zIICntbpzqG7mf6QW5/Sc8/jq6J1juU+r6Dd7Zy8BQc//BsgLN/ilp+jsidnNLvsvPlQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "wPQxHRTOQjHSTCoeRhcaNgUiN6+XLClZ4cF0Vxtx1cNLT6R1h8dkQ6OI86hJ5U0k6xlACnZZK2uPPKyCxHT9hg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "geg256WzQ6sWriZcgPAesEyvxEeQA4bChtNS0oXIHPNcXUli+h57SgF8oAG82YYIWFkw1WtJY8Ipswoj1lIV0w==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Expressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "pUhwb1gZm4nYs1vWOSBEtgFL2sba471wBK56vD+E9QXQPMCotyNoUlXDQU6JKP3iiXcZAYiLph74yDhK9LJn0A==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SN0ezyl68hX6MqubPw+9H/eYd66vXcYcPkGbcIlG2LAbRtLOjunoEFu4zwxbinKOYdIh7CBTCU1yLUFNXtqEcA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "N/L1zj+UTlLogL84AUE3fsJ0qjxlbHN9OxWxbkAlxNC+t47PQU8VssyXu0TjzH1QAclJOiEFTPa/V+My3P60dw==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ewhNB2sVnRTbEIkmOr0bjpn/3QAb6adt5VLjRLM3xYYHBmDotoVcYWOCtzXQoELX3EPhbo9tTt1COmHbOmtBaA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "s/qCR1/wIzV0EbusqDf13kez/m7ovN4qGy/YYgcKso98R+xJxbAtT0tK1e0UCHEHWZ0O0p3X9LraQpSl4Hs6qw==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "AxxXMPKP0sZp7eBBF7HMp8cj4w4vuaoVXHshS8F4qdvPy/nm5DCWOf7f0JX1xmwpsZEQiHj908cbVnNrRk1PzA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rsg/2b0JRcKznNmMJDljYlfHpUQ6LHmKdeKOvMz5DI0XKhY1DttFMNs0cdAjr/rSu4RjKMSjrsh1vWm1gEKutA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "JmkqsVmd/4ZAItnNtQdjPPLdMmsUIXtix/dI6eq2g4edEnqHJnI5naBXLcP49xmnuNo4JLEuSurtUefsp3LfAg==",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZLmOFqjQ8iOxQDHGOcxvIZ0LV8hOD8hFEJmfI3ugWpQfbiVXKuLspFgosbDuSPuxeZL6sBN6oUKa+qNFLF2y2g==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qBUHUk7IqrPHY96THHTa1akCxw0GsNFpsk3XFHbi0A0tMUDBpQprtY1Tbl6yaS1x4c96ilcXU8PocYtmSmkaQQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "zyxULthU5BUBw4RiTuO4zecYbVBIgoq0CrPfonNgWOd5Cl11xxIESMq+Q2TWTsAFkfsD3A6Kp6UTuhnroV6e0w==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Gj7tzvn7Q5lNaXz88jrohC7if2jqHKQpq8pw/yhgpIO9s/Y/nTMUSoeuxAODSO0UzaBh6M3c/F1y1olrpY1lng==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "PGbJReQ7spxIZuCb8nYjVNnNWWQn5Loey6sC8MvGBnHN9oJAetXW/Va9UvDmlB4+nZhY3uW2nbKEOsz6gFf88A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kCgI/sTE4fxnz1Fs0aScBCC+cYFIIR7I0IG1JPWDPjOSQxYs5Qdzi4Gf3eeAIevdE03n3PeCh2JVCKv0/11yrA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1WaMGI7TLOynUVjVzFmgVvxvho/yl2l7lkTc2EdgA0jtLDX9pHpEZkgG7KaY+9G2WMO1GVmuSEBzucbgmsFW2w==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "lvA/29NjaGEYADSOy+fJp6dtZ9NMSMX1cbePx9FHX5w66EwnceLVtggzWv1StQPAULtUrbjicjA7I2eAtvNgOQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Extensions": "4.0.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "Y0igaOCZs653g0Z+zeFiu9vTR/CPhpUmaee+BK4QUixVk2winYIZfGqKGQ9Jn8TBn+CX98adj1Q6OB1/XZXanw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "System.Diagnostics.Process": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "System.Security.Cryptography.ProtectedData": "4.3.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/packages.lock.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/packages.lock.json
@@ -1,0 +1,671 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    },
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "lJSTbsIVqnziQ1ZLPw+NZKyVHw9oABRwWer5dQesnt4kk7V8iLFtW8PhuAxEBlzii/z39FL/p+Kl+GptrRoRmA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "tI5H6Zg4DPqLcJNB232JMLACfX7UGawjTfMYdH8t6z5mXpDpHQVcFRzugqE6gG/EWrpQfAVJJzOVXeLJZ6ZZ+g=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "JFoFlE+s92bQksXVDwfQPBCf/eGLLIBcxEwuUva82KN079lG0KTQiWRTSKaCaXLThMohP9IXgy22eZCkOkwNIA=="
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cFEQkQFLOADfBo4k6zrDqhyg4bffeoFQsD1S1kzrrO06rSl5VeVn747esouUgH1xWNujphM9r6/AN85fxCIBTA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        }
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OJt7kV0xjgrGIO9dmygcZTzr8wFMpr8t17okLvtFEhSL+Hy9gvg8uGPUZH/IR+vjU7LSdg/lKweDNCrHEKHYXw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "A3aDinDgWcac4zUmardLoisyp2aSF+OFy2/1GZEHqKrYlFObrYHx5Oa69YHALUhEBtCjc8UYgAFjpPZCw9fdiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Dynamic.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "M/4NKf2BW3OgjEEIY5zIICntbpzqG7mf6QW5/Sc8/jq6J1juU+r6Dd7Zy8BQc//BsgLN/ilp+jsidnNLvsvPlQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "wPQxHRTOQjHSTCoeRhcaNgUiN6+XLClZ4cF0Vxtx1cNLT6R1h8dkQ6OI86hJ5U0k6xlACnZZK2uPPKyCxHT9hg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "geg256WzQ6sWriZcgPAesEyvxEeQA4bChtNS0oXIHPNcXUli+h57SgF8oAG82YYIWFkw1WtJY8Ipswoj1lIV0w==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Expressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "pUhwb1gZm4nYs1vWOSBEtgFL2sba471wBK56vD+E9QXQPMCotyNoUlXDQU6JKP3iiXcZAYiLph74yDhK9LJn0A==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SN0ezyl68hX6MqubPw+9H/eYd66vXcYcPkGbcIlG2LAbRtLOjunoEFu4zwxbinKOYdIh7CBTCU1yLUFNXtqEcA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "N/L1zj+UTlLogL84AUE3fsJ0qjxlbHN9OxWxbkAlxNC+t47PQU8VssyXu0TjzH1QAclJOiEFTPa/V+My3P60dw==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ewhNB2sVnRTbEIkmOr0bjpn/3QAb6adt5VLjRLM3xYYHBmDotoVcYWOCtzXQoELX3EPhbo9tTt1COmHbOmtBaA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "s/qCR1/wIzV0EbusqDf13kez/m7ovN4qGy/YYgcKso98R+xJxbAtT0tK1e0UCHEHWZ0O0p3X9LraQpSl4Hs6qw==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "AxxXMPKP0sZp7eBBF7HMp8cj4w4vuaoVXHshS8F4qdvPy/nm5DCWOf7f0JX1xmwpsZEQiHj908cbVnNrRk1PzA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rsg/2b0JRcKznNmMJDljYlfHpUQ6LHmKdeKOvMz5DI0XKhY1DttFMNs0cdAjr/rSu4RjKMSjrsh1vWm1gEKutA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.1.1",
+        "contentHash": "xiranjWMIrhBah+YqPRID/+vU7ZfyHGTSMWSkSY27xFhlI1aMM53Mpt9+MnXS0hent6Jt6YMduib9xtJ1hbHvw==",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZLmOFqjQ8iOxQDHGOcxvIZ0LV8hOD8hFEJmfI3ugWpQfbiVXKuLspFgosbDuSPuxeZL6sBN6oUKa+qNFLF2y2g==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qBUHUk7IqrPHY96THHTa1akCxw0GsNFpsk3XFHbi0A0tMUDBpQprtY1Tbl6yaS1x4c96ilcXU8PocYtmSmkaQQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "zyxULthU5BUBw4RiTuO4zecYbVBIgoq0CrPfonNgWOd5Cl11xxIESMq+Q2TWTsAFkfsD3A6Kp6UTuhnroV6e0w==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Gj7tzvn7Q5lNaXz88jrohC7if2jqHKQpq8pw/yhgpIO9s/Y/nTMUSoeuxAODSO0UzaBh6M3c/F1y1olrpY1lng==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "PGbJReQ7spxIZuCb8nYjVNnNWWQn5Loey6sC8MvGBnHN9oJAetXW/Va9UvDmlB4+nZhY3uW2nbKEOsz6gFf88A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kCgI/sTE4fxnz1Fs0aScBCC+cYFIIR7I0IG1JPWDPjOSQxYs5Qdzi4Gf3eeAIevdE03n3PeCh2JVCKv0/11yrA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1WaMGI7TLOynUVjVzFmgVvxvho/yl2l7lkTc2EdgA0jtLDX9pHpEZkgG7KaY+9G2WMO1GVmuSEBzucbgmsFW2w==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "lvA/29NjaGEYADSOy+fJp6dtZ9NMSMX1cbePx9FHX5w66EwnceLVtggzWv1StQPAULtUrbjicjA7I2eAtvNgOQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Extensions": "4.0.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "Y0igaOCZs653g0Z+zeFiu9vTR/CPhpUmaee+BK4QUixVk2winYIZfGqKGQ9Jn8TBn+CX98adj1Q6OB1/XZXanw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "System.Diagnostics.Process": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "System.Security.Cryptography.ProtectedData": "4.3.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/NuGet.Core/NuGet.Frameworks/packages.lock.json
+++ b/src/NuGet.Core/NuGet.Frameworks/packages.lock.json
@@ -1,0 +1,43 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.0": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      }
+    },
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      }
+    },
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "tI5H6Zg4DPqLcJNB232JMLACfX7UGawjTfMYdH8t6z5mXpDpHQVcFRzugqE6gG/EWrpQfAVJJzOVXeLJZ6ZZ+g=="
+      }
+    }
+  }
+}

--- a/src/NuGet.Core/NuGet.Indexing/packages.lock.json
+++ b/src/NuGet.Core/NuGet.Indexing/packages.lock.json
@@ -1,0 +1,64 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "Lucene.Net": {
+        "type": "Direct",
+        "requested": "[3.0.3, )",
+        "resolved": "3.0.3",
+        "contentHash": "A/70q4eDcuuafQeDB9eaiDP9FQG7X29T4VIYRphS7Wk8kAM9gNcfVqYyd0H8BJ1BTpA5C1ORm9RzFn4BiNavrw==",
+        "dependencies": {
+          "SharpZipLib": "0.86.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "0.86.0",
+        "contentHash": "5DbS1SlKLMi+WG00Cm0ueYf2oyXJrowETQk8nx96rmdjTuHsA3laPykGV7Sxi0R5Xxfx0Kh/EfacAZ1f6M7y/g=="
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/NuGet.Core/NuGet.LibraryModel/packages.lock.json
+++ b/src/NuGet.Core/NuGet.LibraryModel/packages.lock.json
@@ -1,0 +1,326 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    },
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "tI5H6Zg4DPqLcJNB232JMLACfX7UGawjTfMYdH8t6z5mXpDpHQVcFRzugqE6gG/EWrpQfAVJJzOVXeLJZ6ZZ+g=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "JFoFlE+s92bQksXVDwfQPBCf/eGLLIBcxEwuUva82KN079lG0KTQiWRTSKaCaXLThMohP9IXgy22eZCkOkwNIA=="
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cFEQkQFLOADfBo4k6zrDqhyg4bffeoFQsD1S1kzrrO06rSl5VeVn747esouUgH1xWNujphM9r6/AN85fxCIBTA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OJt7kV0xjgrGIO9dmygcZTzr8wFMpr8t17okLvtFEhSL+Hy9gvg8uGPUZH/IR+vjU7LSdg/lKweDNCrHEKHYXw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "wPQxHRTOQjHSTCoeRhcaNgUiN6+XLClZ4cF0Vxtx1cNLT6R1h8dkQ6OI86hJ5U0k6xlACnZZK2uPPKyCxHT9hg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Gj7tzvn7Q5lNaXz88jrohC7if2jqHKQpq8pw/yhgpIO9s/Y/nTMUSoeuxAODSO0UzaBh6M3c/F1y1olrpY1lng==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kCgI/sTE4fxnz1Fs0aScBCC+cYFIIR7I0IG1JPWDPjOSQxYs5Qdzi4Gf3eeAIevdE03n3PeCh2JVCKv0/11yrA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1WaMGI7TLOynUVjVzFmgVvxvho/yl2l7lkTc2EdgA0jtLDX9pHpEZkgG7KaY+9G2WMO1GVmuSEBzucbgmsFW2w==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "System.Diagnostics.Process": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/NuGet.Core/NuGet.Localization/packages.lock.json
+++ b/src/NuGet.Core/NuGet.Localization/packages.lock.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "tI5H6Zg4DPqLcJNB232JMLACfX7UGawjTfMYdH8t6z5mXpDpHQVcFRzugqE6gG/EWrpQfAVJJzOVXeLJZ6ZZ+g=="
+      }
+    }
+  }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/packages.lock.json
+++ b/src/NuGet.Core/NuGet.PackageManagement/packages.lock.json
@@ -1,0 +1,95 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "Microsoft.Web.Xdt": {
+        "type": "Direct",
+        "requested": "[2.1.2, )",
+        "resolved": "2.1.2",
+        "contentHash": "YIaNTOOtGzjF8CkQBOx3aUBWi0dD+g/nOjbpsVslx9G0/uldtpmoKLmyldmKdMv/gHs3qg40rBT3+wvEWoY5gg=="
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/NuGet.Core/NuGet.Packaging/packages.lock.json
+++ b/src/NuGet.Core/NuGet.Packaging/packages.lock.json
@@ -1,0 +1,630 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[9.0.1, )",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    },
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[9.0.1, )",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "System.Dynamic.Runtime": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "M/4NKf2BW3OgjEEIY5zIICntbpzqG7mf6QW5/Sc8/jq6J1juU+r6Dd7Zy8BQc//BsgLN/ilp+jsidnNLvsvPlQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "lJSTbsIVqnziQ1ZLPw+NZKyVHw9oABRwWer5dQesnt4kk7V8iLFtW8PhuAxEBlzii/z39FL/p+Kl+GptrRoRmA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "tI5H6Zg4DPqLcJNB232JMLACfX7UGawjTfMYdH8t6z5mXpDpHQVcFRzugqE6gG/EWrpQfAVJJzOVXeLJZ6ZZ+g=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "JFoFlE+s92bQksXVDwfQPBCf/eGLLIBcxEwuUva82KN079lG0KTQiWRTSKaCaXLThMohP9IXgy22eZCkOkwNIA=="
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cFEQkQFLOADfBo4k6zrDqhyg4bffeoFQsD1S1kzrrO06rSl5VeVn747esouUgH1xWNujphM9r6/AN85fxCIBTA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OJt7kV0xjgrGIO9dmygcZTzr8wFMpr8t17okLvtFEhSL+Hy9gvg8uGPUZH/IR+vjU7LSdg/lKweDNCrHEKHYXw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "A3aDinDgWcac4zUmardLoisyp2aSF+OFy2/1GZEHqKrYlFObrYHx5Oa69YHALUhEBtCjc8UYgAFjpPZCw9fdiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "wPQxHRTOQjHSTCoeRhcaNgUiN6+XLClZ4cF0Vxtx1cNLT6R1h8dkQ6OI86hJ5U0k6xlACnZZK2uPPKyCxHT9hg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "geg256WzQ6sWriZcgPAesEyvxEeQA4bChtNS0oXIHPNcXUli+h57SgF8oAG82YYIWFkw1WtJY8Ipswoj1lIV0w==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Expressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "pUhwb1gZm4nYs1vWOSBEtgFL2sba471wBK56vD+E9QXQPMCotyNoUlXDQU6JKP3iiXcZAYiLph74yDhK9LJn0A==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SN0ezyl68hX6MqubPw+9H/eYd66vXcYcPkGbcIlG2LAbRtLOjunoEFu4zwxbinKOYdIh7CBTCU1yLUFNXtqEcA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "N/L1zj+UTlLogL84AUE3fsJ0qjxlbHN9OxWxbkAlxNC+t47PQU8VssyXu0TjzH1QAclJOiEFTPa/V+My3P60dw==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ewhNB2sVnRTbEIkmOr0bjpn/3QAb6adt5VLjRLM3xYYHBmDotoVcYWOCtzXQoELX3EPhbo9tTt1COmHbOmtBaA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "s/qCR1/wIzV0EbusqDf13kez/m7ovN4qGy/YYgcKso98R+xJxbAtT0tK1e0UCHEHWZ0O0p3X9LraQpSl4Hs6qw==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "AxxXMPKP0sZp7eBBF7HMp8cj4w4vuaoVXHshS8F4qdvPy/nm5DCWOf7f0JX1xmwpsZEQiHj908cbVnNrRk1PzA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rsg/2b0JRcKznNmMJDljYlfHpUQ6LHmKdeKOvMz5DI0XKhY1DttFMNs0cdAjr/rSu4RjKMSjrsh1vWm1gEKutA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.1.1",
+        "contentHash": "xiranjWMIrhBah+YqPRID/+vU7ZfyHGTSMWSkSY27xFhlI1aMM53Mpt9+MnXS0hent6Jt6YMduib9xtJ1hbHvw==",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZLmOFqjQ8iOxQDHGOcxvIZ0LV8hOD8hFEJmfI3ugWpQfbiVXKuLspFgosbDuSPuxeZL6sBN6oUKa+qNFLF2y2g==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qBUHUk7IqrPHY96THHTa1akCxw0GsNFpsk3XFHbi0A0tMUDBpQprtY1Tbl6yaS1x4c96ilcXU8PocYtmSmkaQQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "zyxULthU5BUBw4RiTuO4zecYbVBIgoq0CrPfonNgWOd5Cl11xxIESMq+Q2TWTsAFkfsD3A6Kp6UTuhnroV6e0w==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Gj7tzvn7Q5lNaXz88jrohC7if2jqHKQpq8pw/yhgpIO9s/Y/nTMUSoeuxAODSO0UzaBh6M3c/F1y1olrpY1lng==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "PGbJReQ7spxIZuCb8nYjVNnNWWQn5Loey6sC8MvGBnHN9oJAetXW/Va9UvDmlB4+nZhY3uW2nbKEOsz6gFf88A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kCgI/sTE4fxnz1Fs0aScBCC+cYFIIR7I0IG1JPWDPjOSQxYs5Qdzi4Gf3eeAIevdE03n3PeCh2JVCKv0/11yrA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1WaMGI7TLOynUVjVzFmgVvxvho/yl2l7lkTc2EdgA0jtLDX9pHpEZkgG7KaY+9G2WMO1GVmuSEBzucbgmsFW2w==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "lvA/29NjaGEYADSOy+fJp6dtZ9NMSMX1cbePx9FHX5w66EwnceLVtggzWv1StQPAULtUrbjicjA7I2eAtvNgOQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Extensions": "4.0.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "Y0igaOCZs653g0Z+zeFiu9vTR/CPhpUmaee+BK4QUixVk2winYIZfGqKGQ9Jn8TBn+CX98adj1Q6OB1/XZXanw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "System.Diagnostics.Process": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "System.Security.Cryptography.ProtectedData": "4.3.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/packages.lock.json
+++ b/src/NuGet.Core/NuGet.ProjectModel/packages.lock.json
@@ -1,0 +1,687 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    },
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "System.Dynamic.Runtime": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "M/4NKf2BW3OgjEEIY5zIICntbpzqG7mf6QW5/Sc8/jq6J1juU+r6Dd7Zy8BQc//BsgLN/ilp+jsidnNLvsvPlQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "kCgI/sTE4fxnz1Fs0aScBCC+cYFIIR7I0IG1JPWDPjOSQxYs5Qdzi4Gf3eeAIevdE03n3PeCh2JVCKv0/11yrA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "lJSTbsIVqnziQ1ZLPw+NZKyVHw9oABRwWer5dQesnt4kk7V8iLFtW8PhuAxEBlzii/z39FL/p+Kl+GptrRoRmA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "tI5H6Zg4DPqLcJNB232JMLACfX7UGawjTfMYdH8t6z5mXpDpHQVcFRzugqE6gG/EWrpQfAVJJzOVXeLJZ6ZZ+g=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "JFoFlE+s92bQksXVDwfQPBCf/eGLLIBcxEwuUva82KN079lG0KTQiWRTSKaCaXLThMohP9IXgy22eZCkOkwNIA=="
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cFEQkQFLOADfBo4k6zrDqhyg4bffeoFQsD1S1kzrrO06rSl5VeVn747esouUgH1xWNujphM9r6/AN85fxCIBTA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        }
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OJt7kV0xjgrGIO9dmygcZTzr8wFMpr8t17okLvtFEhSL+Hy9gvg8uGPUZH/IR+vjU7LSdg/lKweDNCrHEKHYXw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "A3aDinDgWcac4zUmardLoisyp2aSF+OFy2/1GZEHqKrYlFObrYHx5Oa69YHALUhEBtCjc8UYgAFjpPZCw9fdiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "wPQxHRTOQjHSTCoeRhcaNgUiN6+XLClZ4cF0Vxtx1cNLT6R1h8dkQ6OI86hJ5U0k6xlACnZZK2uPPKyCxHT9hg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "geg256WzQ6sWriZcgPAesEyvxEeQA4bChtNS0oXIHPNcXUli+h57SgF8oAG82YYIWFkw1WtJY8Ipswoj1lIV0w==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Expressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "pUhwb1gZm4nYs1vWOSBEtgFL2sba471wBK56vD+E9QXQPMCotyNoUlXDQU6JKP3iiXcZAYiLph74yDhK9LJn0A==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SN0ezyl68hX6MqubPw+9H/eYd66vXcYcPkGbcIlG2LAbRtLOjunoEFu4zwxbinKOYdIh7CBTCU1yLUFNXtqEcA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "N/L1zj+UTlLogL84AUE3fsJ0qjxlbHN9OxWxbkAlxNC+t47PQU8VssyXu0TjzH1QAclJOiEFTPa/V+My3P60dw==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ewhNB2sVnRTbEIkmOr0bjpn/3QAb6adt5VLjRLM3xYYHBmDotoVcYWOCtzXQoELX3EPhbo9tTt1COmHbOmtBaA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "s/qCR1/wIzV0EbusqDf13kez/m7ovN4qGy/YYgcKso98R+xJxbAtT0tK1e0UCHEHWZ0O0p3X9LraQpSl4Hs6qw==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "AxxXMPKP0sZp7eBBF7HMp8cj4w4vuaoVXHshS8F4qdvPy/nm5DCWOf7f0JX1xmwpsZEQiHj908cbVnNrRk1PzA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rsg/2b0JRcKznNmMJDljYlfHpUQ6LHmKdeKOvMz5DI0XKhY1DttFMNs0cdAjr/rSu4RjKMSjrsh1vWm1gEKutA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.1.1",
+        "contentHash": "xiranjWMIrhBah+YqPRID/+vU7ZfyHGTSMWSkSY27xFhlI1aMM53Mpt9+MnXS0hent6Jt6YMduib9xtJ1hbHvw==",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZLmOFqjQ8iOxQDHGOcxvIZ0LV8hOD8hFEJmfI3ugWpQfbiVXKuLspFgosbDuSPuxeZL6sBN6oUKa+qNFLF2y2g==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qBUHUk7IqrPHY96THHTa1akCxw0GsNFpsk3XFHbi0A0tMUDBpQprtY1Tbl6yaS1x4c96ilcXU8PocYtmSmkaQQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "zyxULthU5BUBw4RiTuO4zecYbVBIgoq0CrPfonNgWOd5Cl11xxIESMq+Q2TWTsAFkfsD3A6Kp6UTuhnroV6e0w==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Gj7tzvn7Q5lNaXz88jrohC7if2jqHKQpq8pw/yhgpIO9s/Y/nTMUSoeuxAODSO0UzaBh6M3c/F1y1olrpY1lng==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "PGbJReQ7spxIZuCb8nYjVNnNWWQn5Loey6sC8MvGBnHN9oJAetXW/Va9UvDmlB4+nZhY3uW2nbKEOsz6gFf88A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1WaMGI7TLOynUVjVzFmgVvxvho/yl2l7lkTc2EdgA0jtLDX9pHpEZkgG7KaY+9G2WMO1GVmuSEBzucbgmsFW2w==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "lvA/29NjaGEYADSOy+fJp6dtZ9NMSMX1cbePx9FHX5w66EwnceLVtggzWv1StQPAULtUrbjicjA7I2eAtvNgOQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Extensions": "4.0.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "Y0igaOCZs653g0Z+zeFiu9vTR/CPhpUmaee+BK4QUixVk2winYIZfGqKGQ9Jn8TBn+CX98adj1Q6OB1/XZXanw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "System.Diagnostics.Process": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "System.Security.Cryptography.ProtectedData": "4.3.0"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/NuGet.Core/NuGet.Protocol/packages.lock.json
+++ b/src/NuGet.Core/NuGet.Protocol/packages.lock.json
@@ -1,0 +1,645 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    },
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "System.Dynamic.Runtime": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "M/4NKf2BW3OgjEEIY5zIICntbpzqG7mf6QW5/Sc8/jq6J1juU+r6Dd7Zy8BQc//BsgLN/ilp+jsidnNLvsvPlQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "lJSTbsIVqnziQ1ZLPw+NZKyVHw9oABRwWer5dQesnt4kk7V8iLFtW8PhuAxEBlzii/z39FL/p+Kl+GptrRoRmA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "tI5H6Zg4DPqLcJNB232JMLACfX7UGawjTfMYdH8t6z5mXpDpHQVcFRzugqE6gG/EWrpQfAVJJzOVXeLJZ6ZZ+g=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "JFoFlE+s92bQksXVDwfQPBCf/eGLLIBcxEwuUva82KN079lG0KTQiWRTSKaCaXLThMohP9IXgy22eZCkOkwNIA=="
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cFEQkQFLOADfBo4k6zrDqhyg4bffeoFQsD1S1kzrrO06rSl5VeVn747esouUgH1xWNujphM9r6/AN85fxCIBTA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        }
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OJt7kV0xjgrGIO9dmygcZTzr8wFMpr8t17okLvtFEhSL+Hy9gvg8uGPUZH/IR+vjU7LSdg/lKweDNCrHEKHYXw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "A3aDinDgWcac4zUmardLoisyp2aSF+OFy2/1GZEHqKrYlFObrYHx5Oa69YHALUhEBtCjc8UYgAFjpPZCw9fdiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "wPQxHRTOQjHSTCoeRhcaNgUiN6+XLClZ4cF0Vxtx1cNLT6R1h8dkQ6OI86hJ5U0k6xlACnZZK2uPPKyCxHT9hg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "geg256WzQ6sWriZcgPAesEyvxEeQA4bChtNS0oXIHPNcXUli+h57SgF8oAG82YYIWFkw1WtJY8Ipswoj1lIV0w==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Expressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "pUhwb1gZm4nYs1vWOSBEtgFL2sba471wBK56vD+E9QXQPMCotyNoUlXDQU6JKP3iiXcZAYiLph74yDhK9LJn0A==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SN0ezyl68hX6MqubPw+9H/eYd66vXcYcPkGbcIlG2LAbRtLOjunoEFu4zwxbinKOYdIh7CBTCU1yLUFNXtqEcA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "N/L1zj+UTlLogL84AUE3fsJ0qjxlbHN9OxWxbkAlxNC+t47PQU8VssyXu0TjzH1QAclJOiEFTPa/V+My3P60dw==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ewhNB2sVnRTbEIkmOr0bjpn/3QAb6adt5VLjRLM3xYYHBmDotoVcYWOCtzXQoELX3EPhbo9tTt1COmHbOmtBaA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "s/qCR1/wIzV0EbusqDf13kez/m7ovN4qGy/YYgcKso98R+xJxbAtT0tK1e0UCHEHWZ0O0p3X9LraQpSl4Hs6qw==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "AxxXMPKP0sZp7eBBF7HMp8cj4w4vuaoVXHshS8F4qdvPy/nm5DCWOf7f0JX1xmwpsZEQiHj908cbVnNrRk1PzA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rsg/2b0JRcKznNmMJDljYlfHpUQ6LHmKdeKOvMz5DI0XKhY1DttFMNs0cdAjr/rSu4RjKMSjrsh1vWm1gEKutA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.1.1",
+        "contentHash": "xiranjWMIrhBah+YqPRID/+vU7ZfyHGTSMWSkSY27xFhlI1aMM53Mpt9+MnXS0hent6Jt6YMduib9xtJ1hbHvw==",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZLmOFqjQ8iOxQDHGOcxvIZ0LV8hOD8hFEJmfI3ugWpQfbiVXKuLspFgosbDuSPuxeZL6sBN6oUKa+qNFLF2y2g==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qBUHUk7IqrPHY96THHTa1akCxw0GsNFpsk3XFHbi0A0tMUDBpQprtY1Tbl6yaS1x4c96ilcXU8PocYtmSmkaQQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "zyxULthU5BUBw4RiTuO4zecYbVBIgoq0CrPfonNgWOd5Cl11xxIESMq+Q2TWTsAFkfsD3A6Kp6UTuhnroV6e0w==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Gj7tzvn7Q5lNaXz88jrohC7if2jqHKQpq8pw/yhgpIO9s/Y/nTMUSoeuxAODSO0UzaBh6M3c/F1y1olrpY1lng==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "PGbJReQ7spxIZuCb8nYjVNnNWWQn5Loey6sC8MvGBnHN9oJAetXW/Va9UvDmlB4+nZhY3uW2nbKEOsz6gFf88A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kCgI/sTE4fxnz1Fs0aScBCC+cYFIIR7I0IG1JPWDPjOSQxYs5Qdzi4Gf3eeAIevdE03n3PeCh2JVCKv0/11yrA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1WaMGI7TLOynUVjVzFmgVvxvho/yl2l7lkTc2EdgA0jtLDX9pHpEZkgG7KaY+9G2WMO1GVmuSEBzucbgmsFW2w==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "lvA/29NjaGEYADSOy+fJp6dtZ9NMSMX1cbePx9FHX5w66EwnceLVtggzWv1StQPAULtUrbjicjA7I2eAtvNgOQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Extensions": "4.0.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "Y0igaOCZs653g0Z+zeFiu9vTR/CPhpUmaee+BK4QUixVk2winYIZfGqKGQ9Jn8TBn+CX98adj1Q6OB1/XZXanw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "System.Diagnostics.Process": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "System.Security.Cryptography.ProtectedData": "4.3.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/NuGet.Core/NuGet.Resolver/packages.lock.json
+++ b/src/NuGet.Core/NuGet.Resolver/packages.lock.json
@@ -1,0 +1,657 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    },
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "lJSTbsIVqnziQ1ZLPw+NZKyVHw9oABRwWer5dQesnt4kk7V8iLFtW8PhuAxEBlzii/z39FL/p+Kl+GptrRoRmA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "tI5H6Zg4DPqLcJNB232JMLACfX7UGawjTfMYdH8t6z5mXpDpHQVcFRzugqE6gG/EWrpQfAVJJzOVXeLJZ6ZZ+g=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "JFoFlE+s92bQksXVDwfQPBCf/eGLLIBcxEwuUva82KN079lG0KTQiWRTSKaCaXLThMohP9IXgy22eZCkOkwNIA=="
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cFEQkQFLOADfBo4k6zrDqhyg4bffeoFQsD1S1kzrrO06rSl5VeVn747esouUgH1xWNujphM9r6/AN85fxCIBTA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        }
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OJt7kV0xjgrGIO9dmygcZTzr8wFMpr8t17okLvtFEhSL+Hy9gvg8uGPUZH/IR+vjU7LSdg/lKweDNCrHEKHYXw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "A3aDinDgWcac4zUmardLoisyp2aSF+OFy2/1GZEHqKrYlFObrYHx5Oa69YHALUhEBtCjc8UYgAFjpPZCw9fdiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Dynamic.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "M/4NKf2BW3OgjEEIY5zIICntbpzqG7mf6QW5/Sc8/jq6J1juU+r6Dd7Zy8BQc//BsgLN/ilp+jsidnNLvsvPlQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "wPQxHRTOQjHSTCoeRhcaNgUiN6+XLClZ4cF0Vxtx1cNLT6R1h8dkQ6OI86hJ5U0k6xlACnZZK2uPPKyCxHT9hg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "geg256WzQ6sWriZcgPAesEyvxEeQA4bChtNS0oXIHPNcXUli+h57SgF8oAG82YYIWFkw1WtJY8Ipswoj1lIV0w==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Expressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "pUhwb1gZm4nYs1vWOSBEtgFL2sba471wBK56vD+E9QXQPMCotyNoUlXDQU6JKP3iiXcZAYiLph74yDhK9LJn0A==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SN0ezyl68hX6MqubPw+9H/eYd66vXcYcPkGbcIlG2LAbRtLOjunoEFu4zwxbinKOYdIh7CBTCU1yLUFNXtqEcA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "N/L1zj+UTlLogL84AUE3fsJ0qjxlbHN9OxWxbkAlxNC+t47PQU8VssyXu0TjzH1QAclJOiEFTPa/V+My3P60dw==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ewhNB2sVnRTbEIkmOr0bjpn/3QAb6adt5VLjRLM3xYYHBmDotoVcYWOCtzXQoELX3EPhbo9tTt1COmHbOmtBaA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "s/qCR1/wIzV0EbusqDf13kez/m7ovN4qGy/YYgcKso98R+xJxbAtT0tK1e0UCHEHWZ0O0p3X9LraQpSl4Hs6qw==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "AxxXMPKP0sZp7eBBF7HMp8cj4w4vuaoVXHshS8F4qdvPy/nm5DCWOf7f0JX1xmwpsZEQiHj908cbVnNrRk1PzA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rsg/2b0JRcKznNmMJDljYlfHpUQ6LHmKdeKOvMz5DI0XKhY1DttFMNs0cdAjr/rSu4RjKMSjrsh1vWm1gEKutA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.1.1",
+        "contentHash": "xiranjWMIrhBah+YqPRID/+vU7ZfyHGTSMWSkSY27xFhlI1aMM53Mpt9+MnXS0hent6Jt6YMduib9xtJ1hbHvw==",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZLmOFqjQ8iOxQDHGOcxvIZ0LV8hOD8hFEJmfI3ugWpQfbiVXKuLspFgosbDuSPuxeZL6sBN6oUKa+qNFLF2y2g==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qBUHUk7IqrPHY96THHTa1akCxw0GsNFpsk3XFHbi0A0tMUDBpQprtY1Tbl6yaS1x4c96ilcXU8PocYtmSmkaQQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "zyxULthU5BUBw4RiTuO4zecYbVBIgoq0CrPfonNgWOd5Cl11xxIESMq+Q2TWTsAFkfsD3A6Kp6UTuhnroV6e0w==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Gj7tzvn7Q5lNaXz88jrohC7if2jqHKQpq8pw/yhgpIO9s/Y/nTMUSoeuxAODSO0UzaBh6M3c/F1y1olrpY1lng==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "PGbJReQ7spxIZuCb8nYjVNnNWWQn5Loey6sC8MvGBnHN9oJAetXW/Va9UvDmlB4+nZhY3uW2nbKEOsz6gFf88A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kCgI/sTE4fxnz1Fs0aScBCC+cYFIIR7I0IG1JPWDPjOSQxYs5Qdzi4Gf3eeAIevdE03n3PeCh2JVCKv0/11yrA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1WaMGI7TLOynUVjVzFmgVvxvho/yl2l7lkTc2EdgA0jtLDX9pHpEZkgG7KaY+9G2WMO1GVmuSEBzucbgmsFW2w==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "lvA/29NjaGEYADSOy+fJp6dtZ9NMSMX1cbePx9FHX5w66EwnceLVtggzWv1StQPAULtUrbjicjA7I2eAtvNgOQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Extensions": "4.0.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "Y0igaOCZs653g0Z+zeFiu9vTR/CPhpUmaee+BK4QUixVk2winYIZfGqKGQ9Jn8TBn+CX98adj1Q6OB1/XZXanw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "System.Diagnostics.Process": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "System.Security.Cryptography.ProtectedData": "4.3.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/NuGet.Core/NuGet.Versioning/packages.lock.json
+++ b/src/NuGet.Core/NuGet.Versioning/packages.lock.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      }
+    },
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "tI5H6Zg4DPqLcJNB232JMLACfX7UGawjTfMYdH8t6z5mXpDpHQVcFRzugqE6gG/EWrpQfAVJJzOVXeLJZ6ZZ+g=="
+      }
+    }
+  }
+}

--- a/test/TestExtensions/API.Test/packages.lock.json
+++ b/test/TestExtensions/API.Test/packages.lock.json
@@ -1,0 +1,792 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "EnvDTE": {
+        "type": "Direct",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "ppW2nOaaMCOy1HNdUWvTM+btoXVbvntTL4RxVvEWBaHFk+Aj/r7vrS3t9x1QrHB4Y9Rrd2n7UAmjzet3Ps63XA==",
+        "dependencies": {
+          "stdole": "7.0.3301"
+        }
+      },
+      "Microsoft.PowerShell.3.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.0, )",
+        "resolved": "1.0.0",
+        "contentHash": "lMDlqY0Dhqg4Fg+1B9MkLwfUuw46wQWdXqWzC1dsJcsFHLEt8BO7um7rtETTuoev+l7rxarRCIeeFcd1aCqRxg=="
+      },
+      "Microsoft.VisualStudio.ComponentModelHost": {
+        "type": "Direct",
+        "requested": "[16.0.189-g83e7c53a57, )",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "79WnMNn2T4xDqNVCAR9u3r2OXrA4QPOHYy36MMDjfIKvhL5mQ5Osgc+e+3wVVfeyD4EUdAYs/hC74+w4k/6ktg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.15.0": {
+        "type": "Direct",
+        "requested": "[15.8.28010, )",
+        "resolved": "15.8.28010",
+        "contentHash": "QurLa40g6/qehW75Qpi5LR7EE9vSW/mZuc5QwlTcBcW9k/H7jzBPwxcmAzZ5teswJPkD0+VvOQecTEIguOvnVQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging": "15.8.28010",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Framework": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": "14.3.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": "15.0.26929",
+          "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": "15.6.27413",
+          "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30730",
+          "Microsoft.VisualStudio.Text.Data": "15.6.27740",
+          "Microsoft.VisualStudio.Threading": "15.6.31"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime": {
+        "type": "Direct",
+        "requested": "[15.0.26932, )",
+        "resolved": "15.0.26932",
+        "contentHash": "g+V5NSN9ISAisyeSm9HFqkfhbXk7jS7FVbNSgGQp3VvfgQyS9oPMNHe+Ky/EcX5cnd/f0wo29U6eOnYWkkbl0A==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111"
+        }
+      },
+      "Microsoft.VisualStudio.Threading": {
+        "type": "Direct",
+        "requested": "[15.8.132, )",
+        "resolved": "15.8.132",
+        "contentHash": "KLjgM7NPjNg0FNv4z8qx8rpiAOnI5ZB6jrZWfJ4ho2YHtxT2dhWi8e94q9+BR4GBOks9ynL90LAnZX2CE3n4/Q==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Validation": "15.3.15"
+        }
+      },
+      "Microsoft.VisualStudio.Threading.Analyzers": {
+        "type": "Direct",
+        "requested": "[15.8.132, )",
+        "resolved": "15.8.132",
+        "contentHash": "SCFubDweTsyzzmXOmQOFedpSnUsN7Rrvh/ZD2phYRkOVBZtz3dX3LVen6IhcePZuDEQMtl4gNW9kzVpjTLlZ0A=="
+      },
+      "EnvDTE80": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "3CBF4ileGBzGDPvNePcI3611sRVP5xMHXMZGGgQtcFV5nUu5L5QAZkkrgnBdM0oD9ZXc6dReVwo+tXOSR91z4Q==",
+        "dependencies": {
+          "EnvDTE": "8.0.1",
+          "stdole": "7.0.3301"
+        }
+      },
+      "Lucene.Net": {
+        "type": "Transitive",
+        "resolved": "3.0.3",
+        "contentHash": "A/70q4eDcuuafQeDB9eaiDP9FQG7X29T4VIYRphS7Wk8kAM9gNcfVqYyd0H8BJ1BTpA5C1ORm9RzFn4BiNavrw==",
+        "dependencies": {
+          "SharpZipLib": "0.86.0"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "iAzPAX/guSnBXJxM+PZ+dVXF+vmE8hxcxJ9fOFrvHUv5cY/ILD1icf2sKjJLltJD0Na8r9oGF5PjNiTMxK8EYw==",
+        "dependencies": {
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.ApplicationInsights.PersistenceChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "V7peE2ssNCCfOqzk1kOJfr3zZLDDPs+M88N34e98L+YPpAoL11wQkLpPxWmztjipTD+DBxJO6PNaVsM9q5bM/A==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "0.17.2-build00169"
+        }
+      },
+      "Microsoft.ApplicationInsights.UniversalTelemetryChannel": {
+        "type": "Transitive",
+        "resolved": "0.17.2-build00169",
+        "contentHash": "8sg18/b63fhYjpr0kZ2v/NEjOEJ3gwpzXaaKZTth04AUPuOKjWvS3/pyVIRQ1mUEhrV3Xn3S2/TkLiWLCTpo7A==",
+        "dependencies": {
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Client": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "w5w8GVLMmo+JzizmcuV01tgYn2OsaVhxGAO0ryKXkO5sob6EVjzcoJv8NHL3Xm98vywSh7kRgeLqbA/lxZuTXg==",
+        "dependencies": {
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.AspNet.WebApi.Core": {
+        "type": "Transitive",
+        "resolved": "5.2.3",
+        "contentHash": "bP+PAx17AVQJ19aU9N7yMnz8yST1U9cekbYHRyIUvQzFLqqzrthEs/gLdyZiLJPmL4ZABuvwGBOXG/ukqmsbDg==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3"
+        }
+      },
+      "Microsoft.Bcl": {
+        "type": "Transitive",
+        "resolved": "1.1.8",
+        "contentHash": "gM+PUzd8ONxJpcPJeNppCJPklDhDuPUMVQkxvK4fe0rd9WyqBNPh4+UFx3Uv8zuG4C1Gapu1c25sfotE7TQtig==",
+        "dependencies": {
+          "Microsoft.Bcl.Build": "1.0.14"
+        }
+      },
+      "Microsoft.Bcl.Async": {
+        "type": "Transitive",
+        "resolved": "1.0.168",
+        "contentHash": "tUNC02eBwDKpGre0BcNIvblLv1q0Q3DnS/vtkRHj2FE1sXwt386HAudztyl5C0U88hllrqHDvtlz8bK0Y8cHDA==",
+        "dependencies": {
+          "Microsoft.Bcl": "1.1.8"
+        }
+      },
+      "Microsoft.Bcl.Build": {
+        "type": "Transitive",
+        "resolved": "1.0.14",
+        "contentHash": "cDLKSvNvRa519hplsbSoYqO69TjdDIhfjtKUM0g20/nVROoWsGav9KCI9HtnGjLmdV1+TcUUDhbotcllibjPEA=="
+      },
+      "Microsoft.Diagnostics.Tracing.EventSource.Redist": {
+        "type": "Transitive",
+        "resolved": "1.1.16-beta",
+        "contentHash": "o1gsKlGjLAnSHRyWBygKnO55Kp0bRXB3AO9e8OeAnqQH7HA5MAW6YAPEEy5e3aRE//7AlkdPtq28F19NqOLZQQ=="
+      },
+      "Microsoft.IdentityModel.Clients.ActiveDirectory": {
+        "type": "Transitive",
+        "resolved": "3.17.2",
+        "contentHash": "zvDoWJlrKg1TQeJScq+5znAZtduyJHlT7M9gEquUjm2PQCIR4C5PqJ0E8xYQsV3eF4bY8cW54uyr0FyhiN0MtQ=="
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "kbmvhMYu5OZXWN3toFXhrj3bSN7B+ZzNWzAZQ4Ofp5x2srk9ZCYFljETGS5faxzPwGd5+7W4WZlAfOI7QvzhlA=="
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "wVWYpXfE6gpkSrIRNo5TDVC7ss6KPTTrmT6x8ysHiZRIMSRAZ8TyHEAmpdATBBPNRmnlevyAs4CK6nPfDpCTqw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "dsDJhsL2zJyL5az5D3LhILIQRt+nXFQ64Bclj6vspIwD96sYRK/fPKTP8xLcLyw0fcosiFUgmWOXRLkWcAm1Pw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]"
+        }
+      },
+      "Microsoft.TeamFoundationServer.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "UBwF/VUULHHy5WHpShIW0ZdcG10N3jADUlW+KEgA7qiKCDB8VYbv7FR0miwutTtyuYFh/lE+G6q4IF0ugDyX6A==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.TeamFoundation.DistributedTask.Common.Contracts": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3"
+        }
+      },
+      "Microsoft.TeamFoundationServer.ExtendedClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "g3G19/HJEOeYR8xFnNWSegBqRcMZRUyPLBmf5JF24pqhVqrY31fSA7ZBUX9r6nHHdSBkmZbRQisR/IvwrfDGqQ==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.AspNet.WebApi.Core": "5.2.3",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.TeamFoundationServer.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.CoreUtility": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "eiepEOoyUJ+5K+7qitTMzXBJB6GcOMp5LdcedFa30dLxGPwgKY+XdVjiqcrxyQps4i7+hHNlYWvZCR6SKnWLRA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.23",
+          "System.ValueTuple": "4.3.0"
+        }
+      },
+      "Microsoft.VisualStudio.Editor": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "EnlJfSZABDJP36kg5td5A4HXqR2TWQrCgjXvDyBTF3peyDFQR6R6XZ63Wul+BY6Yract+UHP6E/8I+LlZ2BvRw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50727",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.ImageCatalog": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "X3nCoei2FTkh1m8tDDL8zEi9nFLVxjyRzMgL5HzPzio4uDCsKW1Oa/F/BkfICwx3cEPuwsyT7MlJjTgVqIbXgQ=="
+      },
+      "Microsoft.VisualStudio.Imaging": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "pDNYWW/w1hZF7Xk1SVhCMQxpxz5jFbaEkqrmSVRp7B8o6uei2fDrAscbMJmTxGcVA4rzV02ABytSCrc3jr1LvA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26930",
+        "contentHash": "gbmcUTMhYF/9oDUHI6b6Ki1PBaEkiqDhYNIdkYrrGy7XN0LhYew/BggDCJORUiEbzc5zJ8Hlc40jYGmqx4qfLg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16"
+        }
+      },
+      "Microsoft.VisualStudio.Language": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "BWRDlPth8bLOqUH7j6ClkBFPwjJ83aApHcr1GtJNPZfSj4Nw32pYRLIxCuBs2NLS2f9AF80yl0AYrzVlO6YRWg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Newtonsoft.Json": "9.0.1",
+          "StreamJsonRpc": "1.3.23",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Language.Intellisense": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "GShi/VaASPpvPLnF+rbJcfjbOlxAgpgtxc+PuQLruStw/9DVsL1LF/dB4dvdzRbkci8Ux0TvkI+Csd0/KeIOAg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Language": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Language.StandardClassification": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "fU1175eTKfdg4XRVwrl08wPNT4/KDuHKxgKrQ/aGaFzA93NMqtxsgyw6PB/zTA16j1eeIvqCOZpZOWigkuQGGg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.OLE.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "6W3YMtSGt+hHRvAqbktXHLWZgEbEpuFZxuC1XiKCX4Th3fGv+7SeKGGH7Gmeu9fp/8kNqq7uovqWaHfhni13Hw=="
+      },
+      "Microsoft.VisualStudio.RemoteControl": {
+        "type": "Transitive",
+        "resolved": "14.0.249-master2E2DC10C",
+        "contentHash": "bqmdFTlPzEH0VkncJBTq3bXmvW0SKM/pCQcKBgYZfCn/othfLnjChUKCyHvwQyJcjcy8JRnFXRejBQ0pqPXpqQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1"
+        }
+      },
+      "Microsoft.VisualStudio.SDK.EmbedInteropTypes": {
+        "type": "Transitive",
+        "resolved": "15.0.16",
+        "contentHash": "iI+b/DL6AaN/D8vHXcLorZJIjY0MvQehT6xfI3mx+AD2w1f/mEGtuXQE5mFfYu425FSDrPtoBIDRf+tKtLDA5g=="
+      },
+      "Microsoft.VisualStudio.Services.Client": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "bdqdkWc2yWnsOD2yVeKNc/u/M2Lq6xs6C2tqcvuMnq7HT0nu7tYq72ymnk4iQQBJGMGZfJFPOrI8r/7tDhJ0KA==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.3",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Services.InteractiveClient": {
+        "type": "Transitive",
+        "resolved": "16.144.1-preview",
+        "contentHash": "5fvdv0vPMcW+ANVv7HLXeVMKaDST1ydI3y10WMTP+tKDNp1Se4r8XzAuhdG9m+uh5Wozxj5cA9CK3wPfX+BQEA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.17.2",
+          "Microsoft.IdentityModel.Logging": "5.2.1",
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Microsoft.VisualStudio.Services.Client": "[16.144.1-preview]",
+          "Newtonsoft.Json": "10.0.3",
+          "System.IdentityModel.Tokens.Jwt": "5.2.1"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Framework": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "BRqUcfXNZ17aiuTTr1jawd/WHpt/A70WmDFUwgDS+vwGd0fp8fendG4ANLY5a4KI7+Yhyhz5DO/jsL3UBujNcQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "15.6.27740",
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.Utilities": "15.8.28010"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6072",
+        "contentHash": "hoaT0t8DMA5YwPQEeiRD7UJpndgJDyK00uYcQl3I2+KvgQroo7lAZfkPNbGIhy2OGW4nOEqlvr0i5OE71hgT1w==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.10.0": {
+        "type": "Transitive",
+        "resolved": "10.0.30320",
+        "contentHash": "RKmdy0EgbXFtzjM2Kcdv9w9XdMJS81QykYUb1D/5SnvUYn28ElVt3criqGlvcC1syLJLmk9DdHomOhX6R50e1A==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.11.0": {
+        "type": "Transitive",
+        "resolved": "11.0.61031",
+        "contentHash": "N8il5VcZNr4GZeAvItmpWE4A5DKwSpFelQQ+I1VoUm1kVj+6dPieZXlhdbFC3bJVyCs1gl0uUzOH7FDVGfdDCw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30320"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.12.0": {
+        "type": "Transitive",
+        "resolved": "12.0.30111",
+        "contentHash": "ToNByCRLH875yHd1G43EmGuQz16bAV0PKICvzArpjuNugx/Cl4Djg15NHu7XUdPHm+UpAfH4W7nYh0u8NxqWHw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": {
+        "type": "Transitive",
+        "resolved": "14.3.26929",
+        "contentHash": "J1WemvOhywfve6BbN91azp2nflhc68bpeGFFazoNnYl4MqEjRM0IUe3eNuieoeRw7a+UsHDubne/7K7XJ8yVdA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.26930",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.0.26929",
+        "contentHash": "hHAmrLBvxnmZDPPIOw6zQjsYenbqAcJfcIHSHDl5n/FyBC0VYleDwG2XcEOx1OkXWXReDMGY9lfeHyRv5SSJJQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.12",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime": {
+        "type": "Transitive",
+        "resolved": "15.6.27413",
+        "contentHash": "Cb0fRe0ek16fLkE0Buea8zU55zu2WyzBp+8HhK1j3azndHBx0FZAfcDj3xnSum8kllcwQKhEerqEfxdpmwt1mw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.16",
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "gGhUi9HaXGFC48HxZPV4nYcjygT/vcYYUow5iNocHp/EfwCCnDTUqe5AisH/o1pqB+iakw64g73KSDFsRNAXcA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.9.0": {
+        "type": "Transitive",
+        "resolved": "9.0.30730",
+        "contentHash": "AjBQfZ3HYtpRLFkLjClhR1vWffeEQXScMkhssKxnDnXFc59zOY3RToYxmIS6ZmjD5MS5ICwJDWy7hPOpKbh3Qg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Telemetry": {
+        "type": "Transitive",
+        "resolved": "15.0.691-master31907920",
+        "contentHash": "nTDxnBLOEY+NsjvnGpEeUHmzJrKtUOJjbgxkYd3UdblGlQrLjceIvkpr9c5v1yWwv8byAa2R6itlutjNjb53dA==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.PersistenceChannel": "[0.17.2-build00169]",
+          "Microsoft.ApplicationInsights.UniversalTelemetryChannel": "[0.17.2-build00169]",
+          "Microsoft.Bcl": "1.1.8",
+          "Microsoft.Bcl.Async": "1.0.168",
+          "Microsoft.Bcl.Build": "1.0.14",
+          "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.16-beta",
+          "Microsoft.VisualStudio.RemoteControl": "[14.0.249-master2E2DC10C]",
+          "Microsoft.VisualStudio.Utilities.Internal": "14.0.54-masterD06D5CD1",
+          "Newtonsoft.Json": "6.0.4"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Data": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "e4OUFLIJ+roHfIeG++y6GZK1S6E0D91iB6LTDQLTz7cC4BvOE3yU3/Eki6Xdy/6inTUKsdqsYUFYEBTWeeF5vA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Text.Logic": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "OG+pya+vxVGjDBp98mBjOWKRj295vwe5HtUmns1w/h727uhO4Y6KxYE4wRs7nOd7JMzB/WSAx2cgdBLtjBOoUg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "System.Collections.Immutable": "1.3.1"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "k8uKuTcTdOeZEtjrKXQAquWlEKswH2x0A/Ycqjinj7NJ6ykajccNCKiGb6jAJzVBkepSn81pWIO2QLpXKzcHuw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.Text.UI.Wpf": {
+        "type": "Transitive",
+        "resolved": "16.0.189-g83e7c53a57",
+        "contentHash": "Oa7/4XzATSR683uEK027pkQaV8yoebHABIRWuKZANe2cKWbInAMeoWibGUFW6T58W+8koX7zOIprTwYe02q4Og==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25408",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "+xdOtk+Hxdt4Bewl4kCA7KQsI7IZa58uZdnkTcNV9CEtT6Om6VxApAMPIBNvt7sZQoA6SOYubX4uAzEADHX55g==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "AicV/XF3LkQhplsacUr1sUyVL+7kuTk/RczvvYAFUr1PGpNtoHh17DqQYfI3zs/8lQIB+RCmpi6ZU7t0SmY0mg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072"
+        }
+      },
+      "Microsoft.VisualStudio.Utilities": {
+        "type": "Transitive",
+        "resolved": "15.8.28010",
+        "contentHash": "A36/u2YlW0Fs2H2WJSyTO9xW1FMGzKD+Oqtvfmgff+LyhlO8ZcSzR8waD7DKh2gZCyCR4M89m1VHvHn0Z/s5xg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.6.31",
+          "StreamJsonRpc": "1.3.23"
+        }
+      },
+      "Microsoft.VisualStudio.Utilities.Internal": {
+        "type": "Transitive",
+        "resolved": "14.0.54-masterD06D5CD1",
+        "contentHash": "vX0Ka1y7dEUs9HGTCw5BNTPREKJXy04OCy/GaDAgken2bSsjPZON8IkiTDFvkN0JtGuGIHCn9AU12lJU/4HLnw=="
+      },
+      "Microsoft.VisualStudio.Validation": {
+        "type": "Transitive",
+        "resolved": "15.3.15",
+        "contentHash": "bvJIwuCLqu7YKXcZqY85VJy0ljtm9QSRkq4CD2bpO/GHynsm72uZxjBDa050VY7kElXS8mb7VW5JNUfg4D/UBA=="
+      },
+      "Microsoft.VisualStudio.Workspace.VSIntegration": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "eSm+OpRg2C7L+h9UXvbzhwwBPdEk/8VAciEVdgtip5yZvhN2JrnzZxl1gPQdmQT8kVSn+B492fHOlDRa/ljcmA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspaces": "15.0.198-pre"
+        }
+      },
+      "Microsoft.VisualStudio.Workspaces": {
+        "type": "Transitive",
+        "resolved": "15.0.198-pre",
+        "contentHash": "Bk83t69Kmo+9t60N5/rUqDy3HC/4IxsXdcV52m4KZVaYo1eTwuiQRhvjQ56013G23RBMTgeId3LYXWj/vWIaLg=="
+      },
+      "Microsoft.Web.Xdt": {
+        "type": "Transitive",
+        "resolved": "2.1.2",
+        "contentHash": "YIaNTOOtGzjF8CkQBOx3aUBWi0dD+g/nOjbpsVslx9G0/uldtpmoKLmyldmKdMv/gHs3qg40rBT3+wvEWoY5gg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "hSXaFmh7hNCuEoC4XNY5DrRkLDzYHqPx/Ik23R4J86Z7PE/Y6YidhG602dFVdLBRSdG6xp9NabH3dXpcoxWvww=="
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "0.86.0",
+        "contentHash": "5DbS1SlKLMi+WG00Cm0ueYf2oyXJrowETQk8nx96rmdjTuHsA3laPykGV7Sxi0R5Xxfx0Kh/EfacAZ1f6M7y/g=="
+      },
+      "stdole": {
+        "type": "Transitive",
+        "resolved": "7.0.3301",
+        "contentHash": "qQW62tF9+Naie3mQ3wAIY5SU8dqNRaiLUPwQ5v2sQRfzhY8h0M1arECSb68M4smTR89RAvuvXRgxBOiJOblkyA=="
+      },
+      "StreamJsonRpc": {
+        "type": "Transitive",
+        "resolved": "1.3.23",
+        "contentHash": "xJU19tAWEgmXn79SdwgUYPWXjXLxXX+xGHw9R1Ody4YCnRde51NqXk/fQyFbSWlQek1AI0m9f9OXqMIDwNxayw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "15.3.20",
+          "Newtonsoft.Json": "6.0.6"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "D3eEHg9hnGHTYsKBHiD/bT8pkBt2tS9BTTCRv2Wx+86FqWTzvsCjuB+I1j0gYIjKQiI5+NSrPtnxWmNHz4CCQw=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "QwALOmIQnwYXO7SZuzHvp+aF9+E8kouJl2JDHe9hyV/Mqzl2KhOwZMlN+mhyIYo5ggHcIVa/LN7E46WD26OEEg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "5.2.1",
+          "Newtonsoft.Json": "10.0.1"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "91UTX0e+S3j5pTVl7V9r8qjBElGhEFp+TBXNT64K68Ecy8DXtM66pFKWQktGBL4GYQRBuZXQdIxX2XuBb77gJA=="
+      },
+      "VSLangProj": {
+        "type": "Transitive",
+        "resolved": "7.0.3300",
+        "contentHash": "/0bb3ssO3rsPUZnVPFNAva2uBQLYNdT4hVLTx0XgxI8+/7acZVuMum18YOaOaE7hnLHMY00o4ypGL/L7JssEww==",
+        "dependencies": {
+          "EnvDTE": "8.0.1"
+        }
+      },
+      "VSLangProj110": {
+        "type": "Transitive",
+        "resolved": "11.0.61030",
+        "contentHash": "ZD0/JubfPji1tUTI7d1fOxEZqC23eHU7PIzoeR0LSY/dmDwEKa32xujNsgx6TT58ZRaSVFY27nUaiVaFdBz5Og==",
+        "dependencies": {
+          "VSLangProj80": "8.0.50727",
+          "VSLangProj90": "9.0.30729"
+        }
+      },
+      "VSLangProj157": {
+        "type": "Transitive",
+        "resolved": "15.7.0",
+        "contentHash": "PjFMHShxIYuZlwqa3feX3MpmCb0RsfCTExjgaJseODGJDXsjApJ5CWolJhlm956W1RHwALQXPiH786H3vZ8upw=="
+      },
+      "VSLangProj2": {
+        "type": "Transitive",
+        "resolved": "7.0.5000",
+        "contentHash": "A286CbJJxrKW4tpVyVaJit5rgVEmTJod/reZ8epekhZWiNoKv2YWkPGaCi0+gQXq4YepqPngE6UpQp5iAXyYDg==",
+        "dependencies": {
+          "VSLangProj": "7.0.3300"
+        }
+      },
+      "VSLangProj80": {
+        "type": "Transitive",
+        "resolved": "8.0.50727",
+        "contentHash": "I2xOMyQcbBXMXKE8zmHljkV1XLAltQ4/T5QRk8Q1mWz7fdd7x1OMp+2VqxZVAJ89Ebfs4wclkcACyvc4FY4wcQ==",
+        "dependencies": {
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "VSLangProj90": {
+        "type": "Transitive",
+        "resolved": "9.0.30729",
+        "contentHash": "xCG2hloStE4TCToHlBai7n/s33sfw/UiEkwqozRPt0AtW9JMr+0hXgGjlOyvPT2rgY6jjKywU55qoTXY2M8f6g=="
+      },
+      "VSSDK.DTE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "uUEaT0sCVnJR54vxfsf5xHpJVWgTrCbl10oKkFuCvJb3I6M5WW4cu9zCTqtYP1i1mYYySGGqooNYiO45kLUkiQ==",
+        "dependencies": {
+          "VSSDK.IDE": "[7.0.4, 8.0.0)"
+        }
+      },
+      "VSSDK.IDE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "KPXgpya93UDz/JZVegRr+AAewTGw46+8Aq7Dl22jWaqjH2KaH/5ycCLG0LET2OX4VBpp15IjhNw08Y5H0vJMKQ=="
+      },
+      "VSSDK.IDE.12": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "XYcSrKW9369JO1tOAuNxzZ6OOlx2QujDuboey4eYpp9GgA3Bd3mo0Fy2ZJd86sZqX27roBRzJfM1Ue/peyWOIg=="
+      },
+      "VSSDK.TemplateWizardInterface": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "stTXrh4h/mftHaQWKZn043WCgP7cmv3QVPB8M3bbBp99kktLdJBTXygPctpgeOYfsBi1TqKJIiNZjG3hCoHNMw==",
+        "dependencies": {
+          "VSSDK.DTE": "[7.0.4, 8.0.0)",
+          "VSSDK.IDE.12": "[12.0.4, 13.0.0)"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Indexing": {
+        "type": "Project",
+        "dependencies": {
+          "Lucene.Net": "3.0.3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.2",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "NuGet.Indexing": "5.0.0-preview3",
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "NuGet.Packaging": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "NuGet.VisualStudio": "5.0.0-preview3",
+          "NuGet.VisualStudio.Common": "5.0.0-preview3",
+          "VSLangProj110": "11.0.61030",
+          "VSLangProj157": "15.7.0",
+          "VSLangProj2": "7.0.5000"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      },
+      "NuGet.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "VSSDK.TemplateWizardInterface": "12.0.4"
+        }
+      },
+      "NuGet.VisualStudio.Common": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.TeamFoundationServer.ExtendedClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.ComponentModelHost": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.CoreUtility": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Editor": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.ImageCatalog": "15.8.28010",
+          "Microsoft.VisualStudio.Language.Intellisense": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Language.StandardClassification": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Services.Client": "16.144.1-preview",
+          "Microsoft.VisualStudio.Services.InteractiveClient": "16.144.1-preview",
+          "Microsoft.VisualStudio.Shell.15.0": "15.8.28010",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "Microsoft.VisualStudio.Telemetry": "15.0.691-master31907920",
+          "Microsoft.VisualStudio.Text.Data": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.Logic": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Text.UI.Wpf": "16.0.189-g83e7c53a57",
+          "Microsoft.VisualStudio.Threading": "15.8.132",
+          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.132",
+          "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre",
+          "NuGet.PackageManagement": "5.0.0-preview3",
+          "VSLangProj": "7.0.3300"
+        }
+      }
+    }
+  }
+}

--- a/test/TestExtensions/GenerateLicenseList/packages.lock.json
+++ b/test/TestExtensions/GenerateLicenseList/packages.lock.json
@@ -1,0 +1,1173 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETCoreApp,Version=v2.0": {
+      "Microsoft.CodeAnalysis": {
+        "type": "Direct",
+        "requested": "[2.9.0, )",
+        "resolved": "2.9.0",
+        "contentHash": "3ldTJNsPJn+VZi8enS/04FKf6Rv/MLMdldqHAiff3f7AYneyTBF56SqvIqDzpu41TFpsPMvrbBI7s9BkF9LM7w==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[2.9.0]",
+          "Microsoft.CodeAnalysis.VisualBasic.Workspaces": "[2.9.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Direct",
+        "requested": "[2.9.0, )",
+        "resolved": "2.9.0",
+        "contentHash": "oiCPHjCLZtyAz/vnMRJI0PrhR/amJiR9RIwPpQ3+DMs7TgegGn65/dqYEcoiWSj8YQvwOK/J640EXMydMDLJVQ==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Common": "[2.9.0]"
+        }
+      },
+      "Microsoft.NETCore.App": {
+        "type": "Direct",
+        "requested": "[2.0.0, )",
+        "resolved": "2.0.0",
+        "contentHash": "/mzXF+UtZef+VpzzN88EpvFq5U6z4rj54ZMq/J968H6pcvyLOmcupmTRpJ3CJm8ILoCGh9WI7qpDdiKtuzswrQ==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetHostPolicy": "2.0.0",
+          "Microsoft.NETCore.Platforms": "2.0.0",
+          "NETStandard.Library": "2.0.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[11.0.2, )",
+        "resolved": "11.0.2",
+        "contentHash": "IvJe1pj7JHEsP8B8J8DwlMEx8UInrs/x+9oVY+oCD13jpLu4JbJU2WCIsMRn5C4yW9+DgkaO8uiVE5VHKjpmdQ=="
+      },
+      "System.Runtime.Loader": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "DHMaRn8D8YCK2GG2pw+UzNxn/OHVfaWx7OTLBD/hPegHZZgcZh3H6seWegrC4BYwsfuGrywIuT+MQs+rPqRLTQ==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "2.6.1",
+        "contentHash": "VsT6gg2SPeToP8SK7PEcsH6Ftryb7aOqnXh9xg11zBeov05+63gP3k/TvrR+v85XIa8Nn0y3+qNl4M+qzNLBfw=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "2.9.0",
+        "contentHash": "M06oYATUMAqL/ympQ09zNHOrRc6sEwgsiueK6z+QPOgyr028i54NviKy7Evfcvv7Kr0LX9MEmrKXPO2NZ+bZ5Q==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "2.6.1",
+          "System.AppContext": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Collections.Immutable": "1.5.0",
+          "System.Console": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.FileVersionInfo": "4.3.0",
+          "System.Diagnostics.StackTrace": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
+          "System.Dynamic.Runtime": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO.Compression": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Metadata": "1.6.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.CodePages": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Tasks.Extensions": "4.3.0",
+          "System.Threading.Tasks.Parallel": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.ValueTuple": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0",
+          "System.Xml.XDocument": "4.3.0",
+          "System.Xml.XPath.XDocument": "4.3.0",
+          "System.Xml.XmlDocument": "4.3.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+        "type": "Transitive",
+        "resolved": "2.9.0",
+        "contentHash": "ZVPi+NQcxLbHbKb77qbtRcne5AjbYQXIJYjQMI2dwLKU8PlZaWajZEEhSbin4FED3t4KL6T0RaAx8m8uJtAX2A==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.CSharp": "[2.9.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[2.9.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic": {
+        "type": "Transitive",
+        "resolved": "2.9.0",
+        "contentHash": "dUKemkcCwT8TfXmvjps7RrI9G5C2XgRf3pjhcMEH+ikyLsXqFstDsA3uP4waeJ4gi+4gaCehjmdDGO3UaaKBSA==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Common": "2.9.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic.Workspaces": {
+        "type": "Transitive",
+        "resolved": "2.9.0",
+        "contentHash": "FkFdX/incH1at2EapaBSAXeJHdilmyMOjS0FIaPfvd7Bau0b57/r312JxSGHslKjEWY+2UlWUPoPCYa9oH5hHw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.VisualBasic": "[2.9.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[2.9.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Transitive",
+        "resolved": "2.9.0",
+        "contentHash": "Py0UX0Cdh04puqDoE6kBS60j+8nJeJqSUxWQPFpxW6btas5Y2A4io4daJIy0DFz4Y49jcMtS5ynvXdkyIWvl/Q==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Common": "[2.9.0]",
+          "System.Composition": "1.0.31",
+          "System.Diagnostics.Contracts": "4.3.0",
+          "System.Linq.Parallel": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.0",
+          "System.Threading.Tasks.Parallel": "4.3.0"
+        }
+      },
+      "Microsoft.NETCore.DotNetAppHost": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "L4GGkcI/Mxl8PKLRpFdGmLb5oI8sGIR05bDTGkzCoamAjdUl1Zhkov2swjEsZvKYT8kkdiz39LtwyGYuCJxm1A=="
+      },
+      "Microsoft.NETCore.DotNetHostPolicy": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "rm7mMn0A93fwyAwVhbyOCcPuu2hZNL0A0dAur9sNG9pEkONPfCEQeF7m2mC8KpqZO0Ol6tpV5J0AF3HTXT3GXA==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetHostResolver": "2.0.0"
+        }
+      },
+      "Microsoft.NETCore.DotNetHostResolver": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "uBbjpeSrwsaTCADZCzRk+3aBzNnMqkC4zftJWBsL+Zk+8u+W+/lMb2thM5Y4hiVrv1YQg9t6dKldXzOKkY+pQw==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetAppHost": "2.0.0"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "VdLJOCXhZaEMY7Hm2GKiULmn7IEPFE4XC5LPSfBVCUIA8YLZVh846gtfBJalsPQF2PlzdD7ecX7DZEulJ402ZQ=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "JFoFlE+s92bQksXVDwfQPBCf/eGLLIBcxEwuUva82KN079lG0KTQiWRTSKaCaXLThMohP9IXgy22eZCkOkwNIA=="
+      },
+      "NETStandard.Library": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "7jnbRU+L08FXKMxqUflxEXtVymWvNOrS8yHgu9s6EM8Anr6T/wIX4nZ08j/u3Asz+tCufp3YVwFSEvFTPYmBPA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OC4N/9/h5o82cVZT5xDYLweAt/DvGfvxRA+LxtAVgIck9UXqZVBPddeUH/uSE9ANGlhE7ar77+kjtOdJpsghyw=="
+      },
+      "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "5hnkCG1lDYlcmcds11NyDLGxfi97dZmStdsY/I2iH0/cBKHrqno9jVlGrFLI8eQWEsxCLop0vj3f4YWGfJxi8w=="
+      },
+      "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "10lC2+5ImKZ3U+WPyYI+Idk+BWVLKSUoCmeZIEtE6UHYq7eiZJBOjCT2A8ivKNX/AALKt5S66RDTWgawVY7guA=="
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OJt7kV0xjgrGIO9dmygcZTzr8wFMpr8t17okLvtFEhSL+Hy9gvg8uGPUZH/IR+vjU7LSdg/lKweDNCrHEKHYXw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "runtime.native.System.IO.Compression": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "2epWZoIZWlzFvyZZIoe/Jk0f3zYkg/4kPH8ufeyZ9V4sdia0WQdGSOO7+AA03eQcLhV8r+kPH3w1Xwb1tIFY4A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "runtime.native.System.Net.Http": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "byd0WJYdKNXFThd70nBpqPUmk5x6Le1YO9iTDJM6vHszz2iFwxNnz5PljhTBBJgwaSjyOkJOdk7C61FLyoUlLQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "runtime.native.System.Security.Cryptography.Apple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "m8177a64R05Tze41qLz7dPtLnvQll4yYgEDYZERVOlEZ+b4ucDmWM0VoSxaGVlWCEr1Dls1Ty9pD7BsWPbSiEQ==",
+        "dependencies": {
+          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": "4.3.0"
+        }
+      },
+      "runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cf5sB00QnqejVbbt5URL548Bs+BAHlXmElWFQASszzKqzR72mw7YwLSaeoAyQ9FqahVp+IIzhJxuqVCXkaM9gA==",
+        "dependencies": {
+          "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fSExnM1euZtjZpymvSd/Wg8njOlk49hAPnmrFokV68c+6LzKy6v2tgJq2LSmATR0Wb7FDejfWkck8fjR46e4tw=="
+      },
+      "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "+FbXEqsv9GOHYGl2QnNQvG2/BZsQVXB+j9NL6nO62lNozdxDHhNFHp04tpOvkKsdVPvSCx5StZSkeAir1VmIbA=="
+      },
+      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "U6DFEEJqW66ctBqfu0Uh1WutOb3QEymGii5jFE8L9/50GbyF6wNLPNx7rTOdjapeOUvFx4J6zET+zwyajN5Efw=="
+      },
+      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cECKTL4dDrFSOixmbBxc7/GSCfabHrPZ6FDahI7he01I0XvQiLAbIJsZgobdMLeBtlFapvvNgSrseLxG9x0tCg=="
+      },
+      "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "oIxC5EeW+6seQtZQjhRJoj3+Mb7t6Ssfar4eTmga/2y+kKob7x03Aey41fzZLq1HPzIScJtE3ItnMm1VSoCszQ=="
+      },
+      "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "GXaC5CPHg/tEJWnGu/RbOxsVYMgN3/XSVh91zNrIZ/nHAeTM0ncPDn297jJWAoGT++JdjQN2FF1g8fFCPd1F8g=="
+      },
+      "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "b8+D5EKHYP0QrjeDwt3/QSmirRPNWZnAb6Wc/opqeCPoO5SfpOZ2u+8DAji3LFU+VHwz0V+GRca8vkACHsMcUQ=="
+      },
+      "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "8PpbWQszEd5vgPDCILpsq1gKgQ1wjl9ObefAU5w0q5WCx54lPl+MPV0lpi50A7yeV93a+sxyuBwi0OZte4h8sA=="
+      },
+      "System.AppContext": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "mxwYJ69Y5xS9/Zl7e/LOdksq451nx0KBpu+xfLPZGGh9BhHESKtnlBc97jFeGHG+yjNGkr1Q3RT2VJcwm2c80w==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "eQAvCk2CKY8IiO/mDwttFqgdmW30yiuIi/SCx+rofGirYGqjjK9j7uVnIUs8P9o5R1flCOKY4MFd2GGh1d4oyA==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Collections.Concurrent": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "s8UqYVK3GEhuuLdl39eo2rXAK4+JpcmpjT45C97x+745VhkkgX4PSts0ilBSKalQG9U7JBIRlicEU7ogawubQA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.5.0",
+        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "1.0.31",
+        "contentHash": "I+D26qpYdoklyAVUdqwUBrEIckMNjAYnuPJy/h9dsQItpQwVREkDFs4b4tkBza0kT2Yk48Lcfsv2QQ9hWsh9Iw==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "1.0.31",
+          "System.Composition.Convention": "1.0.31",
+          "System.Composition.Hosting": "1.0.31",
+          "System.Composition.Runtime": "1.0.31",
+          "System.Composition.TypedParts": "1.0.31"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "Transitive",
+        "resolved": "1.0.31",
+        "contentHash": "NHWhkM3ZkspmA0XJEsKdtTt1ViDYuojgSND3yHhTzwxepiwqZf+BCWuvCbjUt4fe0NxxQhUDGJ5km6sLjo9qnQ==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "1.0.31",
+        "contentHash": "GLjh2Ju71k6C0qxMMtl4efHa68NmWeIUYh4fkUI8xbjQrEBvFmRwMDFcylT8/PR9SQbeeL48IkFxU/+gd0nYEQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Composition.AttributedModel": "1.0.31",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "1.0.31",
+        "contentHash": "fN1bT4RX4vUqjbgoyuJFVUizAl2mYF5VAb+bVIxIYZSSc0BdnX+yGAxcavxJuDDCQ1K+/mdpgyEFc8e9ikjvrg==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Composition.Runtime": "1.0.31",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "1.0.31",
+        "contentHash": "0LEJN+2NVM89CE4SekDrrk5tHV5LeATltkp+9WNYrR+Huiyt0vaCqHbbHtVAjPyeLWIc8dOz/3kthRBj32wGQg==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "1.0.31",
+        "contentHash": "0Zae/FtzeFgDBBuILeIbC/T9HMYbW4olAmi8XqqAGosSOWvXfiQLfARZEhiGd0LVXaYgXr0NhxiU1LldRP1fpQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Composition.AttributedModel": "1.0.31",
+          "System.Composition.Hosting": "1.0.31",
+          "System.Composition.Runtime": "1.0.31",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Console": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SwBToTaKNJZ/+2eg2ECmzY+BOg9o5GwDpNh2o3PXnhmafaPLemiMlKvDUZm08t6XaXIOgKXQH6zkIT6cNV0e9A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Contracts": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "eelRRbnm+OloiQvp9CXS0ixjNQldjjkHO4iIkR5XH2VIP8sUB/SIpa1TdUW6/+HDcQ+MlhP3pNa1u5SbzYuWGA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.FileVersionInfo": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OkNB+cUMrivYpvymUZ/plqBl3Nommoq6myv09hqU725EIBrI4WpMYZ7v58OZHZE2oa9ZldD7SjNT/MUbUM4gkQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Reflection.Metadata": "1.4.1",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "System.Diagnostics.StackTrace": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "IF+gP/yxlsNau1pDpQBCOTToQAirXeMGngyh8McpAVwH6XfIGJKBTL7cRNgbFmcx5q7UNrS8+ZhPA8/eJ57Img==",
+        "dependencies": {
+          "System.IO.FileSystem": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Metadata": "1.4.1",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "isQPnys+OjpIGUBdTFb3QYgcurnbQTJt59hxQo4pWnRxWAwg8aUh9rtFvQnwi0Muq0yLM3/QremlXXdxpf8U5g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tracing": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Krwavn7yTVK68eEzsmXF8ES7xA2vUcgAVASfsGNoRyFyfAcRLH/tEWhSpXx/ILCLkGxbZc47Y1gCfQmAudpRAw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Dynamic.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "M/4NKf2BW3OgjEEIY5zIICntbpzqG7mf6QW5/Sc8/jq6J1juU+r6Dd7Zy8BQc//BsgLN/ilp+jsidnNLvsvPlQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Globalization.Calendars": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "L3YesDrnr9kUjp1Wp3BFd1WR5I8M8afWq+E4vEMMdNSvUi1uBW3TlgPDJQ0rpUuh7xyLgfY3nbmtCNgz5W9Vbw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.Compression": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PEVs0nwe7Bb9/dC479Gej5BEM6XkLv6CVpa8aZ+Ux8QT4udex1fKY8+1BwslovR/VBV21+iDU1iVtDmnth0DTw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Buffers": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.IO.Compression": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "wPQxHRTOQjHSTCoeRhcaNgUiN6+XLClZ4cF0Vxtx1cNLT6R1h8dkQ6OI86hJ5U0k6xlACnZZK2uPPKyCxHT9hg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "geg256WzQ6sWriZcgPAesEyvxEeQA4bChtNS0oXIHPNcXUli+h57SgF8oAG82YYIWFkw1WtJY8Ipswoj1lIV0w==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Expressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "pUhwb1gZm4nYs1vWOSBEtgFL2sba471wBK56vD+E9QXQPMCotyNoUlXDQU6JKP3iiXcZAYiLph74yDhK9LJn0A==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Linq.Parallel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "td7x21K8LalpjTWCzW/nQboQIFbq9i0r+PCyBBCdLWWnm4NBcdN18vpz/G9hCpUaCIfRL+ZxJNVTywlNlB1aLQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SN0ezyl68hX6MqubPw+9H/eYd66vXcYcPkGbcIlG2LAbRtLOjunoEFu4zwxbinKOYdIh7CBTCU1yLUFNXtqEcA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "N/L1zj+UTlLogL84AUE3fsJ0qjxlbHN9OxWxbkAlxNC+t47PQU8VssyXu0TjzH1QAclJOiEFTPa/V+My3P60dw==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ewhNB2sVnRTbEIkmOr0bjpn/3QAb6adt5VLjRLM3xYYHBmDotoVcYWOCtzXQoELX3EPhbo9tTt1COmHbOmtBaA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "s/qCR1/wIzV0EbusqDf13kez/m7ovN4qGy/YYgcKso98R+xJxbAtT0tK1e0UCHEHWZ0O0p3X9LraQpSl4Hs6qw==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "AxxXMPKP0sZp7eBBF7HMp8cj4w4vuaoVXHshS8F4qdvPy/nm5DCWOf7f0JX1xmwpsZEQiHj908cbVnNrRk1PzA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ==",
+        "dependencies": {
+          "System.Collections.Immutable": "1.5.0"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rsg/2b0JRcKznNmMJDljYlfHpUQ6LHmKdeKOvMz5DI0XKhY1DttFMNs0cdAjr/rSu4RjKMSjrsh1vWm1gEKutA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.Numerics": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "57eQH3a3rjAif8bRm5dToYGliFUKUKp5zyVrMW03RBQCwM9Rc9E4LjCNlYE3mCeMBmWaSm4GcLGEB9itUGqSqw==",
+        "dependencies": {
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Algorithms": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "l4dRimDHzWA/6dQ5NcMIbuHRp2nxfHO+ejq5+AmZcMR8dLJA1RK0Y/yIBuwKNX4gIYw2FIWWhgjOwFVZsK3gQg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.Apple": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Cng": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "oA7CLLSH//E5UjBY3zXrXUaALfHdgFiEKDUKJWQYqeu2LJ/JVPIJ/19k2CjyFHSJgp3rqUEP7HLC5zys9+JWcA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Csp": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bAlbofGk6IwmUprrVxpxe68TNapZs6iLvifJVNrvTI1AHZfCRcw9OF/fIW0nEQ8c8SY5K/tEmMakQnMSVL+R5g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "lw23IDVvQHGepzfAP9nVN9cBa1IeajAgdxcv6PvdCDj2atuRATWGvHauzALVwAVNu4jkhd7XD0CE1cz3VmCQPA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Wh3QYL3P6popkYpUlPi7YukI8F3M+0fVBFkquPYI4QfziJnHH+3GYk+mHjFM06NaIGwTO3PqIhn0+T0PoF9CPA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZLmOFqjQ8iOxQDHGOcxvIZ0LV8hOD8hFEJmfI3ugWpQfbiVXKuLspFgosbDuSPuxeZL6sBN6oUKa+qNFLF2y2g==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.X509Certificates": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "znewiGtuNlvOtocECc879Ed/wOOc4sLqyZrsMUewVdRGVbxa/WOs4jBxRDQ6EsGz2QZ2gOiDUAmcj+JOzI628Q==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Calendars": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Cng": "4.3.0",
+          "System.Security.Cryptography.Csp": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.OpenSsl": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.Net.Http": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.CodePages": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ITVTLLG6pilx0r/Y6bwWjvc+Bd0mP4LwzaOIq9zvaci2LuSh4cB8P7X2r1TwjKW2NjdgUSNc5+/6lVsSg2cEzA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "w4QazMGX4NXOQREZufI3OJHp6BdyMMXc3j0Xxm1YmWq7g1QnrpLbiTApglnKF7IfoWuOlmwsWDX9wy45/iBcrQ==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Gj7tzvn7Q5lNaXz88jrohC7if2jqHKQpq8pw/yhgpIO9s/Y/nTMUSoeuxAODSO0UzaBh6M3c/F1y1olrpY1lng==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "8chEm93kVu1VbnT8m2/GuewCrWa4YGWg87gmn/6dg/oi2tvKKlaUUfdF8JpZmRR6maDEgfwIXzMDK2Hi0UqqbQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Parallel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cTytLAz5P2/Y01MatYO5rvpwb2UK4zeyyEuUYDx3GpdCq1lgrEhZz78073N30qwHTGD/DCg1mlWxT4q51H+q+w==",
+        "dependencies": {
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kCgI/sTE4fxnz1Fs0aScBCC+cYFIIR7I0IG1JPWDPjOSQxYs5Qdzi4Gf3eeAIevdE03n3PeCh2JVCKv0/11yrA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "91UTX0e+S3j5pTVl7V9r8qjBElGhEFp+TBXNT64K68Ecy8DXtM66pFKWQktGBL4GYQRBuZXQdIxX2XuBb77gJA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xhCk60B7BNZTtc2KuVbUy7Z0beE4zicoNChqR/AZ0AJfNDn2whB6sBp42wTJbI1IIv6ROCjj5xIF/ghvbb7seA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Tasks.Extensions": "4.3.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fmsnYftaqYYZxXdHXpIO7MGMceL5lsBV/GPuikoGZY2CpI8+SJsXqQOgdNLwfDMB/e7emLi3AZMTgM1XuD9q7g==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0"
+        }
+      },
+      "System.Xml.XmlDocument": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "0gd/idPNS8QcNz1Zv9XaWaXfD1BQJbmQkaHgQEU8K1KK/GyiU2JLj1N+SpjYgr+X1HlVLlPgqb5cnbA+OJb8nw==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0"
+        }
+      },
+      "System.Xml.XPath": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "RIelBaxm3uxPtiHUwAQSRgZGw1NzEO/bwqxAh0huZcLbJA8d3qrsC1CBpIayF1YnrZDAIt/ybjG7HpO/HN56yQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0"
+        }
+      },
+      "System.Xml.XPath.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "CdMs2c9px3E5n/UsrRCd4Bs1I2JdNTB/6iyRqY25p5RLaCbrpHPW4SKQlT41hibdGCZEkS+D5mWjlJ0ENqyioQ==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0",
+          "System.Xml.XDocument": "4.3.0",
+          "System.Xml.XPath": "4.3.0"
+        }
+      }
+    }
+  }
+}

--- a/test/TestExtensions/GenerateTestPackages/packages.lock.json
+++ b/test/TestExtensions/GenerateTestPackages/packages.lock.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "NuGet.Core": {
+        "type": "Direct",
+        "requested": "[2.14.0-rtm-832, )",
+        "resolved": "2.14.0-rtm-832",
+        "contentHash": "0HyAyVEiSfdNEwXBtIFrZ8B6+Pggav7Nl+DLtQA51FrL7z/MT3RrmiZkJPrZJI/zSiHj/kUlp9bxHDxIL2N7gA==",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.0"
+        }
+      },
+      "Microsoft.Web.Xdt": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "/ieJ02r4MEJM21Eyl+c5kwoJWPhy+qEEcN68JaqDoamabgxJI1jGi/kNLuKvHUCl6tU7E0rMvaR6FmEnDWtS4A=="
+      }
+    }
+  }
+}

--- a/test/TestExtensions/NuGet.StaFact/packages.lock.json
+++ b/test/TestExtensions/NuGet.StaFact/packages.lock.json
@@ -1,0 +1,183 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "Xunit.StaFact": {
+        "type": "Direct",
+        "requested": "[0.2.9, )",
+        "resolved": "0.2.9",
+        "contentHash": "AkQPlJlfN0ziGHB2zR6IiC2hGPfGN+b1vAvnUcSHIGA8TsY9BC8dhtenmD6Cqd3gzVO04Mc6HDHuoRIhhs36IA==",
+        "dependencies": {
+          "xunit.extensibility.execution": "2.2.0"
+        }
+      },
+      "Microsoft.Web.Xdt": {
+        "type": "Transitive",
+        "resolved": "2.1.2",
+        "contentHash": "YIaNTOOtGzjF8CkQBOx3aUBWi0dD+g/nOjbpsVslx9G0/uldtpmoKLmyldmKdMv/gHs3qg40rBT3+wvEWoY5gg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "Portable.BouncyCastle": {
+        "type": "Transitive",
+        "resolved": "1.8.1.3",
+        "contentHash": "1jUpszv0ETm+hl78HKnYgY3wPzt6qRtjxaPENNrGCuB8nondbR/j75WAKdd6sxXzOzBcX07WMZhZEYc4s5jVWg=="
+      },
+      "xunit": {
+        "type": "Transitive",
+        "resolved": "2.3.1",
+        "contentHash": "IWux0xXfZ/bC7SgooK5rmW5KwCwFg9GFslmPxA7+pJsT+2SRyhOfOgNUXDd7B09UN4f6kogRT2TqNi6gbWEspA==",
+        "dependencies": {
+          "xunit.analyzers": "0.7.0",
+          "xunit.assert": "[2.3.1]",
+          "xunit.core": "[2.3.1]"
+        }
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.1",
+        "contentHash": "bDm/zdG5rnRDsobKuKwrvL4HccBdC0uvT12be6fG12P3d1U7u9Wkvfoq/PM2GeyIeb0Dtcmm/7k2oaawiqQ2Dg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "0.7.0",
+        "contentHash": "pEjPJ/pd+r9blGBJ9bXg961phkAiCl4k2DwxwWGEZyYC/7Tb1xJ1az0H18uGANX7zFIkvE5ZO1eZZ4vU7gny7w=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.3.1",
+        "contentHash": "+mUMp3aJOS0ag3qJ2tUhVa930KhwjyypxXT4Ab8lQozEQN8/xgkblQnYs0woIWpr2NbzEOxsZojytl9NBVRKxg=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.3.1",
+        "contentHash": "LOG4qOFuVQcjYcIuZbKeo03Uvng3lSb2gZJU9ANljwCf+PTd//iAMZS5qcJQZrjhndc4aOUlJGQy5wa0+/iZ6w==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.3.1]",
+          "xunit.extensibility.execution": "[2.3.1]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.3.1",
+        "contentHash": "1mgYqXeQfU+7zcSRW8/5Uf1jVZ5+5WELmi+BuRTh0xu/x0Q0gK0SuR3FLUF4BSd8sfZzvrRUrhWj3ltpyFxhrg==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.1"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.3.1",
+        "contentHash": "i8xrHfKC5dyBWQ7I15FePzm0m8KNToBsTleCCQbOQuXRPZIvupd4nnfaCPeJuKHHe7yJ8JGtWxjIgw0ow/cMhg==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.3.1]"
+        }
+      },
+      "NuGet.Build.Tasks": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Commands": "5.0.0-preview3"
+        }
+      },
+      "NuGet.CommandLine": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Build.Tasks": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.2",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      },
+      "Test.Utility": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.CommandLine": "5.0.0-preview3",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3",
+          "Portable.BouncyCastle": "1.8.1.3",
+          "xunit": "2.3.1"
+        }
+      }
+    }
+  }
+}

--- a/test/TestExtensions/SampleCommandLineExtensions/packages.lock.json
+++ b/test/TestExtensions/SampleCommandLineExtensions/packages.lock.json
@@ -1,0 +1,109 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "Microsoft.Web.Xdt": {
+        "type": "Transitive",
+        "resolved": "2.1.2",
+        "contentHash": "YIaNTOOtGzjF8CkQBOx3aUBWi0dD+g/nOjbpsVslx9G0/uldtpmoKLmyldmKdMv/gHs3qg40rBT3+wvEWoY5gg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "NuGet.Build.Tasks": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Commands": "5.0.0-preview3"
+        }
+      },
+      "NuGet.CommandLine": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Build.Tasks": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.2",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/test/TestExtensions/TestablePlugin/packages.lock.json
+++ b/test/TestExtensions/TestablePlugin/packages.lock.json
@@ -1,0 +1,800 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETCoreApp,Version=v2.1": {
+      "Microsoft.NETCore.App": {
+        "type": "Direct",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "mVxL8khUMyl0L+MkyY0SLhZU13Z+KoUCcCTDC1MZKaegUVbAuaEzqX0VyGJ5U1lyo8fh6ryJPbsBPJww6qcKpw==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetHostPolicy": "2.1.0",
+          "Microsoft.NETCore.Platforms": "2.1.0",
+          "Microsoft.NETCore.Targets": "2.1.0",
+          "NETStandard.Library": "2.0.3"
+        }
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "lJSTbsIVqnziQ1ZLPw+NZKyVHw9oABRwWer5dQesnt4kk7V8iLFtW8PhuAxEBlzii/z39FL/p+Kl+GptrRoRmA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "Microsoft.NETCore.DotNetAppHost": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "cZiASE81rksPJsGJ04hd/uEn6guNGAoqNsrzE/DP6AaNRPCHwTe6nZvHd4uAPj3MaVRQ3U0c6cRycMaHCYLPUQ=="
+      },
+      "Microsoft.NETCore.DotNetHostPolicy": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "JHyN4ibWkJy/2HlqHnUXBmcpzZfIhCFw7uGqWU5fyL7mzGq5E5vjCHChpFqPzRugM2QS3q31re6CAVzFBzTMqw==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetHostResolver": "2.1.0"
+        }
+      },
+      "Microsoft.NETCore.DotNetHostResolver": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "d+V3yHIMimz3m4MkecBtIrf1NI1oPUez5eaAXbVSWqNyFUuTeBeolYwA3yCYeKCS0zDkV0QjXEOaHd0pjujOZA==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetAppHost": "2.1.0"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "aSTPL94NloSiQVL5Len8wbjFKOnoAX/vOh3s3DF6g3c7GUUMLCDvnBhmA72M2iN2AedyA8hpr7m89kzSAKUnJQ=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "R+z1NrmXptbA6maCVVPcJ9xrCjUZFGEW1CHQeCqOyRni6PFxANYjiEjDBAK7wQUdmdZFy3xKJYUY0qhpb+hSLQ=="
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cFEQkQFLOADfBo4k6zrDqhyg4bffeoFQsD1S1kzrrO06rSl5VeVn747esouUgH1xWNujphM9r6/AN85fxCIBTA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "NETStandard.Library": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        }
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OJt7kV0xjgrGIO9dmygcZTzr8wFMpr8t17okLvtFEhSL+Hy9gvg8uGPUZH/IR+vjU7LSdg/lKweDNCrHEKHYXw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "A3aDinDgWcac4zUmardLoisyp2aSF+OFy2/1GZEHqKrYlFObrYHx5Oa69YHALUhEBtCjc8UYgAFjpPZCw9fdiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Dynamic.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "M/4NKf2BW3OgjEEIY5zIICntbpzqG7mf6QW5/Sc8/jq6J1juU+r6Dd7Zy8BQc//BsgLN/ilp+jsidnNLvsvPlQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "wPQxHRTOQjHSTCoeRhcaNgUiN6+XLClZ4cF0Vxtx1cNLT6R1h8dkQ6OI86hJ5U0k6xlACnZZK2uPPKyCxHT9hg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "geg256WzQ6sWriZcgPAesEyvxEeQA4bChtNS0oXIHPNcXUli+h57SgF8oAG82YYIWFkw1WtJY8Ipswoj1lIV0w==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Expressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "pUhwb1gZm4nYs1vWOSBEtgFL2sba471wBK56vD+E9QXQPMCotyNoUlXDQU6JKP3iiXcZAYiLph74yDhK9LJn0A==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SN0ezyl68hX6MqubPw+9H/eYd66vXcYcPkGbcIlG2LAbRtLOjunoEFu4zwxbinKOYdIh7CBTCU1yLUFNXtqEcA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "N/L1zj+UTlLogL84AUE3fsJ0qjxlbHN9OxWxbkAlxNC+t47PQU8VssyXu0TjzH1QAclJOiEFTPa/V+My3P60dw==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ewhNB2sVnRTbEIkmOr0bjpn/3QAb6adt5VLjRLM3xYYHBmDotoVcYWOCtzXQoELX3EPhbo9tTt1COmHbOmtBaA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "s/qCR1/wIzV0EbusqDf13kez/m7ovN4qGy/YYgcKso98R+xJxbAtT0tK1e0UCHEHWZ0O0p3X9LraQpSl4Hs6qw==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "AxxXMPKP0sZp7eBBF7HMp8cj4w4vuaoVXHshS8F4qdvPy/nm5DCWOf7f0JX1xmwpsZEQiHj908cbVnNrRk1PzA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rsg/2b0JRcKznNmMJDljYlfHpUQ6LHmKdeKOvMz5DI0XKhY1DttFMNs0cdAjr/rSu4RjKMSjrsh1vWm1gEKutA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.1.1",
+        "contentHash": "xiranjWMIrhBah+YqPRID/+vU7ZfyHGTSMWSkSY27xFhlI1aMM53Mpt9+MnXS0hent6Jt6YMduib9xtJ1hbHvw==",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZLmOFqjQ8iOxQDHGOcxvIZ0LV8hOD8hFEJmfI3ugWpQfbiVXKuLspFgosbDuSPuxeZL6sBN6oUKa+qNFLF2y2g==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qBUHUk7IqrPHY96THHTa1akCxw0GsNFpsk3XFHbi0A0tMUDBpQprtY1Tbl6yaS1x4c96ilcXU8PocYtmSmkaQQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "zyxULthU5BUBw4RiTuO4zecYbVBIgoq0CrPfonNgWOd5Cl11xxIESMq+Q2TWTsAFkfsD3A6Kp6UTuhnroV6e0w==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Gj7tzvn7Q5lNaXz88jrohC7if2jqHKQpq8pw/yhgpIO9s/Y/nTMUSoeuxAODSO0UzaBh6M3c/F1y1olrpY1lng==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "PGbJReQ7spxIZuCb8nYjVNnNWWQn5Loey6sC8MvGBnHN9oJAetXW/Va9UvDmlB4+nZhY3uW2nbKEOsz6gFf88A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kCgI/sTE4fxnz1Fs0aScBCC+cYFIIR7I0IG1JPWDPjOSQxYs5Qdzi4Gf3eeAIevdE03n3PeCh2JVCKv0/11yrA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1WaMGI7TLOynUVjVzFmgVvxvho/yl2l7lkTc2EdgA0jtLDX9pHpEZkgG7KaY+9G2WMO1GVmuSEBzucbgmsFW2w==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "lvA/29NjaGEYADSOy+fJp6dtZ9NMSMX1cbePx9FHX5w66EwnceLVtggzWv1StQPAULtUrbjicjA7I2eAtvNgOQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Extensions": "4.0.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "Y0igaOCZs653g0Z+zeFiu9vTR/CPhpUmaee+BK4QUixVk2winYIZfGqKGQ9Jn8TBn+CX98adj1Q6OB1/XZXanw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "System.Diagnostics.Process": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "System.Security.Cryptography.ProtectedData": "4.3.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    },
+    ".NETCoreApp,Version=v2.1/win7-x64": {
+      "Microsoft.NETCore.App": {
+        "type": "Direct",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "mVxL8khUMyl0L+MkyY0SLhZU13Z+KoUCcCTDC1MZKaegUVbAuaEzqX0VyGJ5U1lyo8fh6ryJPbsBPJww6qcKpw==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetHostPolicy": "2.1.0",
+          "Microsoft.NETCore.Platforms": "2.1.0",
+          "Microsoft.NETCore.Targets": "2.1.0",
+          "NETStandard.Library": "2.0.3",
+          "runtime.win-x64.Microsoft.NETCore.App": "2.1.0"
+        }
+      },
+      "Microsoft.NETCore.DotNetAppHost": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "cZiASE81rksPJsGJ04hd/uEn6guNGAoqNsrzE/DP6AaNRPCHwTe6nZvHd4uAPj3MaVRQ3U0c6cRycMaHCYLPUQ==",
+        "dependencies": {
+          "runtime.win-x64.Microsoft.NETCore.DotNetAppHost": "2.1.0"
+        }
+      },
+      "Microsoft.NETCore.DotNetHostPolicy": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "JHyN4ibWkJy/2HlqHnUXBmcpzZfIhCFw7uGqWU5fyL7mzGq5E5vjCHChpFqPzRugM2QS3q31re6CAVzFBzTMqw==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetHostResolver": "2.1.0",
+          "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy": "2.1.0"
+        }
+      },
+      "Microsoft.NETCore.DotNetHostResolver": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "d+V3yHIMimz3m4MkecBtIrf1NI1oPUez5eaAXbVSWqNyFUuTeBeolYwA3yCYeKCS0zDkV0QjXEOaHd0pjujOZA==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetAppHost": "2.1.0",
+          "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver": "2.1.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "runtime.win-x64.Microsoft.NETCore.App": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "1NgFJX+Gz/t80NPchuvTBTqbGV4uWOCdI37LLjHZ4K5juQXDG9hQMTDPi5FF1z2ogmb0c8+xSBs3OpGp2Dzjng=="
+      },
+      "runtime.win-x64.Microsoft.NETCore.DotNetAppHost": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "xmfJHwHAJrK9Ey0eS+PmX2LSRIl4+1j6Ka/hQ7UMEQOArpSeC9yiKmLDSjBdr61UWciky8uitkdfkD3qH7f6cg=="
+      },
+      "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "DeL6JoX3u7I5STe5HZEi2FWHhoAmuy1WM8hurSTIi/mG0h5i+OJeKwYxgotXzdR448qDTL2EL8EaHr1TpzpQGQ==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetHostResolver": "2.1.0"
+        }
+      },
+      "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "CFDkGWDASuC/rGQfBQlndnO6o+6IbB+VrRPo7P/9le0TeFkPI+Z1nCxMoC6da7ke+m2ICCFcseDqmLUryHyLKg==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetAppHost": "2.1.0"
+        }
+      },
+      "System.Diagnostics.Process": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qBUHUk7IqrPHY96THHTa1akCxw0GsNFpsk3XFHbi0A0tMUDBpQprtY1Tbl6yaS1x4c96ilcXU8PocYtmSmkaQQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      }
+    },
+    ".NETFramework,Version=v4.7.2": {
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    },
+    ".NETFramework,Version=v4.7.2/win7-x64": {}
+  }
+}

--- a/test/TestExtensions/TestablePluginCredentialProvider/packages.lock.json
+++ b/test/TestExtensions/TestablePluginCredentialProvider/packages.lock.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "Microsoft.CSharp": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "P+MBhIM0YX+JqROuf7i306ZLJEjQYA9uUyRDE+OqwUI5sh41e2ZbPQV3LfAPh+29cmceE1pUffXsGfR4eMY3KA=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "FyQLmEpjsCrEP+znauLDGAi+h6i9YnaMkITlfIoiM4RYyX3nki306bTHsr/0okiIvIc7BJhQTbOAIZVocccFUw=="
+      }
+    }
+  }
+}

--- a/test/TestExtensions/TestableVSCredentialProvider/packages.lock.json
+++ b/test/TestExtensions/TestableVSCredentialProvider/packages.lock.json
@@ -1,0 +1,135 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "EnvDTE": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "ppW2nOaaMCOy1HNdUWvTM+btoXVbvntTL4RxVvEWBaHFk+Aj/r7vrS3t9x1QrHB4Y9Rrd2n7UAmjzet3Ps63XA==",
+        "dependencies": {
+          "stdole": "7.0.3301"
+        }
+      },
+      "EnvDTE80": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "3CBF4ileGBzGDPvNePcI3611sRVP5xMHXMZGGgQtcFV5nUu5L5QAZkkrgnBdM0oD9ZXc6dReVwo+tXOSR91z4Q==",
+        "dependencies": {
+          "EnvDTE": "8.0.1",
+          "stdole": "7.0.3301"
+        }
+      },
+      "Microsoft.VisualStudio.OLE.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "6W3YMtSGt+hHRvAqbktXHLWZgEbEpuFZxuC1XiKCX4Th3fGv+7SeKGGH7Gmeu9fp/8kNqq7uovqWaHfhni13Hw=="
+      },
+      "Microsoft.VisualStudio.Shell.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6072",
+        "contentHash": "hoaT0t8DMA5YwPQEeiRD7UJpndgJDyK00uYcQl3I2+KvgQroo7lAZfkPNbGIhy2OGW4nOEqlvr0i5OE71hgT1w==",
+        "dependencies": {
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.10.0": {
+        "type": "Transitive",
+        "resolved": "10.0.30320",
+        "contentHash": "RKmdy0EgbXFtzjM2Kcdv9w9XdMJS81QykYUb1D/5SnvUYn28ElVt3criqGlvcC1syLJLmk9DdHomOhX6R50e1A==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.11.0": {
+        "type": "Transitive",
+        "resolved": "11.0.61031",
+        "contentHash": "N8il5VcZNr4GZeAvItmpWE4A5DKwSpFelQQ+I1VoUm1kVj+6dPieZXlhdbFC3bJVyCs1gl0uUzOH7FDVGfdDCw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30320"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.12.0": {
+        "type": "Transitive",
+        "resolved": "12.0.30111",
+        "contentHash": "ToNByCRLH875yHd1G43EmGuQz16bAV0PKICvzArpjuNugx/Cl4Djg15NHu7XUdPHm+UpAfH4W7nYh0u8NxqWHw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61031"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "gGhUi9HaXGFC48HxZPV4nYcjygT/vcYYUow5iNocHp/EfwCCnDTUqe5AisH/o1pqB+iakw64g73KSDFsRNAXcA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50728"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "+xdOtk+Hxdt4Bewl4kCA7KQsI7IZa58uZdnkTcNV9CEtT6Om6VxApAMPIBNvt7sZQoA6SOYubX4uAzEADHX55g==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6071"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50728",
+        "contentHash": "AicV/XF3LkQhplsacUr1sUyVL+7kuTk/RczvvYAFUr1PGpNtoHh17DqQYfI3zs/8lQIB+RCmpi6ZU7t0SmY0mg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6072"
+        }
+      },
+      "stdole": {
+        "type": "Transitive",
+        "resolved": "7.0.3301",
+        "contentHash": "qQW62tF9+Naie3mQ3wAIY5SU8dqNRaiLUPwQ5v2sQRfzhY8h0M1arECSb68M4smTR89RAvuvXRgxBOiJOblkyA=="
+      },
+      "VSSDK.DTE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "uUEaT0sCVnJR54vxfsf5xHpJVWgTrCbl10oKkFuCvJb3I6M5WW4cu9zCTqtYP1i1mYYySGGqooNYiO45kLUkiQ==",
+        "dependencies": {
+          "VSSDK.IDE": "[7.0.4, 8.0.0)"
+        }
+      },
+      "VSSDK.IDE": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "KPXgpya93UDz/JZVegRr+AAewTGw46+8Aq7Dl22jWaqjH2KaH/5ycCLG0LET2OX4VBpp15IjhNw08Y5H0vJMKQ=="
+      },
+      "VSSDK.IDE.12": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "XYcSrKW9369JO1tOAuNxzZ6OOlx2QujDuboey4eYpp9GgA3Bd3mo0Fy2ZJd86sZqX27roBRzJfM1Ue/peyWOIg=="
+      },
+      "VSSDK.TemplateWizardInterface": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "stTXrh4h/mftHaQWKZn043WCgP7cmv3QVPB8M3bbBp99kktLdJBTXygPctpgeOYfsBi1TqKJIiNZjG3hCoHNMw==",
+        "dependencies": {
+          "VSSDK.DTE": "[7.0.4, 8.0.0)",
+          "VSSDK.IDE.12": "[12.0.4, 13.0.0)"
+        }
+      },
+      "NuGet.VisualStudio": {
+        "type": "Project",
+        "dependencies": {
+          "EnvDTE80": "8.0.1",
+          "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30111",
+          "VSSDK.TemplateWizardInterface": "12.0.4"
+        }
+      }
+    },
+    ".NETFramework,Version=v4.7.2/win": {},
+    ".NETFramework,Version=v4.7.2/win-x64": {},
+    ".NETFramework,Version=v4.7.2/win-x86": {}
+  }
+}

--- a/test/TestUtilities/Test.Utility/packages.lock.json
+++ b/test/TestUtilities/Test.Utility/packages.lock.json
@@ -1,0 +1,1133 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETCoreApp,Version=v2.1": {
+      "Microsoft.NETCore.App": {
+        "type": "Direct",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "mVxL8khUMyl0L+MkyY0SLhZU13Z+KoUCcCTDC1MZKaegUVbAuaEzqX0VyGJ5U1lyo8fh6ryJPbsBPJww6qcKpw==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetHostPolicy": "2.1.0",
+          "Microsoft.NETCore.Platforms": "2.1.0",
+          "Microsoft.NETCore.Targets": "2.1.0",
+          "NETStandard.Library": "2.0.3"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Portable.BouncyCastle": {
+        "type": "Direct",
+        "requested": "[1.8.1.3, )",
+        "resolved": "1.8.1.3",
+        "contentHash": "1jUpszv0ETm+hl78HKnYgY3wPzt6qRtjxaPENNrGCuB8nondbR/j75WAKdd6sxXzOzBcX07WMZhZEYc4s5jVWg=="
+      },
+      "System.Diagnostics.Process": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "ta2VhqZEmlZSigj0O4uRddIWzOkSEbK3pGDA3JPDDdOk84Ehc5kcLIhOyDXzTSFCsLfXlqZ7q1GS3ZRVVMqjbg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.IO.Compression.ZipFile": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "nr0tVGg4uU6HSsCPek5voTyGVWge9wIg7fgiDWrL4w5rcsUfkzWvysfHUxnjQHFW4n6n5tXvMepu+W0i6Br1Yg==",
+        "dependencies": {
+          "System.Buffers": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.Compression": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Direct",
+        "requested": "[4.5.2, )",
+        "resolved": "4.5.2",
+        "contentHash": "lIo52x0AAsZs8r1L58lPXaqN6PP51Z/XJts0kZtbZRNYcMguupxqRGjvc/GoqSKTbYa+aBwbkT4xoqQ7EsfN0A==",
+        "dependencies": {
+          "System.Security.Cryptography.Cng": "4.5.0"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.3.1, )",
+        "resolved": "2.3.1",
+        "contentHash": "IWux0xXfZ/bC7SgooK5rmW5KwCwFg9GFslmPxA7+pJsT+2SRyhOfOgNUXDd7B09UN4f6kogRT2TqNi6gbWEspA==",
+        "dependencies": {
+          "xunit.analyzers": "0.7.0",
+          "xunit.assert": "[2.3.1]",
+          "xunit.core": "[2.3.1]"
+        }
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "lJSTbsIVqnziQ1ZLPw+NZKyVHw9oABRwWer5dQesnt4kk7V8iLFtW8PhuAxEBlzii/z39FL/p+Kl+GptrRoRmA==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "Microsoft.NETCore.DotNetAppHost": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "cZiASE81rksPJsGJ04hd/uEn6guNGAoqNsrzE/DP6AaNRPCHwTe6nZvHd4uAPj3MaVRQ3U0c6cRycMaHCYLPUQ=="
+      },
+      "Microsoft.NETCore.DotNetHostPolicy": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "JHyN4ibWkJy/2HlqHnUXBmcpzZfIhCFw7uGqWU5fyL7mzGq5E5vjCHChpFqPzRugM2QS3q31re6CAVzFBzTMqw==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetHostResolver": "2.1.0"
+        }
+      },
+      "Microsoft.NETCore.DotNetHostResolver": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "d+V3yHIMimz3m4MkecBtIrf1NI1oPUez5eaAXbVSWqNyFUuTeBeolYwA3yCYeKCS0zDkV0QjXEOaHd0pjujOZA==",
+        "dependencies": {
+          "Microsoft.NETCore.DotNetAppHost": "2.1.0"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "aSTPL94NloSiQVL5Len8wbjFKOnoAX/vOh3s3DF6g3c7GUUMLCDvnBhmA72M2iN2AedyA8hpr7m89kzSAKUnJQ=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "R+z1NrmXptbA6maCVVPcJ9xrCjUZFGEW1CHQeCqOyRni6PFxANYjiEjDBAK7wQUdmdZFy3xKJYUY0qhpb+hSLQ=="
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cFEQkQFLOADfBo4k6zrDqhyg4bffeoFQsD1S1kzrrO06rSl5VeVn747esouUgH1xWNujphM9r6/AN85fxCIBTA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PjuteKuoymPvXyIR3TAztjd8hnqijsD4H7HbtFnK9mrtvPc7Ao1AjwaQ+LHi52FmvaSL5/5TYg8BH6qfEDVvzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "NETStandard.Library": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        }
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OJt7kV0xjgrGIO9dmygcZTzr8wFMpr8t17okLvtFEhSL+Hy9gvg8uGPUZH/IR+vjU7LSdg/lKweDNCrHEKHYXw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "runtime.native.System.IO.Compression": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "2epWZoIZWlzFvyZZIoe/Jk0f3zYkg/4kPH8ufeyZ9V4sdia0WQdGSOO7+AA03eQcLhV8r+kPH3w1Xwb1tIFY4A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "eQAvCk2CKY8IiO/mDwttFqgdmW30yiuIi/SCx+rofGirYGqjjK9j7uVnIUs8P9o5R1flCOKY4MFd2GGh1d4oyA==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cI8N773VAhZKFYe+o8JwzDvIwRki3FMJZBd4f0aTTfG3i1l5LbHils84CORjii2ygYQhM9RzyXyIR38QcqVeXg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "zhp+cwYGWBxBnJsuelnc39z7RQ/B6GBUoD22NtRCMQaCxTtH2+vLOEjOliKhDk4BE/Z1b+SY6h2gGhnVnGv2dg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "A3aDinDgWcac4zUmardLoisyp2aSF+OFy2/1GZEHqKrYlFObrYHx5Oa69YHALUhEBtCjc8UYgAFjpPZCw9fdiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Diagnostics.Tracing": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Krwavn7yTVK68eEzsmXF8ES7xA2vUcgAVASfsGNoRyFyfAcRLH/tEWhSpXx/ILCLkGxbZc47Y1gCfQmAudpRAw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Dynamic.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "M/4NKf2BW3OgjEEIY5zIICntbpzqG7mf6QW5/Sc8/jq6J1juU+r6Dd7Zy8BQc//BsgLN/ilp+jsidnNLvsvPlQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "WNm6zIYGKI7OfsSHR2nnGNP8ETIOJieuUHqrzCEjsFRW0UhTT1y9OWPGBBMtqoW7dURyBvGW2g+2wNKnrBauTQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "z37g4okYBN5ysx/ARuh7GoypHV98/cffNo7iLnoZSnrFU67NHzt87Ox+sCQYxnDdDmTk9CsV7CnDPLYN3Ay8uA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.Compression": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PEVs0nwe7Bb9/dC479Gej5BEM6XkLv6CVpa8aZ+Ux8QT4udex1fKY8+1BwslovR/VBV21+iDU1iVtDmnth0DTw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Buffers": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.IO.Compression": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aRro7s4tRSbW/C3ukEAvHIiydy3f37Bxvlmw+j/GxLhXcUkv84D4OwiO2vJM3r1KehyszE6EvyX6uoyR/r+vcg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "wPQxHRTOQjHSTCoeRhcaNgUiN6+XLClZ4cF0Vxtx1cNLT6R1h8dkQ6OI86hJ5U0k6xlACnZZK2uPPKyCxHT9hg==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "geg256WzQ6sWriZcgPAesEyvxEeQA4bChtNS0oXIHPNcXUli+h57SgF8oAG82YYIWFkw1WtJY8Ipswoj1lIV0w==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Expressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "pUhwb1gZm4nYs1vWOSBEtgFL2sba471wBK56vD+E9QXQPMCotyNoUlXDQU6JKP3iiXcZAYiLph74yDhK9LJn0A==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SN0ezyl68hX6MqubPw+9H/eYd66vXcYcPkGbcIlG2LAbRtLOjunoEFu4zwxbinKOYdIh7CBTCU1yLUFNXtqEcA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "xFYEoBkfZteFlH90Eq+GZGtERHXVNySkne5Jc07qS8Q+enJCtBwfbYwUhwa+DoyDqz8YlX4PM+1chP+pCLFOow==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "N/L1zj+UTlLogL84AUE3fsJ0qjxlbHN9OxWxbkAlxNC+t47PQU8VssyXu0TjzH1QAclJOiEFTPa/V+My3P60dw==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ewhNB2sVnRTbEIkmOr0bjpn/3QAb6adt5VLjRLM3xYYHBmDotoVcYWOCtzXQoELX3EPhbo9tTt1COmHbOmtBaA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "s/qCR1/wIzV0EbusqDf13kez/m7ovN4qGy/YYgcKso98R+xJxbAtT0tK1e0UCHEHWZ0O0p3X9LraQpSl4Hs6qw==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "AxxXMPKP0sZp7eBBF7HMp8cj4w4vuaoVXHshS8F4qdvPy/nm5DCWOf7f0JX1xmwpsZEQiHj908cbVnNrRk1PzA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "riyJSkf+UnRmFOyjbkQbqtLgCZEAi5nP25UCnlhb1lnejsTWCyGTVgQjOkOkqckCgrUkNasvWeGsr9N4y4vOIw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rsg/2b0JRcKznNmMJDljYlfHpUQ6LHmKdeKOvMz5DI0XKhY1DttFMNs0cdAjr/rSu4RjKMSjrsh1vWm1gEKutA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7ftt8wxHGnMe3GLKctZEAICPl5sUBooUorNIVdQ4C+6OFx/v3xus2+YsbitTmLE+1B6w3swnorDB6LE6DcB/oA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1lL2cGt2nZkCvttqUCJv+bNDPz1knDmOcjXtLhf8wO33OMA9TJEWk+elc6zzoQeZzplfAu2wMmn4+GpeTubOOw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "hn+R1zKFVelw6LsqRKVyTVYGi15XfaVE4GqvV83echa7ef+7f1+7oq8aDotbL+eiFKMdHjlsQ0nrXjbFR9W03g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "aecxbDYhc0mKFFVzYdxfe0xuf+9PXwmIMPcUg09D7wnZVYSOkM345tepU5shPUhrxaA6VlAgFzQp8YnPgaG4Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Ds27zxH5bkEzVu6bvW9FtKn2YdRNWj8Qt449qSLNgMdh4tLDl8ufTYgTQDAoIGpqg9fAJ8rjfP+/cdc7AmK3dA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Formatters": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "giE1EDm3wyZjKOxNQpsg7cmPvlPcUDTevUpUeclRbWBbv8PCg245cFg8A3ihb0jETo2Uzgi4kXWRNIKuVLMDIA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Serialization.Primitives": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "JmkqsVmd/4ZAItnNtQdjPPLdMmsUIXtix/dI6eq2g4edEnqHJnI5naBXLcP49xmnuNo4JLEuSurtUefsp3LfAg==",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Cng": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "O4tqXxWCD8y1IU1VTgzbuBFwoRahrADhDUxHjwezhHCsqyFNyQ5EytjWBxu0EsZuH14b4UO2pFkG063K2h/9Ug=="
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZLmOFqjQ8iOxQDHGOcxvIZ0LV8hOD8hFEJmfI3ugWpQfbiVXKuLspFgosbDuSPuxeZL6sBN6oUKa+qNFLF2y2g==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qBUHUk7IqrPHY96THHTa1akCxw0GsNFpsk3XFHbi0A0tMUDBpQprtY1Tbl6yaS1x4c96ilcXU8PocYtmSmkaQQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1AKqROkTdMVKtVpt+FWhwnJ85deFehKv/s7iGEdg6LADyP6v8hkee/hkyh01Q2KrRa3oWAzKUiFafebwxx8voQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bd3M+NIuCg3HFggdDzZ39FzqYeGRTxMWp4SdVi6fzKhmJpqqpGz3tQ8K9U6wRZhp07mm9cgMxMgpzNYYOe84zQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "zyxULthU5BUBw4RiTuO4zecYbVBIgoq0CrPfonNgWOd5Cl11xxIESMq+Q2TWTsAFkfsD3A6Kp6UTuhnroV6e0w==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Gj7tzvn7Q5lNaXz88jrohC7if2jqHKQpq8pw/yhgpIO9s/Y/nTMUSoeuxAODSO0UzaBh6M3c/F1y1olrpY1lng==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fedfvuTOQtxjxBP0VIw4idWi0rOyhr5vr5VHk3Ja2fplPGZy1SlEawNyTFqwwHoTmt/a0TGZzqMsySCZi8Xreg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "PGbJReQ7spxIZuCb8nYjVNnNWWQn5Loey6sC8MvGBnHN9oJAetXW/Va9UvDmlB4+nZhY3uW2nbKEOsz6gFf88A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kCgI/sTE4fxnz1Fs0aScBCC+cYFIIR7I0IG1JPWDPjOSQxYs5Qdzi4Gf3eeAIevdE03n3PeCh2JVCKv0/11yrA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1WaMGI7TLOynUVjVzFmgVvxvho/yl2l7lkTc2EdgA0jtLDX9pHpEZkgG7KaY+9G2WMO1GVmuSEBzucbgmsFW2w==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "lvA/29NjaGEYADSOy+fJp6dtZ9NMSMX1cbePx9FHX5w66EwnceLVtggzWv1StQPAULtUrbjicjA7I2eAtvNgOQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Extensions": "4.0.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "Y0igaOCZs653g0Z+zeFiu9vTR/CPhpUmaee+BK4QUixVk2winYIZfGqKGQ9Jn8TBn+CX98adj1Q6OB1/XZXanw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.1",
+        "contentHash": "bDm/zdG5rnRDsobKuKwrvL4HccBdC0uvT12be6fG12P3d1U7u9Wkvfoq/PM2GeyIeb0Dtcmm/7k2oaawiqQ2Dg==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "0.7.0",
+        "contentHash": "pEjPJ/pd+r9blGBJ9bXg961phkAiCl4k2DwxwWGEZyYC/7Tb1xJ1az0H18uGANX7zFIkvE5ZO1eZZ4vU7gny7w=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.3.1",
+        "contentHash": "+mUMp3aJOS0ag3qJ2tUhVa930KhwjyypxXT4Ab8lQozEQN8/xgkblQnYs0woIWpr2NbzEOxsZojytl9NBVRKxg==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1"
+        }
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.3.1",
+        "contentHash": "LOG4qOFuVQcjYcIuZbKeo03Uvng3lSb2gZJU9ANljwCf+PTd//iAMZS5qcJQZrjhndc4aOUlJGQy5wa0+/iZ6w==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.3.1]",
+          "xunit.extensibility.execution": "[2.3.1]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.3.1",
+        "contentHash": "1mgYqXeQfU+7zcSRW8/5Uf1jVZ5+5WELmi+BuRTh0xu/x0Q0gK0SuR3FLUF4BSd8sfZzvrRUrhWj3ltpyFxhrg==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "xunit.abstractions": "2.0.1"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.3.1",
+        "contentHash": "i8xrHfKC5dyBWQ7I15FePzm0m8KNToBsTleCCQbOQuXRPZIvupd4nnfaCPeJuKHHe7yJ8JGtWxjIgw0ow/cMhg==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "xunit.extensibility.core": "[2.3.1]"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3",
+          "System.Diagnostics.Process": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "System.Security.Cryptography.ProtectedData": "4.3.0"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3",
+          "System.Runtime.Serialization.Formatters": "4.3.0"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0",
+          "System.Threading.Thread": "4.3.0"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3",
+          "System.Dynamic.Runtime": "4.3.0"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    },
+    ".NETFramework,Version=v4.7.2": {
+      "Microsoft.VisualStudio.ProjectSystem.Interop": {
+        "type": "Direct",
+        "requested": "[1.0.0, )",
+        "resolved": "1.0.0",
+        "contentHash": "43Cogz7ZlcI4cUtDklcZUdCtNTWXejrcb1bZqqqJ8Y9XOSB5A9wC8F3ydubz/yVbGyPYqvnu3qgTawNBq06dQg=="
+      },
+      "Microsoft.VisualStudio.Shell.15.0": {
+        "type": "Direct",
+        "requested": "[15.0.26201, )",
+        "resolved": "15.0.26201",
+        "contentHash": "2lKlpJFXy3VXVM6vCDV+abH/BhC/aAD60fJGf8WYm3Cak98GiV3euW+vDRdH+Txj6BElDr2lMNubGdFoG0RxNQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Imaging": "15.0.26201",
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.Shell.Framework": "15.0.26201",
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50727",
+          "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30729",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.Threading": "15.0.240",
+          "Microsoft.VisualStudio.Utilities": "15.0.26201"
+        }
+      },
+      "PdbGit": {
+        "type": "Direct",
+        "requested": "[3.0.41, )",
+        "resolved": "3.0.41",
+        "contentHash": "LBeCjKYbWdrZHSNVOp/5VusxjmJg4xkU8Pnz9DgSHGXApPYW3RnsOTvfpDErtnACpRaB4W16lHN91id20D4i8w=="
+      },
+      "Portable.BouncyCastle": {
+        "type": "Direct",
+        "requested": "[1.8.1.3, )",
+        "resolved": "1.8.1.3",
+        "contentHash": "1jUpszv0ETm+hl78HKnYgY3wPzt6qRtjxaPENNrGCuB8nondbR/j75WAKdd6sxXzOzBcX07WMZhZEYc4s5jVWg=="
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.3.1, )",
+        "resolved": "2.3.1",
+        "contentHash": "IWux0xXfZ/bC7SgooK5rmW5KwCwFg9GFslmPxA7+pJsT+2SRyhOfOgNUXDd7B09UN4f6kogRT2TqNi6gbWEspA==",
+        "dependencies": {
+          "xunit.analyzers": "0.7.0",
+          "xunit.assert": "[2.3.1]",
+          "xunit.core": "[2.3.1]"
+        }
+      },
+      "Microsoft.VisualStudio.CoreUtility": {
+        "type": "Transitive",
+        "resolved": "15.0.26201",
+        "contentHash": "Fqo/QUJZC86gzYevfo+D1UPeoB77SCsK/8fDM4RLWq5M3CYveq0xwMZKvEEbbRq+e1fKlh0faA7yFitmp8RMdA=="
+      },
+      "Microsoft.VisualStudio.Imaging": {
+        "type": "Transitive",
+        "resolved": "15.0.26201",
+        "contentHash": "+zfcm4ytyHza2hbbZ7ew3/lLSd3rBGykK7VqOFy0C7yPf17IJ2bUVG5BXhB/3pwTsFVrXXU00w4G1arBQ+oLoA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Utilities": "15.0.26201"
+        }
+      },
+      "Microsoft.VisualStudio.OLE.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6070",
+        "contentHash": "p7xNzxIoZWDqSGlCi84u1CsNSL9YL7HWBdurfBUW8TZOsfW/0DS8/2MQcicQZav2Csq1f7Pep+VRdZJZkmQKJA=="
+      },
+      "Microsoft.VisualStudio.Shell.Framework": {
+        "type": "Transitive",
+        "resolved": "15.0.26201",
+        "contentHash": "g9yJ+5m0oasafO/VhRFF860lO51qjQp/E5R+oZC747eGhRTzB2iGtdhb521U99KYPB4C3UF/WpnatwGRHnfmzg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.CoreUtility": "15.0.26201",
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.Utilities": "15.0.26201"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6071",
+        "contentHash": "4mE6I0FhI9I12Ezs04D9W/o9tTSFY3Q/bhvfXrUR4cf5OV8CEKfmZokH6UydOaOnqDjr+pOa3j+v+Rudm24osg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50727",
+        "contentHash": "8OzpFWEdSGrtx4GLBxJtiyqOBG8wQxh3lI6wN5AgFH6TtT7pND7EILjrbOgNfMsVbk3qI8DX4uvoHPdcg+cdMg==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50727"
+        }
+      },
+      "Microsoft.VisualStudio.Shell.Interop.9.0": {
+        "type": "Transitive",
+        "resolved": "9.0.30729",
+        "contentHash": "Qolo2V47CYOwS44mlfCpC7ie+juK44MLBNtBxDSeImolTjvLdY8INv8PtQM1WX51XRcgQBV+g3QiSdScJTtOSQ==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50727",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop": {
+        "type": "Transitive",
+        "resolved": "7.10.6070",
+        "contentHash": "T2i4GSGg5F+yb5oFShihsCHx7X19PHmHSrdGdfxtKlIYZCzlQIxr0Z9gwbOeL8TdyMSLaaG/LV1A1BUun5L7EA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6070"
+        }
+      },
+      "Microsoft.VisualStudio.TextManager.Interop.8.0": {
+        "type": "Transitive",
+        "resolved": "8.0.50727",
+        "contentHash": "SEuUVH8jYiZjeXnCQEkJWDdxSitTChjnwJGk6BVMKCjdsva+rDflNLf4icrsczbiuWZIgDr7esZ4wf4zWceE+g==",
+        "dependencies": {
+          "Microsoft.VisualStudio.OLE.Interop": "7.10.6070",
+          "Microsoft.VisualStudio.Shell.Interop": "7.10.6071",
+          "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070"
+        }
+      },
+      "Microsoft.VisualStudio.Threading": {
+        "type": "Transitive",
+        "resolved": "15.0.240",
+        "contentHash": "s73wFNWfQKAYZr6IhR7VIPDAHWuAGIpUeFTfSyDxtUIH7FOgGRvJZTe8hHQDvIT3OYYu50mKGUATdAuCKirr2Q==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Validation": "15.0.82"
+        }
+      },
+      "Microsoft.VisualStudio.Utilities": {
+        "type": "Transitive",
+        "resolved": "15.0.26201",
+        "contentHash": "Df6Pbn1wIXnZXF9cCzeLt8gbLURR8OTWnrIJ+hV+b3Gyi8ztaXdVun+Pdoqt84Ynjanntps5jj9lvgSFjozk0g=="
+      },
+      "Microsoft.VisualStudio.Validation": {
+        "type": "Transitive",
+        "resolved": "15.0.82",
+        "contentHash": "XwZyVCsHuEtnd6nYScJnA8XkXPzy4Ok0DV5/hqqAe5ccgOhJ6yap7Qh/sU/i6QxEzuYyECPYDQ7IOyEQ3yRQgQ=="
+      },
+      "Microsoft.Web.Xdt": {
+        "type": "Transitive",
+        "resolved": "2.1.2",
+        "contentHash": "YIaNTOOtGzjF8CkQBOx3aUBWi0dD+g/nOjbpsVslx9G0/uldtpmoKLmyldmKdMv/gHs3qg40rBT3+wvEWoY5gg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.1",
+        "contentHash": "bDm/zdG5rnRDsobKuKwrvL4HccBdC0uvT12be6fG12P3d1U7u9Wkvfoq/PM2GeyIeb0Dtcmm/7k2oaawiqQ2Dg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "0.7.0",
+        "contentHash": "pEjPJ/pd+r9blGBJ9bXg961phkAiCl4k2DwxwWGEZyYC/7Tb1xJ1az0H18uGANX7zFIkvE5ZO1eZZ4vU7gny7w=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.3.1",
+        "contentHash": "+mUMp3aJOS0ag3qJ2tUhVa930KhwjyypxXT4Ab8lQozEQN8/xgkblQnYs0woIWpr2NbzEOxsZojytl9NBVRKxg=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.3.1",
+        "contentHash": "LOG4qOFuVQcjYcIuZbKeo03Uvng3lSb2gZJU9ANljwCf+PTd//iAMZS5qcJQZrjhndc4aOUlJGQy5wa0+/iZ6w==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.3.1]",
+          "xunit.extensibility.execution": "[2.3.1]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.3.1",
+        "contentHash": "1mgYqXeQfU+7zcSRW8/5Uf1jVZ5+5WELmi+BuRTh0xu/x0Q0gK0SuR3FLUF4BSd8sfZzvrRUrhWj3ltpyFxhrg==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.1"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.3.1",
+        "contentHash": "i8xrHfKC5dyBWQ7I15FePzm0m8KNToBsTleCCQbOQuXRPZIvupd4nnfaCPeJuKHHe7yJ8JGtWxjIgw0ow/cMhg==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.3.1]"
+        }
+      },
+      "NuGet.Build.Tasks": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Commands": "5.0.0-preview3"
+        }
+      },
+      "NuGet.CommandLine": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Build.Tasks": "5.0.0-preview3",
+          "NuGet.PackageManagement": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Commands": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Credentials": "5.0.0-preview3",
+          "NuGet.ProjectModel": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Frameworks": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Credentials": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.DependencyResolver.Core": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.LibraryModel": "5.0.0-preview3",
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Project"
+      },
+      "NuGet.LibraryModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Common": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.PackageManagement": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.2",
+          "NuGet.Commands": "5.0.0-preview3",
+          "NuGet.Resolver": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Packaging": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "NuGet.Configuration": "5.0.0-preview3",
+          "NuGet.Versioning": "5.0.0-preview3"
+        }
+      },
+      "NuGet.ProjectModel": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.DependencyResolver.Core": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Packaging": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Resolver": {
+        "type": "Project",
+        "dependencies": {
+          "NuGet.Protocol": "5.0.0-preview3"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Project"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Enabled `packages.lock.json` file for NuGet solution.

Note: It will still not run in `locked` mode in CI. Once CI machines are upgraded to VS2019 preview3 then locked mode should be enabled there. Tracking issue# https://github.com/NuGet/Home/issues/7749