### PR TITLE
Fix flaky plugin discovery test

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscovererTests.cs
@@ -69,7 +69,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public async Task DiscoverAsync_DoesNotThrowIfNoValidFilePathsAndFallbackEmbeddedSignatureVerifier()
         {
             using (var discoverer = new PluginDiscoverer(
-                rawPluginPaths: "",
+                rawPluginPaths: ";",
                 verifier: new FallbackEmbeddedSignatureVerifier()))
             {
                 var pluginFiles = await discoverer.DiscoverAsync(CancellationToken.None);


### PR DESCRIPTION
## Bug

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/790678
Regression: Yes
* Last working version:   https://github.com/NuGet/NuGet.Client/pull/2202
* How are we preventing it in future:   It's a test, it will stop failing.

## Fix

Details: Fixes the flaky test in the plugin discoverer tests.
Prior to https://github.com/NuGet/NuGet.Client/pull/2202, the only way the V2 plugins could be discovered was an Env Var. 

Now that convention based discovery is available, sometimes the plugin discovery mechanism would find those plugins on the machine and break this test. 

This change bypasses the discovery of built in plugins, by providing a nearly "empty" plugins path. 

https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs#L147

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
