### PR TITLE
Improve the plugin startup error message

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace NuGet.Protocol {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace NuGet.Protocol {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -40,7 +39,7 @@ namespace NuGet.Protocol {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.Protocol.Strings", typeof(Strings).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.Protocol.Strings", typeof(Strings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -778,6 +777,15 @@ namespace NuGet.Protocol {
         internal static string Plugin_PackageDownloadFailed {
             get {
                 return ResourceManager.GetString("Plugin_PackageDownloadFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Problem starting the plugin  &apos;{0}&apos;. {1}.
+        /// </summary>
+        internal static string Plugin_ProblemStartingPlugin {
+            get {
+                return ResourceManager.GetString("Plugin_ProblemStartingPlugin", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -517,6 +517,6 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
   </data>
   <data name="Plugin_ProblemStartingPlugin" xml:space="preserve">
     <value>Problem starting the plugin  '{0}'. {1}</value>
-    <comment>0 - plugin path, 1 - </comment>
+    <comment>0 - plugin path, 1 - error message </comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -515,4 +515,8 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
   <data name="Plugin_DownloadNotSupportedSinceUnsignedNotAllowed" xml:space="preserve">
     <value>Downloading a package from a plugin is not supported since unsigned packages are not allowed and package download plugins do not support signed package verification.</value>
   </data>
+  <data name="Plugin_ProblemStartingPlugin" xml:space="preserve">
+    <value>Problem starting the plugin  '{0}'. {1}</value>
+    <comment>0 - plugin path, 1 - </comment>
+  </data>
 </root>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7857
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Motivation coming from #7845.

We should not crash the process when an exception happens during the plugin creation.

We will terminate the process regardless, but the error message should be clearer.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  E2E tests for the plugins are not a covered scenario in our automation. 
Validation:  
