### PR TITLE
Plugins:  improve error message when plugin start fails

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginProcess.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginProcess.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
+using System.Threading;
 
 namespace NuGet.Protocol.Plugins
 {
@@ -19,12 +19,17 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Occurs when a process exits.
         /// </summary>
-        event EventHandler Exited;
+        event EventHandler<IPluginProcess> Exited;
 
         /// <summary>
-        /// Gets a value indicating whether the associated process has been terminated.
+        /// Gets the exit code if the process has exited; otherwise, <c>null</c>.
         /// </summary>
-        bool HasExited { get; }
+        int? ExitCode { get; }
+
+        /// <summary>
+        /// Gets the process ID if the process was started; otherwise, <c>null</c>.
+        /// </summary>
+        int? Id { get; }
 
         /// <summary>
         /// Asynchronously starts reading the standard output stream.
@@ -37,7 +42,7 @@ namespace NuGet.Protocol.Plugins
         void CancelRead();
 
         /// <summary>
-        /// Immediately stops the associated process.
+        /// Stops the associated process.
         /// </summary>
         void Kill();
     }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Plugin.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Plugin.cs
@@ -157,8 +157,9 @@ namespace NuGet.Protocol.Plugins
                 _process.Exited -= OnExited;
 
                 _process.Kill();
-                _process.Dispose();
             }
+
+            _process.Dispose();
 
             GC.SuppressFinalize(this);
 
@@ -213,7 +214,7 @@ namespace NuGet.Protocol.Plugins
             }
         }
 
-        private void OnExited(object sender, EventArgs e)
+        private void OnExited(object sender, IPluginProcess pluginProcess)
         {
             Exited?.Invoke(this, new PluginEventArgs(this));
         }

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -646,7 +646,7 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Plugin &apos;{0}&apos; failed within {1} seconds with exit code {2}..
+        ///   Looks up a localized string similar to Plugin &apos;{0}&apos; failed within {1:N3} seconds with exit code {2}..
         /// </summary>
         internal static string Plugin_FailedOnCreation {
             get {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -646,6 +646,15 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Plugin &apos;{0}&apos; failed within {1} seconds with exit code {2}..
+        /// </summary>
+        internal static string Plugin_FailedOnCreation {
+            get {
+                return ResourceManager.GetString("Plugin_FailedOnCreation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Plugin &apos;{0}&apos; failed a {1} operation for package {2}.{3}..
         /// </summary>
         internal static string Plugin_FailedOperationForPackage {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -525,4 +525,10 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
   <data name="PushCommandSkipDuplicateNotImplemented" xml:space="preserve">
     <value>The option to skip duplicates is not currently supported for this type of push.</value>
   </data>
+  <data name="Plugin_FailedOnCreation" xml:space="preserve">
+    <value>Plugin '{0}' failed within {1} seconds with exit code {2}.</value>
+    <comment>{0} is the plugin name
+{1} is the number of seconds
+{2} is the plugin process exit code</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -526,7 +526,7 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
     <value>The option to skip duplicates is not currently supported for this type of push.</value>
   </data>
   <data name="Plugin_FailedOnCreation" xml:space="preserve">
-    <value>Plugin '{0}' failed within {1} seconds with exit code {2}.</value>
+    <value>Plugin '{0}' failed within {1:N3} seconds with exit code {2}.</value>
     <comment>{0} is the plugin name
 {1} is the number of seconds
 {2} is the plugin process exit code</comment>

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/PluginTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/PluginTests.cs
@@ -6,16 +6,15 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.IO.Ports;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Packaging;
 using NuGet.Protocol.Plugins;
 using NuGet.Test.Utility;
-using NuGet.Versioning;
 using Xunit;
 using Xunit.Abstractions;
 using PluginProtocolConstants = NuGet.Protocol.Plugins.ProtocolConstants;
@@ -64,8 +63,11 @@ namespace NuGet.Protocol.FuncTest
                     ConnectionOptions.CreateDefault(),
                     cancellationTokenSource.Token));
 
-                Assert.StartsWith("Plugin 'Plugin.Testable' failed within ", exception.Message);
-                Assert.EndsWith(" seconds with exit code -532462766.", exception.Message);
+                Assert.True(
+                    Regex.IsMatch(
+                        exception.Message,
+                        "^Plugin 'Plugin.Testable' failed within \\d.\\d{3} seconds with exit code -?\\d+.$"),
+                    exception.Message);
             }
         }
 
@@ -82,8 +84,11 @@ namespace NuGet.Protocol.FuncTest
                     ConnectionOptions.CreateDefault(),
                     cancellationTokenSource.Token));
 
