### PR TITLE
Deprecate project.json pack

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -280,6 +280,10 @@ namespace NuGet.CommandLine
             }
             else
             {
+                Logger.Log(
+                    PackagingLogMessage.CreateWarning(
+                        string.Format(NuGetResources.ProjectJsonPack_Deprecated, builder.Id),
+                        NuGetLogCode.NU5126));
                 _usingJsonFile = true;
             }
 
@@ -687,7 +691,7 @@ namespace NuGet.CommandLine
             }
         }
 
-        private bool ProcessJsonFile(Packaging.PackageBuilder builder, string basePath, string id)
+        private bool ProcessJsonFile(PackageBuilder builder, string basePath, string id)
         {
             return PackCommandRunner.ProcessProjectJsonFile(builder, basePath, id, null, null, GetPropertyValue);
         }
@@ -695,7 +699,7 @@ namespace NuGet.CommandLine
         // Creates a package dependency from the given project, which has a corresponding
         // nuspec file.
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We want to continue regardless of any error we encounter extracting metadata.")]
-        private Packaging.Core.PackageDependency CreateDependencyFromProject(dynamic project, Dictionary<string, Packaging.Core.PackageDependency> dependencies)
+        private PackageDependency CreateDependencyFromProject(dynamic project, Dictionary<string, Packaging.Core.PackageDependency> dependencies)
         {
             try
             {
@@ -713,6 +717,12 @@ namespace NuGet.CommandLine
                 if (!projectFactory.ProcessJsonFile(builder, project.DirectoryPath, null))
                 {
                     projectFactory.ProcessNuspec(builder, null);
+                } else
+                {
+                    Logger.Log(
+                    PackagingLogMessage.CreateWarning(
+                        string.Format(NuGetResources.ProjectJsonPack_Deprecated, builder.Id),
+                        NuGetLogCode.NU5126));
                 }
 
                 VersionRange versionRange = null;

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.CommandLine {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class NuGetResources {
@@ -9003,6 +9003,15 @@ namespace NuGet.CommandLine {
         public static string Path_Invalid_NotFileNotUnc {
             get {
                 return ResourceManager.GetString("Path_Invalid_NotFileNotUnc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Project.json pack is deprecated. Please consider migrating &apos;{0}&apos; to PackageReference and using the pack targets..
+        /// </summary>
+        public static string ProjectJsonPack_Deprecated {
+            get {
+                return ResourceManager.GetString("ProjectJsonPack_Deprecated", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -9007,7 +9007,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Project.json pack is deprecated. Please consider migrating &apos;{0}&apos; to PackageReference and using the pack targets..
+        ///   Looks up a localized string similar to `project.json` pack is deprecated. Please consider migrating &apos;{0}&apos; to `PackageReference` and using the pack targets..
         /// </summary>
         public static string ProjectJsonPack_Deprecated {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6178,7 +6178,8 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
     <comment>0 - action</comment>
   </data>
   <data name="ProjectJsonPack_Deprecated" xml:space="preserve">
-    <value>Project.json pack is deprecated. Please consider migrating '{0}' to PackageReference and using the pack targets.</value>
-    <comment>0 - project path (project.json file path)</comment>
+    <value>`project.json` pack is deprecated. Please consider migrating '{0}' to `PackageReference` and using the pack targets.</value>
+    <comment>Do not localize project.json and `PackageReference` 
+0 - project path (project.json file path)</comment>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6177,4 +6177,8 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
     <value>The action '{0}' is not recognized.</value>
     <comment>0 - action</comment>
   </data>
+  <data name="ProjectJsonPack_Deprecated" xml:space="preserve">
+    <value>Project.json pack is deprecated. Please consider migrating '{0}' to PackageReference and using the pack targets.</value>
+    <comment>0 - project path (project.json file path)</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -309,32 +309,6 @@ namespace NuGet.Commands
                 .Where(filePath => fileNames.Contains(Path.GetFileName(filePath)));
         }
 
-        private PackageBuilder CreatePackageBuilderFromProjectJson(string path, Func<string, string> propertyProvider)
-        {
-            // Set the version property if the flag is set
-            if (!String.IsNullOrEmpty(_packArgs.Version))
-            {
-                _packArgs.Properties["version"] = _packArgs.Version;
-            }
-
-            PackageBuilder builder = new PackageBuilder();
-
-            NuGetVersion version = null;
-            if (_packArgs.Version != null)
-            {
-                version = new NuGetVersion(_packArgs.Version);
-            }
-
-            var basePath = string.IsNullOrEmpty(_packArgs.BasePath) ? _packArgs.CurrentDirectory : _packArgs.BasePath;
-
-            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read))
-            {
-                LoadProjectJsonFile(builder, path, basePath, Path.GetFileName(Path.GetDirectoryName(path)), stream, version, _packArgs.Suffix, propertyProvider);
-            }
-
-            return builder;
-        }
-
         public static bool ProcessProjectJsonFile(PackageBuilder builder, string basePath, string id, NuGetVersion version, string suffix, Func<string, string> propertyProvider)
         {
             if (basePath == null)

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -755,6 +755,11 @@ namespace NuGet.Common
         /// </summary>
         NU5125 = 5125,
 
+        ///<summary>
+        /// ProjectJsonPack_Deprecated
+        /// </summary>
+        NU5126 = 5126,
+
         /// <summary>
         /// Undefined package warning
         /// </summary>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -842,6 +842,8 @@ namespace Proj1
                         Path.Combine("lib", "netstandard1.3", "proj1.dll")
                     },
                     files);
+
+                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj1"), r.Item2);
             }
         }
 
@@ -1439,6 +1441,9 @@ public class B
                     waitForExit: true);
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
 
+                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj2"), r.Item2);
+                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj6"), r.Item2);
+
                 // Assert
                 var package = new OptimizedZipPackage(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg"));
                 var files = package.GetFiles().Select(f => f.Path).ToArray();
@@ -1778,6 +1783,9 @@ public class B
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
 
                 // Assert
+                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj2"), r.Item2);
+                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj6"), r.Item2);
+
                 var package = new OptimizedZipPackage(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg"));
                 var files = package.GetFiles().Select(f => f.Path).ToArray();
                 Array.Sort(files);
@@ -1887,6 +1895,9 @@ public class B
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
 
                 // Assert
+                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj2"), r.Item2);
+                Assert.Contains(string.Format(NuGetResources.ProjectJsonPack_Deprecated, "proj6"), r.Item2);
+
                 var package = new OptimizedZipPackage(Path.Combine(proj1Directory, "proj1.0.0.0.nupkg"));
                 var files = package.GetFiles().Select(f => f.Path).ToArray();
                 Array.Sort(files);


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7928
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Adding deprecation warnings for project.json pack. 

There are 2 cases in which this warning will be raised. 

1. The project being packed is project.json
1. A dependency is project.json and/or -IncludeReferencedProjects is used. 

fyi @anangaur 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  Automation
