### PR TITLE
Add a new flag to allow suppressing the transitive flow of FrameworkReference at restore time. 

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
@@ -28,7 +28,6 @@ namespace NuGet.Build.Tasks.Pack
         bool DevelopmentDependency { get; }
         TItem[] FrameworkAssemblyReferences { get; }
         TItem[] FrameworksWithSuppressedDependencies { get; }
-        TItem[] FrameworkReferences { get; }
         string IconUrl { get; }
         bool IncludeBuildOutput { get; }
         bool IncludeSource { get; }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -232,7 +232,6 @@ Copyright (c) .NET Foundation. All rights reserved.
               MinClientVersion="$(MinClientVersion)"
               Serviceable="$(Serviceable)"
               FrameworkAssemblyReferences="@(_FrameworkAssemblyReferences)"
-              FrameworkReferences="@(_FrameworkReferences)"
               ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
               NuspecOutputPath="$(NuspecOutputAbsolutePath)"
               IncludeBuildOutput="$(IncludeBuildOutput)"
@@ -390,17 +389,6 @@ Copyright (c) .NET Foundation. All rights reserved.
           TaskParameter="TargetOutputs"
           ItemName="_FrameworksWithSuppressedDependencies" />
     </MSBuild>
-
-    <MSBuild
-      Projects="$(MSBuildProjectFullPath)"
-      Targets="_GetFrameworkReferences"
-      Properties="TargetFramework=%(_TargetFrameworks.Identity);
-                  BuildProjectReferences=false;">
-
-      <Output
-          TaskParameter="TargetOutputs"
-          ItemName="_FrameworkReferences" />
-    </MSBuild>
   </Target>
 
   <Target Name ="_GetFrameworksWithSuppressedDependencies" Returns="@(_TfmWithDependenciesSuppressed)">
@@ -415,15 +403,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       Condition="'%(ReferencePath.Pack)' != 'false' AND '%(ReferencePath.ResolvedFrom)' == '{TargetFrameworkDirectory}'">
         <TargetFramework>$(TargetFramework)</TargetFramework>
       </TfmSpecificFrameworkAssemblyReferences>
-    </ItemGroup>
-  </Target>
-
-  <Target Name ="_GetFrameworkReferences" Returns="@(TfmSpecificFrameworkReferences)">
-    <ItemGroup>
-      <TfmSpecificFrameworkReferences Include="@(FrameworkReference)"
-                                      Condition="'%(FrameworkReference.Pack)' != 'false' ">
-        <TargetFramework>$(TargetFramework)</TargetFramework>
-      </TfmSpecificFrameworkReferences>
     </ItemGroup>
   </Target>
   

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
@@ -56,7 +56,6 @@ namespace NuGet.Build.Tasks.Pack
         public string MinClientVersion { get; set; }
         public bool Serviceable { get; set; }
         public ITaskItem[] FrameworkAssemblyReferences { get; set; }
-        public ITaskItem[] FrameworkReferences { get; set; }
         public bool ContinuePackingAfterGeneratingNuspec { get; set; }
         public bool NoDefaultExcludes { get; set; }
         public string NuspecOutputPath { get; set; }
@@ -167,7 +166,6 @@ namespace NuGet.Build.Tasks.Pack
                 Description = MSBuildStringUtility.TrimAndGetNullForEmpty(Description),
                 DevelopmentDependency = DevelopmentDependency,
                 FrameworkAssemblyReferences = MSBuildUtility.WrapMSBuildItem(FrameworkAssemblyReferences),
-                FrameworkReferences = MSBuildUtility.WrapMSBuildItem(FrameworkReferences),
                 FrameworksWithSuppressedDependencies = MSBuildUtility.WrapMSBuildItem(FrameworksWithSuppressedDependencies),
                 IconUrl = MSBuildStringUtility.TrimAndGetNullForEmpty(IconUrl),
                 IncludeBuildOutput = IncludeBuildOutput,

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
@@ -21,7 +21,6 @@ namespace NuGet.Build.Tasks.Pack
         public string Description { get; set; }
         public bool DevelopmentDependency { get; set; }
         public IMSBuildItem[] FrameworkAssemblyReferences { get; set; }
