### PR TITLE
Verify the VSIX, nuget.exe, nuget.mssign.exe alongside the nupkgs

### DIFF
--- a/build/ignorecodesign.csv
+++ b/build/ignorecodesign.csv
@@ -1,1 +1,14 @@
-*.xml,ignore xmls
+nuget.tools.vsixdir\modules\nuget\cs\nuget.packagemanagement.powershellcmdlets.dll-help.xml,ignore xml
+nuget.tools.vsixdir\modules\nuget\de\nuget.packagemanagement.powershellcmdlets.dll-help.xml,ignore xml
+nuget.tools.vsixdir\modules\nuget\es\nuget.packagemanagement.powershellcmdlets.dll-help.xml,ignore xml
+nuget.tools.vsixdir\modules\nuget\fr\nuget.packagemanagement.powershellcmdlets.dll-help.xml,ignore xml
+nuget.tools.vsixdir\modules\nuget\it\nuget.packagemanagement.powershellcmdlets.dll-help.xml,ignore xml
+nuget.tools.vsixdir\modules\nuget\ja\nuget.packagemanagement.powershellcmdlets.dll-help.xml,ignore xml
+nuget.tools.vsixdir\modules\nuget\ko\nuget.packagemanagement.powershellcmdlets.dll-help.xml,ignore xml
+nuget.tools.vsixdir\modules\nuget\nuget.packagemanagement.powershellcmdlets.dll-help.xml,ignore xml
+nuget.tools.vsixdir\modules\nuget\pl\nuget.packagemanagement.powershellcmdlets.dll-help.xml,ignore xml
+nuget.tools.vsixdir\modules\nuget\pt-br\nuget.packagemanagement.powershellcmdlets.dll-help.xml,ignore xml
+nuget.tools.vsixdir\modules\nuget\ru\nuget.packagemanagement.powershellcmdlets.dll-help.xml,ignore xml
+nuget.tools.vsixdir\modules\nuget\tr\nuget.packagemanagement.powershellcmdlets.dll-help.xml,ignore xml
+nuget.tools.vsixdir\modules\nuget\zh-hans\nuget.packagemanagement.powershellcmdlets.dll-help.xml,ignore xml
+nuget.tools.vsixdir\modules\nuget\zh-hant\nuget.packagemanagement.powershellcmdlets.dll-help.xml,ignore xml

--- a/build/ignorecodesign.csv
+++ b/build/ignorecodesign.csv
@@ -1,0 +1,1 @@
+*.xml,ignore xmls

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -229,8 +229,9 @@ phases:
   - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
     displayName: Verify Assembly Signatures and StrongName for the nupkgs, exes and VSIX
     inputs:
-      TargetFolders: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
-                     '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
+      TargetFolders: |
+        '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
+        '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
       WhiteListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
       WhiteListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
   

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -229,7 +229,8 @@ phases:
   - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
     displayName: Verify Assembly Signatures and StrongName for the nupkgs, exes and VSIX
     inputs:
-      TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
+      TargetFolders: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
+                     '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
       WhiteListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
       WhiteListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
   

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -227,14 +227,17 @@ phases:
       arguments: "verify -Signatures $(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)\\*.nupkg"
 
   - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
-    displayName: Verify Assembly Signatures and StrongName for the nupkgs, exes and VSIX
+    displayName: Verify Assembly Signatures and StrongName for the nupkgs
     inputs:
-      TargetFolders: |
-        '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
-        '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
+      TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
+
+  - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
+    displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
+    inputs:
+      TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
       WhiteListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
       WhiteListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
-  
+
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -227,16 +227,11 @@ phases:
       arguments: "verify -Signatures $(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)\\*.nupkg"
 
   - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
-    displayName: Verify Assembly Signatures and StrongName for the nupkgs
-    inputs:
-      TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
-
-  - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
-    displayName: Verify Assembly Signatures and StrongName for the VSIX
+    displayName: Verify Assembly Signatures and StrongName for the nupkgs, exes and VSIX
     inputs:
       TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
-      ExcludeFolders: '$(NupkgOutputDir)'
-    condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+      WhiteListPathForCerts: '**\\*nuget.packagemanagement.powershellcmdlets.dll-help.xml'
+      WhiteListPathForSigs: '**\\*nuget.packagemanagement.powershellcmdlets.dll-help.xml'
   
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -230,8 +230,8 @@ phases:
     displayName: Verify Assembly Signatures and StrongName for the nupkgs, exes and VSIX
     inputs:
       TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
-      WhiteListPathForCerts: '*.xml'
-      WhiteListPathForSigs: '*.xml'
+      WhiteListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
+      WhiteListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
   
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -227,9 +227,14 @@ phases:
       arguments: "verify -Signatures $(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)\\*.nupkg"
 
   - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
-    displayName: Verify Assembly Signatures and StrongName
+    displayName: Verify Assembly Signatures and StrongName for the nupkgs
     inputs:
       TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
+
+  - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
+    displayName: Verify Assembly Signatures and StrongName for the VSIX
+    inputs:
+      TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)\\NuGet.Tools.vsix'
   
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -234,7 +234,8 @@ phases:
   - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
     displayName: Verify Assembly Signatures and StrongName for the VSIX
     inputs:
-      TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)\\*.vsix'
+      TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
+      ExcludeFolders: '$(NupkgOutputDir)'
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
   
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -235,11 +235,11 @@ phases:
     displayName: Verify Assembly Signatures and StrongName for the VSIX
     inputs:
       TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)\\*.vsix'
-    condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
+    condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
   
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
-    condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+    condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
   - task: CopyFiles@2
     displayName: "Copy Nupkgs"

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -239,7 +239,7 @@ phases:
   
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
-    condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
+    condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
   - task: CopyFiles@2
     displayName: "Copy Nupkgs"

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -230,8 +230,8 @@ phases:
     displayName: Verify Assembly Signatures and StrongName for the nupkgs, exes and VSIX
     inputs:
       TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
-      WhiteListPathForCerts: '**\\*nuget.packagemanagement.powershellcmdlets.dll-help.xml'
-      WhiteListPathForSigs: '**\\*nuget.packagemanagement.powershellcmdlets.dll-help.xml'
+      WhiteListPathForCerts: '*.xml'
+      WhiteListPathForSigs: '*.xml'
   
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -234,7 +234,8 @@ phases:
   - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
     displayName: Verify Assembly Signatures and StrongName for the VSIX
     inputs:
-      TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)\\NuGet.Tools.vsix'
+      TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)\\*.vsix'
+    condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
   
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7927, https://github.com/NuGet/Home/issues/7668
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

This PR supersedes https://github.com/NuGet/NuGet.Client/pull/2700. 

It should help us catch signing issues with the vsix content and nuget.mssign.exe early enough. 

Note the follow up https://github.com/NuGet/Home/issues/7982, which focuses on figuring out whether the xmls are ok in the exlusion list (note that as far as VS goes, this is fine). 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
