### PR TITLE
Fix the handling of custom names (AssemblyName, PackageId) in packages lock file, construction and validation.

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
 using System.Linq;
-using NuGet.Common;
 using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
@@ -18,13 +16,8 @@ namespace NuGet.Commands
         {
             var lockFile = new PackagesLockFile();
 
-            var libraryLookup = assetsFile.Libraries
-                .Where(e => e.Type == LibraryType.Package)
+            var libraryLookup = assetsFile.Libraries.Where(e => e.Type == LibraryType.Package)
                 .ToDictionary(e => new PackageIdentity(e.Name, e.Version));
-
-            var projectLookup = assetsFile.Libraries
-                .Where(e => e.Type == LibraryType.Project || e.Type == LibraryType.ExternalProject)
-                .ToDictionary(e => e.Name, e => Path.GetFileNameWithoutExtension(e.Path), PathUtility.GetStringComparerBasedOnOS());
 
             foreach (var target in assetsFile.Targets)
             {
@@ -77,18 +70,14 @@ namespace NuGet.Commands
 
                 foreach (var projectReference in libraries.Where(e => e.Type == LibraryType.Project || e.Type == LibraryType.ExternalProject))
                 {
-                    if (projectLookup.TryGetValue(projectReference.Name, out var projectFileName))
+                    var dependency = new LockFileDependency()
                     {
-                        var dependency = new LockFileDependency()
-                        {
-                            // When reading the lock file, the name of the project file is used rather than the friendly name retrieved from the project
-                            Id = projectFileName,
-                            Dependencies = projectReference.Dependencies,
-                            Type = PackageDependencyType.Project
-                        };
+                        Id = projectReference.Name,
+                        Dependencies = projectReference.Dependencies,
+                        Type = PackageDependencyType.Project
+                    };
 
-                        nuGettarget.Dependencies.Add(dependency);
-                    }
+                    nuGettarget.Dependencies.Add(dependency);
                 }
 
                 nuGettarget.Dependencies = nuGettarget.Dependencies.OrderBy(d => d.Type).ToList();

--- a/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
@@ -18,11 +18,13 @@ namespace NuGet.Commands
         {
             var lockFile = new PackagesLockFile();
 
-            var libraryLookup = assetsFile.Libraries.Where(e => e.Type == LibraryType.Package)
+            var libraryLookup = assetsFile.Libraries
+                .Where(e => e.Type == LibraryType.Package)
                 .ToDictionary(e => new PackageIdentity(e.Name, e.Version));
 
-            var projectLookup = assetsFile.Libraries.Where(e => e.Type == LibraryType.Project || e.Type == LibraryType.ExternalProject)
-    .           ToDictionary(e => e.Name, e => Path.GetFileNameWithoutExtension(e.MSBuildProject), StringComparer.OrdinalIgnoreCase);
+            var projectLookup = assetsFile.Libraries
+                .Where(e => e.Type == LibraryType.Project || e.Type == LibraryType.ExternalProject)
+                .ToDictionary(e => e.Name, e => Path.GetFileNameWithoutExtension(e.Path), PathUtility.GetStringComparerBasedOnOS());
 
             foreach (var target in assetsFile.Targets)
             {
@@ -75,20 +77,18 @@ namespace NuGet.Commands
 
                 foreach (var projectReference in libraries.Where(e => e.Type == LibraryType.Project || e.Type == LibraryType.ExternalProject))
                 {
-                    if (!projectLookup.TryGetValue(projectReference.Name, out var projectFileName))
+                    if (projectLookup.TryGetValue(projectReference.Name, out var projectFileName))
                     {
-                        continue;
+                        var dependency = new LockFileDependency()
+                        {
+                            // When reading the lock file, the name of the project file is used rather than the friendly name retrieved from the project
+                            Id = projectFileName,
+                            Dependencies = projectReference.Dependencies,
+                            Type = PackageDependencyType.Project
+                        };
+
+                        nuGettarget.Dependencies.Add(dependency);
                     }
-
-                    var dependency = new LockFileDependency()
-                    {
-                        // When reading the lock file, the name of the project file is used rather than the friendly name retrieved from the project
-                        Id = projectFileName,
-                        Dependencies = projectReference.Dependencies,
-                        Type = PackageDependencyType.Project
-                    };
-
-                    nuGettarget.Dependencies.Add(dependency);
                 }
 
                 nuGettarget.Dependencies = nuGettarget.Dependencies.OrderBy(d => d.Type).ToList();

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -167,13 +167,7 @@ namespace NuGet.Commands
                 inputs.Add(Path.GetFullPath("."));
             }
 
-            // Ignore casing on windows and mac
-            // change here
-            var comparer = (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsMacOSX) ?
-                StringComparer.OrdinalIgnoreCase
-                : StringComparer.Ordinal;
-
-            var uniqueRequest = new HashSet<string>(comparer);
+            var uniqueRequest = new HashSet<string>(PathUtility.GetStringComparerBasedOnOS());
 
             // Create requests
             // Pre-loaded requests

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -168,6 +168,7 @@ namespace NuGet.Commands
             }
 
             // Ignore casing on windows and mac
+            // change here
             var comparer = (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsMacOSX) ?
                 StringComparer.OrdinalIgnoreCase
                 : StringComparer.Ordinal;

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -84,19 +84,21 @@ namespace NuGet.ProjectModel
                     return false;
                 }
 
