### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-﻿; EditorConfig to support per-solution formatting.
+; EditorConfig to support per-solution formatting.
 ; Use the EditorConfig VS add-in to make this work.
 ; http://editorconfig.org/
 
@@ -59,7 +59,7 @@ dotnet_style_null_propagation = true:suggestion
 ; IDE0007 Prefer "var" everywhere
 csharp_style_var_for_built_in_types = true:warning
 csharp_style_var_when_type_is_apparent = true:warning
-csharp_style_var_elsewhere = true:warning
+csharp_style_var_elsewhere = false:warning
 
 ; Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = false:none

--- a/.editorconfig
+++ b/.editorconfig
@@ -56,7 +56,7 @@ dotnet_style_null_propagation = true:suggestion
 
 ; CSharp code style settings
 [*.cs]
-; IDE0007 Prefer "var" everywhere
+; IDE0007 'var' preferences
 csharp_style_var_for_built_in_types = true:warning
 csharp_style_var_when_type_is_apparent = true:warning
 csharp_style_var_elsewhere = false:warning


### PR DESCRIPTION
Disable the `var` elsewhere code style rule.

See [documentation](https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference?view=vs-2019#c-code-style-settings) for an explanation.