### PR TITLE
Update source.extension.vsixmanifest for VS 2019

### DIFF
--- a/test/TestExtensions/TestableVSCredentialProvider/source.extension.vsixmanifest
+++ b/test/TestExtensions/TestableVSCredentialProvider/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <Description xml:space="preserve">Testable NuGet Credential Provider for Visual Studio</Description>
   </Metadata>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
   <Installation>
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,]" />


### PR DESCRIPTION
## Bug

Fixes: Allows Visual Studio 2019 to access this extension

## Fix

Details: Added 17.0 to the manifest to allow Visual Studio 2019 to access it.
