### PR TITLE
Turn NuGet.PackageManagement into a .NET Standard assembly

### DIFF
--- a/build/bootstrap.proj
+++ b/build/bootstrap.proj
@@ -21,7 +21,7 @@
         <PackageDownload Include="Microsoft.VisualStudio.ProjectSystem" version="[16.7.156-pre]" />
         <PackageDownload Include="Microsoft.VisualStudio.ProjectSystem.Managed" version="[16.7.0-beta1-65318-02]" />
         <PackageDownload Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" version="[16.7.0-beta1-65318-02]" />
-        <PackageDownload Include="Microsoft.Web.Xdt" version="[2.1.2]" />
+        <PackageDownload Include="Microsoft.Web.Xdt" version="[3.0.0]" />
         <PackageDownload Include="Newtonsoft.Json" version="[9.0.1]" />
         <PackageDownload Include="NuGet.Build.Tasks.Pack" version="[5.8.0]" />
         <PackageDownload Include="NuGet.Client.EndToEnd.TestData" version="[1.0.0]" />

--- a/build/loc.proj
+++ b/build/loc.proj
@@ -17,8 +17,11 @@
 
   <Target Name="LocalizeNonProjectFiles">
     <ItemGroup>
-      <NonProjectFilesToMove Include="$(SolutionPackagesFolder)microsoft.web.xdt\2.1.2\lib\net40\Microsoft.Web.XmlTransform.dll">
-        <DestinationDir>$(ArtifactsDirectory)microsoft.web.xdt\2.1.2\lib\net40\Microsoft.Web.XmlTransform.dll</DestinationDir>
+      <NonProjectFilesToMove Include="$(SolutionPackagesFolder)microsoft.web.xdt\3.0.0\lib\netstandard2.0\Microsoft.Web.XmlTransform.dll">
+        <DestinationDir>$(ArtifactsDirectory)microsoft.web.xdt\3.0.0\lib\netstandard2.0\Microsoft.Web.XmlTransform.dll</DestinationDir>
+      </NonProjectFilesToMove>
+      <NonProjectFilesToMove Include="$(SolutionPackagesFolder)microsoft.web.xdt\3.0.0\lib\net40\Microsoft.Web.XmlTransform.dll">
+        <DestinationDir>$(ArtifactsDirectory)microsoft.web.xdt\3.0.0\lib\net40\Microsoft.Web.XmlTransform.dll</DestinationDir>
       </NonProjectFilesToMove>
       <NonProjectFilesToMove Include="$(NuGetClientsSrcDirectory)NuGet.VisualStudio.Client\extension.vsixlangpack">
         <DestinationDir>$(ArtifactsDirectory)vsixlangpack\extension.vsixlangpack</DestinationDir>

--- a/build/packages.targets
+++ b/build/packages.targets
@@ -59,9 +59,10 @@
         <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VSThreadingVersion)" />
         <PackageReference Update="Microsoft.VisualStudio.Workspace.VSIntegration" Version="16.6.55-preview-0003" />
         <PackageReference Update="Microsoft.VisualStudio.Utilities" Version="$(VSFrameworkVersion)" />
-        <PackageReference Update="Microsoft.Web.Xdt" Version="2.1.2" />
+        <PackageReference Update="Microsoft.Web.Xdt" Version="3.0.0" />
         <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
         <PackageReference Update="System.Collections.Immutable" Version="1.7.1" />
+        <PackageReference Update="System.ComponentModel.Composition" Version="4.5.0" />
         <PackageReference Update="System.Diagnostics.Debug" Version="$(SystemPackagesVersion)" />
         <PackageReference Update="System.Security.Cryptography.Pkcs" Version="$(CryptographyPackagesVersion)" />
         <PackageReference Update="System.Security.Cryptography.Cng" Version="$(CryptographyPackagesVersion)" />

--- a/build/sign.proj
+++ b/build/sign.proj
@@ -26,7 +26,7 @@
       <FilesToSign Include="$(SolutionPackagesFolder)newtonsoft.json\9.0.1\lib\net45\Newtonsoft.Json.dll">
         <Authenticode>3PartySHA2</Authenticode>
       </FilesToSign>
-      <FilesToSign Include="$(ArtifactsDirectory)microsoft.web.xdt\2.1.2\lib\net40\**\Microsoft.Web.XmlTransform.resources.dll">
+      <FilesToSign Include="$(ArtifactsDirectory)microsoft.web.xdt\3.0.0\lib\net40\**\Microsoft.Web.XmlTransform.resources.dll">
         <Authenticode>Microsoft400</Authenticode>
         <StrongName>67</StrongName>
       </FilesToSign>

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swixproj
@@ -17,7 +17,7 @@
   <PropertyGroup>
     <ReferenceOutputPath>$(ArtifactsDirectory)NuGet.VisualStudio.Client\$(VisualStudioVersion)\bin\$(Configuration)\</ReferenceOutputPath>
     <NuGetTargetsBasePath>$(RepositoryRootDirectory)src\NuGet.Core\NuGet.Build.Tasks\</NuGetTargetsBasePath>
-    <XmlTransformPath>$(ArtifactsDirectory)microsoft.web.xdt\2.1.2\lib\net40\</XmlTransformPath>
+    <XmlTransformPath>$(ArtifactsDirectory)microsoft.web.xdt\3.0.0\lib\net40\</XmlTransformPath>
     <NewtonsoftJsonPath>$(SolutionPackagesFolder)newtonsoft.json\9.0.1\lib\net45\</NewtonsoftJsonPath>
   
 </PropertyGroup>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -67,7 +67,7 @@
       <Link>Newtonsoft.Json.dll</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="$(SolutionPackagesFolder)microsoft.web.xdt\2.1.2\lib\net40\Microsoft.Web.XmlTransform.dll">
