### PR TITLE
Plugins:  fix thread pool starvation

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginManagerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,10 +16,11 @@ namespace NuGet.Protocol.Plugins.Tests
 {
     public class PluginManagerTests
     {
+        private const string PluginFilePath = "a";
+
         [Fact]
         public async Task TryGetSourceAgnosticPluginAsync_WhenExceptionIsThrownDuringPluginCreation_PropagatesException()
         {
-            const string pluginFilePath = "a";
             const string message = "b";
 
             var reader = Mock.Of<IEnvironmentVariableReader>();
@@ -26,7 +28,7 @@ namespace NuGet.Protocol.Plugins.Tests
             var exception = new Exception(message);
 
             pluginFactory.Setup(x => x.GetOrCreateAsync(
-                    It.Is<string>(filePath => string.Equals(filePath, pluginFilePath, StringComparison.Ordinal)),
+                    It.Is<string>(filePath => string.Equals(filePath, PluginFilePath, StringComparison.Ordinal)),
                     It.Is<IEnumerable<string>>(arguments => arguments != null && arguments.Any()),
                     It.IsNotNull<IRequestHandlers>(),
                     It.IsNotNull<ConnectionOptions>(),
@@ -43,7 +45,7 @@ namespace NuGet.Protocol.Plugins.Tests
             {
                 var discoveryResult = new PluginDiscoveryResult(
                     new PluginFile(
-                        pluginFilePath,
+                        PluginFilePath,
                         new Lazy<PluginFileState>(() => PluginFileState.Valid)));
 
                 Tuple<bool, PluginCreationResult> result = await pluginManager.TryGetSourceAgnosticPluginAsync(
@@ -56,11 +58,197 @@ namespace NuGet.Protocol.Plugins.Tests
                 Assert.True(wasSomethingCreated);
                 Assert.NotNull(creationResult);
 
-                Assert.Equal($"Problem starting the plugin '{pluginFilePath}'. {message}", creationResult.Message);
+                Assert.Equal($"Problem starting the plugin '{PluginFilePath}'. {message}", creationResult.Message);
                 Assert.Same(exception, creationResult.Exception);
             }
 
             pluginFactory.Verify();
+        }
+
+        [Fact]
+        public async Task TryGetSourceAgnosticPluginAsync_WhenSuccessfullyCreated_OperationClaimsAreCached()
+        {
+            var operationClaims = new[] { OperationClaim.Authentication };
+
+            using (var test = new PluginManagerTest(PluginFilePath, PluginFileState.Valid, operationClaims))
+            {
+                Assert.False(File.Exists(test.PluginCacheEntry.CacheFileName));
+
+                var discoveryResult = new PluginDiscoveryResult(
+                    new PluginFile(
+                        PluginFilePath,
+                        new Lazy<PluginFileState>(() => PluginFileState.Valid)));
+
+                Tuple<bool, PluginCreationResult> result = await test.PluginManager.TryGetSourceAgnosticPluginAsync(
+                    discoveryResult,
+                    OperationClaim.Authentication,
+                    CancellationToken.None);
+                bool wasSomethingCreated = result.Item1;
+                PluginCreationResult creationResult = result.Item2;
+
+                Assert.True(wasSomethingCreated);
+                Assert.NotNull(creationResult);
+
+                Assert.True(File.Exists(test.PluginCacheEntry.CacheFileName));
+
+                Assert.Null(creationResult.Message);
+                Assert.Null(creationResult.Exception);
+                Assert.Same(test.Plugin, creationResult.Plugin);
+                Assert.NotNull(creationResult.PluginMulticlientUtilities);
+                Assert.Equal(operationClaims, creationResult.Claims);
+            }
+        }
+
+        [Fact]
+        public async Task TryGetSourceAgnosticPluginAsync_WhenCacheFileIndicatesIndicatesNoSupportedOperationClaims_PluginIsCreated()
+        {
+            var operationClaims = Array.Empty<OperationClaim>();
+
+            using (var test = new PluginManagerTest(PluginFilePath, PluginFileState.Valid, operationClaims))
+            {
+                test.PluginCacheEntry.OperationClaims = operationClaims;
+
+                await test.PluginCacheEntry.UpdateCacheFileAsync();
+
+                Assert.True(File.Exists(test.PluginCacheEntry.CacheFileName));
+
+                var discoveryResult = new PluginDiscoveryResult(
+                    new PluginFile(
+                        PluginFilePath,
+                        new Lazy<PluginFileState>(() => PluginFileState.Valid)));
+
+                Tuple<bool, PluginCreationResult> result = await test.PluginManager.TryGetSourceAgnosticPluginAsync(
+                    discoveryResult,
+                    OperationClaim.Authentication,
+                    CancellationToken.None);
+                bool wasSomethingCreated = result.Item1;
+                PluginCreationResult creationResult = result.Item2;
+
+                Assert.True(wasSomethingCreated);
+                Assert.NotNull(creationResult);
+
+                Assert.True(File.Exists(test.PluginCacheEntry.CacheFileName));
+
+                Assert.Null(creationResult.Message);
+                Assert.Null(creationResult.Exception);
+                Assert.Same(test.Plugin, creationResult.Plugin);
+                Assert.NotNull(creationResult.PluginMulticlientUtilities);
+                Assert.Equal(operationClaims, creationResult.Claims);
+            }
+        }
+
+        private sealed class PluginManagerTest : IDisposable
+        {
+            private readonly Mock<IConnection> _connection;
+            private readonly Mock<IPluginFactory> _factory;
+            private readonly Mock<IPlugin> _plugin;
+            private readonly Mock<IPluginDiscoverer> _pluginDiscoverer;
+            private readonly Mock<IEnvironmentVariableReader> _reader;
+            private readonly string _pluginFilePath;
+            private readonly TestDirectory _testDirectory;
+
+            internal IPlugin Plugin { get; }
+            internal PluginCacheEntry PluginCacheEntry { get; }
+            internal PluginManager PluginManager { get; }
+
+            internal PluginManagerTest(
+                string pluginFilePath,
+                PluginFileState pluginFileState,
+                IReadOnlyList<OperationClaim> operationClaims)
+            {
+                _pluginFilePath = pluginFilePath;
+                _reader = new Mock<IEnvironmentVariableReader>(MockBehavior.Strict);
+                _testDirectory = TestDirectory.Create();
+
+                _reader.Setup(x => x.GetEnvironmentVariable(
+                        It.Is<string>(value => value == EnvironmentVariableConstants.PluginPaths)))
+                    .Returns(pluginFilePath);
+                _reader.Setup(x => x.GetEnvironmentVariable(
+                        It.Is<string>(value => value == EnvironmentVariableConstants.RequestTimeout)))
+                    .Returns("RequestTimeout");
+                _reader.Setup(x => x.GetEnvironmentVariable(
+                        It.Is<string>(value => value == EnvironmentVariableConstants.IdleTimeout)))
+                    .Returns("IdleTimeout");
+                _reader.Setup(x => x.GetEnvironmentVariable(
+                        It.Is<string>(value => value == EnvironmentVariableConstants.HandshakeTimeout)))
+                    .Returns("HandshakeTimeout");
+
+                _pluginDiscoverer = new Mock<IPluginDiscoverer>(MockBehavior.Strict);
+
+                _pluginDiscoverer.Setup(x => x.Dispose());
+                _pluginDiscoverer.Setup(x => x.DiscoverAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new[]
+                        {
+                            new PluginDiscoveryResult(new PluginFile(pluginFilePath, new Lazy<PluginFileState>(() => pluginFileState)))
+                        });
+
+                _connection = new Mock<IConnection>(MockBehavior.Strict);
+
+                _connection.Setup(x => x.Dispose());
+                _connection.SetupGet(x => x.Options)
+                    .Returns(ConnectionOptions.CreateDefault());
+
+                _connection.SetupGet(x => x.ProtocolVersion)
+                    .Returns(ProtocolConstants.CurrentVersion);
+
+                _connection.Setup(x => x.SendRequestAndReceiveResponseAsync<MonitorNuGetProcessExitRequest, MonitorNuGetProcessExitResponse>(
+                        It.Is<MessageMethod>(m => m == MessageMethod.MonitorNuGetProcessExit),
+                        It.IsNotNull<MonitorNuGetProcessExitRequest>(),
+                        It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new MonitorNuGetProcessExitResponse(MessageResponseCode.Success));
+
+                _connection.Setup(x => x.SendRequestAndReceiveResponseAsync<InitializeRequest, InitializeResponse>(
+                        It.Is<MessageMethod>(m => m == MessageMethod.Initialize),
+                        It.IsNotNull<InitializeRequest>(),
+                        It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new InitializeResponse(MessageResponseCode.Success));
+
+                _connection.Setup(x => x.SendRequestAndReceiveResponseAsync<GetOperationClaimsRequest, GetOperationClaimsResponse>(
+                        It.Is<MessageMethod>(m => m == MessageMethod.GetOperationClaims),
+                        It.Is<GetOperationClaimsRequest>(g => g.PackageSourceRepository == null),
+                        It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new GetOperationClaimsResponse(operationClaims));
+
+                _plugin = new Mock<IPlugin>(MockBehavior.Strict);
+
+                _plugin.Setup(x => x.Dispose());
+                _plugin.SetupGet(x => x.Connection)
+                    .Returns(_connection.Object);
+                _plugin.SetupGet(x => x.Id)
+                    .Returns("id");
+
+                _factory = new Mock<IPluginFactory>(MockBehavior.Strict);
+
+                _factory.Setup(x => x.Dispose());
+                _factory.Setup(x => x.GetOrCreateAsync(
+                        It.Is<string>(p => p == pluginFilePath),
+                        It.IsNotNull<IEnumerable<string>>(),
+                        It.IsNotNull<IRequestHandlers>(),
+                        It.IsNotNull<ConnectionOptions>(),
+                        It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(_plugin.Object);
+
+                PluginManager = new PluginManager(
+                    _reader.Object,
+                    new Lazy<IPluginDiscoverer>(() => _pluginDiscoverer.Object),
+                    (TimeSpan idleTimeout) => _factory.Object,
+                    new Lazy<string>(() => _testDirectory.Path));
+
+                PluginCacheEntry = new PluginCacheEntry(_testDirectory.Path, pluginFilePath, requestKey: "Source-Agnostic");
+                Plugin = _plugin.Object;
+            }
+
+            public void Dispose()
+            {
+                PluginManager.Dispose();
+                _testDirectory.Dispose();
+
+                _reader.Verify();
+                _pluginDiscoverer.Verify();
+                _connection.Verify();
+                _plugin.Verify();
+                _factory.Verify();
+            }
         }
     }
 }


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/8198.

[`PluginManager`](https://github.com/NuGet/NuGet.Client/blob/f8ad810920d2ca83c9245f07d9d8753b6eba9c92/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs#L199) uses [`ConcurrencyUtilities.ExecuteWithFileLockedAsync(…)`](https://github.com/NuGet/NuGet.Client/blob/f8ad810920d2ca83c9245f07d9d8753b6eba9c92/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs#L20) for synchronized creation of a plugin cache file.

There are several issues with `ConcurrencyUtilities`, which can result in higher than necessary CPU and disk usage.  Briefly, each invocation of `ConcurrencyUtilities.ExecuteWithFileLockedAsync(…)` consumes CPU and disk resources by trying to obtain a file lock, failing with an exception, and then trying again 10 milliseconds later.

The issue here is that the code that `ConcurrencyUtilities.ExecuteWithFileLockedAsync(…)` synchronizes is too coarse grained.  Although this method is asynchronous, each invocation preoccupies a thread pool thread and there are many invocations that queue up from a large restore operation.  The thread pool does create new threads periodically, but not nearly fast enough to keep up with the burst of tasks from a restore operation that reproduces this issue.  When NuGet and a plugin try handshaking under these stressed conditions, NuGet receives a handshake request from a plugin, enqueues a response handler via `Task.Run(…)`, but the task does not execute within a reasonable amount time.  The thread pool is busy with the CPU- and I/O-churning calls to `ConcurrencyUtilities.ExecuteWithFileLockedAsync(…)` .