### PR TITLE
Adds `<icon />` support to .nuspec schema

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
@@ -571,6 +571,15 @@ namespace NuGet.Packaging
             return NuspecUtility.GetFrameworkReferenceGroups(MetadataNode, _frameworkProvider, useMetadataNamespace : true);
         }
 
+        /// <summary>
+        /// Gets the icon metadata from the .nuspec
+        /// </summary>
+        /// <returns>A string containing the icon path or string.Empty if no icon entry is found</returns>
+        public string GetIcon()
+        {
+            return GetMetadataValue("icon");
+        }
+
         private static bool? AttributeAsNullableBool(XElement element, string attributeName)
         {
             bool? result = null;

--- a/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd
+++ b/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd
@@ -156,7 +156,13 @@
                           <xs:element name="icon" maxOccurs="1" minOccurs="0">
                             <xs:complexType>
                             <xs:simpleContent>
-                              <xs:attribute name="type" use="required" type="xs:string" />
+                              <xs:attribute name="type" use="required" type="xs:string">
+                                <xs:simpleType>
+                                  <xs:restriction base="xsd:string">
+                                    <xs:enumeration value="file" />
+                                  </xs:restriction>
+                                </xs:simpleType>
+                              </xs:attribute>
                             </xs:simpleContent>
                             </xs:complexType>
                           </xs:element>

--- a/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd
+++ b/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd
@@ -75,6 +75,7 @@
                             <xs:element name="language" maxOccurs="1" minOccurs="0" type="xs:string" default="en-US" />
                             <xs:element name="tags" maxOccurs="1" minOccurs="0" type="xs:string" />
                             <xs:element name="serviceable" maxOccurs="1" minOccurs="0" type="xs:boolean" />
+                            <xs:element name="icon" maxOccurs="1" minOccurs="0" type="xs:string" />
                             <xs:element name="repository" maxOccurs="1" minOccurs="0">
                               <xs:complexType>
                                 <xs:attribute name="type" type="xs:string" use="optional" />
@@ -153,7 +154,6 @@
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
-                          <xs:element name="icon" maxOccurs="1" minOccurs="0" type="xs:string" />
                         </xs:all>
                         <xs:attribute name="minClientVersion" use="optional" type="xs:string" />
                     </xs:complexType>

--- a/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd
+++ b/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd
@@ -153,19 +153,7 @@
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
-                          <xs:element name="icon" maxOccurs="1" minOccurs="0">
-                            <xs:complexType>
-                            <xs:simpleContent>
-                              <xs:attribute name="type" use="required" type="xs:string">
-                                <xs:simpleType>
-                                  <xs:restriction base="xsd:string">
-                                    <xs:enumeration value="file" />
-                                  </xs:restriction>
-                                </xs:simpleType>
-                              </xs:attribute>
-                            </xs:simpleContent>
-                            </xs:complexType>
-                          </xs:element>
+                          <xs:element name="icon" maxOccurs="1" minOccurs="0" type="xs:string" />
                         </xs:all>
                         <xs:attribute name="minClientVersion" use="optional" type="xs:string" />
                     </xs:complexType>

--- a/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd
+++ b/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd
@@ -153,6 +153,13 @@
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
+                          <xs:element name="icon" maxOccurs="1" minOccurs="0">
+                            <xs:complexType>
+                            <xs:simpleContent>
+                              <xs:attribute name="type" use="required" type="xs:string" />
+                            </xs:simpleContent>
+                            </xs:complexType>
+                          </xs:element>
                         </xs:all>
                         <xs:attribute name="minClientVersion" use="optional" type="xs:string" />
                     </xs:complexType>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuspecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuspecReaderTests.cs
@@ -471,7 +471,7 @@ namespace NuGet.Packaging.Test
                   </metadata>
                 </package>";
 
-        private const string IconSimple = @"<?xml version=""1.0""?>
+        private const string EmbeddedIconTestTemplate = @"<?xml version=""1.0""?>
                 <package xmlns=""http://schemas.microsoft.com/packaging/2016/06/nuspec.xsd"">
                   <metadata>
                     <id>trumpet</id>
@@ -480,20 +480,7 @@ namespace NuGet.Packaging.Test
                     <authors>alice, bob</authors>
                     <owners>alice, bob</owners>
                     <description>This is a package icon test</description>
-                    <icon>icon.jpg</icon>
-                  </metadata>
-                </package>";
-
-        private const string IconEmpty = @"<?xml version=""1.0""?>
-                <package xmlns=""http://schemas.microsoft.com/packaging/2016/06/nuspec.xsd"">
-                  <metadata>
-                    <id>trumpet</id>
-                    <version>0.0.1</version>
-                    <title>trumpet package</title>
-                    <authors>alice, bob</authors>
-                    <owners>alice, bob</owners>
-                    <description>This is a package icon test</description>
-                    <icon></icon>
+                    {0}
                   </metadata>
                 </package>";
 
@@ -1134,30 +1121,25 @@ namespace NuGet.Packaging.Test
             Assert.Null(licenseMetadata);
         }
 
