### PR TITLE
Improve the internal msbuild discovery utility

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -192,7 +192,7 @@ namespace NuGet.CommandLine
         /// </summary>
         protected void SetDefaultCredentialProvider(Lazy<MsBuildToolset> msbuildDirectory)
         {
-            PluginDiscoveryUtility.InternalPluginDiscoveryRoot = new Lazy<string>(() => PluginDiscoveryUtility.GetInternalPluginRelativeToMSBuildExe(msbuildDirectory.Value.Path));
+            PluginDiscoveryUtility.InternalPluginDiscoveryRoot = new Lazy<string>(() => PluginDiscoveryUtility.GetInternalPluginRelativeToMSBuildDirectory(msbuildDirectory.Value.Path));
             CredentialService = new CredentialService(new AsyncLazy<IEnumerable<ICredentialProvider>>(() => GetCredentialProvidersAsync()), NonInteractive, handlesDefaultCredentials: PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders);
 
             CoreV2.NuGet.HttpClient.DefaultCredentialProvider = new CredentialServiceAdapter(CredentialService);

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -192,7 +192,7 @@ namespace NuGet.CommandLine
         /// </summary>
         protected void SetDefaultCredentialProvider(Lazy<MsBuildToolset> msbuildDirectory)
         {
-            Protocol.Plugins.PluginDiscoveryUtility.InternalPluginDiscoveryRoot = new Lazy<string>(() => Protocol.Plugins.PluginDiscoveryUtility.GetInternalPluginRelativeToMSBuildExe(msbuildDirectory.Value.Path));
+            PluginDiscoveryUtility.InternalPluginDiscoveryRoot = new Lazy<string>(() => PluginDiscoveryUtility.GetInternalPluginRelativeToMSBuildExe(msbuildDirectory.Value.Path));
             CredentialService = new CredentialService(new AsyncLazy<IEnumerable<ICredentialProvider>>(() => GetCredentialProvidersAsync()), NonInteractive, handlesDefaultCredentials: PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders);
 
             CoreV2.NuGet.HttpClient.DefaultCredentialProvider = new CredentialServiceAdapter(CredentialService);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
@@ -26,17 +26,17 @@ namespace NuGet.Protocol.Plugins
         }
 
         /// <summary>
-        /// Given Visual Studio 2017 MSBuild.exe path, return the NuGet plugins directory which is in CommonExtensions\NuGet\Plugins
+        /// Given Visual Studio 2017 or later MSBuild.exe directory path, return the NuGet plugins directory which is in CommonExtensions\NuGet\Plugins
         /// </summary>
-        /// <param name="msbuildExePath">The MsBuildExe path. Needs to be a valid path. file:// not supported.</param>
+        /// <param name="msbuildExePath">The MsBuildExe directory path. Needs to be a valid path. file:// not supported.</param>
         /// <returns>The NuGet plugins directory, null if <paramref name="msbuildExePath"/> is null</returns>
-        /// <remarks>The MSBuild.exe is in MSBuild\15.0\Bin\MsBuild.exe, the Plugins directory is in Common7\IDE\CommonExtensions\Microsoft\NuGet\Plugins</remarks>
+        /// <remarks>The MSBuild.exe is in MSBuild\Current\Bin, the Plugins directory is in Common7\IDE\CommonExtensions\Microsoft\NuGet\Plugins</remarks>
         public static string GetInternalPluginRelativeToMSBuildExe(string msbuildExePath)
         {
             var parentDirectory = "..";
             return !string.IsNullOrEmpty(msbuildExePath) ?
                 Path.GetFullPath(Path.Combine(
-                    Path.GetDirectoryName(msbuildExePath),
+                    msbuildExePath,
                     Path.Combine(parentDirectory, parentDirectory, parentDirectory, "Common7", "IDE", "CommonExtensions", "Microsoft", "NuGet", NuGetPluginsDirectory)
                     )) :
                 null;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
@@ -26,17 +26,17 @@ namespace NuGet.Protocol.Plugins
         }
 
         /// <summary>
-        /// Given Visual Studio 2017 or later MSBuild.exe directory path, return the NuGet plugins directory which is in CommonExtensions\NuGet\Plugins
+        /// Given Visual Studio 2017 or later MSBuild directory path, return the NuGet plugins directory which is in CommonExtensions\NuGet\Plugins
         /// </summary>
-        /// <param name="msbuildExePath">The MsBuildExe directory path. Needs to be a valid path. file:// not supported.</param>
-        /// <returns>The NuGet plugins directory, null if <paramref name="msbuildExePath"/> is null</returns>
+        /// <param name="msbuildDirectoryPath">The MsBuildExe directory path. Needs to be a valid path. file:// not supported.</param>
+        /// <returns>The NuGet plugins directory, null if <paramref name="msbuildDirectoryPath"/> is null</returns>
         /// <remarks>The MSBuild.exe is in MSBuild\Current\Bin, the Plugins directory is in Common7\IDE\CommonExtensions\Microsoft\NuGet\Plugins</remarks>
-        public static string GetInternalPluginRelativeToMSBuildExe(string msbuildExePath)
+        public static string GetInternalPluginRelativeToMSBuildDirectory(string msbuildDirectoryPath)
         {
             var parentDirectory = "..";
-            return !string.IsNullOrEmpty(msbuildExePath) ?
+            return !string.IsNullOrEmpty(msbuildDirectoryPath) ?
                 Path.GetFullPath(Path.Combine(
-                    msbuildExePath,
+                    msbuildDirectoryPath,
                     Path.Combine(parentDirectory, parentDirectory, parentDirectory, "Common7", "IDE", "CommonExtensions", "Microsoft", "NuGet", NuGetPluginsDirectory)
                     )) :
                 null;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
@@ -67,10 +67,10 @@ namespace NuGet.Protocol.Plugins.Tests
 
 #if IS_DESKTOP
         [Theory]
-        [InlineData(@"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe",
+        [InlineData(@"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\bin",
             @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\Plugins")]
-        [InlineData(@"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe",
-            @"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\Plugins")]
+        [InlineData(@"C:\Program Files (x86)\Microsoft Visual Studio\2019\IntPreview\MSBuild\Current\bin",
+            @"C:\Program Files (x86)\Microsoft Visual Studio\2019\IntPreview\Common7\IDE\CommonExtensions\Microsoft\NuGet\Plugins")]
         [InlineData(null, null)]
         public void PluginDiscoveryUtility_GetsNuGetPluginPathGivenMSBuildExeLocation(string given, string expected)
         {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
@@ -72,9 +72,9 @@ namespace NuGet.Protocol.Plugins.Tests
         [InlineData(@"C:\Program Files (x86)\Microsoft Visual Studio\2019\IntPreview\MSBuild\Current\bin",
             @"C:\Program Files (x86)\Microsoft Visual Studio\2019\IntPreview\Common7\IDE\CommonExtensions\Microsoft\NuGet\Plugins")]
         [InlineData(null, null)]
-        public void PluginDiscoveryUtility_GetsNuGetPluginPathGivenMSBuildExeLocation(string given, string expected)
+        public void PluginDiscoveryUtility_GetsNuGetPluginPathGivenMSBuildDirectory(string given, string expected)
         {
-            var result = PluginDiscoveryUtility.GetInternalPluginRelativeToMSBuildExe(given);
+            var result = PluginDiscoveryUtility.GetInternalPluginRelativeToMSBuildDirectory(given);
             Assert.Equal(expected, result);
         }
 #endif


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8269
Regression: Yes
* Last working version: Never worked properly
* How are we preventing it in future:   

## Fix

Details: 

The utility assumed the path was to msbuild.exe and not to the msbuild directory. 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
