### PR TITLE
NuGet.CommandLine: improve xbuild detection

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -447,15 +447,15 @@ namespace NuGet.CommandLine
 
         public static IEnumerable<string> GetAllProjectFileNames(
             string solutionFile,
-            string msbuildPath)
+            string pathToMsbuildDir)
         {
             if (RuntimeEnvironmentHelper.IsMono &&
-                (msbuildPath.Contains("xbuild") || GetMsbuild(msbuildPath).Contains("xbuild")))
+                (pathToMsbuildDir.Contains("xbuild") || GetMsbuild(pathToMsbuildDir).Contains("xbuild")))
             {
                 return GetAllProjectFileNamesWithXBuild(solutionFile);
             }
 
-            return GetAllProjectFileNamesWithMsBuild(solutionFile, msbuildPath);
+            return GetAllProjectFileNamesWithMsBuild(solutionFile, pathToMsbuildDir);
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -449,7 +449,8 @@ namespace NuGet.CommandLine
             string solutionFile,
             string msbuildPath)
         {
-            if (RuntimeEnvironmentHelper.IsMono && msbuildPath.Contains("xbuild"))
+            if (RuntimeEnvironmentHelper.IsMono &&
+                (msbuildPath.Contains("xbuild") || GetMsbuild(msbuildPath).Contains("xbuild")))
             {
                 return GetAllProjectFileNamesWithXBuild(solutionFile);
             }


### PR DESCRIPTION


## Bug

Fixes: https://github.com/NuGet/Home/issues/7202
Regression: Not sure
* Last working version:   Not sure
* How are we preventing it in future: The real issue here is using strings to keep track of paths, which I'll try to fix in a PR soon (by using DirectoryInfo and FileInfo objects instead of primitive string objects, directory paths can't be confused with file paths).

## Fix

Details: Just look for "xbuild" string inside the msbuild binary's path too, not only the msbuild directory path.

## Testing/Validation

Tests Added: No
Reason for not adding tests:  I don't think any mono/xbuild behaviours are covered by tests right now.
Validation:  ?
