### PR TITLE
Enable TreatWarningsAsErrors in the test projects

### DIFF
--- a/build/restorehelper.targets
+++ b/build/restorehelper.targets
@@ -1,6 +1,15 @@
 <Project ToolsVersion="15.0" DefaultTargets="Restore">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'common.props'))\common.props" />
-  
-  <!-- <Target Name="_SplitProjectReferencesByFileExistence">
-  </Target> -->
+
+  <Target Name="BeforeRestore" BeforeTargets="Restore">
+	<Message Text="$(RestoreGraphProjectInput)" Importance="high" />
+  </Target>
+
+  <!-- Import the existing NuGet targets file -->
+  <PropertyGroup>
+    <VSNuGetTargetsExist Condition=" Exists('$(MSBuildExtensionsPath)\..\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets')">true</VSNuGetTargetsExist>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildExtensionsPath)/NuGet.targets" Condition=" '$(IsXPlat)' == 'true' OR '$(VSNuGetTargetsExist)' != 'true'" />
+  <Import Project="$(MSBuildExtensionsPath)\..\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets" Condition=" '$(IsXPlat)' != 'true' AND '$(VSNuGetTargetsExist)' == 'true'" />
 </Project>

--- a/build/restorehelper.targets
+++ b/build/restorehelper.targets
@@ -1,7 +1,6 @@
 <Project ToolsVersion="15.0" DefaultTargets="Restore">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'common.props'))\common.props" />
   
-  <Target Name="_SplitProjectReferencesByFileExistence">
-  	<!-- Noop -->
-  </Target>
+  <!-- <Target Name="_SplitProjectReferencesByFileExistence">
+  </Target> -->
 </Project>

--- a/build/restorehelper.targets
+++ b/build/restorehelper.targets
@@ -1,17 +1,5 @@
 <Project ToolsVersion="15.0" DefaultTargets="Restore">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'common.props'))\common.props" />
-
-  <Target Name="BeforeRestore" BeforeTargets="Restore">
-	<Message Text="$(RestoreGraphProjectInput)" Importance="high" />
-  </Target>
-
-  <!-- Import the existing NuGet targets file -->
-  <PropertyGroup>
-    <VSNuGetTargetsExist Condition=" Exists('$(MSBuildExtensionsPath)\..\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets')">true</VSNuGetTargetsExist>
-  </PropertyGroup>
-
-  <Import Project="$(MSBuildExtensionsPath)/NuGet.targets" Condition=" '$(IsXPlat)' == 'true' OR '$(VSNuGetTargetsExist)' != 'true'" />
-  <Import Project="$(MSBuildExtensionsPath)\..\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets" Condition=" '$(IsXPlat)' != 'true' AND '$(VSNuGetTargetsExist)' == 'true'" />
   
   <Target Name="_SplitProjectReferencesByFileExistence">
   	<!-- Noop -->

--- a/build/test.targets
+++ b/build/test.targets
@@ -6,8 +6,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
-    <WarningsAsErrors>False</WarningsAsErrors>
     <NoWarn>$(NoWarn);CS1701;xUnit2013;xUnit2000;xUnit2017;xUnit2006;xUnit2009;xUnit2013;xUnit2014;xUnit2003;xUnit2010;xUnit2015;xUnit2007;xUnit1013;xUnit1014;xUnit2002;xUnit2012;xUnit2004</NoWarn>
   </PropertyGroup>
   

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.8.132" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.8.132" />
     <PackageReference Include="VSLangProj" Version="7.0.3300" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/WpfTestCase.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/WpfTestCase.cs
@@ -65,7 +65,7 @@ namespace NuGet.PackageManagement.UI.Test
 
                         // Arrange to pump messages to execute any async work associated with the test.
                         var frame = new DispatcherFrame();
-                        Task.Run(async delegate
+                        _ = Task.Run(async delegate
                         {
                             try
                             {

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1855,7 +1855,7 @@ namespace NuGet.Commands.FuncTest
 #if IS_DESKTOP
         // TODO: To work on coreclr we need to address https://github.com/NuGet/Home/issues/7588
         [Fact]
-        public async Task RestoreCommand_PathTooLongException()
+        public void RestoreCommand_PathTooLongException()
         {
             // Arrange
             var sources = new List<PackageSource>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
@@ -116,7 +116,7 @@ namespace NuGet.Commands.Test
                 packages.Add(packageX1Runtime);
                 packages.Add(packageX2Runtime);
 
-                SimpleTestPackageUtility.CreatePackagesAsync(packages, repository);
+                await SimpleTestPackageUtility.CreatePackagesAsync(packages, repository);
 
                 var sources = new List<PackageSource>();
                 sources.Add(new PackageSource(repository));

--- a/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/NuGet.PackageManagement.UI.TestContract.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/NuGet.PackageManagement.UI.TestContract.csproj
@@ -10,6 +10,7 @@
   <PropertyGroup>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
     <OutputType>Library</OutputType>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(NuGetClientsSrcDirectory)NuGet.PackageManagement.UI\NuGet.PackageManagement.UI.csproj" />


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8009
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Enable warn as error everywhere and clean up the warnings. 

The analyzer warnings are helpful and can help us avoid test flakiness. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
