### PR TITLE
Run coreFunct,coreUnit,UnitTests,ApexTests depending on VSVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
     `git clone https://github.com/NuGet/NuGet.Client`
 
-2. Start PowerShell. CD into the cloned repository directory.
+2. Start Develooper Command Prompt for VS. Then, start PowerShell and navigate into the cloned repository directory:
+
+    ```shell
+    powershell
+    cd path\to\NuGet.Client
+    ```
 
 3. Run configuration script
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
     `git clone https://github.com/NuGet/NuGet.Client`
 
-2. Start Develooper Command Prompt for VS. Then, start PowerShell and navigate into the cloned repository directory:
-
-    ```shell
-    powershell
-    cd path\to\NuGet.Client
-    ```
+2. Start PowerShell. CD into the cloned repository directory.
 
 3. Run configuration script
 

--- a/build/build.proj
+++ b/build/build.proj
@@ -37,7 +37,7 @@
     <PropertyGroup>
       <TestProjectPaths>@(CoreFuncTestProjects)</TestProjectPaths>
       <TestResultsFileName>CoreFuncTests</TestResultsFileName>
-      <TestVisualStudioVersion>15.0</TestVisualStudioVersion>
+      <TestVisualStudioVersion>$(VisualStudioVersion)</TestVisualStudioVersion>
     </PropertyGroup>
 
     <!-- Run tests as a batch -->
@@ -63,7 +63,7 @@
     <PropertyGroup>
       <TestProjectPaths>@(CoreUnitTestProjects)</TestProjectPaths>
       <TestResultsFileName>CoreUnitTests</TestResultsFileName>
-      <TestVisualStudioVersion>15.0</TestVisualStudioVersion>
+      <TestVisualStudioVersion>$(VisualStudioVersion)</TestVisualStudioVersion>
     </PropertyGroup>
 
     <!-- Run tests as a batch -->
@@ -89,7 +89,7 @@
     <PropertyGroup>
       <TestProjectPaths>@(VSUnitTestProjects)</TestProjectPaths>
       <TestResultsFileName>UnitTestsVS15</TestResultsFileName>
-      <TestVisualStudioVersion>15.0</TestVisualStudioVersion>
+      <TestVisualStudioVersion>$(VisualStudioVersion)</TestVisualStudioVersion>
     </PropertyGroup>
 
     <!-- Run tests as a batch -->
@@ -116,7 +116,7 @@
     <PropertyGroup>
       <TestProjectPaths>$(RepositoryRootDirectory)test\NuGet.Tests.Apex\NuGet.Tests.Apex\NuGet.Tests.Apex.csproj</TestProjectPaths>
       <TestResultsFileName>ApexTestsVS15</TestResultsFileName>
-      <TestVisualStudioVersion>15.0</TestVisualStudioVersion>
+      <TestVisualStudioVersion>$(VisualStudioVersion)</TestVisualStudioVersion>
     </PropertyGroup>
 
     <!-- Run tests as a batch -->

--- a/build/build.proj
+++ b/build/build.proj
@@ -116,7 +116,7 @@
     <PropertyGroup>
       <TestProjectPaths>$(RepositoryRootDirectory)test\NuGet.Tests.Apex\NuGet.Tests.Apex\NuGet.Tests.Apex.csproj</TestProjectPaths>
       <TestResultsFileName>ApexTestsVS15</TestResultsFileName>
-      <TestVisualStudioVersion>$(VisualStudioVersion)</TestVisualStudioVersion>
+      <TestVisualStudioVersion>15.0</TestVisualStudioVersion>
     </PropertyGroup>
 
     <!-- Run tests as a batch -->

--- a/build/build.proj
+++ b/build/build.proj
@@ -37,7 +37,6 @@
     <PropertyGroup>
       <TestProjectPaths>@(CoreFuncTestProjects)</TestProjectPaths>
       <TestResultsFileName>CoreFuncTests</TestResultsFileName>
-      <TestVisualStudioVersion>$(VisualStudioVersion)</TestVisualStudioVersion>
     </PropertyGroup>
 
     <!-- Run tests as a batch -->
