### PR TITLE
Make the VSSettings config reading lazy 

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
@@ -123,7 +123,7 @@ namespace NuGet.PackageManagement.VisualStudio
             "Microsoft.Design",
             "CA1031:DoNotCatchGeneralExceptionTypes",
             Justification = "We want to log an exception as a warning and move on")]
-        public void MarkPackageDirectoryForDeletion(
+        public void c(
             PackageIdentity package,
             string packageDirectory,
             INuGetProjectContext projectContext)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
@@ -123,7 +123,7 @@ namespace NuGet.PackageManagement.VisualStudio
             "Microsoft.Design",
             "CA1031:DoNotCatchGeneralExceptionTypes",
             Justification = "We want to log an exception as a warning and move on")]
-        public void c(
+        public void MarkPackageDirectoryForDeletion(
             PackageIdentity package,
             string packageDirectory,
             INuGetProjectContext projectContext)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
@@ -213,7 +213,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             // We need to do the check even on Solution Closed because, let's say if the yellow Update bar
             // is showing and the user closes the solution; in that case, we want to hide the Update bar.
-            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () => await DeleteMarkedPackageDirectoriesAsync(SolutionManager.NuGetProjectContext));
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () => await DeleteMarkedPackageDirectoriesAsync(SolutionManager.NuGetProjectContext));
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
@@ -19,7 +19,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private const string NuGetSolutionSettingsFolder = ".nuget";
 
         // to initialize SolutionSettings first time outside MEF constructor
-        private Tuple<string, ISettings> _solutionSettings;
+        private Tuple<string, Lazy<ISettings>> _solutionSettings;
 
         private ISettings SolutionSettings
         {
@@ -31,7 +31,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     ResetSolutionSettingsIfNeeded();
                 }
 
-                return _solutionSettings.Item2;
+                return _solutionSettings.Item2.Value;
             }
         }
 
@@ -79,9 +79,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 // That however is not the case for solution close and  same session close -> open events. Those will be on the UI thread.
                 if (!string.Equals(root, _solutionSettings?.Item1))
                 {
-                    _solutionSettings = new Tuple<string, ISettings>(
+                    _solutionSettings = new Tuple<string, Lazy<ISettings>>(
                         item1: root,
-                        item2: Settings.LoadDefaultSettings(root, configFileName: null, machineWideSettings: MachineWideSettings));
+                        item2: new Lazy<ISettings>(() => Settings.LoadDefaultSettings(root, configFileName: null, machineWideSettings: MachineWideSettings)));
                     return true;
                 }
             }
@@ -92,7 +92,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             if (_solutionSettings == null)
             {
-                _solutionSettings = new Tuple<string, ISettings>(null, NullSettings.Instance);
+                _solutionSettings = new Tuple<string, Lazy<ISettings>>(null, new Lazy<ISettings>(() => NullSettings.Instance));
                 return true;
             }
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8156
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Follow up/improvement on top of https://github.com/NuGet/NuGet.Client/pull/2858. 

Make the VSSettings read lazy. 
Prior to this the VS Settings would often times be initialized at a solution load/unload event. 

Unfortunately this will not fix every config read on the UI thread. 

At solution load time with: 
- Any packages.Config project in the solution, at project initialization time, we need to get the packages.config packages path. 
- Only SDK based projects this should not be a problem anymore, since the read with often be the PackageRestoreConsent check. In some weird cases the VSDeleteOnRestart manager will beat it to that. 
The event for the VSDeleteOnRestoreManager comes on the UI thread, but it's "ok" to run that asynchronously on a worker thread.

Even with this change there are reads of the configs on the UI thread. 

TryCreateContext invokes on the UI thread. This is an extensibility method that should not be invoked on the UI thread. (Specfically https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.VisualStudio/Extensibility/IVsPathContext2.cs). I will reach out to the team using it to correct this. (Update: reached out to the team, we will wait for Watson feedback on that one)

The initialization of a packages.config project. Potentially we could make the read of that config lazy but it's very involved for something whose impact we don't understand, as it's not shown up in the top UI Delays. 

Even with that known issue We are still going down for multiple UI thread reads to only one!


## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
