### PR TITLE
Fix issue casing issue with GeneratePathProperty

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -501,7 +501,7 @@ namespace NuGet.Commands
                 var projectGraph = targetGraph.Graphs.FirstOrDefault();
 
                 // Distinct union of tool packages and packages with GeneratePathProperty=true
-                var packageIdsToCreatePropertiesFor = packagesWithTools.Union(projectGraph.Item.Data.Dependencies.Where(i => i.GeneratePathProperty).Select(i => i.Name)).Distinct(StringComparer.OrdinalIgnoreCase);
+                var packageIdsToCreatePropertiesFor = new HashSet<string>(packagesWithTools.Union(projectGraph.Item.Data.Dependencies.Where(i => i.GeneratePathProperty).Select(i => i.Name)), StringComparer.OrdinalIgnoreCase);
 
                 var localPackages = sortedPackages.Select(e => e.Value);
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -656,7 +656,7 @@ namespace NuGet.Commands.Test
                 {
                     GeneratePathProperty = true,
                     IncludeType = LibraryIncludeFlags.All,
-                    LibraryRange = new LibraryRange(identity.Id, new VersionRange(identity.Version), LibraryDependencyTarget.Package)
+                    LibraryRange = new LibraryRange(identity.Id.ToUpperInvariant(), new VersionRange(identity.Version), LibraryDependencyTarget.Package)
                 });
 
                 var targetGraphs = new List<RestoreTargetGraph>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7843
Regression: No  

## Fix

Details: Use a case insenstive `HashSet<string>` instead of an `IEnumerable<string>`.  This removes the need to change the case comparison and should improve performance.  I didn't catch the fact that the Linq query was being executed a lot of times.  

## Testing/Validation
Tests Added: Yes

