### PR TITLE
fix : Restore does not generate lock file on NoOp

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnexpectedDependencyMessages.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnexpectedDependencyMessages.cs
@@ -39,7 +39,7 @@ namespace NuGet.Commands
 
             // Ignore generating NU1603/NU1602 across entire graph if lock file is enabled. Because
             // lock file enforce a fixed resolved version for all the different requests for the same package ID.
-            if (!PackagesLockFileUtilities.IsNuGetLockFileSupported(project))
+            if (!PackagesLockFileUtilities.IsNuGetLockFileEnabled(project))
             {
                 // 2. Detect dependency and source issues across the entire graph 
                 //    where the minimum version was not matched exactly.

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -130,7 +130,7 @@ namespace NuGet.Commands
                         {
                             noOpTelemetry.StartIntervalMeasure();
 
-                            var noOpSuccess = NoOpRestoreUtilities.VerifyAssetsAndMSBuildFilesAndLockFilesAndPackagesArePresent(_request);
+                            var noOpSuccess = NoOpRestoreUtilities.VerifyRestoreOutput(_request);
 
                             noOpTelemetry.EndIntervalMeasure(MsbuildAssetsVerificationDuration);
                             noOpTelemetry.TelemetryEvent[MsbuildAssetsVerificationResult] = noOpSuccess;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -167,7 +167,7 @@ namespace NuGet.Commands
 
                 using (var lockFileTelemetry = TelemetryActivity.CreateTelemetryActivityWithNewOperationIdAndEvent(parentId: _operationId, eventName: RestoreLockFileInformation))
                 {
-                    lockFileTelemetry.TelemetryEvent[IsLockFileEnabled] = PackagesLockFileUtilities.IsNuGetLockFileSupported(_request.Project);
+                    lockFileTelemetry.TelemetryEvent[IsLockFileEnabled] = PackagesLockFileUtilities.IsNuGetLockFileEnabled(_request.Project);
 
                     var packagesLockFileResult = await EvaluatePackagesLockFileAsync(packagesLockFilePath, contextForProject, lockFileTelemetry);
 
@@ -309,7 +309,7 @@ namespace NuGet.Commands
                         // clear out the existing lock file so that we don't over-write the same file
                         packagesLockFile = null;
                     }
-                    else if (PackagesLockFileUtilities.IsNuGetLockFileSupported(_request.Project))
+                    else if (PackagesLockFileUtilities.IsNuGetLockFileEnabled(_request.Project))
                     {
                         // generate packages.lock.json file if enabled
                         packagesLockFile = new PackagesLockFileBuilder()

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -130,7 +130,7 @@ namespace NuGet.Commands
                         {
                             noOpTelemetry.StartIntervalMeasure();
 
-                            var noOpSuccess = NoOpRestoreUtilities.VerifyAssetsAndMSBuildFilesAndPackagesArePresent(_request);
+                            var noOpSuccess = NoOpRestoreUtilities.VerifyAssetsAndMSBuildFilesAndLockFilesAndPackagesArePresent(_request);
 
                             noOpTelemetry.EndIntervalMeasure(MsbuildAssetsVerificationDuration);
                             noOpTelemetry.TelemetryEvent[MsbuildAssetsVerificationResult] = noOpSuccess;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -111,7 +111,7 @@ namespace NuGet.Commands
         /// This method verifies that the props/targets files and all the packages written out in the lock file are present on disk
         /// This does not account if the files were manually modified since the last restore
         /// </summary>
-        internal static bool VerifyAssetsAndMSBuildFilesAndPackagesArePresent(RestoreRequest request)
+        internal static bool VerifyAssetsAndMSBuildFilesAndLockFilesAndPackagesArePresent(RestoreRequest request)
         {
 
             if (!File.Exists(request.ExistingLockFile?.Path))
@@ -132,6 +132,12 @@ namespace NuGet.Commands
                 if (!File.Exists(propsFilePath))
                 {
                     request.Log.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_PropsFileNotOnDisk, request.Project.Name, propsFilePath));
+                    return false;
+                }
+                var packageLockFilePath = PackagesLockFileUtilities.GetNuGetLockFilePath(request.Project);
+                if (!File.Exists(packageLockFilePath))
+                {
+                    request.Log.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_LockFileNotOnDisk, request.Project.Name, packageLockFilePath));
                     return false;
                 }
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -134,12 +134,16 @@ namespace NuGet.Commands
                     request.Log.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_PropsFileNotOnDisk, request.Project.Name, propsFilePath));
                     return false;
                 }
