### PR TITLE
Fix the Build Tools package generation

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -442,7 +442,7 @@ phases:
   condition: "and(succeeded(),eq(variables['RunTestsOnLinux'], 'true')) "  	
   queue:
     name: DDNuGet-Linux
-    timeoutInMinutes: 45
+    timeoutInMinutes: 60
     demands: sh
 
   steps:
@@ -493,7 +493,7 @@ phases:
   condition: "and(succeeded(),eq(variables['RunTestsOnMac'], 'true')) "  	
   queue:
     name: VSEng-MicroBuildMacSierra
-    timeoutInMinutes: 60
+    timeoutInMinutes: 75
     demands: sh
 
   steps:

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
@@ -18,13 +18,14 @@
     <ReferenceOutputPath>$(ArtifactsDirectory)NuGet.VisualStudio.Client\15.0\bin\$(Configuration)\</ReferenceOutputPath>
     <NuGetTargetsPath>$(RepositoryRootDirectory)src\NuGet.Core\NuGet.Build.Tasks\NuGet.targets</NuGetTargetsPath>
     <XmlTransformPath>$(ArtifactsDirectory)Microsoft.Web.Xdt.2.1.2\lib\net40\</XmlTransformPath>
+    <NewtonsoftJsonPath>$(SolutionPackagesFolder)Newtonsoft.Json.9.0.1\lib\net45\</NewtonsoftJsonPath>
   </PropertyGroup>
 
   <PropertyGroup>
     <!-- Variables added here will be usable in the swr file.  This is a semi colon delimited
           list of name=value items.  Use $(name) in the swr file to reference the variable.
     -->
-    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);ReferenceOutputPath=$(ReferenceOutputPath);NuGetTargetsPath=$(NuGetTargetsPath);XmlTransformPath=$(XmlTransformPath);BuildNumber=$(BuildNumber);MajorNuGetVersion=$(MajorNuGetVersion);MinorNuGetVersion=$(MinorNuGetVersion);PatchNuGetVersion=$(PatchNuGetVersion);MajorVSVersion=$(MajorVSVersion;SolutionPackagesFolder=$(SolutionPackagesFolder)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);ReferenceOutputPath=$(ReferenceOutputPath);NuGetTargetsPath=$(NuGetTargetsPath);XmlTransformPath=$(XmlTransformPath);BuildNumber=$(BuildNumber);MajorNuGetVersion=$(MajorNuGetVersion);MinorNuGetVersion=$(MinorNuGetVersion);PatchNuGetVersion=$(PatchNuGetVersion);MajorVSVersion=$(MajorVSVersion;NewtonsoftJsonPath=$(NewtonsoftJsonPath)</PackagePreprocessorDefinitions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
@@ -24,7 +24,7 @@
     <!-- Variables added here will be usable in the swr file.  This is a semi colon delimited
           list of name=value items.  Use $(name) in the swr file to reference the variable.
     -->
-    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);ReferenceOutputPath=$(ReferenceOutputPath);NuGetTargetsPath=$(NuGetTargetsPath);XmlTransformPath=$(XmlTransformPath);BuildNumber=$(BuildNumber);MajorNuGetVersion=$(MajorNuGetVersion);MinorNuGetVersion=$(MinorNuGetVersion);PatchNuGetVersion=$(PatchNuGetVersion);MajorVSVersion=$(MajorVSVersion)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);ReferenceOutputPath=$(ReferenceOutputPath);NuGetTargetsPath=$(NuGetTargetsPath);XmlTransformPath=$(XmlTransformPath);BuildNumber=$(BuildNumber);MajorNuGetVersion=$(MajorNuGetVersion);MinorNuGetVersion=$(MinorNuGetVersion);PatchNuGetVersion=$(PatchNuGetVersion);MajorVSVersion=$(MajorVSVersion;SolutionPackagesFolder=$(SolutionPackagesFolder)</PackagePreprocessorDefinitions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
@@ -25,7 +25,7 @@
     <!-- Variables added here will be usable in the swr file.  This is a semi colon delimited
           list of name=value items.  Use $(name) in the swr file to reference the variable.
     -->
-    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);ReferenceOutputPath=$(ReferenceOutputPath);NuGetTargetsPath=$(NuGetTargetsPath);XmlTransformPath=$(XmlTransformPath);BuildNumber=$(BuildNumber);MajorNuGetVersion=$(MajorNuGetVersion);MinorNuGetVersion=$(MinorNuGetVersion);PatchNuGetVersion=$(PatchNuGetVersion);MajorVSVersion=$(MajorVSVersion;NewtonsoftJsonPath=$(NewtonsoftJsonPath)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);ReferenceOutputPath=$(ReferenceOutputPath);NuGetTargetsPath=$(NuGetTargetsPath);XmlTransformPath=$(XmlTransformPath);BuildNumber=$(BuildNumber);MajorNuGetVersion=$(MajorNuGetVersion);MinorNuGetVersion=$(MinorNuGetVersion);PatchNuGetVersion=$(PatchNuGetVersion);MajorVSVersion=$(MajorVSVersion);NewtonsoftJsonPath=$(NewtonsoftJsonPath)</PackagePreprocessorDefinitions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
@@ -7,7 +7,7 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet
         file source=$(NuGetTargetsPath)
         file source=$(ReferenceOutputPath)Microsoft.Web.XmlTransform.dll
         file source=$(ReferenceOutputPath)Microsoft.Build.NuGetSdkResolver.dll
-        file source=$(ReferenceOutputPath)Newtonsoft.Json.dll
+        file source=$(SolutionPackagesFolder)Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll
         file source=$(ReferenceOutputPath)NuGet.Build.Tasks.dll  
         file source=$(ReferenceOutputPath)NuGet.Commands.dll  
         file source=$(ReferenceOutputPath)NuGet.Common.dll  

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
@@ -7,7 +7,7 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet
         file source=$(NuGetTargetsPath)
         file source=$(ReferenceOutputPath)Microsoft.Web.XmlTransform.dll
         file source=$(ReferenceOutputPath)Microsoft.Build.NuGetSdkResolver.dll
-        file source=$(SolutionPackagesFolder)Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll
+        file source=$(NewtonsoftJsonPath)Newtonsoft.Json.dll
         file source=$(ReferenceOutputPath)NuGet.Build.Tasks.dll  
         file source=$(ReferenceOutputPath)NuGet.Commands.dll  
         file source=$(ReferenceOutputPath)NuGet.Common.dll  


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7706  
Regression: Yes  
* Last working version:   16.0 P1 - regressed in https://github.com/NuGet/NuGet.Client/pull/2580
* How are we preventing it in future:  We have tests that caught this, they are just not automated unfortunately at this point.

## Fix

Details: 

The newtonsoft.json version in the reference path was bumped up due to dependency changes. 
The newtonsoft.json nuget brings with it is always 9.0.1. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
