### PR TITLE
Do not set NoBuild with GeneratePackageOnBuild because property reuse breaks publish

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -53,7 +53,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
   <PropertyGroup Condition="'$(NoBuild)' != 'true' and '$(GeneratePackageOnBuild)' != 'true'">
     <GenerateNuspecDependsOn>Build;$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
-</PropertyGroup>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectCapability Include="Pack"/>
   </ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -38,7 +38,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ContentTargetFolders Condition="'$(ContentTargetFolders)' == ''">content;contentFiles</ContentTargetFolders>
     <PackDependsOn>$(BeforePack); _IntermediatePack; GenerateNuspec; $(PackDependsOn)</PackDependsOn>
     <IsInnerBuild Condition="'$(TargetFramework)' != '' AND '$(TargetFrameworks)' != ''">true</IsInnerBuild>
-    <NoBuild Condition="'$(GeneratePackageOnBuild)' == 'true'">true</NoBuild>
     <SymbolPackageFormat Condition="'$(SymbolPackageFormat)' == ''">symbols.nupkg</SymbolPackageFormat>
     <AddPriFileDependsOn Condition="'$(MicrosoftPortableCurrentVersionPropsHasBeenImported)' == 'true'">DeterminePortableBuildCapabilities</AddPriFileDependsOn>
     <NuspecOutputPath Condition="'$(NuspecOutputPath)' == ''">$(BaseIntermediateOutputPath)$(Configuration)\</NuspecOutputPath>
@@ -49,12 +48,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder Condition="'$(SymbolPackageFormat)' == 'snupkg'">.pdb</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
     <SuppressDependenciesWhenPacking Condition="'$(SuppressDependenciesWhenPacking)' == ''">false</SuppressDependenciesWhenPacking>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(NoBuild)' == 'true' ">
+  <PropertyGroup Condition="'$(NoBuild)' == 'true' or '$(GeneratePackageOnBuild)' == 'true'">
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(NoBuild)' != 'true' ">
+  <PropertyGroup Condition="'$(NoBuild)' != 'true' and '$(GeneratePackageOnBuild)' != 'true'">
     <GenerateNuspecDependsOn>Build;$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
-  </PropertyGroup>
+</PropertyGroup>
   <ItemGroup>
     <ProjectCapability Include="Pack"/>
   </ItemGroup>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -3959,8 +3959,11 @@ namespace ClassLibrary
                     ProjectFileUtils.AddProperty(xml, "GeneratePackageOnBuild", "true");
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
-                // Run and assert.
-                msbuildFixture.RunDotnet(workingDirectory, $"publish {projectFile}");
+                // Act
+                var result = msbuildFixture.RunDotnet(workingDirectory, $"publish {projectFile}");
+
+                // Assert
+                Assert.True(result.Success);
             }
         }
     }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -3952,21 +3952,15 @@ namespace ClassLibrary
                 // Act
                 msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " console");
 
-                var projectFile = Path.Combine(testDirectory.Path, $"{projectName}.csproj");
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
                 using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
                 {
                     var xml = XDocument.Load(stream);
                     ProjectFileUtils.AddProperty(xml, "GeneratePackageOnBuild", "true");
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
-
-                msbuildFixture.RunDotnet(workingDirectory, $"publish {projectName}");
-
-                // Assert
-                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
-                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
-                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
-                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+                // Run and assert.
+                msbuildFixture.RunDotnet(workingDirectory, $"publish {projectFile}");
             }
         }
     }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -3951,8 +3951,15 @@ namespace ClassLibrary
                 var workingDirectory = Path.Combine(testDirectory, projectName);
                 // Act
                 msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " console");
-                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
-                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory}");
+
+                var projectFile = Path.Combine(testDirectory.Path, $"{projectName}.csproj");
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.AddProperty(xml, "GeneratePackageOnBuild", "true");
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
                 msbuildFixture.RunDotnet(workingDirectory, $"publish {projectName}");
 
                 // Assert

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -3941,5 +3941,26 @@ namespace ClassLibrary
                 }
             }
         }
+
+        [PlatformFact(Platform.Windows)]
+        public void PackCommand_WithGeneratePackageOnBuildSet_CanPublish()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                // Act
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " console");
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory}");
+                msbuildFixture.RunDotnet(workingDirectory, $"publish {projectName}");
+
+                // Assert
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7801
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

GeneratePackageOnBuild setting NoBuild prevents basic projects from publishing. 

This is a backwards compatible change. 

I have added a test to confirm that this actually fixes the aforementioned problem. 
We're "technically" testing a different product here, so there's potential that this could be a noisy test (highly unlikely). 

//cc @peterhuene

Will merge this when dev switches to 5.2.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