-                var queue = new Queue<string>();
+                var queue = new Queue<Tuple<string, string>>();
                 var visitedP2PReference = new HashSet<string>();
 
                 foreach (var projectReference in framework.ProjectReferences)
                 {
                     if (visitedP2PReference.Add(projectReference.ProjectUniqueName))
                     {
-                        queue.Enqueue(projectReference.ProjectUniqueName);
+                        var spec = dgSpec.GetProjectSpec(projectReference.ProjectUniqueName);
+                        queue.Enqueue(new Tuple<string, string>(spec.Name, projectReference.ProjectUniqueName));
 
                         while (queue.Count > 0)
                         {
-                            var p2pUniqueName = queue.Dequeue();
-                            var p2pProjectName = Path.GetFileNameWithoutExtension(p2pUniqueName);
+                            var projectNames = queue.Dequeue();
+                            var p2pUniqueName = projectNames.Item2;
+                            var p2pProjectName = projectNames.Item1;
 
                             var projectDependency = target.Dependencies.FirstOrDefault(
                                 dep => dep.Type == PackageDependencyType.Project &&
@@ -110,23 +112,26 @@ namespace NuGet.ProjectModel
 
                             var p2pSpec = dgSpec.GetProjectSpec(p2pUniqueName);
 
-                            // ignore if this p2p packageSpec not found in DGSpec, It'll fail restore with different error at later stage
+                            // ignore if this p2p packageSpec not found in DGSpec, it'll fail restore with a different error at later stage
+                            // TODO NK: Why? Why not just say "return false;"
                             if (p2pSpec != null)
                             {
                                 var p2pSpecTarget = NuGetFrameworkUtility.GetNearest(p2pSpec.TargetFrameworks, framework.FrameworkName, e => e.FrameworkName);
 
-                                // ignore if compatible framework not found for p2p reference which means current project didn't
-                                // get anything transitively from this p2p
+                                // ignore if compatible framework are not found for p2p reference
+                                // It'll fail restore with different error at later stage
+                                // TODO NK: Why? Why not just say "return false;"
                                 if (p2pSpecTarget != null)
                                 {
+                                    // TODO NK What happens if a P2P project dependency is gone?, This only checks packages
                                     if (HasP2PDependencyChanged(p2pSpecTarget.Dependencies, projectDependency))
                                     {
-                                        // P2P transitive package dependencies has changed
+                                        // P2P transitive package dependencies have changed
                                         return false;
                                     }
 
                                     var p2pSpecProjectRefTarget = p2pSpec.RestoreMetadata.TargetFrameworks.FirstOrDefault(
-                                        t => PathUtility.GetStringComparerBasedOnOS().Equals(p2pSpecTarget.FrameworkName.GetShortFolderName(), t.FrameworkName.GetShortFolderName()));
+                                        t => Equals(p2pSpecTarget.FrameworkName, t.FrameworkName));
 
                                     if (p2pSpecProjectRefTarget != null)
                                     {
@@ -134,7 +139,8 @@ namespace NuGet.ProjectModel
                                         {
                                             if (visitedP2PReference.Add(reference.ProjectUniqueName))
                                             {
-                                                queue.Enqueue(reference.ProjectUniqueName);
+                                                var referenceSpec = dgSpec.GetProjectSpec(reference.ProjectUniqueName);
+                                                queue.Enqueue(new Tuple<string, string>(referenceSpec.Name, reference.ProjectUniqueName));
                                             }
                                         }
                                     }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -86,17 +86,17 @@ namespace NuGet.ProjectModel
 
                 var queue = new Queue<string>();
                 var visitedP2PReference = new HashSet<string>();
-                
+
                 foreach (var projectReference in framework.ProjectReferences)
                 {
                     if (visitedP2PReference.Add(projectReference.ProjectUniqueName))
                     {
-                        queue.Enqueue(projectReference.ProjectUniqueName); // Important thing to consider that the project unique is more than just the file name.
+                        queue.Enqueue(projectReference.ProjectUniqueName);
 
                         while (queue.Count > 0)
                         {
                             var p2pUniqueName = queue.Dequeue();
-                            var p2pProjectName = Path.GetFileNameWithoutExtension(p2pUniqueName);  // TODO NK - What happens if the ID has changed? Is that the unique name
+                            var p2pProjectName = Path.GetFileNameWithoutExtension(p2pUniqueName);
 
                             var projectDependency = target.Dependencies.FirstOrDefault(
                                 dep => dep.Type == PackageDependencyType.Project &&

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -112,18 +112,14 @@ namespace NuGet.ProjectModel
 
                             var p2pSpec = dgSpec.GetProjectSpec(p2pUniqueName);
 
-                            // ignore if this p2p packageSpec not found in DGSpec, it'll fail restore with a different error at later stage
-                            // TODO NK: Why? Why not just say "return false;"
+                            // The package spec not found in the dg spec. This could mean that the project does not exist anymore.
                             if (p2pSpec != null)
                             {
                                 var p2pSpecTarget = NuGetFrameworkUtility.GetNearest(p2pSpec.TargetFrameworks, framework.FrameworkName, e => e.FrameworkName);
 
-                                // ignore if compatible framework are not found for p2p reference
-                                // It'll fail restore with different error at later stage
-                                // TODO NK: Why? Why not just say "return false;"
+                                // No compatible framework found
                                 if (p2pSpecTarget != null)
                                 {
-                                    // TODO NK What happens if a P2P project dependency is gone?, This only checks packages
                                     if (HasP2PDependencyChanged(p2pSpecTarget.Dependencies, projectDependency))
                                     {
                                         // P2P transitive package dependencies have changed
@@ -131,7 +127,7 @@ namespace NuGet.ProjectModel
                                     }
 
                                     var p2pSpecProjectRefTarget = p2pSpec.RestoreMetadata.TargetFrameworks.FirstOrDefault(
-                                        t => Equals(p2pSpecTarget.FrameworkName, t.FrameworkName));
+                                        t => EqualityUtility.EqualsWithNullCheck(p2pSpecTarget.FrameworkName, t.FrameworkName));
 
                                     if (p2pSpecProjectRefTarget != null)
                                     {
@@ -145,6 +141,14 @@ namespace NuGet.ProjectModel
                                         }
                                     }
                                 }
+                                else
+                                {
+                                    return false;
+                                }
+                            }
+                            else
+                            {
+                                return false;
                             }
                         }
                     }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -91,12 +91,12 @@ namespace NuGet.ProjectModel
                 {
                     if (visitedP2PReference.Add(projectReference.ProjectUniqueName))
                     {
-                        queue.Enqueue(projectReference.ProjectUniqueName);
+                        queue.Enqueue(projectReference.ProjectUniqueName); // Important thing to consider that the project unique is more than just the file name.
 
                         while (queue.Count > 0)
                         {
                             var p2pUniqueName = queue.Dequeue();
-                            var p2pProjectName = Path.GetFileNameWithoutExtension(p2pUniqueName);
+                            var p2pProjectName = Path.GetFileNameWithoutExtension(p2pUniqueName); // These really need to be unique, shared methods and all. 
 
                             var projectDependency = target.Dependencies.FirstOrDefault(
                                 dep => dep.Type == PackageDependencyType.Project &&

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -86,7 +86,7 @@ namespace NuGet.ProjectModel
 
                 var queue = new Queue<string>();
                 var visitedP2PReference = new HashSet<string>();
-
+                
                 foreach (var projectReference in framework.ProjectReferences)
                 {
                     if (visitedP2PReference.Add(projectReference.ProjectUniqueName))

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -96,7 +96,7 @@ namespace NuGet.ProjectModel
                         while (queue.Count > 0)
                         {
                             var p2pUniqueName = queue.Dequeue();
-                            var p2pProjectName = Path.GetFileNameWithoutExtension(p2pUniqueName); // These really need to be unique, shared methods and all. 
+                            var p2pProjectName = Path.GetFileNameWithoutExtension(p2pUniqueName);  // TODO NK - What happens if the ID has changed? Is that the unique name
 
                             var projectDependency = target.Dependencies.FirstOrDefault(
                                 dep => dep.Type == PackageDependencyType.Project &&

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -6124,10 +6124,10 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public async Task RestoreNetCore_MultiTFM_ProjectToProject_PackagesLockFile()
         {
-            // Arrange	
+            // Arrange
             using (var pathContext = new SimpleTestPathContext())
             {
-                // Set up solution, project, and packages	
+                // Set up solution, project, and packages
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
 
                 var projectA = SimpleTestProjectContext.CreateNETCore(
@@ -6154,31 +6154,31 @@ namespace NuGet.CommandLine.Test
                    pathContext.PackageSource,
                    packageX);
 
-                // A -> B	
+                // A -> B
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.AddProjectToAllFrameworks(projectB);
 
-                // B	
+                // B
                 projectB.AddPackageToFramework("net45", packageX);
 
                 solution.Projects.Add(projectA);
                 solution.Projects.Add(projectB);
                 solution.Create(pathContext.SolutionRoot);
 
-                // Act	
+                // Act
                 var r = Util.RestoreSolution(pathContext);
 
-                // Assert	
+                // Assert
                 r.Success.Should().BeTrue();
                 Assert.True(File.Exists(projectA.AssetsFileOutputPath));
                 Assert.True(File.Exists(projectB.AssetsFileOutputPath));
                 Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
 
-                // Second Restore	
+                // Second Restore
                 r = Util.RestoreSolution(pathContext);
 
-                // Assert	
+                // Assert
                 r.Success.Should().BeTrue();
             }
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -7588,7 +7588,11 @@ namespace NuGet.CommandLine.Test
                 Assert.False(File.Exists(projectB.NuGetLockFileOutputPath));
                 var lockFile = PackagesLockFileFormat.Read(projectA.NuGetLockFileOutputPath);
 
+<<<<<<< HEAD
                  // Assert that the project name is the project File name.
+=======
+                // Assert that the project name is the project File name.
+>>>>>>> fix tests
                 Assert.Equal(lockFile.Targets.First().Dependencies.Count, 2);
                 Assert.Equal(lockFile.Targets.First().Dependencies.First(e => e.Type == PackageDependencyType.Project).Id, "CustomName");
 
@@ -7661,7 +7665,7 @@ namespace NuGet.CommandLine.Test
                 Assert.False(File.Exists(projectB.NuGetLockFileOutputPath));
                 var lockFile = PackagesLockFileFormat.Read(projectA.NuGetLockFileOutputPath);
 
-                 // Assert that the project name is the project File name.
+                 // Assert that the project name is the custom name.
                 Assert.Equal(lockFile.Targets.First().Dependencies.Count, 2);
                 Assert.Equal(lockFile.Targets.First().Dependencies.First(e => e.Type == PackageDependencyType.Project).Id, "CustomName");
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -6122,6 +6122,68 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        public async Task RestoreNetCore_MultiTFM_ProjectToProject_PackagesLockFile()
+        {
+            // Arrange	
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages	
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                   "a",
+                   pathContext.SolutionRoot,
+                   NuGetFramework.Parse("net46"),
+                   NuGetFramework.Parse("net45"));
+
+                var projectB = SimpleTestProjectContext.CreateNETCore(
+                   "b",
+                   pathContext.SolutionRoot,
+                   NuGetFramework.Parse("net45"),
+                   NuGetFramework.Parse("net46"));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net45/x.dll");
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                   pathContext.PackageSource,
+                   packageX);
+
+                // A -> B	
+                projectA.Properties.Add("RestorePackagesWithLockFile", "true");
+                projectA.Properties.Add("RestoreLockedMode", "true");
+                projectA.AddProjectToAllFrameworks(projectB);
+
+                // B	
+                projectB.AddPackageToFramework("net45", packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Projects.Add(projectB);
+                solution.Create(pathContext.SolutionRoot);
+
+                // Act	
+                var r = Util.RestoreSolution(pathContext);
+
+                // Assert	
+                r.Success.Should().BeTrue();
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath));
+                Assert.True(File.Exists(projectB.AssetsFileOutputPath));
+                Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
+
+                // Second Restore	
+                r = Util.RestoreSolution(pathContext);
+
+                // Assert	
+                r.Success.Should().BeTrue();
+            }
+        }
+
+        [Fact]
         public async Task RestoreNetCore_BuildTransitive()
         {
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -7630,7 +7630,11 @@ namespace NuGet.CommandLine.Test
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
                 projectB.Properties.Add("AssemblyName", "CustomName");
 
+<<<<<<< HEAD
                  projectA.AddProjectToAllFrameworks(projectB);
+=======
+                projectA.AddProjectToAllFrameworks(projectB);
+>>>>>>> address feedback
 
                  // B
                 projectB.AddPackageToFramework(tfm, packageX);
@@ -7650,11 +7654,7 @@ namespace NuGet.CommandLine.Test
                 Assert.False(File.Exists(projectB.NuGetLockFileOutputPath));
                 var lockFile = PackagesLockFileFormat.Read(projectA.NuGetLockFileOutputPath);
 
-<<<<<<< HEAD
-                 // Assert that the project name is the project File name.
-=======
-                // Assert that the project name is the project File name.
->>>>>>> fix tests
+                // Assert that the project name is the project custom name.
                 Assert.Equal(lockFile.Targets.First().Dependencies.Count, 2);
                 Assert.Equal(lockFile.Targets.First().Dependencies.First(e => e.Type == PackageDependencyType.Project).Id, "CustomName");
 
@@ -7707,7 +7707,7 @@ namespace NuGet.CommandLine.Test
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
                 projectB.Properties.Add("PackageId", "CustomName");
 
-                 projectA.AddProjectToAllFrameworks(projectB);
+                projectA.AddProjectToAllFrameworks(projectB);
 
                  // B
                 projectB.AddPackageToFramework(tfm, packageX);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -7630,11 +7630,7 @@ namespace NuGet.CommandLine.Test
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
                 projectB.Properties.Add("AssemblyName", "CustomName");
 
-<<<<<<< HEAD
-                 projectA.AddProjectToAllFrameworks(projectB);
-=======
                 projectA.AddProjectToAllFrameworks(projectB);
->>>>>>> address feedback
 
                  // B
                 projectB.AddPackageToFramework(tfm, packageX);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -1449,13 +1449,13 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext);
 
                 // Assert
-                Assert.Equal(0,r.Item1);
+                Assert.Equal(0, r.Item1);
                 Assert.Contains("Writing cache file", r.Item2);
 
                 //re-arrange again
                 project.AddPackageToAllFrameworks(packageZ);
                 project.Save();
-                
+
                 //assert
                 Assert.Contains("Writing cache file", r.Item2);
                 Assert.Equal(0, r.Item1);
@@ -1557,7 +1557,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.Equal(0, r.Item1);
                 Assert.Contains("Writing cache file", r.Item2);
-                
+
                 // build project
                 var project2 = SimpleTestProjectContext.CreateNETCore(
                     $"proj2",
@@ -2087,7 +2087,7 @@ namespace NuGet.CommandLine.Test
 
 
         [Fact]
-        public async Task RestoreNetCore_MultipleProjects_SameTool_NoOpAsync() 
+        public async Task RestoreNetCore_MultipleProjects_SameTool_NoOpAsync()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -6050,7 +6050,7 @@ namespace NuGet.CommandLine.Test
                     packageX);
 
                 // Prerequisites
-                var r1 = Util.Restore(pathContext,project.ProjectPath);
+                var r1 = Util.Restore(pathContext, project.ProjectPath);
                 Assert.Equal(0, r1.Item1);
                 Assert.Contains("Writing cache file", r1.Item2);
                 Assert.Contains("Writing assets file to disk", r1.Item2);
@@ -6118,68 +6118,6 @@ namespace NuGet.CommandLine.Test
                     Assert.True(library.CompileTimeAssemblies.Any(embed => embed.Path.Equals("lib/net461/a.dll")));
                     Assert.True(library.RuntimeAssemblies.Any(embed => embed.Path.Equals("lib/net461/a.dll")));
                 }
-            }
-        }
-
-        [Fact]
-        public async Task RestoreNetCore_MultiTFM_ProjectToProject_PackagesLockFile()
-        {
-            // Arrange
-            using (var pathContext = new SimpleTestPathContext())
-            {
-                // Set up solution, project, and packages
-                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-
-                var projectA = SimpleTestProjectContext.CreateNETCore(
-                    "a",
-                    pathContext.SolutionRoot,
-                    NuGetFramework.Parse("net46"),
-                    NuGetFramework.Parse("net45"));
-
-                var projectB = SimpleTestProjectContext.CreateNETCore(
-                    "b",
-                    pathContext.SolutionRoot,
-                    NuGetFramework.Parse("net45"),
-                    NuGetFramework.Parse("net46"));
-
-                var packageX = new SimpleTestPackageContext()
-                {
-                    Id = "x",
-                    Version = "1.0.0"
-                };
-                packageX.Files.Clear();
-                packageX.AddFile("lib/net45/x.dll");
-
-                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    pathContext.PackageSource,
-                    packageX);
-
-                // A -> B
-                projectA.Properties.Add("RestorePackagesWithLockFile", "true");
-                projectA.Properties.Add("RestoreLockedMode", "true");
-                projectA.AddProjectToAllFrameworks(projectB);
-
-                // B
-                projectB.AddPackageToFramework("net45", packageX);
-
-                solution.Projects.Add(projectA);
-                solution.Projects.Add(projectB);
-                solution.Create(pathContext.SolutionRoot);
-
-                // Act
-                var r = Util.RestoreSolution(pathContext);
-
-                // Assert
-                r.Success.Should().BeTrue();
-                Assert.True(File.Exists(projectA.AssetsFileOutputPath));
-                Assert.True(File.Exists(projectB.AssetsFileOutputPath));
-                Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
-
-                // Second Restore
-                r = Util.RestoreSolution(pathContext);
-
-                // Assert
-                r.Success.Should().BeTrue();
             }
         }
 
@@ -6316,52 +6254,52 @@ namespace NuGet.CommandLine.Test
                 // Set up solution, project, and packages
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
 
-                 var packageX = new SimpleTestPackageContext()
+                var packageX = new SimpleTestPackageContext()
                 {
                     Id = "x",
                     Version = "1.0.0"
                 };
 
-                 var projects = new List<SimpleTestProjectContext>();
+                var projects = new List<SimpleTestProjectContext>();
 
-                 var project = SimpleTestProjectContext.CreateNETCore(
-                    $"proj",
-                    pathContext.SolutionRoot,
-                    NuGetFramework.Parse("net45"));
+                var project = SimpleTestProjectContext.CreateNETCore(
+                   $"proj",
+                   pathContext.SolutionRoot,
+                   NuGetFramework.Parse("net45"));
 
-                 project.AddPackageToAllFrameworks(packageX);
+                project.AddPackageToAllFrameworks(packageX);
                 solution.Projects.Add(project);
                 solution.Create(pathContext.SolutionRoot);
 
 
-                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    pathContext.PackageSource,
-                    PackageSaveMode.Defaultv3,
-                    packageX);
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                   pathContext.PackageSource,
+                   PackageSaveMode.Defaultv3,
+                   packageX);
 
-                 // Prerequisites
+                // Prerequisites
                 var result = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
                 Assert.Equal(0, result.Item1);
                 Assert.Contains("Writing cache file", result.Item2);
                 Assert.Contains("Writing assets file to disk", result.Item2);
                 Assert.Contains("Persisting no-op dg", result.Item2);
 
-                 var dgSpecFileName = Path.Combine(Path.GetDirectoryName(project.AssetsFileOutputPath), $"{Path.GetFileName(project.ProjectPath)}.nuget.dgspec.json");
+                var dgSpecFileName = Path.Combine(Path.GetDirectoryName(project.AssetsFileOutputPath), $"{Path.GetFileName(project.ProjectPath)}.nuget.dgspec.json");
 
-                 var fileInfo = new FileInfo(dgSpecFileName);
+                var fileInfo = new FileInfo(dgSpecFileName);
                 Assert.True(fileInfo.Exists);
                 var lastWriteTime = fileInfo.LastWriteTime;
 
-                 // Act
+                // Act
                 result = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
 
-                 // Assert
+                // Assert
                 Assert.Equal(0, result.Item1);
                 Assert.DoesNotContain("Writing cache file", result.Item2);
                 Assert.DoesNotContain("Writing assets file to disk", result.Item2);
                 Assert.DoesNotContain("Persisting no-op dg", result.Item2);
 
-                 fileInfo = new FileInfo(dgSpecFileName);
+                fileInfo = new FileInfo(dgSpecFileName);
                 Assert.True(fileInfo.Exists);
                 Assert.Equal(lastWriteTime, fileInfo.LastWriteTime);
             }
@@ -6376,55 +6314,55 @@ namespace NuGet.CommandLine.Test
                 // Set up solution, project, and packages
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
 
-                 var packageX = new SimpleTestPackageContext()
+                var packageX = new SimpleTestPackageContext()
                 {
                     Id = "x",
                     Version = "1.0.0"
                 };
 
-                 var projects = new List<SimpleTestProjectContext>();
+                var projects = new List<SimpleTestProjectContext>();
 
-                 var project = SimpleTestProjectContext.CreateNETCore(
-                    $"proj",
-                    pathContext.SolutionRoot,
-                    NuGetFramework.Parse("net45"));
+                var project = SimpleTestProjectContext.CreateNETCore(
+                   $"proj",
+                   pathContext.SolutionRoot,
+                   NuGetFramework.Parse("net45"));
 
-                 project.AddPackageToAllFrameworks(packageX);
+                project.AddPackageToAllFrameworks(packageX);
                 solution.Projects.Add(project);
                 solution.Create(pathContext.SolutionRoot);
 
 
-                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    pathContext.PackageSource,
-                    PackageSaveMode.Defaultv3,
-                    packageX);
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                   pathContext.PackageSource,
+                   PackageSaveMode.Defaultv3,
+                   packageX);
 
