### PR TITLE
Make NetCoreApp 3.0 map to NetStandard 2.1

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -368,6 +368,11 @@ namespace NuGet.Frameworks
                         CreateStandardMapping(
                             FrameworkConstants.CommonFrameworks.NetCoreApp20,
                             FrameworkConstants.CommonFrameworks.NetStandard20),
+
+                        // NetCoreApp3.0 projects support NetStandard2.1
+                        CreateStandardMapping(
+                            FrameworkConstants.CommonFrameworks.NetCoreApp30,
+                            FrameworkConstants.CommonFrameworks.NetStandard21),
 
                         // net463 projects support NetStandard2.0
                         CreateStandardMapping(

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
@@ -157,6 +157,8 @@ namespace NuGet.Frameworks
                 = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(1, 7, 0, 0));
             public static readonly NuGetFramework NetStandard20
                 = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(2, 0, 0, 0));
+            public static readonly NuGetFramework NetStandard21
+                = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(2, 1, 0, 0));
 
             public static readonly NuGetFramework NetStandardApp15
                 = new NuGetFramework(FrameworkIdentifiers.NetStandardApp, new Version(1, 5, 0, 0));
@@ -174,6 +176,8 @@ namespace NuGet.Frameworks
                 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, new Version(2, 1, 0, 0));
             public static readonly NuGetFramework NetCoreApp22
                 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, new Version(2, 2, 0, 0));
+            public static readonly NuGetFramework NetCoreApp30
+                = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, new Version(3, 0, 0, 0));
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -504,6 +504,10 @@ namespace NuGet.Frameworks
                 case "netstandard20":
                     framework = FrameworkConstants.CommonFrameworks.NetStandard20;
                     break;
+                case "netstandard2.1":
+                case "netstandard21":
+                    framework = FrameworkConstants.CommonFrameworks.NetStandard21;
+                    break;
                 case "netstandardapp1.5":
                 case "netstandardapp15":
                     framework = FrameworkConstants.CommonFrameworks.NetStandardApp15;
@@ -515,6 +519,10 @@ namespace NuGet.Frameworks
                 case "netcoreapp2.0":
                 case "netcoreapp20":
                     framework = FrameworkConstants.CommonFrameworks.NetCoreApp20;
+                    break;
+                case "netcoreapp3.0":
+                case "netcoreapp30":
+                    framework = FrameworkConstants.CommonFrameworks.NetCoreApp30;
                     break;
             }
 

--- a/test/EndToEnd/tests/ServicesTest.ps1
+++ b/test/EndToEnd/tests/ServicesTest.ps1
@@ -574,6 +574,7 @@ function Test-GetNetStandardVersions
     Assert-AreEqual ".NETStandard,Version=v1.6" ($actual | Select-Object -Index 6)
     Assert-AreEqual ".NETStandard,Version=v1.7" ($actual | Select-Object -Index 7)
     Assert-AreEqual ".NETStandard,Version=v2.0" ($actual | Select-Object -Index 8)
+    Assert-AreEqual ".NETStandard,Version=v2.1" ($actual | Select-Object -Index 9)
 }
 
 function Test-GetFrameworksSupportingNetStandard

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsFrameworkCompatibilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsFrameworkCompatibilityTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Runtime.Versioning;
 using Xunit;
@@ -179,7 +179,8 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
             Assert.Equal(".NETStandard,Version=v1.6", actual[6].ToString());
             Assert.Equal(".NETStandard,Version=v1.7", actual[7].ToString());
             Assert.Equal(".NETStandard,Version=v2.0", actual[8].ToString());
-            Assert.Equal(9, actual.Length);
+            Assert.Equal(".NETStandard,Version=v2.1", actual[9].ToString());
+            Assert.Equal(10, actual.Length);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityListProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityListProviderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
@@ -231,6 +231,49 @@ namespace NuGet.Frameworks.Test
 
             // count
             Assert.Equal(19, actual.Length);
