### PR TITLE
Fix minimal logging - Add a dotnet restore test

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -239,7 +239,7 @@ namespace NuGet.Commands
             }
 
             DirectoryUtility.CreateSharedDirectory(Path.GetDirectoryName(dgPath));
-            log.LogMinimal($"Persisting no-op dg to {dgPath}");
+            log.LogVerbose($"Persisting no-op dg to {dgPath}");
             spec.Save(dgPath);
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions;
 using NuGet.Common;
@@ -115,6 +117,84 @@ EndGlobal";
                 var args = $"--source \"{packageSourceDirectory.Path}\" ";
 
                 _msbuildFixture.RestoreProject(workingDirectory, projectName, args);
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task DotnetRestore_WarnsForNonRestoreableProjects()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var testDirectory = pathContext.SolutionRoot;
+                var pkgX = new SimpleTestPackageContext("x", "1.0.0");
+                await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, pkgX);
+
+                var projectName1 = "ClassLibrary1";
+                var workingDirectory1 = Path.Combine(testDirectory, projectName1);
+                var projectFile1 = Path.Combine(workingDirectory1, $"{projectName1}.csproj");
+                _msbuildFixture.CreateDotnetNewProject(testDirectory, projectName1, " classlib");
+
+                using (var stream = File.Open(projectFile1, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "net45");
+
+                    var attributes = new Dictionary<string, string>() { { "Version", "1.0.0" } };
+
+                        ProjectFileUtils.AddItem(
+                            xml,
+                            "PackageReference",
+                            "x",
+                            "netstandard1.3",
+                            new Dictionary<string, string>(),
+                            attributes);
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                var slnContents = @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27330.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""ClassLibrary1"", ""ClassLibrary1\ClassLibrary1.csproj"", ""{216FF388-8C16-4AF4-87A8-9094030692FA}""
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{216FF388-8C16-4AF4-87A8-9094030692FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{216FF388-8C16-4AF4-87A8-9094030692FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{216FF388-8C16-4AF4-87A8-9094030692FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{216FF388-8C16-4AF4-87A8-9094030692FA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9A6704E2-6E77-4FF4-9E54-B789D88829DD}
+	EndGlobalSection
+EndGlobal";
+
+                var slnPath = Path.Combine(pathContext.SolutionRoot, "proj.sln");
+                File.WriteAllText(slnPath, slnContents);
+
+                // Act
+                var result = _msbuildFixture.RunDotnet(pathContext.SolutionRoot, $"restore proj.sln {$"--source \"{pathContext.PackageSource}\""}", ignoreExitCode: true);
+
+                // Assert
+                Assert.True(result.Item1 == 0);
+                Assert.Equal(1, result.AllOutput.Split(Environment.NewLine).Length);
+
+                // Act - make sure no-op does the same thing.
+                result = _msbuildFixture.RunDotnet(pathContext.SolutionRoot, $"restore proj.sln {$"--source \"{pathContext.PackageSource}\""}", ignoreExitCode: true);
+
+                // Assert
+                Assert.True(result.Item1 == 0);
+                Assert.Equal(1, result.AllOutput.Split(Environment.NewLine).Length);
+
             }
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -193,7 +193,7 @@ EndGlobal";
 
                 // Assert
                 Assert.True(result.Item1 == 0);
-                Assert.Equal(1, result.AllOutput.Split(Environment.NewLine).Length, result.AllOutput);
+                Assert.True(1 == result.AllOutput.Split(Environment.NewLine).Length, result.AllOutput);
 
             }
         }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -186,14 +186,14 @@ EndGlobal";
 
                 // Assert
                 Assert.True(result.Item1 == 0);
-                Assert.Equal(1, result.AllOutput.Split(Environment.NewLine).Length);
+                Assert.True(1 == result.AllOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Length, result.AllOutput);
 
                 // Act - make sure no-op does the same thing.
                 result = _msbuildFixture.RunDotnet(pathContext.SolutionRoot, $"restore proj.sln {$"--source \"{pathContext.PackageSource}\""}", ignoreExitCode: true);
 
                 // Assert
                 Assert.True(result.Item1 == 0);
-                Assert.True(1 == result.AllOutput.Split(Environment.NewLine).Length, result.AllOutput);
+                Assert.True(1 == result.AllOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Length, result.AllOutput);
 
             }
         }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -121,7 +121,7 @@ EndGlobal";
         }
 
         [PlatformFact(Platform.Windows)]
-        public async Task DotnetRestore_WarnsForNonRestoreableProjects()
+        public async Task DotnetRestore_OneLinePerRestore()
         {
             using (var pathContext = new SimpleTestPathContext())
             {
@@ -193,7 +193,7 @@ EndGlobal";
 
                 // Assert
                 Assert.True(result.Item1 == 0);
-                Assert.Equal(1, result.AllOutput.Split(Environment.NewLine).Length);
+                Assert.Equal(1, result.AllOutput.Split(Environment.NewLine).Length, result.AllOutput);
 
             }
         }


### PR DESCRIPTION
## Bug

Fixes: Follow up to https://github.com/NuGet/NuGet.Client/pull/2577. 
Regression: Yes
* Last working version:   
* How are we preventing it in future:  Better tests.

## Fix

Details: 

There was some extra logging added (inadvertently I assume) in https://github.com/NuGet/NuGet.Client/commit/aee50eaa0dc31a503315ca64d1e8f5a83541b699, but as https://github.com/NuGet/Home/issues/4695 says, we should not have more than 1 line per project per restore. 

Removing that. It definitely does not need to be there. 

//cc @nguerrera This is the verbosity fix issue you raised via e-mail. 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
