### PR TITLE
Plugins:  enable diagnostic logging

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Connection.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Connection.cs
@@ -79,7 +79,7 @@ namespace NuGet.Protocol.Plugins
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="receiver" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="options" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
-        public Connection(IMessageDispatcher dispatcher, ISender sender, IReceiver receiver, ConnectionOptions options, IPluginLogger logger)
+        internal Connection(IMessageDispatcher dispatcher, ISender sender, IReceiver receiver, ConnectionOptions options, IPluginLogger logger)
         {
             if (dispatcher == null)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Connection.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Connection.cs
@@ -16,6 +16,7 @@ namespace NuGet.Protocol.Plugins
         private bool _isDisposed;
         private readonly IReceiver _receiver;
         private readonly ISender _sender;
+        private readonly IPluginLogger _logger;
 
         private int _state = (int)ConnectionState.ReadyToConnect;
 
@@ -61,6 +62,24 @@ namespace NuGet.Protocol.Plugins
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="receiver" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="options" /> is <c>null</c>.</exception>
         public Connection(IMessageDispatcher dispatcher, ISender sender, IReceiver receiver, ConnectionOptions options)
+            : this(dispatcher, sender, receiver, options, PluginLogger.DefaultInstance)
+        {
+        }
+
+        /// <summary>
+        /// Instantiates a new instance of the <see cref="Connection" /> class.
+        /// </summary>
+        /// <param name="dispatcher">A message dispatcher.</param>
+        /// <param name="sender">A sender.</param>
+        /// <param name="receiver">A receiver.</param>
+        /// <param name="options">Connection options.</param>
+        /// <param name="logger">A plugin logger.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="dispatcher" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="sender" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="receiver" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="options" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
+        public Connection(IMessageDispatcher dispatcher, ISender sender, IReceiver receiver, ConnectionOptions options, IPluginLogger logger)
         {
             if (dispatcher == null)
             {
@@ -82,10 +101,16 @@ namespace NuGet.Protocol.Plugins
                 throw new ArgumentNullException(nameof(options));
             }
 
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
             MessageDispatcher = dispatcher;
             _sender = sender;
             _receiver = receiver;
             Options = options;
+            _logger = logger;
 
             MessageDispatcher.SetConnection(this);
         }
@@ -102,6 +127,8 @@ namespace NuGet.Protocol.Plugins
                 _receiver.Dispose();
                 _sender.Dispose();
                 MessageDispatcher.Dispose();
+
+                // Do not dispose of _logger.  This connection does not own it.
 
                 GC.SuppressFinalize(this);
 
@@ -215,7 +242,17 @@ namespace NuGet.Protocol.Plugins
                 throw new InvalidOperationException(Strings.Plugin_NotConnected);
             }
 
+            if (_logger.IsEnabled)
+            {
+                _logger.Write(new CommunicationsLogMessage(message.RequestId, message.Method, message.Type, MessageState.Sending));
+            }
+
             await _sender.SendAsync(message, cancellationToken);
+
+            if (_logger.IsEnabled)
+            {
+                _logger.Write(new CommunicationsLogMessage(message.RequestId, message.Method, message.Type, MessageState.Sent));
+            }
         }
 
         /// <summary>
