### PR TITLE
Very minor typo fix

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -285,7 +285,7 @@ namespace NuGet.Configuration
         /// <param name="configFileName">The user specified configuration file.</param>
         /// <param name="machineWideSettings">
         /// The machine wide settings. If it's not null, the
-        /// settings files in the machine wide settings are added after the user sepcific
+        /// settings files in the machine wide settings are added after the user specific
         /// config file.
         /// </param>
         /// <returns>The settings object loaded.</returns>


### PR DESCRIPTION
## Fix
Details: Fixing minor typo in documentation for Settings.LoadDefaultSettings

## Testing/Validation
Tests Added: No
Reason for not adding tests:  Not needed. Only documentation affected.