### PR TITLE
Interactive does not take any arguments

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/DeleteCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/DeleteCommand.cs
@@ -54,7 +54,7 @@ namespace NuGet.CommandLine.XPlat
                 var interactive = delete.Option(
                     "--interactive",
                     Strings.NuGetXplatCommand_Interactive,
-                    CommandOptionType.SingleValue);
+                    CommandOptionType.NoValue);
 
                 delete.OnExecute(async () =>
                 {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
@@ -83,7 +83,7 @@ namespace NuGet.CommandLine.XPlat
                 var interactive = listpkg.Option(
                     "--interactive",
                     Strings.NuGetXplatCommand_Interactive,
-                    CommandOptionType.SingleValue);
+                    CommandOptionType.NoValue);
 
                 listpkg.OnExecute(async () =>
                 {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
@@ -74,7 +74,7 @@ namespace NuGet.CommandLine.XPlat
                 var interactive = push.Option(
                     "--interactive",
                     Strings.NuGetXplatCommand_Interactive,
-                    CommandOptionType.SingleValue);
+                    CommandOptionType.NoValue);
 
                 push.OnExecute(async () =>
                 {

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -1,0 +1,84 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.CommandLineUtils;
+using Moq;
+using NuGet.CommandLine.XPlat;
+using NuGet.Protocol;
+using Xunit;
+
+namespace NuGet.XPlat.FuncTest
+{
+    [Collection("NuGet XPlat Test Collection")]
+    public class ListPackageTests
+    {
+
+        [Fact]
+        public void BasicListPackageParsing_Interactive()
+        {
+            // Arrange
+            var projectPath = Path.Combine(Path.GetTempPath(), "project.csproj");
+            File.Create(projectPath).Dispose();
+
+            var argList = new List<string>() {
+                "list",
+                "--interactive",
+                projectPath};
+
+            var logger = new TestCommandOutputLogger();
+            var testApp = new CommandLineApplication();
+            var mockCommandRunner = new Mock<IListPackageCommandRunner>();
+            mockCommandRunner
+                .Setup(m => m.ExecuteCommandAsync(It.IsAny<ListPackageArgs>()))
+                .Returns(Task.CompletedTask);
+
+            testApp.Name = "dotnet nuget_test";
+            ListPackageCommand.Register(testApp,
+                () => logger,
+                () => mockCommandRunner.Object);
+
+            // Act
+            var result = testApp.Execute(argList.ToArray());
+
+            XPlatTestUtils.DisposeTemporaryFile(projectPath);
+
+            // Assert
+            mockCommandRunner.Verify();
+            Assert.NotNull(HttpHandlerResourceV3.CredentialService);
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void BasicListPackageParsing_InteractiveTakesNoArguments()
+        {
+            // Arrange
+            var projectPath = Path.Combine(Path.GetTempPath(), "project.csproj");
+            File.Create(projectPath).Dispose();
+
+
+            var argList = new List<string>() {
+                "list",
+                "--interactive",
+                "no",
+                projectPath};
+
+            var logger = new TestCommandOutputLogger();
+            var testApp = new CommandLineApplication();
+            var mockCommandRunner = new Mock<IListPackageCommandRunner>();
+            mockCommandRunner
+                .Setup(m => m.ExecuteCommandAsync(It.IsAny<ListPackageArgs>()))
+                .Returns(Task.CompletedTask);
+
+            testApp.Name = "dotnet nuget_test";
+            ListPackageCommand.Register(testApp,
+                () => logger,
+                () => mockCommandRunner.Object);
+
+            // Act
+            Assert.Throws<CommandParsingException>(() => testApp.Execute(argList.ToArray()));
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatPushTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatPushTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -38,7 +38,8 @@ namespace NuGet.XPlat.FuncTest
                     "--source",
                     packageSource.Source,
                     "--api-key",
-                    apiKey
+                    apiKey,
+                    "--interactive"
                 };
 
                 // Act


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7800
Regression: Bug in new feature.
* Last working version:   
* How are we preventing it in future:  Adding tests

## Fix

Details: Interactive should not be taking any arguments. 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
