### PR TITLE
Logging:  fix exception logging when verbosity is detailed

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -151,7 +151,7 @@ namespace NuGet.CommandLine
                 UserAgent.SetUserAgentString(new UserAgentStringBuilder(CommandLineConstants.UserAgent));
 
                 OutputNuGetVersion();
-                ExecuteCommandAsync().Wait();
+                ExecuteCommandAsync().GetAwaiter().GetResult();
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/CommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/CommandTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+
+namespace NuGet.CommandLine.Test
+{
+    public class CommandTests
+    {
+        [Fact]
+        public void Execute_WhenExceptionIsThrown_PropagatesOriginalException()
+        {
+            var command = new TestCommand()
+            {
+                Console = Mock.Of<IConsole>()
+            };
+
+            Assert.Throws<DivideByZeroException>(() => command.Execute());
+        }
+
+        private sealed class TestCommand : Command
+        {
+            public override async Task ExecuteCommandAsync()
+            {
+                await Task.CompletedTask;
+
+                throw new DivideByZeroException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolve https://github.com/NuGet/Home/issues/7955.

This change enables exception callstack reporting when logging verbosity is detailed.

Prior to this change [this issue](https://github.com/NuGet/Home/issues/7837) would only report the exception message (i.e.:  "A task was canceled.").  With this change, the full exception callstack is displayed too, which is can be useful when investigating a generic error like this.