-        [Fact]
-        public void NuspecReaderTests_IconSimple()
+        [Theory]
+        [InlineData("<icon>icon.jpg</icon>", "icon.jpg")]
+        [InlineData("<icon></icon>", "")]
+        [InlineData("<icon/>", "")]
+        [InlineData("", "")]
+        [InlineData("<icon>path/icon.jpg</icon>", "path/icon.jpg")]
+        [InlineData("<icon>content\\icon.jpg</icon>", "content\\icon.jpg")]
+        public void NuspecReaderTests_EmbeddedIcon(string icon, string expectedRead)
         {
+            string nuspec = string.Format(EmbeddedIconTestTemplate, icon);
+
             // Arrange
-            var reader = GetReader(IconSimple);
+            var reader = GetReader(nuspec);
 
             // Act
             var iconPath = reader.GetIcon();
 
             // Assert
-            Assert.NotNull(iconPath);
-        }
-
-        [Fact]
-        public void NuspecReaderTests_IconEmpty()
-        {
-            // Arrange
-            var reader = GetReader(IconEmpty);
-
-            // Act
-            var iconPath = reader.GetIcon();
-
-            // Assert
-            Assert.Equal(iconPath, string.Empty);
+            Assert.Equal(iconPath, expectedRead);
         }
 
         private static NuspecReader GetReader(string nuspec)

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuspecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuspecReaderTests.cs
@@ -471,6 +471,32 @@ namespace NuGet.Packaging.Test
                   </metadata>
                 </package>";
 
+        private const string IconSimple = @"<?xml version=""1.0""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2016/06/nuspec.xsd"">
+                  <metadata>
+                    <id>trumpet</id>
+                    <version>0.0.1</version>
+                    <title>trumpet package</title>
+                    <authors>alice, bob</authors>
+                    <owners>alice, bob</owners>
+                    <description>This is a package icon test</description>
+                    <icon>icon.jpg</icon>
+                  </metadata>
+                </package>";
+
+        private const string IconEmpty = @"<?xml version=""1.0""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2016/06/nuspec.xsd"">
+                  <metadata>
+                    <id>trumpet</id>
+                    <version>0.0.1</version>
+                    <title>trumpet package</title>
+                    <authors>alice, bob</authors>
+                    <owners>alice, bob</owners>
+                    <description>This is a package icon test</description>
+                    <icon></icon>
+                  </metadata>
+                </package>";
+
         public static IEnumerable<object[]> GetValidVersions()
         {
             return GetVersionRange(validVersions: true);
@@ -1106,6 +1132,32 @@ namespace NuGet.Packaging.Test
 
             // Assert
             Assert.Null(licenseMetadata);
+        }
+
+        [Fact]
+        public void NuspecReaderTests_IconSimple()
+        {
+            // Arrange
+            var reader = GetReader(IconSimple);
+
+            // Act
+            var iconPath = reader.GetIcon();
+
+            // Assert
+            Assert.NotNull(iconPath);
+        }
+
+        [Fact]
+        public void NuspecReaderTests_IconEmpty()
+        {
+            // Arrange
+            var reader = GetReader(IconEmpty);
+
+            // Act
+            var iconPath = reader.GetIcon();
+
+            // Assert
+            Assert.Equal(iconPath, string.Empty);
         }
 
         private static NuspecReader GetReader(string nuspec)


### PR DESCRIPTION
## Bug

Fixes: https://github.com/nuget/home/issues/7991
Regression: No

## Fix

Adds a new XML entry to the .nuspec schema. Now, you can specify the icon file with `<icon/>`

## Testing/Validation

Tests Added: Yes. Two simple scenarios
Validation:  CI pipeline

**NOTE**: This will not be merged into `dev` until complete embedded icon functionality is ready.