### PR TITLE
Update config.props to hard-code the preview#

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -17,10 +17,11 @@
     <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">release/2.2.4xx;release/2.1.8xx</CliTargetBranches>
     <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</SdkTargetBranches>
     <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">release/2.2.4xx;release/2.1.8xx</SdkTargetBranches>
-    <!-- We need to update this netcoreassembly build number with every milestone to workaround any breaking api
-    changes we might have made-->
+    <!-- We need to update this netcoreassembly build number with every insertion into VS to workaround any breaking api
+    changes we might have made.-->
     <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">1</NetCoreAssemblyBuildNumber>
-    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview$(NetCoreAssemblyBuildNumber)</ReleaseLabel>
+    <!-- Check the VS schedule and manually enter a preview number here that makes sense. -->
+    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview2</ReleaseLabel>
   </PropertyGroup>
 
   <!-- Dependency versions -->


### PR DESCRIPTION
## Bug
Build process generated a preview2 nuget.exe which was put on Nuget.org. However, I was releasing preview3. There is a variable in the build process that is not referenced anywhere else which is incrementing based on something irrelevant.

Fixes: https://github.com/NuGet/Home/issues/8123
Regression: No

## Fix

Details: Just hard-code the preview# into the build script to match the VS Preview number.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  This is becoming a manual process.
Validation:  
