### PR TITLE
Remove NoBuild and enable the old deps generation logic

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -9,7 +9,6 @@
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <Shipping>true</Shipping>
     <PackProject>true</PackProject>
-    <NoBuild>true</NoBuild>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <PreserveCompilationContext>true</PreserveCompilationContext>
@@ -20,6 +19,7 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <PackageDescription>NuGet pack for dotnet CLI.</PackageDescription>
     <NoWarn>$(NoWarn);NU5100</NoWarn>
+    <DepsFileGenerationMode>old</DepsFileGenerationMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -19,7 +19,7 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <PackageDescription>NuGet pack for dotnet CLI.</PackageDescription>
     <NoWarn>$(NoWarn);NU5100</NoWarn>
-    <DepsFileGenerationMode>old</DepsFileGenerationMode>
+    <!-- <DepsFileGenerationMode>old</DepsFileGenerationMode> -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -19,7 +19,7 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <PackageDescription>NuGet pack for dotnet CLI.</PackageDescription>
     <NoWarn>$(NoWarn);NU5100</NoWarn>
-    <!-- <DepsFileGenerationMode>old</DepsFileGenerationMode> -->
+    <DepsFileGenerationMode>old</DepsFileGenerationMode>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8055
Regression: Yes/No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Building NuGet.Build.Tasks.Pack fails with the 3.0.0 SDK due to NETSDK108

The root cause is that we have set NoBuild in our pack project. 

It was set here,https://github.com/NuGet/NuGet.Client/pull/1310/files,  to avoid building again when packing since we ILMerge.
The problem is that NoBuild is using in places beyond the pack targets. 

Fortunately for us we can remove it because we pack with NoBuild=true, so it's technically not a breaking change. 

Note that if we remove that we'll get unsigned binaries in packages which will be caught by the validation step anyways.

See https://github.com/NuGet/Home/issues/7801
https://github.com/dotnet/sdk/issues/3001

https://github.com/NuGet/NuGet.Client/pull/1148
https://github.com/NuGet/docs.microsoft.com-nuget/blob/master/docs/reference/msbuild-targets.md#packing-using-a-nuspec
https://github.com/dotnet/cli/issues/9656

The reason for the DepsFileGenerationMode being old is the following error; 

```
F:\NuGet.Client\src\NuGet.Core\NuGet.Build.Tasks.Pack\NuGet.Build.Tasks.Pack.csproj" (default target) (1:15) ->
"F:\NuGet.Client\src\NuGet.Core\NuGet.Build.Tasks.Pack\NuGet.Build.Tasks.Pack.csproj" (Build target) (1:16) ->
(GenerateBuildDependencyFile target) ->
  C:\Program Files\dotnet\sdk\3.0.100-preview4-011223\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.targets(145,5): error : Internal error: new deps file ge
neration logic did not produce the same result as the old logic. [F:\NuGet.Client\src\NuGet.Core\NuGet.Build.Tasks.Pack\NuGet.Build.Tasks.Pack.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview4-011223\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.targets(145,5): error :     Please file an issue for this
at https://github.com/dotnet/sdk and include the following two files:  [F:\NuGet.Client\src\NuGet.Core\NuGet.Build.Tasks.Pack\NuGet.Build.Tasks.Pack.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview4-011223\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.targets(145,5): error :     Deps file from old logic: F:\N
uGet.Client\artifacts\NuGet.Build.Tasks.Pack\16.0\bin\Debug\net472\NuGet.Build.Tasks.Pack.deps.json [F:\NuGet.Client\src\NuGet.Core\NuGet.Build.Tasks.Pack\NuGe
t.Build.Tasks.Pack.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview4-011223\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.targets(145,5): error :     Deps file from new logic: F:\N
uGet.Client\artifacts\NuGet.Build.Tasks.Pack\16.0\bin\Debug\net472\NuGet.Build.Tasks.Pack.deps.new.json [F:\NuGet.Client\src\NuGet.Core\NuGet.Build.Tasks.Pack\
NuGet.Build.Tasks.Pack.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview4-011223\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.targets(145,5): error :     You can work around this by se
tting the DepsFileGenerationMode MSBuild property to 'old' [F:\NuGet.Client\src\NuGet.Core\NuGet.Build.Tasks.Pack\NuGet.Build.Tasks.Pack.csproj]
```

Tracking here: https://github.com/dotnet/sdk/issues/3146
## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  There is existing validation that ensures the correct things are build/packed/signed.
