### PR TITLE
Use project full path as document path when opening PM UI for project

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -386,7 +386,7 @@ namespace NuGetVSExtension
             ThreadHelper.ThrowIfNotOnUIThread();
 
             var vsProject = VsHierarchyUtility.ToVsHierarchy(project);
-            var documentName = project.UniqueName;
+            var documentName = project.FullName;
 
             // Find existing hierarchy and item id of the document window if it's
             // already registered.


### PR DESCRIPTION
You can right click the window tab in Visual Studio and select "Copy
Full Path" or "Open Containing Folder". VS needs to know the full path
to the project file for this to work.

## Bug

Fixes: NuGet/Home#7913
Regression: No  
* Last working version:   
* How are we preventing it in future:   vendor tests

## Fix

Details: Give Visual Studio the full path to the project file, rather than the relative path used in the .sln file.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  minor UI fix
Validation:  