@@ -257,6 +294,11 @@ namespace NuGet.Protocol.Plugins
 
         private void OnMessageReceived(object sender, MessageEventArgs e)
         {
+            if (_logger.IsEnabled)
+            {
+                _logger.Write(new CommunicationsLogMessage(e.Message.RequestId, e.Message.Method, e.Message.Type, MessageState.Received));
+            }
+
             MessageReceived?.Invoke(this, e);
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/ConnectionOptions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/ConnectionOptions.cs
@@ -13,9 +13,6 @@ namespace NuGet.Protocol.Plugins
     /// </summary>
     public sealed class ConnectionOptions
     {
-        private const string _handshakeTimeoutEnvironmentVariable = "NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS";
-        private const string _requestTimeoutEnvironmentVariable = "NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS";
-
         /// <summary>
         /// Gets the plugin handshake timeout.
         /// </summary>
@@ -136,8 +133,8 @@ namespace NuGet.Protocol.Plugins
         {
             reader = reader ?? new EnvironmentVariableWrapper();
 
-            var handshakeTimeoutInSeconds = reader.GetEnvironmentVariable(_handshakeTimeoutEnvironmentVariable);
-            var requestTimeoutInSeconds = reader.GetEnvironmentVariable(_requestTimeoutEnvironmentVariable);
+            var handshakeTimeoutInSeconds = reader.GetEnvironmentVariable(EnvironmentVariableConstants.HandshakeTimeout);
+            var requestTimeoutInSeconds = reader.GetEnvironmentVariable(EnvironmentVariableConstants.RequestTimeout);
 
             var handshakeTimeout = TimeoutUtilities.GetTimeout(handshakeTimeoutInSeconds, ProtocolConstants.HandshakeTimeout);
             var requestTimeout = TimeoutUtilities.GetTimeout(requestTimeoutInSeconds, ProtocolConstants.RequestTimeout);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/EnvironmentVariableConstants.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/EnvironmentVariableConstants.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Protocol.Plugins
+{
+    internal static class EnvironmentVariableConstants
+    {
+        internal const string EnableLog = "NUGET_PLUGIN_ENABLE_LOG";
+        internal const string HandshakeTimeout = "NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS";
+        internal const string IdleTimeout = "NUGET_PLUGIN_IDLE_TIMEOUT_IN_SECONDS";
+        internal const string PluginPaths = "NUGET_PLUGIN_PATHS";
+        internal const string RequestTimeout = "NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS";
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestContext.cs
@@ -16,6 +16,7 @@ namespace NuGet.Protocol.Plugins
         private readonly CancellationTokenSource _cancellationTokenSource;
         private readonly IConnection _connection;
         private bool _isDisposed;
+        private readonly IPluginLogger _logger;
 
         /// <summary>
         /// Gets the request ID.
@@ -36,6 +37,28 @@ namespace NuGet.Protocol.Plugins
             IConnection connection,
             string requestId,
             CancellationToken cancellationToken)
+            : this(connection, requestId, cancellationToken, PluginLogger.DefaultInstance)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="InboundRequestContext" /> class.
+        /// </summary>
+        /// <param name="connection">A connection.</param>
+        /// <param name="requestId">A request ID.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <param name="logger">A plugin logger.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="connection" />
+        /// is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="requestId" />
+        /// is either <c>null</c> or an empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
+        /// is <c>null</c>.</exception>
+        public InboundRequestContext(
+            IConnection connection,
+            string requestId,
+            CancellationToken cancellationToken,
+            IPluginLogger logger)
         {
             if (connection == null)
             {
@@ -47,6 +70,11 @@ namespace NuGet.Protocol.Plugins
                 throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(requestId));
             }
 
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
             _connection = connection;
             RequestId = requestId;
 
@@ -55,6 +83,8 @@ namespace NuGet.Protocol.Plugins
             // Capture the cancellation token now because if the cancellation token source
             // is disposed race conditions may cause an exception acccessing its Token property.
             _cancellationToken = _cancellationTokenSource.Token;
+
+            _logger = logger;
         }
 
         /// <summary>
@@ -78,7 +108,7 @@ namespace NuGet.Protocol.Plugins
             {
             }
 
-            // Do not dispose of _connection.
+            // Do not dispose of _connection or _logger.  This context does not own them.
 
             GC.SuppressFinalize(this);
 
@@ -113,11 +143,21 @@ namespace NuGet.Protocol.Plugins
                 request.Method,
                 JsonSerializationUtilities.FromObject(responsePayload));
 
+            if (_logger.IsEnabled)
+            {
+                _logger.Write(new TaskLogMessage(response.RequestId, response.Method, response.Type, TaskState.Queued));
+            }
+
             Task.Run(async () =>
                 {
                     // Top-level exception handler for a worker pool thread.
                     try
                     {
+                        if (_logger.IsEnabled)
+                        {
+                            _logger.Write(new TaskLogMessage(response.RequestId, response.Method, response.Type, TaskState.Executing));
+                        }
+
                         await _connection.SendAsync(response, _cancellationToken);
                     }
                     catch (Exception)
@@ -159,11 +199,21 @@ namespace NuGet.Protocol.Plugins
                 throw new ArgumentNullException(nameof(responseHandler));
             }
 
+            if (_logger.IsEnabled)
+            {
+                _logger.Write(new TaskLogMessage(request.RequestId, request.Method, request.Type, TaskState.Queued));
+            }
+
             Task.Run(async () =>
                 {
                     // Top-level exception handler for a worker pool thread.
                     try
                     {
+                        if (_logger.IsEnabled)
+                        {
+                            _logger.Write(new TaskLogMessage(request.RequestId, request.Method, request.Type, TaskState.Executing));
+                        }
+
                         await requestHandler.HandleResponseAsync(
                             _connection,
                             request,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestContext.cs
@@ -54,7 +54,7 @@ namespace NuGet.Protocol.Plugins
         /// is either <c>null</c> or an empty string.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
         /// is <c>null</c>.</exception>
-        public InboundRequestContext(
+        internal InboundRequestContext(
             IConnection connection,
             string requestId,
             CancellationToken cancellationToken,
@@ -163,6 +163,13 @@ namespace NuGet.Protocol.Plugins
                     catch (Exception)
                     {
                     }
+                    finally
+                    {
+                        if (_logger.IsEnabled)
+                        {
+                            _logger.Write(new TaskLogMessage(response.RequestId, response.Method, response.Type, TaskState.Completed));
+                        }
+                    }
                 },
                 _cancellationToken);
         }
@@ -229,6 +236,13 @@ namespace NuGet.Protocol.Plugins
                     catch (Exception ex)
                     {
                         BeginFaultAsync(request, ex);
+                    }
+                    finally
+                    {
+                        if (_logger.IsEnabled)
+                        {
+                            _logger.Write(new TaskLogMessage(request.RequestId, request.Method, request.Type, TaskState.Completed));
+                        }
                     }
                 },
                 _cancellationToken);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/AssemblyLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/AssemblyLogMessage.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.Protocol.Plugins
+{
+    internal sealed class AssemblyLogMessage : PluginLogMessage
+    {
+        private readonly string _fileVersion;
+        private readonly string _fullName;
+        private readonly string _informationalVersion;
+
+        internal AssemblyLogMessage()
+        {
+            var assembly = typeof(PluginFactory).Assembly;
+            var informationalVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            var fileVersionAttribute = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
+
+            _fullName = assembly.FullName;
+
+            if (fileVersionAttribute != null)
+            {
+                _fileVersion = fileVersionAttribute.Version;
+            }
+
+            if (informationalVersionAttribute != null)
+            {
+                _informationalVersion = informationalVersionAttribute.InformationalVersion;
+            }
+        }
+
+        public override string ToString()
+        {
+            var message = new JObject(new JProperty("assembly full name", _fullName));
+
+            if (!string.IsNullOrEmpty(_fileVersion))
+            {
+                message.Add("file version", _fileVersion);
+            }
+
+            if (!string.IsNullOrEmpty(_informationalVersion))
+            {
+                message.Add("informational version", _informationalVersion);
+            }
+
+            return ToString("assembly", message);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/CommunicationsLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/CommunicationsLogMessage.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.Protocol.Plugins
+{
+    internal sealed class CommunicationsLogMessage : PluginLogMessage
+    {
+        private readonly MessageMethod _method;
+        private readonly string _requestId;
+        private readonly MessageState _state;
+        private readonly MessageType _type;
+
+        internal CommunicationsLogMessage(string requestId, MessageMethod method, MessageType type, MessageState state)
+        {
+            _requestId = requestId;
+            _method = method;
+            _type = type;
+            _state = state;
+        }
+
+        public override string ToString()
+        {
+            var message = new JObject(
+                new JProperty("request ID", _requestId),
+                new JProperty("method", _method),
+                new JProperty("type", _type),
+                new JProperty("state", _state));
+
+            return ToString("communications", message);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/IPluginLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/IPluginLogMessage.cs
@@ -1,0 +1,9 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Protocol.Plugins
+{
+    public interface IPluginLogMessage
+    {
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/IPluginLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/IPluginLogMessage.cs
@@ -3,7 +3,7 @@
 
 namespace NuGet.Protocol.Plugins
 {
-    public interface IPluginLogMessage
+    internal interface IPluginLogMessage
     {
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/IPluginLogger.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/IPluginLogger.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Protocol.Plugins
+{
+    public interface IPluginLogger : IDisposable
+    {
+        bool IsEnabled { get; }
+
+        void Write(IPluginLogMessage message);
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/IPluginLogger.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/IPluginLogger.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace NuGet.Protocol.Plugins
 {
-    public interface IPluginLogger : IDisposable
+    internal interface IPluginLogger : IDisposable
     {
         bool IsEnabled { get; }
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/MachineLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/MachineLogMessage.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.Protocol.Plugins
+{
+    internal sealed class MachineLogMessage : PluginLogMessage
+    {
+        private readonly int _logicalProcessorCount;
+
+        internal MachineLogMessage()
+        {
+            _logicalProcessorCount = Environment.ProcessorCount;
+        }
+
+        public override string ToString()
+        {
+            var message = new JObject(new JProperty("logical processor count", _logicalProcessorCount));
+
+            return ToString("machine", message);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/MessageState.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/MessageState.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Protocol.Plugins
+{
+    internal enum MessageState
+    {
+        Sending,
+        Sent,
+        Received,
+        Cancelled
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogMessage.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.Protocol.Plugins
+{
+    internal abstract class PluginLogMessage : IPluginLogMessage
+    {
+        private static readonly StringEnumConverter _enumConverter = new StringEnumConverter();
+
+        protected string ToString(string type, JObject message)
+        {
+            if (string.IsNullOrEmpty(type))
+            {
+                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(type));
+            }
+
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            var outerMessage = new JObject(
+                new JProperty("now", DateTime.UtcNow.ToString("O")), // round-trip format
+                new JProperty("type", type),
+                new JProperty("message", message));
+
+            return outerMessage.ToString(Formatting.None, _enumConverter);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogger.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogger.cs
@@ -1,0 +1,106 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using NuGet.Common;
+
+namespace NuGet.Protocol.Plugins
+{
+    internal sealed class PluginLogger : IPluginLogger
+    {
+        private bool _isDisposed;
+        private readonly Lazy<StreamWriter> _streamWriter;
+        private readonly object _streamWriterLock;
+
+        internal static PluginLogger DefaultInstance { get; } = new PluginLogger(new EnvironmentVariableWrapper());
+
+        public bool IsEnabled { get; }
+
+        internal PluginLogger(IEnvironmentVariableReader environmentVariableReader)
+        {
+            if (environmentVariableReader == null)
+            {
+                throw new ArgumentNullException(nameof(environmentVariableReader));
+            }
+
+            var value = environmentVariableReader.GetEnvironmentVariable(EnvironmentVariableConstants.EnableLog);
+
+            IsEnabled = bool.TryParse(value, out var enable) && enable;
+
+            _streamWriter = new Lazy<StreamWriter>(CreateStreamWriter);
+            _streamWriterLock = new object();
+        }
+
+        public void Dispose()
+        {
+            if (!_isDisposed)
+            {
+                if (_streamWriter.IsValueCreated)
+                {
+                    _streamWriter.Value.Dispose();
+                }
+
+                GC.SuppressFinalize(this);
+                _isDisposed = true;
+            }
+        }
+
+        public void Write(IPluginLogMessage message)
+        {
+            if (!IsEnabled)
+            {
+                return;
+            }
+
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(PluginLogger));
+            }
+
+            if (message == null)
+            {
+                throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(message));
+            }
+
+            lock (_streamWriterLock)
+            {
+                _streamWriter.Value.WriteLine(message.ToString());
+            }
+        }
+
+        private StreamWriter CreateStreamWriter()
+        {
+            if (IsEnabled)
+            {
+                FileInfo file;
+
+                using (var process = Process.GetCurrentProcess())
+                {
+                    file = new FileInfo(process.MainModule.FileName);
+                }
+
+                var fileName = $"NuGet_PluginLogFor_{Path.GetFileNameWithoutExtension(file.Name)}.log";
+                var stream = File.OpenWrite(fileName);
+
+                try
+                {
+                    var streamWriter = new StreamWriter(stream);
+
+                    streamWriter.AutoFlush = true;
+
+                    return streamWriter;
+                }
+                catch (Exception)
+                {
+                    stream.Dispose();
+
+                    throw;
+                }
+            }
+
+            return StreamWriter.Null;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/TaskLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/TaskLogMessage.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.Protocol.Plugins
+{
+    internal sealed class TaskLogMessage : PluginLogMessage
+    {
+        private readonly MessageMethod _method;
+        private readonly string _requestId;
+        private readonly TaskState _state;
+        private readonly MessageType _type;
+
+        internal TaskLogMessage(string requestId, MessageMethod method, MessageType type, TaskState state)
+        {
+            _requestId = requestId;
+            _method = method;
+            _type = type;
+            _state = state;
+        }
+
+        public override string ToString()
+        {
+            var message = new JObject(
+                new JProperty("request ID", _requestId),
+                new JProperty("method", _method),
+                new JProperty("type", _type),
+                new JProperty("state", _state));
+
+            return ToString("task", message);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/TaskState.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/TaskState.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Protocol.Plugins
+{
+    internal enum TaskState
+    {
+        Queued,
+        Executing
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/TaskState.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/TaskState.cs
@@ -6,6 +6,7 @@ namespace NuGet.Protocol.Plugins
     internal enum TaskState
     {
         Queued,
-        Executing
+        Executing,
+        Completed
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/ThreadPoolLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/ThreadPoolLogMessage.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.Protocol.Plugins
+{
+    internal sealed class ThreadPoolLogMessage : PluginLogMessage
+    {
+        private readonly int _maxCompletionPortThreads;
+        private readonly int _maxWorkerThreads;
+        private readonly int _minCompletionPortThreads;
+        private readonly int _minWorkerThreads;
+
+        internal ThreadPoolLogMessage()
+        {
+            ThreadPool.GetMinThreads(out _minWorkerThreads, out _minCompletionPortThreads);
+            ThreadPool.GetMaxThreads(out _maxWorkerThreads, out _maxCompletionPortThreads);
+        }
+
+        public override string ToString()
+        {
+            var message = new JObject(
+                new JProperty("worker thread minimum count", _minWorkerThreads),
+                new JProperty("worker thread maximum count", _maxWorkerThreads),
+                new JProperty("completion port thread minimum count", _minCompletionPortThreads),
+                new JProperty("completion port thread maximum count", _maxCompletionPortThreads));
+
+            return ToString("thread pool", message);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
@@ -20,6 +20,7 @@ namespace NuGet.Protocol.Plugins
         private bool _isClosed;
         private bool _isDisposed;
         private readonly ConcurrentDictionary<string, InboundRequestContext> _inboundRequestContexts;
+        private readonly IPluginLogger _logger;
         private readonly ConcurrentDictionary<string, OutboundRequestContext> _outboundRequestContexts;
 
         /// <summary>
@@ -37,6 +38,22 @@ namespace NuGet.Protocol.Plugins
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="idGenerator" />
         /// is <c>null</c>.</exception>
         public MessageDispatcher(IRequestHandlers requestHandlers, IIdGenerator idGenerator)
+            : this(requestHandlers, idGenerator, PluginLogger.DefaultInstance)
+        {
+        }
+
+        /// <summary>
+        /// Instantiates a new <see cref="MessageDispatcher" /> class.
+        /// </summary>
+        /// <param name="requestHandlers">Request handlers.</param>
+        /// <param name="idGenerator">A unique identifier generator.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="requestHandlers" />
+        /// is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="idGenerator" />
+        /// is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
+        /// is <c>null</c>.</exception>
+        public MessageDispatcher(IRequestHandlers requestHandlers, IIdGenerator idGenerator, IPluginLogger logger)
         {
             if (requestHandlers == null)
             {
@@ -48,8 +65,14 @@ namespace NuGet.Protocol.Plugins
                 throw new ArgumentNullException(nameof(idGenerator));
             }
 
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
             RequestHandlers = requestHandlers;
             _idGenerator = idGenerator;
+            _logger = logger;
 
             _inboundRequestContexts = new ConcurrentDictionary<string, InboundRequestContext>();
             _outboundRequestContexts = new ConcurrentDictionary<string, OutboundRequestContext>();
@@ -68,6 +91,8 @@ namespace NuGet.Protocol.Plugins
             Close();
 
             SetConnection(connection: null);
+
+            // Do not dispose of _logger.  This message dispatcher does not own it.
 
             GC.SuppressFinalize(this);
 
@@ -458,6 +483,11 @@ namespace NuGet.Protocol.Plugins
                     }
                     catch (OperationCanceledException) when (requestContext.CancellationToken.IsCancellationRequested)
                     {
+                        if (_logger.IsEnabled)
+                        {
+                            _logger.Write(new CommunicationsLogMessage(message.RequestId, message.Method, message.Type, MessageState.Cancelled));
+                        }
+
                         // Keep the request context around if cancellation was requested.
                         // A race condition exists where after sending a cancellation request,
                         // we could receive a response (which was in flight) or a cancellation
@@ -668,7 +698,8 @@ namespace NuGet.Protocol.Plugins
             return new InboundRequestContext(
                 _connection,
                 message.RequestId,
-                cancellationToken);
+                cancellationToken,
+                _logger);
         }
 
         private OutboundRequestContext<TIncoming> CreateOutboundRequestContext<TIncoming>(
@@ -682,7 +713,8 @@ namespace NuGet.Protocol.Plugins
                 message,
                 timeout,
                 isKeepAlive,
-                cancellationToken);
+                cancellationToken,
+                _logger);
         }
 
         private static bool GetIsKeepAlive(IConnection connection, MessageType type, MessageMethod method)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
@@ -53,7 +53,7 @@ namespace NuGet.Protocol.Plugins
         /// is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
         /// is <c>null</c>.</exception>
-        public MessageDispatcher(IRequestHandlers requestHandlers, IIdGenerator idGenerator, IPluginLogger logger)
+        internal MessageDispatcher(IRequestHandlers requestHandlers, IIdGenerator idGenerator, IPluginLogger logger)
         {
             if (requestHandlers == null)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext`1.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext`1.cs
@@ -21,6 +21,7 @@ namespace NuGet.Protocol.Plugins
         private bool _isClosed;
         private bool _isDisposed;
         private bool _isKeepAlive;
+        private readonly IPluginLogger _logger;
         private readonly Message _request;
         private readonly TaskCompletionSource<TResult> _taskCompletionSource;
         private readonly TimeSpan? _timeout;
@@ -52,6 +53,35 @@ namespace NuGet.Protocol.Plugins
             TimeSpan? timeout,
             bool isKeepAlive,
             CancellationToken cancellationToken)
+            : this(connection, request, timeout, isKeepAlive, cancellationToken, PluginLogger.DefaultInstance)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="OutboundRequestContext{TResult}" /> class.
+        /// </summary>
+        /// <param name="connection">A connection.</param>
+        /// <param name="request">A request.</param>
+        /// <param name="timeout">An optional request timeout.</param>
+        /// <param name="isKeepAlive">A flag indicating whether or not the request supports progress notifications
+        /// to reset the request timeout.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <param name="logger">A plugin logger.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="connection" />
+        /// is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" />
+        /// is <c>null</c>.</exception>
+        /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
+        /// is cancelled.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
+        /// is <c>null</c>.</exception>
+        public OutboundRequestContext(
+            IConnection connection,
+            Message request,
+            TimeSpan? timeout,
+            bool isKeepAlive,
+            CancellationToken cancellationToken,
+            IPluginLogger logger)
         {
             if (connection == null)
             {
@@ -61,6 +91,11 @@ namespace NuGet.Protocol.Plugins
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
             }
 
             _connection = connection;
@@ -80,6 +115,8 @@ namespace NuGet.Protocol.Plugins
             }
 
             _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            _logger = logger;
 
             _cancellationTokenSource.Token.Register(TryCancel);
 
@@ -170,7 +207,7 @@ namespace NuGet.Protocol.Plugins
             {
                 Close();
 
-                // Do not dispose of _connection.
+                // Do not dispose of _connection or _logger.  This context does not own them.
             }
 
             _isDisposed = true;
@@ -215,11 +252,21 @@ namespace NuGet.Protocol.Plugins
             {
                 if (Interlocked.CompareExchange(ref _isCancellationRequested, value: 1, comparand: 0) == 0)
                 {
+                    if (_logger.IsEnabled)
+                    {
+                        _logger.Write(new TaskLogMessage(_request.RequestId, _request.Method, MessageType.Cancel, TaskState.Queued));
+                    }
+
                     Task.Run(async () =>
                     {
                         // Top-level exception handler for a worker pool thread.
                         try
                         {
+                            if (_logger.IsEnabled)
+                            {
+                                _logger.Write(new TaskLogMessage(_request.RequestId, _request.Method, MessageType.Cancel, TaskState.Executing));
+                            }
+
                             await _connection.MessageDispatcher.DispatchCancelAsync(_request, CancellationToken.None);
                         }
                         catch (Exception)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext`1.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext`1.cs
@@ -75,7 +75,7 @@ namespace NuGet.Protocol.Plugins
         /// is cancelled.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
         /// is <c>null</c>.</exception>
-        public OutboundRequestContext(
+        internal OutboundRequestContext(
             IConnection connection,
             Message request,
             TimeSpan? timeout,
@@ -271,6 +271,13 @@ namespace NuGet.Protocol.Plugins
                         }
                         catch (Exception)
                         {
+                        }
+                        finally
+                        {
+                            if (_logger.IsEnabled)
+                            {
+                                _logger.Write(new TaskLogMessage(_request.RequestId, _request.Method, MessageType.Cancel, TaskState.Completed));
+                            }
                         }
                     });
                 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
@@ -6,7 +6,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,9 +26,6 @@ namespace NuGet.Protocol.Core.Types
     {
         private static readonly Lazy<IPluginManager> Lazy = new Lazy<IPluginManager>(() => new PluginManager());
         public static IPluginManager Instance => Lazy.Value;
-
-        private const string _idleTimeoutEnvironmentVariable = "NUGET_PLUGIN_IDLE_TIMEOUT_IN_SECONDS";
-        private const string _pluginPathsEnvironmentVariable = "NUGET_PLUGIN_PATHS";
 
         private ConnectionOptions _connectionOptions;
         private Lazy<IPluginDiscoverer> _discoverer;
@@ -291,11 +287,11 @@ namespace NuGet.Protocol.Core.Types
                 throw new ArgumentNullException(nameof(pluginFactoryCreator));
             }
 
-            _rawPluginPaths = reader.GetEnvironmentVariable(_pluginPathsEnvironmentVariable);
+            _rawPluginPaths = reader.GetEnvironmentVariable(EnvironmentVariableConstants.PluginPaths);
 
             _connectionOptions = ConnectionOptions.CreateDefault(reader);
 
-            var idleTimeoutInSeconds = EnvironmentVariableReader.GetEnvironmentVariable(_idleTimeoutEnvironmentVariable);
+            var idleTimeoutInSeconds = EnvironmentVariableReader.GetEnvironmentVariable(EnvironmentVariableConstants.IdleTimeout);
             var idleTimeout = TimeoutUtilities.GetTimeout(idleTimeoutInSeconds, PluginConstants.IdleTimeout);
 
             _pluginFactory = pluginFactoryCreator(idleTimeout);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/ConnectionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/ConnectionTests.cs
@@ -17,33 +17,27 @@ namespace NuGet.Protocol.Plugins.Tests
         [Fact]
         public void Constructor_ThrowsForNullDispatcher()
         {
-            using (var cancellationTokenSource = new CancellationTokenSource())
-            {
-                var exception = Assert.Throws<ArgumentNullException>(
-                    () => new Connection(
-                        dispatcher: null,
-                        sender: new Sender(TextWriter.Null),
-                        receiver: new StandardInputReceiver(TextReader.Null),
-                        options: ConnectionOptions.CreateDefault()));
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new Connection(
+                    dispatcher: null,
+                    sender: new Sender(TextWriter.Null),
+                    receiver: new StandardInputReceiver(TextReader.Null),
+                    options: ConnectionOptions.CreateDefault()));
 
-                Assert.Equal("dispatcher", exception.ParamName);
-            }
+            Assert.Equal("dispatcher", exception.ParamName);
         }
 
         [Fact]
         public void Constructor_ThrowsForNullSender()
         {
-            using (var cancellationTokenSource = new CancellationTokenSource())
-            {
-                var exception = Assert.Throws<ArgumentNullException>(
-                    () => new Connection(
-                        new MessageDispatcher(new RequestHandlers(), new RequestIdGenerator()),
-                        sender: null,
-                        receiver: new StandardInputReceiver(TextReader.Null),
-                        options: ConnectionOptions.CreateDefault()));
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new Connection(
+                    new MessageDispatcher(new RequestHandlers(), new RequestIdGenerator()),
+                    sender: null,
+                    receiver: new StandardInputReceiver(TextReader.Null),
+                    options: ConnectionOptions.CreateDefault()));
 
-                Assert.Equal("sender", exception.ParamName);
-            }
+            Assert.Equal("sender", exception.ParamName);
         }
 
         [Fact]
@@ -61,17 +55,28 @@ namespace NuGet.Protocol.Plugins.Tests
         [Fact]
         public void Constructor_ThrowsForNullOptions()
         {
-            using (var cancellationTokenSource = new CancellationTokenSource())
-            {
-                var exception = Assert.Throws<ArgumentNullException>(
-                    () => new Connection(
-                        new MessageDispatcher(new RequestHandlers(), new RequestIdGenerator()),
-                        new Sender(TextWriter.Null),
-                        new StandardInputReceiver(TextReader.Null),
-                        options: null));
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new Connection(
+                    new MessageDispatcher(new RequestHandlers(), new RequestIdGenerator()),
+                    new Sender(TextWriter.Null),
+                    new StandardInputReceiver(TextReader.Null),
+                    options: null));
 
-                Assert.Equal("options", exception.ParamName);
-            }
+            Assert.Equal("options", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_ThrowsForNullLogger()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new Connection(
+                    new MessageDispatcher(new RequestHandlers(), new RequestIdGenerator()),
+                    new Sender(TextWriter.Null),
+                    new StandardInputReceiver(TextReader.Null),
+                    ConnectionOptions.CreateDefault(),
+                    logger: null));
+
+            Assert.Equal("logger", exception.ParamName);
         }
 
         [Fact]
@@ -571,12 +576,14 @@ namespace NuGet.Protocol.Plugins.Tests
         {
             internal Connection Connection { get; }
             internal Mock<IMessageDispatcher> Dispatcher { get; }
+            internal Mock<IPluginLogger> Logger { get; }
             internal Mock<ISender> Sender { get; }
             internal Mock<IReceiver> Receiver { get; }
 
             internal MockConnectionTest()
             {
                 Dispatcher = new Mock<IMessageDispatcher>(MockBehavior.Strict);
+                Logger = new Mock<IPluginLogger>(MockBehavior.Strict);
                 Sender = new Mock<ISender>(MockBehavior.Strict);
                 Receiver = new Mock<IReceiver>(MockBehavior.Strict);
 
@@ -592,7 +599,8 @@ namespace NuGet.Protocol.Plugins.Tests
                     Dispatcher.Object,
                     Sender.Object,
                     Receiver.Object,
-                    ConnectionOptions.CreateDefault());
+                    ConnectionOptions.CreateDefault(),
+                    Logger.Object);
             }
 
             public void Dispose()
@@ -600,6 +608,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 Connection.Dispose();
 
                 Dispatcher.Verify();
+                Logger.Verify(); // The logger should not be disposed.  The lack of a call to Setup(...) verifies this.
                 Sender.Verify();
                 Receiver.Verify();
             }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/AssemblyLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/AssemblyLogMessageTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using Xunit;
+
+namespace NuGet.Protocol.Plugins.Tests
+{
+    public class AssemblyLogMessageTests : LogMessageTests
+    {
+        [Fact]
+        public void ToString_ReturnsJson()
+        {
+            var logMessage = new AssemblyLogMessage();
+
+            var message = VerifyOuterMessageAndReturnInnerMessage(logMessage, "assembly");
+
+            Assert.Equal(3, message.Count);
+
+            var actualAssemblyFullName = message.Value<string>("assembly full name");
+            var actualFileVersion = message.Value<string>("file version");
+            var actualInformationalVersion = message.Value<string>("informational version");
+
+            GetExpectedValues(
+                out var expectedAssemblyFullName,
+                out var expectedFileVersion,
+                out var expectedActualInformationalVersion);
+
+            Assert.Equal(expectedAssemblyFullName, actualAssemblyFullName);
+            Assert.Equal(expectedFileVersion, actualFileVersion);
+            Assert.Equal(expectedActualInformationalVersion, actualInformationalVersion);
+        }
+
+        private static void GetExpectedValues(
+            out object expectedAssemblyFullName,
+            out object expectedFileVersion,
+            out object expectedActualInformationalVersion)
+        {
+            var assembly = typeof(PluginFactory).Assembly;
+            var informationalVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            var fileVersionAttribute = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
+
+            expectedAssemblyFullName = assembly.FullName;
+            expectedFileVersion = fileVersionAttribute.Version;
+            expectedActualInformationalVersion = informationalVersionAttribute.InformationalVersion;
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/CommunicationsLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/CommunicationsLogMessageTests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace NuGet.Protocol.Plugins.Tests
+{
+    public class CommunicationsLogMessageTests : LogMessageTests
+    {
+        [Fact]
+        public void ToString_ReturnsJson()
+        {
+            const string requestId = "a";
+            const MessageMethod method = MessageMethod.GetOperationClaims;
+            const MessageType type = MessageType.Request;
+            const MessageState state = MessageState.Sent;
+
+            var logMessage = new CommunicationsLogMessage(requestId, method, type, state);
+
+            var message = VerifyOuterMessageAndReturnInnerMessage(logMessage, "communications");
+
+            Assert.Equal(4, message.Count);
+
+            var actualRequestId = message.Value<string>("request ID");
+            var actualMethod = Enum.Parse(typeof(MessageMethod), message.Value<string>("method"));
+            var actualType = Enum.Parse(typeof(MessageType), message.Value<string>("type"));
+            var actualState = Enum.Parse(typeof(MessageState), message.Value<string>("state"));
+
+            Assert.Equal(requestId, actualRequestId);
+            Assert.Equal(method, actualMethod);
+            Assert.Equal(type, actualType);
+            Assert.Equal(state, actualState);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/LogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/LogMessageTests.cs
@@ -16,7 +16,7 @@ namespace NuGet.Protocol.Plugins.Tests
             DateParseHandling = DateParseHandling.None
         };
 
-        protected JObject VerifyOuterMessageAndReturnInnerMessage(IPluginLogMessage logMessage, string expectedType)
+        internal JObject VerifyOuterMessageAndReturnInnerMessage(IPluginLogMessage logMessage, string expectedType)
         {
             var json = logMessage.ToString();
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/LogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/LogMessageTests.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace NuGet.Protocol.Plugins.Tests
+{
+    public abstract class LogMessageTests
+    {
+        private static readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings()
+        {
+            DateParseHandling = DateParseHandling.None
+        };
+
+        protected JObject VerifyOuterMessageAndReturnInnerMessage(IPluginLogMessage logMessage, string expectedType)
+        {
+            var json = logMessage.ToString();
+
+            var actualResult = JsonConvert.DeserializeObject<JObject>(json, _jsonSettings);
+
+            Assert.Equal(3, actualResult.Count);
+
+            var actualNow = actualResult.Value<string>("now");
+
+            Verify(actualNow);
+
+            var actualType = actualResult.Value<string>("type");
+
+            Assert.Equal(expectedType, actualType);
+
+            var message = actualResult.Value<JObject>("message");
+
+            Assert.NotNull(message);
+
+            return message;
+        }
+
+        private void Verify(string actualNowString)
+        {
+            var actualNow = DateTime.Parse(actualNowString, provider: null, styles: DateTimeStyles.RoundtripKind);
+            var utcNow = DateTime.UtcNow;
+
+            Assert.Equal(DateTimeKind.Utc, actualNow.Kind);
+            Assert.InRange(actualNow, utcNow.AddMinutes(-1), utcNow);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/MachineLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/MachineLogMessageTests.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace NuGet.Protocol.Plugins.Tests
+{
+    public class MachineLogMessageTests : LogMessageTests
+    {
+        [Fact]
+        public void ToString_ReturnsJson()
+        {
+            var logMessage = new MachineLogMessage();
+
+            var message = VerifyOuterMessageAndReturnInnerMessage(logMessage, "machine");
+
+            Assert.Equal(1, message.Count);
+
+            var actualLogicalProcessorCount = message.Value<int>("logical processor count");
+
+            Assert.Equal(Environment.ProcessorCount, actualLogicalProcessorCount);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/PluginLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/PluginLoggerTests.cs
@@ -1,0 +1,152 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Moq;
+using NuGet.Common;
+using Xunit;
+
+namespace NuGet.Protocol.Plugins.Tests
+{
+    public class PluginLoggerTests
+    {
+        [Fact]
+        public void Constructor_WhenEnvironmentVariableReaderIsNull_Throws()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => new PluginLogger(environmentVariableReader: null));
+
+            Assert.Equal("environmentVariableReader", exception.ParamName);
+        }
+
+        [Fact]
+        public void IsEnabled_WhenLoggingIsNotEnabled_ReturnsTrue()
+        {
+            var environmentVariableReader = CreateEnvironmentVariableReaderMock(isLoggingEnabled: false);
+
+            using (var logger = new PluginLogger(environmentVariableReader.Object))
+            {
+                Assert.False(logger.IsEnabled);
+            }
+
+            environmentVariableReader.VerifyAll();
+        }
+
+        [Fact]
+        public void IsEnabled_WhenLoggingIsEnabled_ReturnsTrue()
+        {
+            var environmentVariableReader = CreateEnvironmentVariableReaderMock(isLoggingEnabled: true);
+
+            using (var logger = new PluginLogger(environmentVariableReader.Object))
+            {
+                Assert.True(logger.IsEnabled);
+            }
+
+            environmentVariableReader.VerifyAll();
+        }
+
+        [Fact]
+        public void Write_WhenLoggingIsNotEnabled_DoesNotCreateLogFile()
+        {
+            var environmentVariableReader = CreateEnvironmentVariableReaderMock(isLoggingEnabled: false);
+            var logMessage = new RandomLogMessage();
+            var logFile = GetLogFile();
+
+            if (logFile.Exists)
+            {
+                logFile.Delete();
+            }
+
+            using (var logger = new PluginLogger(environmentVariableReader.Object))
+            {
+                logger.Write(logMessage);
+            }
+
+            logFile.Refresh();
+
+            Assert.False(logFile.Exists);
+
+            environmentVariableReader.VerifyAll();
+        }
+
+        [Fact]
+        public void Write_WhenLoggingIsEnabled_WritesToStringResult()
+        {
+            var environmentVariableReader = CreateEnvironmentVariableReaderMock(isLoggingEnabled: true);
+            var logMessage = new RandomLogMessage();
+            var logFile = GetLogFile();
+
+            if (logFile.Exists)
+            {
+                logFile.Delete();
+            }
+
+            try
+            {
+                using (var logger = new PluginLogger(environmentVariableReader.Object))
+                {
+                    logger.Write(logMessage);
+                }
+
+                logFile.Refresh();
+
+                Assert.True(logFile.Exists);
+
+                var actualContent = File.ReadAllText(logFile.FullName);
+
+                Assert.Equal(logMessage.Message + Environment.NewLine, actualContent);
+            }
+            finally
+            {
+                if (logFile.Exists)
+                {
+                    logFile.Delete();
+                }
+            }
+
+
+            environmentVariableReader.VerifyAll();
+        }
+
+        private static Mock<IEnvironmentVariableReader> CreateEnvironmentVariableReaderMock(bool isLoggingEnabled)
+        {
+            var environmentVariableReader = new Mock<IEnvironmentVariableReader>(MockBehavior.Strict);
+
+            environmentVariableReader.Setup(x => x.GetEnvironmentVariable(
+                    It.Is<string>(value => value == EnvironmentVariableConstants.EnableLog)))
+                .Returns(isLoggingEnabled ? bool.TrueString : bool.FalseString);
+
+            return environmentVariableReader;
+        }
+
+        private static FileInfo GetLogFile()
+        {
+            FileInfo file;
+
+            using (var process = Process.GetCurrentProcess())
+            {
+                file = new FileInfo(process.MainModule.FileName);
+            }
+
+            var fileName = $"NuGet_PluginLogFor_{Path.GetFileNameWithoutExtension(file.Name)}.log";
+
+            return new FileInfo(fileName);
+        }
+
+        private sealed class RandomLogMessage : IPluginLogMessage
+        {
+            internal string Message { get; }
+
+            internal RandomLogMessage()
+            {
+                Message = Guid.NewGuid().ToString();
+            }
+
+            public override string ToString()
+            {
+                return Message;
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/TaskLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/TaskLogMessageTests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace NuGet.Protocol.Plugins.Tests
+{
+    public class TaskLogMessageTests : LogMessageTests
+    {
+        [Fact]
+        public void ToString_ReturnsJson()
+        {
+            const string requestId = "a";
+            const MessageMethod method = MessageMethod.GetOperationClaims;
+            const MessageType type = MessageType.Request;
+            const TaskState state = TaskState.Executing;
+
+            var logMessage = new TaskLogMessage(requestId, method, type, state);
+
+            var message = VerifyOuterMessageAndReturnInnerMessage(logMessage, "task");
+
+            Assert.Equal(4, message.Count);
+
+            var actualRequestId = message.Value<string>("request ID");
+            var actualMethod = Enum.Parse(typeof(MessageMethod), message.Value<string>("method"));
+            var actualType = Enum.Parse(typeof(MessageType), message.Value<string>("type"));
+            var actualState = Enum.Parse(typeof(TaskState), message.Value<string>("state"));
+
+            Assert.Equal(requestId, actualRequestId);
+            Assert.Equal(method, actualMethod);
+            Assert.Equal(type, actualType);
+            Assert.Equal(state, actualState);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/ThreadPoolLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/ThreadPoolLogMessageTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using Xunit;
+
+namespace NuGet.Protocol.Plugins.Tests
+{
+    public class ThreadPoolLogMessageTests : LogMessageTests
+    {
+        [Fact]
+        public void ToString_ReturnsJson()
+        {
+            var logMessage = new ThreadPoolLogMessage();
+
+            var message = VerifyOuterMessageAndReturnInnerMessage(logMessage, "thread pool");
+
+            Assert.Equal(4, message.Count);
+
+            var actualWorkerThreadMinimumCount = message.Value<int>("worker thread minimum count");
+            var actualWorkerThreadMaximumCount = message.Value<int>("worker thread maximum count");
+            var actualCompletionPortThreadMinimumCount = message.Value<int>("completion port thread minimum count");
+            var actualCompletionPortThreadMaximumCount = message.Value<int>("completion port thread maximum count");
+
+            GetExpectedValues(
+                out var expectedWorkerThreadMinimumCount,
+                out var expectedWorkerThreadMaximumCount,
+                out var expectedCompletionPortThreadMinimumCount,
+                out var expectedCompletionPortThreadMaximumCount);
+
+            Assert.Equal(expectedWorkerThreadMinimumCount, actualWorkerThreadMinimumCount);
+            Assert.Equal(expectedWorkerThreadMaximumCount, actualWorkerThreadMaximumCount);
+            Assert.Equal(expectedCompletionPortThreadMinimumCount, actualCompletionPortThreadMinimumCount);
+            Assert.Equal(expectedCompletionPortThreadMaximumCount, actualCompletionPortThreadMaximumCount);
+        }
+
+        private void GetExpectedValues(
+            out int expectedWorkerThreadMinimumCount,
+            out int expectedWorkerThreadMaximumCount,
+            out int expectedCompletionPortThreadMinimumCount,
+            out int expectedCompletionPortThreadMaximumCount)
+        {
+            ThreadPool.GetMinThreads(out expectedWorkerThreadMinimumCount, out expectedCompletionPortThreadMinimumCount);
+            ThreadPool.GetMaxThreads(out expectedWorkerThreadMaximumCount, out expectedCompletionPortThreadMaximumCount);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/MessageDispatcherTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/MessageDispatcherTests.cs
@@ -38,6 +38,15 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
         [Fact]
+        public void Constructor_ThrowsForNullLogger()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new MessageDispatcher(new RequestHandlers(), new ConstantIdGenerator(), logger: null));
+
+            Assert.Equal("logger", exception.ParamName);
+        }
+
+        [Fact]
         public void Constructor_InitializesProperties()
         {
             using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator))
@@ -179,6 +188,19 @@ namespace NuGet.Protocol.Plugins.Tests
                 Assert.Equal(MessageMethod.Handshake, message.Method);
                 Assert.Equal("{\"ProtocolVersion\":\"1.0.0\",\"MinimumProtocolVersion\":\"1.0.0\"}",
                     message.Payload.ToString(Formatting.None));
+            }
+        }
+
+        [Fact]
+        public void Dispose_DoesNotDisposeLogger()
+        {
+            var logger = new Mock<IPluginLogger>(MockBehavior.Strict);
+
+            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator, logger.Object))
+            {
+                dispatcher.Dispose();
+
+                logger.Verify();
             }
         }
 


### PR DESCRIPTION
Resolve https://github.com/NuGet/Home/issues/7859.

This PR adds a new environment variable (`NUGET_PLUGIN_ENABLE_LOG`) that when set will create two log files:  one on the NuGet client side and one on the plugin side.

The log files contain structured data about:

* machine:  logical processor count
* thread pool:  min and max counts for worker threads and completion port threads
* assembly:  NuGet.Protocol version information
* communications:  basic information about messages sent between NuGet and a plugin
* task:  when a task is queued to the thread pool and when it's executing