### PR TITLE
Settings:  avoid crash and improve error message

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -13,7 +12,6 @@ using System.Windows.Forms;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.PackageManagement.UI;
 using NuGet.Protocol.Core.Types;
@@ -330,6 +328,11 @@ namespace NuGet.Options
 
         private void OnAddButtonClick(object sender, EventArgs e)
         {
+            if (_packageSources == null)
+            {
+                return;
+            }
+
             _packageSources.Add(CreateNewPackageSource());
 
             // auto-select the newly-added item

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -70,6 +70,11 @@ namespace NuGet.Common
         NU1005 = 1005,
 
         /// <summary>
+        /// NuGet configuration file has an invalid package source value.
+        /// </summary>
+        NU1006 = 1006,
+
+        /// <summary>
         /// Unable to resolve package, generic message for unknown type constraints.
         /// </summary>
         NU1100 = 1100,

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace NuGet.Configuration {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace NuGet.Configuration {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -40,7 +39,7 @@ namespace NuGet.Configuration {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.Configuration.Resources", typeof(Resources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.Configuration.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -337,6 +336,15 @@ namespace NuGet.Configuration {
         internal static string ShowError_CannotHaveChildren {
             get {
                 return ResourceManager.GetString("ShowError_CannotHaveChildren", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}: NuGet.Config has an invalid package source value &apos;{1}&apos;. Reason: {2}.
+        /// </summary>
+        internal static string ShowError_ConfigHasInvalidPackageSource {
+            get {
+                return ResourceManager.GetString("ShowError_ConfigHasInvalidPackageSource", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -226,6 +226,12 @@
   <data name="ShowError_CannotHaveChildren" xml:space="preserve">
     <value>Error parsing NuGet.Config. Element '{0}' cannot have descendant elements. Path: '{1}'.</value>
   </data>
+  <data name="ShowError_ConfigHasInvalidPackageSource" xml:space="preserve">
+    <value>{0}: NuGet.Config has an invalid package source value '{1}'. Reason: {2}</value>
+    <comment>0 - NU log code
+1 - package source value
+2 - original exception message</comment>
+  </data>
   <data name="ShowError_ConfigInvalidOperation" xml:space="preserve">
     <value>NuGet.Config is malformed. Path: '{0}'.</value>
   </data>


### PR DESCRIPTION
Resolve https://github.com/NuGet/Home/issues/7820.

*  Avoid a crash in NuGet Package Manager tools UI when reading package sources throws an exception due to invalid file system path.
*  Improve the error message so that it is more actionable.

Scenario | Before | After
--- | --- | ---
After invoking "Manage Packages..." on a project or "Manage NuGet Packages for Solution..." on a solution | ![before_0_manage](https://user-images.githubusercontent.com/12734758/54772214-26509800-4bc4-11e9-9562-32c2c802f926.png) | ![after_0_manage](https://user-images.githubusercontent.com/12734758/54775765-e392be00-4bcb-11e9-8c1f-3cbca1f4145b.png)
After navigating to the "Package Sources" page of NuGet Package Manager settings UI | ![before_1](https://user-images.githubusercontent.com/12734758/54772267-3e281c00-4bc4-11e9-8e40-2dfeaf437576.png) | ![after_1_tools](https://user-images.githubusercontent.com/12734758/54775784-eab9cc00-4bcb-11e9-885c-70f2788caee8.png)
After dismissing the above error dialog in NuGet Package Manager settings UI | ![before_2](https://user-images.githubusercontent.com/12734758/54772308-51d38280-4bc4-11e9-95d4-b65501a9524c.png) | (no change, see https://github.com/NuGet/Home/issues/7897)
After clicking the new package source (+) button | crash | no crash
After invoking "Restore NuGet Packages" on the solution | ![before_3_restore](https://user-images.githubusercontent.com/12734758/54772320-55ffa000-4bc4-11e9-82e7-3df36b1a66c8.png) | ![after_3_restore](https://user-images.githubusercontent.com/12734758/54775792-f1484380-4bcb-11e9-81d7-6d3ff307a30b.png)

Embedding the NU code in the exception message is suboptimal.  Opened https://github.com/NuGet/Home/issues/7896.