### PR TITLE
Add component governance to our build

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -223,6 +223,10 @@ phases:
     displayName: Verify Assembly Signatures and StrongName
     inputs:
       TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
+  
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'
+    condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
   - task: CopyFiles@2
     displayName: "Copy Nupkgs"


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7635
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

Adding component governance validation to our build. 

It's raising some alerts (mostly tests), which will be addressed in the future. 

Right now we have to manually go to https://devdiv.visualstudio.com/DevDiv/_componentGovernance/ and search for our repository, look at the branch act on the alerts. 

For now it's manual work, in the future we can work with the CG team to get better integration. 

The compliance/security tenet owner should be the one in charge of this. 

Any time someone adds a new dependency, 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
