### PR TITLE
Fix the vsix version for the build tools package

### DIFF
--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -42,7 +42,7 @@ Function Get-Version {
         # Generate the new minor version: 4.0.0 => 40000, 4.11.5 => 41105. 
         # This assumes we only get to NuGet major/minor 99 at worst, otherwise the logic breaks. 
         #The final version for NuGet 4.0.0, build number 3128 would be 15.0.40000.3128
-        $finalVersion = "15.0.$((-join ($ProductVersion -split '\.' | %{ '{0:D2}' -f ($_ -as [int]) } )).TrimStart("0")).$build"    
+        $finalVersion = "16.0.$((-join ($ProductVersion -split '\.' | %{ '{0:D2}' -f ($_ -as [int]) } )).TrimStart("0")).$build"    
     
         Write-Host "The new VSIX Version is: $finalVersion"
         return $finalVersion    

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -39,10 +39,13 @@ Function Get-Version {
         [string]$build
     )
         Write-Host "Evaluating the new VSIX Version : ProductVersion $ProductVersion, build $build"
-        # Generate the new minor version: 4.0.0 => 40000, 4.11.5 => 41105. 
-        # This assumes we only get to NuGet major/minor 99 at worst, otherwise the logic breaks. 
-        #The final version for NuGet 4.0.0, build number 3128 would be 15.0.40000.3128
-        $finalVersion = "16.0.$((-join ($ProductVersion -split '\.' | %{ '{0:D2}' -f ($_ -as [int]) } )).TrimStart("0")).$build"    
+        # The major version is NuGetMajorVersion + 11, to match VS's number.
+        # The new minor version is: 4.0.0 => 40000, 4.11.5 => 41105. 
+        # This assumes we only get to NuGet major/minor/patch 99 at worst, otherwise the logic breaks. 
+        # The final version for NuGet 4.0.0, build number 3128 would be 15.0.40000.3128
+        $versionParts = $ProductVersion -split '\.'
+        $major = $($versionParts / 1) + 11
+        $finalVersion = "$major.0.$((-join ($versionParts | %{ '{0:D2}' -f ($_ -as [int]) } )).TrimStart("0")).$build"    
     
         Write-Host "The new VSIX Version is: $finalVersion"
         return $finalVersion    

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -44,7 +44,7 @@ Function Get-Version {
         # This assumes we only get to NuGet major/minor/patch 99 at worst, otherwise the logic breaks. 
         # The final version for NuGet 4.0.0, build number 3128 would be 15.0.40000.3128
         $versionParts = $ProductVersion -split '\.'
-        $major = $($versionParts / 1) + 11
+        $major = $($versionParts[0] / 1) + 11
         $finalVersion = "$major.0.$((-join ($versionParts | %{ '{0:D2}' -f ($_ -as [int]) } )).TrimStart("0")).$build"    
     
         Write-Host "The new VSIX Version is: $finalVersion"

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
@@ -23,7 +23,7 @@
     <!-- Variables added here will be usable in the swr file.  This is a semi colon delimited
           list of name=value items.  Use $(name) in the swr file to reference the variable.
     -->
-    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);ReferenceOutputPath=$(ReferenceOutputPath);NuGetTargetsPath=$(NuGetTargetsPath);XmlTransformPath=$(XmlTransformPath);BuildNumber=$(BuildNumber)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);ReferenceOutputPath=$(ReferenceOutputPath);NuGetTargetsPath=$(NuGetTargetsPath);XmlTransformPath=$(XmlTransformPath);BuildNumber=$(BuildNumber);MajorNuGetVersion=$(MajorNuGetVersion);MinorNuGetVersion=$(MinorNuGetVersion);PatchNuGetVersion=$(PatchNuGetVersion)</PackagePreprocessorDefinitions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
@@ -9,6 +9,7 @@
     <OutputName>$(MSBuildProjectName)</OutputName>
     <OutputType>vsix</OutputType>
     <IsPackage>true</IsPackage>