-                 // Prerequisites
+                // Prerequisites
                 var result = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
                 Assert.Equal(0, result.Item1);
                 Assert.Contains("Writing cache file", result.Item2);
                 Assert.Contains("Writing assets file to disk", result.Item2);
                 Assert.Contains("Persisting no-op dg", result.Item2);
 
-                 var dgSpecFileName = Path.Combine(Path.GetDirectoryName(project.AssetsFileOutputPath), $"{Path.GetFileName(project.ProjectPath)}.nuget.dgspec.json");
+                var dgSpecFileName = Path.Combine(Path.GetDirectoryName(project.AssetsFileOutputPath), $"{Path.GetFileName(project.ProjectPath)}.nuget.dgspec.json");
 
-                 var fileInfo = new FileInfo(dgSpecFileName);
+                var fileInfo = new FileInfo(dgSpecFileName);
                 Assert.True(fileInfo.Exists);
                 fileInfo.Delete();
                 fileInfo = new FileInfo(dgSpecFileName);
                 Assert.False(fileInfo.Exists);
 
 
-                 // Act
+                // Act
                 result = Util.Restore(pathContext, project.ProjectPath, additionalArgs: "-verbosity Detailed");
 
-                 // Assert
+                // Assert
                 Assert.Equal(0, result.Item1);
                 Assert.DoesNotContain("Writing cache file", result.Item2);
                 Assert.DoesNotContain("Writing assets file to disk", result.Item2);
                 Assert.Contains("Persisting no-op dg", result.Item2);
 