+    <Content Include="$(SolutionPackagesFolder)microsoft.web.xdt\3.0.0\lib\net40\Microsoft.Web.XmlTransform.dll">
       <Link>Microsoft.Web.XmlTransform.dll</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -444,7 +444,7 @@
     </MSBuild>
     <ItemGroup>
       <VSIXSourceItem Include="@(LocalizedFilesForVsix)" />
-      <_LocalizedFiles Include="$(ArtifactsDirectory)microsoft.web.xdt\2.1.2\lib\net40\**\Microsoft.Web.XmlTransform.resources.dll" />
+      <_LocalizedFiles Include="$(ArtifactsDirectory)microsoft.web.xdt\3.0.0\lib\net40\**\Microsoft.Web.XmlTransform.resources.dll" />
       <_LocalizedFiles Include="$(ArtifactsDirectory)vsixlangpack\**\extension.vsixlangpack" />
       <_LocalizedFiles Include="$(ArtifactsDirectory)eulas\**\eula.rtf" />
       <_VsixLocFiles Include="@(_LocalizedFiles)">

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -321,7 +321,7 @@ namespace NuGet.PackageManagement
             List<IAssetsLogMessage> allAdditionalMessages = null;
 
             var projects = (await solutionManager.GetNuGetProjectsAsync()).OfType<IDependencyGraphProject>().ToList();
-            var knownProjects = projects.Select(e => e.MSBuildProjectPath).ToHashSet(PathUtility.GetStringComparerBasedOnOS());
+            var knownProjects = new HashSet<string>(projects.Select(e => e.MSBuildProjectPath), PathUtility.GetStringComparerBasedOnOS());
 
             for (var i = 0; i < projects.Count; i++)
             {

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGet.PackageManagement.csproj
@@ -4,11 +4,18 @@
 
   <PropertyGroup>
     <Description>NuGet Package Management functionality for Visual Studio installation flow.</Description>
-    <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
+    <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1580;CS1574;CS1573</NoWarn>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>
+    <XPLATProject>true</XPLATProject>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
+    <TargetFrameworks />
+    <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,6 +35,10 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   
+  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardVersion)' ">
+    <PackageReference Include="System.ComponentModel.Composition" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Update="Strings.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGet.PackageManagement.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGet.PackageManagement.Test.csproj
@@ -3,7 +3,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFrameworks>$(NETFXTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksExe)</TargetFrameworks>
     <TargetFrameworks Condition=" '$(IsXPlat)' == 'true' ">$(NETCoreTargetFramework)</TargetFrameworks>
     <TestProject>true</TestProject>
     <UseParallelXunit>true</UseParallelXunit>
@@ -12,6 +12,10 @@
 
   <ItemGroup>
     <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
+    <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.PackageManagement\NuGet.PackageManagement.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
     <ProjectReference Include="$(NuGetClientsSrcDirectory)NuGet.VisualStudio.Common\NuGet.VisualStudio.Common.csproj" />
   </ItemGroup>
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -26,7 +26,9 @@ using NuGet.Protocol.Core.Types;
 using NuGet.Resolver;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
+#if IS_DESKTOP
 using NuGet.VisualStudio;
+#endif
 using Test.Utility;
 using Xunit;
 using Xunit.Abstractions;
@@ -6062,6 +6064,7 @@ namespace NuGet.Test
             }
         }
 
+#if IS_DESKTOP
         [Fact]
         public async Task TestPacMan_PreviewInstallPackage_PackagesConfig_RaiseTelemetryEvents()
         {
@@ -6675,6 +6678,7 @@ namespace NuGet.Test
                     Any(p => (string)p["SubStepName"] == TelemetryConstants.ExecuteActionStepName));
             }
         }
+#endif
 
         [Fact]
         public async Task TestPacManPreviewInstallPackage_WithGlobalPackageFolder()
@@ -7041,6 +7045,7 @@ namespace NuGet.Test
             }
         }
 
+#if IS_DESKTOP
         private class TestNuGetVSTelemetryService : NuGetVSTelemetryService
         {
             private ITelemetrySession _telemetrySession;
@@ -7076,5 +7081,6 @@ namespace NuGet.Test
                 _telemetrySession.PostEvent(telemetryData);
             }
         }
+#endif
     }
 }

--- a/test/TestUtilities/Test.Utility/Test.Utility.csproj
+++ b/test/TestUtilities/Test.Utility/Test.Utility.csproj
@@ -46,6 +46,7 @@
   <ItemGroup>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Commands\NuGet.Commands.csproj" />
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Resolver\NuGet.Resolver.csproj" />
+    <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.PackageManagement\NuGet.PackageManagement.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -74,8 +75,7 @@
 
   <!-- Remove files that do not support netcore -->
   <ItemGroup Condition=" '$(IsCore)' == 'true' ">
-    <Compile Remove="PackageManagement\*.cs" />
-    <Compile Remove="ProjectManagement\*.cs" />
+    <Compile Remove="ProjectManagement\TestProjectKProject.cs" />
     <Compile Remove="Threading\*.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#6150
Regression: No

## Fix

Updated PackageManagement to also support .NET Standard, to ease transition to .NET Core.
Note:
* Had to bump Microsoft.Web.Xdt to 3.0.
* Using NuGet version of System.ComponentModel.Composition 4.5.0 for .NET Standard and keeping global one for .NET 4.5. Another option would be to use NuGet version everywhere (but not sure of impact it could have).

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
