### PR TITLE
Exclude the explicit assembly references from the nuspec when generating the snupkg. Explicit assembly references are not relevant from a snupkg perspective

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -905,9 +905,9 @@ namespace NuGet.Commands
             {
                 symbolsBuilder.PackageTypes.Clear();
                 symbolsBuilder.PackageTypes.Add(PackageType.SymbolsPackage);
-                symbolsBuilder.PackageAssemblyReferences.Clear();
                 // Remove the references when building the symbols package.
                 // They are not relevant for the symbols packages (snupkgs specifically).
+                symbolsBuilder.PackageAssemblyReferences.Clear();
             }
 
             // remove unnecessary files when building the symbols package

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -905,6 +905,9 @@ namespace NuGet.Commands
             {
                 symbolsBuilder.PackageTypes.Clear();
                 symbolsBuilder.PackageTypes.Add(PackageType.SymbolsPackage);
+                symbolsBuilder.PackageAssemblyReferences.Clear();
+                // Remove the references when building the symbols package.
+                // They are not relevant for the symbols packages (snupkgs specifically).
             }
 
             // remove unnecessary files when building the symbols package

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -466,15 +466,15 @@ namespace NuGet.CommandLine.Test
                     Assert.Equal(
                         new string[]
                         {
-                        "contentFiles/any/any/image.jpg",
-                        "contentFiles/cs/net45/code.cs",
-                        Path.Combine("lib", "uap10.0", "packageA.dll").Replace('\\', '/'),
+                            "contentFiles/any/any/image.jpg",
+                            "contentFiles/cs/net45/code.cs",
+                            "lib/uap10.0/packageA.dll",
                         },
                         files);
                     Assert.Equal(
                         new string[]
                         {
-                        Path.Combine("lib", "uap10.0", "packageA.pdb").Replace('\\','/'),
+                            "lib/uap10.0/packageA.pdb",
                         },
                         symbolFiles);
                 }
@@ -552,15 +552,15 @@ namespace NuGet.CommandLine.Test
                     Assert.Equal(
                         new string[]
                         {
-                        "contentFiles/any/any/image.jpg",
-                        "contentFiles/cs/net45/code.cs",
-                        Path.Combine("lib", "uap10.0", "packageA.dll").Replace('\\', '/'),
+                            "contentFiles/any/any/image.jpg",
+                            "contentFiles/cs/net45/code.cs",
+                            "lib/uap10.0/packageA.dll",
                         },
                         files);
                     Assert.Equal(
                         new string[]
                         {
-                        Path.Combine("lib", "uap10.0", "packageA.pdb").Replace('\\','/'),
+                            "lib/uap10.0/packageA.pdb",
                         },
                         symbolFiles);
                 }
@@ -641,15 +641,15 @@ namespace NuGet.CommandLine.Test
                     Assert.Equal(
                         new string[]
                         {
-                        "contentFiles/any/any/image.jpg",
-                        "contentFiles/cs/net45/code.cs",
-                        Path.Combine("lib", "uap10.0", "packageA.dll").Replace('\\', '/'),
+                            "contentFiles/any/any/image.jpg",
+                            "contentFiles/cs/net45/code.cs",
+                            "lib/uap10.0/packageA.dll",
                         },
                         files);
                     Assert.Equal(
                         new string[]
                         {
-                        Path.Combine("lib", "uap10.0", "packageA.pdb").Replace('\\','/'),
+                            "lib/uap10.0/packageA.pdb",
                         },
                         symbolFiles);
                 }
@@ -1106,22 +1106,23 @@ namespace Proj2
                         .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package"))
                         .ToArray();
                     Array.Sort(files);
