### PR TITLE
Improve the error case handling in the ManifestMetadata

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
@@ -333,7 +333,7 @@ namespace NuGet.Packaging
                 yield return NuGetResources.Manifest_RequireLicenseAcceptanceRequiresLicenseUrl;
             }
 
-            if (LicenseUrl != null && LicenseMetadata != null && !LicenseUrl.Equals(LicenseMetadata.LicenseUrl))
+            if (_licenseUrl != null && LicenseMetadata != null && (string.IsNullOrWhiteSpace(_licenseUrl) || !LicenseUrl.Equals(LicenseMetadata.LicenseUrl)))
             {
                 yield return NuGetResources.Manifest_LicenseUrlCannotBeUsedWithLicenseMetadata;
             }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -1979,7 +1979,7 @@ Description is required.");
         }
 
         [Fact]
-        public void PackageBuilderThrowsWhenLicenseUrlIsWhiteSpace()
+        public void PackageBuilderThrowsWhenLicenseUrlIsWhiteSpaceAndLicenseExpressionIsNotNull()
         {
             // Arrange
             string spec = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -1990,13 +1990,14 @@ Description is required.");
     <authors>Velio Ivanov</authors>
     <description>This is the Description (With, Comma-Separated, Words, in Parentheses).</description>
     <language>en-US</language>
+    <license type=""expression"">MIT</license>
     <licenseUrl>    </licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
   </metadata>
 </package>";
 
             // Act
-            ExceptionAssert.Throws<Exception>(() => new PackageBuilder(spec.AsStream(), null), "LicenseUrl cannot be empty.");
+            ExceptionAssert.Throws<Exception>(() => new PackageBuilder(spec.AsStream(), null), $"LicenseUrl cannot be empty.{Environment.NewLine}The licenseUrl and license elements cannot be used together.");
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -1979,6 +1979,27 @@ Description is required.");
         }
 
         [Fact]
+        public void PackageBuilderThrowsWhenLicenseUrlIsWhiteSpace()
+        {
+            // Arrange
+            string spec = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<package>
+  <metadata>
+    <id>Artem.XmlProviders</id>
+    <version>2.5</version>
+    <authors>Velio Ivanov</authors>
+    <description>This is the Description (With, Comma-Separated, Words, in Parentheses).</description>
+    <language>en-US</language>
+    <licenseUrl>    </licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+  </metadata>
+</package>";
+
+            // Act
+            ExceptionAssert.Throws<Exception>(() => new PackageBuilder(spec.AsStream(), null), "LicenseUrl cannot be empty.");
+        }
+
+        [Fact]
         public void PackageBuilderThrowsWhenLicenseUrlIsWhiteSpaceAndLicenseExpressionIsNotNull()
         {
             // Arrange


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7915
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Imrpvoe the error case handling in the ManifestMetadata. Fix the manifest metadata tests. Add more tests.

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
