### PR TITLE
Respect RestoreLockedMode even when the lock file is invalid

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -465,7 +465,7 @@ namespace NuGet.Commands
                 packagesLockFile = PackagesLockFileFormat.Read(packagesLockFilePath, _logger);
                 lockFileTelemetry.EndIntervalMeasure(ReadLockFileDuration);
 
-                if (_request.DependencyGraphSpec != null && packagesLockFile.Targets.Count > 0)
+                if (_request.DependencyGraphSpec != null)
                 {
                     // check if lock file is out of sync with project data
                     lockFileTelemetry.StartIntervalMeasure();


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8160
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

Whenever the lock is enabled we should always rread the lock file. 
If it's broken & and we are in locked mode we should fail the operation. 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  Manual, automation