+        }
+        [Fact]
+        public void CompatibilityListProvider_NetStandard21Supporting()
+        {
+            // Arrange
+            var provider = CompatibilityListProvider.Default;
+
+            // Act
+            var actual = provider
+                .GetFrameworksSupporting(FrameworkConstants.CommonFrameworks.NetStandard21)
+                .Select(f => f.ToString())
+                .ToArray();
+
+            // Assert
+            // positive
+            Assert.Contains(".NETCoreApp,Version=v3.0", actual);
+            Assert.Contains(".NETStandard,Version=v2.1", actual);
+            Assert.Contains(".NETStandardApp,Version=v2.1", actual);
+
+            // negative
+            Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // only the minimum support version is returned
+            Assert.DoesNotContain(".NETFramework,Version=v4.6", actual); // versions that are too small are not returned
+            Assert.DoesNotContain(".NETPlatform,Version=v5.6", actual); // frameworks with no relationship are not returned
+            Assert.DoesNotContain("DNXCore,Version=v5.0", actual);
+            Assert.DoesNotContain(".NETFramework,Version=v4.6.1", actual);
+            Assert.DoesNotContain("DNX,Version=v4.6.1", actual);
+            Assert.DoesNotContain("MonoAndroid,Version=v0.0", actual);
+            Assert.DoesNotContain("MonoMac,Version=v0.0", actual);
+            Assert.DoesNotContain("MonoTouch,Version=v0.0", actual);
+            Assert.DoesNotContain("Xamarin.iOS,Version=v0.0", actual);
+            Assert.DoesNotContain("Xamarin.Mac,Version=v0.0", actual);
+            Assert.DoesNotContain("Xamarin.PlayStation3,Version=v0.0", actual);
+            Assert.DoesNotContain("Xamarin.PlayStation4,Version=v0.0", actual);
+            Assert.DoesNotContain("Xamarin.PlayStationVita,Version=v0.0", actual);
+            Assert.DoesNotContain("Xamarin.TVOS,Version=v0.0", actual);
+            Assert.DoesNotContain("Xamarin.WatchOS,Version=v0.0", actual);
+            Assert.DoesNotContain("Xamarin.Xbox360,Version=v0.0", actual);
+            Assert.DoesNotContain("Xamarin.XboxOne,Version=v0.0", actual);
+            Assert.DoesNotContain("Tizen,Version=v4.0", actual);
+            Assert.DoesNotContain("UAP,Version=v10.0.15064", actual);
+
+            // count
+            Assert.Equal(3, actual.Length);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityListProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityListProviderTests.cs
@@ -248,19 +248,16 @@ namespace NuGet.Frameworks.Test
             // positive
             Assert.Contains(".NETCoreApp,Version=v3.0", actual);
             Assert.Contains(".NETStandard,Version=v2.1", actual);
-            Assert.Contains(".NETStandardApp,Version=v2.1", actual);
 
             // negative
-            Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // only the minimum support version is returned
-            Assert.DoesNotContain(".NETFramework,Version=v4.6", actual); // versions that are too small are not returned
+            Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // frameworks with no relationship are not returned
             Assert.DoesNotContain(".NETPlatform,Version=v5.6", actual); // frameworks with no relationship are not returned
             Assert.DoesNotContain("DNXCore,Version=v5.0", actual);
-            Assert.DoesNotContain(".NETFramework,Version=v4.6.1", actual);
             Assert.DoesNotContain("DNX,Version=v4.6.1", actual);
             Assert.DoesNotContain("MonoAndroid,Version=v0.0", actual);
             Assert.DoesNotContain("MonoMac,Version=v0.0", actual);
             Assert.DoesNotContain("MonoTouch,Version=v0.0", actual);
-            Assert.DoesNotContain("Xamarin.iOS,Version=v0.0", actual);
+            Assert.DoesNotContain("Xamarin.iOS,Version=v0.0", actual); 
             Assert.DoesNotContain("Xamarin.Mac,Version=v0.0", actual);
             Assert.DoesNotContain("Xamarin.PlayStation3,Version=v0.0", actual);
             Assert.DoesNotContain("Xamarin.PlayStation4,Version=v0.0", actual);

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
@@ -555,7 +555,7 @@ namespace NuGet.Test
         [InlineData("netstandardapp1.5", "win8", false)]
 
         // netcoreapp only supports netstandard
-        [InlineData("netcoreapp9.0", "netstandard2.1", false)]
+        [InlineData("netcoreapp9.0", "netstandard2.1", true)]
         [InlineData("netcoreapp9.0", "netstandard2.0", true)]
         [InlineData("netcoreapp9.0", "netstandard1.7", true)]
         [InlineData("netcoreapp9.0", "netstandard1.6", true)]

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
@@ -555,6 +555,7 @@ namespace NuGet.Test
         [InlineData("netstandardapp1.5", "win8", false)]
 
         // netcoreapp only supports netstandard
+        [InlineData("netcoreapp9.0", "netstandard2.2", false)]
         [InlineData("netcoreapp9.0", "netstandard2.1", true)]
         [InlineData("netcoreapp9.0", "netstandard2.0", true)]
         [InlineData("netcoreapp9.0", "netstandard1.7", true)]

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkNameProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkNameProviderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -34,7 +34,8 @@ namespace NuGet.Test
             Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard16, versions[6]);
             Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard17, versions[7]);
             Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard20, versions[8]);
