### PR TITLE
Can nuget client build in a linux environment? If not ,why?

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -19,7 +19,7 @@
     <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">$(CliBranchForTesting);release/2.1.6xx</SdkTargetBranches>
     <!-- We need to update this netcoreassembly build number with every milestone to workaround any breaking api
     changes we might have made-->
-    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">5</NetCoreAssemblyBuildNumber>
+    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">6</NetCoreAssemblyBuildNumber>
     <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">rtm</ReleaseLabel>
   </PropertyGroup>
 


### PR DESCRIPTION
I am happy that microsoft can open the source code of nuget, powershell, etc.
I want to build nuget client in a linux environment, but it seems that there is no way to build it in linux. Could you tell me how could I build it in linux?
If it can't be build in linux, tell me the reason，OK?