@@ -45,7 +44,6 @@
         Projects="$(MSBuildThisFileFullPath)"
         Targets="RunTestsOnProjects"
         Properties="$(CommonMSBuildProperties);
-                    VisualStudioVersion=$(TestVisualStudioVersion);
                     TestResultsFileName=$(TestResultsFileName);
                     TestProjectPaths=$(TestProjectPaths)">
       <Output TaskParameter="TargetOutputs"
@@ -63,7 +61,6 @@
     <PropertyGroup>
       <TestProjectPaths>@(CoreUnitTestProjects)</TestProjectPaths>
       <TestResultsFileName>CoreUnitTests</TestResultsFileName>
-      <TestVisualStudioVersion>$(VisualStudioVersion)</TestVisualStudioVersion>
     </PropertyGroup>
 
     <!-- Run tests as a batch -->
@@ -71,7 +68,6 @@
         Projects="$(MSBuildThisFileFullPath)"
         Targets="RunTestsOnProjects"
         Properties="$(CommonMSBuildProperties);
-                    VisualStudioVersion=$(TestVisualStudioVersion);
                     TestResultsFileName=$(TestResultsFileName);
                     TestProjectPaths=$(TestProjectPaths)">
       <Output TaskParameter="TargetOutputs"
@@ -89,7 +85,6 @@
     <PropertyGroup>
       <TestProjectPaths>@(VSUnitTestProjects)</TestProjectPaths>
       <TestResultsFileName>UnitTestsVS15</TestResultsFileName>
-      <TestVisualStudioVersion>$(VisualStudioVersion)</TestVisualStudioVersion>
     </PropertyGroup>
 
     <!-- Run tests as a batch -->
@@ -97,7 +92,6 @@
         Projects="$(MSBuildThisFileFullPath)"
         Targets="RunTestsOnProjects"
         Properties="$(CommonMSBuildProperties);
-                    VisualStudioVersion=$(TestVisualStudioVersion);
                     TestResultsFileName=$(TestResultsFileName);
                     TestProjectPaths=$(TestProjectPaths)">
       <Output TaskParameter="TargetOutputs"
@@ -116,7 +110,6 @@
     <PropertyGroup>
       <TestProjectPaths>$(RepositoryRootDirectory)test\NuGet.Tests.Apex\NuGet.Tests.Apex\NuGet.Tests.Apex.csproj</TestProjectPaths>
       <TestResultsFileName>ApexTestsVS15</TestResultsFileName>
-      <TestVisualStudioVersion>$(VisualStudioVersion)</TestVisualStudioVersion>
     </PropertyGroup>
 
     <!-- Run tests as a batch -->
@@ -124,7 +117,6 @@
         Projects="$(MSBuildThisFileFullPath)"
         Targets="RunTestsOnProjects"
         Properties="$(CommonMSBuildProperties);
-                    VisualStudioVersion=$(TestVisualStudioVersion);
                     TestResultsFileName=$(TestResultsFileName);
                     TestProjectPaths=$(TestProjectPaths);
                     Verbosity=-verbose">

--- a/build/build.proj
+++ b/build/build.proj
@@ -116,7 +116,7 @@
     <PropertyGroup>
       <TestProjectPaths>$(RepositoryRootDirectory)test\NuGet.Tests.Apex\NuGet.Tests.Apex\NuGet.Tests.Apex.csproj</TestProjectPaths>
       <TestResultsFileName>ApexTestsVS15</TestResultsFileName>
-      <TestVisualStudioVersion>15.0</TestVisualStudioVersion>
+      <TestVisualStudioVersion>$(VisualStudioVersion)</TestVisualStudioVersion>
     </PropertyGroup>
 
     <!-- Run tests as a batch -->


### PR DESCRIPTION
## Bug

When you run .\build.ps1, unit tests don't run. This is a PR for fix that. 

Fixes: https://github.com/NuGet/Home/issues/7898
Regression: No
* Last working version: 
* How are we preventing it in future: Using more

## Fix

The basic idea is to update the VS version variable in the build\build.proj file.

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
