### PR TITLE
Add NU5104 no warn for projects that build with prerelease dependencies by design

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -43,6 +43,7 @@
     <IsBuildOnlyXPLATProjects>$(DotNetBuildFromSource)</IsBuildOnlyXPLATProjects>
     <BlobPublishTargetsPath>$(SolutionPackagesFolder)Microsoft.DotNet.Build.Tasks.Feed.2.1.0-prerelease-02419-02\build\Microsoft.DotNet.Build.Tasks.Feed.targets</BlobPublishTargetsPath>
     <NoWarn>$(NoWarn);NU5105</NoWarn>
+    <!-- These cause a NU5104 warning. When upgrading to a stable version of this package, remove the above warnings from the respective projects -->
     <VSServicesVersion>16.144.1-preview</VSServicesVersion>
     <VSComponentsVersion>16.0.189-g83e7c53a57</VSComponentsVersion>
     <SystemPackagesVersion>4.3.0</SystemPackagesVersion>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -43,7 +43,7 @@
     <IsBuildOnlyXPLATProjects>$(DotNetBuildFromSource)</IsBuildOnlyXPLATProjects>
     <BlobPublishTargetsPath>$(SolutionPackagesFolder)Microsoft.DotNet.Build.Tasks.Feed.2.1.0-prerelease-02419-02\build\Microsoft.DotNet.Build.Tasks.Feed.targets</BlobPublishTargetsPath>
     <NoWarn>$(NoWarn);NU5105</NoWarn>
-    <!-- These cause a NU5104 warning. When upgrading to a stable version of this package, remove the above warnings from the respective projects -->
+    <!-- These cause a NU5104 warning. When upgrading to a stable version of this package, remove the no warns from the respective projects -->
     <VSServicesVersion>16.144.1-preview</VSServicesVersion>
     <VSComponentsVersion>16.0.189-g83e7c53a57</VSComponentsVersion>
     <SystemPackagesVersion>4.3.0</SystemPackagesVersion>

--- a/build/config.props
+++ b/build/config.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0">
   <!-- Version -->
   <PropertyGroup>
-    <IsEscrowMode>true</IsEscrowMode>
+    <IsEscrowMode>false</IsEscrowMode>
     <!-- when changing any of the NuGetVersion props below, also update ProductVersion in src\NuGet.Clients\NuGet.Tools\NuGetPackage.cs -->
     <MajorNuGetVersion Condition="'$(MajorNuGetVersion)' == ''">5</MajorNuGetVersion>
     <MinorNuGetVersion Condition="'$(MinorNuGetVersion)' == ''">1</MinorNuGetVersion>
@@ -10,13 +10,13 @@
     <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">$(MajorNuGetVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</SemanticVersion>
     <VsTargetBranch>lab/d16.$(MinorNuGetVersion)stg</VsTargetBranch>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>
-    <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">release/2.2.2xx</CliBranchForTesting>
+    <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">release/2.2.3xx</CliBranchForTesting>
     <!-- This branches are used for creating insertion PRs -->
     <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d16.$(MinorNuGetVersion)</VsTargetBranch>
     <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</CliTargetBranches>
-    <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">$(CliBranchForTesting);release/2.1.6xx</CliTargetBranches>
+    <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">$(CliBranchForTesting);release/2.1.7xx</CliTargetBranches>
     <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</SdkTargetBranches>
-    <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">$(CliBranchForTesting);release/2.1.6xx</SdkTargetBranches>
+    <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">$(CliBranchForTesting);release/2.1.7xx</SdkTargetBranches>
     <!-- We need to update this netcoreassembly build number with every milestone to workaround any breaking api
     changes we might have made-->
     <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">0</NetCoreAssemblyBuildNumber>

--- a/build/config.props
+++ b/build/config.props
@@ -10,13 +10,13 @@
     <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">$(MajorNuGetVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</SemanticVersion>
     <VsTargetBranch>lab/d16.$(MinorNuGetVersion)stg</VsTargetBranch>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>
-    <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">release/2.2.3xx</CliBranchForTesting>
+    <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">release/2.2.2xx</CliBranchForTesting>
     <!-- This branches are used for creating insertion PRs -->
     <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d16.$(MinorNuGetVersion)</VsTargetBranch>
     <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</CliTargetBranches>
-    <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">$(CliBranchForTesting);release/2.1.7xx</CliTargetBranches>
+    <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">release/2.2.3xx;release/2.1.7xx</CliTargetBranches>
     <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</SdkTargetBranches>
-    <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">$(CliBranchForTesting);release/2.1.7xx</SdkTargetBranches>
+    <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">release/2.2.3xx;release/2.1.7xx</SdkTargetBranches>
     <!-- We need to update this netcoreassembly build number with every milestone to workaround any breaking api
     changes we might have made-->
     <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">0</NetCoreAssemblyBuildNumber>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -18,6 +18,7 @@
     <TargetFrameworkVersion>$(NETFXTargetFrameworkVersion)</TargetFrameworkVersion>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
   <ItemGroup Condition="'$(VisualStudioVersion)' == '16.0'">
     <Reference Include="Microsoft.VisualStudio.VCProjectEngine, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -286,8 +287,8 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <!-- This causes a NU5104 warning. When upgrading to a stable version of this package, remove the above no warn. -->
     <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="15.0.198-pre" />
-    <!-- can this be removed?, upgraded version-->
     <PackageReference Include="VSLangProj110" Version="11.0.61030" />
     <PackageReference Include="VSLangProj2" Version="7.0.5000" />
     <PackageReference Include="VSLangProj157" Version="15.7.0" />

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
@@ -8,10 +8,8 @@
     <Shipping>true</Shipping>
     <IncludeInVsix>true</IncludeInVsix>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <RootNamespace>NuGet.VisualStudio</RootNamespace>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -6,7 +6,7 @@
     <Description>NuGet wrapper for dotnet.exe.</Description>
     <TargetFrameworks>$(TargetFrameworksExe)</TargetFrameworks>
     <RuntimeIdentifier Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">win7-x86</RuntimeIdentifier>
-    <NoWarn>$(NoWarn);CS1591;CS1701</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;CS1701;NU5104</NoWarn>
     <OutputType>Exe</OutputType>
     <Shipping>true</Shipping>
     <PackProject>true</PackProject>
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.0.1" />
+    <!-- This causes a NU5104 warning. When upgrading to a stable version of this package, remove the no warn -->
     <PackageReference Include="Microsoft.Build.Runtime" Version="16.0.0-preview.256" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="$(SystemPackagesVersion)" />
   </ItemGroup>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7936
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

Can be seen in https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2543327 under the build unit test and RTM

Root cause is https://github.com/NuGet/Home/issues/7404

We are building with prerelease dependencies by design because the stable packages have not be published yet by the respective teams. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  It's a tooling bug.
Validation:  
