### PR TITLE
Package Manager Console:  remove UI delay reading DefaultProject

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/NuGet.Console.csproj
+++ b/src/NuGet.Clients/NuGet.Console/NuGet.Console.csproj
@@ -61,6 +61,7 @@
     <Compile Include="SimpleExpansion.cs" />
     <Compile Include="Token.cs" />
     <Compile Include="TokenType.cs" />
+    <Compile Include="Utils\CommandUiUtilities.cs" />
     <Compile Include="Xamls\ConsoleContainer.xaml.cs">
       <DependentUpon>ConsoleContainer.xaml</DependentUpon>
     </Compile>

--- a/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
+++ b/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
@@ -6,18 +6,15 @@ using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Input;
-using System.Windows.Threading;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Threading;
 using NuGet.PackageManagement;
@@ -37,6 +34,7 @@ namespace NuGetConsole.Implementation
     {
         private JoinableTask _loadTask;
         private const string F1KeywordValuePmc = "VS.NuGet.PackageManager.Console";
+
         /// <summary>
         /// Get VS IComponentModel service.
         /// </summary>
@@ -161,7 +159,7 @@ namespace NuGetConsole.Implementation
                 windowFrame.SetGuidProperty((int)__VSFPROPID.VSFPROPID_InheritKeyBindings, ref cmdUi);
             });
 
