### PR TITLE
Add new VS nomination APIs that contain changes for PackageDownload

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectRestoreInfo2.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectRestoreInfo2.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace NuGet.SolutionRestoreManager
+{
+    /// <summary>
+    /// Contains project metadata needed for project restore operation.
+    /// </summary>
+    [ComImport]
+    [Guid("0D500311-7E7C-49C0-95DA-7A33FFCEE4D6")]
+    public interface IVsProjectRestoreInfo2
+    {
+        /// <summary>
+        /// The MSBuildProjectExtensionsPath of the project (originally BaseIntermediateOutputPath was used,
+        /// but rather than create a new interface, we changed the meaning of this property).
+        /// </summary>
+        string BaseIntermediatePath { get; }
+
+        /// <summary>
+        /// Target frameworks metadata.
+        /// </summary>
+        IVsTargetFrameworks2 TargetFrameworks { get; }
+
+        /// <summary>
+        /// Collection of tool references.
+        /// </summary>
+        IVsReferenceItems ToolReferences { get; }
+
+        /// <summary>
+        /// Original raw value of TargetFrameworks property as set in a project file.
+        /// </summary>
+        string OriginalTargetFrameworks { get; }
+    }
+}

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsSolutionRestoreService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -17,6 +17,7 @@ namespace NuGet.SolutionRestoreManager
     {
         /// <summary>
         /// A task providing last/current restore operation status.
+        /// Could be null if restore has not started yet.
         /// </summary>
         /// <remarks>
         /// This task is a reflection of the current state of the current-restore-operation or
@@ -31,7 +32,7 @@ namespace NuGet.SolutionRestoreManager
         /// An entry point used by CPS to indicate given project needs to be restored.
         /// </summary>
         /// <param name="projectUniqueName">
-        /// Unique identificator of the project. Should be a full path to project file.
+        /// Unique identifier of the project. Should be a full path to project file.
         /// </param>
         /// <param name="projectRestoreInfo">Metadata <see cref="IVsProjectRestoreInfo"/> needed for restoring the project.</param>
         /// <param name="token">Cancellation token.</param>
@@ -40,6 +41,9 @@ namespace NuGet.SolutionRestoreManager
         /// NuGet will batch restore requests so it's possible the same restore task will be returned for multiple projects.
         /// When the requested restore operation for the given project completes the task will indicate operation success or failure.
         /// </returns>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="projectUniqueName" /> is not the path of a project file.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="projectRestoreInfo" /> is <c>null</c>.</exception>
+        /// <exception cref="OperationCanceledException">Thrown if <paramref name="token" /> is cancelled.</exception>
         Task<bool> NominateProjectAsync(string projectUniqueName, IVsProjectRestoreInfo projectRestoreInfo, CancellationToken token);
     }
 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsSolutionRestoreService3.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsSolutionRestoreService3.cs
@@ -17,6 +17,7 @@ namespace NuGet.SolutionRestoreManager
     {
         /// <summary>
         /// A task providing last/current restore operation status.
+        /// Could be null if restore has not started yet.
         /// </summary>
         /// <remarks>
         /// This task is a reflection of the current state of the current-restore-operation or
@@ -32,7 +33,7 @@ namespace NuGet.SolutionRestoreManager
         /// This entry point also handles PackageDownload items
         /// </summary>
         /// <param name="projectUniqueName">
-        /// Unique identificator of the project. Should be a full path to project file.
+        /// Unique identifier of the project. Should be a full path to project file.
         /// </param>
         /// <param name="projectRestoreInfo">Metadata <see cref="IVsProjectRestoreInfo2"/> needed for restoring the project.</param>
         /// <param name="token">Cancellation token.</param>
@@ -41,6 +42,9 @@ namespace NuGet.SolutionRestoreManager
         /// NuGet will batch restore requests so it's possible the same restore task will be returned for multiple projects.
         /// When the requested restore operation for the given project completes the task will indicate operation success or failure.
         /// </returns>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="projectUniqueName" /> is not the path of a project file.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="projectRestoreInfo" /> is <c>null</c>.</exception>
+        /// <exception cref="OperationCanceledException">Thrown if <paramref name="token" /> is cancelled.</exception>
         Task<bool> NominateProjectAsync(string projectUniqueName, IVsProjectRestoreInfo2 projectRestoreInfo, CancellationToken token);
     }
 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsSolutionRestoreService3.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsSolutionRestoreService3.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.SolutionRestoreManager
+{
+    /// <summary>
+    /// Represents a package restore service API for integration with a project system.
+    /// </summary>
+    [ComImport]
+    [Guid("3C2A20BC-6305-4E76-A83E-B59C95F01661")]
+    public interface IVsSolutionRestoreService3
+    {
+        /// <summary>
+        /// A task providing last/current restore operation status.
+        /// </summary>
+        /// <remarks>
+        /// This task is a reflection of the current state of the current-restore-operation or
+        /// recently-completed-restore. The usage of this property will be to continue,
+        /// e.g. to build solution or something) on completion of this task.
+        /// Also, on completion, if the task returns false then it means the restore failed and
+        /// the build task will be terminated.
+        /// </remarks>
+        Task<bool> CurrentRestoreOperation { get; }
+
+        /// <summary>
+        /// An entry point used by CPS to indicate given project needs to be restored.
+        /// This entry point also handles PackageDownload items
+        /// </summary>
+        /// <param name="projectUniqueName">
+        /// Unique identificator of the project. Should be a full path to project file.
+        /// </param>
+        /// <param name="projectRestoreInfo">Metadata <see cref="IVsProjectRestoreInfo2"/> needed for restoring the project.</param>
+        /// <param name="token">Cancellation token.</param>
+        /// <returns>
+        /// Returns a restore task corresponding to the nominated project request.
+        /// NuGet will batch restore requests so it's possible the same restore task will be returned for multiple projects.
+        /// When the requested restore operation for the given project completes the task will indicate operation success or failure.
+        /// </returns>
+        Task<bool> NominateProjectAsync(string projectUniqueName, IVsProjectRestoreInfo2 projectRestoreInfo, CancellationToken token);
+    }
+}

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsTargetFrameworkInfo2.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsTargetFrameworkInfo2.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace NuGet.SolutionRestoreManager
+{
+    /// <summary>
+    /// Contains target framework metadata needed for restore operation. Compared to IVsTargetFrameworkInfo, this adds support for PackageDownload
+    /// </summary>
+    [ComImport]
+    [Guid("451ACBA6-FE6A-4412-99D2-3882790BF338")]
+    public interface IVsTargetFrameworkInfo2 : IVsTargetFrameworkInfo
+    {
+        /// <summary>
+        /// Collection of package downloads.
+        /// </summary>
+        IVsReferenceItems PackageDownloads { get; }
+    }
+}

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsTargetFrameworks2.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsTargetFrameworks2.cs
@@ -24,6 +24,7 @@ namespace NuGet.SolutionRestoreManager
         /// </summary>
         /// <param name="index">Reference name or index.</param>
         /// <returns>Reference item matching index.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="index" /> is <c>null</c>.</exception>
         IVsTargetFrameworkInfo2 Item(object index);
     }
 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsTargetFrameworks2.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsTargetFrameworks2.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Runtime.InteropServices;
