### PR TITLE
VS:  use ProvideCodeBase instead of ProvideBindingPath

### DIFF
--- a/NuGet.sln
+++ b/NuGet.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28404.58
@@ -169,6 +169,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.VisualStudio.Interop", "src\NuGet.Clients\NuGet.VisualStudio.Interop\NuGet.VisualStudio.Interop.csproj", "{7DB43FE1-75E1-49F9-B2C8-06A552BA2144}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGetConsole.Host.PowerShell", "src\NuGet.Clients\NuGetConsole.Host.PowerShell\NuGetConsole.Host.PowerShell.csproj", "{5A79EEF3-51C0-4A14-8D37-50EF38AD835D}"
+	ProjectSection(ProjectDependencies) = postProject
+		# Make NuGetConsole.Host.PowerShell depend on NuGet.PackageManagement.PowerShellCmdlets.  This is so NuGetConsole.Host.PowerShell's build can update NuGet.psd1 based on the strong name of NuGet.PackageManagement.PowerShellCmdlets.dll
+		{26DC17AC-A390-4515-A2C0-07A0950036C5} = {26DC17AC-A390-4515-A2C0-07A0950036C5}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Console", "src\NuGet.Clients\NuGet.Console\NuGet.Console.csproj", "{50E33DA2-AF14-486D-81B8-BD8409744A38}"
 EndProject