-                    var actual = symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg ? new string[]
+                    var actual = symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg ?
+                        new string[]
                         {
-                        Path.Combine("content", "proj1_file2.txt"),
-                        Path.Combine("lib", "net40", "proj1.dll"),
-                        Path.Combine("lib", "net40", "proj1.pdb"),
-                        Path.Combine("lib", "net40", "proj2.dll"),
-                        Path.Combine("lib", "net40", "proj2.pdb"),
-                        "proj2.nuspec",
-                        Path.Combine("src", "proj1", "proj1_file1.cs"),
-                        Path.Combine("src", "proj2", "proj2_file1.cs"),
+                            Path.Combine("content", "proj1_file2.txt"),
+                            Path.Combine("lib", "net40", "proj1.dll"),
+                            Path.Combine("lib", "net40", "proj1.pdb"),
+                            Path.Combine("lib", "net40", "proj2.dll"),
+                            Path.Combine("lib", "net40", "proj2.pdb"),
+                            "proj2.nuspec",
+                            Path.Combine("src", "proj1", "proj1_file1.cs"),
+                            Path.Combine("src", "proj2", "proj2_file1.cs"),
                         }
                         : new string[]
                         {
-                        Path.Combine("lib", "net40", "proj1.pdb"),
-                        Path.Combine("lib", "net40", "proj2.pdb"),
-                        "proj2.nuspec"
+                            Path.Combine("lib", "net40", "proj1.pdb"),
+                            Path.Combine("lib", "net40", "proj2.pdb"),
+                            "proj2.nuspec"
                         };
                     actual = actual.Select(t => NuGet.Common.PathUtility.GetPathWithForwardSlashes(t)).ToArray();
                     Assert.Equal(actual, files);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -422,12 +422,12 @@ namespace NuGet.CommandLine.Test
                 Util.CreateFile(
                     Path.Combine(workingDirectory, "contentFiles", "any", "any"),
                     "image.jpg",
-                    "");
+                    string.Empty);
 
                 Util.CreateFile(
                     Path.Combine(workingDirectory, "contentFiles", "cs", "net45"),
                     "code.cs",
-                    "");
+                    string.Empty);
 
                 Util.CreateFile(
                     workingDirectory,
@@ -456,36 +456,38 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 var path = Path.Combine(workingDirectory, "packageA.1.0.0.nupkg");
                 var symbolPath = Path.Combine(workingDirectory, "packageA.1.0.0.snupkg");
-                var package = new PackageArchiveReader(path);
-                var symbolPackage = new PackageArchiveReader(symbolPath);
-                var files = package.GetFiles()
+                using (var package = new PackageArchiveReader(path))
+                using (var symbolPackage = new PackageArchiveReader(symbolPath))
+                {
+                    var files = package.GetFiles()
                     .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package") && !t.EndsWith("nuspec"))
                     .ToArray();
-                var symbolFiles = symbolPackage.GetFiles()
-                    .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package") && !t.EndsWith("nuspec"))
-                    .ToArray();
-                Array.Sort(files);
-                Array.Sort(symbolFiles);
+                    var symbolFiles = symbolPackage.GetFiles()
+                        .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package") && !t.EndsWith("nuspec"))
+                        .ToArray();
+                    Array.Sort(files);
+                    Array.Sort(symbolFiles);
 
-                Assert.Equal(
-                    new string[]
-                    {
+                    Assert.Equal(
+                        new string[]
+                        {
                         "contentFiles/any/any/image.jpg",
                         "contentFiles/cs/net45/code.cs",
                         Path.Combine("lib", "uap10.0", "packageA.dll").Replace('\\', '/'),
-                    },
-                    files);
-                Assert.Equal(
-                    new string[]
-                    {
+                        },
+                        files);
+                    Assert.Equal(
+                        new string[]
+                        {
                         Path.Combine("lib", "uap10.0", "packageA.pdb").Replace('\\','/'),
-                    },
-                    symbolFiles);
+                        },
+                        symbolFiles);
+                }
             }
         }
 
         [Fact]
-        public void PackCommand_SymbolPackageWithNuspecFileAndReference()
+        public void PackCommand_WhenPackingSymbolsPackage_ExcludesExplicitAssemblyReferences()
         {
             var nugetexe = Util.GetNuGetExePath();
 
@@ -505,12 +507,12 @@ namespace NuGet.CommandLine.Test
                 Util.CreateFile(
                     Path.Combine(workingDirectory, "contentFiles", "any", "any"),
                     "image.jpg",
-                    "");
+                    string.Empty);
 
                 Util.CreateFile(
                     Path.Combine(workingDirectory, "contentFiles", "cs", "net45"),
                     "code.cs",
-                    "");
+                    string.Empty);
 
                 Util.CreateFile(
                     workingDirectory,
@@ -539,36 +541,38 @@ namespace NuGet.CommandLine.Test
                     workingDirectory,
                     "pack packageA.nuspec -symbols -SymbolPackageFormat snupkg",
                     waitForExit: true);
-                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(r.Success, r.AllOutput);
 
                 // Assert
                 var path = Path.Combine(workingDirectory, "packageA.1.0.0.nupkg");
                 var symbolPath = Path.Combine(workingDirectory, "packageA.1.0.0.snupkg");
