### PR TITLE
Add automation for inserting into toolset. Add custom logic to allow …

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0">
+
+  <!-- Special project import for dotnet source build
+
+  The dotnet source-build Repo API overrides *PackageVersion properties with versions that were built before.
+  Those paackages are injected in this props file
+
+  See: https://github.com/dotnet/source-build/blob/master/Documentation/auto-dependency-flow/api.md#-pdotnetpackageversionpropspathpath
+  -->
+  <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != ''" />
+
   <!-- Version -->
   <PropertyGroup>
     <IsEscrowMode>false</IsEscrowMode>
@@ -14,24 +24,17 @@
     <!-- This branches are used for creating insertion PRs -->
     <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d16.$(MinorNuGetVersion)</VsTargetBranch>
     <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</CliTargetBranches>
-    <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">release/2.2.4xx;release/2.1.8xx</CliTargetBranches>
+    <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">release/2.2.4xx;release/2.1.8xx;release/3.0.1xx</CliTargetBranches>
     <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</SdkTargetBranches>
-    <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">release/2.2.4xx;release/2.1.8xx</SdkTargetBranches>
+    <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">release/2.2.4xx;release/2.1.8xx;release/3.0.1xx</SdkTargetBranches>
+    <ToolsetTargetBranches Condition="'$(OverrideToolsetTargetBranches)' != ''">$(OverrideToolsetTargetBranches)</ToolsetTargetBranches>
+    <ToolsetTargetBranches Condition="'$(OverrideToolsetTargetBranches)' == ''">release/3.0.1xx</ToolsetTargetBranches>
     <!-- We need to update this netcoreassembly build number with every insertion into VS to workaround any breaking api
     changes we might have made.-->
     <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">2</NetCoreAssemblyBuildNumber>
     <!-- Check the VS schedule and manually enter a preview number here that makes sense. -->
     <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview2</ReleaseLabel>
   </PropertyGroup>
-
-  <!-- Special project import for dotnet source build
-
-  The dotnet source-build Repo API overrides *PackageVersion properties with versions that were built before.
-  Those paackages are injected in this props file
-
-  See: https://github.com/dotnet/source-build/blob/master/Documentation/auto-dependency-flow/api.md#-pdotnetpackageversionpropspathpath
-  -->
-  <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != ''" />
 
   <!-- Dependency versions -->
   <PropertyGroup>
@@ -74,6 +77,9 @@
   </Target>
   <Target Name="GetSdkTargetBranches">
     <Message Text="$(SdkTargetBranches)" Importance="High"/>
+  </Target>
+  <Target Name="GetToolsetTargetBranches">
+    <Message Text="$(ToolsetTargetBranches)" Importance="High"/>
   </Target>
   <Target Name="GetCliBranchForTesting">
       <Message Text="$(CliBranchForTesting)" Importance="High"/>

--- a/build/config.props
+++ b/build/config.props
@@ -2,10 +2,8 @@
 <Project ToolsVersion="15.0">
 
   <!-- Special project import for dotnet source build
-
   The dotnet source-build Repo API overrides *PackageVersion properties with versions that were built before.
   Those paackages are injected in this props file
-
   See: https://github.com/dotnet/source-build/blob/master/Documentation/auto-dependency-flow/api.md#-pdotnetpackageversionpropspathpath
   -->
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != ''" />

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -201,6 +201,7 @@ else
     $VsTargetBranch = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetBranch
     $CliTargetBranches = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetCliTargetBranches
     $SdkTargetBranches = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSdkTargetBranches
+    $ToolsetTargetBranches = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetToolsetTargetBranches
     Write-Host $VsTargetBranch
     $jsonRepresentation = @{
         BuildNumber = $newBuildCounter
@@ -211,6 +212,7 @@ else
         VsTargetBranch = $VsTargetBranch.Trim()
         CliTargetBranches = $CliTargetBranches.Trim()
         SdkTargetBranches = $SdkTargetBranches.Trim()
+        ToolsetTargetBranches = $ToolsetTargetBranches.Trim()
     }
 
     New-Item $BuildInfoJsonFile -Force

--- a/scripts/utils/InsertNuGetIntoDotnet.ps1
+++ b/scripts/utils/InsertNuGetIntoDotnet.ps1
@@ -1,6 +1,6 @@
 ﻿<#
 .SYNOPSIS
-Script to insert NuGet into CLI, SDK, and TOOLSET
+Script to insert NuGet into dotnet specific repos; CLI, SDK, and TOOLSET
 
 .DESCRIPTION
 Uses the Personal Access Token of NuGetLurker to automate the insertion process into CLI, SDK, and TOOLSET

--- a/scripts/utils/InsertNuGetIntoSdkAndCli.ps1
+++ b/scripts/utils/InsertNuGetIntoSdkAndCli.ps1
@@ -1,6 +1,6 @@
 ﻿<#
 .SYNOPSIS
-Script to insert NuGet into CLI, SDK, and TOOLSET
+Script to insert NuGet into dotnet; CLI, SDK, and TOOLSET repos
 
 .DESCRIPTION
 Uses the Personal Access Token of NuGetLurker to automate the insertion process into CLI, SDK, and TOOLSET

--- a/scripts/utils/InsertNuGetIntoSdkAndCli.ps1
+++ b/scripts/utils/InsertNuGetIntoSdkAndCli.ps1
@@ -1,6 +1,6 @@
 ﻿<#
 .SYNOPSIS
-Script to insert NuGet into dotnet specific repos; CLI, SDK, and TOOLSET
+Script to insert NuGet into CLI, SDK, and TOOLSET
 
 .DESCRIPTION
 Uses the Personal Access Token of NuGetLurker to automate the insertion process into CLI, SDK, and TOOLSET

--- a/scripts/utils/InsertNuGetIntoSdkAndCli.ps1
+++ b/scripts/utils/InsertNuGetIntoSdkAndCli.ps1
@@ -38,9 +38,7 @@ param
     [Parameter(Mandatory=$True)]
     [string]$NuGetTag,
     [Parameter(Mandatory=$True)]
-    [string]$BuildOutputPath,
-    [Parameter(Mandatory=$False)]
-    [string]$AlternativeFilePath
+    [string]$BuildOutputPath
 )
 
 Function UpdateNuGetVersionInXmlFile {
@@ -222,8 +220,8 @@ ForEach ($Branch in $BranchesToInsert) {
     $VersionsFilePath = $FilePath
     # Hack to allow us to specify the arcade version props location if the branch is 3.0 or later. 
     # We can remove this when we stop inserting into 2.x
-    if((-not [string]::IsNullOrEmpty($AlternativeFilePath)) -and ($Branch.StartsWith("master") -or $Branch.StartsWith("release/3"))){
-        $VersionsFilePath = $AlternativeFilePath
+    if($Branch.StartsWith("master") -or $Branch.StartsWith("release/3")){
+        $VersionsFilePath = "eng/Versions.props"
     } 
 
     $xml = GetDependencyVersionPropsFile -RepositoryName $RepositoryName -BranchName $Branch -FilePath $VersionsFilePath


### PR DESCRIPTION
…us to specify alternative paths for 3.0 and later SDK/CLI branches

## Bug

Fixes: https://github.com/NuGet/Home/issues/8181
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

Self descriptive. 

Additionally I removed the need for the Publish Packages release definition as all of that logic has been merged to the release one. 

The reason for us having 2 was the triggers. 
When we initially wrote these, the release definition had an automatic trigger, while the publish packages build definition had all of the trigger steps manual. 

Now a mix of triggers is allowed. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