-        public IMSBuildItem[] FrameworkReferences { get; set; }
         public string IconUrl { get; set; }
         public bool IncludeBuildOutput { get; set; }
         public bool IncludeSource { get; set; }

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreFrameworkReferencesTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreFrameworkReferencesTask.cs
@@ -61,6 +61,7 @@ namespace NuGet.Build.Tasks
                 {
                     properties.Add("TargetFrameworks", TargetFrameworks);
                 }
+                BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "PrivateAssets");
 
                 entries.Add(new TaskItem(Guid.NewGuid().ToString(), properties));
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -591,7 +591,10 @@ namespace NuGet.Commands
                 KnownLibraryProperties.FrameworkReferences,
                 out frameworkReferencesObject))
             {
-                projectLib.FrameworkReferences.AddRange((IEnumerable<string>)frameworkReferencesObject);
+                projectLib.FrameworkReferences.AddRange(
+                    ((ISet<FrameworkDependency>)frameworkReferencesObject)
+                        .Where(e => e.PrivateAssets != FrameworkDependencyFlags.All)
+                        .Select(f => f.Name));
             }
 
             // Exclude items

--- a/src/NuGet.Core/NuGet.Common/ComparisonUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/ComparisonUtility.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Common
+{
+    public static class ComparisonUtility
+    {
+        public static readonly StringComparer FrameworkReferenceNameComparer = StringComparer.OrdinalIgnoreCase;
+    }
+}

