### PR TITLE
Fix ServiceIndexResourceV3Provider tests in MacOS Mojave

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ServiceIndexResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ServiceIndexResourceV3ProviderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -61,7 +62,7 @@ namespace NuGet.Protocol.Tests
         public async Task TryCreate_Throws_IfSourceLocationReturnsFailureCode()
         {
             // Arrange
-            var source = "https://does-not-exist.server/does-not-exist.json";
+            var source = $"https://does-not-exist.server-{new Guid().ToString()}/does-not-exist.json";
             // This will return a 404 - NotFound.
             var httpProvider = StaticHttpSource.CreateHttpSource(new Dictionary<string, string> { { source, string.Empty } });
             var provider = new ServiceIndexResourceV3Provider();
@@ -85,7 +86,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
         public async Task TryCreate_Throws_IfSourceLocationDoesNotReturnValidJson(string content)
         {
             // Arrange
-            var source = "https://fake.server/users.json";
+            var source = $"https://fake.server-{new Guid().ToString()}/users.json";
             var httpProvider = StaticHttpSource.CreateHttpSource(new Dictionary<string, string> { { source, content } });
             var provider = new ServiceIndexResourceV3Provider();
             var sourceRepository = new SourceRepository(new PackageSource(source),
@@ -107,7 +108,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
         public async Task TryCreate_Throws_IfInvalidVersionInJson(string content)
         {
             // Arrange
-            var source = "https://fake.server/users.json";
+            var source = $"https://fake.server-{new Guid().ToString()}/users.json";
             var httpProvider = StaticHttpSource.CreateHttpSource(new Dictionary<string, string> { { source, content } });
             var provider = new ServiceIndexResourceV3Provider();
             var sourceRepository = new SourceRepository(new PackageSource(source),
@@ -130,7 +131,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
         public async Task TryCreate_Throws_IfNoVersionInJson(string content)
         {
             // Arrange
-            var source = "https://fake.server/users.json";
+            var source = $"https://fake.server-{new Guid().ToString()}/users.json";
             var httpProvider = StaticHttpSource.CreateHttpSource(new Dictionary<string, string> { { source, content } });
             var provider = new ServiceIndexResourceV3Provider();
             var sourceRepository = new SourceRepository(new PackageSource(source),
@@ -150,7 +151,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
         public async Task TryCreate_ReturnsTrue_IfSourceLocationReturnsValidJson()
         {
             // Arrange
-            var source = "https://some-site.org/test.json";
+            var source = $"https://some-site-{new Guid().ToString()}.org/test.json";
             var content = @"{ version: '3.1.0-beta' }";
             var httpProvider = StaticHttpSource.CreateHttpSource(new Dictionary<string, string> { { source, content } });
             var provider = new ServiceIndexResourceV3Provider();
@@ -168,7 +169,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
         public async Task Query_For_Particular_Resource()
         {
             // Arrange
-            var source = "https://some-site.org/test.json";
+            var source = $"https://some-site-{new Guid().ToString()}.org/test.json";
             var content = CreateTestIndex();
 
             var httpProvider = StaticHttpSource.CreateHttpSource(new Dictionary<string, string> { { source, content } });
@@ -198,7 +199,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
         public async Task Query_For_Particular_Multi_Value_Resource()
         {
             // Arrange
-            var source = "https://some-site.org/test.json";
+            var source = $"https://some-site-{new Guid().ToString()}.org/test.json";
             var content = CreateTestIndex();
 
             var httpProvider = StaticHttpSource.CreateHttpSource(new Dictionary<string, string> { { source, content } });
@@ -230,7 +231,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
         public async Task Query_For_Resource_With_Precedence()
         {
             // Arrange
-            var source = "https://some-site.org/test.json";
+            var source = $"https://some-site-{new Guid().ToString()}.org/test.json";
             var content = CreateTestIndex();
 
             var httpProvider = StaticHttpSource.CreateHttpSource(new Dictionary<string, string> { { source, content } });
@@ -250,7 +251,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
 
             var endpoints = resource.GetServiceEntryUris(new NuGetVersion(4, 0, 0), "Chocolate", "Vegetable");
 
-            Assert.True(endpoints.Count == 1);
+            // Assert.True(endpoints.Count == 1);
 
             var endpointSet = new HashSet<string>(endpoints.Select(u => u.AbsoluteUri));
             Assert.True(endpointSet.Contains("http://tempuri.org/chocolate"));
@@ -260,7 +261,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
         public async Task Query_For_Resource_With_VersionPrecedence_ExactMatch()
         {
             // Arrange
-            var source = "https://some-site.org/test.json";
+            var source = $"https://some-site-{new Guid().ToString()}.org/test.json";
             var content = CreateVersionedTestIndex();
 
             var httpProvider = StaticHttpSource.CreateHttpSource(new Dictionary<string, string> { { source, content } });
@@ -290,7 +291,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
         public async Task Query_For_Resource_With_NoCompatibleVersion()
         {
             // Arrange
-            var source = "https://some-site.org/test.json";
+            var source = $"https://some-site-{new Guid().ToString()}.org/test.json";
             var content = CreateVersionedTestIndex();
 
             var httpProvider = StaticHttpSource.CreateHttpSource(new Dictionary<string, string> { { source, content } });
@@ -317,7 +318,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
         public async Task Query_For_Resource_With_VersionPrecedence_LowerVersion()
         {
             // Arrange
-            var source = "https://some-site.org/test.json";
+            var source = $"https://some-site-{new Guid().ToString()}.org/test.json";
             var content = CreateVersionedTestIndex();
 
             var httpProvider = StaticHttpSource.CreateHttpSource(new Dictionary<string, string> { { source, content } });
@@ -347,7 +348,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
         public async Task Query_For_Resource_With_VersionPrecedence_NoFallbackBetweenTypes()
         {
             // Arrange
-            var source = "https://some-site.org/test.json";
+            var source = $"https://some-site-{new Guid().ToString()}.org/test.json";
             var content = CreateVersionedTestIndex2();
 
             var httpProvider = StaticHttpSource.CreateHttpSource(new Dictionary<string, string> { { source, content } });
@@ -377,7 +378,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
         public async Task Query_For_Resource_ReturnAllOfSameTypeVersion()
         {
             // Arrange
-            var source = "https://some-site.org/test.json";
+            var source = $"https://some-site-{new Guid().ToString()}.org/test.json";
             var content = CreateVersionedTestIndex3();
 
             var httpProvider = StaticHttpSource.CreateHttpSource(new Dictionary<string, string> { { source, content } });

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ServiceIndexResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ServiceIndexResourceV3ProviderTests.cs
@@ -251,7 +251,7 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
 
             var endpoints = resource.GetServiceEntryUris(new NuGetVersion(4, 0, 0), "Chocolate", "Vegetable");
 
-            // Assert.True(endpoints.Count == 1);
+            Assert.True(endpoints.Count == 1);
 
             var endpointSet = new HashSet<string>(endpoints.Select(u => u.AbsoluteUri));
             Assert.True(endpointSet.Contains("http://tempuri.org/chocolate"));


### PR DESCRIPTION
## Bug

Fixes some tests that fail on MacOS Mojave. For some reason xunit seems to be caching the the `ServiceIndexResourceV3Provider` so when multiple tests use the same source url the test fails. This PR makes sure all the source url used on these tests are different.

**Note:** Our mac CI runs on MacOS Sierra, therefore this tests are not currently failing on CI and this PR shouldn't affect the current state of the tests in any other platform