### PR TITLE
Add support for DependencyVersion to NuGet.exe cli UpdateCommand

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -245,37 +245,9 @@ namespace NuGet.CommandLine
             return new CommandLineSourceRepositoryProvider(SourceProvider);
         }
 
-        private DependencyBehavior TryGetDependencyBehavior(string behaviorStr)
-        {
-            DependencyBehavior dependencyBehavior;
 
-            if (!Enum.TryParse<DependencyBehavior>(behaviorStr, ignoreCase: true, result: out dependencyBehavior) || !Enum.IsDefined(typeof(DependencyBehavior), dependencyBehavior))
-            {
-                throw new CommandException(string.Format(CultureInfo.CurrentCulture, LocalizedResourceManager.GetString("InstallCommandUnknownDependencyVersion"), behaviorStr));
-            }
 
-            return dependencyBehavior;
-        }
 
-        private DependencyBehavior GetDependencyBehavior()
-        {
-            // If dependencyVersion is not set by either the config or commandline, default dependency behavior is 'Lowest'.
-            var dependencyBehavior = DependencyBehavior.Lowest;
-
-            var settingsDependencyVersion = SettingsUtility.GetConfigValue(Settings, "dependencyVersion");
-
-            // Check to see if commandline flag is set. Else check for dependencyVersion in .config.
-            if (!string.IsNullOrEmpty(DependencyVersion))
-            {
-                dependencyBehavior = TryGetDependencyBehavior(DependencyVersion);
-            }
-            else if (!string.IsNullOrEmpty(settingsDependencyVersion))
-            {
-                dependencyBehavior = TryGetDependencyBehavior(settingsDependencyVersion);
-            }
-
-            return dependencyBehavior;
-        }
 
         private async Task InstallPackageAsync(
             string packageId,
@@ -307,7 +279,7 @@ namespace NuGet.CommandLine
 
             var allowPrerelease = Prerelease || (version != null && version.IsPrerelease);
 
-            var dependencyBehavior = GetDependencyBehavior();
+            var dependencyBehavior = DependencyBehaviorHelper.GetDependencyBehavior(DependencyBehavior.Lowest, DependencyVersion, Settings);
 
             using (var sourceCacheContext = new SourceCacheContext())
             {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -37,6 +37,9 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "UpdateCommandVersionDescription")]
         public string Version { get; set; }
 
+        [Option(typeof(NuGetCommand), "UpdateCommandDependencyVersion")]
+        public string DependencyVersion { get; set; }
+
         [Option(typeof(NuGetCommand), "UpdateCommandRepositoryPathDescription")]
         public string RepositoryPath { get; set; }
 