+
+namespace NuGet.SolutionRestoreManager
+{
+    /// <summary>
+    /// Represents a collection of target framework metadata items
+    /// </summary>
+    [ComImport]
+    [Guid("0C9117CB-828D-4E16-B73F-FEEA9BD6A027")]
+    public interface IVsTargetFrameworks2 : IEnumerable
+    {
+        /// <summary>
+        /// Total count of references in container.
+        /// </summary>
+        int Count { get; }
+
+        /// <summary>
+        /// Retrieves a reference by name or index.
+        /// </summary>
+        /// <param name="index">Reference name or index.</param>
+        /// <returns>Reference item matching index.</returns>
+        IVsTargetFrameworkInfo2 Item(object index);
+    }
+}

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.SolutionRestoreManager {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -75,6 +75,15 @@ namespace NuGet.SolutionRestoreManager {
         internal static string DialogTitle {
             get {
                 return ResourceManager.GetString("DialogTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is not an exact version like &apos;[1.0.0]&apos;. Only exact versions are allowed with PackageDownload..
+        /// </summary>
+        internal static string Error_PackageDownload_OnlyExactVersionsAreAllowed {
+            get {
+                return ResourceManager.GetString("Error_PackageDownload_OnlyExactVersionsAreAllowed", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
@@ -126,6 +126,10 @@
   <data name="ErrorOccurredRestoringPackages" xml:space="preserve">
     <value>Error occurred while restoring NuGet packages: {0}</value>
   </data>
+  <data name="Error_PackageDownload_OnlyExactVersionsAreAllowed" xml:space="preserve">
+    <value>'{0}' is not an exact version like '[1.0.0]'. Only exact versions are allowed with PackageDownload.</value>
+    <comment>0 - the version string that's not exact</comment>
+  </data>
   <data name="NothingToRestore" xml:space="preserve">
     <value>All packages are already installed and there is nothing to restore.</value>
   </data>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -31,17 +31,17 @@ namespace NuGet.SolutionRestoreManager
         * ToolReferences *
         ******************/
 
-        internal static void ProcessToolReferences(ProjectNames projectNames, IEnumerable TargetFrameworks, IVsReferenceItems ToolReferences, DependencyGraphSpec dgSpec)
+        internal static void ProcessToolReferences(ProjectNames projectNames, IEnumerable targetFrameworks, IVsReferenceItems toolReferences, DependencyGraphSpec dgSpec)
         {
-            var toolFramework = GetToolFramework(TargetFrameworks);
-            var packagesPath = GetRestoreProjectPath(TargetFrameworks);
-            var fallbackFolders = GetRestoreFallbackFolders(TargetFrameworks).AsList();
-            var sources = GetRestoreSources(TargetFrameworks)
+            var toolFramework = GetToolFramework(targetFrameworks);
+            var packagesPath = GetRestoreProjectPath(targetFrameworks);
+            var fallbackFolders = GetRestoreFallbackFolders(targetFrameworks).AsList();
+            var sources = GetRestoreSources(targetFrameworks)
                 .Select(e => new PackageSource(e))
                 .ToList();
 
             
-            ToolReferences
+            toolReferences
                 .Cast<IVsReferenceItem>()
                 .Select(r => ToolRestoreUtility.GetSpec(
                     projectNames.FullName,
@@ -345,7 +345,7 @@ namespace NuGet.SolutionRestoreManager
             var versionRange = GetVersionRange(item);
             if (!(versionRange.HasLowerAndUpperBounds && versionRange.MinVersion.Equals(versionRange.MaxVersion)))
             {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "Strings.Error_PackageDownload_OnlyExactVersionsAreAllowed TODO NK", versionRange.OriginalString));
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Error_PackageDownload_OnlyExactVersionsAreAllowed, versionRange.OriginalString));
             }
 
             var downloadDependency = new DownloadDependency(id, versionRange);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -62,7 +62,7 @@ namespace NuGet.SolutionRestoreManager
 
         #region IVSTargetFrameworksAPIs
         /**********************************************************************
-         * IVSTargetFrameworks based APIs (1st iteration of the nominate API.) * 
+         * IVSTargetFrameworks based APIs                                     * 
          **********************************************************************/
 
         internal static RuntimeGraph GetRuntimeGraph(IEnumerable targetFrameworks)

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using NuGet.Commands;
@@ -24,19 +26,22 @@ namespace NuGet.SolutionRestoreManager
 {
     internal class VSNominationUtilities
     {
-        #region IVsProjectRestoreInfoAPIs
+        #region ToolReferenceAPIs
+        /******************
+        * ToolReferences *
+        ******************/
 
-        internal static void ProcessToolReferences(ProjectNames projectNames, IVsProjectRestoreInfo projectRestoreInfo, DependencyGraphSpec dgSpec)
+        internal static void ProcessToolReferences(ProjectNames projectNames, IEnumerable TargetFrameworks, IVsReferenceItems ToolReferences, DependencyGraphSpec dgSpec)
         {
-            var toolFramework = GetToolFramework(projectRestoreInfo.TargetFrameworks);
-            var packagesPath = GetRestoreProjectPath(projectRestoreInfo.TargetFrameworks);
-            var fallbackFolders = GetRestoreFallbackFolders(projectRestoreInfo.TargetFrameworks).AsList();
-            var sources = GetRestoreSources(projectRestoreInfo.TargetFrameworks)
+            var toolFramework = GetToolFramework(TargetFrameworks);
+            var packagesPath = GetRestoreProjectPath(TargetFrameworks);
+            var fallbackFolders = GetRestoreFallbackFolders(TargetFrameworks).AsList();
+            var sources = GetRestoreSources(TargetFrameworks)
                 .Select(e => new PackageSource(e))
                 .ToList();
 
-            projectRestoreInfo
-                .ToolReferences
+            
+            ToolReferences
                 .Cast<IVsReferenceItem>()
                 .Select(r => ToolRestoreUtility.GetSpec(
                     projectNames.FullName,
@@ -53,11 +58,16 @@ namespace NuGet.SolutionRestoreManager
                     dgSpec.AddProject(ts);
                 });
         }
+        #endregion ToolReferenceAPIs
 
-        internal static RuntimeGraph GetRuntimeGraph(IVsProjectRestoreInfo projectRestoreInfo)
+        #region IVSTargetFrameworksAPIs
+        /**********************************************************************
+         * IVSTargetFrameworks based APIs (1st iteration of the nominate API.) * 
+         **********************************************************************/
+
+        internal static RuntimeGraph GetRuntimeGraph(IEnumerable targetFrameworks)
         {
-            var runtimes = projectRestoreInfo
-                .TargetFrameworks
+            var runtimes = targetFrameworks
                 .Cast<IVsTargetFrameworkInfo>()
                 .SelectMany(tfi => new[]
                 {
@@ -69,8 +79,7 @@ namespace NuGet.SolutionRestoreManager
                 .Select(rid => new RuntimeDescription(rid))
                 .ToList();
 
-            var supports = projectRestoreInfo
-                .TargetFrameworks
+            var supports = targetFrameworks
                 .Cast<IVsTargetFrameworkInfo>()
                 .Select(tfi => GetPropertyValueOrNull(tfi.Properties, ProjectBuildProperties.RuntimeSupports))
                 .SelectMany(MSBuildStringUtility.Split)
@@ -80,9 +89,6 @@ namespace NuGet.SolutionRestoreManager
 
             return new RuntimeGraph(runtimes, supports);
         }
-        #endregion IVsProjectRestoreInfoAPIs
-
-        #region IVSTargetFrameworkInfoAPIs
 
         internal static TargetFrameworkInformation ToTargetFrameworkInformation(
             IVsTargetFrameworkInfo targetFrameworkInfo)
@@ -110,6 +116,17 @@ namespace NuGet.SolutionRestoreManager
                         .Cast<IVsReferenceItem>()
                         .Select(ToPackageLibraryDependency));
             }
+            
+            if(targetFrameworkInfo is IVsTargetFrameworkInfo2 targetFrameworkInfo2)
+            {
+                if (targetFrameworkInfo2.PackageDownloads != null)
+                {
+                    tfi.DownloadDependencies.AddRange(
+                       targetFrameworkInfo2.PackageDownloads
+                           .Cast<IVsReferenceItem>()
+                           .Select(ToPackageDownloadDependency));
+                }
+            }
 
             return tfi;
         }
@@ -135,17 +152,13 @@ namespace NuGet.SolutionRestoreManager
             return tfi;
         }
 
-        #endregion IVSTargetFrameworkInfoAPIs
-
-        #region IVSTargetFrameworksAPIs
-
-        internal static string GetPackageId(ProjectNames projectNames, IVsTargetFrameworks tfms)
+        internal static string GetPackageId(ProjectNames projectNames, IEnumerable tfms)
         {
             var packageId = GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.PackageId, v => v);
             return packageId ?? projectNames.ShortName;
         }
 
-        internal static NuGetVersion GetPackageVersion(IVsTargetFrameworks tfms)
+        internal static NuGetVersion GetPackageVersion(IEnumerable tfms)
         {
             // $(PackageVersion) property if set overrides the $(Version)
             var versionPropertyValue =
@@ -155,20 +168,20 @@ namespace NuGet.SolutionRestoreManager
             return versionPropertyValue ?? PackageSpec.DefaultVersion;
         }
 
-        internal static string GetRestoreProjectPath(IVsTargetFrameworks tfms)
+        internal static string GetRestoreProjectPath(IEnumerable values)
         {
-            return GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.RestorePackagesPath, e => e);
+            return GetSingleNonEvaluatedPropertyOrNull(values, ProjectBuildProperties.RestorePackagesPath, e => e);
         }
 
-        internal static RestoreLockProperties GetRestoreLockProperties(IVsTargetFrameworks tfms)
+        internal static RestoreLockProperties GetRestoreLockProperties(IEnumerable values)
         {
             return new RestoreLockProperties(
-                        GetRestorePackagesWithLockFile(tfms),
-                        GetNuGetLockFilePath(tfms),
-                        IsLockFileFreezeOnRestore(tfms));
+                        GetRestorePackagesWithLockFile(values),
+                        GetNuGetLockFilePath(values),
+                        IsLockFileFreezeOnRestore(values));
         }
 
-        internal static WarningProperties GetProjectWideWarningProperties(IVsTargetFrameworks targetFrameworks)
+        internal static WarningProperties GetProjectWideWarningProperties(IEnumerable targetFrameworks)
         {
             return WarningProperties.GetWarningProperties(
                         treatWarningsAsErrors: GetSingleOrDefaultPropertyValue(targetFrameworks, ProjectBuildProperties.TreatWarningsAsErrors, e => e),
@@ -180,14 +193,14 @@ namespace NuGet.SolutionRestoreManager
         /// The result will contain CLEAR and no sources specified in RestoreSources if the clear keyword is in it.
         /// If there are additional sources specified, the value AdditionalValue will be set in the result and then all the additional sources will follow
         /// </summary>
-        internal static IEnumerable<string> GetRestoreSources(IVsTargetFrameworks tfms)
+        internal static IEnumerable<string> GetRestoreSources(IEnumerable values)
         {
-            var sources = HandleClear(MSBuildStringUtility.Split(GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.RestoreSources, e => e)));
+            var sources = HandleClear(MSBuildStringUtility.Split(GetSingleNonEvaluatedPropertyOrNull(values, ProjectBuildProperties.RestoreSources, e => e)));
 
             // Read RestoreAdditionalProjectSources from the inner build, these may be different between frameworks.
             // Exclude is not allowed for sources
             var additional = MSBuildRestoreUtility.AggregateSources(
-                values: GetAggregatePropertyValues(tfms, ProjectBuildProperties.RestoreAdditionalProjectSources),
+                values: GetAggregatePropertyValues(values, ProjectBuildProperties.RestoreAdditionalProjectSources),
                 excludeValues: Enumerable.Empty<string>());
 
             return VSRestoreSettingsUtilities.GetEntriesWithAdditional(sources, additional.ToArray());
@@ -197,7 +210,7 @@ namespace NuGet.SolutionRestoreManager
         /// The result will contain CLEAR and no sources specified in RestoreFallbackFolders if the clear keyword is in it.
         /// If there are additional fallback folders specified, the value AdditionalValue will be set in the result and then all the additional fallback folders will follow
         /// </summary>
-        internal static IEnumerable<string> GetRestoreFallbackFolders(IVsTargetFrameworks tfms)
+        internal static IEnumerable<string> GetRestoreFallbackFolders(IEnumerable tfms)
         {
             var folders = HandleClear(MSBuildStringUtility.Split(GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.RestoreFallbackFolders, e => e)));
 
@@ -210,22 +223,22 @@ namespace NuGet.SolutionRestoreManager
             return VSRestoreSettingsUtilities.GetEntriesWithAdditional(folders, additional.ToArray());
         }
 
-        private static string GetRestorePackagesWithLockFile(IVsTargetFrameworks tfms)
+        private static string GetRestorePackagesWithLockFile(IEnumerable tfms)
         {
             return GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.RestorePackagesWithLockFile, v => v);
         }
 
-        private static string GetNuGetLockFilePath(IVsTargetFrameworks tfms)
+        private static string GetNuGetLockFilePath(IEnumerable tfms)
         {
             return GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.NuGetLockFilePath, v => v);
         }
 
-        private static bool IsLockFileFreezeOnRestore(IVsTargetFrameworks tfms)
+        private static bool IsLockFileFreezeOnRestore(IEnumerable tfms)
         {
             return GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.RestoreLockedMode, MSBuildStringUtility.IsTrue);
         }
 
-        private static NuGetFramework GetToolFramework(IVsTargetFrameworks targetFrameworks)
+        private static NuGetFramework GetToolFramework(IEnumerable targetFrameworks)
         {
             return GetSingleNonEvaluatedPropertyOrNull(
                     targetFrameworks,
@@ -234,34 +247,32 @@ namespace NuGet.SolutionRestoreManager
         }
 
         private static TValue GetSingleOrDefaultPropertyValue<TValue>(
-            IVsTargetFrameworks tfms,
+            IEnumerable values,
             string propertyName,
             Func<string, TValue> valueFactory)
         {
-            var properties = GetNonEvaluatedPropertyOrNull(tfms, propertyName, valueFactory);
+            var properties = GetNonEvaluatedPropertyOrNull(values, propertyName, valueFactory);
 
             return properties.Count() > 1 ? default(TValue) : properties.SingleOrDefault();
         }
 
         private static IEnumerable<NuGetLogCode> GetSingleOrDefaultNuGetLogCodes(
-            IVsTargetFrameworks tfms,
+            IEnumerable values,
             string propertyName,
             Func<string, IEnumerable<NuGetLogCode>> valueFactory)
         {
-            var logCodeProperties = GetNonEvaluatedPropertyOrNull(tfms, propertyName, valueFactory);
+            var logCodeProperties = GetNonEvaluatedPropertyOrNull(values, propertyName, valueFactory);
 
             return MSBuildStringUtility.GetDistinctNuGetLogCodesOrDefault(logCodeProperties);
         }
 
-        /// <summary>
-        /// Trying to fetch a list of property value from all tfm property bags.
-        /// </summary>
+        // Trying to fetch a list of property value from all tfm property bags.
         private static IEnumerable<TValue> GetNonEvaluatedPropertyOrNull<TValue>(
-            IVsTargetFrameworks tfms,
+            IEnumerable values,
             string propertyName,
             Func<string, TValue> valueFactory)
         {
-            return tfms
+            return values
                 .Cast<IVsTargetFrameworkInfo>()
                 .Select(tfm =>
                 {
@@ -271,30 +282,29 @@ namespace NuGet.SolutionRestoreManager
                 .Distinct();
         }
 
-        /// <summary>
-        ///Trying to fetch a property value from tfm property bags.
-        /// If defined the property should have identical values in all of the occurances.
-        /// </summary>
+        // Trying to fetch a property value from tfm property bags.
+        // If defined the property should have identical values in all of the occurances.
         private static TValue GetSingleNonEvaluatedPropertyOrNull<TValue>(
-            IVsTargetFrameworks tfms,
+            IEnumerable values,
             string propertyName,
             Func<string, TValue> valueFactory)
         {
-            return GetNonEvaluatedPropertyOrNull(tfms, propertyName, valueFactory).SingleOrDefault();
+            return GetNonEvaluatedPropertyOrNull(values, propertyName, valueFactory).SingleOrDefault();
         }
 
         /// <summary>
         /// Fetch all property values from each target framework and combine them.
         /// </summary>
         private static IEnumerable<string> GetAggregatePropertyValues(
-                IVsTargetFrameworks tfms,
+                IEnumerable values,
                 string propertyName)
         {
             // Only non-null values are added to the list as part of the split.
-            return tfms
+            return values
                 .Cast<IVsTargetFrameworkInfo>()
                 .SelectMany(tfm => MSBuildStringUtility.Split(GetPropertyValueOrNull(tfm.Properties, propertyName)));
         }
+
         #endregion IVSTargetFrameworksAPIs
 
         #region IVSReferenceItemAPIs
@@ -327,6 +337,20 @@ namespace NuGet.SolutionRestoreManager
                 privateAssets: GetPropertyValueOrNull(item, ProjectBuildProperties.PrivateAssets));
 
             return dependency;
+        }
+
+        private static DownloadDependency ToPackageDownloadDependency(IVsReferenceItem item)
+        {
+            var id = item.Name;
+            var versionRange = GetVersionRange(item);
+            if (!(versionRange.HasLowerAndUpperBounds && versionRange.MinVersion.Equals(versionRange.MaxVersion)))
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "Strings.Error_PackageDownload_OnlyExactVersionsAreAllowed TODO NK", versionRange.OriginalString));
+            }
+
+            var downloadDependency = new DownloadDependency(id, versionRange);
+
+            return downloadDependency;
         }
 
         private static ProjectRestoreReference ToProjectRestoreReference(IVsReferenceItem item, string projectDirectory)
@@ -426,7 +450,6 @@ namespace NuGet.SolutionRestoreManager
         }
         #endregion IVSReferenceItemAPIs
 
-        #region Common
         private static string[] HandleClear(string[] input)
         {
             if (input.Any(e => StringComparer.OrdinalIgnoreCase.Equals(ProjectBuildProperties.Clear, e)))
@@ -436,6 +459,5 @@ namespace NuGet.SolutionRestoreManager
 
             return input;
         }
-        #endregion Common
     }
 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -91,6 +91,11 @@ namespace NuGet.SolutionRestoreManager
                 throw new ArgumentNullException(nameof(projectRestoreInfo));
             }
 
