### PR TITLE
Improve performance of global.json reader in NuGetSdkResolver

### DIFF
--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Build.NuGetSdkResolver
     {
         public const string GlobalJsonFileName = "global.json";
 
-        private static readonly Regex MsBuildSdksSectionRegex = new Regex("\\\"msbuild-sdks\\\"\\s*:\\s*\\{(?<Packages>[^}]+)\\}");
+        private static readonly Regex MsBuildSdksSectionRegex = new Regex("\\\"msbuild-sdks\\\"\\s*:\\s*\\{(?<Packages>[^}]+)\\}", RegexOptions.None, TimeSpan.FromSeconds(1));
 
-        private static readonly Regex MsBuildSdksContentsRegex = new Regex("\\\"(?<Id>[^\\\"]+)\\\"\\s*:\\s*\\\"(?<Version>[^\\\"]+)\\\"");
+        private static readonly Regex MsBuildSdksContentsRegex = new Regex("\\\"(?<Id>[^\\\"]+)\\\"\\s*:\\s*\\\"(?<Version>[^\\\"]+)\\\"", RegexOptions.None, TimeSpan.FromSeconds(1));
 
         /// <summary>
         /// Walks up the directory tree to find the first global.json and reads the msbuild-sdks section.
@@ -45,7 +45,7 @@ namespace Microsoft.Build.NuGetSdkResolver
 
             try
             {
-                Dictionary<string, string> packages = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                var packages = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                 var matches = MsBuildSdksContentsRegex.Matches(match.Groups["Packages"].Value);
                 for (int i = 0; i < matches.Count; i++)
                 {

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
@@ -19,9 +19,7 @@ namespace Microsoft.Build.NuGetSdkResolver
 {
     /// <summary>
     /// Represents a NuGet-based SDK resolver.  It is very important that this class does not reference any NuGet assemblies
-    /// directly as an optimization to avoid loading them unless they are needed.  The current implementation only loads
-    /// Newtonsoft.Json if a global.json is found and it contains the msbuild-sdks section and a few NuGet assemblies to parse
-    /// a version.  The remaining NuGet assemblies are then loaded to do a restore.
+    /// directly as an optimization to avoid loading them unless they are needed.
     /// </summary>
     public sealed class NuGetSdkResolver : SdkResolver
     {

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/GlobalJsonReader_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/GlobalJsonReader_Tests.cs
@@ -53,33 +53,6 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         }
 
         [Fact]
-        public void InvalidJsonLogsMessage()
-        {
-            var expectedVersions = new Dictionary<string, string>
-            {
-                {"foo", "1.0.0"},
-                {"bar", "2.0.0"}
-            };
-
-            using (var testEnvironment = TestEnvironment.Create())
-            {
-                var testFolder = testEnvironment.CreateFolder();
-                var projectFile = testEnvironment.CreateFile(testFolder, ".proj");
-
-
-                var globalJsonPath = WriteGlobalJson(testFolder.FolderPath, expectedVersions, additionalcontent: ", abc");
-
-                var context = new MockSdkResolverContext(projectFile.Path);
-
-                GlobalJsonReader.GetMSBuildSdkVersions(context).Should().BeNull();
-
-                context.MockSdkLogger.LoggedMessages.Count.Should().Be(1);
-                context.MockSdkLogger.LoggedMessages.First().Key.Should().Be(
-                    $"Failed to parse \"{globalJsonPath}\". Invalid JavaScript property identifier character: }}. Path \'msbuild-sdks\', line 6, position 5.");
-            }
-        }
-
-        [Fact]
         public void SdkVersionsAreSuccessfullyLoaded()
         {
             var expectedVersions = new Dictionary<string, string>


### PR DESCRIPTION
## Bug
Addresses part of https://github.com/microsoft/msbuild/issues/4025 and https://github.com/NuGet/Home/issues/8157

## Fix

Details: Use Regex instead of JSON parser to reduce JIT time and overall performance.  This will make make some parser errors since it now only works if everything is formatted correctly.  But the performance increase is worth it.

## Testing/Validation

Tests Added: Yes
