### PR TITLE
Filter framework-mismatched assemblies from NUGET_PLUGIN_PATHS

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
@@ -154,7 +154,10 @@ namespace NuGet.Protocol.Plugins
                 return PluginDiscoveryUtility.GetConventionBasedPlugins(directories);
             }
 
-            return _rawPluginPaths.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            // even if there are no relevant plugins, we will not fall back to built-ins
+            // to maintain some typo-guard consistency with the previous no-filter flow
+            return _rawPluginPaths.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                .Where(PluginDiscoveryUtility.IsPluginRelevant);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
@@ -95,5 +95,14 @@ namespace NuGet.Protocol.Plugins
             }
             return paths;
         }
+
+        public static bool IsPluginRelevant(string path)
+        {
+#if IS_DESKTOP
+           return path.EndsWith(".exe", StringComparison.OrdinalIgnoreCase);
+#else
+           return path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase);
+#endif
+        }
     }
 }


### PR DESCRIPTION
Prior to this, if you configured both a netcore and a netfx plugin to handle both nuget and dotnet,
both would fail.  One would fail on the dll, the other on the exe.
nuget_plugin_paths=d:\tools\credprovider\plugins\netcore\CredentialProvider.Microsoft\CredentialProvider.Microsoft.dll;d:\tools\credprovider\plugins\netfx\CredentialProvider.Microsoft\CredentialProvider.Microsoft.exe

This change does a naive filter based on existing discovery models for convention-based plugin loading.

## Bug

Fixes: nuget/home#8151
Regression: No  

## Fix
Use the same logic as the convention based plugin discovery to filter the paths in NUGET_PLUGIN_PATHS.  Do not fallback to the baseline discovery if all paths are filtered out to hold a line on typo discovery.  This does exclude self-contained dotnet exes from plugin_paths, but since they weren't possible in discovery anyway this feels like an ok compromise.

## Testing/Validation

Tests Added: Yes 
Validation:  
verified failure of nuget 5.0.0 as in the linked issue, verified failing unit test as created, fixed the code, verified passing unit tests and passing commandline of built-nuget.exe
