### PR TITLE
Fix the threading issues of the directory utility on nix platforms

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PathUtil/DirectoryUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/DirectoryUtility.cs
@@ -45,10 +45,7 @@ namespace NuGet.Common
                         // This simple lock ensures that we are consistent.
                         lock (LockObject)
                         {
-                            if (!Directory.Exists(currentPath))
-                            {
-                                CreateSingleSharedDirectory(currentPath);
-                            }
+                            CreateSingleSharedDirectory(currentPath);
                         }
                     }
                 } while (sepPos != -1);
@@ -62,12 +59,15 @@ namespace NuGet.Common
         /// <param name="path"></param>
         private static void CreateSingleSharedDirectory(string path)
         {
-            Directory.CreateDirectory(path);
-            if (chmod(path, UGO_RWX) == -1)
+            if (!Directory.Exists(path))
             {
-                // it's very unlikely we can't set the permissions of a directory we just created
-                var errno = Marshal.GetLastWin32Error(); // fetch the errno before running any other operation
-                throw new InvalidOperationException($"Unable to set permission while creating {path}, errno={errno}.");
+                Directory.CreateDirectory(path);
+                if (chmod(path, UGO_RWX) == -1)
+                {
+                    // it's very unlikely we can't set the permissions of a directory we just created
+                    var errno = Marshal.GetLastWin32Error(); // fetch the errno before running any other operation
+                    throw new InvalidOperationException($"Unable to set permission while creating {path}, errno={errno}.");
+                }
             }
         }
 

--- a/src/NuGet.Core/NuGet.Common/PathUtil/DirectoryUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/DirectoryUtility.cs
@@ -56,7 +56,7 @@ namespace NuGet.Common
         /// Creating a directory and setting the permissions are two operations. To avoid race
         /// conditions, we create a different directory, this call should be called in a thread safe manner.
         /// </summary>
-        /// <param name="path"></param>
+        /// <param name="path">the path to be created with the <see cref="UGO_RWX"/> permissions set</param>
         private static void CreateSingleSharedDirectory(string path)
         {
             if (!Directory.Exists(path))

--- a/src/NuGet.Core/NuGet.Common/PathUtil/DirectoryUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/DirectoryUtility.cs
@@ -13,7 +13,7 @@ namespace NuGet.Common
     public static class DirectoryUtility
     {
         // The lock object
-        private static object LockObject = new object();
+        private static readonly object LockObject = new object();
 
         /// <summary>
         /// Creates all directories and subdirectories in the specified path unless they already exist.


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7977
Might be the root cause for some of the reports in https://github.com/NuGet/Home/issues/7341
Regression: No  
* Last working version: This was never correct
* How are we preventing it in future:   

## Fix

Details: Fix the directory utility threading issues. 

During the investigation of https://github.com/NuGet/Home/issues/7908, I found that this utility has threading issues. I have a test app that reliably repros the behavior: https://github.com/nkolev92/NuGet.Tools/tree/master/DirectoryUtilityRepro/TestApp

The Directory.CreateDirectory & Directory.Move methods do not guarantee thread safety. They merely guarantee filesystem consistency. 

Through my tests I narrowed down the issue to Directory.Move not throwing every time when the dest path exists in the case where multiple threads are trying to create the same directory. Directory.Move never claims thread safety, but rather only filesystem consistency. Effectively on Linux we’d have multiple moves succeed, because the underlying “rename” syscall allows for the destdir to be overridden. 

If I try to introduce the same concurrency, the failure is that a “process is using the file”, so not sure if the root cause is the same.

I considered fixing this with more granular locking but then I'd need to use a concurrent collection which adds its own complexity. 
We can take the "small" performance hit here for the sake of correctness. 

//cc @jeremykuhne

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  I ran the repro script overnight and did not reproduce the issue. https://github.com/nkolev92/NuGet.Tools/tree/master/DirectoryUtilityRepro/TestApp
Without the fixed behavior, I can reliably reproduce the issue in > 100 runs.