-                 fileInfo = new FileInfo(dgSpecFileName);
+                fileInfo = new FileInfo(dgSpecFileName);
                 Assert.True(fileInfo.Exists);
             }
         }
@@ -6596,7 +6534,7 @@ namespace NuGet.CommandLine.Test
 
                 var packageLockFileName = project.NuGetLockFileOutputPath;
                 Assert.False(File.Exists(packageLockFileName));
-                File.Create(packageLockFileName).Close(); 
+                File.Create(packageLockFileName).Close();
                 Assert.True(File.Exists(packageLockFileName));
 
 
@@ -6698,7 +6636,7 @@ namespace NuGet.CommandLine.Test
                 // Set up solution, project, and packages
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
                 var projectFrameworks = "net46";
-                
+
                 var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
                             projectName: "a",
                             solutionRoot: pathContext.SolutionRoot,
@@ -6717,7 +6655,7 @@ namespace NuGet.CommandLine.Test
                     packageX);
 
                 projectA.AddPackageDownloadToAllFrameworks(packageX);
-                
+
                 solution.Projects.Add(projectA);
                 solution.Create(pathContext.SolutionRoot);
 
@@ -6790,7 +6728,7 @@ namespace NuGet.CommandLine.Test
                 Assert.Equal($"[{packageX2.Version}, {packageX2.Version}]", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().VersionRange.ToNormalizedString());
                 Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.Last().Name);
                 Assert.Equal($"[{packageX1.Version}, {packageX1.Version}]", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.Last().VersionRange.ToNormalizedString());
