### PR TITLE
move comment in solution file to avoid msbuild bug that prevented dotnet list package from working on nuget.sln

### DIFF
--- a/NuGet.sln
+++ b/NuGet.sln
@@ -169,10 +169,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.VisualStudio.Interop", "src\NuGet.Clients\NuGet.VisualStudio.Interop\NuGet.VisualStudio.Interop.csproj", "{7DB43FE1-75E1-49F9-B2C8-06A552BA2144}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGetConsole.Host.PowerShell", "src\NuGet.Clients\NuGetConsole.Host.PowerShell\NuGetConsole.Host.PowerShell.csproj", "{5A79EEF3-51C0-4A14-8D37-50EF38AD835D}"
-	ProjectSection(ProjectDependencies) = postProject
-		# Make NuGetConsole.Host.PowerShell depend on NuGet.PackageManagement.PowerShellCmdlets.  This is so NuGetConsole.Host.PowerShell's build can update NuGet.psd1 based on the strong name of NuGet.PackageManagement.PowerShellCmdlets.dll
-		{26DC17AC-A390-4515-A2C0-07A0950036C5} = {26DC17AC-A390-4515-A2C0-07A0950036C5}
-	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Console", "src\NuGet.Clients\NuGet.Console\NuGet.Console.csproj", "{50E33DA2-AF14-486D-81B8-BD8409744A38}"
 EndProject

--- a/NuGet.sln
+++ b/NuGet.sln
@@ -169,7 +169,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.VisualStudio.Interop", "src\NuGet.Clients\NuGet.VisualStudio.Interop\NuGet.VisualStudio.Interop.csproj", "{7DB43FE1-75E1-49F9-B2C8-06A552BA2144}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGetConsole.Host.PowerShell", "src\NuGet.Clients\NuGetConsole.Host.PowerShell\NuGetConsole.Host.PowerShell.csproj", "{5A79EEF3-51C0-4A14-8D37-50EF38AD835D}"
-EndProject
+	ProjectSection(ProjectDependencies) = postProject
+		{26DC17AC-A390-4515-A2C0-07A0950036C5} = {26DC17AC-A390-4515-A2C0-07A0950036C5}
+	EndProjectSectionEndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Console", "src\NuGet.Clients\NuGet.Console\NuGet.Console.csproj", "{50E33DA2-AF14-486D-81B8-BD8409744A38}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.CommandLine.FuncTest", "test\NuGet.Clients.FuncTests\NuGet.CommandLine.FuncTest\NuGet.CommandLine.FuncTest.csproj", "{23725516-0A6E-48F9-A148-B5E3FA515B13}"

--- a/NuGet.sln
+++ b/NuGet.sln
@@ -171,7 +171,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGetConsole.Host.PowerShell", "src\NuGet.Clients\NuGetConsole.Host.PowerShell\NuGetConsole.Host.PowerShell.csproj", "{5A79EEF3-51C0-4A14-8D37-50EF38AD835D}"
 	ProjectSection(ProjectDependencies) = postProject
 		{26DC17AC-A390-4515-A2C0-07A0950036C5} = {26DC17AC-A390-4515-A2C0-07A0950036C5}
-	EndProjectSectionEndProject
+	EndProjectSection
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Console", "src\NuGet.Clients\NuGet.Console\NuGet.Console.csproj", "{50E33DA2-AF14-486D-81B8-BD8409744A38}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.CommandLine.FuncTest", "test\NuGet.Clients.FuncTests\NuGet.CommandLine.FuncTest\NuGet.CommandLine.FuncTest.csproj", "{23725516-0A6E-48F9-A148-B5E3FA515B13}"

--- a/NuGet.sln
+++ b/NuGet.sln
@@ -169,6 +169,7 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.VisualStudio.Interop", "src\NuGet.Clients\NuGet.VisualStudio.Interop\NuGet.VisualStudio.Interop.csproj", "{7DB43FE1-75E1-49F9-B2C8-06A552BA2144}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGetConsole.Host.PowerShell", "src\NuGet.Clients\NuGetConsole.Host.PowerShell\NuGetConsole.Host.PowerShell.csproj", "{5A79EEF3-51C0-4A14-8D37-50EF38AD835D}"
+	# Make NuGetConsole.Host.PowerShell depend on NuGet.PackageManagement.PowerShellCmdlets.  This is so NuGetConsole.Host.PowerShell's build can update NuGet.psd1 based on the strong name of NuGet.PackageManagement.PowerShellCmdlets.dll
 	ProjectSection(ProjectDependencies) = postProject
 		{26DC17AC-A390-4515-A2C0-07A0950036C5} = {26DC17AC-A390-4515-A2C0-07A0950036C5}
 	EndProjectSection

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -143,6 +143,15 @@ phases:
       msbuildArguments: "/t:BuildNoVSIX /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
 
   - task: MSBuild@1
+    displayName: "Ensure msbuild.exe can parse nuget.sln"
+    continueOnError: "false"
+    inputs:
+      solution: "nuget.sln"
+      msbuildVersion: "16.0"
+      msbuildArguments: "/t:EnsureNewtonsoftJsonVersion"
+    condition: "succeeded()"
+
+  - task: MSBuild@1
     displayName: "Run unit tests"
     continueOnError: "true"
     inputs:

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
@@ -133,12 +133,6 @@
       <Project>{eea49a74-6efc-410e-9745-bad367ac151d}</Project>
       <Name>NuGet.VisualStudio.Common</Name>
     </ProjectReference>
-    <ProjectReference Include="..\NuGet.PackageManagement.PowerShellCmdlets\NuGet.PackageManagement.PowerShellCmdlets.csproj">
-      <Project>{26dc17ac-a390-4515-a2c0-07a0950036c5}</Project>
-      <Name>NuGet.PackageManagement.PowerShellCmdlets</Name>
-      <!-- This project should wait until PowerShellCmdlets is built before building, so NuGet.psd1 can refer to strong name -->
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/NuGetConsole.Host.PowerShell.csproj
@@ -133,6 +133,12 @@
       <Project>{eea49a74-6efc-410e-9745-bad367ac151d}</Project>
       <Name>NuGet.VisualStudio.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.PackageManagement.PowerShellCmdlets\NuGet.PackageManagement.PowerShellCmdlets.csproj">
+      <Project>{26dc17ac-a390-4515-a2c0-07a0950036c5}</Project>
+      <Name>NuGet.PackageManagement.PowerShellCmdlets</Name>
+      <!-- This project should wait until PowerShellCmdlets is built before building, so NuGet.psd1 can refer to strong name -->
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersionCore)" NoWarn="NU1605" />


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8239 - `dotnet list package` and `msbuild /t:<any target>` fails to run on nuget.sln
Regression: Yes
* Last working version:   **5.1**
* How are we preventing it in future:   **added test to confirm that nuget.sln can be parsed by msbuild**

## Fix

Details:
- Moved comment outside of ProjectSection, so msbuild doesn't fail to parse solution file.
    (will file msbuild bug, but tested in 15.9 and it had same behavior.)

## Testing/Validation

Tests Added: Yes
Validation:  
- ran dotnet list nuget.sln package
- ran msbuild /t:restore nuget.sln