### PR TITLE
Create release-5.1.x branch and moving to rtm branded builds

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0">
   <!-- Version -->
   <PropertyGroup>
-    <IsEscrowMode>false</IsEscrowMode>
+    <IsEscrowMode>true</IsEscrowMode>
     <!-- when changing any of the NuGetVersion props below, also update ProductVersion in src\NuGet.Clients\NuGet.Tools\NuGetPackage.cs -->
     <MajorNuGetVersion Condition="'$(MajorNuGetVersion)' == ''">5</MajorNuGetVersion>
     <MinorNuGetVersion Condition="'$(MinorNuGetVersion)' == ''">1</MinorNuGetVersion>
@@ -19,8 +19,8 @@
     <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">release/2.2.3xx;release/2.1.7xx</SdkTargetBranches>
     <!-- We need to update this netcoreassembly build number with every milestone to workaround any breaking api
     changes we might have made-->
-    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">3</NetCoreAssemblyBuildNumber>
-    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview$(NetCoreAssemblyBuildNumber)</ReleaseLabel>
+    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">4</NetCoreAssemblyBuildNumber>
+    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">rtm</ReleaseLabel>
   </PropertyGroup>
 
   <!-- Dependency versions -->


### PR DESCRIPTION
## Bug

Fixes: 
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Creating a 5.1.x branch moving to rtm branded builds

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
