### PR TITLE
fix the comparison to allow the generated nuspec to be read by the ma…

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
@@ -333,7 +333,7 @@ namespace NuGet.Packaging
                 yield return NuGetResources.Manifest_RequireLicenseAcceptanceRequiresLicenseUrl;
             }
 
-            if(_licenseUrl != null && LicenseMetadata != null && !_licenseUrl.Equals(LicenseMetadata.LicenseUrl))
+            if (_licenseUrl != null && LicenseMetadata != null && !new Uri(_licenseUrl).Equals(LicenseMetadata.LicenseUrl))
             {
                 yield return NuGetResources.Manifest_LicenseUrlCannotBeUsedWithLicenseMetadata;
             }

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
@@ -333,7 +333,7 @@ namespace NuGet.Packaging
                 yield return NuGetResources.Manifest_RequireLicenseAcceptanceRequiresLicenseUrl;
             }
 
-            if (_licenseUrl != null && LicenseMetadata != null && !new Uri(_licenseUrl).Equals(LicenseMetadata.LicenseUrl))
+            if (LicenseUrl != null && LicenseMetadata != null && !LicenseUrl.Equals(LicenseMetadata.LicenseUrl))
             {
                 yield return NuGetResources.Manifest_LicenseUrlCannotBeUsedWithLicenseMetadata;
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -4563,7 +4563,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
 
                 // Assert
                 var nupkgPath = Path.Combine(workingDirectory, $"{packageName}.{version}.nupkg");
-                var nuspecPath = Path.Combine(workingDirectory, $"generatedNuspec.nuspec");
 
                 using (var nupkgReader = new PackageArchiveReader(nupkgPath))
                 {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -2227,6 +2227,12 @@ public class B
                     Assert.Equal("https://github.com/NuGet/NuGet.Client.git", nuspecReader.GetRepositoryMetadata().Url);
                     Assert.Equal("dev", nuspecReader.GetRepositoryMetadata().Branch);
                     Assert.Equal("e1c65e4524cd70ee6e22abe33e6cb6ec73938cb3", nuspecReader.GetRepositoryMetadata().Commit);
+                    // Validate the nuspec round trips.
+                    using (var nuspecStream = nupkgReader.GetStream($"packageA.nuspec"))
+                    {
+                        var manifest = Packaging.Manifest.ReadFrom(nuspecStream, true);
+
+                    }
                 }
 
                 // Verify the package directory has the resolved nuspec
@@ -2321,6 +2327,12 @@ public class B
                     Assert.Equal("the description", nuspecReader.GetDescription());
                     Assert.Equal("Copyright (C) Microsoft 2013", nuspecReader.GetCopyright());
                     Assert.Equal("Microsoft,Sample,CustomTag", nuspecReader.GetTags());
+                    // Validate the nuspec round trips.
+                    using (var nuspecStream = nupkgReader.GetStream($"packageA.nuspec"))
+                    {
+                        var manifest = Packaging.Manifest.ReadFrom(nuspecStream, true);
+
+                    }
                 }
 
                 // Verify the package directory has the resolved nuspec
@@ -4652,6 +4664,12 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     Assert.Equal(licenseMetadata.License, licenseExpr);
                     Assert.False(licenseMetadata.LicenseExpression.HasOnlyStandardIdentifiers());
                     Assert.Equal(licenseExpr, licenseMetadata.LicenseExpression.ToString());
+                    // Validate the nuspec round trips.
+                    using (var nuspecStream = nupkgReader.GetStream($"{packageName}.nuspec"))
+                    {
+                        var manifest = Packaging.Manifest.ReadFrom(nuspecStream, true);
+
+                    }
                 }
             }
         }
@@ -4868,6 +4886,12 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     Assert.Equal(licenseMetadata.Version, LicenseMetadata.EmptyVersion);
                     Assert.Equal(licenseMetadata.License, licenseFileName);
                     Assert.Null(licenseMetadata.LicenseExpression);