-            // start a task when VS is idle and dont await it immediately
+            // start a task when VS is idle and don't await it immediately
             _loadTask = NuGetUIThreadHelper.JoinableTaskFactory.StartOnIdle(
                 async () =>
                 {

--- a/src/NuGet.Clients/NuGet.Console/Utils/CommandUiUtilities.cs
+++ b/src/NuGet.Clients/NuGet.Console/Utils/CommandUiUtilities.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Shell.Interop;
+using NuGet.VisualStudio;
+using NuGetConsole.Implementation;
+
+namespace NuGetConsole
+{
+    public static class CommandUiUtilities
+    {
+        private static readonly Lazy<IVsInvalidateCachedCommandState> CommandStateCacheInvalidator;
+
+        static CommandUiUtilities()
+        {
+            CommandStateCacheInvalidator = new Lazy<IVsInvalidateCachedCommandState>(
+                () => ServiceLocator.GetGlobalServiceFreeThreaded<SVsInvalidateCachedCommandState, IVsInvalidateCachedCommandState>());
+        }
+
+        public static void InvalidateDefaultProject()
+        {
+            var command = new VSCommandId()
+            {
+                CommandSet = GuidList.guidNuGetCmdSet,
+                CommandId = PkgCmdIDList.cmdidProjects
+            };
+
+            CommandStateCacheInvalidator.Value.InvalidateSpecificCommandUIState(command);
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
@@ -1,4 +1,4 @@
-﻿# assemblies not to be included in VSIX
+# assemblies not to be included in VSIX
 
 ICSharpCode.SharpZipLib.dll
 Microsoft.ApplicationInsights.dll
@@ -78,6 +78,7 @@ Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.dll
 Microsoft.VisualStudio.Services.TestResults.WebApi.dll
 Microsoft.VisualStudio.Services.WebApi.dll
 Microsoft.VisualStudio.Services.WebApi.resources.dll
+Microsoft.VisualStudio.Shell.Interop.16.0.DesignTime.dll
 Microsoft.VisualStudio.Workspace.dll
 Microsoft.VisualStudio.Workspace.Extensions.dll
 Microsoft.VisualStudio.Workspace.Extensions.VS.dll

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.legacy.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.common.props')" />
@@ -284,9 +284,6 @@
   </ItemGroup>
   <ItemGroup>
     <VsixIgnoreFile Include=".vsixignore" />
-    <None Include="source.extension.vsixmanifest">
-      <SubType>Designer</SubType>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Lucene.Net">

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.15.0" Version="15.0.25123-Dev15Preview">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.16.0.DesignTime" Version="16.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="15.0.691-master31907920" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(VSComponentsVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Logic" Version="$(VSComponentsVersion)" />

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
@@ -108,6 +108,22 @@ namespace NuGet.VisualStudio
             return Package.GetGlobalService(typeof(TService)) as TInterface;
         }
 
+        public static TInterface GetGlobalServiceFreeThreaded<TService, TInterface>() where TInterface : class
+        {
+            if (PackageServiceProvider != null)
+            {
+                var result = PackageServiceProvider.GetService(typeof(TService));
+                var service = result as TInterface;
+
+                if (service != null)
+                {
+                    return service;
+                }
+            }
+
+            return Package.GetGlobalService(typeof(TService)) as TInterface;
+        }
+
         private static async Task<TService> GetDTEServiceAsync<TService>() where TService : class
         {
             var dte = await GetGlobalServiceAsync<SDTE, DTE>();

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Task = System.Threading.Tasks.Task;
 using VsServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
 namespace NuGet.VisualStudio
@@ -95,20 +96,10 @@ namespace NuGet.VisualStudio
             // and so this method can RPC into main thread. Switch to main thread explictly, since method has STA requirement
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            if (PackageServiceProvider != null)
-            {
-                var result = PackageServiceProvider.GetService(typeof(TService));
-                TInterface service = result as TInterface;
-                if (service != null)
-                {
-                    return service;
-                }
-            }
-
-            return Package.GetGlobalService(typeof(TService)) as TInterface;
+            return await GetGlobalServiceFreeThreadedAsync<TService, TInterface>();
         }
 
-        public static TInterface GetGlobalServiceFreeThreaded<TService, TInterface>() where TInterface : class
+        public static Task<TInterface> GetGlobalServiceFreeThreadedAsync<TService, TInterface>() where TInterface : class
         {
             if (PackageServiceProvider != null)
             {
@@ -117,11 +108,11 @@ namespace NuGet.VisualStudio
 
                 if (service != null)
                 {
-                    return service;
+                    return Task.FromResult(service);
                 }
             }
 
-            return Package.GetGlobalService(typeof(TService)) as TInterface;
+            return Task.FromResult(Package.GetGlobalService(typeof(TService)) as TInterface);
         }
 
         private static async Task<TService> GetDTEServiceAsync<TService>() where TService : class

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.VisualStudio.Telemetry
+{
+    public static class TelemetryUtility
+    {
+        public static string CreateFileAndForgetEventName(string typeName, string memberName)
+        {
+            if (string.IsNullOrEmpty(typeName))
+            {
+                throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(typeName));
+            }
+
+            if (string.IsNullOrEmpty(memberName))
+            {
+                throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(memberName));
+            }
+
+            return $"{VSTelemetrySession.VSEventNamePrefix}{typeName}/{memberName}";
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -325,7 +325,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
                                 DefaultProject = null;
 
-                                CommandUiUtilities.InvalidateDefaultProject();
+                                NuGetUIThreadHelper.JoinableTaskFactory.Run(CommandUiUtilities.InvalidateDefaultProjectAsync);
                             };
                         }
                         _solutionManager.Value.NuGetProjectAdded += (o, e) => UpdateWorkingDirectoryAndAvailableProjects();
@@ -745,7 +745,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                     {
                         DefaultProject = newValue;
 
-                        CommandUiUtilities.InvalidateDefaultProject();
+                        await CommandUiUtilities.InvalidateDefaultProjectAsync();
                     }
                 })
                 .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(PowerShellHost), nameof(StartAsyncDefaultProjectUpdate)));

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -719,6 +719,8 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
+                    await TaskScheduler.Default;
+
                     NuGetProject project = await _solutionManager.Value.GetDefaultNuGetProjectAsync();
 
                     var oldValue = DefaultProject;

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/TelemetryUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/TelemetryUtilityTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.VisualStudio.Telemetry;
+using Xunit;
+
+namespace NuGet.VisualStudio.Common.Test
+{
+    public class TelemetryUtilityTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void CreateFileAndForgetEventName_WhenTypeNameIsNullOrEmpty_Throws(string typeName)
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(() => TelemetryUtility.CreateFileAndForgetEventName(typeName, "memberName"));
+
+            Assert.Equal("typeName", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void CreateFileAndForgetEventName_WhenMemberNameIsNullOrEmpty_Throws(string memberName)
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(() => TelemetryUtility.CreateFileAndForgetEventName("typeName", memberName));
+
+            Assert.Equal("memberName", exception.ParamName);
+        }
+
+        [Fact]
+        public void CreateFileAndForgetEventName_WhenArgumentsAreValid_ReturnsString()
+        {
+            string actualResult = TelemetryUtility.CreateFileAndForgetEventName("a", "b");
+
+            Assert.Equal("VS/NuGet/a/b", actualResult);
+        }
+    }
+}


### PR DESCRIPTION
Fix internal bug 634844.
Fix https://github.com/NuGet/Home/issues/8235.

VS calls into NuGet to get the current value to display in Package Manager Console's "Default project" combobox.

Before this change, the call could incur UI delays because getting the current default project required that NuGet build its project cache.

After this change, the call merely reads a cached value for the default project.  The cached value is asynchronously invalidated and updated with solution and project events.  Finally, NuGet tells VS to invalidate the "Default project" combobox, which causes VS to requery the (new) cached value at VS's earliest convenience.  This means that the "Default project" combobox selected value is immediately blank (null) and updated lazily.