### PR TITLE
Test:  add script/nuspec to generate E2E test data package

### DIFF
--- a/scripts/e2etests/CreateTestDataPackage.ps1
+++ b/scripts/e2etests/CreateTestDataPackage.ps1
@@ -1,0 +1,154 @@
+<#
+.SYNOPSIS
+Creates a package containing NuGet client EndToEnd test data.
+
+.PARAMETER configuration
+The build configuration.  The default value is 'debug'.
+
+.PARAMETER toolsetVersion
+The toolset version.  The default value is 15.
+
+.PARAMETER outputDirectoryPath
+The output directory where the test data package will be created.  The default value is the current directory.
+
+.EXAMPLE
+.\CreateTestDataPackage.ps1 -configuration 'debug' -toolsetVersion 15 -outputDirectoryPath 'C:\git\NuGet.Client\artifacts\nupkgs'
+#>
+
+[CmdletBinding()]
+param (
+    [ValidateSet('debug', 'release')]
+    [string] $configuration = 'debug',
+    [ValidateSet(15, 16)]
+    [int] $toolsetVersion = 15,
+    [string] $outputDirectoryPath = $PWD
+)
+
+Function Get-DirectoryPath([string[]] $pathParts)
+{
+    Return [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($pathParts))
+}
+
+Set-Variable repositoryRootDirectoryPath -Option Constant -Value $(Get-DirectoryPath($PSScriptRoot, '..', '..'))
+
+Function Get-Directory([string[]] $pathParts)
+{
+    $directoryPath = Get-DirectoryPath($pathParts)
+
+    Return [System.IO.DirectoryInfo]::new($directoryPath)
+}
+
+Function Get-File([string[]] $pathParts)
+{
+    $filePath = [System.IO.Path]::Combine($pathParts)
+
+    $file = [System.IO.FileInfo]::new($filePath)
+
+    If (-Not $file.Exists)
+    {
+        throw [System.IO.FileNotFoundException]::new("Could not find $($file.Name) at $($file.FullName).  Please build first.", $file.FullName)
+    }
+
+    Return $file
+}
+
+Function Get-GenerateTestPackagesFile()
+{
+    Return Get-File($repositoryRootDirectoryPath, 'artifacts', 'GenerateTestPackages', "$toolsetVersion.0", 'bin', $configuration, 'net472', 'GenerateTestPackages.exe')
+}
+
+Function Get-NuGetFile()
+{
+    Return Get-File($repositoryRootDirectoryPath, 'artifacts', 'VS15', 'nuget.exe')
+}
+
+Function Create-TestPackages()
+{
+    $generateTestPackagesFile = Get-GenerateTestPackagesFile
+    $testPackagesDirectory = Get-Directory($repositoryRootDirectoryPath, 'test', 'EndToEnd', 'Packages')
+
+    Set-Location -Path $testPackagesDirectory.FullName
+
+    $rootDirectoryPath = Get-Location
+    $testDirectoryPaths = [System.IO.Directory]::GetDirectories($rootDirectoryPath)
+
+    $testDirectoryPaths | %{
+        $testDirectoryPath = $_
+        $packagesDirectory = Get-Directory($testDirectoryPath, 'Packages')
+        $assembliesDirectory = Get-Directory($testDirectoryPath, 'Assemblies')
+        $recursive = $True
+
+        If ($packagesDirectory.Exists)
+        {
+            $packagesDirectory.Delete($recursive)
+        }
+
+        If ($assembliesDirectory.Exists)
+        {
+            $assembliesDirectory.Delete($recursive)
+        }
+
+        Get-ChildItem $testDirectoryPath\* -Include *.dgml,*.nuspec | %{
+            Write-Host "Running $($generateTestPackagesFile.Name) on $($_.FullName)...  " -NoNewLine
+
+            $process = Start-Process `
+                -FilePath $generateTestPackagesFile.FullName `
+                -WorkingDirectory $testDirectoryPath `
+                -WindowStyle Hidden `
+                -PassThru `
+                -Wait `
+                -ArgumentList $_.FullName
+
+            If ($process.ExitCode -eq 0)
+            {
+                Write-Host 'Success.'
+            }
+            else
+            {
+                Write-Error "Failed.  Exit code is $($process.ExitCode)."
+            }
+        }
+
+        If ($assembliesDirectory.Exists)
+        {
+            $assembliesDirectory.Delete($recursive)
+        }
+    }
+}
+
+Function Create-TestDataPackage()
+{
+    $nuspecFile = Get-File($repositoryRootDirectoryPath, 'test', 'EndToEnd', 'NuGet.Client.EndToEnd.TestData.nuspec')
+    $outputDirectoryPath = [System.IO.Path]::Combine($repositoryRootDirectoryPath, 'artifacts', 'nupkgs')
+    $nupkgFilePath = [System.IO.Path]::Combine($outputDirectoryPath, 'NuGet.Client.EndToEnd.TestData.nupkg')
+    $nugetFile = Get-NuGetFile
+
+    $process = Start-Process `
+        -FilePath $nugetFile.FullName `
+        -WorkingDirectory $nuspecFile.DirectoryName `
+        -WindowStyle Hidden `
+        -PassThru `
+        -Wait `
+        -ArgumentList 'pack', $nuspecFile.FullName, "-OutputDirectory `"$outputDirectoryPath`"", '-NoDefaultExcludes', '-NonInteractive'
+
+    If ($process.ExitCode -eq 0)
+    {
+        Write-Host "Created test data package $nupkgFilePath."
+    }
+    else
+    {
+        Write-Error "$($nugetFile.Name) failed.  Exit code is $($process.ExitCode)."
+    }
+}
+
+$originalDirectoryPath = Get-Location
+
+Try
+{
+    Create-TestPackages
+    Create-TestDataPackage
+}
+Finally
+{
+    Set-Location $originalDirectoryPath
+}

--- a/scripts/e2etests/CreateTestDataPackage.ps1
+++ b/scripts/e2etests/CreateTestDataPackage.ps1
@@ -67,10 +67,7 @@ Function Create-TestPackages()
     $generateTestPackagesFile = Get-GenerateTestPackagesFile
     $testPackagesDirectory = Get-Directory($repositoryRootDirectoryPath, 'test', 'EndToEnd', 'Packages')
 
-    Set-Location -Path $testPackagesDirectory.FullName
-
-    $rootDirectoryPath = Get-Location
-    $testDirectoryPaths = [System.IO.Directory]::GetDirectories($rootDirectoryPath)
+    $testDirectoryPaths = [System.IO.Directory]::GetDirectories($testPackagesDirectory.FullName)
 
     $testDirectoryPaths | %{
         $testDirectoryPath = $_
@@ -141,14 +138,5 @@ Function Create-TestDataPackage()
     }
 }
 
-$originalDirectoryPath = Get-Location
-
-Try
-{
-    Create-TestPackages
-    Create-TestDataPackage
-}
-Finally
-{
-    Set-Location $originalDirectoryPath
-}
+Create-TestPackages
+Create-TestDataPackage

--- a/test/EndToEnd/NuGet.Client.EndToEnd.TestData.nuspec
+++ b/test/EndToEnd/NuGet.Client.EndToEnd.TestData.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>NuGet.Client.EndToEnd.TestData</id>
+    <version>1.0.0</version>
+    <title>Test data for NuGet.Client EndToEnd tests</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <projectUrl>https://aka.ms/nugetprj</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/NuGet/Media/master/Images/MainLogo/256x256/nuget_256.png</iconUrl>
+    <description>This package provides test data that is used during the execution of the NuGet.Client EndToEnd  tests.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>nuget endtoend testdata</tags>
+  </metadata>
+  <files>
+    <file src="Packages\**\*.nupkg" target="content\Packages" />
+  </files>
+</package>

--- a/test/EndToEnd/NuGet.Client.EndToEnd.TestData.nuspec
+++ b/test/EndToEnd/NuGet.Client.EndToEnd.TestData.nuspec
@@ -7,7 +7,6 @@
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <license type="expression">Apache-2.0</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <projectUrl>https://aka.ms/nugetprj</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/NuGet/Media/master/Images/MainLogo/256x256/nuget_256.png</iconUrl>
     <description>This package provides test data that is used during the execution of the NuGet.Client EndToEnd  tests.</description>


### PR DESCRIPTION
Progress on https://github.com/NuGet/Home/issues/7984.

This PR adds a PowerShell script and a .nuspec file that will generate a package (NuGet.Client.EndToEnd.TestData.nupkg) which contains pregenerated inputs for end-to-end tests.

The idea is that a test data package would be generated and published.  A subsequent change will consume the package and incorporate the test data in the EndToEnd.zip file.  This will eliminate the need to run GenerateTestPackages.exe repeatedly for every E2E test run.

The package version is hard-coded to 1.0.0 and would need to be incremented manually should a new package be published.  Given how infrequently we update E2E tests, I think this is a reasonable solution for now.