### PR TITLE
MSBuild resolvable path to the assets file in the nuget.g.props

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -142,12 +142,12 @@ namespace NuGet.Commands
 
             if (firstImport != null)
             {
-                // Write the assets file path relative to the props file.
+                // Write the assets file path to the props file in an MSBuild resolvable manner.
                 // This allows the project to be moved and avoid a large number of project errors
                 // until restore can run again.
-                var relativeAssetsPath = PathUtility.GetRelativePath(firstImport.Path, assetsFilePath);
+                var resolvableAssetsFilePath = @"$(MSBuildThisFileDirectory)" + PathUtility.GetRelativePath(firstImport.Path, assetsFilePath);
 
-                AddNuGetProperties(firstImport.Content, packageFolders, repositoryRoot, projectStyle, relativeAssetsPath, success);
+                AddNuGetProperties(firstImport.Content, packageFolders, repositoryRoot, projectStyle, resolvableAssetsFilePath, success);
             }
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -142,7 +142,12 @@ namespace NuGet.Commands
 
             if (firstImport != null)
             {
-                AddNuGetProperties(firstImport.Content, packageFolders, repositoryRoot, projectStyle, assetsFilePath, success);
+                // Write the assets file path relative to the props file.
+                // This allows the project to be moved and avoid a large number of project errors
+                // until restore can run again.
+                var relativeAssetsPath = PathUtility.GetRelativePath(firstImport.Path, assetsFilePath);
+
+                AddNuGetProperties(firstImport.Content, packageFolders, repositoryRoot, projectStyle, relativeAssetsPath, success);
             }
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -145,7 +145,7 @@ namespace NuGet.Commands
                 // Write the assets file path to the props file in an MSBuild resolvable manner.
                 // This allows the project to be moved and avoid a large number of project errors
                 // until restore can run again.
-                var resolvableAssetsFilePath = @"$(MSBuildThisFileDirectory)" + PathUtility.GetRelativePath(firstImport.Path, assetsFilePath);
+                var resolvableAssetsFilePath = @"$(MSBuildThisFileDirectory)" + Path.GetFileName(assetsFilePath);
 
                 AddNuGetProperties(firstImport.Content, packageFolders, repositoryRoot, projectStyle, resolvableAssetsFilePath, success);
             }
@@ -396,7 +396,7 @@ namespace NuGet.Commands
             ILogger log)
         {
             // Generate file names
-            var targetsPath = GetMSBuildFilePath(project,request,"targets");
+            var targetsPath = GetMSBuildFilePath(project, request, "targets");
             var propsPath = GetMSBuildFilePath(project, request, "props");
 
             // Targets files contain a macro for the repository root. If only the user package folder was used

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -186,14 +186,14 @@ EndGlobal";
                 var result = _msbuildFixture.RunDotnet(pathContext.SolutionRoot, $"restore proj.sln {$"--source \"{pathContext.PackageSource}\""}", ignoreExitCode: true);
 
                 // Assert
-                Assert.True(result.Item1 == 0);
+                Assert.True(result.ExitCode == 0);
                 Assert.True(1 == result.AllOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Length, result.AllOutput);
 
                 // Act - make sure no-op does the same thing.
                 result = _msbuildFixture.RunDotnet(pathContext.SolutionRoot, $"restore proj.sln {$"--source \"{pathContext.PackageSource}\""}", ignoreExitCode: true);
 
                 // Assert
-                Assert.True(result.Item1 == 0);
+                Assert.True(result.ExitCode == 0);
                 Assert.True(1 == result.AllOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Length, result.AllOutput);
 
             }
@@ -218,7 +218,7 @@ EndGlobal";
                 var projectFile1 = Path.Combine(projectDirectory, $"{projectName}.csproj");
                 var movedProjectFile = Path.Combine(movedDirectory, $"{projectName}.csproj");
 
-                _msbuildFixture.CreateDotnetNewProject(testDirectory, projectName, " classlib");
+                _msbuildFixture.CreateDotnetNewProject(testDirectory, projectName, "classlib");
 
                 using (var stream = File.Open(projectFile1, FileMode.Open, FileAccess.ReadWrite))
                 {
@@ -243,7 +243,7 @@ EndGlobal";
 
 
                 // Assert
-                Assert.True(result.Item1 == 0, result.AllOutput);
+                Assert.True(result.ExitCode == 0, result.AllOutput);
                 Assert.Contains("Restore completed", result.AllOutput);
 
                 Directory.Move(projectDirectory, movedDirectory);
@@ -251,7 +251,7 @@ EndGlobal";
                 result = _msbuildFixture.RunDotnet(movedDirectory, $"build {movedProjectFile} --no-restore", ignoreExitCode: true);
 
                 // Assert
-                Assert.True(result.Item1 == 0, result.AllOutput);
+                Assert.True(result.ExitCode == 0, result.AllOutput);
                 Assert.DoesNotContain("Restore completed", result.AllOutput);
 
             }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions;
 using NuGet.Common;
