### PR TITLE
Rename the target name to CollectPackageReferences

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -177,10 +177,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
    <!--
     ============================================================
-    _CollectFrameworkReferences
+    CollectFrameworkReferences
     ============================================================
   -->
-  <Target Name="_CollectFrameworkReferences" Returns="@(FrameworkReference)" />
+  <Target Name="CollectFrameworkReferences" Returns="@(FrameworkReference)" />
 
   <!--
     ============================================================
@@ -791,7 +791,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GenerateProjectRestoreGraphPerFramework"
-    DependsOnTargets="_GetRestoreProjectStyle;CollectPackageReferences;CollectPackageDownloads;_CollectFrameworkReferences"
+    DependsOnTargets="_GetRestoreProjectStyle;CollectPackageReferences;CollectPackageDownloads;CollectFrameworkReferences"
     Returns="@(_RestoreGraphEntry)">
 
     <!-- Write out project references -->


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8005  
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
https://github.com/NuGet/Home/issues/8005

The project-system wants to use this target to read the Framework References.
## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
