### PR TITLE
Add a PackageDownloadSupported property

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -55,6 +55,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_RestoreSolutionFileUsed Condition=" '$(_RestoreSolutionFileUsed)' == '' AND '$(SolutionDir)' != '' AND $(MSBuildProjectFullPath.EndsWith('.metaproj')) == 'true' " >true</_RestoreSolutionFileUsed>
     <!-- We default to MSBuildInteractive. -->
     <NuGetInteractive Condition=" '$(NuGetInteractive)' == '' ">$(MSBuildInteractive)</NuGetInteractive>
+    <!-- Mark that this targets file supports package download. -->
+    <PackageDownloadSupported>true</PackageDownloadSupported>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8106
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Needed so that the SDK can understand whether they can use PackageDownload.

//cc @livarcocc @dsplaisted @nguerrera 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  Manual + automation
