### PR TITLE
Only allow dev and release-* branches to be build on official build

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -11,6 +11,18 @@ phases:
 
   steps:
   - task: PowerShell@1
+    displayName: "Official only branch checks"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        $needOfficialBuild = $Env:BUILD_SOURCEBRANCHNAME -eq 'dev' -or $Env:BUILD_SOURCEBRANCHNAME.StartsWith('release-')
+        if ($needOfficialBuild)
+        {
+          throw [System.Exception] ($Env:BUILD_SOURCEBRANCHNAME + ' should only be built from the official build definition')
+        }
+    condition: " not(eq(variables['IsOfficialBuild'], 'true')) "
+
+  - task: PowerShell@1
     displayName: "Initialize Git Commit Status on GitHub"
     inputs:
       scriptType: "inlineScript"


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8191
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: have vsts yaml check branch being built and only run dev and release-* builds on official build definition. Attempt 2 as the first time didn't read the `IsOfficialBuild` variable correctly.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  build definition change
Validation:  
