### PR TITLE
Remove unnecessary refreshes from the PM UI, when the browse tab is open - reduce unneccessary load for the project PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGetPackageManagerControlSearchTask.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGetPackageManagerControlSearchTask.cs
@@ -22,7 +22,6 @@ namespace NuGet.PackageManagement.UI
             SetStatus(VsSearchTaskStatus.Created);
 
         }
-
         public void Start()
         {
             SetStatus(VsSearchTaskStatus.Started);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGetPackageManagerControlSearchTask.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGetPackageManagerControlSearchTask.cs
@@ -22,6 +22,7 @@ namespace NuGet.PackageManagement.UI
             SetStatus(VsSearchTaskStatus.Created);
 
         }
+
         public void Start()
         {
             SetStatus(VsSearchTaskStatus.Started);


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/6570
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

The PM UI is prone to refreshing too often. 
Specifically whenever the PM UI control is loaded (not initialzied, which happens once), we trigger a refresh. 

We should not trigger an expensive refresh if we are on the Browse tab already.

Note that at this point we cannot make that assumption about the installed and updates tabs do not need updating as those could've been updated. 
There are many gestures for changing the packages that do not go through the PM UI. 
For some it's even hard to distinguish what the source was. 

Ofc, if we had some detailed project package changes events we could improve this, but it's out of scope as of now, as the current approach is the bigger gain. 


[Fewer reloads by NuGet UI.zip](https://github.com/NuGet/NuGet.Client/files/3340611/Fewer.reloads.by.NuGet.UI.zip)


PS. I am open to feedback where the user would need to click to reload for the UI to update when on the installed/update tabs. 
PPS. Anand suggests that it is ok to always refresh the updates/intstall tabs. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
