### PR TITLE
Fix the package selection when the range has an exclusive lower bound, and the lower bound is on the server

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -208,7 +208,7 @@ namespace NuGet.Commands
             {
                 await EnsureResource();
 
-                if (libraryRange.VersionRange?.MinVersion != null && libraryRange.VersionRange?.IsFloating != true)
+                if (libraryRange.VersionRange?.MinVersion != null && libraryRange.VersionRange.IsMinInclusive && !libraryRange.VersionRange.IsFloating)
                 {
                     // first check if the exact min version exist then simply return that
                     if (await _findPackagesByIdResource.DoesPackageExistAsync(

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -7949,6 +7949,10 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 r.Success.Should().BeTrue();
                 Assert.True(File.Exists(projectA.AssetsFileOutputPath));
+                Assert.Equal(1, projectA.AssetsFile.Libraries.Count);
+                var packageX = projectA.AssetsFile.Libraries.First();
+                Assert.NotNull(packageX);
+                Assert.Equal("1.1.0", packageX.Version.ToString());
             }
         }
 
@@ -8013,6 +8017,10 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 r.Success.Should().BeTrue();
                 Assert.True(File.Exists(projectA.AssetsFileOutputPath));
+                Assert.Equal(2, projectA.AssetsFile.Libraries.Count);
+                var packageX = projectA.AssetsFile.Libraries.FirstOrDefault(e => e.Name.Equals("x"));
+                Assert.NotNull(packageX);
+                Assert.Equal("1.1.0", packageX.Version.ToString());
             }
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -7896,5 +7896,124 @@ namespace NuGet.CommandLine.Test
                 r.Success.Should().BeTrue();
             }
         }
+
+        [Fact]
+        public async Task RestoreNetCore_ExclusiveLowerBound_RestoreSucceeds()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+                var tfm = "net45";
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                   "a",
+                   pathContext.SolutionRoot,
+                   NuGetFramework.Parse(tfm));
+
+                var packageX100 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+
+                var packageX110 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.1.0"
+                };
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                   pathContext.PackageSource,
+                   packageX100,
+                   packageX110);
+
+                solution.Projects.Add(projectA);
+
+                solution.Create(pathContext.SolutionRoot);
+
+                // Inject dependency with exclusive lower bound
+                var doc = XDocument.Load(projectA.ProjectPath);
+                var ns = doc.Root.GetDefaultNamespace().NamespaceName;
+                doc.Root.AddFirst(
+                        new XElement(XName.Get("ItemGroup", ns),
+                            new XElement(XName.Get("PackageReference", ns),
+                                new XAttribute(XName.Get("Include"), "x"),
+                                new XAttribute(XName.Get("Version"), "(1.0.0, )"))));
+
+                doc.Save(projectA.ProjectPath);
+                // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath));
+            }
+        }
+
+        [Fact]
+        public async Task RestoreNetCore_PackageDependencyWithExclusiveLowerBound_RestoreSucceeds()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+                var tfm = "net45";
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                   "a",
+                   pathContext.SolutionRoot,
+                   NuGetFramework.Parse(tfm));
+
+                var packageY = new SimpleTestPackageContext("y", "1.0.0")
+                {
+                    Nuspec = XDocument.Parse($@"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <package>
+                        <metadata>
+                            <id>y</id>
+                            <version>1.0.0</version>
+                            <title />
+                            <dependencies>
+                                <group targetFramework=""net45"">
+                                    <dependency id=""x"" version=""(1.0.0, )"" />
+                                </group>
+                            </dependencies>
+                        </metadata>
+                        </package>")
+                };
+
+                var packageX100 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                var packageX110 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.1.0"
+                };
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                   pathContext.PackageSource,
+                   packageX100,
+                   packageX110,
+                   packageY);
+
+                projectA.AddPackageToAllFrameworks(packageY);
+
+                solution.Projects.Add(projectA);
+
+                solution.Create(pathContext.SolutionRoot);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath));
+            }
+        }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8054  
Regression: Yes  
* Last working version:  4.9.x
* How are we preventing it in future: Better tests

## Fix

Details: In 5.0.0 we added a short-circuit to avoid the enumeration of all versions of a package locally on disk.
That logic had an issue, as it checked for a min version, but it did not check that the min range was inclusive. 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
