### PR TITLE
Add a plugin deprecation message for the old plugin model

### DIFF
--- a/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
@@ -24,6 +24,7 @@ namespace NuGet.Credentials
         private readonly string _verbosity;
         private const string NormalVerbosity = "normal";
         private const string CrossPlatformPluginLink = "https://aka.ms/nuget-cross-platform-authentication-plugin";
+        private int _deprecationMessageWarningLogged; 
 
         /// <summary>
         /// Constructor
@@ -111,8 +112,10 @@ namespace NuGet.Credentials
                     Verbosity = _verbosity
                 };
                 PluginCredentialResponse response;
-
-                _logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Resources.PluginWarning_PluginIsBeingDeprecated, Path, CrossPlatformPluginLink));
+                if (Interlocked.CompareExchange(ref _deprecationMessageWarningLogged, 1, 0) == 0)
+                {
+                    _logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Resources.PluginWarning_PluginIsBeingDeprecated, Path, CrossPlatformPluginLink));
+                }
 
                 try
                 {

--- a/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
@@ -23,6 +23,7 @@ namespace NuGet.Credentials
         private readonly Common.ILogger _logger;
         private readonly string _verbosity;
         private const string NormalVerbosity = "normal";
+        private const string CrossPlatformPluginLink = "https://aka.ms/nuget-cross-platform-authentication-plugin";
 
         /// <summary>
         /// Constructor
@@ -111,7 +112,7 @@ namespace NuGet.Credentials
                 };
                 PluginCredentialResponse response;
 
-                _logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Resources.PluginWarning_PluginIsBeingDeprecated, Path));
+                _logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Resources.PluginWarning_PluginIsBeingDeprecated, Path, CrossPlatformPluginLink));
 
                 try
                 {

--- a/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -110,7 +111,8 @@ namespace NuGet.Credentials
                 };
                 PluginCredentialResponse response;
 