+    <MajorVSVersion>$([MSBuild]::Add($(MajorNuGetVersion), 11))</MajorVSVersion>
     <!-- We set this to false here so we can batch sign the vsix later -->
     <MicroBuild_SigningEnabled>false</MicroBuild_SigningEnabled>
   </PropertyGroup>
@@ -23,7 +24,7 @@
     <!-- Variables added here will be usable in the swr file.  This is a semi colon delimited
           list of name=value items.  Use $(name) in the swr file to reference the variable.
     -->
-    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);ReferenceOutputPath=$(ReferenceOutputPath);NuGetTargetsPath=$(NuGetTargetsPath);XmlTransformPath=$(XmlTransformPath);BuildNumber=$(BuildNumber);MajorNuGetVersion=$(MajorNuGetVersion);MinorNuGetVersion=$(MinorNuGetVersion);PatchNuGetVersion=$(PatchNuGetVersion)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);ReferenceOutputPath=$(ReferenceOutputPath);NuGetTargetsPath=$(NuGetTargetsPath);XmlTransformPath=$(XmlTransformPath);BuildNumber=$(BuildNumber);MajorNuGetVersion=$(MajorNuGetVersion);MinorNuGetVersion=$(MinorNuGetVersion);PatchNuGetVersion=$(PatchNuGetVersion);MajorVSVersion=$(MajorVSVersion)</PackagePreprocessorDefinitions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
@@ -1,7 +1,7 @@
 use vs
 
 package name=Microsoft.VisualStudio.NuGet.BuildTools
-        version=16.0.$(MajorVersion)0$(MinorVersion)0$(PatchVersion).$(BuildNumber)
+        version=16.0.$(MajorNuGetVersion)0$(MinorNuGetVersion)0$(PatchNuGetVersion).$(BuildNumber)
 
 folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet 
         file source=$(NuGetTargetsPath)

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
@@ -1,7 +1,7 @@
 use vs
 
 package name=Microsoft.VisualStudio.NuGet.BuildTools
-        version=16.0.$(MajorNuGetVersion)0$(MinorNuGetVersion)0$(PatchNuGetVersion).$(BuildNumber)
+        version=$([MSBuild]::Add($(MajorNuGetVersion),11).0.$(MajorNuGetVersion)0$(MinorNuGetVersion)0$(PatchNuGetVersion).$(BuildNumber)
 
 folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet 
         file source=$(NuGetTargetsPath)

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
@@ -1,7 +1,7 @@
 use vs
 
 package name=Microsoft.VisualStudio.NuGet.BuildTools
-        version=15.0.40800.$(BuildNumber)
+        version=16.0.$(MajorVersion)0$(MinorVersion)0$(PatchVersion).$(BuildNumber)
 
 folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet 
         file source=$(NuGetTargetsPath)

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
@@ -1,7 +1,7 @@
 use vs
 
 package name=Microsoft.VisualStudio.NuGet.BuildTools
-        version=$([MSBuild]::Add($(MajorNuGetVersion),11).0.$(MajorNuGetVersion)0$(MinorNuGetVersion)0$(PatchNuGetVersion).$(BuildNumber)
+        version=$(MajorVSVersion).0.$(MajorNuGetVersion)0$(MinorNuGetVersion)0$(PatchNuGetVersion).$(BuildNumber)
 
 folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet 
         file source=$(NuGetTargetsPath)


### PR DESCRIPTION
## Bug

Fixes: 
Regression: Yes 
* Last working version:   4.8.0 was valid. 4.9.0 and all insertion to 5.0 so far, not so much.
* How are we preventing it in future: The fix itself auto updates. There is no manual action needed anymore.

## Fix

Details: 

The changes are self descriptive. 

We want the VSIX version to be:
`$(VSMajorVersion).$(NuGetMajorVersion)0$(NuGetMinorVersion)0$(NuGetPatchVersion).$(BuildNumber)`
This ensure that we never need to change the build tools version ever again and we only need to update the VSMajorVersion bit in the configure script. 

I looked through the VSSDK targets and there didn't seem to be a way to specify the version through msbuild. 

fyi @rainersigwald This will fix the version issue you pinged me about. 
## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
