### PR TITLE
Respect HideWarningsAsErrors when appropriate

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -288,7 +288,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Warn for projects that do not support restore. -->
     <WarnForInvalidProjectsTask
-      Condition=" '$(DisableWarnForInvalidRestoreProjects)' != 'true' "
+      Condition=" '$(DisableWarnForInvalidRestoreProjects)' != 'true' AND '$(HideWarningsAndErrors)' != 'true' "
       AllProjects="@(FilteredRestoreGraphProjectInputItemsWithoutDuplicates)"
       ValidProjects="@(FilteredRestoreGraphProjectInputItems)" />
   </Target>

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -131,7 +131,7 @@ namespace NuGet.Build.Tasks
 
         private async Task<bool> ExecuteAsync(Common.ILogger log)
         {
-            if (RestoreGraphItems.Length < 1)
+            if (RestoreGraphItems.Length < 1 && !HideWarningsAndErrors)
             {
                 log.LogWarning(Strings.NoProjectsProvidedToTask);
                 return true;


### PR DESCRIPTION
## Bug

Fixes: One part of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/849782
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Readign the linked issue is ideal. 

The 2 changes in this PR are:

1. We should not log any sort of warnings if errors and warnings are hidden.
1. If someone has passed HideWarningsAsErrors, they should not see unneeded NU1503.

## Testing/Validation

Tests Added: No  
Reason for not adding tests: This is extremely difficult to test. We need special templates and msbuild tests (dotnet.exe tests are insufficient, as the scenario there would be different). I have created a follow up issue to add msbuild pack/restore tests.   https://github.com/NuGet/Home/issues/8110
Validation:  manual