+            if (projectRestoreInfo == null && projectRestoreInfo2 == null)
+            {
+                throw new ArgumentException($"Internal error: Both {nameof(projectRestoreInfo)} and {nameof(projectRestoreInfo2)} cannot have values. Please file an issue at NuGet/Home if you see this exception.");
+            }
+
             if (projectRestoreInfo != null)
             {
                 if (projectRestoreInfo.TargetFrameworks == null)

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
@@ -26,7 +27,7 @@ namespace NuGet.SolutionRestoreManager
     [PartCreationPolicy(CreationPolicy.Shared)]
     [Export(typeof(IVsSolutionRestoreService))]
     [Export(typeof(IVsSolutionRestoreService2))]
-    public sealed class VsSolutionRestoreService : IVsSolutionRestoreService, IVsSolutionRestoreService2
+    public sealed class VsSolutionRestoreService : IVsSolutionRestoreService, IVsSolutionRestoreService2, IVsSolutionRestoreService3
     {
         private readonly IProjectSystemCache _projectSystemCache;
         private readonly ISolutionRestoreWorker _restoreWorker;
@@ -60,19 +61,48 @@ namespace NuGet.SolutionRestoreManager
 
         public Task<bool> NominateProjectAsync(string projectUniqueName, IVsProjectRestoreInfo projectRestoreInfo, CancellationToken token)
         {
+            return NominateProjectAsync(projectUniqueName, projectRestoreInfo, null, token);
+        }
+
+        public Task<bool> NominateProjectAsync(string projectUniqueName, IVsProjectRestoreInfo2 projectRestoreInfo, CancellationToken token)
+        {
+            return NominateProjectAsync(projectUniqueName, null, projectRestoreInfo, token);
+        }
+
+        /// <summary>
+        /// This is where the nominate calls for the IVs1 and IVS3 APIs combine. The reason for this method is to avoid duplication and potential issues 
+        /// The issue with this method is that it has some weird custom logging to ensure backward compatibility. It's on the implementer to ensure these calls are correct.
+        /// <param name="projectUniqueName">projectUniqueName</param>
+        /// <param name="projectRestoreInfo">projectRestoreInfo. Can be null</param>
+        /// <param name="projectRestoreInfo2">proectRestoreInfo2. Can be null</param>
+        /// <param name="token"></param>
+        /// <remarks>Only and exactly one of projectRestoreInfos can be null.</remarks>
+        /// <returns>The task that scheduled restore</returns>
+        private Task<bool> NominateProjectAsync(string projectUniqueName, IVsProjectRestoreInfo projectRestoreInfo, IVsProjectRestoreInfo2 projectRestoreInfo2, CancellationToken token)
+        {
             if (string.IsNullOrEmpty(projectUniqueName))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(projectUniqueName));
             }
 
-            if (projectRestoreInfo == null)
+            if (projectRestoreInfo == null && projectRestoreInfo2 == null)
             {
                 throw new ArgumentNullException(nameof(projectRestoreInfo));
             }
 
-            if (projectRestoreInfo.TargetFrameworks == null)
+            if (projectRestoreInfo != null)
             {
-                throw new InvalidOperationException("TargetFrameworks cannot be null.");
+                if (projectRestoreInfo.TargetFrameworks == null)
+                {
+                    throw new InvalidOperationException("TargetFrameworks cannot be null.");
+                }
+            }
+            else
+            {
+                if (projectRestoreInfo2.TargetFrameworks == null)
+                {
+                    throw new InvalidOperationException("TargetFrameworks cannot be null.");
+                }
             }
 
             try
@@ -82,7 +112,8 @@ namespace NuGet.SolutionRestoreManager
 
                 var projectNames = ProjectNames.FromFullProjectPath(projectUniqueName);
 
-                var dgSpec = ToDependencyGraphSpec(projectNames, projectRestoreInfo);
+                var dgSpec = ToDependencyGraphSpec(projectNames, projectRestoreInfo, projectRestoreInfo2);
+
                 _projectSystemCache.AddProjectRestoreInfo(projectNames, dgSpec);
 
                 // returned task completes when scheduled restore operation completes.
@@ -105,26 +136,32 @@ namespace NuGet.SolutionRestoreManager
             }
         }
 
-        private static DependencyGraphSpec ToDependencyGraphSpec(ProjectNames projectNames, IVsProjectRestoreInfo projectRestoreInfo)
+        private static DependencyGraphSpec ToDependencyGraphSpec(ProjectNames projectNames, IVsProjectRestoreInfo projectRestoreInfo, IVsProjectRestoreInfo2 projectRestoreInfo2)
         {
             var dgSpec = new DependencyGraphSpec();
 
-            var packageSpec = ToPackageSpec(projectNames, projectRestoreInfo);
+            var packageSpec = projectRestoreInfo != null ?
+                ToPackageSpec(projectNames, projectRestoreInfo.TargetFrameworks, projectRestoreInfo.OriginalTargetFrameworks, projectRestoreInfo.BaseIntermediatePath) :
+                ToPackageSpec(projectNames, projectRestoreInfo2.TargetFrameworks, projectRestoreInfo2.OriginalTargetFrameworks, projectRestoreInfo2.BaseIntermediatePath);
+
             dgSpec.AddRestore(packageSpec.RestoreMetadata.ProjectUniqueName);
             dgSpec.AddProject(packageSpec);
 
-            if (projectRestoreInfo.ToolReferences != null)
+            if (projectRestoreInfo != null && projectRestoreInfo.ToolReferences != null)
             {
-                VSNominationUtilities.ProcessToolReferences(projectNames, projectRestoreInfo, dgSpec);
+                VSNominationUtilities.ProcessToolReferences(projectNames, projectRestoreInfo.TargetFrameworks, projectRestoreInfo.ToolReferences, dgSpec);
+            }
+            else if (projectRestoreInfo2 != null && projectRestoreInfo2.ToolReferences != null)
+            {
+                VSNominationUtilities.ProcessToolReferences(projectNames, projectRestoreInfo2.TargetFrameworks, projectRestoreInfo2.ToolReferences, dgSpec);
             }
 
             return dgSpec;
         }
 
-        private static PackageSpec ToPackageSpec(ProjectNames projectNames, IVsProjectRestoreInfo projectRestoreInfo)
+        private static PackageSpec ToPackageSpec(ProjectNames projectNames, IEnumerable TargetFrameworks, string OriginalTargetFrameworks, string BaseIntermediatePath)
         {
-            var tfis = projectRestoreInfo
-                .TargetFrameworks
+            var tfis = TargetFrameworks
                 .Cast<IVsTargetFrameworkInfo>()
                 .Select(VSNominationUtilities.ToTargetFrameworkInformation)
                 .ToArray();
@@ -139,10 +176,10 @@ namespace NuGet.SolutionRestoreManager
             var crossTargeting = originalTargetFrameworks.Length > 1;
 
             // if "TargetFrameworks" property presents in the project file prefer the raw value.
-            if (!string.IsNullOrWhiteSpace(projectRestoreInfo.OriginalTargetFrameworks))
+            if (!string.IsNullOrWhiteSpace(OriginalTargetFrameworks))
             {
                 originalTargetFrameworks = MSBuildStringUtility.Split(
-                    projectRestoreInfo.OriginalTargetFrameworks);
+                    OriginalTargetFrameworks);
                 // cross-targeting is always ON even in case of a single tfm in the list.
                 crossTargeting = true;
             }
@@ -150,14 +187,14 @@ namespace NuGet.SolutionRestoreManager
             var outputPath = Path.GetFullPath(
                                 Path.Combine(
                                     projectDirectory,
-                                    projectRestoreInfo.BaseIntermediatePath));
+                                    BaseIntermediatePath));
 
-            var projectName = VSNominationUtilities.GetPackageId(projectNames, projectRestoreInfo.TargetFrameworks);
+            var projectName = VSNominationUtilities.GetPackageId(projectNames, TargetFrameworks);
 
             var packageSpec = new PackageSpec(tfis)
             {
                 Name = projectName,
-                Version = VSNominationUtilities.GetPackageVersion(projectRestoreInfo.TargetFrameworks),
+                Version = VSNominationUtilities.GetPackageVersion(TargetFrameworks),
                 FilePath = projectFullPath,
                 RestoreMetadata = new ProjectRestoreMetadata
                 {
@@ -166,7 +203,7 @@ namespace NuGet.SolutionRestoreManager
                     ProjectPath = projectFullPath,
                     OutputPath = outputPath,
                     ProjectStyle = ProjectStyle.PackageReference,
-                    TargetFrameworks = projectRestoreInfo.TargetFrameworks
+                    TargetFrameworks = TargetFrameworks
                         .Cast<IVsTargetFrameworkInfo>()
                         .Select(item => VSNominationUtilities.ToProjectRestoreMetadataFrameworkInfo(item, projectDirectory))
                         .ToList(),
@@ -175,20 +212,20 @@ namespace NuGet.SolutionRestoreManager
 
                     // Read project properties for settings. ISettings values will be applied later since
                     // this value is put in the nomination cache and ISettings could change.
-                    PackagesPath = VSNominationUtilities.GetRestoreProjectPath(projectRestoreInfo.TargetFrameworks),
-                    FallbackFolders = VSNominationUtilities.GetRestoreFallbackFolders(projectRestoreInfo.TargetFrameworks).AsList(),
-                    Sources = VSNominationUtilities.GetRestoreSources(projectRestoreInfo.TargetFrameworks)
+                    PackagesPath = VSNominationUtilities.GetRestoreProjectPath(TargetFrameworks),
+                    FallbackFolders = VSNominationUtilities.GetRestoreFallbackFolders(TargetFrameworks).AsList(),
+                    Sources = VSNominationUtilities.GetRestoreSources(TargetFrameworks)
                                     .Select(e => new PackageSource(e))
                                     .ToList(),
-                    ProjectWideWarningProperties = VSNominationUtilities.GetProjectWideWarningProperties(projectRestoreInfo.TargetFrameworks),
+                    ProjectWideWarningProperties = VSNominationUtilities.GetProjectWideWarningProperties(TargetFrameworks),
                     CacheFilePath = NoOpRestoreUtilities.GetProjectCacheFilePath(cacheRoot: outputPath, projectPath: projectFullPath),
-                    RestoreLockProperties = VSNominationUtilities.GetRestoreLockProperties(projectRestoreInfo.TargetFrameworks)
+                    RestoreLockProperties = VSNominationUtilities.GetRestoreLockProperties(TargetFrameworks)
                 },
-                RuntimeGraph = VSNominationUtilities.GetRuntimeGraph(projectRestoreInfo),
+                RuntimeGraph = VSNominationUtilities.GetRuntimeGraph(TargetFrameworks),
                 RestoreSettings = new ProjectRestoreSettings() { HideWarningsAndErrors = true }
             };
 
             return packageSpec;
-        }        
+        }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ProjectRestoreInfoBuilder.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ProjectRestoreInfoBuilder.cs
@@ -106,22 +106,22 @@ namespace NuGet.SolutionRestoreManager.Test
         public ProjectRestoreInfoBuilder WithTargetFrameworkInfo(
             IVsTargetFrameworkInfo tfi)
         {
-            if(_projectRestoreInfo.TargetFrameworks is VsTargetFrameworks && tfi is VsTargetFrameworkInfo)
+            if(_projectRestoreInfo.TargetFrameworks is VsTargetFrameworks vsTargetFrameworks && tfi is VsTargetFrameworkInfo)
             {
-                (_projectRestoreInfo.TargetFrameworks as VsTargetFrameworks).Add(tfi);
+                vsTargetFrameworks.Add(tfi);
             }
 
-            if (_projectRestoreInfo2.TargetFrameworks is VsTargetFrameworks2 && tfi is VsTargetFrameworkInfo2)
+            if (_projectRestoreInfo2.TargetFrameworks is VsTargetFrameworks2 vsTargetFrameworks2 && tfi is VsTargetFrameworkInfo2)
             {
-                (_projectRestoreInfo2.TargetFrameworks as VsTargetFrameworks2).Add((IVsTargetFrameworkInfo2) tfi);
+                vsTargetFrameworks2.Add((IVsTargetFrameworkInfo2) tfi);
             }
 
             return this;
         }
 
-        public VsProjectRestoreInfo Build() => _projectRestoreInfo;
+        public VsProjectRestoreInfo ProjectRestoreInfo => _projectRestoreInfo;
 
