### PR TITLE
Tool restore does not mention the csproj on minimal logging

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -279,6 +279,8 @@ namespace NuGet.Commands
             {
                 log.LogMinimal(string.Format(
                     CultureInfo.CurrentCulture,
+                    summaryRequest.Request.ProjectStyle == ProjectStyle.DotnetToolReference ?
+                    Strings.Log_RestoreCompleteDotnetTool :
                     Strings.Log_RestoreComplete,
                     DatetimeUtility.ToReadableTimeFormat(result.ElapsedTime),
                     summaryRequest.InputPath));
@@ -287,6 +289,8 @@ namespace NuGet.Commands
             {
                 log.LogMinimal(string.Format(
                     CultureInfo.CurrentCulture,
+                    summaryRequest.Request.ProjectStyle == ProjectStyle.DotnetToolReference ?
+                    Strings.Log_RestoreFailedDotnetTool :
                     Strings.Log_RestoreFailed,
                     DatetimeUtility.ToReadableTimeFormat(result.ElapsedTime),
                     summaryRequest.InputPath));

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.Commands {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -1196,11 +1196,29 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Restore completed in {0}..
+        /// </summary>
+        internal static string Log_RestoreCompleteDotnetTool {
+            get {
+                return ResourceManager.GetString("Log_RestoreCompleteDotnetTool", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Restore failed in {0} for {1}..
         /// </summary>
         internal static string Log_RestoreFailed {
             get {
                 return ResourceManager.GetString("Log_RestoreFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Restore failed in {0}..
+        /// </summary>
+        internal static string Log_RestoreFailedDotnetTool {
+            get {
+                return ResourceManager.GetString("Log_RestoreFailedDotnetTool", resourceCulture);
             }
         }
         
@@ -1237,15 +1255,6 @@ namespace NuGet.Commands {
         internal static string Log_RestoringPackagesForCompat {
             get {
                 return ResourceManager.GetString("Log_RestoringPackagesForCompat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Restoring packages for tool &apos;{0}&apos; in {1}....
-        /// </summary>
-        internal static string Log_RestoringToolPackages {
-            get {
-                return ResourceManager.GetString("Log_RestoringToolPackages", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -269,12 +269,6 @@
   <data name="Error_InvalidCommandLineInputConfig" xml:space="preserve">
     <value>Invalid input '{0}'. Valid file names are 'packages.config' or 'packages.*.config'.</value>
   </data>
-  <data name="Log_RestoringToolPackages" xml:space="preserve">
-    <value>Restoring packages for tool '{0}' in {1}...</value>
-    <comment>String format parameters:
-{0} is replaced with the tool ID.
-{1} is replaced with a path to the project that is being restored.</comment>
-  </data>
   <data name="Error_UnableToLocateRestoreTarget" xml:space="preserve">
     <value>The folder '{0}' does not contain a project to restore.</value>
   </data>
@@ -870,5 +864,13 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="SuccessfullySynchronizedTrustedRepository" xml:space="preserve">
     <value>Successfully synchronized the trusted repository '{0}'.</value>
     <comment>0 - name</comment>
+  </data>
+  <data name="Log_RestoreCompleteDotnetTool" xml:space="preserve">
+    <value>Restore completed in {0}.</value>
+    <comment>{0} is the restore duration.</comment>
+  </data>
+  <data name="Log_RestoreFailedDotnetTool" xml:space="preserve">
+    <value>Restore failed in {0}.</value>
+    <comment>{0} is the restore duration.</comment>
   </data>
 </root>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetToolTests.cs
@@ -111,6 +111,8 @@ namespace Dotnet.Integration.Test
 
                 // Assert
                 Assert.True(result.Item1 == 0, result.AllOutput);
+                Assert.True(1 == result.AllOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Count(), result.AllOutput);
+                Assert.DoesNotContain("csproj", result.AllOutput); // The output for tool restore should not contain csproj mentions
                 // Verify the assets file
                 var lockFile = LockFileUtilities.GetLockFile(Path.Combine(testDirectory, projectName, "project.assets.json"), NullLogger.Instance);
                 Assert.NotNull(lockFile);


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7647
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
During tool restore we should not mention the csproj on min logging. That's the default experience and we don't want any guid-like names in it. 

fyi @wli3 
@rrelyea Do we want to take this in 5.0 or should we wait for 5.1? 
It's fairly inconsequential so I don't imagine any fall outs from it. 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