-                Assert.StartsWith("Plugin 'Plugin.Testable' failed within ", exception.Message);
-                Assert.EndsWith(" seconds with exit code 1.", exception.Message);
+                Assert.True(
+                    Regex.IsMatch(
+                        exception.Message,
+                        "^Plugin 'Plugin.Testable' failed within \\d.\\d{3} seconds with exit code 1.$"),
+                    exception.Message);
             }
         }
 
@@ -100,8 +105,11 @@ namespace NuGet.Protocol.FuncTest
                     ConnectionOptions.CreateDefault(),
                     cancellationTokenSource.Token));
 
-                Assert.StartsWith("Plugin 'Plugin.Testable' failed within ", exception.Message);
-                Assert.EndsWith(" seconds with exit code -1.", exception.Message);
+                Assert.True(
+                    Regex.IsMatch(
+                        exception.Message,
+                        "^Plugin 'Plugin.Testable' failed within \\d.\\d{3} seconds with exit code -1.$"),
+                    exception.Message);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginProcessTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginProcessTests.cs
@@ -1,7 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
+using System.Threading;
+using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.Protocol.Plugins.Tests
@@ -9,11 +12,160 @@ namespace NuGet.Protocol.Plugins.Tests
     public class PluginProcessTests
     {
         [Fact]
-        public void Constructor_ThrowsForNullProcess()
+        public void Constructor_WhenStartInfoIsNull_Throws()
         {
-            Assert.Throws<ArgumentNullException>(() => new PluginProcess(process: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => new PluginProcess(startInfo: null));
+
+            Assert.Equal("startInfo", exception.ParamName);
         }
 
-        // Cannot test other members since System.Diagnostics.Process is not mockable.
+        [PlatformFact(Platform.Windows)]
+        public void Exited_WhenProcessExits_Fires()
+        {
+            ProcessStartInfo startInfo = CreateProcessStartInfo();
+
+            using (var exitedEvent = new ManualResetEventSlim(initialState: false))
+            using (var pluginProcess = new PluginProcess(startInfo))
+            {
+                IPluginProcess argument = null;
+
+                pluginProcess.Exited += (object sender, IPluginProcess e) =>
+                {
+                    argument = e;
+
+                    exitedEvent.Set();
+                };
+
+                pluginProcess.Start();
+
+                exitedEvent.Wait();
+
+                Assert.Same(pluginProcess, argument);
+            }
+        }
+
+        [Fact]
+        public void ExitCode_WithUnstartedProcess_IsNull()
+        {
+            TestWithUnstartedProcess(pluginProcess => Assert.Null(pluginProcess.ExitCode));
+        }
+
+        [Fact]
+        public void ExitCode_WithRunningProcess_IsNull()
+        {
+            TestWithRunningProcess((process, pluginProcess) => Assert.Null(pluginProcess.ExitCode));
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void ExitCode_WithExitedProcess_IsNotNull()
+        {
+            TestWithExitedProcess(pluginProcess => Assert.NotNull(pluginProcess.ExitCode));
+        }
+
+        [Fact]
+        public void FilePath_WithUnstartedProcess_Throws()
+        {
+            TestWithUnstartedProcess(pluginProcess => Assert.Throws<InvalidOperationException>(() => pluginProcess.FilePath));
+        }
+
+        [Fact]
+        public void FilePath_WithRunningProcess_IsValid()
+        {
+            TestWithRunningProcess((process, pluginProcess) => Assert.Equal(process.MainModule.FileName, pluginProcess.FilePath));
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void FilePath_WithExitedProcess_Throws()
+        {
+            TestWithExitedProcess(pluginProcess => Assert.ThrowsAny<Exception>(() => pluginProcess.FilePath));
+        }
+
+        [Fact]
+        public void Id_WithUnstartedProcess_IsNull()
+        {
+            TestWithUnstartedProcess(pluginProcess => Assert.Null(pluginProcess.Id));
+        }
+
+        [Fact]
+        public void Id_WithRunningProcess_IsValid()
+        {
+            TestWithRunningProcess((process, pluginProcess) => Assert.Equal(process.Id, pluginProcess.Id));
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void Id_WithExitedProcess_IsNotNull()
+        {
+            TestWithExitedProcess(pluginProcess => Assert.NotNull(pluginProcess.Id));
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void Kill_WhenCalled_TerminatesProcess()
+        {
+            var startInfo = new ProcessStartInfo("timeout")
+            {
+                Arguments = "1000", // seconds
+                UseShellExecute = true,
+                CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden
+            };
+
+            using (var exitedEvent = new ManualResetEventSlim(initialState: false))
+            using (var pluginProcess = new PluginProcess(startInfo))
+            {
+                pluginProcess.Exited += (object sender, IPluginProcess e) =>
+                {
+                    exitedEvent.Set();
+                };
+
+                pluginProcess.Start();
+
+                pluginProcess.Kill();
+
+                exitedEvent.Wait();
+
+                Assert.NotNull(pluginProcess.ExitCode);
+            }
+        }
+
+        private static ProcessStartInfo CreateProcessStartInfo()
+        {
+            return new ProcessStartInfo("find")
+            {
+                UseShellExecute = true,
+                CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden
+            };
+        }
+
+        private static void TestWithUnstartedProcess(Action<PluginProcess> verify)
+        {
+            using (var pluginProcess = new PluginProcess(new ProcessStartInfo()))
+            {
+                verify(pluginProcess);
+            }
+        }
+
+        private static void TestWithRunningProcess(Action<Process, PluginProcess> verify)
+        {
+            using (var process = Process.GetCurrentProcess())
+            using (var pluginProcess = new PluginProcess())
+            {
+                verify(process, pluginProcess);
+            }
+        }
+
+        private static void TestWithExitedProcess(Action<PluginProcess> verify)
+        {
+            ProcessStartInfo startInfo = CreateProcessStartInfo();
+
+            using (var pluginProcess = new PluginProcess(startInfo))
+            {
+                pluginProcess.Start();
+
+                pluginProcess.Kill();
+
+                verify(pluginProcess);
+            }
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginTests.cs
@@ -246,9 +246,6 @@ namespace NuGet.Protocol.Plugins.Tests
         {
             var process = new Mock<IPluginProcess>();
 
-            process.Setup(x => x.HasExited)
-                .Returns(true);
-
             using (var exitedEvent = new ManualResetEventSlim(initialState: false))
             using (var plugin = new Plugin(
                 filePath: @"C:\a\b\c.d",
@@ -266,7 +263,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     exitedEvent.Set();
                 };
 
-                process.Raise(x => x.Exited += null, EventArgs.Empty);
+                process.Raise(x => x.Exited += null, process.Object, process.Object);
 
                 exitedEvent.Wait();
 

--- a/test/TestExtensions/TestablePlugin/Arguments.cs
+++ b/test/TestExtensions/TestablePlugin/Arguments.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace NuGet.Test.TestExtensions.TestablePlugin
@@ -8,6 +9,7 @@ namespace NuGet.Test.TestExtensions.TestablePlugin
     internal sealed class Arguments
     {
         internal ushort PortNumber { get; private set; }
+        internal SimulateException SimulateException { get; private set; }
         internal int TestRunnerProcessId { get; private set; }
 
         private Arguments() { }
@@ -19,6 +21,7 @@ namespace NuGet.Test.TestExtensions.TestablePlugin
             ushort portNumber = 0;
             var testRunnerProcessId = 0;
             var isPlugin = false;
+            var simulateException = SimulateException.None;
 
             for (var i = 0; i < args.Count; ++i)
             {
@@ -42,6 +45,20 @@ namespace NuGet.Test.TestExtensions.TestablePlugin
 
                     case "-plugin":
                         isPlugin = true;
+                        break;
+
+                    case "-simulateexception":
+                        if (i + 1 == args.Count)
+                        {
+                            return false;
+                        }
+
+                        ++i;
+
+                        if (!Enum.TryParse(args[i], ignoreCase: true, out simulateException))
+                        {
+                            return false;
+                        }
                         break;
 
                     case "-testrunnerprocessid":
@@ -71,6 +88,7 @@ namespace NuGet.Test.TestExtensions.TestablePlugin
             arguments = new Arguments()
             {
                 PortNumber = portNumber,
+                SimulateException = simulateException,
                 TestRunnerProcessId = testRunnerProcessId
             };
 

--- a/test/TestExtensions/TestablePlugin/Arguments.cs
+++ b/test/TestExtensions/TestablePlugin/Arguments.cs
@@ -8,9 +8,11 @@ namespace NuGet.Test.TestExtensions.TestablePlugin
 {
     internal sealed class Arguments
     {
+        internal bool CauseProtocolException { get; private set; }
+        internal bool Hang { get; private set; }
         internal ushort PortNumber { get; private set; }
-        internal SimulateException SimulateException { get; private set; }
         internal int TestRunnerProcessId { get; private set; }
+        internal ThrowException ThrowException { get; private set; }
 
         private Arguments() { }
 
@@ -18,10 +20,12 @@ namespace NuGet.Test.TestExtensions.TestablePlugin
         {
             arguments = null;
 
+            var causeProtocolException = false;
+            var hang = false;
             ushort portNumber = 0;
             var testRunnerProcessId = 0;
             var isPlugin = false;
-            var simulateException = SimulateException.None;
+            var throwException = ThrowException.None;
 
             for (var i = 0; i < args.Count; ++i)
             {
@@ -29,6 +33,14 @@ namespace NuGet.Test.TestExtensions.TestablePlugin
 
                 switch (flag.ToLower())
                 {
+                    case "-causeprotocolexception":
+                        causeProtocolException = true;
+                        break;
+
+                    case "-hang":
+                        hang = true;
+                        break;
+
                     case "-portnumber":
                         if (i + 1 == args.Count)
                         {
@@ -47,20 +59,6 @@ namespace NuGet.Test.TestExtensions.TestablePlugin
                         isPlugin = true;
                         break;
 
-                    case "-simulateexception":
-                        if (i + 1 == args.Count)
-                        {
-                            return false;
-                        }
-
-                        ++i;
-
-                        if (!Enum.TryParse(args[i], ignoreCase: true, out simulateException))
-                        {
-                            return false;
-                        }
-                        break;
-
                     case "-testrunnerprocessid":
                         if (i + 1 == args.Count)
                         {
@@ -70,6 +68,20 @@ namespace NuGet.Test.TestExtensions.TestablePlugin
                         ++i;
 
                         if (!int.TryParse(args[i], out testRunnerProcessId))
+                        {
+                            return false;
+                        }
+                        break;
+
+                    case "-throwexception":
+                        if (i + 1 == args.Count)
+                        {
+                            return false;
+                        }
+
+                        ++i;
+
+                        if (!Enum.TryParse(args[i], ignoreCase: true, out throwException))
                         {
                             return false;
                         }
@@ -87,9 +99,11 @@ namespace NuGet.Test.TestExtensions.TestablePlugin
 
             arguments = new Arguments()
             {
+                CauseProtocolException = causeProtocolException,
+                Hang = hang,
                 PortNumber = portNumber,
-                SimulateException = simulateException,
-                TestRunnerProcessId = testRunnerProcessId
+                TestRunnerProcessId = testRunnerProcessId,
+                ThrowException = throwException
             };
 
             return true;

--- a/test/TestExtensions/TestablePlugin/Program.cs
+++ b/test/TestExtensions/TestablePlugin/Program.cs
@@ -95,7 +95,7 @@ namespace NuGet.Test.TestExtensions.TestablePlugin
                     }
                     catch (Win32Exception)
                     {
-                        // Running non-elevated.
+                        // Can occur while debugging.
                     }
 
                     var responseReceiver = new ResponseReceiver(arguments.PortNumber, responses);

--- a/test/TestExtensions/TestablePlugin/SimulateException.cs
+++ b/test/TestExtensions/TestablePlugin/SimulateException.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Test.TestExtensions.TestablePlugin
+{
+    internal enum SimulateException
+    {
+        None,
+        Handled,
+        Unhandled
+    }
+}

--- a/test/TestExtensions/TestablePlugin/ThrowException.cs
+++ b/test/TestExtensions/TestablePlugin/ThrowException.cs
@@ -3,7 +3,7 @@
 
 namespace NuGet.Test.TestExtensions.TestablePlugin
 {
-    internal enum SimulateException
+    internal enum ThrowException
     {
         None,
         Handled,


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/8271.

Improve the error message from "A task was canceled." to "Plugin 'x' failed within y seconds with exit code z."