### PR TITLE
Make Tizen6 map to NetStandard 2.1

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
@@ -349,6 +349,11 @@ namespace NuGet.Frameworks
                             FrameworkConstants.CommonFrameworks.Tizen4,
                             FrameworkConstants.CommonFrameworks.NetStandard20),
 
+                        // Tizen6 projects support NETStandard2.1
+                        CreateStandardMapping(
+                            FrameworkConstants.CommonFrameworks.Tizen6,
+                            FrameworkConstants.CommonFrameworks.NetStandard21),
+
                         // UAP 10.0.15064.0 projects support NETStandard2.0
                         CreateStandardMapping(
                             new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, new Version(10, 0, 15064, 0)),

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
@@ -107,6 +107,7 @@ namespace NuGet.Frameworks
 
             public static readonly NuGetFramework Tizen3 = new NuGetFramework(FrameworkIdentifiers.Tizen, new Version(3, 0, 0, 0));
             public static readonly NuGetFramework Tizen4 = new NuGetFramework(FrameworkIdentifiers.Tizen, new Version(4, 0, 0, 0));
+            public static readonly NuGetFramework Tizen6 = new NuGetFramework(FrameworkIdentifiers.Tizen, new Version(6, 0, 0, 0));
 
             public static readonly NuGetFramework AspNet = new NuGetFramework(FrameworkIdentifiers.AspNet, EmptyVersion);
             public static readonly NuGetFramework AspNetCore = new NuGetFramework(FrameworkIdentifiers.AspNetCore, EmptyVersion);

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityListProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityListProviderTests.cs
@@ -248,6 +248,7 @@ namespace NuGet.Frameworks.Test
             // positive
             Assert.Contains(".NETCoreApp,Version=v3.0", actual);
             Assert.Contains(".NETStandard,Version=v2.1", actual);
+            Assert.Contains("Tizen,Version=v6.0", actual);
 
             // negative
             Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // frameworks with no relationship are not returned
@@ -257,7 +258,7 @@ namespace NuGet.Frameworks.Test
             Assert.DoesNotContain("MonoAndroid,Version=v0.0", actual);
             Assert.DoesNotContain("MonoMac,Version=v0.0", actual);
             Assert.DoesNotContain("MonoTouch,Version=v0.0", actual);
-            Assert.DoesNotContain("Xamarin.iOS,Version=v0.0", actual); 
+            Assert.DoesNotContain("Xamarin.iOS,Version=v0.0", actual);
             Assert.DoesNotContain("Xamarin.Mac,Version=v0.0", actual);
             Assert.DoesNotContain("Xamarin.PlayStation3,Version=v0.0", actual);
             Assert.DoesNotContain("Xamarin.PlayStation4,Version=v0.0", actual);
@@ -266,11 +267,10 @@ namespace NuGet.Frameworks.Test
             Assert.DoesNotContain("Xamarin.WatchOS,Version=v0.0", actual);
             Assert.DoesNotContain("Xamarin.Xbox360,Version=v0.0", actual);
             Assert.DoesNotContain("Xamarin.XboxOne,Version=v0.0", actual);
-            Assert.DoesNotContain("Tizen,Version=v4.0", actual);
             Assert.DoesNotContain("UAP,Version=v10.0.15064", actual);
 
             // count
-            Assert.Equal(3, actual.Length);
+            Assert.Equal(4, actual.Length);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
@@ -396,7 +396,7 @@ namespace NuGet.Test
         [InlineData("win8", "dotnet5.2", true)]
         [InlineData("win8", "dotnet5.1", true)]
 
-        // tizen3/tizen4 -> netstandard
+        // tizen -> netstandard
         [InlineData("tizen3.0", "netstandard1.7", false)]
         [InlineData("tizen3.0", "netstandard1.6", true)]
         [InlineData("tizen3.0", "netstandard1.5", true)]
@@ -427,6 +427,23 @@ namespace NuGet.Test
         [InlineData("tizen4.0", "dotnet5.3", false)]
         [InlineData("tizen4.0", "dotnet5.2", false)]
         [InlineData("tizen4.0", "dotnet5.1", false)]
+        [InlineData("tizen6.0", "netstandard2.2", false)]
+        [InlineData("tizen6.0", "netstandard2.1", true)]
+        [InlineData("tizen6.0", "netstandard2.0", true)]
+        [InlineData("tizen6.0", "netstandard1.7", true)]
+        [InlineData("tizen6.0", "netstandard1.6", true)]
+        [InlineData("tizen6.0", "netstandard1.5", true)]
+        [InlineData("tizen6.0", "netstandard1.4", true)]
+        [InlineData("tizen6.0", "netstandard1.3", true)]
+        [InlineData("tizen6.0", "netstandard1.2", true)]
+        [InlineData("tizen6.0", "netstandard1.1", true)]
+        [InlineData("tizen6.0", "netstandard1.0", true)]
+        [InlineData("tizen6.0", "dotnet5.6", false)]
+        [InlineData("tizen6.0", "dotnet5.5", false)]
+        [InlineData("tizen6.0", "dotnet5.4", false)]
+        [InlineData("tizen6.0", "dotnet5.3", false)]
+        [InlineData("tizen6.0", "dotnet5.2", false)]
+        [InlineData("tizen6.0", "dotnet5.1", false)]
 
         // Older things don't support dotnet, netstandard, netstandardapp, or netcoreapp at all
         [InlineData("sl4", "netcoreapp1.0", false)]
@@ -595,7 +612,7 @@ namespace NuGet.Test
         [InlineData("netcoreapp1.0", "net4", false)]
         [InlineData("netcoreapp1.0", "win8", false)]
 
-        // UAP 10.0.15064.0 is compatible with netstandard2.0 
+        // UAP 10.0.15064.0 is compatible with netstandard2.0
         [InlineData("uap10.0.15064.0", "netstandard2.0", true)]
         [InlineData("uap10.0.15064.0", "netstandard1.9", true)]
         [InlineData("uap10.0.15064.0", "netstandard1.5", true)]


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7773
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Make Tizen6 map to NetStandard 2.1
Updated DefaultFrameworkMappings, FrameworkConstants and related tests.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  Yes