--- a/src/NuGet.Core/NuGet.LibraryModel/FrameworkDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/FrameworkDependency.cs
@@ -1,0 +1,56 @@
+// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Common;
+
+namespace NuGet.LibraryModel
+{
+    public sealed class FrameworkDependency : IEquatable<FrameworkDependency>, IComparable<FrameworkDependency>
+    {
+        public string Name { get; }
+
+        public FrameworkDependencyFlags PrivateAssets { get; }
+
+        public FrameworkDependency(
+            string name,
+            FrameworkDependencyFlags privateAssets)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            PrivateAssets = privateAssets;
+        }
+
+        public int CompareTo(FrameworkDependency other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return 1;
+            }
+
+            var compare = ComparisonUtility.FrameworkReferenceNameComparer.Compare(Name, other.Name);
+
+            if (compare == 0)
+            {
+                return PrivateAssets.CompareTo(other.PrivateAssets);
+            }
+
+            return compare;
+        }
+
+        public bool Equals(FrameworkDependency other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return ComparisonUtility.FrameworkReferenceNameComparer.Equals(Name, other.Name) &&
+                   PrivateAssets.Equals(other.PrivateAssets);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.LibraryModel/FrameworkDependencyFlags.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/FrameworkDependencyFlags.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.LibraryModel
+{
+    [Flags]
+    public enum FrameworkDependencyFlags : ushort
+    {
+        None = 0,
+        All = ushort.MaxValue,
+    }
+}

--- a/src/NuGet.Core/NuGet.LibraryModel/FrameworkDependencyFlagsUtils.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/FrameworkDependencyFlagsUtils.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGet.LibraryModel
+{
+    public class FrameworkDependencyFlagsUtils
+    {
+        public static readonly FrameworkDependencyFlags Default = FrameworkDependencyFlags.None;
+
+        /// <summary>
+        /// Convert set of flag strings into a FrameworkDependencyFlags.
+        /// </summary>
+        /// <param name="values">A list of values to generate the flags out of</param>
+        public static FrameworkDependencyFlags GetFlags(IEnumerable<string> values)
+        {
+            var result = FrameworkDependencyFlags.None;
+
+            if (values != null)
+            {
+                foreach (var value in values)
+                {
+                    if (Enum.TryParse<FrameworkDependencyFlags>(value, ignoreCase: true, result: out var flag))
+                    {
+                        result |= flag;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Convert framework dependency flags to a friendly string.
+        /// </summary>
+        public static string GetFlagString(FrameworkDependencyFlags flags)
+        {
+            switch (flags)
+            {
+                case FrameworkDependencyFlags.All:
+                    return "all";
+                case FrameworkDependencyFlags.None:
+                default:
+                    return "none";
+            }
+        }
+
+        /// <summary>
+        /// Convert set of flag strings into a LibraryIncludeFlags.
+        /// If the <paramref name="flags"/> is null, it returns the default value of <see cref="FrameworkDependencyFlags.None"/>
+        /// </summary>
+        public static FrameworkDependencyFlags GetFlags(string flags)
+        {
+            var result = FrameworkDependencyFlags.None;
+
+            if (!string.IsNullOrEmpty(flags))
+            {
+                var splitFlags = flags.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(s => s.Trim())
+                    .Where(s => !string.IsNullOrEmpty(s))
+                    .ToArray();
+
+                if (splitFlags.Length > 0)
+                {
+                    result = GetFlags(splitFlags);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryIncludeFlag.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryIncludeFlag.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 
 namespace NuGet.LibraryModel
 {

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryIncludeFlagUtils.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryIncludeFlagUtils.cs
@@ -101,7 +101,7 @@ namespace NuGet.LibraryModel
         /// </summary>
         public static LibraryIncludeFlags GetFlags(string flags, LibraryIncludeFlags defaultFlags)
         {
-            LibraryIncludeFlags result = defaultFlags;
+            var result = defaultFlags;
 
             if (!string.IsNullOrEmpty(flags))
             {

--- a/src/NuGet.Core/NuGet.Packaging/Core/FrameworkReference.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Core/FrameworkReference.cs
@@ -3,14 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using NuGet.Common;
 using NuGet.Shared;
 
 namespace NuGet.Packaging
 {
-    public class FrameworkReference : IEquatable<FrameworkReference>, IComparer<FrameworkReference>, IComparable<FrameworkReference>
+    public sealed class FrameworkReference : IEquatable<FrameworkReference>, IComparer<FrameworkReference>, IComparable<FrameworkReference>
     {
-        public static StringComparer FrameworkReferenceNameComparer = StringComparer.OrdinalIgnoreCase;
-
         public string Name { get; }
 
         public FrameworkReference(string name)
@@ -20,7 +19,7 @@ namespace NuGet.Packaging
 
         public int Compare(FrameworkReference x, FrameworkReference y)
         {
-            return FrameworkReferenceNameComparer.Compare(x.Name, y.Name);
+            return ComparisonUtility.FrameworkReferenceNameComparer.Compare(x.Name, y.Name);
         }
 
         public bool Equals(FrameworkReference other)
@@ -35,7 +34,7 @@ namespace NuGet.Packaging
                 return true;
             }
 
-            return FrameworkReferenceNameComparer.Equals(Name, other.Name);
+            return ComparisonUtility.FrameworkReferenceNameComparer.Equals(Name, other.Name);
         }
 
         public override bool Equals(object obj)
@@ -46,7 +45,7 @@ namespace NuGet.Packaging
         public override int GetHashCode()
         {
             var combiner = new HashCodeCombiner();
-            combiner.AddObject(Name, FrameworkReferenceNameComparer);
+            combiner.AddObject(Name, ComparisonUtility.FrameworkReferenceNameComparer);
             return combiner.CombinedHash;
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/Core/NuspecUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Core/NuspecUtility.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
+using NuGet.Common;
 using NuGet.Frameworks;
 
 namespace NuGet.Packaging.Core
@@ -168,7 +169,7 @@ namespace NuGet.Packaging.Core
 
         private static IEnumerable<string> GetFrameworkReferences(IEnumerable<XElement> nodes)
         {
-            return new HashSet<string>(nodes.Select(e => GetAttributeValue(e, Name)), Packaging.FrameworkReference.FrameworkReferenceNameComparer);
+            return new HashSet<string>(nodes.Select(e => GetAttributeValue(e, Name)), ComparisonUtility.FrameworkReferenceNameComparer);
         }
 
         private static string GetAttributeValue(XElement element, string attributeName)

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -504,11 +504,19 @@ namespace NuGet.ProjectModel
             }
         }
 
-        private static void SetFrameworkReferences(IObjectWriter writer, ISet<string> frameworkReferences)
+        private static void SetFrameworkReferences(IObjectWriter writer, ISet<FrameworkDependency> frameworkReferences)
         {
             if (frameworkReferences?.Any() == true)
             {
-                writer.WriteNameArray("frameworkReferences", frameworkReferences.OrderBy(e => e));
+                writer.WriteObjectStart("frameworkReferences");
+
+                foreach (var dependency in frameworkReferences.OrderBy(dep => dep))
+                {
+                    writer.WriteObjectStart(dependency.Name);
+                    SetValue(writer, "privateAssets", FrameworkDependencyFlagsUtils.GetFlagString(dependency.PrivateAssets));
+                    writer.WriteObjectEnd();
+                }
+                writer.WriteObjectEnd();
             }
         }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
@@ -41,7 +41,7 @@ namespace NuGet.ProjectModel
         /// <summary>
         /// A set of unique FrameworkReferences
         /// </summary>
-        public ISet<string> FrameworkReferences { get; } = new HashSet<string>(FrameworkReference.FrameworkReferenceNameComparer);
+        public ISet<FrameworkDependency> FrameworkReferences { get; } = new HashSet<FrameworkDependency>();
 
         public override string ToString()
         {
@@ -84,7 +84,7 @@ namespace NuGet.ProjectModel
                    Imports.SequenceEqualWithNullCheck(other.Imports) &&
                    AssetTargetFallback == other.AssetTargetFallback &&
                    DownloadDependencies.OrderedEquals(other.DownloadDependencies, dep => dep) &&
-                   FrameworkReferences.OrderedEquals(other.FrameworkReferences, keySelector: e => e, orderComparer: StringComparer.OrdinalIgnoreCase, sequenceComparer: StringComparer.OrdinalIgnoreCase);
+                   FrameworkReferences.OrderedEquals(other.FrameworkReferences, fr => fr);
         }
 
         public TargetFrameworkInformation Clone()

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ProjectRestoreInfoBuilder.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ProjectRestoreInfoBuilder.cs
@@ -170,7 +170,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 .DownloadDependencies
                 .Select(ToPackageDownload);
 
-            var frameworkReferences = tfm.FrameworkReferences.Select(e => new VsReferenceItem(e, new VsReferenceProperties()));
+            var frameworkReferences = tfm.FrameworkReferences.Select(ToFrameworkReference);
 
             var projectProperties = new VsProjectProperties
             {
@@ -187,6 +187,14 @@ namespace NuGet.SolutionRestoreManager.Test
                 packageDownloads,
                 frameworkReferences,
                 projectProperties.Concat(globalProperties));
+        }
+
+        private static IVsReferenceItem ToFrameworkReference(FrameworkDependency frameworkDependency)
+        {
+            var properties = new VsReferenceProperties(
+                new[] { new VsReferenceProperty("PrivateAssets", FrameworkDependencyFlagsUtils.GetFlagString(frameworkDependency.PrivateAssets)) }
+            );
+            return new VsReferenceItem(frameworkDependency.Name, properties);
         }
 
         private static IVsReferenceItem ToPackageReference(LibraryDependency library)

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -1384,10 +1384,14 @@ namespace NuGet.SolutionRestoreManager.Test
                     ""version"": ""5.1.0""
                 },
             },
-            ""frameworkReferences"": [
-                ""Microsoft.WindowsDesktop.App|WPF"",
-                ""Microsoft.WindowsDesktop.App|WinForms""
-            ]
+            ""frameworkReferences"": {
+                ""Microsoft.WindowsDesktop.App|WPF"" : {
+                    ""privateAssets"" : ""none""
+                },
+                ""Microsoft.WindowsDesktop.App|WinForms"" : {
+                    ""privateAssets"" : ""all""
+                }
+            }
             }
         }
     }";
@@ -1420,8 +1424,8 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.Equal(expectedFramework, actualTfi.FrameworkName);
 
             AssertFrameworkReferences(actualTfi,
-                "Microsoft.WindowsDesktop.App|WPF",
-                "Microsoft.WindowsDesktop.App|WinForms");
+                "Microsoft.WindowsDesktop.App|WinForms:all",
+                "Microsoft.WindowsDesktop.App|WPF:none");
         }
 
         [Fact]
@@ -1436,10 +1440,14 @@ namespace NuGet.SolutionRestoreManager.Test
                     ""version"": ""5.1.0""
                 },
             },
-            ""frameworkReferences"": [
-                ""Microsoft.WindowsDesktop.App|WinForms"",
-                ""Microsoft.WindowsDesktop.App|WINFORMS""
-            ]
+            ""frameworkReferences"": {
+                ""Microsoft.WindowsDesktop.App|WinForms"" : {
+                    ""privateAssets"" : ""none""
+                },
+                ""Microsoft.WindowsDesktop.App|WINFORMS"" : {
+                    ""privateAssets"" : ""none""
+                }
+            }
             }
         }
     }";
