### PR TITLE
 Remove Newtonsoft.Json reference from NuGet.PackageManagement.VisualStudio

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SearchPageTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SearchPageTelemetryEvent.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Threading;
 using NuGet.Common;
 using NuGet.PackageManagement.VisualStudio;
 
@@ -16,7 +15,7 @@ namespace NuGet.PackageManagement.Telemetry
     /// </summary>
     public class SearchPageTelemetryEvent : TelemetryEvent
     {
-        private StringBuilder _stringBuilder;
+        private StringBuilder _stringBuilder = new StringBuilder();
 
         public SearchPageTelemetryEvent(
             Guid parentId,
@@ -38,30 +37,20 @@ namespace NuGet.PackageManagement.Telemetry
 
         private string ToJsonArray(IEnumerable<TimeSpan> sourceTimings)
         {
-            var sb = Interlocked.Exchange(ref _stringBuilder, null);
-            if (sb == null)
-            {
-                sb = new StringBuilder();
-            }
-            else
-            {
-                sb.Clear();
-            }
-
-            sb.Append("[");
+            _stringBuilder.Clear();
+            _stringBuilder.Append("[");
             foreach (var item in sourceTimings)
             {
-                sb.Append(item.TotalSeconds);
+                _stringBuilder.Append(item.TotalSeconds);
+                _stringBuilder.Append(",");
             }
-            if (sb[sb.Length - 1] == ',')
+            if (_stringBuilder[_stringBuilder.Length - 1] == ',')
             {
-                sb.Length--;
+                _stringBuilder.Length--;
             }
-            sb.Append("]");
+            _stringBuilder.Append("]");
 
-            var result = sb.ToString();
-            Interlocked.Exchange(ref _stringBuilder, sb);
-            return result;
+            return _stringBuilder.ToString();
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SearchPageTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SearchPageTelemetryEvent.cs
@@ -15,8 +15,6 @@ namespace NuGet.PackageManagement.Telemetry
     /// </summary>
     public class SearchPageTelemetryEvent : TelemetryEvent
     {
-        private StringBuilder _stringBuilder = new StringBuilder();
-
         public SearchPageTelemetryEvent(
             Guid parentId,
             int pageIndex,
@@ -37,20 +35,20 @@ namespace NuGet.PackageManagement.Telemetry
 
         private string ToJsonArray(IEnumerable<TimeSpan> sourceTimings)
         {
-            _stringBuilder.Clear();
-            _stringBuilder.Append("[");
+            var sb = new StringBuilder();
+            sb.Append("[");
             foreach (var item in sourceTimings)
             {
-                _stringBuilder.Append(item.TotalSeconds);
-                _stringBuilder.Append(",");
+                sb.Append(item.TotalSeconds);
+                sb.Append(",");
             }
-            if (_stringBuilder[_stringBuilder.Length - 1] == ',')
+            if (sb[sb.Length - 1] == ',')
             {
-                _stringBuilder.Length--;
+                sb.Length--;
             }
-            _stringBuilder.Append("]");
+            sb.Append("]");
 
-            return _stringBuilder.ToString();
+            return sb.ToString();
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SearchPageTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SearchPageTelemetryEvent.cs
@@ -33,7 +33,7 @@ namespace NuGet.PackageManagement.Telemetry
             base["LoadingStatus"] = loadingStatus.ToString();
         }
 
-        private string ToJsonArray(IEnumerable<TimeSpan> sourceTimings)
+        private static string ToJsonArray(IEnumerable<TimeSpan> sourceTimings)
         {
             var sb = new StringBuilder();
             sb.Append("[");

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SearchPageTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/SearchPageTelemetryEvent.cs
@@ -43,6 +43,10 @@ namespace NuGet.PackageManagement.Telemetry
             {
                 sb = new StringBuilder();
             }
+            else
+            {
+                sb.Clear();
+            }
 
             sb.Append("[");
             foreach (var item in sourceTimings)


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8109
Regression: No
* Last working version: 
* How are we preventing it in future:   NuGet/Home#8108

## Fix

Details: manually create JSON string, rather than using Newtonsoft.Json

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Urgent insertion needed
Validation: 
