### PR TITLE
Use a shorter path for the plugins cache. On average make it shorter than the http cache.

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheEntry.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheEntry.cs
@@ -25,8 +25,8 @@ namespace NuGet.Protocol.Plugins
         /// <param name="requestKey">A unique request key for the operation claims. Ideally the packageSourceRepository value of the PluginRequestKey. Example https://protected.package.feed/index.json, or Source-Agnostic</param>
         public PluginCacheEntry(string rootCacheFolder, string pluginFilePath, string requestKey)
         {
-            RootFolder = Path.Combine(rootCacheFolder, CachingUtility.RemoveInvalidFileNameChars(CachingUtility.ComputeHash(pluginFilePath)));
-            CacheFileName = Path.Combine(RootFolder, CachingUtility.RemoveInvalidFileNameChars(requestKey) + ".dat");
+            RootFolder = Path.Combine(rootCacheFolder, CachingUtility.RemoveInvalidFileNameChars(CachingUtility.ComputeHash(pluginFilePath, addIdentifiableCharacters: false)));
+            CacheFileName = Path.Combine(RootFolder, CachingUtility.RemoveInvalidFileNameChars(CachingUtility.ComputeHash(requestKey, addIdentifiableCharacters: false)) + ".dat");
             NewCacheFileName = CacheFileName + "-new";
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Properties/AssemblyInfo.cs
@@ -1,6 +1,15 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.CompilerServices;
 
 [assembly: CLSCompliant(true)]
+
+#if SIGNED_BUILD
+[assembly: InternalsVisibleTo("NuGet.Protocol.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+#else
+[assembly: InternalsVisibleTo("NuGet.Protocol.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+#endif

--- a/src/NuGet.Core/NuGet.Protocol/Utility/CachingUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/CachingUtility.cs
@@ -14,11 +14,12 @@ namespace NuGet.Protocol
         public const int BufferSize = 8192;
 
         /// <summary>
-        /// Given a string, it hashes said string and appends identifiable characters to make the root of the cache more human readable
+        /// Given a string, it hashes said string and if <paramref name="addIdentifiableCharacters"/> is true appends identifiable characters to make the root of the cache more human readable
         /// </summary>
         /// <param name="value"></param>
+        /// <param name="addIdentifiableCharacters">whether to addIdentifiableCharacters. The default is true</param>
         /// <returns>hash</returns>
-        public static string ComputeHash(string value)
+        public static string ComputeHash(string value, bool addIdentifiableCharacters = true)
         {
             var trailing = value.Length > 32 ? value.Substring(value.Length - 32) : value;
             byte[] hash;
@@ -28,7 +29,7 @@ namespace NuGet.Protocol
             }
 
             const string hex = "0123456789abcdef";
-            return hash.Aggregate("$" + trailing, (result, ch) => "" + hex[ch / 0x10] + hex[ch % 0x10] + result);
+            return hash.Aggregate(addIdentifiableCharacters ? "$" + trailing : string.Empty, (result, ch) => "" + hex[ch / 0x10] + hex[ch % 0x10] + result);
         }
 
         public static Stream ReadCacheFile(TimeSpan maxAge, string cacheFile)

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGet.Protocol.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGet.Protocol.Tests.csproj
@@ -26,12 +26,6 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="$(SharedDirectory)\EqualityUtility.cs">
-      <Link>EqualityUtility.cs</Link>
-    </Compile>
-  </ItemGroup>
   
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCacheEntryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCacheEntryTests.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading.Tasks;
 using NuGet.Protocol.Plugins;
 using NuGet.Shared;
@@ -82,7 +80,9 @@ namespace NuGet.Protocol.Tests.Plugins
                 entry.OperationClaims = list;
                 await entry.UpdateCacheFileAsync();
 
-                var CacheFileName = Path.Combine(Path.Combine(testDirectory.Path, CachingUtility.RemoveInvalidFileNameChars(CachingUtility.ComputeHash("a"))), CachingUtility.RemoveInvalidFileNameChars("b") + ".dat");
+                var CacheFileName = Path.Combine(
+                    Path.Combine(testDirectory.Path, CachingUtility.RemoveInvalidFileNameChars(CachingUtility.ComputeHash("a", false))),
+                    CachingUtility.RemoveInvalidFileNameChars(CachingUtility.ComputeHash("b", false)) + ".dat");
 
                 Assert.True(File.Exists(CacheFileName));
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCacheEntryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCacheEntryTests.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 using NuGet.Protocol.Plugins;
 using NuGet.Shared;
@@ -22,6 +24,24 @@ namespace NuGet.Protocol.Tests.Plugins
                 var entry = new PluginCacheEntry(testDirectory.Path, "a", "b");
                 entry.LoadFromFile();
                 Assert.Null(entry.OperationClaims);
+            }
+        }
+
+        [Fact]
+        public void PluginCacheEntry_UsesShorterPaths()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var pluginPath = @"C:\Users\Roki2\.nuget\plugins\netfx\CredentialProvider.Microsoft\CredentialProvider.Microsoft.exe";
+                var url = @"https:\\nugetsspecialfeed.pkgs.visualstudio.com\packaging\ea8caa50-9cf8-4ed7-b410-5bca3b71ec1c\nuget\v3\index.json";
+
+                var entry = new PluginCacheEntry(testDirectory.Path, pluginPath, url);
+                entry.LoadFromFile();
+
+                Assert.Equal(86, entry.CacheFileName.Length - testDirectory.Path.Length);
+                // This makes it about as long as http cache which is more important.
+                // The http cache is 40 + 1 + [1,32] + packageName
+                Assert.True(200 > entry.CacheFileName.Length, "The cache file should be short");
             }
         }
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7770
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

Have the plugins cache path length be deterministic. 
Use only the sha1 hash rather than including identifiable strings. 
While the identifiable strings are nice they are not important. 

Could potentially consider only 1 identifiable string (either plugin or source name), as that would make it a comparable length as the http cache. 

The http and plugins cache file path lengths compares as follows: 

http cache - 
RootNuGetDir + SHA1 of Url + $ + first 32 chars of URL + dir separator + packageName + .dat
RootNuGetDir.Length + 40 + 1 + Min(Url.Length,32) + 1 + packageName.Count + 4
plugins cache - 
RootNuGetDir+ PluginName SHA1 + Directory Separator + Source SHA1 + .dat 
RootNuGetDir.Length + 40 + 1 + 40 + 4

The average feed name is longer than 32, for example https://api.nuget.org/v3/index.json is 35 chars. 
While I don't dare to guess what the average package name is, I think it's safe to suggest that it's more than 8 characters. 

This is not a good fix. In an ideal world, the locking would be attempted on a shorter path and the cache itself just not written, but that can kind of fall back is challenging and risky to implement for 5.0

//cc @zarenner

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
