### PR TITLE
WIP <change default symbol package format to snupkg>

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -38,7 +38,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ContentTargetFolders Condition="'$(ContentTargetFolders)' == ''">content;contentFiles</ContentTargetFolders>
     <PackDependsOn>$(BeforePack); _IntermediatePack; GenerateNuspec; $(PackDependsOn)</PackDependsOn>
     <IsInnerBuild Condition="'$(TargetFramework)' != '' AND '$(TargetFrameworks)' != ''">true</IsInnerBuild>
-    <SymbolPackageFormat Condition="'$(SymbolPackageFormat)' == ''">symbols.nupkg</SymbolPackageFormat>
+    <SymbolPackageFormat Condition="'$(SymbolPackageFormat)' == ''">snupkg</SymbolPackageFormat>
     <AddPriFileDependsOn Condition="'$(MicrosoftPortableCurrentVersionPropsHasBeenImported)' == 'true'">DeterminePortableBuildCapabilities</AddPriFileDependsOn>
     <NuspecOutputPath Condition="'$(NuspecOutputPath)' == ''">$(BaseIntermediateOutputPath)$(Configuration)\</NuspecOutputPath>
     <WarnOnPackingNonPackableProject Condition="'$(WarnOnPackingNonPackableProject)' == ''">false</WarnOnPackingNonPackableProject>

--- a/src/NuGet.Core/NuGet.Commands/CommandArgs/PackArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandArgs/PackArgs.cs
@@ -27,7 +27,7 @@ namespace NuGet.Commands
         public bool InstallPackageToOutputPath { get; set; }
         public IMachineWideSettings MachineWideSettings { get; set; }
         public Version MinClientVersion { get; set; }
-        public SymbolPackageFormat SymbolPackageFormat { get; set; } = SymbolPackageFormat.SymbolsNupkg;
+        public SymbolPackageFormat SymbolPackageFormat { get; set; } = SymbolPackageFormat.Snupkg;
         public Lazy<string> MsBuildDirectory { get; set; }
         public bool NoDefaultExcludes { get; set; }
         public bool NoPackageAnalysis { get; set; }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -186,7 +186,7 @@ namespace Dotnet.Integration.Test
                 }
 
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
-                var args = includeSymbols ? $"-o {workingDirectory} --include-symbols" : $"-o {workingDirectory}";
+                var args = includeSymbols ? $"-o {workingDirectory} --include-symbols -p:SymbolPackageFormat=symbols.nupkg" : $"-o {workingDirectory}";
                 msbuildFixture.PackProject(workingDirectory, projectName, args);
 
                 var nupkgPath = includeSymbols
@@ -2016,7 +2016,7 @@ namespace ClassLibrary
 
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
                 msbuildFixture.PackProject(workingDirectory, projectName,
-                    $"--include-source /p:PackageOutputPath={workingDirectory}");
+                    $"--include-source -p:PackageOutputPath={workingDirectory} -p:SymbolPackageFormat=symbols.nupkg");
 
                 var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
                 var symbolsNupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.symbols.nupkg");

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -87,7 +87,6 @@ namespace NuGet.Build.Tasks.Pack.Test
                         OutputDirectory = directory,
                         Path = nuspecPath,
                         Exclude = Array.Empty<string>(),
-                        Symbols = true,
                         Logger = NullLogger.Instance
                     },
                     MSBuildProjectFactory.ProjectCreator,

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/DefaultManifestValuesRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/DefaultManifestValuesRuleTests.cs
@@ -50,7 +50,6 @@ urlMetadata +
                         OutputDirectory = testDirectory,
                         Path = nuspecPath,
                         Exclude = Array.Empty<string>(),
-                        Symbols = true,
                         Logger = NullLogger.Instance
                     },
                     MSBuildProjectFactory.ProjectCreator,
@@ -108,7 +107,6 @@ urlMetadata +
                         OutputDirectory = testDirectory,
                         Path = nuspecPath,
                         Exclude = Array.Empty<string>(),
-                        Symbols = true,
                         Logger = NullLogger.Instance
                     },
                     MSBuildProjectFactory.ProjectCreator,

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/InvalidFrameworkFolderRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/InvalidFrameworkFolderRuleTests.cs
@@ -53,7 +53,6 @@ namespace NuGet.Packaging.Test
                         OutputDirectory = testDirectory,
                         Path = nuspecPath,
                         Exclude = Array.Empty<string>(),
-                        Symbols = true,
                         Logger = NullLogger.Instance
                     },
                     MSBuildProjectFactory.ProjectCreator,
@@ -115,7 +114,6 @@ namespace NuGet.Packaging.Test
                         OutputDirectory = testDirectory,
                         Path = nuspecPath,
                         Exclude = Array.Empty<string>(),
-                        Symbols = true,
                         Logger = NullLogger.Instance
                     },
                     MSBuildProjectFactory.ProjectCreator,


### PR DESCRIPTION
## Bug

Fixes: [NuGet/Home#7815](https://github.com/NuGet/Home/issues/7815)
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: For both dotnet pack and nuget pack, change the default symbol package format to snupkg from .symbols.nupkg.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