-        public VsProjectRestoreInfo2 Build2() => _projectRestoreInfo2;
+        public VsProjectRestoreInfo2 ProjectRestoreInfo2 => _projectRestoreInfo2;
 
         private static VsTargetFrameworkInfo ToTargetFrameworkInfo(
             TargetFrameworkInformation tfm, 

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsProjectRestoreInfo2.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsProjectRestoreInfo2.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.SolutionRestoreManager.Test
+{
+    /// <summary>
+    /// Root object containing project restore info.
+    /// Implementation of <see cref="IVsProjectRestoreInfo"/> for internal consumption.
+    /// Used solely by <see cref="ProjectRestoreInfoBuilder"/>.
+    /// </summary>
+    internal class VsProjectRestoreInfo2 : IVsProjectRestoreInfo2
+    {
+        public string BaseIntermediatePath { get; }
+
+        public string MSBuildProjectExtensionsPath { get; }
+
+        public string OriginalTargetFrameworks { get; set; }
+
+        public IVsTargetFrameworks2 TargetFrameworks { get; }
+
+        public IVsReferenceItems ToolReferences { get; set; }
+
+        public VsProjectRestoreInfo2(
+            string baseIntermediatePath,
+            IVsTargetFrameworks2 targetFrameworks)
+        {
+            if (string.IsNullOrEmpty(baseIntermediatePath))
+            {
+                throw new ArgumentException("Argument cannot be null or empty", nameof(baseIntermediatePath));
+            }
+
+            BaseIntermediatePath = baseIntermediatePath;
+            TargetFrameworks = targetFrameworks ?? throw new ArgumentNullException(nameof(targetFrameworks));
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsReferenceItems.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsReferenceItems.cs
@@ -3,15 +3,37 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace NuGet.SolutionRestoreManager.Test
 {
-    internal class VsReferenceItems : VsItemList<IVsReferenceItem>, IVsReferenceItems
+    internal class VsReferenceItems : Collection<IVsReferenceItem>, IVsReferenceItems
     {
         public VsReferenceItems() : base() { }
 
-        public VsReferenceItems(IEnumerable<IVsReferenceItem> collection) : base(collection) { }
+        public VsReferenceItems(IEnumerable<IVsReferenceItem> collection)
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
 
-        protected override String GetKeyForItem(IVsReferenceItem value) => value.Name;
+            foreach (var item in collection)
+            {
+                Add(item);
+            }
+        }
+
+        public IVsReferenceItem Item(Object index)
+        {
+            if (index is int)
+            {
+                return this[(int)index];
+            }
+            else
+            {
+                return null;
+            }
+        }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -37,8 +37,10 @@ namespace NuGet.SolutionRestoreManager.Test
             _testDirectory.Dispose();
         }
 
-        [Fact]
-        public void NominateProjectAsync_Always_SchedulesAutoRestore()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void NominateProjectAsync_Always_SchedulesAutoRestore(bool isV2Nomination)
         {
             var cps = NewCpsProject();
 
@@ -60,10 +62,11 @@ namespace NuGet.SolutionRestoreManager.Test
                 .Returns(completedRestoreTask);
 
             var service = new VsSolutionRestoreService(
-                cache, restoreWorker, NuGet.Common.NullLogger.Instance);
+                cache, restoreWorker, NullLogger.Instance);
 
             // Act
-            var actualRestoreTask = service.NominateProjectAsync(cps.ProjectFullPath, cps.ProjectRestoreInfo, CancellationToken.None);
+            var actualRestoreTask = isV2Nomination ? service.NominateProjectAsync(cps.ProjectFullPath, cps.ProjectRestoreInfo2, CancellationToken.None)
+                : service.NominateProjectAsync(cps.ProjectFullPath, cps.ProjectRestoreInfo, CancellationToken.None);
 
             Assert.Same(completedRestoreTask, actualRestoreTask);
 
@@ -74,8 +77,10 @@ namespace NuGet.SolutionRestoreManager.Test
                     "Service should schedule auto-restore operation.");
         }
 
-        [Fact]
-        public async Task NominateProjectAsync_ConsoleAppTemplate()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task NominateProjectAsync_ConsoleAppTemplate(bool isV2Nomination)
         {
             var consoleAppProjectJson = @"{
     ""frameworks"": {
@@ -95,11 +100,13 @@ namespace NuGet.SolutionRestoreManager.Test
 }";
             var projectName = "ConsoleApp1";
             var cps = NewCpsProject(consoleAppProjectJson, projectName);
-            var pri = cps.ProjectRestoreInfo;
             var projectFullPath = cps.ProjectFullPath;
+            var expectedBaseIntermediate = cps.ProjectRestoreInfo.BaseIntermediatePath == cps.ProjectRestoreInfo2.BaseIntermediatePath ? cps.ProjectRestoreInfo.BaseIntermediatePath : "The test builder is broken!";
 
             // Act
-            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, pri);
+            var actualRestoreSpec = isV2Nomination ?
+                await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo2) :
+                await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo);
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -113,7 +120,7 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.Equal(projectFullPath, actualMetadata.ProjectPath);
             Assert.Equal(projectName, actualMetadata.ProjectName);
             Assert.Equal(ProjectStyle.PackageReference, actualMetadata.ProjectStyle);
-            Assert.Equal(pri.BaseIntermediatePath, actualMetadata.OutputPath);
+            Assert.Equal(expectedBaseIntermediate, actualMetadata.OutputPath);
 
             Assert.Single(actualProjectSpec.TargetFrameworks);
             var actualTfi = actualProjectSpec.TargetFrameworks.Single();
@@ -126,8 +133,10 @@ namespace NuGet.SolutionRestoreManager.Test
                 "Microsoft.NETCore.App:1.0.1");
         }
 
-        [Fact]
-        public async Task NominateProjectAsync_WithCliTool()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task NominateProjectAsync_WithCliTool(bool isV2Nomination)
         {
             const string toolProjectJson = @"{
     ""frameworks"": {
@@ -135,11 +144,14 @@ namespace NuGet.SolutionRestoreManager.Test
     }
 }";
             var cps = NewCpsProject(toolProjectJson);
-            var pri = cps.Builder.WithTool("Foo.Test.Tools", "2.0.0").Build();
+            var builder = cps.Builder.WithTool("Foo.Test.Tools", "2.0.0");
             var projectFullPath = cps.ProjectFullPath;
 
             // Act
-            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, pri);
+            var actualRestoreSpec = isV2Nomination ?
+                await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
+                await CaptureNominateResultAsync(projectFullPath, builder.Build());
+
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -173,32 +185,49 @@ namespace NuGet.SolutionRestoreManager.Test
         }
 
         [Theory]
+        [InlineData("netcoreapp2.0", @"..\packages", @"..\source1;..\source2", @"..\fallback1;..\fallback2", false)]
+        [InlineData("netcoreapp2.0", @"C:\packagesPath", @"..\source1;..\source2", @"C:\fallback1;C:\fallback2", false)]
+        [InlineData("netcoreapp2.0", null, null, null, false)]
+        [InlineData("netcoreapp1.0", null, null, null, false)]
         [InlineData("netcoreapp2.0", @"..\packages", @"..\source1;..\source2", @"..\fallback1;..\fallback2")]
         [InlineData("netcoreapp2.0", @"C:\packagesPath", @"..\source1;..\source2", @"C:\fallback1;C:\fallback2")]
         [InlineData("netcoreapp2.0", null, null, null)]
         [InlineData("netcoreapp1.0", null, null, null)]
         public async Task NominateProjectAsync_WithCliTool_RestoreSettings(
-            string toolFramework, string restorePackagesPath, string restoreSources, string fallbackFolders)
+            string toolFramework, string restorePackagesPath, string restoreSources, string fallbackFolders, bool isV2Nominate = true)
         {
             var expectedToolFramework = NuGetFramework.Parse(toolFramework);
 
-            var cps = NewCpsProject(@"{ }");
-            var pri = cps.Builder
-                .WithTool("Foo.Test.Tools", "2.0.0")
-                .WithTargetFrameworkInfo(
-                    new VsTargetFrameworkInfo(
+            var tfms = isV2Nominate ?
+                (IVsTargetFrameworkInfo)
+                new VsTargetFrameworkInfo2(
+                        "netcoreapp2.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("RestorePackagesPath", restorePackagesPath),
+                                new VsProjectProperty("RestoreSources", restoreSources),
+                                new VsProjectProperty("RestoreFallbackFolders", fallbackFolders),
+                                new VsProjectProperty("DotnetCliToolTargetFramework", toolFramework) }) :
+                new VsTargetFrameworkInfo(
                         "netcoreapp2.0",
                         Enumerable.Empty<IVsReferenceItem>(),
                         Enumerable.Empty<IVsReferenceItem>(),
                         new[] { new VsProjectProperty("RestorePackagesPath", restorePackagesPath),
                                 new VsProjectProperty("RestoreSources", restoreSources),
                                 new VsProjectProperty("RestoreFallbackFolders", fallbackFolders),
-                                new VsProjectProperty("DotnetCliToolTargetFramework", toolFramework) }))
-                .Build();
+                                new VsProjectProperty("DotnetCliToolTargetFramework", toolFramework) });
+            var cps = NewCpsProject(@"{ }");
+            var builder = cps.Builder
+                .WithTool("Foo.Test.Tools", "2.0.0")
+                .WithTargetFrameworkInfo(tfms);
+
             var projectFullPath = cps.ProjectFullPath;
 
             // Act
-            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, pri);
+            var actualRestoreSpec = isV2Nominate ?
+                await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
+                await CaptureNominateResultAsync(projectFullPath, builder.Build());
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -262,18 +291,43 @@ namespace NuGet.SolutionRestoreManager.Test
         ""net46"": { }
     }
 }", "\r\n    netstandard1.4;\r\n    net46\r\n    ", "netstandard1.4;net46")]
+        [InlineData(
+@"{
+    ""frameworks"": {
+        ""netstandard1.4"": { }
+    }
+}", "netstandard1.4", "netstandard1.4", false)]
+        [InlineData(
+@"{
+    ""frameworks"": {
+        ""netstandard1.4"": { },
+        ""net46"": { }
+    }
+}", "netstandard1.4;net46", "netstandard1.4;net46", false)]
+        [InlineData(
+@"{
+    ""frameworks"": {
+        ""netstandard1.4"": { },
+        ""net46"": { }
+    }
+}", "\r\n    netstandard1.4;\r\n    net46\r\n    ", "netstandard1.4;net46", false)]
         public async Task NominateProjectAsync_CrossTargeting(
-            string projectJson, string rawOriginalTargetFrameworks, string expectedOriginalTargetFrameworks)
+            string projectJson, string rawOriginalTargetFrameworks, string expectedOriginalTargetFrameworks, bool isV2Nominate = true)
         {
             var cps = NewCpsProject(
                 projectJson: projectJson,
                 crossTargeting: true);
             var projectFullPath = cps.ProjectFullPath;
             var pri = cps.ProjectRestoreInfo;
+            var pri2 = cps.ProjectRestoreInfo2;
+
             pri.OriginalTargetFrameworks = rawOriginalTargetFrameworks;
+            pri2.OriginalTargetFrameworks = rawOriginalTargetFrameworks;
 
             // Act
-            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, pri);
+            var actualRestoreSpec = isV2Nominate ?
+                await CaptureNominateResultAsync(projectFullPath, pri) :
+                await CaptureNominateResultAsync(projectFullPath, pri2);
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -291,8 +345,10 @@ namespace NuGet.SolutionRestoreManager.Test
                 actualOriginalTargetFrameworks);
         }
 
-        [Fact]
-        public async Task NominateProjectAsync_Imports()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task NominateProjectAsync_Imports(bool isV2Nomination)
         {
             const string projectJson = @"{
     ""frameworks"": {
@@ -305,8 +361,9 @@ namespace NuGet.SolutionRestoreManager.Test
             var projectFullPath = cps.ProjectFullPath;
 
             // Act
-            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo);
-
+            var actualRestoreSpec = isV2Nomination ?
+                await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo2) :
+                await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo);
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
 
@@ -318,8 +375,10 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.Equal("dotnet5.3;portable-net452+win81", actualImports);
         }
 
-        [Fact]
-        public async Task NominateProjectAsync_WithValidPackageVersion()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task NominateProjectAsync_WithValidPackageVersion(bool isV2Nomination)
         {
             const string projectJson = @"{
     ""version"": ""1.2.0-beta1"",
@@ -331,7 +390,9 @@ namespace NuGet.SolutionRestoreManager.Test
             var projectFullPath = cps.ProjectFullPath;
 
             // Act
-            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo);
+            var actualRestoreSpec = isV2Nomination ?
+                await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo2) :
+                await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo);
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -375,29 +436,81 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.Equal(version1, actualProjectSpec.Version.ToString());
         }
 
-        // The data in the restore settings should be unprocessed meaning the paths should stay relative.
-        // The processing of the paths will be done later in the netcorepackagereferenceproject
         [Theory]
