### PR TITLE
Plugins:  improve logging

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/EnvironmentVariableConstants.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/EnvironmentVariableConstants.cs
@@ -6,6 +6,7 @@ namespace NuGet.Protocol.Plugins
     internal static class EnvironmentVariableConstants
     {
         internal const string EnableLog = "NUGET_PLUGIN_ENABLE_LOG";
+        internal const string LogDirectoryPath = "NUGET_PLUGIN_LOG_DIRECTORY_PATH";
         internal const string HandshakeTimeout = "NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS";
         internal const string IdleTimeout = "NUGET_PLUGIN_IDLE_TIMEOUT_IN_SECONDS";
         internal const string PluginPaths = "NUGET_PLUGIN_PATHS";

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/EnvironmentVariablesLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/EnvironmentVariablesLogMessage.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json.Linq;
+using NuGet.Common;
+
+namespace NuGet.Protocol.Plugins
+{
+    internal sealed class EnvironmentVariablesLogMessage : PluginLogMessage
+    {
+        private readonly int? _handshakeTimeout;
+        private readonly int? _idleTimeout;
+        private readonly int? _requestTimeout;
+
+        internal EnvironmentVariablesLogMessage(IEnvironmentVariableReader environmentVariableReader = null)
+        {
+            var reader = environmentVariableReader ?? new EnvironmentVariableWrapper();
+
+            _handshakeTimeout = Read(reader, EnvironmentVariableConstants.HandshakeTimeout);
+            _idleTimeout = Read(reader, EnvironmentVariableConstants.IdleTimeout);
+            _requestTimeout = Read(reader, EnvironmentVariableConstants.RequestTimeout);
+
+            // Some variables are not logged:
+            //
+            //  * EnvironmentVariableConstants.EnableLog:  it will always be true when logs are generated.
+            //  * EnvironmentVariableConstants.LogDirectoryPath:  the value may contain PII.
+            //  * EnvironmentVariableConstants.PluginPaths:  the value may contain PII.
+        }
+
+        public override string ToString()
+        {
+            var message = new JObject();
+
+            if (_handshakeTimeout.HasValue)
+            {
+                message.Add("handshake timeout in seconds", _handshakeTimeout.Value);
+            }
+
+            if (_idleTimeout.HasValue)
+            {
+                message.Add("idle timeout in seconds", _idleTimeout.Value);
+            }
+
+            if (_requestTimeout.HasValue)
+            {
+                message.Add("request timeout in seconds", _requestTimeout.Value);
+            }
+
+            return ToString("environment variables", message);
+        }
+
+        private static int? Read(IEnvironmentVariableReader reader, string variableName)
+        {
+            var variableValue = reader.GetEnvironmentVariable(variableName);
+
+            if (int.TryParse(variableValue, out var value))
+            {
+                return value;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginInstanceLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginInstanceLogMessage.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.Protocol.Plugins
+{
+    internal sealed class PluginInstanceLogMessage : PluginLogMessage
+    {
+        private readonly int _processId;
+
+        internal PluginInstanceLogMessage(int processId)
+        {
+            _processId = processId;
+        }
+
+        public override string ToString()
+        {
+            var message = new JObject(new JProperty("process ID", _processId));
+
+            return ToString("plugin instance", message);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/ProcessLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/ProcessLogMessage.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.Protocol.Plugins
+{
+    internal sealed class ProcessLogMessage : PluginLogMessage
+    {
+        private readonly int _processId;
+        private readonly string _processName;
+
+        internal ProcessLogMessage()
+        {
+            using (var process = Process.GetCurrentProcess())
+            {
+                _processId = process.Id;
+                _processName = process.ProcessName;
+            }
+        }
+
+        public override string ToString()
+        {
+            var message = new JObject(
+                new JProperty("process ID", _processId),
+                new JProperty("process name", _processName));
+
+            return ToString("process", message);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/TaskLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/TaskLogMessage.cs
@@ -1,12 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
 namespace NuGet.Protocol.Plugins
 {
     internal sealed class TaskLogMessage : PluginLogMessage
     {
+        private readonly int? _currentTaskId;
         private readonly MessageMethod _method;
         private readonly string _requestId;
         private readonly TaskState _state;
@@ -18,6 +20,7 @@ namespace NuGet.Protocol.Plugins
             _method = method;
             _type = type;
             _state = state;
+            _currentTaskId = Task.CurrentId;
         }
 
         public override string ToString()
@@ -27,6 +30,11 @@ namespace NuGet.Protocol.Plugins
                 new JProperty("method", _method),
                 new JProperty("type", _type),
                 new JProperty("state", _state));
+
+            if (_currentTaskId.HasValue)
+            {
+                message.Add(new JProperty("current task ID", _currentTaskId.Value));
+            }
 
             return ToString("task", message);
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
@@ -178,6 +178,8 @@ namespace NuGet.Protocol.Plugins
             if (_logger.IsEnabled)
             {
                 WriteCommonLogMessages(_logger);
+
+                _logger.Write(new PluginInstanceLogMessage(process.Id));
             }
 
             var messageDispatcher = new MessageDispatcher(requestHandlers, new RequestIdGenerator(), _logger);
@@ -375,6 +377,8 @@ namespace NuGet.Protocol.Plugins
         {
             logger.Write(new AssemblyLogMessage());
             logger.Write(new MachineLogMessage());
+            logger.Write(new EnvironmentVariablesLogMessage());
+            logger.Write(new ProcessLogMessage());
             logger.Write(new ThreadPoolLogMessage());
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/EnvironmentVariablesLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/EnvironmentVariablesLogMessageTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using NuGet.Common;
+using Xunit;
+
+namespace NuGet.Protocol.Plugins.Tests
+{
+    public class EnvironmentVariablesLogMessageTests : LogMessageTests
+    {
+        [Fact]
+        public void ToString_WhenVariablesHaveIllegalValues_ReturnsJson()
+        {
+            const string expectedHandshakeTimeoutInSeconds = "a";
+            const string expectedIdleTimeoutInSeconds = "b";
+            const string expectedRequestTimeoutInSeconds = "c";
+
+            var reader = new Mock<IEnvironmentVariableReader>(MockBehavior.Strict);
+
+            reader.Setup(x => x.GetEnvironmentVariable(It.Is<string>(name => name == EnvironmentVariableConstants.HandshakeTimeout)))
+                .Returns(expectedHandshakeTimeoutInSeconds);
+            reader.Setup(x => x.GetEnvironmentVariable(It.Is<string>(name => name == EnvironmentVariableConstants.IdleTimeout)))
+                .Returns(expectedIdleTimeoutInSeconds);
+            reader.Setup(x => x.GetEnvironmentVariable(It.Is<string>(name => name == EnvironmentVariableConstants.RequestTimeout)))
+                .Returns(expectedRequestTimeoutInSeconds);
+
+            var logMessage = new EnvironmentVariablesLogMessage(reader.Object);
+
+            var message = VerifyOuterMessageAndReturnInnerMessage(logMessage, "environment variables");
+
+            Assert.Equal(0, message.Count);
+
+            reader.VerifyAll();
+        }
+
+        [Fact]
+        public void ToString_WhenNoVariablesAreDefined_ReturnsJson()
+        {
+            var reader = new Mock<IEnvironmentVariableReader>(MockBehavior.Strict);
+
+            reader.Setup(x => x.GetEnvironmentVariable(It.Is<string>(name => name == EnvironmentVariableConstants.HandshakeTimeout)))
+                .Returns((string)null);
+            reader.Setup(x => x.GetEnvironmentVariable(It.Is<string>(name => name == EnvironmentVariableConstants.IdleTimeout)))
+                .Returns((string)null);
+            reader.Setup(x => x.GetEnvironmentVariable(It.Is<string>(name => name == EnvironmentVariableConstants.RequestTimeout)))
+                .Returns((string)null);
+
+            var logMessage = new EnvironmentVariablesLogMessage(reader.Object);
+
+            var message = VerifyOuterMessageAndReturnInnerMessage(logMessage, "environment variables");
+
+            Assert.Equal(0, message.Count);
+
+            reader.VerifyAll();
+        }
+
+        [Fact]
+        public void ToString_WhenAllVariablesAreDefined_ReturnsJson()
+        {
+            const int expectedHandshakeTimeoutInSeconds = 1;
+            const int expectedIdleTimeoutInSeconds = 2;
+            const int expectedRequestTimeoutInSeconds = 3;
+
+            var reader = new Mock<IEnvironmentVariableReader>(MockBehavior.Strict);
+
+            reader.Setup(x => x.GetEnvironmentVariable(It.Is<string>(name => name == EnvironmentVariableConstants.HandshakeTimeout)))
+                .Returns(expectedHandshakeTimeoutInSeconds.ToString());
+            reader.Setup(x => x.GetEnvironmentVariable(It.Is<string>(name => name == EnvironmentVariableConstants.IdleTimeout)))
+                .Returns(expectedIdleTimeoutInSeconds.ToString());
+            reader.Setup(x => x.GetEnvironmentVariable(It.Is<string>(name => name == EnvironmentVariableConstants.RequestTimeout)))
+                .Returns(expectedRequestTimeoutInSeconds.ToString());
+
+            var logMessage = new EnvironmentVariablesLogMessage(reader.Object);
+
+            var message = VerifyOuterMessageAndReturnInnerMessage(logMessage, "environment variables");
+
+            Assert.Equal(3, message.Count);
+
+            var actualHandshakeTimeoutInSeconds = message.Value<int>("handshake timeout in seconds");
+            var actualIdleTimeoutInSeconds = message.Value<int>("idle timeout in seconds");
+            var actualRequestTimeoutInSeconds = message.Value<int>("request timeout in seconds");
+
+            Assert.Equal(expectedHandshakeTimeoutInSeconds, actualHandshakeTimeoutInSeconds);
+            Assert.Equal(expectedIdleTimeoutInSeconds, actualIdleTimeoutInSeconds);
+            Assert.Equal(expectedRequestTimeoutInSeconds, actualRequestTimeoutInSeconds);
+
+            reader.VerifyAll();
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/PluginInstanceLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/PluginInstanceLogMessageTests.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using Xunit;
+
+namespace NuGet.Protocol.Plugins.Tests
+{
+    public class PluginInstanceLogMessageTests : LogMessageTests
+    {
+        [Fact]
+        public void ToString_ReturnsJson()
+        {
+            const int expectedProcessId = 7;
+
+            var logMessage = new PluginInstanceLogMessage(expectedProcessId);
+
+            var message = VerifyOuterMessageAndReturnInnerMessage(logMessage, "plugin instance");
+
+            Assert.Equal(1, message.Count);
+
+            var actualProcessId = message.Value<int>("process ID");
+
+            Assert.Equal(expectedProcessId, actualProcessId);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/ProcessLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/ProcessLogMessageTests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using Xunit;
+
+namespace NuGet.Protocol.Plugins.Tests
+{
+    public class ProcessLogMessageTests : LogMessageTests
+    {
+        [Fact]
+        public void ToString_ReturnsJson()
+        {
+            var logMessage = new ProcessLogMessage();
+
+            var message = VerifyOuterMessageAndReturnInnerMessage(logMessage, "process");
+
+            Assert.Equal(2, message.Count);
+
+            int expectedProcessId;
+            string expectedProcessName;
+
+            using (var process = Process.GetCurrentProcess())
+            {
+                expectedProcessId = process.Id;
+                expectedProcessName = process.ProcessName;
+            }
+
+            var actualProcessId = message.Value<int>("process ID");
+            var actualProcessName = message.Value<string>("process name");
+
+            Assert.Equal(expectedProcessId, actualProcessId);
+            Assert.Equal(expectedProcessName, actualProcessName);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/TaskLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/TaskLogMessageTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace NuGet.Protocol.Plugins.Tests
@@ -20,17 +21,19 @@ namespace NuGet.Protocol.Plugins.Tests
 
             var message = VerifyOuterMessageAndReturnInnerMessage(logMessage, "task");
 
-            Assert.Equal(4, message.Count);
+            Assert.Equal(5, message.Count);
 
             var actualRequestId = message.Value<string>("request ID");
             var actualMethod = Enum.Parse(typeof(MessageMethod), message.Value<string>("method"));
             var actualType = Enum.Parse(typeof(MessageType), message.Value<string>("type"));
             var actualState = Enum.Parse(typeof(TaskState), message.Value<string>("state"));
+            var actualCurrentTaskId = message.Value<int>("current task ID");
 
             Assert.Equal(requestId, actualRequestId);
             Assert.Equal(method, actualMethod);
             Assert.Equal(type, actualType);
             Assert.Equal(state, actualState);
+            Assert.Equal(Task.CurrentId, actualCurrentTaskId);
         }
     }
 }


### PR DESCRIPTION
Improve on https://github.com/NuGet/Home/issues/7859.

Changes:

* log current process ID and name
* log process ID's of launched plugins
* log timeout-related environment variables
* log current `Task` ID
* enable setting a custom log directory path
* make the log file name unique