@@ -1472,7 +1480,7 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.Equal(expectedFramework, actualTfi.FrameworkName);
 
             AssertFrameworkReferences(actualTfi,
-                "Microsoft.WindowsDesktop.App|WinForms");
+                "Microsoft.WindowsDesktop.App|WinForms:none");
         }
 
         [Fact]
@@ -1481,15 +1489,21 @@ namespace NuGet.SolutionRestoreManager.Test
             var consoleAppProjectJson = @"{
     ""frameworks"": {
         ""netcoreapp3.0"": {
-            ""frameworkReferences"": [
-                ""Microsoft.WindowsDesktop.App|WPF"",
-                ""Microsoft.WindowsDesktop.App|WinForms""
-            ]
+            ""frameworkReferences"": {
+                ""Microsoft.WindowsDesktop.App|WPF"" : {
+                    ""privateAssets"" : ""none""
+                }, 
+                ""Microsoft.WindowsDesktop.App|WinForms"" : {
+                    ""privateAssets"" : ""none""
+                }
+            }
         },
          ""netcoreapp3.1"": {
-            ""frameworkReferences"": [
-                ""Microsoft.ASPNetCore.App""
-            ]
+            ""frameworkReferences"": {
+                ""Microsoft.ASPNetCore.App"" : {
+                    ""privateAssets"" : ""none""
+                }
+            }
             }
         }
         },