+using NuGet.Frameworks;
 using NuGet.Test.Utility;
 using Xunit;
 
@@ -194,6 +195,64 @@ EndGlobal";
                 // Assert
                 Assert.True(result.Item1 == 0);
                 Assert.True(1 == result.AllOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Length, result.AllOutput);
+
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task DotnetRestore_ProjectMovedDoesNotRunRestore()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var testDirectory = pathContext.SolutionRoot;
+                var pkgX = new SimpleTestPackageContext("x", "1.0.0");
+                pkgX.Files.Clear();
+                pkgX.AddFile($"lib/netstandard2.0/x.dll", "netstandard2.0");
+
+                await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, pkgX);
+
+                var projectName = "ClassLibrary1";
+                var projectDirectory = Path.Combine(testDirectory, projectName);
+                var movedDirectory = Path.Combine(testDirectory, projectName + "-new");
+
+                var projectFile1 = Path.Combine(projectDirectory, $"{projectName}.csproj");
+                var movedProjectFile = Path.Combine(movedDirectory, $"{projectName}.csproj");
+
+                _msbuildFixture.CreateDotnetNewProject(testDirectory, projectName, " classlib");
+
+                using (var stream = File.Open(projectFile1, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+
+                    var attributes = new Dictionary<string, string>() { { "Version", "1.0.0" } };
+
+                    ProjectFileUtils.AddItem(
+                        xml,
+                        "PackageReference",
+                        "x",
+                        (NuGetFramework)null,
+                        new Dictionary<string, string>(),
+                        attributes);
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+
+                // Act
+                var result = _msbuildFixture.RunDotnet(projectDirectory, $"build {projectFile1} {$"--source \"{pathContext.PackageSource}\""}", ignoreExitCode: true);
+
+
+                // Assert
+                Assert.True(result.Item1 == 0, result.AllOutput);
+                Assert.Contains("Restore completed", result.AllOutput);
+
+                Directory.Move(projectDirectory, movedDirectory);
+
+                result = _msbuildFixture.RunDotnet(movedDirectory, $"build {movedProjectFile} --no-restore", ignoreExitCode: true);
+
+                // Assert
+                Assert.True(result.Item1 == 0, result.AllOutput);
+                Assert.DoesNotContain("Restore completed", result.AllOutput);
 
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -866,10 +866,11 @@ namespace NuGet.Commands.Test
                 var props = TargetsUtility.GetMSBuildProperties(doc);
 
                 // Assert
-                Assert.Equal("project.assets.json", props["ProjectAssetsFile"]);
+                Assert.Equal("$(MSBuildThisFileDirectory)project.assets.json", props["ProjectAssetsFile"]);
             }
         }
