### PR TITLE
Add the DotnetPlatform package type

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityIssue.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityIssue.cs
@@ -132,6 +132,22 @@ namespace NuGet.Commands
                 availableFrameworkRuntimePairs: Enumerable.Empty<FrameworkRuntimePair>());
         }
 
+
+        internal static CompatibilityIssue IncompatiblePackageType(
+            PackageIdentity packageIdentity,
+            NuGetFramework framework,
+            string runtimeIdentifier)
+        {
+            return new CompatibilityIssue(
+                CompatibilityIssueType.PackageTypeIncompatible,
+                packageIdentity,
+                string.Empty,
+                framework,
+                runtimeIdentifier,
+                Enumerable.Empty<NuGetFramework>(),
+                Enumerable.Empty<FrameworkRuntimePair>());
+        }
+
         public override string ToString()
         {
             // NOTE(anurse): Why not just use Format's implementation as ToString? I feel like ToString should be
@@ -234,6 +250,17 @@ namespace NuGet.Commands
                                Strings.Error_ToolsPackageWithExtraPackageTypes,
                                Package.Id,
                                Package.Version.ToNormalizedString());
+                        return FormatMessage(message, string.Empty, string.Empty);
+                    }
+                case CompatibilityIssueType.PackageTypeIncompatible:
+                    {
+                        var message = string.Format(CultureInfo.CurrentCulture,
+                        Strings.Error_IncompatiblePackageType,
+                        Package.Id,
+                        Package.Version.ToNormalizedString(),
+                        PackageType.DotnetPlatform.Name,
+                        FormatFramework(Framework, RuntimeIdentifier));
+
                         return FormatMessage(message, string.Empty, string.Empty);
                     }
                 default:
@@ -344,6 +371,7 @@ namespace NuGet.Commands
         PackageToolsAssetsIncompatible,
         ProjectWithIncorrectDependencyCount,
         IncompatiblePackageWithDotnetTool,
-        ToolsPackageWithExtraPackageTypes
+        ToolsPackageWithExtraPackageTypes,
+        PackageTypeIncompatible
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -196,6 +196,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package {0} {1} has a package type {2} that is incompatible with this project..
+        /// </summary>
+        internal static string Error_IncompatiblePackageType {
+            get {
+                return ResourceManager.GetString("Error_IncompatiblePackageType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Please specify a nuspec, project.json, or project file to use.
         /// </summary>
         internal static string Error_InputFileNotSpecified {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -877,4 +877,8 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>'{0}' is not an exact version like '[1.0.0]'. Only exact versions are allowed with PackageDownload.</value>
     <comment>0 - the version string that's not exact</comment>
   </data>
+  <data name="Error_IncompatiblePackageType" xml:space="preserve">
+    <value>The package {0} {1} has a package type {2} that is incompatible with this project.</value>
+    <comment>0 - package id, 1 - version, 2 - package type</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -151,6 +151,11 @@ namespace NuGet.Common
         NU1212 = 1212,
 
         /// <summary>
+        /// Incompatible package type
+        /// </summary>
+        NU1213 = 1213,
+
+        /// <summary>
         /// Package MinClientVersion did not match.
         /// </summary>
         NU1401 = 1401,

--- a/src/NuGet.Core/NuGet.Packaging/Core/PackageType.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Core/PackageType.cs
@@ -19,7 +19,7 @@ namespace NuGet.Packaging.Core
         public static readonly PackageType SymbolsPackage = new PackageType("SymbolsPackage", version: EmptyVersion);
         public static readonly PackageType DotnetPlatform = new PackageType("DotnetPlatform", version: EmptyVersion);
 
-        public static StringComparer PackageTypeNameComparer = StringComparer.OrdinalIgnoreCase;
+        public static readonly StringComparer PackageTypeNameComparer = StringComparer.OrdinalIgnoreCase;
 
         public PackageType(string name, Version version)
         {
@@ -110,11 +110,6 @@ namespace NuGet.Packaging.Core
             }
 
             return Version.CompareTo(other.Version);
-        }
-
-        public override string ToString()
-        {
-            return $"{Name} {Version}";
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Core/PackageType.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Core/PackageType.cs
@@ -17,6 +17,7 @@ namespace NuGet.Packaging.Core
         public static readonly PackageType Dependency = new PackageType("Dependency", version: EmptyVersion);
         public static readonly PackageType DotnetTool = new PackageType("DotnetTool", version: EmptyVersion);
         public static readonly PackageType SymbolsPackage = new PackageType("SymbolsPackage", version: EmptyVersion);
+        public static readonly PackageType DotnetPlatform = new PackageType("DotnetPlatform", version: EmptyVersion);
 
         public PackageType(string name, Version version)
         {
@@ -25,13 +26,8 @@ namespace NuGet.Packaging.Core
                 throw new ArgumentException(Strings.StringCannotBeNullOrEmpty, nameof(name));
             }
 
-            if (version == null)
-            {
-                throw new ArgumentNullException(nameof(version));
-            }
-
             Name = name;
-            Version = version;
+            Version = version ?? throw new ArgumentNullException(nameof(version));
         }
 
 
@@ -112,6 +108,11 @@ namespace NuGet.Packaging.Core
             }
 
             return Version.CompareTo(other.Version);
+        }
+
+        public override string ToString()
+        {
+            return $"{Name} {Version}";
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Core/PackageType.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Core/PackageType.cs
@@ -19,6 +19,8 @@ namespace NuGet.Packaging.Core
         public static readonly PackageType SymbolsPackage = new PackageType("SymbolsPackage", version: EmptyVersion);
         public static readonly PackageType DotnetPlatform = new PackageType("DotnetPlatform", version: EmptyVersion);
 
+        public static StringComparer PackageTypeNameComparer = StringComparer.OrdinalIgnoreCase;
+
         public PackageType(string name, Version version)
         {
             if (string.IsNullOrEmpty(name))
@@ -100,7 +102,7 @@ namespace NuGet.Packaging.Core
                 return 0;
             }
 
-            var res = StringComparer.OrdinalIgnoreCase.Compare(Name, other.Name);
+            var res = PackageTypeNameComparer.Compare(Name, other.Name);
 
             if (res != 0)
             {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7337
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Adding the `DotnetPlatform` package type. This package type is not compatible in the regular projects.

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