@@ -1524,15 +1538,15 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.Equal(expectedFramework, tfi.FrameworkName);
 
             AssertFrameworkReferences(tfi,
-                "Microsoft.WindowsDesktop.App|WPF",
-                "Microsoft.WindowsDesktop.App|WinForms");
+                "Microsoft.WindowsDesktop.App|WinForms:none",
+                "Microsoft.WindowsDesktop.App|WPF:none");
 
             tfi = actualProjectSpec.TargetFrameworks.Last();
             expectedFramework = NuGetFramework.Parse("netcoreapp3.1");
             Assert.Equal(expectedFramework, tfi.FrameworkName);
 
             AssertFrameworkReferences(tfi,
-                "Microsoft.ASPNetCore.App");
+                "Microsoft.ASPNetCore.App:none");
         }
 
         [Theory]
@@ -1725,7 +1739,11 @@ namespace NuGet.SolutionRestoreManager.Test
 
         private static void AssertFrameworkReferences(TargetFrameworkInformation actualTfi, params string[] expectedPackages)
         {
-            Assert.Equal(expectedPackages, actualTfi.FrameworkReferences);
+            Assert.Equal(expectedPackages,
+                actualTfi.FrameworkReferences
+                .OrderBy(e => e)
+                .Select(e => e.Name + ":" + FrameworkDependencyFlagsUtils.GetFlagString(e.PrivateAssets))
+                .ToArray());
         }
 
         private class TestContext

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -3820,7 +3820,7 @@ namespace ClassLibrary
                         var properties = new Dictionary<string, string>();
                         if (!frameworkRef.Value)
                         {
-                            attributes["Pack"] = "false";
+                            attributes["PrivateAssets"] = "all";
                         }
                         ProjectFileUtils.AddItem(
                             xml,

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
@@ -661,7 +661,6 @@ namespace NuGet.Build.Tasks.Pack.Test
                     Logger = new TestLogger(),
                     SymbolPackageFormat = "symbols.nupkg",
                     FrameworkAssemblyReferences = new MSBuildItem[] { },
-                    FrameworkReferences = new MSBuildItem[] { },
                 };
             }
 
