### PR TITLE
Choose localization branch according to NuGet.Client branch

### DIFF
--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -118,17 +118,16 @@ $NuGetLocalization = Join-Path $Submodules NuGet.Build.Localization -Resolve
 # Check if there is a localization branch associated with this branch repo 
 $currentNuGetBranch = $env:BUILD_SOURCEBRANCHNAME
 $lsRemoteOpts = 'ls-remote', 'origin', $currentNuGetBranch
-Write-Host "Looking for branch '$currentNuGetBranch' in NuGet.Build.Localization..."
+Write-Host "Looking for branch '$currentNuGetBranch' in NuGet.Build.Localization"
 $lsResult = & git -C $NuGetLocalization $lsRemoteOpts
 
 if ($lsResult) {
-    Write-Host "Found branch '$currentNuGetBranch' in NuGet.Build.Localization"
     $NuGetLocalizationRepoBranch = $currentNuGetBranch
 }
 else {
-    Write-Host "Branch '$currentNuGetBranch' not found in NuGet.Build.Localization. Defaulting to dev"
     $NuGetLocalizationRepoBranch = 'dev'
 }
+Write-Host "NuGet.Build.Localization Branch: $NuGetLocalizationRepoBranch"
 
 # update submodule NuGet.Build.Localization
 $updateOpts = 'pull', 'origin', $NuGetLocalizationRepoBranch

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -121,10 +121,12 @@ $lsRemoteOpts = 'ls-remote', 'origin', $currentNuGetBranch
 Write-Host "Looking for branch '$currentNuGetBranch' in NuGet.Build.Localization"
 $lsResult = & git -C $NuGetLocalization $lsRemoteOpts
 
-if ($lsResult) {
+if ($lsResult)
+{
     $NuGetLocalizationRepoBranch = $currentNuGetBranch
 }
-else {
+else
+{
     $NuGetLocalizationRepoBranch = 'dev'
 }
 Write-Host "NuGet.Build.Localization Branch: $NuGetLocalizationRepoBranch"

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -109,14 +109,29 @@ DisableStrongNameVerification -publicKeyToken '31bf3856ad364e35' # NuGet
 $regKeyFileSystem = "HKLM:SYSTEM\CurrentControlSet\Control\FileSystem"
 $enableLongPathSupport = "LongPathsEnabled"
 
-# update submodule NuGet.Build.Localization
 $NuGetClientRoot = $env:BUILD_REPOSITORY_LOCALPATH
 $Submodules = Join-Path $NuGetClientRoot submodules -Resolve
 
+# NuGet.Build.Localization repository set-up
 $NuGetLocalization = Join-Path $Submodules NuGet.Build.Localization -Resolve
-$NuGetLocalizationRepoBranch = 'master'
-$updateOpts = 'pull', 'origin', $NuGetLocalizationRepoBranch
 
+# Check if there is a localization branch associated with this branch repo 
+$currentNuGetBranch = $env:BUILD_SOURCEBRANCHNAME
+$lsRemoteOpts = 'ls-remote', 'origin', $currentNuGetBranch
+Write-Host "Looking for branch '$currentNuGetBranch' in NuGet.Build.Localization..."
+$lsResult = & git -C $NuGetLocalization $lsRemoteOpts
+
+if ($lsResult) {
+    Write-Host "Found branch '$currentNuGetBranch' in NuGet.Build.Localization"
+    $NuGetLocalizationRepoBranch = $currentNuGetBranch
+}
+else {
+    Write-Host "Branch '$currentNuGetBranch' not found in NuGet.Build.Localization. Defaulting to dev"
+    $NuGetLocalizationRepoBranch = 'dev'
+}
+
+# update submodule NuGet.Build.Localization
+$updateOpts = 'pull', 'origin', $NuGetLocalizationRepoBranch
 Write-Host "git update NuGet.Build.Localization at $NuGetLocalization"
 & git -C $NuGetLocalization $updateOpts 2>&1 | Write-Host
 # Get the commit of the localization repository that will be used for this build.


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8056

Regression: No
* Last working version: 
* How are we preventing it in future: 

## Fix

Uses `git ls-remote` to figure out if exists a corresponding branch in NuGet.Build.Localizaiton

## Testing/Validation

Tests Added: No  
Reason for not adding tests: CI Build scripts. Hard to test in local environments.
Validation: By creating an example script
