### PR TITLE
Conditionally import the pack targets in the solution build

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -30,7 +30,7 @@
     <XunitConsoleExePath>$(SolutionPackagesFolder)xunit.runner.console.2.3.1\tools\net452\xunit.console.x86.exe</XunitConsoleExePath>
     <ILMergeExePath>$(SolutionPackagesFolder)ILMerge.3.0.21\tools\net452\ILMerge.exe</ILMergeExePath>
     <XunitXmlLoggerDirectory>$(SolutionPackagesFolder)XunitXml.TestLogger.2.0.0\build\_common</XunitXmlLoggerDirectory>
-    <NuGetBuildTasksPackTargets>$(SolutionPackagesFolder)NuGet.Build.Tasks.Pack.4.9.2\build\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
+    <NuGetBuildTasksPackTargets Condition="Exists('$(SolutionPackagesFolder)NuGet.Build.Tasks.Pack.4.9.2\build\NuGet.Build.Tasks.Pack.targets')">$(SolutionPackagesFolder)NuGet.Build.Tasks.Pack.4.9.2\build\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
     <EnlistmentRoot>$(RepositoryRootDirectory)</EnlistmentRoot>
     <EnlistmentRootSrc>$(RepositoryRootDirectory)src</EnlistmentRootSrc>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(RepositoryRootDirectory)</SolutionDir>

--- a/build/common.targets
+++ b/build/common.targets
@@ -38,7 +38,7 @@
   </PropertyGroup>
 
   <ImportGroup Condition=" '$(PackProject)' == 'true' ">
-      <Import Condition="Exists('$(NuGetBuildTasksPackTargets)')" Project="$(NuGetBuildTasksPackTargets)" />
+      <Import Project="$(NuGetBuildTasksPackTargets)" />
   </ImportGroup>
 
   <!-- Test Projects -->

--- a/build/common.targets
+++ b/build/common.targets
@@ -37,7 +37,7 @@
     <DocumentationFile Condition=" '$(DocumentationFile)' == '' AND '$(GenerateDocumentationFile)' == 'true' AND '$(IsNetCoreProject)' != 'true' ">$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
-  <ImportGroup Condition=" '$(PackProject)' == 'true' ">
+  <ImportGroup Condition=" '$(PackProject)' == 'true' AND '$(NuGetBuildTasksPackTargets)' != '' ">
       <Import Project="$(NuGetBuildTasksPackTargets)" />
   </ImportGroup>
 

--- a/build/common.targets
+++ b/build/common.targets
@@ -38,7 +38,7 @@
   </PropertyGroup>
 
   <ImportGroup Condition=" '$(PackProject)' == 'true' ">
-      <Import Project="$(NuGetBuildTasksPackTargets)" />
+      <Import Condition="Exists('$(NuGetBuildTasksPackTargets)')" Project="$(NuGetBuildTasksPackTargets)" />
   </ImportGroup>
 
   <!-- Test Projects -->


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7905
Regression: Yes  
* Last working version:   5.0
* How are we preventing it in future:   

## Fix

Details: 

source-build runs `/t:RestoreXPLAT` to restore the NuGet libraries. 

Now if they tried that on the latest NuGet repository it would fail because it won't find the pack targets bootstrapped by  nuget.exe packages.config (note that they cannot run this cross-plat.)

As they only use this for building, the potential inconsistency with the pack output is ok. 

fyi @dagood if you see NuGet caused failures

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
