### PR TITLE
Don't lowercase projects with custom assembly names in packages lock file

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
@@ -46,7 +46,7 @@ namespace NuGet.Commands
 
                     var dependency = new LockFileDependency()
                     {
-                        Id = library.Name,
+                        Id = library.Name.ToLowerInvariant(),
                         ResolvedVersion = library.Version,
                         ContentHash = libraryLookup[identity].Sha512,
                         Dependencies = library.Dependencies

--- a/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Linq;
 using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
@@ -70,9 +71,14 @@ namespace NuGet.Commands
 
                 foreach (var projectReference in libraries.Where(e => e.Type == LibraryType.Project || e.Type == LibraryType.ExternalProject))
                 {
+                    var projectLibrary = assetsFile.Libraries.Single(a => a.Name == projectReference.Name && a.Version == projectReference.Version);
+                    var id = string.Equals(Path.GetFileNameWithoutExtension(projectLibrary.MSBuildProject), projectReference.Name, StringComparison.OrdinalIgnoreCase)
+                        ? projectReference.Name.ToLowerInvariant()
+                        : projectReference.Name;
+
                     var dependency = new LockFileDependency()
                     {
-                        Id = projectReference.Name.ToLowerInvariant(),
+                        Id = id,
                         Dependencies = projectReference.Dependencies,
                         Type = PackageDependencyType.Project
                     };

--- a/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using NuGet.Common;
 using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
@@ -69,10 +70,15 @@ namespace NuGet.Commands
                     nuGettarget.Dependencies.Add(dependency);
                 }
 
+                var projectFullPaths = assetsFile.Libraries
+                    .Where(l => l.Type == LibraryType.Project || l.Type == LibraryType.ExternalProject)
+                    .ToDictionary(l => new PackageIdentity(l.Name, l.Version), l => l.MSBuildProject);
+
                 foreach (var projectReference in libraries.Where(e => e.Type == LibraryType.Project || e.Type == LibraryType.ExternalProject))
                 {
-                    var projectLibrary = assetsFile.Libraries.Single(a => a.Name == projectReference.Name && a.Version == projectReference.Version);
-                    var id = string.Equals(Path.GetFileNameWithoutExtension(projectLibrary.MSBuildProject), projectReference.Name, StringComparison.OrdinalIgnoreCase)
+                    var projectIdentity= new PackageIdentity(projectReference.Name, projectReference.Version);
+                    var projectFullPath = projectFullPaths[projectIdentity];
+                    var id = PathUtility.GetStringComparerBasedOnOS().Equals(Path.GetFileNameWithoutExtension(projectFullPath), projectReference.Name)
                         ? projectReference.Name.ToLowerInvariant()
                         : projectReference.Name;
 

--- a/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs
@@ -46,7 +46,7 @@ namespace NuGet.Commands
 
                     var dependency = new LockFileDependency()
                     {
-                        Id = library.Name.ToLowerInvariant(),
+                        Id = library.Name,
                         ResolvedVersion = library.Version,
                         ContentHash = libraryLookup[identity].Sha512,
                         Dependencies = library.Dependencies

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -7830,7 +7830,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert that the project name is the project custom name.
                 Assert.Equal(lockFile.Targets.First().Dependencies.Count, 2);
-                Assert.Equal("customname", lockFile.Targets.First().Dependencies.First(e => e.Type == PackageDependencyType.Project).Id);
+                Assert.Equal("CustomName", lockFile.Targets.First().Dependencies.First(e => e.Type == PackageDependencyType.Project).Id);
 
                  // Setup - Enable locked mode
                 projectA.Properties.Add("RestoreLockedMode", "true");
@@ -7903,7 +7903,7 @@ namespace NuGet.CommandLine.Test
 
                  // Assert that the project name is the custom name.
                 Assert.Equal(lockFile.Targets.First().Dependencies.Count, 2);
-                Assert.Equal("customname", lockFile.Targets.First().Dependencies.First(e => e.Type == PackageDependencyType.Project).Id);
+                Assert.Equal("CustomName", lockFile.Targets.First().Dependencies.First(e => e.Type == PackageDependencyType.Project).Id);
 
                  // Setup - Enable locked mode
                 projectA.Properties.Add("RestoreLockedMode", "true");

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -6219,8 +6219,8 @@ namespace NuGet.CommandLine.Test
                 Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
 
                 var lockFile = PackagesLockFileFormat.Read(projectA.NuGetLockFileOutputPath);
-                lockFile.Targets.Should().HaveCount(1);
-                var projectReference = lockFile.Targets[0].Dependencies.SingleOrDefault(d => d.Type == PackageDependencyType.Project);
+                var target = lockFile.Targets.Single(t => t.RuntimeIdentifier == null);
+                var projectReference = target.Dependencies.SingleOrDefault(d => d.Type == PackageDependencyType.Project);
                 StringComparer.Ordinal.Equals(projectReference.Id, projectB.ProjectName.ToLowerInvariant()).Should().BeTrue();
             }
         }
@@ -7830,7 +7830,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert that the project name is the project custom name.
                 Assert.Equal(lockFile.Targets.First().Dependencies.Count, 2);
-                Assert.Equal(lockFile.Targets.First().Dependencies.First(e => e.Type == PackageDependencyType.Project).Id, "CustomName");
+                Assert.Equal("customname", lockFile.Targets.First().Dependencies.First(e => e.Type == PackageDependencyType.Project).Id);
 
                  // Setup - Enable locked mode
                 projectA.Properties.Add("RestoreLockedMode", "true");
@@ -7886,7 +7886,7 @@ namespace NuGet.CommandLine.Test
                  // B
                 projectB.AddPackageToFramework(tfm, packageX);
 
-                 solution.Projects.Add(projectA);
+                solution.Projects.Add(projectA);
                 solution.Projects.Add(projectB);
                 solution.Create(pathContext.SolutionRoot);
 
@@ -7903,7 +7903,7 @@ namespace NuGet.CommandLine.Test
 
                  // Assert that the project name is the custom name.
                 Assert.Equal(lockFile.Targets.First().Dependencies.Count, 2);
-                Assert.Equal(lockFile.Targets.First().Dependencies.First(e => e.Type == PackageDependencyType.Project).Id, "CustomName");
+                Assert.Equal("customname", lockFile.Targets.First().Dependencies.First(e => e.Type == PackageDependencyType.Project).Id);
 
                  // Setup - Enable locked mode
                 projectA.Properties.Add("RestoreLockedMode", "true");

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
@@ -150,7 +150,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     // set up projects
                     var projectTargetFrameworkStr = "net45";
-                    var fullProjectPathB = Path.Combine(testSolutionManager.TestDirectory, "ProjectB", "project2.csproj");
+                    var fullProjectPathB = Path.Combine(testSolutionManager.TestDirectory, "ProjectB", "Project2.csproj");
                     var projectNamesB = new ProjectNames(
                         fullName: fullProjectPathB,
                         uniqueName: Path.GetFileName(fullProjectPathB),
@@ -179,7 +179,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         _threadingService);
 
                     var projectPathA = Path.Combine(testSolutionManager.TestDirectory, "ProjectA");
-                    var fullProjectPathA = Path.Combine(projectPathA, "project1.csproj");
+                    var fullProjectPathA = Path.Combine(projectPathA, "Project1.csproj");
                     var projectNamesA = new ProjectNames(
                         fullName: fullProjectPathA,
                         uniqueName: Path.GetFileName(fullProjectPathA),
@@ -256,9 +256,9 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     Assert.Equal(".NETFramework,Version=v4.5", lockFile.Targets[0].Name);
                     Assert.Equal(3, lockFile.Targets[0].Dependencies.Count);
-                    Assert.Equal("packageA", lockFile.Targets[0].Dependencies[0].Id);
+                    Assert.Equal("packagea", lockFile.Targets[0].Dependencies[0].Id);
                     Assert.Equal(PackageDependencyType.Direct, lockFile.Targets[0].Dependencies[0].Type);
-                    Assert.Equal("packageB", lockFile.Targets[0].Dependencies[1].Id);
+                    Assert.Equal("packageb", lockFile.Targets[0].Dependencies[1].Id);
                     Assert.Equal(PackageDependencyType.Transitive, lockFile.Targets[0].Dependencies[1].Type);
                     Assert.Equal("project2", lockFile.Targets[0].Dependencies[2].Id);
                     Assert.Equal(PackageDependencyType.Project, lockFile.Targets[0].Dependencies[2].Type);
@@ -1633,7 +1633,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     Assert.Equal(".NETFramework,Version=v4.6.1", lockFile.Targets[0].Name);
                     Assert.Equal(2, lockFile.Targets[0].Dependencies.Count);
-                    Assert.Equal("packageA", lockFile.Targets[0].Dependencies[0].Id);
+                    Assert.Equal("packagea", lockFile.Targets[0].Dependencies[0].Id);
                     Assert.Equal(PackageDependencyType.Direct, lockFile.Targets[0].Dependencies[0].Type);
                     Assert.Equal("project2", lockFile.Targets[0].Dependencies[1].Id);
                     Assert.Equal(PackageDependencyType.Project, lockFile.Targets[0].Dependencies[1].Type);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
@@ -256,9 +256,9 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     Assert.Equal(".NETFramework,Version=v4.5", lockFile.Targets[0].Name);
                     Assert.Equal(3, lockFile.Targets[0].Dependencies.Count);
-                    Assert.Equal("packagea", lockFile.Targets[0].Dependencies[0].Id);
+                    Assert.Equal("packageA", lockFile.Targets[0].Dependencies[0].Id);
                     Assert.Equal(PackageDependencyType.Direct, lockFile.Targets[0].Dependencies[0].Type);
-                    Assert.Equal("packageb", lockFile.Targets[0].Dependencies[1].Id);
+                    Assert.Equal("packageB", lockFile.Targets[0].Dependencies[1].Id);
                     Assert.Equal(PackageDependencyType.Transitive, lockFile.Targets[0].Dependencies[1].Type);
                     Assert.Equal("project2", lockFile.Targets[0].Dependencies[2].Id);
                     Assert.Equal(PackageDependencyType.Project, lockFile.Targets[0].Dependencies[2].Type);
@@ -1633,7 +1633,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                     Assert.Equal(".NETFramework,Version=v4.6.1", lockFile.Targets[0].Name);
                     Assert.Equal(2, lockFile.Targets[0].Dependencies.Count);
-                    Assert.Equal("packagea", lockFile.Targets[0].Dependencies[0].Id);
+                    Assert.Equal("packageA", lockFile.Targets[0].Dependencies[0].Id);
                     Assert.Equal(PackageDependencyType.Direct, lockFile.Targets[0].Dependencies[0].Type);
                     Assert.Equal("project2", lockFile.Targets[0].Dependencies[1].Id);
                     Assert.Equal(PackageDependencyType.Project, lockFile.Targets[0].Dependencies[1].Type);


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8114
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Detect project ids that are generated from the project filename, and lowercase only those, leaving projects with custom assembly names to use the assembly casing.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  tests already exists, just fixed them to work with lowercase ids.
Validation:  