-                var package = new PackageArchiveReader(path);
-                var symbolPackage = new PackageArchiveReader(symbolPath);
-                var files = package.GetFiles()
+                using (var package = new PackageArchiveReader(path))
+                using (var symbolPackage = new PackageArchiveReader(symbolPath))
+                {
+                    var files = package.GetFiles()
                     .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package") && !t.EndsWith("nuspec"))
                     .ToArray();
-                var symbolFiles = symbolPackage.GetFiles()
-                    .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package") && !t.EndsWith("nuspec"))
-                    .ToArray();
-                Array.Sort(files);
-                Array.Sort(symbolFiles);
+                    var symbolFiles = symbolPackage.GetFiles()
+                        .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package") && !t.EndsWith("nuspec"))
+                        .ToArray();
+                    Array.Sort(files);
+                    Array.Sort(symbolFiles);
 
-                Assert.Equal(
-                    new string[]
-                    {
+                    Assert.Equal(
+                        new string[]
+                        {
                         "contentFiles/any/any/image.jpg",
                         "contentFiles/cs/net45/code.cs",
                         Path.Combine("lib", "uap10.0", "packageA.dll").Replace('\\', '/'),
-                    },
-                    files);
-                Assert.Equal(
-                    new string[]
-                    {
+                        },
+                        files);
+                    Assert.Equal(
+                        new string[]
+                        {
                         Path.Combine("lib", "uap10.0", "packageA.pdb").Replace('\\','/'),
-                    },
-                    symbolFiles);
+                        },
+                        symbolFiles);
+                }
             }
         }
 
@@ -1109,13 +1113,14 @@ namespace Proj2
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
 
                 // Assert
-                var package = new PackageArchiveReader(Path.Combine(proj2Directory, $"proj2.0.0.0.{extension}"));
-                var files = package.GetFiles()
-                    .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package"))                    
-                    .ToArray();
-                Array.Sort(files);
-                var actual = symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg ? new string[]
-                    {
+                using (var package = new PackageArchiveReader(Path.Combine(proj2Directory, $"proj2.0.0.0.{extension}")))
+                {
+                    var files = package.GetFiles()
+                        .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package"))
+                        .ToArray();
+                    Array.Sort(files);
+                    var actual = symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg ? new string[]
+                        {
                         Path.Combine("content", "proj1_file2.txt"),
                         Path.Combine("lib", "net40", "proj1.dll"),
                         Path.Combine("lib", "net40", "proj1.pdb"),
@@ -1124,16 +1129,16 @@ namespace Proj2
                         "proj2.nuspec",
                         Path.Combine("src", "proj1", "proj1_file1.cs"),
                         Path.Combine("src", "proj2", "proj2_file1.cs"),
-                    }
-                    : new string[]
-                    {
+                        }
+                        : new string[]
+                        {
                         Path.Combine("lib", "net40", "proj1.pdb"),
                         Path.Combine("lib", "net40", "proj2.pdb"),
                         "proj2.nuspec"
-                    };
-                actual = actual.Select(t => NuGet.Common.PathUtility.GetPathWithForwardSlashes(t)).ToArray();
-                Assert.Equal(actual, files);
-                
+                        };
+                    actual = actual.Select(t => NuGet.Common.PathUtility.GetPathWithForwardSlashes(t)).ToArray();
+                    Assert.Equal(actual, files);
+                }
             }
         }
 
@@ -1181,25 +1186,29 @@ namespace Proj2
                 Assert.True(result.Item1 == 0, result.Item2 + " " + result.Item3);
 
                 // Assert
-                var package = new PackageArchiveReader(Path.Combine(projDirectory, $"A.0.0.0.{extension}"));
-                var files = package.GetFiles()
-                    .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package"))
-                    .ToArray();
-                Array.Sort(files);
-                var actual = symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg ?  new string[]
-                    {
+                using (var package = new PackageArchiveReader(Path.Combine(projDirectory, $"A.0.0.0.{extension}")))
+                {
+
+
+                    var files = package.GetFiles()
+                        .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package"))
+                        .ToArray();
+                    Array.Sort(files);
+                    var actual = symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg ? new string[]
+                        {
                         "A.nuspec",
                         "lib/net40/A.dll",
                         "lib/net40/A.pdb",
                         "src/B.cs"
-                    }
-                    : new string[]
-                    {
+                        }
+                        : new string[]
+                        {
                         "A.nuspec",
                         "lib/net40/A.pdb"
-                    };
-                actual = actual.Select(t => NuGet.Common.PathUtility.GetPathWithForwardSlashes(t)).ToArray();
-                Assert.Equal(actual, files);
+                        };
+                    actual = actual.Select(t => NuGet.Common.PathUtility.GetPathWithForwardSlashes(t)).ToArray();
+                    Assert.Equal(actual, files);
+                }
             }
         }
 
@@ -1249,24 +1258,26 @@ public class B
                 Assert.True(result.Item1 == 0, result.Item2 + " " + result.Item3);
 
                 // Assert