-
+        // TODO NK - Add better tests, can the assets file and the props file ever be different?
+        // Would this work for project.json?
         [Fact]
         public void BuildAssetsUtils_GenerateProjectRelativeAssetsFilePathInOtherDir()
         {
@@ -894,7 +895,7 @@ namespace NuGet.Commands.Test
                 var props = TargetsUtility.GetMSBuildProperties(doc);
 
                 // Assert
-                Assert.Equal("../nuget/project.assets.json".Replace('/', Path.DirectorySeparatorChar), props["ProjectAssetsFile"]);
+                Assert.Equal("$(MSBuildThisFileDirectory)project.assets.json".Replace('/', Path.DirectorySeparatorChar), props["ProjectAssetsFile"]);
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,7 +14,6 @@ using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Repositories;
-using NuGet.RuntimeModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Xunit;
@@ -841,6 +839,62 @@ namespace NuGet.Commands.Test
                 {
                     Assert.Null(actualPropertyElement);
                 }
+            }
+        }
+
+        [Fact]
+        public void BuildAssetsUtils_GenerateProjectRelativeAssetsFilePath()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var filePath = Path.Combine(workingDir, "obj", "test.props");
+                var assetsPath = Path.Combine(workingDir, "obj", "project.assets.json");
+
+                var doc = BuildAssetsUtils.GenerateEmptyImportsFile();
+                var file = new MSBuildOutputFile(filePath, doc);
+
+                // Act
+                BuildAssetsUtils.AddNuGetPropertiesToFirstImport(
+                    new[] { file },
+                    Enumerable.Empty<string>(),
+                    string.Empty,
+                    ProjectStyle.PackageReference,
+                    assetsPath,
+                    success: true);
+
+                var props = TargetsUtility.GetMSBuildProperties(doc);
+
+                // Assert
+                Assert.Equal("project.assets.json", props["ProjectAssetsFile"]);
+            }
+        }
+
+        [Fact]
+        public void BuildAssetsUtils_GenerateProjectRelativeAssetsFilePathInOtherDir()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var filePath = Path.Combine(workingDir, "obj", "test.props");
+                var assetsPath = Path.Combine(workingDir, "nuget", "project.assets.json");
+
+                var doc = BuildAssetsUtils.GenerateEmptyImportsFile();
+                var file = new MSBuildOutputFile(filePath, doc);
+
+                // Act
+                BuildAssetsUtils.AddNuGetPropertiesToFirstImport(
+                    new[] { file },
+                    Enumerable.Empty<string>(),
+                    string.Empty,
+                    ProjectStyle.PackageReference,
+                    assetsPath,
+                    success: true);
+
+                var props = TargetsUtility.GetMSBuildProperties(doc);
+
+                // Assert
+                Assert.Equal("../nuget/project.assets.json".Replace('/', Path.DirectorySeparatorChar), props["ProjectAssetsFile"]);
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -869,8 +869,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal("$(MSBuildThisFileDirectory)project.assets.json", props["ProjectAssetsFile"]);
             }
         }
-        // TODO NK - Add better tests, can the assets file and the props file ever be different?
-        // Would this work for project.json?
+
         [Fact]
         public void BuildAssetsUtils_GenerateProjectRelativeAssetsFilePathInOtherDir()
         {
@@ -894,8 +893,6 @@ namespace NuGet.Commands.Test
 
                 var props = TargetsUtility.GetMSBuildProperties(doc);
 
-                // Assert
-                // TODO NK - This is wrong
                 Assert.Equal("$(MSBuildThisFileDirectory)project.assets.json".Replace('/', Path.DirectorySeparatorChar), props["ProjectAssetsFile"]);
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -895,6 +895,7 @@ namespace NuGet.Commands.Test
                 var props = TargetsUtility.GetMSBuildProperties(doc);
 
                 // Assert
+                // TODO NK - This is wrong
                 Assert.Equal("$(MSBuildThisFileDirectory)project.assets.json".Replace('/', Path.DirectorySeparatorChar), props["ProjectAssetsFile"]);
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -124,6 +124,8 @@ namespace NuGet.Test.Utility
         /// </summary>
         public bool SingleTargetFramework { get; set; }
 
+        public bool SetMSBuildProjectExtensionsPath { get; set; } = true;
+
         /// <summary>
         /// project.lock.json or project.assets.json
         /// </summary>
@@ -431,9 +433,12 @@ namespace NuGet.Test.Utility
             //  MSBuildProjectExtensionsPath needs to be set before Microsoft.Common.props is imported, so add a new
             //  PropertyGroup as the first element under the Project
             var ns = xml.Root.GetDefaultNamespace();
-            var propertyGroup = new XElement(ns + "PropertyGroup");
-            propertyGroup.Add(new XElement(ns + "MSBuildProjectExtensionsPath", OutputPath));
-            xml.Root.AddFirst(propertyGroup);
+            if (SetMSBuildProjectExtensionsPath)
+            {
+                var propertyGroup = new XElement(ns + "PropertyGroup");
+                propertyGroup.Add(new XElement(ns + "MSBuildProjectExtensionsPath", OutputPath));
+                xml.Root.AddFirst(propertyGroup);
+            }
 
             ProjectFileUtils.AddProperties(xml, new Dictionary<string, string>()
             {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/4582
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Makes things better for cases in which the props file changes only with a new pointer to the assets file. 

This really only fixes the scenario in which a project is only moved on disk without changing anything else. 
Restore will still need to run as no-op is defeated by virtue of having a different load path for configs and directory.build.props/targets imports.
However the msbuild props will not be overwritten since the dirty checks returns "false" so the intelisense will be populated from the onset. 

//cc @davkean @emgarten 
@dsplaisted any concerns with this change? 

## Testing/Validation

Tests Added: Yes 
Reason for not adding tests:  
Validation:  