-        [InlineData(@"..\packages", @"..\source1;..\source2", @"..\fallback1;..\fallback2")]
-        [InlineData(@"C:\packagesPath", @"..\source1;..\source2", @"C:\fallback1;C:\fallback2")]
-        [InlineData(null, null, null)]
-        public async Task NominateProjectAsync_RestoreSettings(string restorePackagesPath, string restoreSources, string fallbackFolders)
+        [InlineData("1.2.3", "1.2.3")]
+        [InlineData("1.2.0-beta1", "1.2.0-beta1")]
+        [InlineData("1.0.0", "1.0.0.0")]
+        public async Task NominateProjectAsync_PRI2_WithIdenticalPackageVersions(string version1, string version2)
         {
             var cps = NewCpsProject("{ }");
             var projectFullPath = cps.ProjectFullPath;
             var pri = cps.Builder
                 .WithTargetFrameworkInfo(
-                    new VsTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo2(
+                        "netcoreapp1.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("PackageVersion", version1) }))
+                .WithTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo2(
+                        "net46",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("PackageVersion", version2) }))
+                .Build2();
+
+            // Act
+            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, pri);
+
+            // Assert
+            SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
+
+            var actualProjectSpec = actualRestoreSpec.GetProjectSpec(projectFullPath);
+            Assert.NotNull(actualProjectSpec);
+            Assert.Equal(version1, actualProjectSpec.Version.ToString());
+        }
+
+        // The data in the restore settings should be unprocessed meaning the paths should stay relative.
+        // The processing of the paths will be done later in the netcorepackagereferenceproject
+        [Theory]
+        [InlineData(@"..\packages", @"..\source1;..\source2", @"..\fallback1;..\fallback2", false)]
+        [InlineData(@"C:\packagesPath", @"..\source1;..\source2", @"C:\fallback1;C:\fallback2", false)]
+        [InlineData(null, null, null, false)]
+        [InlineData(@"..\packages", @"..\source1;..\source2", @"..\fallback1;..\fallback2", true)]
+        [InlineData(@"C:\packagesPath", @"..\source1;..\source2", @"C:\fallback1;C:\fallback2", true)]
+        [InlineData(null, null, null, true)]
+        public async Task NominateProjectAsync_RestoreSettings(string restorePackagesPath, string restoreSources, string fallbackFolders, bool isV2Nominate)
+        {
+            var cps = NewCpsProject("{ }");
+            var projectFullPath = cps.ProjectFullPath;
+
+            var vstfm = isV2Nominate ?
+                (IVsTargetFrameworkInfo) new VsTargetFrameworkInfo2(
+                        "netcoreapp1.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] {new VsProjectProperty("RestorePackagesPath", restorePackagesPath),
+                               new VsProjectProperty("RestoreSources", restoreSources),
+                               new VsProjectProperty("RestoreFallbackFolders", fallbackFolders)}) :
+
+                new VsTargetFrameworkInfo(
                         "netcoreapp1.0",
                         Enumerable.Empty<IVsReferenceItem>(),
                         Enumerable.Empty<IVsReferenceItem>(),
                         new[] {new VsProjectProperty("RestorePackagesPath", restorePackagesPath),
                                new VsProjectProperty("RestoreSources", restoreSources),
-                               new VsProjectProperty("RestoreFallbackFolders", fallbackFolders)}))
-                .Build();
+                               new VsProjectProperty("RestoreFallbackFolders", fallbackFolders)});
+
+            var builder = cps.Builder
+                .WithTargetFrameworkInfo(vstfm);
 
             // Act
-            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo);
+            var actualRestoreSpec = isV2Nominate ?
+                await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
+                await CaptureNominateResultAsync(projectFullPath, builder.Build());
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -416,26 +529,40 @@ namespace NuGet.SolutionRestoreManager.Test
         }
 
         [Theory]
-        [InlineData(@"..\packages", @"..\source1;..\source2", @"..\fallback1;Clear;..\fallback2")]
-        [InlineData(@"C:\packagesPath", @"Clear;..\source1;..\source2", @"C:\fallback1;C:\fallback2")]
-        public async Task NominateProjectAsync_RestoreSettingsClear(string restorePackagesPath, string restoreSources, string fallbackFolders)
+        [InlineData(@"..\packages", @"..\source1;..\source2", @"..\fallback1;Clear;..\fallback2", false)]
+        [InlineData(@"C:\packagesPath", @"Clear;..\source1;..\source2", @"C:\fallback1;C:\fallback2", false)]
+        [InlineData(@"..\packages", @"..\source1;..\source2", @"..\fallback1;Clear;..\fallback2", true)]
+        [InlineData(@"C:\packagesPath", @"Clear;..\source1;..\source2", @"C:\fallback1;C:\fallback2", true)]
+        public async Task NominateProjectAsync_RestoreSettingsClear(string restorePackagesPath, string restoreSources, string fallbackFolders, bool isV2Nominate)
         {
+            var vstfm = isV2Nominate ?
+                (IVsTargetFrameworkInfo)
+                new VsTargetFrameworkInfo2(
+                    "netcoreapp1.0",
+                    Enumerable.Empty<IVsReferenceItem>(),
+                    Enumerable.Empty<IVsReferenceItem>(),
+                    Enumerable.Empty<IVsReferenceItem>(),
+                    new[] {new VsProjectProperty("RestorePackagesPath", restorePackagesPath),
+                            new VsProjectProperty("RestoreSources", restoreSources),
+                            new VsProjectProperty("RestoreFallbackFolders", fallbackFolders)}) :
+                new VsTargetFrameworkInfo(
+                    "netcoreapp1.0",
+                    Enumerable.Empty<IVsReferenceItem>(),
+                    Enumerable.Empty<IVsReferenceItem>(),
+                    new[] {new VsProjectProperty("RestorePackagesPath", restorePackagesPath),
+                            new VsProjectProperty("RestoreSources", restoreSources),
+                            new VsProjectProperty("RestoreFallbackFolders", fallbackFolders)});
+
             var cps = NewCpsProject("{ }");
             var projectFullPath = cps.ProjectFullPath;
-            var pri = cps.Builder
+            var builder = cps.Builder
                 .WithTargetFrameworkInfo(
-                    new VsTargetFrameworkInfo(
-                        "netcoreapp1.0",
-                        Enumerable.Empty<IVsReferenceItem>(),
-                        Enumerable.Empty<IVsReferenceItem>(),
-                        new[] {new VsProjectProperty("RestorePackagesPath", restorePackagesPath),
-                               new VsProjectProperty("RestoreSources", restoreSources),
-                               new VsProjectProperty("RestoreFallbackFolders", fallbackFolders)}))
-                .Build();
+                    vstfm);
 
             // Act
-            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo);
-
+            var actualRestoreSpec = isV2Nominate ?
+                await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
+                await CaptureNominateResultAsync(projectFullPath, builder.Build());
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
 
@@ -452,22 +579,35 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.True(Enumerable.SequenceEqual(expectedFallback.OrderBy(t => t), specFallback.OrderBy(t => t)));
         }
 
-        [Fact]
-        public async Task NominateProjectAsync_CacheFilePathInPackageSpec_Succeeds()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task NominateProjectAsync_CacheFilePathInPackageSpec_Succeeds(bool isV2Nominate)
         {
+
+            var vstfm = isV2Nominate ?
+                        (IVsTargetFrameworkInfo)
+                        new VsTargetFrameworkInfo2(
+                            "netcoreapp1.0",
+                            Enumerable.Empty<IVsReferenceItem>(),
+                            Enumerable.Empty<IVsReferenceItem>(),
+                            Enumerable.Empty<IVsReferenceItem>(),
+                            new IVsProjectProperty[] { }) :
+                        new VsTargetFrameworkInfo(
+                            "netcoreapp1.0",
+                            Enumerable.Empty<IVsReferenceItem>(),
+                            Enumerable.Empty<IVsReferenceItem>(),
+                            new IVsProjectProperty[] { });
+
             var cps = NewCpsProject("{ }");
             var projectFullPath = cps.ProjectFullPath;
-            var pri = cps.Builder
-                .WithTargetFrameworkInfo(
-                    new VsTargetFrameworkInfo(
-                        "netcoreapp1.0",
-                        Enumerable.Empty<IVsReferenceItem>(),
-                        Enumerable.Empty<IVsReferenceItem>(),
-                        new IVsProjectProperty[] {}))
-                .Build();
+            var builder = cps.Builder
+                .WithTargetFrameworkInfo(vstfm);
 
             // Act
-            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo);
+           var actualRestoreSpec = isV2Nominate ?
+                        await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
+                        await CaptureNominateResultAsync(projectFullPath, builder.Build());
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -513,22 +653,71 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.False(result, "Project restore nomination must fail.");
         }
 
-        [Fact]
-        public async Task NominateProjectAsync_PackageId()
+        [Theory]
+        [InlineData("1.0.0", "1.2.3")]
+        [InlineData("1.0.0", "")]
+        [InlineData("1.0.0", "   ")]
+        [InlineData("1.0.0", null)]
+        public async Task NominateProjectAsync_PRI2_WithDifferentPackageVersions_Fails(string version1, string version2)
         {
             var cps = NewCpsProject("{ }");
             var projectFullPath = cps.ProjectFullPath;
             var pri = cps.Builder
                 .WithTargetFrameworkInfo(
-                    new VsTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo2(
                         "netcoreapp1.0",
                         Enumerable.Empty<IVsReferenceItem>(),
                         Enumerable.Empty<IVsReferenceItem>(),
-                        new[] { new VsProjectProperty("PackageId", "TestPackage") }))
-                .Build();
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("PackageVersion", version1) }))
+                .WithTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo2(
+                        "net46",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("PackageVersion", version2) }))
+                .Build2();
+
+            var cache = Mock.Of<IProjectSystemCache>();
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+
+            var service = new VsSolutionRestoreService(
+                cache, restoreWorker, NuGet.Common.NullLogger.Instance);
 
             // Act
-            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo);
+            var result = await service.NominateProjectAsync(projectFullPath, pri, CancellationToken.None);
+
+            Assert.False(result, "Project restore nomination must fail.");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task NominateProjectAsync_PackageId(bool isV2Nominate)
+        {
+            var vstfm = isV2Nominate ?
+                (IVsTargetFrameworkInfo) new VsTargetFrameworkInfo2(
+                        "netcoreapp1.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("PackageId", "TestPackage") }) :
+                new VsTargetFrameworkInfo(
+                        "netcoreapp1.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("PackageId", "TestPackage") });
+
+            var cps = NewCpsProject("{ }");
+            var projectFullPath = cps.ProjectFullPath;
+            var builder = cps.Builder
+                .WithTargetFrameworkInfo(vstfm);
+
+            // Act
+           var actualRestoreSpec = isV2Nominate ?
+                        await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
+                        await CaptureNominateResultAsync(projectFullPath, builder.Build());
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -583,6 +772,53 @@ namespace NuGet.SolutionRestoreManager.Test
         }
 
         [Fact]
+        public async Task NominateProjectAsync_PRI2_VerifySourcesAreCombinedAcrossFrameworks()
+        {
+            var cps = NewCpsProject(@"{ }");
+            var pri = cps.Builder
+                .WithTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo2(
+                        "netcoreapp1.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("RestoreSources", "base"),
+                                new VsProjectProperty("RestoreFallbackFolders", "base"),
+                                new VsProjectProperty("RestoreAdditionalProjectSources", "a;d"),
+                                new VsProjectProperty("RestoreAdditionalProjectFallbackFolders", "x;z")}))
+                .WithTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo2(
+                        "netcoreapp2.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("RestoreSources", "base"),
+                                new VsProjectProperty("RestoreFallbackFolders", "base"),
+                                new VsProjectProperty("RestoreAdditionalProjectSources", "b"),
+                                new VsProjectProperty("RestoreAdditionalProjectFallbackFolders", "y")}))
+                .WithTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo2(
+                        "netcoreapp2.1",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("RestoreSources", "base"),
+                                new VsProjectProperty("RestoreFallbackFolders", "base"),
+                                new VsProjectProperty("RestoreAdditionalProjectSources", "b"),
+                                new VsProjectProperty("RestoreAdditionalProjectFallbackFolders", "y")}))
+                .Build2();
+            var projectFullPath = cps.ProjectFullPath;
+
+            // Act
+            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, pri);
+            var metadata = actualRestoreSpec.Projects.Single().RestoreMetadata;
+
+            // Assert
+            metadata.Sources.Select(e => e.Source).ShouldBeEquivalentTo(new[] { "base", VSRestoreSettingsUtilities.AdditionalValue, "a", "b", "d" });
+            metadata.FallbackFolders.ShouldBeEquivalentTo(new[] { "base", VSRestoreSettingsUtilities.AdditionalValue, "x", "y", "z" });
+        }
+
+        [Fact]
         public async Task NominateProjectAsync_VerifyExcludedFallbackFoldersAreRemoved()
         {
             var cps = NewCpsProject(@"{ }");
@@ -605,6 +841,42 @@ namespace NuGet.SolutionRestoreManager.Test
                                 new VsProjectProperty("RestoreAdditionalProjectSources", "a"),
                                 new VsProjectProperty("RestoreAdditionalProjectFallbackFoldersExcludes", "x")})) // Remove FF
                 .Build();
+            var projectFullPath = cps.ProjectFullPath;
+
+            // Act
+            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, pri);
+            var metadata = actualRestoreSpec.Projects.Single().RestoreMetadata;
+
+            // Assert
+            metadata.Sources.Select(e => e.Source).ShouldBeEquivalentTo(new[] { "base", VSRestoreSettingsUtilities.AdditionalValue, "a" });
+            metadata.FallbackFolders.ShouldBeEquivalentTo(new[] { "base" });
+        }
+
+        [Fact]
+        public async Task NominateProjectAsync_PRI2_VerifyExcludedFallbackFoldersAreRemoved()
+        {
+            var cps = NewCpsProject(@"{ }");
+            var pri = cps.Builder
+                .WithTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo2(
+                        "netcoreapp1.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("RestoreSources", "base"),
+                                new VsProjectProperty("RestoreFallbackFolders", "base"),
+                                new VsProjectProperty("RestoreAdditionalProjectFallbackFolders", "x")})) // Add FF
+                .WithTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo2(
+                        "netcoreapp2.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("RestoreSources", "base"),
+                                new VsProjectProperty("RestoreFallbackFolders", "base"),
+                                new VsProjectProperty("RestoreAdditionalProjectSources", "a"),
+                                new VsProjectProperty("RestoreAdditionalProjectFallbackFoldersExcludes", "x")})) // Remove FF
+                .Build2();
             var projectFullPath = cps.ProjectFullPath;
 
             // Act
