### PR TITLE
Load default settings on VS load

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
@@ -75,7 +75,7 @@ namespace NuGet.PackageManagement.VisualStudio
             // In the open PM UI scenario (no restore run), there is an asynchronous invocation of this code path. This changes ensures that
             // the synchronous calls that come after the asynchrnous calls don't do duplicate work.
             // That however is not the case for solution close and  same session close -> open events. Those will be on the UI thread.
-            if (_solutionSettings == null || !string.Equals(root, _solutionSettings?.Item1))
+            if (_solutionSettings == null || !string.Equals(root, _solutionSettings.Item1))
             {
                 _solutionSettings = new Tuple<string, Lazy<ISettings>>(
                     item1: root,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
@@ -69,30 +69,28 @@ namespace NuGet.PackageManagement.VisualStudio
                 root = Path.Combine(SolutionManager.SolutionDirectory, NuGetSolutionSettingsFolder);
             }
 
-            try
+            // This is a performance optimization.
+            // The solution load/unload events are called in the UI thread and are used to reset the settings.
+            // In some cases there's a synchronous dependency between the invocation of the Solution event and the settings being reset.
+            // In the open PM UI scenario (no restore run), there is an asynchronous invocation of this code path. This changes ensures that
+            // the synchronous calls that come after the asynchrnous calls don't do duplicate work.
+            // That however is not the case for solution close and  same session close -> open events. Those will be on the UI thread.
+            if (_solutionSettings == null || !string.Equals(root, _solutionSettings?.Item1))
             {
-                // This is a performance optimization.
-                // The solution load/unload events are called in the UI thread and are used to reset the settings.
-                // In some cases there's a synchronous dependency between the invocation of the Solution event and the settings being reset.
-                // In the open PM UI scenario (no restore run), there is an asynchronous invocation of this code path. This changes ensures that
-                // the synchronous calls that come after the asynchrnous calls don't do duplicate work.
-                // That however is not the case for solution close and  same session close -> open events. Those will be on the UI thread.
-                if (!string.Equals(root, _solutionSettings?.Item1))
-                {
-                    _solutionSettings = new Tuple<string, Lazy<ISettings>>(
-                        item1: root,
-                        item2: new Lazy<ISettings>(() => Settings.LoadDefaultSettings(root, configFileName: null, machineWideSettings: MachineWideSettings)));
-                    return true;
-                }
-            }
-            catch (NuGetConfigurationException ex)
-            {
-                MessageHelper.ShowErrorMessage(ExceptionUtilities.DisplayMessage(ex), Strings.ConfigErrorDialogBoxTitle);
-            }
-
-            if (_solutionSettings == null)
-            {
-                _solutionSettings = new Tuple<string, Lazy<ISettings>>(null, new Lazy<ISettings>(() => NullSettings.Instance));
+                _solutionSettings = new Tuple<string, Lazy<ISettings>>(
+                    item1: root,
+                    item2: new Lazy<ISettings>(() =>
+                        {
+                            try
+                            {
+                                return Settings.LoadDefaultSettings(root, configFileName: null, machineWideSettings: MachineWideSettings);
+                            }
+                            catch (NuGetConfigurationException ex)
+                            {
+                                MessageHelper.ShowErrorMessage(ExceptionUtilities.DisplayMessage(ex), Strings.ConfigErrorDialogBoxTitle);
+                                return NullSettings.Instance;
+                            }
+                        }));
                 return true;
             }
 


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8231  
Regression: Yes
* Last working version:   NuGet 5.1/VS16.1
* How are we preventing it in future:   vendors test it

## Fix

Details: Change the initialised value on load to read the default settings, rather than a null settings provider.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  VS integration/singleton class
Validation:  
