### PR TITLE
Add .proj to the list of known extensions for restore

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -234,6 +234,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                    '%(RestoreGraphProjectInputItems.Extension)' == '.vbproj' Or
                    '%(RestoreGraphProjectInputItems.Extension)' == '.fsproj' Or
                    '%(RestoreGraphProjectInputItems.Extension)' == '.nuproj' Or
+                   '%(RestoreGraphProjectInputItems.Extension)' == '.proj' Or
                    '%(RestoreGraphProjectInputItems.Extension)' == '.msbuildproj' Or
                    '%(RestoreGraphProjectInputItems.Extension)' == '.vcxproj' " />
     </ItemGroup>


### PR DESCRIPTION
Since it's pretty trivial to get those projects to load in VS, offering a far 
better editing experience, make it possible to do restore on them by 
default just like for `.msbuildproj`.

See https://github.com/microsoft/MSBuildSdks/issues/97.
Fixes https://github.com/NuGet/Home/issues/8212