@@ -653,31 +925,89 @@ namespace NuGet.SolutionRestoreManager.Test
             metadata.FallbackFolders.ShouldBeEquivalentTo(new[] { "base", VSRestoreSettingsUtilities.AdditionalValue, "x" });
         }
 
-        [Theory]
-        [InlineData(@"..\source1", @"..\additionalsource", @"..\fallback1", @"..\additionalFallback1")]
-        [InlineData(@"..\source1", null, @"..\fallback1", null)]
-        [InlineData(null, @"..\additionalsource", null, @"..\additionalFallback1")]
-        [InlineData(@"Clear;C:\source1", @"C:\additionalsource", @"C:\fallback1;Clear", @"C:\additionalFallback1")]
-        [InlineData(@"C:\source1;Clear", @"C:\additionalsource", @"Clear;C:\fallback1", @"C:\additionalFallback1")]
-        public async Task NominateProjectAsync_WithRestoreAdditionalSourcesAndFallbackFolders(string restoreSources, string restoreAdditionalProjectSources, string restoreFallbackFolders, string restoreAdditionalFallbackFolders)
+        [Fact]
+        public async Task NominateProjectAsync_PRI2_VerifyToolRestoresUseAdditionalSourcesAndFallbackFolders()
         {
             var cps = NewCpsProject(@"{ }");
             var pri = cps.Builder
-                .WithTool("Foo.Test", "2.0.0")
+                .WithTool("ToolTest", "2.0.0")
                 .WithTargetFrameworkInfo(
-                    new VsTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo2(
+                        "netcoreapp1.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("RestoreSources", "base"),
+                                new VsProjectProperty("RestoreFallbackFolders", "base"),
+                                new VsProjectProperty("RestoreAdditionalProjectFallbackFolders", "x;y")}))
+                .WithTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo2(
+                        "netcoreapp2.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("RestoreSources", "base"),
+                                new VsProjectProperty("RestoreFallbackFolders", "base"),
+                                new VsProjectProperty("RestoreAdditionalProjectSources", "a"),
+                                new VsProjectProperty("RestoreAdditionalProjectFallbackFoldersExcludes", "y")}))
+                .Build2();
+            var projectFullPath = cps.ProjectFullPath;
+
+            // Act
+            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, pri);
+
+            // Find the tool spec
+            var metadata = actualRestoreSpec.Projects.Single(e => e.RestoreMetadata.ProjectStyle == ProjectStyle.DotnetCliTool).RestoreMetadata;
+
+            // Assert
+            metadata.Sources.Select(e => e.Source).ShouldBeEquivalentTo(new[] { "base", VSRestoreSettingsUtilities.AdditionalValue, "a" });
+            metadata.FallbackFolders.ShouldBeEquivalentTo(new[] { "base", VSRestoreSettingsUtilities.AdditionalValue, "x" });
+        }
+
+        [Theory]
+        [InlineData(@"..\source1", @"..\additionalsource", @"..\fallback1", @"..\additionalFallback1", false)]
+        [InlineData(@"..\source1", null, @"..\fallback1", null, false)]
+        [InlineData(null, @"..\additionalsource", null, @"..\additionalFallback1", false)]
+        [InlineData(@"Clear;C:\source1", @"C:\additionalsource", @"C:\fallback1;Clear", @"C:\additionalFallback1", false)]
+        [InlineData(@"C:\source1;Clear", @"C:\additionalsource", @"Clear;C:\fallback1", @"C:\additionalFallback1", false)]
+        [InlineData(@"..\source1", @"..\additionalsource", @"..\fallback1", @"..\additionalFallback1", true)]
+        [InlineData(@"..\source1", null, @"..\fallback1", null, true)]
+        [InlineData(null, @"..\additionalsource", null, @"..\additionalFallback1", true)]
+        [InlineData(@"Clear;C:\source1", @"C:\additionalsource", @"C:\fallback1;Clear", @"C:\additionalFallback1", true)]
+        [InlineData(@"C:\source1;Clear", @"C:\additionalsource", @"Clear;C:\fallback1", @"C:\additionalFallback1", true)]
+        public async Task NominateProjectAsync_WithRestoreAdditionalSourcesAndFallbackFolders(string restoreSources, string restoreAdditionalProjectSources, string restoreFallbackFolders, string restoreAdditionalFallbackFolders, bool isV2Nominate)
+        {
+            var vstfms = isV2Nominate ?
+                (IVsTargetFrameworkInfo)
+                new VsTargetFrameworkInfo2(
+                        "netcoreapp2.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("RestoreSources", restoreSources),
+                                new VsProjectProperty("RestoreFallbackFolders", restoreFallbackFolders),
+                                new VsProjectProperty("RestoreAdditionalProjectSources", restoreAdditionalProjectSources),
+                                new VsProjectProperty("RestoreAdditionalProjectFallbackFolders", restoreAdditionalFallbackFolders)}) :
+                new VsTargetFrameworkInfo(
                         "netcoreapp2.0",
                         Enumerable.Empty<IVsReferenceItem>(),
                         Enumerable.Empty<IVsReferenceItem>(),
                         new[] { new VsProjectProperty("RestoreSources", restoreSources),
                                 new VsProjectProperty("RestoreFallbackFolders", restoreFallbackFolders),
                                 new VsProjectProperty("RestoreAdditionalProjectSources", restoreAdditionalProjectSources),
-                                new VsProjectProperty("RestoreAdditionalProjectFallbackFolders", restoreAdditionalFallbackFolders)}))
-                .Build();
+                                new VsProjectProperty("RestoreAdditionalProjectFallbackFolders", restoreAdditionalFallbackFolders)});
+
+            var cps = NewCpsProject(@"{ }");
+            var builder = cps.Builder
+                .WithTool("Foo.Test", "2.0.0")
+                .WithTargetFrameworkInfo(vstfms);
+
             var projectFullPath = cps.ProjectFullPath;
 
             // Act
-            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, pri);
+            var actualRestoreSpec = isV2Nominate ?
+                await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
+                await CaptureNominateResultAsync(projectFullPath, builder.Build());
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -718,30 +1048,49 @@ namespace NuGet.SolutionRestoreManager.Test
 
 
         [Theory]
-        [InlineData(@"C:\source1", @"C:\additionalsource",@"C:\source1;C:\additionalsource", @"C:\fallback1", @"C:\additionalFallback1", @"C:\fallback1;C:\additionalFallback1")]
-        [InlineData(@"C:\source1", null, @"C:\source1", @"C:\fallback1", null, @"C:\fallback1")]
-        [InlineData(null, @"C:\additionalsource", @"C:\additionalsource",  null, @"C:\additionalFallback1", @"C:\additionalFallback1")]
-        [InlineData(@"Clear;C:\source1", @"C:\additionalsource", @"C:\additionalsource",  @"C:\fallback1;Clear", @"C:\additionalFallback1", @"C:\additionalFallback1")]
-        [InlineData(@"C:\source1;Clear", @"C:\additionalsource", @"C:\additionalsource", @"Clear;C:\fallback1", @"C:\additionalFallback1", @"C:\additionalFallback1")]
-        public async Task VSSolutionRestoreService_VSRestoreSettingsUtilities_Integration(string restoreSources, string restoreAdditionalProjectSources, string expectedRestoreSources, string restoreFallbackFolders, string restoreAdditionalFallbackFolders, string expectedFallbackFolders)
+        [InlineData(@"C:\source1", @"C:\additionalsource",@"C:\source1;C:\additionalsource", @"C:\fallback1", @"C:\additionalFallback1", @"C:\fallback1;C:\additionalFallback1", false)]
+        [InlineData(@"C:\source1", null, @"C:\source1", @"C:\fallback1", null, @"C:\fallback1", false)]
+        [InlineData(null, @"C:\additionalsource", @"C:\additionalsource",  null, @"C:\additionalFallback1", @"C:\additionalFallback1", false)]
+        [InlineData(@"Clear;C:\source1", @"C:\additionalsource", @"C:\additionalsource",  @"C:\fallback1;Clear", @"C:\additionalFallback1", @"C:\additionalFallback1", false)]
+        [InlineData(@"C:\source1;Clear", @"C:\additionalsource", @"C:\additionalsource", @"Clear;C:\fallback1", @"C:\additionalFallback1", @"C:\additionalFallback1", false)]
+        [InlineData(@"C:\source1", @"C:\additionalsource", @"C:\source1;C:\additionalsource", @"C:\fallback1", @"C:\additionalFallback1", @"C:\fallback1;C:\additionalFallback1", true)]
+        [InlineData(@"C:\source1", null, @"C:\source1", @"C:\fallback1", null, @"C:\fallback1", true)]
+        [InlineData(null, @"C:\additionalsource", @"C:\additionalsource", null, @"C:\additionalFallback1", @"C:\additionalFallback1", true)]
+        [InlineData(@"Clear;C:\source1", @"C:\additionalsource", @"C:\additionalsource", @"C:\fallback1;Clear", @"C:\additionalFallback1", @"C:\additionalFallback1", true)]
+        [InlineData(@"C:\source1;Clear", @"C:\additionalsource", @"C:\additionalsource", @"Clear;C:\fallback1", @"C:\additionalFallback1", @"C:\additionalFallback1", true)]
+        public async Task VSSolutionRestoreService_VSRestoreSettingsUtilities_Integration(string restoreSources, string restoreAdditionalProjectSources, string expectedRestoreSources, string restoreFallbackFolders, string restoreAdditionalFallbackFolders, string expectedFallbackFolders, bool isV2Nominate)
         {
+
+            var vstfms = isV2Nominate ?
+                        (IVsTargetFrameworkInfo)
+                        new VsTargetFrameworkInfo2(
+                            "netcoreapp2.0",
+                            Enumerable.Empty<IVsReferenceItem>(),
+                            Enumerable.Empty<IVsReferenceItem>(),
+                            Enumerable.Empty<IVsReferenceItem>(),
+                            new[] { new VsProjectProperty("RestoreSources", restoreSources),
+                                    new VsProjectProperty("RestoreFallbackFolders", restoreFallbackFolders),
+                                    new VsProjectProperty("RestoreAdditionalProjectSources", restoreAdditionalProjectSources),
+                                    new VsProjectProperty("RestoreAdditionalProjectFallbackFolders", restoreAdditionalFallbackFolders)}) :
+                        new VsTargetFrameworkInfo(
+                            "netcoreapp2.0",
+                            Enumerable.Empty<IVsReferenceItem>(),
+                            Enumerable.Empty<IVsReferenceItem>(),
+                            new[] { new VsProjectProperty("RestoreSources", restoreSources),
+                                    new VsProjectProperty("RestoreFallbackFolders", restoreFallbackFolders),
+                                    new VsProjectProperty("RestoreAdditionalProjectSources", restoreAdditionalProjectSources),
+                                    new VsProjectProperty("RestoreAdditionalProjectFallbackFolders", restoreAdditionalFallbackFolders)});
+
             var cps = NewCpsProject(@"{ }");
-            var pri = cps.Builder
+            var builder = cps.Builder
                 .WithTool("Foo.Test", "2.0.0")
-                .WithTargetFrameworkInfo(
-                    new VsTargetFrameworkInfo(
-                        "netcoreapp2.0",
-                        Enumerable.Empty<IVsReferenceItem>(),
-                        Enumerable.Empty<IVsReferenceItem>(),
-                        new[] { new VsProjectProperty("RestoreSources", restoreSources),
-                                new VsProjectProperty("RestoreFallbackFolders", restoreFallbackFolders),
-                                new VsProjectProperty("RestoreAdditionalProjectSources", restoreAdditionalProjectSources),
-                                new VsProjectProperty("RestoreAdditionalProjectFallbackFolders", restoreAdditionalFallbackFolders)}))
-                .Build();
+                .WithTargetFrameworkInfo(vstfms);
             var projectFullPath = cps.ProjectFullPath;
 
             // Act
-            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, pri);
+            var actualRestoreSpec = isV2Nominate ?
+                await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
+                await CaptureNominateResultAsync(projectFullPath, builder.Build());
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -765,31 +1114,48 @@ namespace NuGet.SolutionRestoreManager.Test
         }
 
         [Theory]
