### PR TITLE
Add interactivity switch for the remove package reference command

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -34,13 +34,21 @@ namespace NuGet.CommandLine.XPlat
                     Strings.RemovePkg_ProjectPathDescription,
                     CommandOptionType.SingleValue);
 
+                var interactive = removePkg.Option(
+                    "--interactive",
+                    Strings.AddPkg_InteractiveDescription,
+                    CommandOptionType.NoValue);
+
                 removePkg.OnExecute(() =>
                 {
                     ValidateArgument(id, removePkg.Name);
                     ValidateArgument(projectPath, removePkg.Name);
                     ValidateProjectPath(projectPath, removePkg.Name);
                     var logger = getLogger();
-                    var packageRefArgs = new PackageReferenceArgs(projectPath.Value(), id.Value(), logger);
+                    var packageRefArgs = new PackageReferenceArgs(projectPath.Value(), id.Value(), logger)
+                    {
+                        Interactive = interactive.HasValue()
+                    };
                     var msBuild = new MSBuildAPIUtility(logger);
                     var removePackageRefCommandRunner = getCommandRunner();
                     return removePackageRefCommandRunner.ExecuteCommand(packageRefArgs, msBuild);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.Threading.Tasks;
+using NuGet.Credentials;
 using NuGet.LibraryModel;
 
 namespace NuGet.CommandLine.XPlat
@@ -16,6 +17,9 @@ namespace NuGet.CommandLine.XPlat
                 Strings.Info_RemovePkgRemovingReference,
                 packageReferenceArgs.PackageDependency.Id,
                 packageReferenceArgs.ProjectPath));
+
+            //Setup the Credential Service - This allows the msbuild sdk resolver to auth if needed.
+            DefaultCredentialServiceUtility.SetupDefaultCredentialService(packageReferenceArgs.Logger, packageReferenceArgs.Interactive);
 
             var libraryDependency = new LibraryDependency
             {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
@@ -19,7 +19,7 @@ namespace NuGet.CommandLine.XPlat
                 packageReferenceArgs.ProjectPath));
 
             //Setup the Credential Service - This allows the msbuild sdk resolver to auth if needed.
-            DefaultCredentialServiceUtility.SetupDefaultCredentialService(packageReferenceArgs.Logger, packageReferenceArgs.Interactive);
+            DefaultCredentialServiceUtility.SetupDefaultCredentialService(packageReferenceArgs.Logger, !packageReferenceArgs.Interactive);
 
             var libraryDependency = new LibraryDependency
             {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7727
Regression: Yes/No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

The details are illustrated in the issue. 

Basically if the evaluation of the project needs to download the sdk, the resolver will never auth because when the credential service is setup, the interactivity context is false (unless you set MSBuildInteractive in the csproj). 

I am not super confident this is the right approach, so I'd like us to discuss before doing this. 

//cc @anangaur @rrelyea @kathleendollard

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