-                var packageLockFilePath = PackagesLockFileUtilities.GetNuGetLockFilePath(request.Project);
-                if (!File.Exists(packageLockFilePath))
+                if (PackagesLockFileUtilities.IsNuGetLockFileSupported(request.Project))
                 {
-                    request.Log.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_LockFileNotOnDisk, request.Project.Name, packageLockFilePath));
-                    return false;
+                    var packageLockFilePath = PackagesLockFileUtilities.GetNuGetLockFilePath(request.Project);
+                    if (!File.Exists(packageLockFilePath))
+                    {
+                        request.Log.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_LockFileNotOnDisk, request.Project.Name, packageLockFilePath));
+                        return false;
+                    }
                 }
+                
             }
 
             if (!VerifyPackagesOnDisk(request))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -108,8 +108,8 @@ namespace NuGet.Commands
         }
 
         /// <summary>
-        /// This method verifies that the assets files, props/targets files and all the packages written out in the lock file are present on disk
-        /// When package lock file is supported, this method also verifies if the package lock file is present on disk 
+        /// This method verifies that the assets files, props/targets files and all the packages written out in the assets file are present on disk
+        /// When the project has opted into packages lock file, it also verified that the lock file is present on disk.
         /// This does not account if the files were manually modified since the last restore
         /// </summary>
         internal static bool VerifyRestoreOutput(RestoreRequest request)
@@ -135,7 +135,7 @@ namespace NuGet.Commands
                     request.Log.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_PropsFileNotOnDisk, request.Project.Name, propsFilePath));
                     return false;
                 }
-                if (PackagesLockFileUtilities.IsNuGetLockFileSupported(request.Project))
+                if (PackagesLockFileUtilities.IsNuGetLockFileEnabled(request.Project))
                 {
                     var packageLockFilePath = PackagesLockFileUtilities.GetNuGetLockFilePath(request.Project);
                     if (!File.Exists(packageLockFilePath))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -108,10 +108,11 @@ namespace NuGet.Commands
         }
 
         /// <summary>
-        /// This method verifies that the props/targets files and all the packages written out in the lock file are present on disk
+        /// This method verifies that the assets files, props/targets files and all the packages written out in the lock file are present on disk
+        /// When package lock file is supported, this method also verifies if the package lock file is present on disk 
         /// This does not account if the files were manually modified since the last restore
         /// </summary>