-        [InlineData("true", null, "false")]
-        [InlineData(null, "packages.A.lock.json", null)]
-        [InlineData("true", null, "true")]
-        [InlineData("false", null, "false")]
+        [InlineData("true", null, "false", false)]
+        [InlineData(null, "packages.A.lock.json", null, false)]
+        [InlineData("true", null, "true", false)]
+        [InlineData("false", null, "false", false)]
+        [InlineData("true", null, "false", true)]
+        [InlineData(null, "packages.A.lock.json", null, true)]
+        [InlineData("true", null, "true", true)]
+        [InlineData("false", null, "false", true)]
         public async Task NominateProjectAsync_LockFileSettings(
             string restorePackagesWithLockFile,
             string lockFilePath,
-            string restoreLockedMode)
+            string restoreLockedMode,
+            bool isV2Nominate)
         {
-            var cps = NewCpsProject("{ }");
-            var projectFullPath = cps.ProjectFullPath;
-            var pri = cps.Builder
-                .WithTargetFrameworkInfo(
-                    new VsTargetFrameworkInfo(
+            var vstfms = isV2Nominate ?
+                (IVsTargetFrameworkInfo)
+                new VsTargetFrameworkInfo2(
+                        "netcoreapp1.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] {
+                            new VsProjectProperty("RestorePackagesWithLockFile", restorePackagesWithLockFile),
+                            new VsProjectProperty("NuGetLockFilePath", lockFilePath),
+                            new VsProjectProperty("RestoreLockedMode", restoreLockedMode)}) :
+                new VsTargetFrameworkInfo(
                         "netcoreapp1.0",
                         Enumerable.Empty<IVsReferenceItem>(),
                         Enumerable.Empty<IVsReferenceItem>(),
                         new[] {
                             new VsProjectProperty("RestorePackagesWithLockFile", restorePackagesWithLockFile),
                             new VsProjectProperty("NuGetLockFilePath", lockFilePath),
-                            new VsProjectProperty("RestoreLockedMode", restoreLockedMode)}))
-                .Build();
+                            new VsProjectProperty("RestoreLockedMode", restoreLockedMode)});
+            var cps = NewCpsProject("{ }");
+            var projectFullPath = cps.ProjectFullPath;
+            var builder = cps.Builder
+                .WithTargetFrameworkInfo(vstfms);
 
             // Act
-            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo);
+            var actualRestoreSpec = isV2Nominate ?
+                await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
+                await CaptureNominateResultAsync(projectFullPath, builder.Build());
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -801,24 +1167,38 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.Equal(MSBuildStringUtility.IsTrue(restoreLockedMode), actualProjectSpec.RestoreMetadata.RestoreLockProperties.RestoreLockedMode);
         }
 
-        [Fact]
-        public async Task NominateProjectAsync_RuntimeGraph()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task NominateProjectAsync_RuntimeGraph(bool isV2Nominate)
         {
-            var cps = NewCpsProject("{ }");
-            var projectFullPath = cps.ProjectFullPath;
-            var pri = cps.Builder
-                .WithTargetFrameworkInfo(
-                    new VsTargetFrameworkInfo(
+            var vstfms = isV2Nominate ?
+                (IVsTargetFrameworkInfo)
+                new VsTargetFrameworkInfo2(
+                        "netcoreapp1.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] {
+                            new VsProjectProperty("RuntimeIdentifier", "win10-x64")
+                        }) :
+                new VsTargetFrameworkInfo(
                         "netcoreapp1.0",
                         Enumerable.Empty<IVsReferenceItem>(),
                         Enumerable.Empty<IVsReferenceItem>(),
                         new[] {
                             new VsProjectProperty("RuntimeIdentifier", "win10-x64")
-                        }))
-                .Build();
+                        });
+
+            var cps = NewCpsProject("{ }");
+            var projectFullPath = cps.ProjectFullPath;
+            var builder = cps.Builder
+                .WithTargetFrameworkInfo(vstfms);
 
             // Act
-            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo);
+            var actualRestoreSpec = isV2Nominate ?
+                await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
+                await CaptureNominateResultAsync(projectFullPath, builder.Build());
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -829,26 +1209,183 @@ namespace NuGet.SolutionRestoreManager.Test
         }
 
         [Fact]
-        public async Task NominateProjectAsync_WarningProperties()
+        public async Task NominateProjectAsync_BasicPackageDownload()
+        {
+            var consoleAppProjectJson = @"{
+    ""frameworks"": {
+        ""netcoreapp3.0"": {
+            ""dependencies"": {
+                ""NuGet.Protocol"": {
+                    ""target"": ""Package"",
+                    ""version"": ""5.1.0""
+                },
+            },
+            ""downloadDependencies"": [
+                {""name"" : ""NetCoreTargetingPack"", ""version"" : ""[1.0.0]""},
+                {""name"" : ""NetCoreRuntimePack"", ""version"" : ""[1.0.0]""},
+                {""name"" : ""NetCoreApphostPack"", ""version"" : ""[1.0.0]""},
+            ]
+            }
+        }
+    }";
+            var projectName = "ConsoleApp1";
+            var cps = NewCpsProject(consoleAppProjectJson, projectName);
+            var projectFullPath = cps.ProjectFullPath;
+            var expectedBaseIntermediate = cps.ProjectRestoreInfo2.BaseIntermediatePath;
+
+            // Act
+            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo2);
+
+            // Assert
+            SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
+
+            var actualProjectSpec = actualRestoreSpec.GetProjectSpec(projectFullPath);
+            Assert.NotNull(actualProjectSpec);
+            Assert.Equal("1.0.0", actualProjectSpec.Version.ToString());
+
+            var actualMetadata = actualProjectSpec.RestoreMetadata;
+            Assert.NotNull(actualMetadata);
+            Assert.Equal(projectFullPath, actualMetadata.ProjectPath);
+            Assert.Equal(projectName, actualMetadata.ProjectName);
+            Assert.Equal(ProjectStyle.PackageReference, actualMetadata.ProjectStyle);
+            Assert.Equal(expectedBaseIntermediate, actualMetadata.OutputPath);
+
+            Assert.Single(actualProjectSpec.TargetFrameworks);
+            var actualTfi = actualProjectSpec.TargetFrameworks.Single();
+
+            var expectedFramework = NuGetFramework.Parse("netcoreapp3.0");
+            Assert.Equal(expectedFramework, actualTfi.FrameworkName);
+
+            AssertPackages(actualTfi,
+                "NuGet.Protocol:5.1.0");
+            AssertDownloadPackages(actualTfi,
+                "NetCoreTargetingPack:[1.0.0]",
+                "NetCoreRuntimePack:[1.0.0]",
+                "NetCoreApphostPack:[1.0.0]"
+                );
+        }
+
+        [Fact]
+        public async Task NominateProjectAsync_PackageDownload_AllowsDuplicateIds()
+        {
+            var consoleAppProjectJson = @"{
+    ""frameworks"": {
+        ""netcoreapp3.0"": {
+            ""dependencies"": {
+                ""NuGet.Protocol"": {
+                    ""target"": ""Package"",
+                    ""version"": ""5.1.0""
+                },
+            },
+            ""downloadDependencies"": [
+                {""name"" : ""NetCoreTargetingPack"", ""version"" : ""[1.0.0]""},
+                {""name"" : ""NetCoreTargetingPack"", ""version"" : ""[2.0.0]""},
+            ]
+            }
+        }
+    }";
+            var projectName = "ConsoleApp1";
+            var cps = NewCpsProject(consoleAppProjectJson, projectName);
+            var projectFullPath = cps.ProjectFullPath;
+            var expectedBaseIntermediate = cps.ProjectRestoreInfo2.BaseIntermediatePath;
+
+            // Act
+            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo2);
+
+            // Assert
+            SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
+
+            var actualProjectSpec = actualRestoreSpec.GetProjectSpec(projectFullPath);
+            Assert.NotNull(actualProjectSpec);
+            Assert.Equal("1.0.0", actualProjectSpec.Version.ToString());
+
+            var actualMetadata = actualProjectSpec.RestoreMetadata;
+            Assert.NotNull(actualMetadata);
+            Assert.Equal(projectFullPath, actualMetadata.ProjectPath);
+            Assert.Equal(projectName, actualMetadata.ProjectName);
+            Assert.Equal(ProjectStyle.PackageReference, actualMetadata.ProjectStyle);
+            Assert.Equal(expectedBaseIntermediate, actualMetadata.OutputPath);
+
+            Assert.Single(actualProjectSpec.TargetFrameworks);
+            var actualTfi = actualProjectSpec.TargetFrameworks.Single();
+
+            var expectedFramework = NuGetFramework.Parse("netcoreapp3.0");
+            Assert.Equal(expectedFramework, actualTfi.FrameworkName);
+
+            AssertPackages(actualTfi,
+                "NuGet.Protocol:5.1.0");
+            AssertDownloadPackages(actualTfi,
+                "NetCoreTargetingPack:[1.0.0]",
+                "NetCoreTargetingPack:[2.0.0]"
+                );
+        }
+
+        [Fact]
+        public async Task NominateProjectAsync_PackageDownload_InexactVersionsNotAllowed()
+        {
+            var consoleAppProjectJson = @"{
+    ""frameworks"": {
+        ""netcoreapp3.0"": {
+            ""dependencies"": {
+                ""NuGet.Protocol"": {
+                    ""target"": ""Package"",
+                    ""version"": ""5.1.0""
+                },
+            },
+            ""downloadDependencies"": [
+                {""name"" : ""NetCoreTargetingPack"", ""version"" : ""[1.0.0, )""},
+            ]
+            }
+        }
+    }";
+            var projectName = "ConsoleApp1";
+            var cps = NewCpsProject(consoleAppProjectJson, projectName);
+            var projectFullPath = cps.ProjectFullPath;
+            var cache = Mock.Of<IProjectSystemCache>();
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+
+            var service = new VsSolutionRestoreService(
+                cache, restoreWorker, NullLogger.Instance);
+
+            var result = await service.NominateProjectAsync(projectFullPath, cps.ProjectRestoreInfo2, CancellationToken.None);
+
+            Assert.False(result, "Project restore nomination must fail.");
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task NominateProjectAsync_WarningProperties(bool  isV2Nominate)
         {
             var packageReference = new VsReferenceItem("NuGet.Protocol", new VsReferenceProperties() { new VsReferenceProperty("NoWarn", "NU1605") } );
 
-            var cps = NewCpsProject("{ }");
-            var projectFullPath = cps.ProjectFullPath;
-            var pri = cps.Builder
-                .WithTargetFrameworkInfo(
-                    new VsTargetFrameworkInfo(
+            var vstfms = isV2Nominate ?
+                (IVsTargetFrameworkInfo)
+                new VsTargetFrameworkInfo2(
+                        "netcoreapp1.0",
+                        new IVsReferenceItem[] { packageReference },
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] {
+                            new VsProjectProperty("TreatWarningsAsErrors", "true")
+                        }) :
+                new VsTargetFrameworkInfo(
                         "netcoreapp1.0",
                         new IVsReferenceItem[] { packageReference },
                         Enumerable.Empty<IVsReferenceItem>(),
                         new[] {
                             new VsProjectProperty("TreatWarningsAsErrors", "true")
-                        }))
-                .Build();
+                        });
+
+            var cps = NewCpsProject("{ }");
+            var projectFullPath = cps.ProjectFullPath;
+            var builder = cps.Builder
+                .WithTargetFrameworkInfo(vstfms);
 
             // Act
-            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo);
-
+            var actualRestoreSpec = isV2Nominate ?
+                    await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
+                    await CaptureNominateResultAsync(projectFullPath, builder.Build());
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
 
@@ -881,6 +1418,38 @@ namespace NuGet.SolutionRestoreManager.Test
 
             var service = new VsSolutionRestoreService(
                 cache, restoreWorker, NuGet.Common.NullLogger.Instance);
+
+            // Act
+            var result = await service.NominateProjectAsync(projectFullPath, pri, CancellationToken.None);
+
+            Assert.True(result, "Project restore nomination should succeed.");
+
+            return capturedRestoreSpec;
+        }
+
+        private async Task<DependencyGraphSpec> CaptureNominateResultAsync(
+            string projectFullPath, IVsProjectRestoreInfo2 pri)
+        {
+            DependencyGraphSpec capturedRestoreSpec = null;
+
+            var cache = Mock.Of<IProjectSystemCache>();
+            Mock.Get(cache)
+                .Setup(x => x.AddProjectRestoreInfo(
+                    It.IsAny<ProjectNames>(),
+                    It.IsAny<DependencyGraphSpec>()))
+                .Callback<ProjectNames, DependencyGraphSpec>(
+                    (_, dg) => { capturedRestoreSpec = dg; })
+                .Returns(true);
+
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+            Mock.Get(restoreWorker)
+                .Setup(x => x.ScheduleRestoreAsync(
+                    It.IsAny<SolutionRestoreRequest>(),
+                    CancellationToken.None))
+                .ReturnsAsync(true);
+
+            var service = new VsSolutionRestoreService(
+                cache, restoreWorker, NullLogger.Instance);
 
             // Act
             var result = await service.NominateProjectAsync(projectFullPath, pri, CancellationToken.None);
@@ -935,12 +1504,24 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.Equal(expectedPackages, actualPackages);
         }
 