@@ -703,7 +702,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                 if (!File.Exists(fullpath))
                 {
                     // Create a file to write to.
-                    using (StreamWriter sw = File.CreateText(fullpath))
+                    using (var sw = File.CreateText(fullpath))
                     {
                         sw.WriteLine(content);
                     }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -363,7 +363,6 @@ namespace NuGet.Build.Tasks.Pack.Test
                 BuildOutputInPackage = new ITaskItem[0],
                 TargetPathsToSymbols = new ITaskItem[0],
                 FrameworksWithSuppressedDependencies = new ITaskItem[0],
-                FrameworkReferences = new ITaskItem[0],
     };
 
             var settings = new JsonSerializerSettings

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
@@ -1572,9 +1572,11 @@ namespace NuGet.Commands.Test
                     ""dependencies"": {
                         ""x"": ""1.0.0""
                     },
-                    ""frameworkReferences"": [
-                        ""a""
-                    ]
+                    ""frameworkReferences"": {
+                        ""a"" : {
+                            ""privateAssets"" : ""none""
+                        }
+                    }
                 }
               }
             }";
@@ -1632,7 +1634,8 @@ namespace NuGet.Commands.Test
                     Assert.Equal(1, lockFile.Libraries.Count); // Only X is written in the libraries section.
                     Assert.Equal("x", lockFile.Targets.First().Libraries.First().Name);
                     Assert.Equal(0, lockFile.LogMessages.Count);
-                    Assert.Equal("a", lockFile.PackageSpec.TargetFrameworks.First().FrameworkReferences.Single());
+                    Assert.Equal("a", lockFile.PackageSpec.TargetFrameworks.First().FrameworkReferences.Single().Name);
+                    Assert.Equal("none", FrameworkDependencyFlagsUtils.GetFlagString(lockFile.PackageSpec.TargetFrameworks.First().FrameworkReferences.Single().PrivateAssets));
                     Assert.True(File.Exists(targetsPath));
                     Assert.True(File.Exists(propsPath));
                 }
@@ -1766,9 +1769,11 @@ namespace NuGet.Commands.Test
                     ""dependencies"": {
                         ""x"": ""1.0.0""
                     },
-                    ""frameworkReferences"": [
-                        ""Microsoft.WindowsDesktop.App|WPF""
-                    ]
+                    ""frameworkReferences"": {
+                        ""Microsoft.WindowsDesktop.App|WPF"" : {
+                            ""privateAssets"" : ""none""
+                        }
+                    }
                 }
               }
             }";
@@ -1858,7 +1863,7 @@ namespace NuGet.Commands.Test
                     Assert.Equal("x", xTarget2.Name);
                     Assert.Equal("Microsoft.WindowsDesktop.App|WinForms", xTarget2.FrameworkReferences.Single());
                     Assert.Equal(0, lockFile.LogMessages.Count);