-                // TODO: Extend the plug protocol to pass in the credential request type.
+                _logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Resources.PluginWarning_PluginIsBeingDeprecated, Path));
+
                 try
                 {
                     response = GetPluginResponse(request, cancellationToken);

--- a/src/NuGet.Core/NuGet.Credentials/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Credentials/Resources.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace NuGet.Credentials {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace NuGet.Credentials {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -40,7 +39,7 @@ namespace NuGet.Credentials {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.Credentials.Resources", typeof(Resources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.Credentials.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -139,6 +138,15 @@ namespace NuGet.Credentials {
         internal static string PluginException_UnreadableResponse_Format {
             get {
                 return ResourceManager.GetString("PluginException_UnreadableResponse_Format", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The credential plugin model used by &apos;{0}&apos; is getting deprecated. Please contact the provider of the plugin for an alternative. More information about the recommended plugin model can be found at https://docs.microsoft.com/en-us/nuget/reference/extensibility/nuget-cross-platform-authentication-plugin..
+        /// </summary>
+        internal static string PluginWarning_PluginIsBeingDeprecated {
+            get {
+                return ResourceManager.GetString("PluginWarning_PluginIsBeingDeprecated", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Credentials/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Credentials/Resources.Designer.cs
@@ -142,7 +142,7 @@ namespace NuGet.Credentials {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The credential plugin model used by &apos;{0}&apos; is getting deprecated. Please contact the provider of the plugin for an alternative. More information about the recommended plugin model can be found at &apos;{1}&apos;..
+        ///   Looks up a localized string similar to The credential plugin model used by &apos;{0}&apos; is deprecated. Please contact the provider of the plugin for an alternative. More information about the recommended plugin model can be found at &apos;{1}&apos;..
         /// </summary>
         internal static string PluginWarning_PluginIsBeingDeprecated {
             get {

--- a/src/NuGet.Core/NuGet.Credentials/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Credentials/Resources.Designer.cs
@@ -142,7 +142,7 @@ namespace NuGet.Credentials {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The credential plugin model used by &apos;{0}&apos; is getting deprecated. Please contact the provider of the plugin for an alternative. More information about the recommended plugin model can be found at https://docs.microsoft.com/en-us/nuget/reference/extensibility/nuget-cross-platform-authentication-plugin..
+        ///   Looks up a localized string similar to The credential plugin model used by &apos;{0}&apos; is getting deprecated. Please contact the provider of the plugin for an alternative. More information about the recommended plugin model can be found at &apos;{1}&apos;..
         /// </summary>
         internal static string PluginWarning_PluginIsBeingDeprecated {
             get {

--- a/src/NuGet.Core/NuGet.Credentials/Resources.resx
+++ b/src/NuGet.Core/NuGet.Credentials/Resources.resx
@@ -145,7 +145,7 @@
     <value>Credential plugin {0} returned {1} with an unreadable payload.</value>
   </data>
   <data name="PluginWarning_PluginIsBeingDeprecated" xml:space="preserve">
-    <value>The credential plugin model used by '{0}' is getting deprecated. Please contact the provider of the plugin for an alternative. More information about the recommended plugin model can be found at https://docs.microsoft.com/en-us/nuget/reference/extensibility/nuget-cross-platform-authentication-plugin.</value>
+    <value>The credential plugin model used by '{0}' is getting deprecated. Please contact the provider of the plugin for an alternative. More information about the recommended plugin model can be found at '{1}'.</value>
   </data>
   <data name="ProviderException_InvalidCredentialResponse" xml:space="preserve">
     <value>Could not create credential response object because the response was invalid.</value>

--- a/src/NuGet.Core/NuGet.Credentials/Resources.resx
+++ b/src/NuGet.Core/NuGet.Credentials/Resources.resx
@@ -145,7 +145,7 @@
     <value>Credential plugin {0} returned {1} with an unreadable payload.</value>
   </data>
   <data name="PluginWarning_PluginIsBeingDeprecated" xml:space="preserve">
-    <value>The credential plugin model used by '{0}' is getting deprecated. Please contact the provider of the plugin for an alternative. More information about the recommended plugin model can be found at '{1}'.</value>
+    <value>The credential plugin model used by '{0}' is deprecated. Please contact the provider of the plugin for an alternative. More information about the recommended plugin model can be found at '{1}'.</value>
   </data>
   <data name="ProviderException_InvalidCredentialResponse" xml:space="preserve">
     <value>Could not create credential response object because the response was invalid.</value>

--- a/src/NuGet.Core/NuGet.Credentials/Resources.resx
+++ b/src/NuGet.Core/NuGet.Credentials/Resources.resx
@@ -144,6 +144,9 @@
   <data name="PluginException_UnreadableResponse_Format" xml:space="preserve">
     <value>Credential plugin {0} returned {1} with an unreadable payload.</value>
   </data>
+  <data name="PluginWarning_PluginIsBeingDeprecated" xml:space="preserve">
+    <value>The credential plugin model used by '{0}' is getting deprecated. Please contact the provider of the plugin for an alternative. More information about the recommended plugin model can be found at https://docs.microsoft.com/en-us/nuget/reference/extensibility/nuget-cross-platform-authentication-plugin.</value>
+  </data>
   <data name="ProviderException_InvalidCredentialResponse" xml:space="preserve">
     <value>Could not create credential response object because the response was invalid.</value>
   </data>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7819
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

Added a deprecation warning message for the plugin.

Example message; 
```
C:\Users\Roki2\Documents\Code\NuGet\NuGet.Client [dev-nkolev92-pluginDeprecationMessage ≡]> .\artifacts\VS15\NuGet.exe restore C:\Users\Roki2\Source\Repos\ConsoleApp4\ConsoleApp4\ConsoleApp4.csproj
MSBuild auto-detection: using msbuild version '16.0.450.56488' from 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin'.
Restoring packages for C:\Users\Roki2\Source\Repos\ConsoleApp4\ConsoleApp4\ConsoleApp4.csproj...
WARNING: The credential plugin model used by 'C:\Users\Roki2\Downloads\CredentialProviderBundle\CredentialProvider.VSS.exe' is deprecated. Please contact the provider of the plugin for an alternative. More information about the recommended plugin model can be found at https://docs.microsoft.com/en-us/nuget/reference/extensibility/nuget-cross-platform-authentication-plugin
```

There will be 1 log message per plugin, only if that plugin ends up getting used. 

This is important, as the client needs to be able to understand all the plugins that are getting deprecated off of 1 run. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  No infrastructure for commandline plugin tests.
Validation:  Manual
