### PR TITLE
Write lowercase project name to lock file

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
@@ -73,7 +73,7 @@ namespace NuGet.Commands
                 {
                     var dependency = new LockFileDependency()
                     {
-                        Id = projectReference.Name,
+                        Id = projectReference.Name.ToLowerInvariant(),
                         Dependencies = projectReference.Dependencies,
                         Type = PackageDependencyType.Project
                     };

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -100,7 +100,7 @@ namespace NuGet.ProjectModel
 
                             var projectDependency = target.Dependencies.FirstOrDefault(
                                 dep => dep.Type == PackageDependencyType.Project &&
-                                PathUtility.GetStringComparerBasedOnOS().Equals(dep.Id, p2pProjectName));
+                                StringComparer.OrdinalIgnoreCase.Equals(dep.Id, p2pProjectName));
 
                             if (projectDependency == null)
                             {


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#7840
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: when generating the lock file, use `.ToLowerInvariant()` on the project name for project to project references.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  The highest risk is on Linux, where the file system is case-sensitive (because previously the code was doing a case sensitive comparison, only on Linux). However, dotnet integration tests do not currently run on Linux and it's too much effort to improve as part of this issue.
Validation:  Manually tested `dotnet restore` with and without locked mode on Windows and Linux.