-                    Assert.Equal("Microsoft.WindowsDesktop.App|WPF", lockFile.PackageSpec.TargetFrameworks.Single().FrameworkReferences.Single());
+                    Assert.Equal("Microsoft.WindowsDesktop.App|WPF", lockFile.PackageSpec.TargetFrameworks.Single().FrameworkReferences.Single().Name);
                     Assert.True(File.Exists(targetsPath2));
                     Assert.True(File.Exists(propsPath2));
 

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/FrameworkDependencyFlagsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/FrameworkDependencyFlagsUtilsTests.cs
@@ -1,0 +1,43 @@
+// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace NuGet.LibraryModel.Tests
+{
+    public class FrameworkDependencyFlagsUtilsTests
+    {
+        [Fact]
+        public void FrameworkDependencyFlagsUtils_GetFlagString_ReturnsExpectedString()
+        {
+            Assert.Equal("all", FrameworkDependencyFlagsUtils.GetFlagString(FrameworkDependencyFlags.All));
+            Assert.Equal("none", FrameworkDependencyFlagsUtils.GetFlagString(FrameworkDependencyFlags.None));
+        }
+
+        [Fact]
+        public void FrameworkDependencyFlagsUtils_GetFlagsFromString_ReturnsExpectedFlags()
+        {
+            Assert.Equal(FrameworkDependencyFlags.All, FrameworkDependencyFlagsUtils.GetFlags("all"));
+            Assert.Equal(FrameworkDependencyFlags.All, FrameworkDependencyFlagsUtils.GetFlags("All"));
+            Assert.Equal(FrameworkDependencyFlags.None, FrameworkDependencyFlagsUtils.GetFlags("None"));
+            Assert.Equal(FrameworkDependencyFlags.None, FrameworkDependencyFlagsUtils.GetFlags("none"));
+            Assert.Equal(FrameworkDependencyFlags.None, FrameworkDependencyFlagsUtils.GetFlags((string)null));
+            Assert.Equal(FrameworkDependencyFlags.All, FrameworkDependencyFlagsUtils.GetFlags("none,all")); // Stupid to write this, but pointless to enforce that people don't :)
+            Assert.Equal(FrameworkDependencyFlags.All, FrameworkDependencyFlagsUtils.GetFlags("all,none")); // Stupid to write this, but pointless to enforce that people don't :)
+        }
+
+        [Fact]
+        public void FrameworkDependencyFlagsUtils_GetFlagsFromAnEnumerable_ReturnsExpectedFlags()
+        {
+            Assert.Equal(FrameworkDependencyFlags.None, FrameworkDependencyFlagsUtils.GetFlags((IEnumerable<string>)null));
+            Assert.Equal(FrameworkDependencyFlags.All, FrameworkDependencyFlagsUtils.GetFlags(new string[] { "all" }));
+            Assert.Equal(FrameworkDependencyFlags.None, FrameworkDependencyFlagsUtils.GetFlags(new string[] { "none" }));
+            Assert.Equal(FrameworkDependencyFlags.All, FrameworkDependencyFlagsUtils.GetFlags(new string[] { "all", "none" }));
+            Assert.Equal(FrameworkDependencyFlags.All, FrameworkDependencyFlagsUtils.GetFlags(new string[] { "none", "all" }));
+            Assert.Equal(FrameworkDependencyFlags.All, FrameworkDependencyFlagsUtils.GetFlags(new string[] { "All", "None" }));
+
+
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/FrameworkDependencyTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/FrameworkDependencyTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace NuGet.LibraryModel
+{
+    public class FrameworkDependencyTests
+    {
+        [Fact]
+        public void FrameworkDependecy_ConstructorWithNullName_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new FrameworkDependency(null, FrameworkDependencyFlags.All));
+        }
+
+        [Fact]
+        public void FrameworkDependecy_NamesWithDifferentCasing_AreEqual()
+        {
+            Assert.Equal(new FrameworkDependency("AAA", FrameworkDependencyFlags.All),
+                        new FrameworkDependency("aaa", FrameworkDependencyFlags.All));
+        }
+
+        [Fact]
+        public void FrameworkDependency_DifferentFlags_AreNotEqual()
+        {
+            Assert.NotEqual(new FrameworkDependency("AAA", FrameworkDependencyFlags.All),
+                        new FrameworkDependency("AAA", FrameworkDependencyFlags.None));
+        }
+
+        [Fact]
+        public void FrameworkDependecy_NamesWithDifferentCasign_DoNotAffectCompare()
+        {
+            var frameworkDependencies = new List<FrameworkDependency>();
+
+            frameworkDependencies.Add(new FrameworkDependency("aa", FrameworkDependencyFlags.None));
+            frameworkDependencies.Add(new FrameworkDependency("Aa", FrameworkDependencyFlags.None));
+            frameworkDependencies.Add(new FrameworkDependency("AA", FrameworkDependencyFlags.None));
+
+            // Act
+            frameworkDependencies.Sort();
+
+            Assert.Equal("aa,Aa,AA", string.Join(",", frameworkDependencies.Select(e => e.Name)));
+        }
+
+        [Fact]
+        public void FrameworkDependecy_DifferentFlags_AffectCompare()
+        {
+            Assert.Equal(1, new FrameworkDependency("AAA", FrameworkDependencyFlags.All).CompareTo(new FrameworkDependency("AAA", FrameworkDependencyFlags.None)));
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecCloningTests.cs
@@ -610,8 +610,8 @@ namespace NuGet.ProjectModel.Test
             originalTargetFrameworkInformation.AssetTargetFallback = false;
             originalTargetFrameworkInformation.Imports = new List<NuGetFramework>() { imports };
             originalTargetFrameworkInformation.DownloadDependencies.Add(new DownloadDependency("X", VersionRange.Parse("1.0.0")));
-            originalTargetFrameworkInformation.FrameworkReferences.Add("frameworkRef");
-            originalTargetFrameworkInformation.FrameworkReferences.Add("FrameworkReference");
+            originalTargetFrameworkInformation.FrameworkReferences.Add(new FrameworkDependency("frameworkRef", FrameworkDependencyFlags.All));
+            originalTargetFrameworkInformation.FrameworkReferences.Add(new FrameworkDependency("FrameworkReference", FrameworkDependencyFlags.None));
 
             return originalTargetFrameworkInformation;
         }
@@ -667,8 +667,8 @@ namespace NuGet.ProjectModel.Test
             //Setup
             var cloneToTestFrameworkReferenceEquality = originalTargetFrameworkInformation.Clone();
             cloneToTestFrameworkReferenceEquality.FrameworkReferences.Clear();
-            cloneToTestFrameworkReferenceEquality.FrameworkReferences.Add("frameworkRef");
-            cloneToTestFrameworkReferenceEquality.FrameworkReferences.Add("frameworkReference");
+            cloneToTestFrameworkReferenceEquality.FrameworkReferences.Add(new FrameworkDependency("frameworkRef", FrameworkDependencyFlags.All));
+            cloneToTestFrameworkReferenceEquality.FrameworkReferences.Add(new FrameworkDependency("frameworkReference", FrameworkDependencyFlags.None));
 
             // Assert
             Assert.Equal(originalTargetFrameworkInformation, cloneToTestFrameworkReferenceEquality);

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -414,10 +414,14 @@ namespace NuGet.ProjectModel.Test
                             {""name"" : ""c"", ""version"" : ""[2.0.0]""},
                             {""name"" : ""d"", ""version"" : ""[2.0.0]""},
                        ],
-                       ""frameworkReferences"" : [
-                            ""b"",
-                            ""a""
-                       ]
+                       ""frameworkReferences"" : {
+                            ""b"": {
+                                ""privateAssets"": ""none"",
+                            },
+                            ""a"": {
+                                ""privateAssets"": ""none"",
+                            }
+                        }
                     }
                   }
                 }";