-                var package = new PackageArchiveReader(Path.Combine(projDirectory, $"A.0.0.0.{extension}"));
-                var files = package.GetFiles()
-                    .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package"))
-                    .ToArray();
-                Array.Sort(files);
-                var actual = symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg ? new string[]
-                    {
+                using (var package = new PackageArchiveReader(Path.Combine(projDirectory, $"A.0.0.0.{extension}")))
+                {
+                    var files = package.GetFiles()
+                        .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package"))
+                        .ToArray();
+                    Array.Sort(files);
+                    var actual = symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg ? new string[]
+                        {
                         "A.nuspec",
                         "lib/net40/A.exe",
                         "lib/net40/A.pdb",
                         "src/B.cs"
-                    }
-                    : new string[]
-                    {
+                        }
+                        : new string[]
+                        {
                         "A.nuspec",
                         "lib/net40/A.pdb"
-                    };
-                Assert.Equal(actual, files);
+                        };
+                    Assert.Equal(actual, files);
+                }
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using NuGet.Commands;
 using NuGet.Common;
@@ -282,7 +281,7 @@ namespace NuGet.CommandLine.Test
             using (var workingDirectory = TestDirectory.Create())
             {
                 // Arrange
-                string id = Path.GetFileName(workingDirectory);
+                var id = Path.GetFileName(workingDirectory);
 
                 Util.CreateFile(
                     Path.Combine(workingDirectory, "ref", "uap10.0"),
@@ -459,12 +458,8 @@ namespace NuGet.CommandLine.Test
                 using (var package = new PackageArchiveReader(path))
                 using (var symbolPackage = new PackageArchiveReader(symbolPath))
                 {
-                    var files = package.GetFiles()
-                    .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package") && !t.EndsWith("nuspec"))
-                    .ToArray();
-                    var symbolFiles = symbolPackage.GetFiles()
-                        .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package") && !t.EndsWith("nuspec"))
-                        .ToArray();
+                    var files = package.GetNonPackageDefiningFiles();
+                    var symbolFiles = symbolPackage.GetNonPackageDefiningFiles();
                     Array.Sort(files);
                     Array.Sort(symbolFiles);
 
@@ -549,12 +544,8 @@ namespace NuGet.CommandLine.Test
                 using (var package = new PackageArchiveReader(path))
                 using (var symbolPackage = new PackageArchiveReader(symbolPath))
                 {
-                    var files = package.GetFiles()
-                    .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package") && !t.EndsWith("nuspec"))
-                    .ToArray();
-                    var symbolFiles = symbolPackage.GetFiles()
-                        .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package") && !t.EndsWith("nuspec"))
-                        .ToArray();
+                    var files = package.GetNonPackageDefiningFiles();
+                    var symbolFiles = symbolPackage.GetNonPackageDefiningFiles();
                     Array.Sort(files);
                     Array.Sort(symbolFiles);
 
@@ -638,12 +629,8 @@ namespace NuGet.CommandLine.Test
                 using (var package = new PackageArchiveReader(path))
                 using (var symbolPackage = new PackageArchiveReader(symbolPath))
                 {
-                    var files = package.GetFiles()
-                        .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package") && !t.EndsWith("nuspec"))
-                        .ToArray();
-                    var symbolFiles = symbolPackage.GetFiles()
-                        .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package") && !t.EndsWith("nuspec"))
-                        .ToArray();
+                    var files = package.GetNonPackageDefiningFiles();
+                    var symbolFiles = symbolPackage.GetNonPackageDefiningFiles();
                     Array.Sort(files);
                     Array.Sort(symbolFiles);
 
@@ -4194,7 +4181,7 @@ namespace Proj2
             var projectDirectory = Path.Combine(baseDirectory, projectName);
             Directory.CreateDirectory(projectDirectory);
 
-            string reference = string.Empty;
+            var reference = string.Empty;
             if (referencedProject != null && referencedProject.Length > 0)
             {
                 var sb = new StringBuilder();
@@ -5431,11 +5418,12 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
                     }
 
                     var files = symbolsReader.GetFiles()
-                  .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package"))
-                  .ToArray();
+                        .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package"))
+                        .ToArray();
                     Array.Sort(files);
                     var actual = symbolPackageFormat == SymbolPackageFormat.SymbolsNupkg ? new string[]
                         {
+
                          $"{packageName}.nuspec",
                          $"lib/net40/{packageName}.dll",
                          $"lib/net40/{packageName}.pdb",
@@ -5627,6 +5615,17 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
             {
                 Assert.NotNull(Packaging.Manifest.ReadFrom(nuspecStream, validateSchema: true));
             }
+        }
+    }
+
+    internal static class PackageArchiveReaderTestExtensions
+    {
+
+        public static string[] GetNonPackageDefiningFiles(this PackageArchiveReader package)
+        {
+            return package.GetFiles()
+                .Where(t => !t.StartsWith("[Content_Types]") && !t.StartsWith("_rels") && !t.StartsWith("package") && !t.EndsWith("nuspec"))
+                .ToArray();
         }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7638
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Exclude the explicit assembly references from the nuspec when generating the snupkg. Explicit assembly references are not relevant from a snupkg perspective. 
Refer to https://github.com/NuGet/Home/issues/7638#issuecomment-498380498 for more details. 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  Manual, automation
