### PR TITLE
Use async service provider in ServiceLocator

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -69,8 +69,6 @@ namespace NuGetVSExtension
         // It is displayed in the Help - About box of Visual Studio
         public const string ProductVersion = "5.2.0";
         private const string F1KeywordValuePmUI = "VS.NuGet.PackageManager.UI";
-        private static readonly object _credentialsPromptLock = new object();
-        private readonly HashSet<Uri> _credentialRequested = new HashSet<Uri>();
 
         private AsyncLazy<IVsMonitorSelection> _vsMonitorSelection;
         private IVsMonitorSelection VsMonitorSelection => ThreadHelper.JoinableTaskFactory.Run(_vsMonitorSelection.GetValueAsync);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
@@ -92,11 +92,6 @@ namespace NuGet.VisualStudio
             // and so this method can RPC into main thread. Switch to main thread explictly, since method has STA requirement
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            return await GetGlobalServiceFreeThreadedAsync<TService, TInterface>();
-        }
-
-        public static Task<TInterface> GetGlobalServiceFreeThreadedAsync<TService, TInterface>() where TInterface : class
-        {
             if (PackageServiceProvider != null)
             {
                 var result = await PackageServiceProvider.GetServiceAsync(typeof(TService));
@@ -106,11 +101,6 @@ namespace NuGet.VisualStudio
                     return service;
                 }
             }
-
-            // VS Threading Rule #1
-            // Access to ServiceProvider and a lot of casts are performed in this method,
-            // and so this method can RPC into main thread. Switch to main thread explictly, since method has STA requirement
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             return Package.GetGlobalService(typeof(TService)) as TInterface;
         }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
@@ -105,6 +105,22 @@ namespace NuGet.VisualStudio
             return Package.GetGlobalService(typeof(TService)) as TInterface;
         }
 
+        public static async Task<TInterface> GetGlobalServiceFreeThreadedAsync<TService, TInterface>() where TInterface : class
+        {
+            if (PackageServiceProvider != null)
+            {
+                var result = await PackageServiceProvider.GetServiceAsync(typeof(TService));
+                var service = result as TInterface;
+
+                if (service != null)
+                {
+                    return service;
+                }
+            }
+
+            return Package.GetGlobalService(typeof(TService)) as TInterface;
+        }
+
         private static async Task<TService> GetDTEServiceAsync<TService>() where TService : class
         {
             var dte = await GetGlobalServiceAsync<SDTE, DTE>();
@@ -113,7 +129,7 @@ namespace NuGet.VisualStudio
 
         private static async Task<TService> GetComponentModelServiceAsync<TService>() where TService : class
         {
-            IComponentModel componentModel = await GetGlobalServiceAsync<SComponentModel, IComponentModel>();
+            IComponentModel componentModel = await GetGlobalServiceFreeThreadedAsync<SComponentModel, IComponentModel>();
             return componentModel?.GetService<TService>();
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ServiceLocator.cs
@@ -107,6 +107,11 @@ namespace NuGet.VisualStudio
                 }
             }
 
+            // VS Threading Rule #1
+            // Access to ServiceProvider and a lot of casts are performed in this method,
+            // and so this method can RPC into main thread. Switch to main thread explictly, since method has STA requirement
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
             return Package.GetGlobalService(typeof(TService)) as TInterface;
         }
 


### PR DESCRIPTION
## Bug

Fixes: [899473](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/899473/)
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

From the issue: 

GetComponentModelServiceAsync which actually just switches to the UI thread and then calls GetService. This is REALLY bad for MEF which can be very expensive to initialize. NuGet needs to use the async service provider which is MUCH smarter about only switching if needed, ensuring packages that need to be loaded and can be loaded off the UI thread are, etc...

The NuGetPackage is already async and we use the IAsyncServiceProvider in some other related codepaths. 
https://github.com/NuGet/NuGet.Client/pull/2163 & https://github.com/NuGet/NuGet.Client/pull/2179

@dtivel This is the change that would conflict with the change in your PR. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Threading changes
Validation:  