--- a/NuGet.sln
+++ b/NuGet.sln
@@ -230,6 +230,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GenerateLicenseList", "test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Packaging.Core", "src\NuGet.Core\NuGet.Packaging.Core\NuGet.Packaging.Core.csproj", "{02B7C422-C592-4BA6-89A7-ACBD7923B34D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Tools.Test", "test\NuGet.Clients.Tests\NuGet.Tools.Test\NuGet.Tools.Test.csproj", "{437C6B7E-B625-4AE5-A4CE-F2B3747FE1CE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -556,6 +558,10 @@ Global
 		{02B7C422-C592-4BA6-89A7-ACBD7923B34D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{02B7C422-C592-4BA6-89A7-ACBD7923B34D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{02B7C422-C592-4BA6-89A7-ACBD7923B34D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{437C6B7E-B625-4AE5-A4CE-F2B3747FE1CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{437C6B7E-B625-4AE5-A4CE-F2B3747FE1CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{437C6B7E-B625-4AE5-A4CE-F2B3747FE1CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{437C6B7E-B625-4AE5-A4CE-F2B3747FE1CE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -651,6 +657,7 @@ Global
 		{1EDFC48B-2CEC-49DD-90DA-3A69BDDAB8CF} = {01BC4531-1E25-48D7-A8FD-A47D6FEC47FB}
 		{98A04824-9BCE-48BD-8544-916F3F0007D0} = {23CEFC88-9365-4464-A517-700224ECA033}
 		{02B7C422-C592-4BA6-89A7-ACBD7923B34D} = {506AF844-92E0-4404-BBFC-0AB073890A72}
+		{437C6B7E-B625-4AE5-A4CE-F2B3747FE1CE} = {01BC4531-1E25-48D7-A8FD-A47D6FEC47FB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3747A66A-00D1-41B8-A9C5-ED0D7BEA9D25}

--- a/build.ps1
+++ b/build.ps1
@@ -21,7 +21,7 @@ Indicates the build script is invoked from CI
 Indicates whether to create the end to end package.
 
 .PARAMETER SkipDelaySign
-Indicates whether to skip delay signing.  The default is false; assemblies will be delay signed.
+Indicates whether to skip delay signing.  By default assemblies will be delay signed.
 
 .EXAMPLE
 .\build.ps1

--- a/build.ps1
+++ b/build.ps1
@@ -20,7 +20,7 @@ Indicates the build script is invoked from CI
 .PARAMETER PackageEndToEnd
 Indicates whether to create the end to end package.
 
-.PARAMETER SkipDelaySign
+.PARAMETER SkipDelaySigning
 Indicates whether to skip delay signing.  By default assemblies will be delay signed.
 
 .EXAMPLE
@@ -51,7 +51,7 @@ param (
     [switch]$Fast,
     [switch]$CI,
     [switch]$PackageEndToEnd,
-    [switch]$SkipDelaySign
+    [switch]$SkipDelaySigning
 )
 
 . "$PSScriptRoot\build\common.ps1"
@@ -116,12 +116,10 @@ Invoke-BuildStep $VSMessage {
 
     $args = 'build\build.proj', "/t:$VSTarget", "/p:Configuration=$Configuration", "/p:ReleaseLabel=$ReleaseLabel", "/p:BuildNumber=$BuildNumber", '/v:m', '/m:1'
 
-    If (!$SkipDelaySign)
+    If ($SkipDelaySigning)
     {
-        $keysDirectoryPath = [System.IO.Path]::Combine($PSScriptRoot, 'keys')
-
-        $args += "/p:MS_PFX_PATH=$keysDirectoryPath\35MSSharedLib1024.snk"
-        $args += "/p:NUGET_PFX_PATH=$keysDirectoryPath\NuGetKey.snk"
+        $args += "/p:MS_PFX_PATH="
+        $args += "/p:NUGET_PFX_PATH="
     }
 
     # Build and (If not $SkipUnitTest) Pack, Core unit tests, and Unit tests for VS

--- a/build/UpdateNuGetModuleManifest.ps1
+++ b/build/UpdateNuGetModuleManifest.ps1
@@ -35,6 +35,6 @@ If ($startIndex -ne -1)
 
 $ManifestModuleDestinationFile = [System.IO.FileInfo]::new($ManifestModuleDestinationFilePath)
 
-[System.IO.Directory]::CreateDirectory($ManifestModuleDestinationFile.DirectoryName)
+[System.IO.Directory]::CreateDirectory($ManifestModuleDestinationFile.DirectoryName) | Out-Null
 
 [System.IO.File]::WriteAllText($ManifestModuleDestinationFilePath, $manifestModuleFileContents)

--- a/build/config.props
+++ b/build/config.props
@@ -63,6 +63,11 @@
     <PackageIconUrl>https://raw.githubusercontent.com/NuGet/Media/master/Images/MainLogo/256x256/nuget_256.png</PackageIconUrl>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NUGET_PFX_PATH>$(MSBuildThisFileDirectory)\..\keys\NuGetKey.snk</NUGET_PFX_PATH>
+    <MS_PFX_PATH>$(MSBuildThisFileDirectory)\..\keys\35MSSharedLib1024.snk</MS_PFX_PATH>
+  </PropertyGroup>
+
   <Target Name="GetSemanticVersion">
     <Message Text="$(SemanticVersion)" Importance="High"/>
   </Target>

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -128,7 +128,7 @@ phases:
       solution: "build\\build.proj"
       msbuildVersion: "16.0"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:BuildNoVSIX /p:NUGET_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\NuGetKey.snk /p:MS_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\35MSSharedLib1024.snk /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
+      msbuildArguments: "/t:BuildNoVSIX /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
 
   - task: MSBuild@1
     displayName: "Run unit tests"
@@ -137,7 +137,7 @@ phases:
       solution: "build\\build.proj"
       msbuildVersion: "16.0"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:NUGET_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\NuGetKey.snk /p:MS_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\35MSSharedLib1024.snk  /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml"
+      msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml"
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
   - task: PublishTestResults@2
@@ -462,7 +462,7 @@ phases:
       solution: "build\\build.proj"
       msbuildVersion: "16.0"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:CoreFuncTests  /p:BuildRTM=false  /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:NUGET_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\NuGetKey.snk /p:MS_PFX_PATH=$(Build.Repository.LocalPath)\\keys\\35MSSharedLib1024.snk"
+      msbuildArguments: "/t:CoreFuncTests /p:BuildRTM=false /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml"
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
@@ -793,7 +793,7 @@ phases:
       solution: "build\\build.proj"
       msbuildVersion: "16.0"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml  /p:NUGET_PFX_PATH=$(System.DefaultWorkingDirectory)\\keys\\NuGetKey.snk /p:MS_PFX_PATH=$(System.DefaultWorkingDirectory)\\keys\\35MSSharedLib1024.snk /p:BuildNumber=$(BuildNumber)"
+      msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml /p:BuildNumber=$(BuildNumber)"
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.Shell;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -14,3 +15,24 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("06662133-1292-4918-90f3-36c930c0b16f")]
+
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Lucene.Net.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Newtonsoft.Json.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Commands.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Common.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Configuration.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Credentials.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.DependencyResolver.Core.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Frameworks.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Indexing.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.LibraryModel.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.PackageManagement.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.PackageManagement.VisualStudio.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Packaging.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.ProjectModel.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Protocol.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Resolver.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.SolutionRestoreManager.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Versioning.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.Common.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.dll")]

--- a/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
+++ b/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.legacy.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.common.props')" />
@@ -48,6 +48,7 @@
     <Compile Include="NuGetSearchProvider.cs" />
     <Compile Include="NuGetSearchTask.cs" />
     <Compile Include="NuGetSettings.cs" />
+    <Compile Include="NuGetSettingsSerializer.cs" />
     <Compile Include="NuGetStaticSearchResult.cs" />
     <Compile Include="NuGetUIFactory.cs" />
     <Compile Include="OutputConsoleLogger.cs" />
@@ -93,6 +94,11 @@
       <Project>{32a23995-14c7-483b-98c3-0ae4185373ea}</Project>
       <Name>NuGet.Credentials</Name>
     </ProjectReference>
+    <!-- NuGet.PackageManagement.PowerShellCmdlets is referenced only to enable generation of .pkgdef entries via ProvideCodeBaseAttribute. -->
+    <ProjectReference Include="..\NuGet.PackageManagement.PowerShellCmdlets\NuGet.PackageManagement.PowerShellCmdlets.csproj">
+      <Project>{26dc17ac-a390-4515-a2c0-07a0950036c5}</Project>
+      <Name>NuGet.PackageManagement.PowerShellCmdlets</Name>
+    </ProjectReference>
     <ProjectReference Include="..\NuGet.PackageManagement.VisualStudio\NuGet.PackageManagement.VisualStudio.csproj">
       <Project>{306cddfa-ff0b-4299-930c-9ec6c9308160}</Project>
       <Name>NuGet.PackageManagement.VisualStudio</Name>
@@ -104,6 +110,11 @@
     <ProjectReference Include="..\NuGet.VisualStudio.Common\NuGet.VisualStudio.Common.csproj">
       <Project>{eea49a74-6efc-410e-9745-bad367ac151d}</Project>
       <Name>NuGet.VisualStudio.Common</Name>
+    </ProjectReference>
+    <!-- NuGet.VisualStudio.Interop is referenced only to enable generation of .pkgdef entries via ProvideCodeBaseAttribute. -->
+    <ProjectReference Include="..\NuGet.VisualStudio.Interop\NuGet.VisualStudio.Interop.csproj">
+      <Project>{7db43fe1-75e1-49f9-b2c8-06a552ba2144}</Project>
+      <Name>NuGet.VisualStudio.Interop</Name>
     </ProjectReference>
     <ProjectReference Include="..\NuGet.VisualStudio\NuGet.VisualStudio.csproj">
       <Project>{e5556bc6-a7fd-4d8e-8a7d-7648df1d7471}</Project>

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -45,7 +45,6 @@ namespace NuGetVSExtension
     [ProvideOptionPage(typeof(PackageSourceOptionsPage), "NuGet Package Manager", "Package Sources", 113, 114, true)]
     [ProvideOptionPage(typeof(GeneralOptionPage), "NuGet Package Manager", "General", 113, 115, true)]
     [ProvideSearchProvider(typeof(NuGetSearchProvider), "NuGet Search")]
-    [ProvideBindingPath] // Definition dll needs to be on VS binding path
     // UI Context rule for a project that could be upgraded to PackageReference from packages.config based project.
     // Only exception is this UI context doesn't get enabled for right-click on Reference since there is no extension point on references
     // to know if there is packages.config file in this project hierarchy. So first-time right click on reference in a new VS instance

--- a/src/NuGet.Clients/NuGet.Tools/NuGetSettingsSerializer.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetSettingsSerializer.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace NuGetVSExtension
+{
+    internal sealed class NuGetSettingsSerializer
+    {
+        private const int _bufferSize = 4096;
+
+        private readonly JsonSerializer _serializer;
+
+        internal NuGetSettingsSerializer()
+        {
+            _serializer = new JsonSerializer();
+
+            _serializer.Converters.Add(new StringEnumConverter());
+        }
+
+        internal NuGetSettings Deserialize(Stream stream)
+        {
+            using (var streamReader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: _bufferSize, leaveOpen: true))
+            using (var jsonReader = new JsonTextReader(streamReader))
+            {
+                jsonReader.CloseInput = false;
+
+                return _serializer.Deserialize<NuGetSettings>(jsonReader);
+            }
+        }
+
+        internal void Serialize(Stream stream, NuGetSettings settings)
+        {
+            using (var streamWriter = new StreamWriter(stream, Encoding.UTF8, bufferSize: _bufferSize, leaveOpen: true))
+            using (var jsonWriter = new JsonTextWriter(streamWriter))
+            {
+                _serializer.Serialize(jsonWriter, settings);
+            }
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.Tools/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Properties/AssemblyInfo.cs
@@ -2,8 +2,44 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.Shell;
 
 [assembly: AssemblyTitle("NuGet.Tools")]
 [assembly: AssemblyDescription("Visual Studio Extensibility Package (vsix)")]
 [assembly: ComVisible(false)]
+
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Lucene.Net.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Web.XmlTransform.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Newtonsoft.Json.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Commands.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Common.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Configuration.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Console.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Credentials.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.DependencyResolver.Core.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Frameworks.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Indexing.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.LibraryModel.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.PackageManagement.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.PackageManagement.PowerShellCmdlets.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.PackageManagement.UI.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.PackageManagement.VisualStudio.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Packaging.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.ProjectModel.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Protocol.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Resolver.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Tools.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Versioning.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.Common.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.Interop.dll")]
+
+#if SIGNED_BUILD
+[assembly: InternalsVisibleTo("NuGet.Tools.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+#else
+[assembly: InternalsVisibleTo("NuGet.Tools.Test")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+#endif

--- a/src/NuGet.Clients/NuGet.Tools/SolutionUserOptions.cs
+++ b/src/NuGet.Clients/NuGet.Tools/SolutionUserOptions.cs
@@ -20,7 +20,7 @@ namespace NuGetVSExtension
     [PartCreationPolicy(CreationPolicy.Shared)]
     internal sealed class SolutionUserOptions : IUserSettingsManager, IVsPersistSolutionOpts
     {
-        private const string _nuGetOptionsStreamKey = "nuget";
+        private const string NuGetOptionsStreamKey = "nuget";
 
         private readonly IServiceProvider _serviceProvider;
         private readonly NuGetSettingsSerializer _serializer;
@@ -80,7 +80,7 @@ namespace NuGetVSExtension
             ThreadHelper.ThrowIfNotOnUIThread();
 
             var solutionPersistence = Package.GetGlobalService(typeof(SVsSolutionPersistence)) as IVsSolutionPersistence;
-            if (solutionPersistence.LoadPackageUserOpts(this, _nuGetOptionsStreamKey) != VSConstants.S_OK)
+            if (solutionPersistence.LoadPackageUserOpts(this, NuGetOptionsStreamKey) != VSConstants.S_OK)
             {
                 return false;
             }
@@ -93,7 +93,7 @@ namespace NuGetVSExtension
             ThreadHelper.ThrowIfNotOnUIThread();
 
             var solutionPersistence = Package.GetGlobalService(typeof(SVsSolutionPersistence)) as IVsSolutionPersistence;
-            if (solutionPersistence.SavePackageUserOpts(this, _nuGetOptionsStreamKey) != VSConstants.S_OK)
+            if (solutionPersistence.SavePackageUserOpts(this, NuGetOptionsStreamKey) != VSConstants.S_OK)
             {
                 return false;
             }
@@ -108,7 +108,7 @@ namespace NuGetVSExtension
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            pPersistence.LoadPackageUserOpts(this, _nuGetOptionsStreamKey);
+            pPersistence.LoadPackageUserOpts(this, NuGetOptionsStreamKey);
             return VSConstants.S_OK;
         }
 
@@ -143,7 +143,7 @@ namespace NuGetVSExtension
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            pPersistence.SavePackageUserOpts(this, _nuGetOptionsStreamKey);
+            pPersistence.SavePackageUserOpts(this, NuGetOptionsStreamKey);
             return VSConstants.S_OK;
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -70,27 +70,27 @@
       <Link>Lucene.Net.dll</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\NuGetConsole.Host.PowerShell\Scripts\Add-WrapperMembers.ps1">
+    <Content Include="$(ArtifactsDirectory)\Scripts\Add-WrapperMembers.ps1">
       <Link>Modules\NuGet\Add-WrapperMembers.ps1</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\NuGetConsole.Host.PowerShell\Scripts\NuGet.Format.ps1xml">
+    <Content Include="$(ArtifactsDirectory)\Scripts\NuGet.Format.ps1xml">
       <Link>Modules\NuGet\NuGet.Format.ps1xml</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="$(BaseIntermediateOutputPath)$(Configuration)\NuGet.psd1">
+    <Content Include="$(ArtifactsDirectory)\Scripts\NuGet.psd1">
       <Link>Modules\NuGet\NuGet.psd1</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\NuGetConsole.Host.PowerShell\Scripts\nuget.psm1">
+    <Content Include="$(ArtifactsDirectory)\Scripts\nuget.psm1">
       <Link>Modules\NuGet\nuget.psm1</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\NuGetConsole.Host.PowerShell\Scripts\NuGet.Types.ps1xml">
+    <Content Include="$(ArtifactsDirectory)\Scripts\NuGet.Types.ps1xml">
       <Link>Modules\NuGet\NuGet.Types.ps1xml</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\NuGetConsole.Host.PowerShell\Scripts\Profile.ps1">
+    <Content Include="$(ArtifactsDirectory)\Scripts\Profile.ps1">
       <Link>Modules\NuGet\Profile.ps1</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -273,10 +273,6 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' " />
   <Import Project="$(VSSDKRoot)\build\Microsoft.VSSDK.BuildTools.targets" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' " />
-
-  <Target Name="BeforeBuild">
-    <Exec Command="powershell.exe -ExecutionPolicy Bypass &quot;$(ProjectDir)UpdateNuGetModuleManifest.ps1&quot; -NuGetPackageManagementPowerShellCmdletsFilePath &quot;$(ArtifactsDirectory)NuGet.PackageManagement.PowerShellCmdlets\$(VisualStudioVersion)\bin\$(Configuration)\NuGet.PackageManagement.PowerShellCmdlets.dll&quot; -ManifestModuleSourceFilePath &quot;$(ProjectDir)..\NuGetConsole.Host.PowerShell\Scripts\NuGet.psd1&quot; -ManifestModuleDestinationFilePath &quot;$(BaseIntermediateOutputPath)$(Configuration)\NuGet.psd1&quot;" />
-  </Target>
 
   <Target Name="FindSourceVsixManifest">
     <ItemGroup>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -78,7 +78,7 @@
       <Link>Modules\NuGet\NuGet.Format.ps1xml</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\NuGetConsole.Host.PowerShell\Scripts\NuGet.psd1">
+    <Content Include="$(BaseIntermediateOutputPath)$(Configuration)\NuGet.psd1">
       <Link>Modules\NuGet\NuGet.psd1</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -273,6 +273,11 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' " />
   <Import Project="$(VSSDKRoot)\build\Microsoft.VSSDK.BuildTools.targets" Condition="'$(IsXplat)' != 'true' AND '$(IsBuildOnlyXPLATProjects)' != 'true' " />
+
+  <Target Name="BeforeBuild">
+    <Exec Command="powershell.exe -ExecutionPolicy Bypass &quot;$(ProjectDir)UpdateNuGetModuleManifest.ps1&quot; -NuGetPackageManagementPowerShellCmdletsFilePath &quot;$(ArtifactsDirectory)NuGet.PackageManagement.PowerShellCmdlets\$(VisualStudioVersion)\bin\$(Configuration)\NuGet.PackageManagement.PowerShellCmdlets.dll&quot; -ManifestModuleSourceFilePath &quot;$(ProjectDir)..\NuGetConsole.Host.PowerShell\Scripts\NuGet.psd1&quot; -ManifestModuleDestinationFilePath &quot;$(BaseIntermediateOutputPath)$(Configuration)\NuGet.psd1&quot;" />
+  </Target>
+
   <Target Name="FindSourceVsixManifest">
     <ItemGroup>
       <SourceVsixManifest Include="source.extension.vsixmanifest" />

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/UpdateNuGetModuleManifest.ps1
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/UpdateNuGetModuleManifest.ps1
@@ -1,0 +1,40 @@
+param (
+    [Parameter(Mandatory = $True)]
+    [string] $NuGetPackageManagementPowerShellCmdletsFilePath,
+    [Parameter(Mandatory = $True)]
+    [string] $ManifestModuleSourceFilePath,
+    [Parameter(Mandatory = $True)]
+    [string] $ManifestModuleDestinationFilePath)
+
+$assembly = [System.Reflection.Assembly]::LoadFile($NuGetPackageManagementPowerShellCmdletsFilePath)
+
+[string] $manifestModuleFileContents = [System.IO.File]::ReadAllText($ManifestModuleSourceFilePath)
+
+$from = 'NuGet.PackageManagement.PowerShellCmdlets.dll'
+$to = $assembly.FullName
+
+Write-Host "Source file:  $ManifestModuleSourceFilePath"
+Write-Host "Destination file:  $ManifestModuleSourceFilePath"
+Write-Host "Replacing `'$from`' with `'$to`'"
+
+$startIndex = $manifestModuleFileContents.IndexOf($from)
+
+If ($startIndex -eq -1)
+{
+    Throw [System.Exception]::new("No occurrences of `'$from`' found in $ManifestModuleSourceFilePath")
+}
+
+$manifestModuleFileContents = $manifestModuleFileContents.Replace($from, $to)
+
+$startIndex = $manifestModuleFileContents.IndexOf($from, $startIndex + 1)
+
+If ($startIndex -ne -1)
+{
+    Throw [System.Exception]::new("Extra occurrences of `'$from`' found in $ManifestModuleSourceFilePath")
+}
+
+$ManifestModuleDestinationFile = [System.IO.FileInfo]::new($ManifestModuleDestinationFilePath)
+
+[System.IO.Directory]::CreateDirectory($ManifestModuleDestinationFile.DirectoryName)
+
+[System.IO.File]::WriteAllText($ManifestModuleDestinationFilePath, $manifestModuleFileContents)

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
@@ -150,9 +150,18 @@
     <LocTargets>$(LocTargets);GetPowerShellCmdletsHelpFile</LocTargets>
     <GetLocalizedFilesForVsixDependsOn>GetLocalizedPowerShellCmdletHelpFile</GetLocalizedFilesForVsixDependsOn>
   </PropertyGroup>
+
+  <Target Name="BeforeBuild">
+    <ItemGroup>
+      <PowerShellScripts Include="$(MSBuildProjectDirectory)\Scripts\*.ps*" Exclude="$(MSBuildProjectDirectory)\Scripts\NuGet.psd1" />
+    </ItemGroup>
+    <Copy SourceFiles="@(PowerShellScripts)"
+          DestinationFolder="$(ArtifactsDirectory)Scripts" />
+    <Exec Command="powershell.exe -ExecutionPolicy Bypass &quot;$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\UpdateNuGetModuleManifest.ps1&quot; -NuGetPackageManagementPowerShellCmdletsFilePath &quot;$(ArtifactsDirectory)NuGet.PackageManagement.PowerShellCmdlets\$(VisualStudioVersion)\bin\$(Configuration)\NuGet.PackageManagement.PowerShellCmdlets.dll&quot; -ManifestModuleSourceFilePath &quot;$(MSBuildProjectDirectory)\Scripts\NuGet.psd1&quot; -ManifestModuleDestinationFilePath &quot;$(ArtifactsDirectory)Scripts\NuGet.psd1&quot;" />
+  </Target>
   <Target Name="GetScriptsForSigning" Returns="@(ScriptsToSign)">
     <ItemGroup>
-      <ScriptsToSign Include="$(MSBuildProjectDirectory)\Scripts\*.ps*">
+      <ScriptsToSign Include="$(ArtifactsDirectory)Scripts\*.ps*">
         <Authenticode>Microsoft402</Authenticode>
       </ScriptsToSign>
     </ItemGroup>

--- a/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGet.Tools.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGet.Tools.Test.csproj
@@ -1,0 +1,28 @@
+﻿<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
+    <TestProject>true</TestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(NuGetClientsSrcDirectory)NuGet.Tools\NuGet.Tools.csproj" />
+    <ProjectReference Include="..\..\TestUtilities\Test.Utility\Test.Utility.csproj" />
+  </ItemGroup>
+
+  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)embedinterop.targets"/>
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>

--- a/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGet.Tools.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGet.Tools.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
@@ -6,10 +6,6 @@
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
     <TestProject>true</TestProject>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
 
   <ItemGroup>
     <None Include="xunit.runner.json">
@@ -23,6 +19,5 @@
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets"/>
-  <Import Project="$(BuildCommonDirectory)embedinterop.targets"/>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGetSettingsSerializerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGetSettingsSerializerTests.cs
@@ -17,7 +17,7 @@ namespace NuGet.Tools.Test
         [Fact]
         public void NuGetSettings_WhenSerializing_FieldCountIsExpected()
         {
-            var fields = GetSerializableFields<NuGetSettings>();
+            IReadOnlyList<FieldInfo> fields = GetSerializableFields<NuGetSettings>();
 
             Assert.Equal(0, fields.Count);
         }
@@ -25,7 +25,7 @@ namespace NuGet.Tools.Test
         [Fact]
         public void NuGetSettings_WhenSerializing_PropertyCountIsExpected()
         {
-            var properties = GetSerializableProperties<NuGetSettings>();
+            IReadOnlyList<PropertyInfo> properties = GetSerializableProperties<NuGetSettings>();
 
             Assert.Equal(1, properties.Count);
         }
@@ -33,7 +33,7 @@ namespace NuGet.Tools.Test
         [Fact]
         public void UserSettings_WhenSerializing_FieldCountIsExpected()
         {
-            var fields = GetSerializableFields<UserSettings>();
+            IReadOnlyList<FieldInfo> fields = GetSerializableFields<UserSettings>();
 
             Assert.Equal(0, fields.Count);
         }
@@ -41,7 +41,7 @@ namespace NuGet.Tools.Test
         [Fact]
         public void UserSettings_WhenSerializing_PropertyCountIsExpected()
         {
-            var properties = GetSerializableProperties<UserSettings>();
+            IReadOnlyList<PropertyInfo> properties = GetSerializableProperties<UserSettings>();
 
             Assert.Equal(12, properties.Count);
         }

--- a/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGetSettingsSerializerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGetSettingsSerializerTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+using NuGet.PackageManagement.UI;
+using NuGetVSExtension;
+using Xunit;
+
+namespace NuGet.Tools.Test
+{
+    public class NuGetSettingsSerializerTests
+    {
+        [Fact]
+        public void NuGetSettings_WhenSerializing_FieldCountIsExpected()
+        {
+            var fields = GetSerializableFields<NuGetSettings>();
+
+            Assert.Equal(0, fields.Count);
+        }
+
+        [Fact]
+        public void NuGetSettings_WhenSerializing_PropertyCountIsExpected()
+        {
+            var properties = GetSerializableProperties<NuGetSettings>();
+
+            Assert.Equal(1, properties.Count);
+        }
+
+        [Fact]
+        public void UserSettings_WhenSerializing_FieldCountIsExpected()
+        {
+            var fields = GetSerializableFields<UserSettings>();
+
+            Assert.Equal(0, fields.Count);
+        }
+
+        [Fact]
+        public void UserSettings_WhenSerializing_PropertyCountIsExpected()
+        {
+            var properties = GetSerializableProperties<UserSettings>();
+
+            Assert.Equal(12, properties.Count);
+        }
+
+        [Fact]
+        public void Serialization_WhenDeserializing_Succeeds()
+        {
+            NuGetSettings expectedSettings = CreateNuGetSettings();
+
+            var serializer = new NuGetSettingsSerializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(stream, expectedSettings);
+
+                Assert.NotEqual(0, stream.Length);
+
+                stream.Seek(offset: 0, loc: SeekOrigin.Begin);
+
+                NuGetSettings actualSettings = serializer.Deserialize(stream);
+
+                Assert.NotSame(expectedSettings, actualSettings);
+                AssertAreEquivalent(expectedSettings, actualSettings);
+            }
+        }
+
+        private static void AssertAreEquivalent(NuGetSettings expectedSettings, NuGetSettings actualSettings)
+        {
+            Assert.Equal(expectedSettings.WindowSettings.Count, actualSettings.WindowSettings.Count);
+
+            IReadOnlyList<PropertyInfo> properties = GetSerializableProperties<UserSettings>();
+
+            foreach (string key in expectedSettings.WindowSettings.Keys)
+            {
+                Assert.True(actualSettings.WindowSettings.ContainsKey(key));
+
+                UserSettings expectedUserSettings = expectedSettings.WindowSettings[key];
+                UserSettings actualUserSettings = actualSettings.WindowSettings[key];
+
+                foreach (PropertyInfo property in properties)
+                {
+                    object expectedValue = property.GetValue(expectedUserSettings);
+                    object actualValue = property.GetValue(actualUserSettings);
+
+                    Assert.Equal(expectedValue, actualValue);
+                }
+            }
+        }
+
+        private static NuGetSettings CreateNuGetSettings()
+        {
+            var settings = new NuGetSettings();
+
+            var userSettings = new UserSettings()
+            {
+                SourceRepository = "a",
+                ShowPreviewWindow = true,
+                ShowDeprecatedFrameworkWindow = false,
+                RemoveDependencies = true,
+                ForceRemove = false,
+                IncludePrerelease = true,
+                SelectedFilter = ItemFilter.Installed,
+                DependencyBehavior = Resolver.DependencyBehavior.HighestMinor,
+                FileConflictAction = ProjectManagement.FileConflictAction.Overwrite,
+                OptionsExpanded = true,
+                SortPropertyName = "b",
+                SortDirection = System.ComponentModel.ListSortDirection.Descending
+            };
+
+            settings.WindowSettings.Add("c", userSettings);
+
+            return settings;
+        }
+
+        private static IReadOnlyList<FieldInfo> GetSerializableFields<T>()
+        {
+            return typeof(T).GetFields(BindingFlags.Public | BindingFlags.Instance)
+                .Where(field => !field.GetCustomAttributes<JsonIgnoreAttribute>().Any())
+                .ToArray();
+        }
+
+        private static IReadOnlyList<PropertyInfo> GetSerializableProperties<T>()
+        {
+            return typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(property => !property.GetCustomAttributes<JsonIgnoreAttribute>().Any())
+                .ToArray();
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.Tools.Test/xunit.runner.json
+++ b/test/NuGet.Clients.Tests/NuGet.Tools.Test/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "maxParallelThreads": 1,
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
Fix internal bug 677891.  Also, fix https://github.com/NuGet/Home/issues/8166.

Use [ProvideCodeBaseAttribute](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.providecodebaseattribute?view=visualstudiosdk-2017) instead of the antiquated [ProvideBindingPathAttribute](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.providebindingpathattribute?view=visualstudiosdk-2017).

Before this change, there were numerous code paths which resulted in loading NuGet assemblies using a discouraged fallback assembly resolution mechanism in Visual Studio.

After this change, NuGet assemblies must be loadable with information in devenv.exe.config.  At build time, the `ProvideCodeBaseAttribute` translates into .pkgdef entries.  These entries are merged with your private devenv.exe.config on the first launch of Visual Studio after installing the NuGet VSIX.  Then, when Visual Studio tries to load an assembly by its full assembly name, Visual Studio uses the predetermined assembly location in devenv.exe.config.  Except for 2 exceptional cases, there's no more dynamic searching for NuGet assemblies.

For this new method to work, NuGet assemblies must be strong name signed (at least delay signed).

* build.ps1 will now delay sign by default.  Pass `-SkipDelaySign` to skip delay signing.
* At build time the `ProvideCodeBaseAttribute` attribute looks for the specified assembly so the assembly's full name can be read and added to the .pkgdef file.  This means that the package projects (NuGet.Tools and NuGet.SolutionRestoreManager) must have all referenced files in their output directory.  I added project-to-project references from NuGet.Tools to NuGet.PackageManagement.PowerShellCmdlets and NuGet.VisualStudio.Interop for no other reason than to enable automatic .pkgdef entry generation via the `ProvideCodeBaseAttribute`.  An alternative to the project-to-project references would be to generate .pkgdef entries ourselves, but that seems like a worse option.
* I replaced binary serialization of NuGet solution user options with JSON.  Binary serialization includes full type and assembly name information.  Successful binary deserialization requires that the same assembly (per strong name) be loaded or loadable.  However, if you install a Visual Studio update which updates NuGet, [this deserialization will always fail](https://github.com/NuGet/Home/issues/8166) you'll get "default" user settings until new settings are serialized using the newer NuGet assemblies.  Since every NuGet update was essentially a breaking change with respect to deserialization of NuGet solution user options, I changed serialization to be more resilient to version changes.
* The PowerShell manifest module NuGet.psd1 for NuGet Package Manager Console indicates the following assembly dependency.  However, this assembly reference must be an assembly full name.  At build time a [new PowerShell script](https://github.com/NuGet/NuGet.Client/pull/2863/files#diff-c960a1132937786d7771b2d317097a3d) will create a copy of the original NuGet.psd1 file with the assembly full name instead of a simple name.
[`NestedModules = @('NuGet.PackageManagement.PowerShellCmdlets.dll')`](https://github.com/NuGet/NuGet.Client/blob/ec48ee474965d3d5f41ed7e5b4199af79868351a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/Scripts/NuGet.psd1#L58)

There are 2 cases where the discouraged Visual Studio assembly resolution mechanism is still used:
* opening NuGet Package Manager UI
* opening NuGet Package Manager Console

In both cases:
* the respective assembly is correctly loaded using the assembly full name
* a XAML control is loaded, which causes the WPF BAML reader to try to load the same assembly with a version of 0.0.0.0.

For example, when opening Package Manager UI, NuGet.PackageManagement.UI.dll is loaded correctly using the assembly full name like:

    NuGet.PackageManagement.UI, Version=5.2.0.1874, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a

Then as Package Manager UI is loading, the WPF runtime tries to load:

    NuGet.PackageManagement.UI, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a

There is no entry in devenv.exe.config for version 0.0.0.0 of this assembly, so Visual Studio falls back to the deprecated assembly resolution code path.

A similar load happens with NuGet.Console.dll and Package Manager Console.