@@ -282,8 +285,9 @@ namespace NuGet.CommandLine
 
             using (var sourceCacheContext = new SourceCacheContext())
             {
+                var dependencyBehavior = DependencyBehaviorHelper.GetDependencyBehavior(DependencyBehavior.Highest, DependencyVersion, Settings);
                 var resolutionContext = new ResolutionContext(
-                               Resolver.DependencyBehavior.Highest,
+                               dependencyBehavior,
                                Prerelease,
                                includeUnlisted: false,
                                versionConstraints: versionConstraints,

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -21,6 +21,7 @@ using NuGet.Versioning;
 using NuGet.Packaging.Signing;
 using NuGet.Packaging;
 using NuGet.Packaging.PackageExtraction;
+using NuGet.Resolver;
 
 namespace NuGet.CommandLine
 {

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/DependencyBehaviorHelper.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/DependencyBehaviorHelper.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using NuGet.Configuration;
+using NuGet.Resolver;
+
+namespace NuGet.CommandLine
+{
+    internal static class DependencyBehaviorHelper
+    {
+        private static DependencyBehavior TryGetDependencyBehavior(string behaviorStr)
+        {
+            DependencyBehavior dependencyBehavior;
+
+            if (!Enum.TryParse<DependencyBehavior>(behaviorStr, ignoreCase: true, result: out dependencyBehavior) ||
+                !Enum.IsDefined(typeof(DependencyBehavior), dependencyBehavior))
+            {
+                throw new CommandLineException(string.Format(CultureInfo.CurrentCulture,
+                    LocalizedResourceManager.GetString("Error_UnknownDependencyVersion"), behaviorStr));
+            }
+
+            return dependencyBehavior;
+        }
+
+        public static DependencyBehavior GetDependencyBehavior(DependencyBehavior defaultBehavior, string dependencyVersion, Configuration.ISettings settings)
+        {
+            // Check to see if dependencyVersion parameter is set. Else check for dependencyVersion in .config.
+            if (!string.IsNullOrEmpty(dependencyVersion))
+            {
+                return TryGetDependencyBehavior(dependencyVersion);
+            }
+
+            // If the dependencyVersion wasn't provided , try to get the dependencyBehavior from the .config.
+            string settingsDependencyVersion =
+                SettingsUtility.GetConfigValue(settings, ConfigurationConstants.DependencyVersion);
+
+            if (!string.IsNullOrEmpty(settingsDependencyVersion))
+            {
+                return TryGetDependencyBehavior(settingsDependencyVersion);
+            }
+
+            return defaultBehavior;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/DependencyBehaviorHelper.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/DependencyBehaviorHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using NuGet.Commands;
 using NuGet.Configuration;
 using NuGet.Resolver;
 
@@ -17,7 +18,7 @@ namespace NuGet.CommandLine
             if (!Enum.TryParse<DependencyBehavior>(behaviorStr, ignoreCase: true, result: out dependencyBehavior) ||
                 !Enum.IsDefined(typeof(DependencyBehavior), dependencyBehavior))
             {
-                throw new CommandLineException(string.Format(CultureInfo.CurrentCulture,
+                throw new CommandException(string.Format(CultureInfo.CurrentCulture,
                     LocalizedResourceManager.GetString("Error_UnknownDependencyVersion"), behaviorStr));
             }
 

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -13640,7 +13640,14 @@ namespace NuGet.CommandLine {
                 return ResourceManager.GetString("TrustedSignersCommandUsageSummary", resourceCulture);
             }
         }
-        
+        /// <summary>
+        ///   Looks up a localized string similar to Overrides the default dependency resolution behavior..
+        /// </summary>
+        internal static string UpdateCommandDependencyVersion {
+            get {
+                return ResourceManager.GetString("UpdateCommandDependencyVersion", resourceCulture);
+            }
+        }
         /// <summary>
         ///   Looks up a localized string similar to Update packages to latest available versions. This command also updates NuGet.exe itself..
         /// </summary>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5531,6 +5531,9 @@ nuget trusted-signers Remove -Name TrustedRepo</value>
   <data name="TrustedSignersCommandServiceIndexDescription" xml:space="preserve">
     <value>Service index for a repository to be trusted.</value>
   </data>
+  <data name="UpdateCommandDependencyVersion" xml:space="preserve">
+    <value>Overrides the default dependency resolution behavior.</value>
+  </data>
   <data name="PushCommandSkipDuplicateDescription" xml:space="preserve">
     <value>If a package and version already exists, skip it and continue with the next package in the push, if any.</value>
   </data>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -3444,6 +3444,15 @@ namespace NuGet.CommandLine {
             }
         }
         
+		/// <summary>
+        ///   Looks up a localized string similar to Invalid value given for &apos;DependencyVersion&apos;: &quot;{0}&quot;..
+        /// </summary>
+        public static string Error_UnknownDependencyVersion {
+            get {
+                return ResourceManager.GetString("Error_UnknownDependencyVersion", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to This version of msbuild is not supported: &apos;{0}&apos;.
         /// </summary>
@@ -4883,16 +4892,7 @@ namespace NuGet.CommandLine {
                 return ResourceManager.GetString("InstallCommandUnableToFindPackage", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Invalid value given for &apos;DependencyVersion&apos;: &quot;{0}&quot;..
-        /// </summary>
-        public static string InstallCommandUnknownDependencyVersion {
-            get {
-                return ResourceManager.GetString("InstallCommandUnknownDependencyVersion", resourceCulture);
-            }
-        }
-        
+              
         /// <summary>
         ///   Looks up a localized string similar to Installing package &apos;{0}&apos; to &apos;{1}&apos;..
         /// </summary>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -5367,10 +5367,6 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="PackageRestoreConsentCheckBoxText" xml:space="preserve">
     <value>&amp;Allow NuGet to download missing packages</value>
   </data>
-  <data name="InstallCommandUnknownDependencyVersion" xml:space="preserve">
-    <value>Invalid value given for 'DependencyVersion': "{0}".</value>
-    <comment>Please don't localize "DependencyVersion".</comment>
-  </data>
   <data name="UnsupportedFramework" xml:space="preserve">
     <value>'{0}' is not a valid target framework.</value>
   </data>
@@ -5416,5 +5412,9 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
     <value>`project.json` pack is deprecated. Please consider migrating '{0}' to `PackageReference` and using the pack targets.</value>
     <comment>Do not localize project.json and `PackageReference` 
 0 - project path (project.json file path)</comment>
+  </data>
+  <data name="Error_UnknownDependencyVersion" xml:space="preserve">
+    <value>Invalid value given for 'DependencyVersion': "{0}".</value>
+    <comment>Please don't localize "DependencyVersion".</comment>
   </data>
 </root>


### PR DESCRIPTION
Adding -DependencyVersion to NuGet Update

Linked to issue : https://github.com/NuGet/Home/issues/7694

Details: 
* Add new helper to handle the DependencyVersion, to avoid to duplicate code between the Install and Update command.
* Add the related unit tests to ensure the default behavior still works and the new features work as expect

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
