### PR TITLE
Consider whether the customer asked for a user version before checking for msbuild/xbuild in the path

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -482,7 +482,7 @@ namespace NuGet.CommandLine
                 }
 
                 // If the userVersion is not specified, favor the value in the $Path Env variable
-                if (!string.IsNullOrEmpty(userVersion))
+                if (string.IsNullOrEmpty(userVersion))
                 {
                     var msbuildExe = GetMSBuild();
 

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -474,6 +474,13 @@ namespace NuGet.CommandLine
 
             try
             {
+                // If Mono, test well known paths and bail if found
+                toolset = GetMsBuildFromMonoPaths(userVersion);
+                if (toolset != null)
+                {
+                    return toolset;
+                }
+
                 // first try from $Path Env variable
                 var msbuildExe = GetMSBuild();
 
@@ -482,13 +489,6 @@ namespace NuGet.CommandLine
                     var msBuildDirectory = Path.GetDirectoryName(msbuildExe);
                     var msbuildVersion = FileVersionInfo.GetVersionInfo(msbuildExe)?.FileVersion;
                     return toolset = new MsBuildToolset(msbuildVersion, msBuildDirectory);
-                }
-
-                // If Mono, test well known paths and bail if found
-                toolset = GetMsBuildFromMonoPaths(userVersion);
-                if (toolset != null)
-                {
-                    return toolset;
                 }
 
                 using (var projectCollection = LoadProjectCollection())

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -481,14 +481,17 @@ namespace NuGet.CommandLine
                     return toolset;
                 }
 
-                // first try from $Path Env variable
-                var msbuildExe = GetMSBuild();
-
-                if (msbuildExe != null)
+                // If the userVersion is not specified, favor the value in the $Path Env variable
+                if (!string.IsNullOrEmpty(userVersion))
                 {
-                    var msBuildDirectory = Path.GetDirectoryName(msbuildExe);
-                    var msbuildVersion = FileVersionInfo.GetVersionInfo(msbuildExe)?.FileVersion;
-                    return toolset = new MsBuildToolset(msbuildVersion, msBuildDirectory);
+                    var msbuildExe = GetMSBuild();
+
+                    if (msbuildExe != null)
+                    {
+                        var msBuildDirectory = Path.GetDirectoryName(msbuildExe);
+                        var msbuildVersion = FileVersionInfo.GetVersionInfo(msbuildExe)?.FileVersion;
+                        return toolset = new MsBuildToolset(msbuildVersion, msBuildDirectory);
+                    }
                 }
 
                 using (var projectCollection = LoadProjectCollection())

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -201,14 +201,15 @@ namespace NuGet.CommandLine.Test
         {
             using (var vsPath = TestDirectory.Create())
             {
+
+                if (RuntimeEnvironmentHelper.IsMono)
+                { // Mono does not have SxS installations so it's not relevant to get msbuild from the path.
+                    return;
+                }
+
                 var msBuild159BinPath = Directory.CreateDirectory(Path.Combine(vsPath, "MSBuild", "15.9", "Bin")).FullName;
 
                 var msBuild159ExePath = Path.Combine(msBuild159BinPath, "msbuild.exe").ToString();
-
-                if (RuntimeEnvironmentHelper.IsMono)
-                {
-                    msBuild159ExePath = Path.Combine(msBuild159BinPath, "msbuild").ToString();
-                }
 
                 using (var fs15 = File.CreateText(msBuild159ExePath))
                 {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -441,7 +441,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(_successCode, r.Item1);
+                Assert.True(_successCode == r.Item1, $"Expected: {_successCode} - Actual: {r.Item1}{Environment.NewLine} {r.AllOutput}");
                 var packageFileA = Path.Combine(workingPath, @"packages", "packageA.1.1.0", "packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, @"packages", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7786
Regression: Yes/No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Consider whether the customer asked for a user version before checking for msbuild/xbuild in the path. 

The mono behavior should be backwards compatible.

fyi @rrelyea 
## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