+        private static void AssertDownloadPackages(TargetFrameworkInformation actualTfi, params string[] expectedPackages)
+        {
+            var actualPackages = actualTfi
+                .DownloadDependencies
+                .Select(ld => $"{ld.Name}:{ld.VersionRange.OriginalString}");
+
+            Assert.Equal(expectedPackages, actualPackages);
+        }
+
         private class TestContext
         {
             public string ProjectFullPath { get; set; }
             public ProjectRestoreInfoBuilder Builder { get; set; }
 
             public VsProjectRestoreInfo ProjectRestoreInfo => Builder.Build();
+
+            public VsProjectRestoreInfo2 ProjectRestoreInfo2 => Builder.Build2();
+
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -149,8 +149,8 @@ namespace NuGet.SolutionRestoreManager.Test
 
             // Act
             var actualRestoreSpec = isV2Nomination ?
-                await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
-                await CaptureNominateResultAsync(projectFullPath, builder.Build());
+                await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo2) :
+                await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo);
 
 
             // Assert
@@ -226,8 +226,8 @@ namespace NuGet.SolutionRestoreManager.Test
 
             // Act
             var actualRestoreSpec = isV2Nominate ?
-                await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
-                await CaptureNominateResultAsync(projectFullPath, builder.Build());
+                await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo2) :
+                await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo);
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -423,7 +423,7 @@ namespace NuGet.SolutionRestoreManager.Test
                         Enumerable.Empty<IVsReferenceItem>(),
                         Enumerable.Empty<IVsReferenceItem>(),
                         new[] { new VsProjectProperty("PackageVersion", version2) }))
-                .Build();
+                .ProjectRestoreInfo;
 
             // Act
             var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo);
@@ -459,7 +459,7 @@ namespace NuGet.SolutionRestoreManager.Test
                         Enumerable.Empty<IVsReferenceItem>(),
                         Enumerable.Empty<IVsReferenceItem>(),
                         new[] { new VsProjectProperty("PackageVersion", version2) }))
-                .Build2();
+                .ProjectRestoreInfo2;
 
             // Act
             var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, pri);
@@ -509,8 +509,8 @@ namespace NuGet.SolutionRestoreManager.Test
 
             // Act
             var actualRestoreSpec = isV2Nominate ?
-                await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
-                await CaptureNominateResultAsync(projectFullPath, builder.Build());
+                await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo2) :
+                await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo);
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -561,8 +561,8 @@ namespace NuGet.SolutionRestoreManager.Test
 
             // Act
             var actualRestoreSpec = isV2Nominate ?
-                await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
-                await CaptureNominateResultAsync(projectFullPath, builder.Build());
+                await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo2) :
+                await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo);
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
 
@@ -606,8 +606,8 @@ namespace NuGet.SolutionRestoreManager.Test
 
             // Act
            var actualRestoreSpec = isV2Nominate ?
-                        await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
-                        await CaptureNominateResultAsync(projectFullPath, builder.Build());
+                        await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo2) :
+                        await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo);
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -639,7 +639,7 @@ namespace NuGet.SolutionRestoreManager.Test
                         Enumerable.Empty<IVsReferenceItem>(),
                         Enumerable.Empty<IVsReferenceItem>(),
                         new[] { new VsProjectProperty("PackageVersion", version2) }))
-                .Build();
+                .ProjectRestoreInfo;
 
             var cache = Mock.Of<IProjectSystemCache>();
             var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
@@ -677,7 +677,7 @@ namespace NuGet.SolutionRestoreManager.Test
                         Enumerable.Empty<IVsReferenceItem>(),
                         Enumerable.Empty<IVsReferenceItem>(),
                         new[] { new VsProjectProperty("PackageVersion", version2) }))
-                .Build2();
+                .ProjectRestoreInfo2;
 
             var cache = Mock.Of<IProjectSystemCache>();
             var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
@@ -716,8 +716,8 @@ namespace NuGet.SolutionRestoreManager.Test
 
             // Act
            var actualRestoreSpec = isV2Nominate ?
-                        await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
-                        await CaptureNominateResultAsync(projectFullPath, builder.Build());
+                        await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo2) :
+                        await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo);
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -759,7 +759,7 @@ namespace NuGet.SolutionRestoreManager.Test
                                 new VsProjectProperty("RestoreFallbackFolders", "base"),
                                 new VsProjectProperty("RestoreAdditionalProjectSources", "b"),
                                 new VsProjectProperty("RestoreAdditionalProjectFallbackFolders", "y")}))
-                .Build();
+                .ProjectRestoreInfo;
             var projectFullPath = cps.ProjectFullPath;
 
             // Act
@@ -806,7 +806,7 @@ namespace NuGet.SolutionRestoreManager.Test
                                 new VsProjectProperty("RestoreFallbackFolders", "base"),
                                 new VsProjectProperty("RestoreAdditionalProjectSources", "b"),
                                 new VsProjectProperty("RestoreAdditionalProjectFallbackFolders", "y")}))
-                .Build2();
+                .ProjectRestoreInfo2;
             var projectFullPath = cps.ProjectFullPath;
 
             // Act
@@ -840,7 +840,7 @@ namespace NuGet.SolutionRestoreManager.Test
                                 new VsProjectProperty("RestoreFallbackFolders", "base"),
                                 new VsProjectProperty("RestoreAdditionalProjectSources", "a"),
                                 new VsProjectProperty("RestoreAdditionalProjectFallbackFoldersExcludes", "x")})) // Remove FF
-                .Build();
+                .ProjectRestoreInfo;
             var projectFullPath = cps.ProjectFullPath;
 
             // Act
@@ -876,7 +876,7 @@ namespace NuGet.SolutionRestoreManager.Test
                                 new VsProjectProperty("RestoreFallbackFolders", "base"),
                                 new VsProjectProperty("RestoreAdditionalProjectSources", "a"),
                                 new VsProjectProperty("RestoreAdditionalProjectFallbackFoldersExcludes", "x")})) // Remove FF
-                .Build2();
+                .ProjectRestoreInfo2;
             var projectFullPath = cps.ProjectFullPath;
 
             // Act
@@ -911,7 +911,7 @@ namespace NuGet.SolutionRestoreManager.Test
                                 new VsProjectProperty("RestoreFallbackFolders", "base"),
                                 new VsProjectProperty("RestoreAdditionalProjectSources", "a"),
                                 new VsProjectProperty("RestoreAdditionalProjectFallbackFoldersExcludes", "y")}))
-                .Build();
+                .ProjectRestoreInfo;
             var projectFullPath = cps.ProjectFullPath;
 
             // Act
@@ -950,7 +950,7 @@ namespace NuGet.SolutionRestoreManager.Test
                                 new VsProjectProperty("RestoreFallbackFolders", "base"),
                                 new VsProjectProperty("RestoreAdditionalProjectSources", "a"),
                                 new VsProjectProperty("RestoreAdditionalProjectFallbackFoldersExcludes", "y")}))
-                .Build2();
+                .ProjectRestoreInfo2;
             var projectFullPath = cps.ProjectFullPath;
 
             // Act
@@ -1006,8 +1006,8 @@ namespace NuGet.SolutionRestoreManager.Test
 
             // Act
             var actualRestoreSpec = isV2Nominate ?
-                await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
-                await CaptureNominateResultAsync(projectFullPath, builder.Build());
+                await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo2) :
+                await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo);
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -1089,8 +1089,8 @@ namespace NuGet.SolutionRestoreManager.Test
 
             // Act
             var actualRestoreSpec = isV2Nominate ?
-                await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
-                await CaptureNominateResultAsync(projectFullPath, builder.Build());
+                await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo2) :
+                await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo);
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -1154,8 +1154,8 @@ namespace NuGet.SolutionRestoreManager.Test
 
             // Act
             var actualRestoreSpec = isV2Nominate ?
-                await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
-                await CaptureNominateResultAsync(projectFullPath, builder.Build());
+                await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo2) :
+                await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo);
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -1197,8 +1197,8 @@ namespace NuGet.SolutionRestoreManager.Test
 
             // Act
             var actualRestoreSpec = isV2Nominate ?
-                await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
-                await CaptureNominateResultAsync(projectFullPath, builder.Build());
+                await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo2) :
+                await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo);
 
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
@@ -1384,8 +1384,8 @@ namespace NuGet.SolutionRestoreManager.Test
 
             // Act
             var actualRestoreSpec = isV2Nominate ?
-                    await CaptureNominateResultAsync(projectFullPath, builder.Build2()) :
-                    await CaptureNominateResultAsync(projectFullPath, builder.Build());
+                    await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo2) :
+                    await CaptureNominateResultAsync(projectFullPath, builder.ProjectRestoreInfo);
             // Assert
             SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
 
@@ -1518,9 +1518,9 @@ namespace NuGet.SolutionRestoreManager.Test
             public string ProjectFullPath { get; set; }
             public ProjectRestoreInfoBuilder Builder { get; set; }
 
-            public VsProjectRestoreInfo ProjectRestoreInfo => Builder.Build();
+            public VsProjectRestoreInfo ProjectRestoreInfo => Builder.ProjectRestoreInfo;
 
-            public VsProjectRestoreInfo2 ProjectRestoreInfo2 => Builder.Build2();
+            public VsProjectRestoreInfo2 ProjectRestoreInfo2 => Builder.ProjectRestoreInfo2;
 
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -1395,6 +1395,32 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.True(actualProjectSpec.TargetFrameworks.First().Dependencies.First().NoWarn.First().Equals(NuGetLogCode.NU1605));
         }
 
+        [Fact]
+        public void NominateProjectAsync_ThrowsNullReferenceException()
+        {
+            var cache = Mock.Of<IProjectSystemCache>();
+
+            Mock.Get(cache)
+                .Setup(x => x.AddProjectRestoreInfo(
+                    It.IsAny<ProjectNames>(),
+                    It.IsAny<DependencyGraphSpec>()))
+                .Returns(true);
+
+            var completedRestoreTask = Task.FromResult(true);
+
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+
+            var service = new VsSolutionRestoreService(
+                cache, restoreWorker, NullLogger.Instance);
+
+            // Act
+            _ = Assert.ThrowsAsync<ArgumentNullException>(async () => await service.NominateProjectAsync(@"F:\project\project.csproj", (IVsProjectRestoreInfo)null, CancellationToken.None));
+
+            _ = Assert.ThrowsAsync<ArgumentNullException>(async () => await service.NominateProjectAsync(@"F:\project\project.csproj", (IVsProjectRestoreInfo2)null, CancellationToken.None));
+
+
+        }
+
         private async Task<DependencyGraphSpec> CaptureNominateResultAsync(
             string projectFullPath, IVsProjectRestoreInfo pri)
         {

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworkInfo2.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworkInfo2.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.SolutionRestoreManager.Test
+{
+    internal class VsTargetFrameworkInfo2 : IVsTargetFrameworkInfo2
+    {
+        public IVsReferenceItems PackageReferences { get; }
+
+        public IVsReferenceItems ProjectReferences { get; }
+
+        public IVsReferenceItems PackageDownloads { get; }
+
+        public IVsProjectProperties Properties { get; }
+
+        public string TargetFrameworkMoniker { get; }
+
+        public VsTargetFrameworkInfo2(
+            string targetFrameworkMoniker,
+            IEnumerable<IVsReferenceItem> packageReferences,
+            IEnumerable<IVsReferenceItem> projectReferences,
+            IEnumerable<IVsReferenceItem> packageDownloads,
+            IEnumerable<IVsProjectProperty> projectProperties)
+        {
+            if (string.IsNullOrEmpty(targetFrameworkMoniker))
+            {
+                throw new ArgumentException("Argument cannot be null or empty", nameof(targetFrameworkMoniker));
+            }
+
+            if (packageReferences == null)
+            {
+                throw new ArgumentNullException(nameof(packageReferences));
+            }
+
+            if (projectReferences == null)
+            {
+                throw new ArgumentNullException(nameof(projectReferences));
+            }
+
+            if (packageDownloads == null)
+            {
+                throw new ArgumentNullException(nameof(packageDownloads));
+            }
+
+            if (projectProperties == null)
+            {
+                throw new ArgumentNullException(nameof(projectProperties));
+            }
+
+            TargetFrameworkMoniker = targetFrameworkMoniker;
+            PackageReferences = new VsReferenceItems(packageReferences);
+            ProjectReferences = new VsReferenceItems(projectReferences);
+            PackageDownloads = new VsReferenceItems(packageDownloads);
+            Properties = new VsProjectProperties(projectProperties);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworks2.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworks2.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.SolutionRestoreManager.Test
+{
+    internal class VsTargetFrameworks2 : VsItemList<IVsTargetFrameworkInfo2>, IVsTargetFrameworks2
+    {
+        public VsTargetFrameworks2() : base() { }
+
+        public VsTargetFrameworks2(IEnumerable<IVsTargetFrameworkInfo2> collection) : base(collection) { }
+
+        protected override string GetKeyForItem(IVsTargetFrameworkInfo2 value) => value.TargetFrameworkMoniker;
+    }
+}


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#7719
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Builds on top of https://github.com/NuGet/NuGet.Client/pull/2696 (and all previous PackageDownload PRs)

Adds new APIs for nomination that contain PackageDownload. 
The same APIs will be amended to handle FrameworkReference later on as well. 

## Testing/Validation

Tests Added: Not yet. 
Reason for not adding tests:  
Validation:  