-                
+
                 Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX1.Identity.Id, packageX1.Version)), $"{packageX1.ToString()} is not installed");
                 Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX2.Identity.Id, packageX2.Version)), $"{packageX2.ToString()} is not installed");
             }
@@ -7594,5 +7532,150 @@ namespace NuGet.CommandLine.Test
             }
         }
 
+        [Fact]
+        public async Task RestoreNetCore_PackagesLockFile_CustomAssemblyName_DoesNotBreakLockedMode()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+                var tfm = "net45";
+
+                 var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse(tfm));
+
+                 var projectB = SimpleTestProjectContext.CreateNETCore(
+                    "b",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse(tfm));
+
+                 var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile($"lib/{tfm}/x.dll");
+
+                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX);
+
+                 // A -> B
+                projectA.Properties.Add("RestorePackagesWithLockFile", "true");
+                projectB.Properties.Add("AssemblyName", "CustomName");
+
+                 projectA.AddProjectToAllFrameworks(projectB);
+
+                 // B
+                projectB.AddPackageToFramework(tfm, packageX);
+
+                 solution.Projects.Add(projectA);
+                solution.Projects.Add(projectB);
+                solution.Create(pathContext.SolutionRoot);
+
+                 // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                 // Assert
+                r.Success.Should().BeTrue();
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath));
+                Assert.True(File.Exists(projectB.AssetsFileOutputPath));
+                Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
+                Assert.False(File.Exists(projectB.NuGetLockFileOutputPath));
+                var lockFile = PackagesLockFileFormat.Read(projectA.NuGetLockFileOutputPath);
+
+                 // Assert that the project name is the project File name.
+                Assert.Equal(lockFile.Targets.First().Dependencies.Count, 2);
+                Assert.Equal(lockFile.Targets.First().Dependencies.First(e => e.Type == PackageDependencyType.Project).Id, "CustomName");
+
+                 // Setup - Enable locked mode
+                projectA.Properties.Add("RestoreLockedMode", "true");
+                projectA.Save();
+                File.Delete(projectA.AssetsFileOutputPath);
+
+                 // Act
+                r = Util.RestoreSolution(pathContext);
+
+                 // Assert
+                r.Success.Should().BeTrue();
+            }
+        }
+
+        [Fact]
+        public async Task RestoreNetCore_PackagesLockFile_CustomPackageId_DoesNotBreakLockedMode()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+                var tfm = "net45";
+
+                 var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse(tfm));
+
+                 var projectB = SimpleTestProjectContext.CreateNETCore(
+                    "b",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse(tfm));
+
+                 var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile($"lib/{tfm}/x.dll");
+
+                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX);
+
+                 // A -> B
+                projectA.Properties.Add("RestorePackagesWithLockFile", "true");
+                projectB.Properties.Add("PackageId", "CustomName");
+
+                 projectA.AddProjectToAllFrameworks(projectB);
+
+                 // B
+                projectB.AddPackageToFramework(tfm, packageX);
+
+                 solution.Projects.Add(projectA);
+                solution.Projects.Add(projectB);
+                solution.Create(pathContext.SolutionRoot);
+
+                 // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                 // Assert
+                r.Success.Should().BeTrue();
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath));
+                Assert.True(File.Exists(projectB.AssetsFileOutputPath));
+                Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
+                Assert.False(File.Exists(projectB.NuGetLockFileOutputPath));
+                var lockFile = PackagesLockFileFormat.Read(projectA.NuGetLockFileOutputPath);
+
+                 // Assert that the project name is the project File name.
+                Assert.Equal(lockFile.Targets.First().Dependencies.Count, 2);
+                Assert.Equal(lockFile.Targets.First().Dependencies.First(e => e.Type == PackageDependencyType.Project).Id, "CustomName");
+
+                 // Setup - Enable locked mode
+                projectA.Properties.Add("RestoreLockedMode", "true");
+                projectA.Save();
+                File.Delete(projectA.AssetsFileOutputPath);
+
+                 // Act
+                r = Util.RestoreSolution(pathContext);
+
+                 // Assert
+                r.Success.Should().BeTrue();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/nuget/home/issues/7889
Regression: No, Never worked
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
The comparison now uses the short project name which is what's used when writing the lock file. 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