-            Assert.Equal(9, versions.Length);
+            Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard21, versions[9]);
+            Assert.Equal(10, versions.Length);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
@@ -229,10 +229,12 @@ namespace NuGet.Test
         [InlineData("netstandardapp1.0", ".NETStandardApp,Version=v1.0")]
         [InlineData("netstandardapp1.5", ".NETStandardApp,Version=v1.5")]
         [InlineData("netstandardapp2.0", ".NETStandardApp,Version=v2.0")]
+        [InlineData("netstandardapp2.1", ".NETStandardApp,Version=v2.1")]
         [InlineData("netcoreapp", ".NETCoreApp,Version=v0.0")]
         [InlineData("netcoreapp1.0", ".NETCoreApp,Version=v1.0")]
         [InlineData("netcoreapp1.5", ".NETCoreApp,Version=v1.5")]
         [InlineData("netcoreapp2.0", ".NetCoreApp,Version=v2.0")]
+        [InlineData("netcoreapp3.0", ".NetCoreApp,Version=v3.0")]
         public void NuGetFramework_ParseToShortName(string expected, string fullName)
         {
             // Arrange
@@ -276,11 +278,13 @@ namespace NuGet.Test
         [InlineData("netstandardapp1", ".NETStandardApp,Version=v1.0")]
         [InlineData("netstandardapp1.5", ".NETStandardApp,Version=v1.5")]
         [InlineData("netstandardapp2", ".NETStandardApp,Version=v2.0")]
+        [InlineData("netstandardapp2.1", ".NETStandardApp,Version=v2.1")]
         [InlineData("netcoreapp", ".NETCoreApp,Version=v0.0")]
         [InlineData("netcoreapp0.0", ".NETCoreApp,Version=v0.0")]
         [InlineData("netcoreapp1", ".NETCoreApp,Version=v1.0")]
         [InlineData("netcoreapp1.5", ".NETCoreApp,Version=v1.5")]
         [InlineData("netcoreapp2", ".NETCoreApp,Version=v2.0")]
+        [InlineData("netcoreapp3", ".NETCoreApp,Version=v3.0")]
         public void NuGetFramework_Basic(string folderName, string fullName)
         {
             string output = NuGetFramework.Parse(folderName).DotNetFrameworkName;
@@ -407,6 +411,10 @@ namespace NuGet.Test
         [InlineData("netstandard2.0", "netstandard20")]
         [InlineData("netstandard20", "netstandard2.0")]
         [InlineData("netstandard20", "netstandard20")]
+        [InlineData("netstandard2.1", "netstandard2.1")]
+        [InlineData("netstandard2.1", "netstandard21")]
+        [InlineData("netstandard21", "netstandard2.1")]
+        [InlineData("netstandard21", "netstandard21")]
         [InlineData("netstandardapp1.5", "netstandardapp1.5")]
         [InlineData("netstandardapp1.5", "netstandardapp15")]
         [InlineData("netstandardapp15", "netstandardapp1.5")]
@@ -419,6 +427,10 @@ namespace NuGet.Test
         [InlineData("netcoreapp2.0", "netcoreapp20")]
         [InlineData("netcoreapp20", "netcoreapp2.0")]
         [InlineData("netcoreapp20", "netcoreapp20")]
+        [InlineData("netcoreapp3.0", "netcoreapp3.0")]
+        [InlineData("netcoreapp3.0", "netcoreapp30")]
+        [InlineData("netcoreapp30", "netcoreapp3.0")]
+        [InlineData("netcoreapp30", "netcoreapp30")]
         public void NuGetFramework_TryParseCommonFramework_ParsesCommonFrameworks(string frameworkString1, string frameworkString2)
         {
             var framework1 = NuGetFramework.Parse(frameworkString1);


### PR DESCRIPTION
## Bug

Fixes: [NuGet/Home#7762](https://github.com/NuGet/Home/issues/7762)
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Make NetCoreApp 3.0 map to NetStandard 2.1. 
Updated DefaultFrameworkMappings, FrameworkConstants, NuGetFrameworkFactory and several tests.

## Testing/Validation

Tests Added: Yes 
Reason for not adding tests:  
Validation:  Yes
