### PR TITLE
Conditional Newtonsoft.Json version from source-build RepoAPI

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -36,7 +36,8 @@
 
   <!-- Dependency versions -->
   <PropertyGroup>
-    <NewtonsoftJsonVersionCore>9.0.1</NewtonsoftJsonVersionCore>
+    <NewtonsoftJsonVersionCore Condition="$(NewtonsoftJsonPackageVersion) == ''">9.0.1</NewtonsoftJsonVersionCore>
+    <NewtonsoftJsonVersionCore Condition="$(NewtonsoftJsonPackageVersion) != ''">$(NewtonsoftJsonPackageVersion)</NewtonsoftJsonVersionCore>
     <XunitVersion>2.3.1</XunitVersion>
     <TestSDKVersion>15.5.0</TestSDKVersion>
     <MoqVersion>4.10.1</MoqVersion>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8249
Regression: No
* Last working version:   
* How are we preventing it in future: Adopt a convention on PackageVersion variables

## Fix

Details: Use `$(NewtonsoftJsonPackageVersion)` in case this variable is defined. Otherwise, use our default version 9.0.1

## Testing/Validation

Tests Added: No  
Reason for not adding tests: Build infrastructure
Validation: Manual validation with dotnet/source-build run