@@ -437,10 +441,14 @@ namespace NuGet.ProjectModel.Test
                             {""name"" : ""c"", ""version"" : ""[2.0.0, 2.0.0]""},
                             {""name"" : ""d"", ""version"" : ""[2.0.0, 2.0.0]""},
                        ],
-                      ""frameworkReferences"" : [
-                          ""a"",
-                          ""b""
-                      ]
+                      ""frameworkReferences"" : {
+                            ""a"": {
+                                ""privateAssets"": ""none"",
+                            },
+                            ""b"": {
+                                ""privateAssets"": ""none"",
+                            }
+                        }
                     }
                   }
                 }";
@@ -504,10 +512,14 @@ namespace NuGet.ProjectModel.Test
                                 ""autoReferenced"": true
                             }
                         },
-                        ""frameworkReferences"": [
-                            ""Microsoft.WindowsDesktop.App|WinForms"",
-                            ""Microsoft.WindowsDesktop.App|WPF""
-                        ]
+                        ""frameworkReferences"": {
+                            ""Microsoft.WindowsDesktop.App|WinForms"" : {
+                                ""privateAssets"" : ""none""
+                            },
+                            ""Microsoft.WindowsDesktop.App|WPF"" : {
+                                ""privateAssets"" : ""none""
+                            }
+                        }
                     }
                   }
                 }";


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7988
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Introduce a PrivateAssets flag to control the dependency flow of FrameworkReference through restore. 

Alongside that remove the Pack=false flag, as PrivateAssets accomplishes the same purpose.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
