### PR TITLE
Fix lucene signing

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -290,6 +290,7 @@
   <ItemGroup>
     <PackageReference Include="Lucene.Net">
       <Version>3.0.3</Version>
+      <ExcludeAssets>all</ExcludeAssets>
     </PackageReference>
   </ItemGroup>
   <Target Name="AfterBuild" DependsOnTargets="PublishVS15" />

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -290,6 +290,7 @@
   <ItemGroup>
     <PackageReference Include="Lucene.Net">
       <Version>3.0.3</Version>
+      <!-- This is important because otherwise the VSSDK will include the unsigned version coming from the global packages folder instead of the in-place signed one from the bootstrapped packages folder -->
       <ExcludeAssets>all</ExcludeAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
## Bug

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/784528
Regression: Yes  
* Last working version:  Before https://github.com/NuGet/NuGet.Client/commit/0dde6500a51e3e8c2dcc1e45ed2eedf03c94b130 
* How are we preventing it in future:   We have a validation step that doesn't seem to work. i am investigating that on the side. 

## Fix

Details: 

With the upgrade of the VSSDK to 15.9 it started including an unsigned version of the lucene.net.dll. 

Since the lucene.net package is not relevant for build, we can just exclude all the assets from the vsix packing project and let it pack the lucene.net.dll from the packages folder. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  Manual
