### PR TITLE
Fix help for "Source" parameter in nuget push

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -1814,7 +1814,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specifies the server URL..
+        ///   Looks up a localized string similar to Package source (URL, UNC/folder path or package source name) to delete from. Defaults to DefaultPushSource if specified in NuGet.Config..
         /// </summary>
         internal static string DeleteCommandSourceDescription {
             get {
@@ -9015,7 +9015,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specifies the server URL. If not specified, nuget.org is used unless DefaultPushSource config value is set in the NuGet config file..
+        ///   Looks up a localized string similar to Package source (URL, UNC/folder path or package source name) to push to. Defaults to DefaultPushSource if specified in NuGet.Config..
         /// </summary>
         internal static string PushCommandSourceDescription {
             get {
@@ -9141,7 +9141,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specifies the symbol server URL. If not specified, nuget.smbsrc.net is used when pushing to nuget.org..
+        ///   Looks up a localized string similar to Symbol server URL to push to..
         /// </summary>
         internal static string PushCommandSymbolSourceDescription {
             get {
@@ -9150,7 +9150,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specifies the timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes)..
+        ///   Looks up a localized string similar to Timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes)..
         /// </summary>
         internal static string PushCommandTimeoutDescription {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -143,7 +143,7 @@ nuget config HTTP_PROXY</value>
     <value>Do not prompt when deleting.</value>
   </data>
   <data name="DeleteCommandSourceDescription" xml:space="preserve">
-    <value>Specifies the server URL.</value>
+    <value>Package source (URL, UNC/folder path or package source name) to delete from. Defaults to DefaultPushSource if specified in NuGet.Config.</value>
   </data>
   <data name="DeleteCommandUsageDescription" xml:space="preserve">
     <value>Specify the Id and version of the package to delete from the server.</value>
@@ -324,14 +324,14 @@ nuget pack foo.nuspec -Version 2.1.0</value>
     <value>Pushes a package to the server and publishes it.</value>
   </data>
   <data name="PushCommandSourceDescription" xml:space="preserve">
-    <value>Specifies the server URL. If not specified, nuget.org is used unless DefaultPushSource config value is set in the NuGet config file.</value>
+    <value>Package source (URL, UNC/folder path or package source name) to push to. Defaults to DefaultPushSource if specified in NuGet.Config.</value>
     <comment>Please don't localize "DefaultPushSource"</comment>
   </data>
   <data name="PushCommandSymbolSourceDescription" xml:space="preserve">
-    <value>Specifies the symbol server URL. If not specified, nuget.smbsrc.net is used when pushing to nuget.org.</value>
+    <value>Symbol server URL to push to.</value>
   </data>
   <data name="PushCommandTimeoutDescription" xml:space="preserve">
-    <value>Specifies the timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes).</value>
+    <value>Timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes).</value>
   </data>
   <data name="PushCommandUsageDescription" xml:space="preserve">
     <value>Specify the path to the package and your API key to push the package to the server.</value>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -1203,7 +1203,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specifies the timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes)..
+        ///   Looks up a localized string similar to Timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes)..
         /// </summary>
         internal static string Push_Timeout_Description {
             get {
@@ -1374,7 +1374,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specifies the server URL.
+        ///   Looks up a localized string similar to Package source (URL, UNC/folder path or package source name) to use. Defaults to DefaultPushSource if specified in NuGet.Config..
         /// </summary>
         internal static string Source_Description {
             get {
@@ -1509,7 +1509,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specifies the symbol server URL. If not specified, nuget.smbsrc.net is used when pushing to nuget.org..
+        ///   Looks up a localized string similar to Symbol server URL to use..
         /// </summary>
         internal static string SymbolSource_Description {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -178,7 +178,7 @@
     <value>Specify the path to the package and your API key to push the package to the server.</value>
   </data>
   <data name="Push_Timeout_Description" xml:space="preserve">
-    <value>Specifies the timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes).</value>
+    <value>Timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes).</value>
   </data>
   <data name="Restore_Arg_ProjectName_Description" xml:space="preserve">
     <value>List of projects and project folders to restore. Each value can be: a path to a project.json or global.json file, or a folder to recursively search for project.json files.</value>
@@ -202,7 +202,7 @@
     <value>Specifies a NuGet package source to use during the restore.</value>
   </data>
   <data name="Source_Description" xml:space="preserve">
-    <value>Specifies the server URL</value>
+    <value>Package source (URL, UNC/folder path or package source name) to use. Defaults to DefaultPushSource if specified in NuGet.Config.</value>
   </data>
   <data name="Switch_Verbosity" xml:space="preserve">
     <value>The verbosity of logging to use. Allowed values: Debug, Verbose, Information, Minimal, Warning, Error.</value>
@@ -299,7 +299,7 @@
     <value>Sets the nuspec serviceable element to true.</value>
   </data>
   <data name="SymbolSource_Description" xml:space="preserve">
-    <value>Specifies the symbol server URL. If not specified, nuget.smbsrc.net is used when pushing to nuget.org.</value>
+    <value>Symbol server URL to use.</value>
   </data>
   <data name="SymbolApiKey_Description" xml:space="preserve">
     <value>The API key for the symbol server.</value>


### PR DESCRIPTION
This fixes NuGet/Home#9265. The `Source` parameter was still not documented properly within the command line help.

I’ve used [the text from docs.microsoft.com](https://github.com/NuGet/docs.microsoft.com-nuget/blob/3b09f7a0bf3893451f9da001640609c7b307a925/docs/tools/cli-ref-push.md) for this.