### PR TITLE
Upgrades .NET reference assemblies to support net472 in .NET Core SDK

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -9,7 +9,7 @@
   </ItemGroup>
   <!-- When building on non-Windows machines, we need the reference assemblies to build full-framework assemblies. -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND '$(DotNetBuildFromSource)' == 'true'">
-     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-alpha-003" PrivateAssets="All" />
+     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-alpha-5" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup Condition="'$(IsNetCoreProject)' == 'true' AND '$(Shipping)' == 'true' AND '$(IsXPlat)' != 'true'">
     <DebugType>full</DebugType>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IsXPlat)' == 'true' ">$(NETCoreTargetFramework)</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AssemblyName>NuGet.Build.Tasks.Pack</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -4,7 +4,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(IsXPlat)' == 'true' ">$(NETCoreTargetFramework)</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AssemblyName>NuGet.Build.Tasks.Pack</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>


### PR DESCRIPTION
## Bug

Fixes: 
- https://github.com/NuGet/Home/issues/8214
- https://github.com/NuGet/Home/issues/8139

Regression: No
* Last working version:  
* How are we preventing it in future: A possible solution would be pattern matching versions

## Fix

### Upgrades .NET Framework reference assemblies to 1.0.0-alpha-5

With this upgrade, we can build .NET Framework 4.7.2 code using .NET Core SDK in any machine that support the .NET Core SDK.

Our current dependency only support code based on .NET framework up to 4.7.1

More info: https://github.com/Microsoft/dotnet/tree/master/releases/reference-assemblies

## Testing/Validation

Tests Added: No
Reason for not adding tests: Need an external repository to make a test.
Validation: Independent build verification with dotnet/source-build on Linux