-        internal static bool VerifyAssetsAndMSBuildFilesAndLockFilesAndPackagesArePresent(RestoreRequest request)
+        internal static bool VerifyRestoreOutput(RestoreRequest request)
         {
 
             if (!File.Exists(request.ExistingLockFile?.Path))

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -998,7 +998,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Lock file for {0} at location {1} does not exist, no-op is not possible. Continuing restore..
+        ///   Looks up a localized string similar to The lock file for {0} at location {1} does not exist, no-op is not possible. Continuing restore..
         /// </summary>
         internal static string Log_LockFileNotOnDisk {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -998,6 +998,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The Lock file for {0} at location {1} does not exist, no-op is not possible. Continuing restore..
+        /// </summary>
+        internal static string Log_LockFileNotOnDisk {
+            get {
+                return ResourceManager.GetString("Log_LockFileNotOnDisk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The lock file is out-of-date relative to the project file. Regenerating the lock file and re-locking..
         /// </summary>
         internal static string Log_LockFileOutOfDate {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -539,6 +539,9 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="Log_TargetsFileNotOnDisk" xml:space="preserve">
     <value>The targets file for {0} at location {1} does not exist, no-op is not possible. Continuing restore.</value>
   </data>
+  <data name="Log_LockFileNotOnDisk" xml:space="preserve">
+    <value>The Lock file for {0} at location {1} does not exist, no-op is not possible. Continuing restore.</value>
+  </data>
   <data name="Warning_MinVersionDoesNotExist" xml:space="preserve">
     <value>{0} depends on {1} but {2} was not found. An approximate best match of {3} was resolved.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -540,7 +540,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>The targets file for {0} at location {1} does not exist, no-op is not possible. Continuing restore.</value>
   </data>
   <data name="Log_LockFileNotOnDisk" xml:space="preserve">
-    <value>The Lock file for {0} at location {1} does not exist, no-op is not possible. Continuing restore.</value>
+    <value>The lock file for {0} at location {1} does not exist, no-op is not possible. Continuing restore.</value>
   </data>
   <data name="Warning_MinVersionDoesNotExist" xml:space="preserve">
     <value>{0} depends on {1} but {2} was not found. An approximate best match of {3} was resolved.</value>

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2829,7 +2829,7 @@ namespace NuGet.PackageManagement
                 }
 
                 // add packages lock file into project
-                if (PackagesLockFileUtilities.IsNuGetLockFileSupported(projectAction.RestoreResult.LockFile.PackageSpec))
+                if (PackagesLockFileUtilities.IsNuGetLockFileEnabled(projectAction.RestoreResult.LockFile.PackageSpec))
                 {
                     var lockFilePath = PackagesLockFileUtilities.GetNuGetLockFilePath(projectAction.RestoreResult.LockFile.PackageSpec);
 

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -14,7 +14,7 @@ namespace NuGet.ProjectModel
 {
     public static class PackagesLockFileUtilities
     {
-        public static bool IsNuGetLockFileSupported(PackageSpec project)
+        public static bool IsNuGetLockFileEnabled(PackageSpec project)
         {
             var restorePackagesWithLockFile = project.RestoreMetadata?.RestoreLockProperties.RestorePackagesWithLockFile;
             return MSBuildStringUtility.IsTrue(restorePackagesWithLockFile) || File.Exists(GetNuGetLockFilePath(project));

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -6631,7 +6631,7 @@ namespace NuGet.CommandLine.Test
             // Related issue: https://github.com/NuGet/Home/issues/7807
             // Contrast test to the second senario : do not delete package lock file at the end of the first restore.
             //      First restore should fail the No-op, regenerate the package lock file. DO NOT delete the package lock file, run the second restore.
-            //      The second restore: No lockfile will be generated. And no-op succeed. 
+            //      The second restore: No-op should succeed, lock file will not be regenerated.
 
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -6685,7 +6685,7 @@ namespace NuGet.CommandLine.Test
                 Assert.Equal(0, result2.Item1);
                 Assert.Contains(noOpSucceedMsg, result2.Item2);
                 Assert.DoesNotContain("Writing packages lock file at disk.", result2.Item2);
-                Assert.False(File.Exists(packageLockFileName));
+                Assert.True(File.Exists(packageLockFileName));
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -6470,7 +6470,7 @@ namespace NuGet.CommandLine.Test
 
 
                 var packageLockFileName = project.NuGetLockFileOutputPath;
-                var noOpFailedMsg = "The Lock file for " + project.ProjectName + " at location " + packageLockFileName + " does not exist, no-op is not possible. Continuing restore.";
+                var noOpFailedMsg = "The lock file for " + project.ProjectName + " at location " + packageLockFileName + " does not exist, no-op is not possible. Continuing restore.";
 
                 // Act  
                 var result1 = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
@@ -6536,7 +6536,7 @@ namespace NuGet.CommandLine.Test
 
 
                 var packageLockFileName = project.NuGetLockFileOutputPath;
-                var noOpFailedMsg = "The Lock file for " + project.ProjectName + " at location " + packageLockFileName + " does not exist, no-op is not possible. Continuing restore.";
+                var noOpFailedMsg = "The lock file for " + project.ProjectName + " at location " + packageLockFileName + " does not exist, no-op is not possible. Continuing restore.";
                 var noOpSucceedMsg = "No-Op restore. The cache will not be updated.";
 
                 // Act  
@@ -6600,7 +6600,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(File.Exists(packageLockFileName));
 
 
-                var noOpFailedMsg = "The Lock file for " + project.ProjectName + " at location " + packageLockFileName + " does not exist, no-op is not possible. Continuing restore.";
+                var noOpFailedMsg = "The lock file for " + project.ProjectName + " at location " + packageLockFileName + " does not exist, no-op is not possible. Continuing restore.";
                 var noOpSucceedMsg = "No-Op restore. The cache will not be updated.";
 
                 // Act
@@ -6667,7 +6667,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(File.Exists(packageLockFileName));
 
 
-                var noOpFailedMsg = "The Lock file for " + project.ProjectName + " at location " + packageLockFileName + " does not exist, no-op is not possible. Continuing restore.";
+                var noOpFailedMsg = "The lock file for " + project.ProjectName + " at location " + packageLockFileName + " does not exist, no-op is not possible. Continuing restore.";
                 var noOpSucceedMsg = "No-Op restore. The cache will not be updated.";
 
                 // Act


### PR DESCRIPTION
## Bug

Fixes:  [NuGet/Home#7807](https://github.com/NuGet/Home/issues/7807)  
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Add validation of checking the existence of package lock file. If not, failed the no-op.   

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  

Note: the message of "Writing packages lock file at disk." will not be displayed by default if it's dotnet restore. But if add "-verbosity normal", then the message will show up.