+                    // Validate the nuspec round trips.
+                    using (var nuspecStream = nupkgReader.GetStream($"{packageName}.nuspec"))
+                    {
+                        var manifest = Packaging.Manifest.ReadFrom(nuspecStream, true);
+
+                    }
                 }
             }
         }
@@ -5135,6 +5159,12 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     var licenseMetadata = nuspecReader.GetLicenseMetadata();
                     Assert.Null(nuspecReader.GetLicenseMetadata());
                     Assert.NotNull(nuspecReader.GetLicenseUrl());
+                    // Validate the nuspec round trips.
+                    using (var nuspecStream = nupkgReader.GetStream($"{packageName}.nuspec"))
+                    {
+                        var manifest = Packaging.Manifest.ReadFrom(nuspecStream, true);
+
+                    }
                 }
             }
         }
@@ -5212,6 +5242,13 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                         var value = textReader.ReadToEnd();
                         Assert.Equal(new FileInfo(Path.Combine(workingDirectory, licenseFileName)).Length, licenseFileEntry.Length);
                         Assert.Equal(licenseText, value);
+                    }
+
+                    // Validate the nuspec round trips.
+                    using (var nuspecStream = nupkgReader.GetStream($"{packageName}.nuspec"))
+                    {
+                        var manifest = Packaging.Manifest.ReadFrom(nuspecStream, true);
+
                     }
                 }
             }
@@ -5308,6 +5345,12 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     Assert.Equal(licenseMetadata.Version, LicenseMetadata.EmptyVersion);
                     Assert.Equal(licenseMetadata.License, licenseFileName);
                     Assert.Null(licenseMetadata.LicenseExpression);
+                    // Validate the nuspec round trips.
+                    using (var nuspecStream = nupkgReader.GetStream($"{packageName}.nuspec"))
+                    {
+                        var manifest = Packaging.Manifest.ReadFrom(nuspecStream, true);
+
+                    }
                 }
 
                 using (var symbolsReader = new PackageArchiveReader(symbolsPath))

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -5373,7 +5373,6 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
             using (var nuspecStream = nupkgReader.GetStream(nuspecName))
             {
                 Assert.NotNull(Packaging.Manifest.ReadFrom(nuspecStream, validateSchema: true));
-
             }
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -5372,7 +5372,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
             // Validate the nuspec round trips.
             using (var nuspecStream = nupkgReader.GetStream(nuspecName))
             {
-                Assert.NotNull(Packaging.Manifest.ReadFrom(nuspecStream, true));
+                Assert.NotNull(Packaging.Manifest.ReadFrom(nuspecStream, validateSchema: true));
 
             }
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -4563,6 +4563,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
 
                 // Assert
                 var nupkgPath = Path.Combine(workingDirectory, $"{packageName}.{version}.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, $"generatedNuspec.nuspec");
 
                 using (var nupkgReader = new PackageArchiveReader(nupkgPath))
                 {
@@ -4580,6 +4581,12 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     Assert.Equal(licenseMetadata.Version, LicenseMetadata.EmptyVersion);
                     Assert.Equal(licenseMetadata.License, licenseExpr);
                     Assert.Equal(licenseExpr, licenseMetadata.LicenseExpression.ToString());
+                    // Validate the nuspec round trips.
+                    using (var nuspecStream = nupkgReader.GetStream($"{packageName}.nuspec"))
+                    {
+                        var manifest = Packaging.Manifest.ReadFrom(nuspecStream, true);
+
+                    }
                 }
             }
         }


### PR DESCRIPTION
…nifest reader

## Bug

Fixes: https://github.com/NuGet/Home/issues/7894
Regression: No
* Last working version:  
* How are we preventing it in future:   

## Fix

Details: The equality check should be uri based, not string based. Note that I can't make any assumption about the exact url (string comparison), as we don't know if it's NuGet generated or the user manually entered it. 

//cc @ericstj 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
