### PR TITLE
Test:  fix flaky package signing tests

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -491,7 +491,7 @@ namespace NuGet.Packaging.FuncTest
                 revocationMode: RevocationMode.Online);
 
             using (var dir = TestDirectory.Create())
-            using (var trustedCertificate = _testFixture.TrustedTestCertificateWillExpireIn10Seconds)
+            using (var trustedCertificate = _testFixture.CreateTrustedTestCertificateThatWillExpireSoon())
             using (var willExpireCert = new X509Certificate2(trustedCertificate.Source.Cert))
             using (var repoTestCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
@@ -539,7 +539,7 @@ namespace NuGet.Packaging.FuncTest
             var verifier = new PackageSignatureVerifier(_trustProviders);
 
             using (var testDirectory = TestDirectory.Create())
-            using (var untrustedCertificate = _testFixture.UntrustedTestCertificateWillExpireIn10Seconds.Cert)
+            using (var untrustedCertificate = _testFixture.CreateUntrustedTestCertificateThatWillExpireSoon().Cert)
             using (var repositoryCertificate = new X509Certificate2(_testFixture.TrustedRepositoryCertificate.Source.Cert))
             {
                 var signedPackagePath = await SignedArchiveTestUtility.AuthorSignPackageAsync(
@@ -588,7 +588,7 @@ namespace NuGet.Packaging.FuncTest
                 revocationMode: RevocationMode.Online);
 
             using (var dir = TestDirectory.Create())
-            using (var trustedCertificate = _testFixture.TrustedTestCertificateWillExpireIn10Seconds)
+            using (var trustedCertificate = _testFixture.CreateTrustedTestCertificateThatWillExpireSoon())
             using (var willExpireCert = new X509Certificate2(trustedCertificate.Source.Cert))
             using (var repoTestCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningTestFixture.cs
@@ -16,6 +16,8 @@ namespace NuGet.Packaging.FuncTest
     /// </summary>
     public class SigningTestFixture : IDisposable
     {
+        private static readonly TimeSpan SoonDuration = TimeSpan.FromSeconds(20);
+
         private TrustedTestCert<TestCertificate> _trustedTestCert;
         private TrustedTestCert<TestCertificate> _trustedRepositoryCertificate;
         private TrustedTestCert<TestCertificate> _trustedTestCertExpired;
@@ -92,12 +94,6 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        // We should not memoize this call because it is a time-sensitive operation.
-        public TrustedTestCert<TestCertificate> TrustedTestCertificateWillExpireIn10Seconds => SigningTestUtility.GenerateTrustedTestCertificateThatExpiresIn10Seconds();
-
-        // We should not memoize this call because it is a time-sensitive operation.
-        public TestCertificate UntrustedTestCertificateWillExpireIn10Seconds => TestCertificate.Generate(SigningTestUtility.CertificateModificationGeneratorExpireIn10Seconds);
-
         public IReadOnlyList<TrustedTestCert<TestCertificate>> TrustedTestCertificateWithReissuedCertificate
         {
             get
@@ -166,6 +162,18 @@ namespace NuGet.Packaging.FuncTest
 
                 return _signingSpecifications;
             }
+        }
+
+        public TrustedTestCert<TestCertificate> CreateTrustedTestCertificateThatWillExpireSoon()
+        {
+            return SigningTestUtility.GenerateTrustedTestCertificateThatWillExpireSoon(SoonDuration);
+        }
+
+        public TestCertificate CreateUntrustedTestCertificateThatWillExpireSoon()
+        {
+            Action<TestCertificateGenerator> actionGenerator = SigningTestUtility.CertificateModificationGeneratorForCertificateThatWillExpireSoon(SoonDuration);
+
+            return TestCertificate.Generate(actionGenerator);
         }
 
         public async Task<ISigningTestServer> GetSigningTestServerAsync()


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/8284.

There are 3 package signing tests that are particularly time sensitive.  They create a certificate, sign while the certificate is valid, and then verify signatures after the certificate has expired.  Because a certificate's expiration time must be fixed at certificate generation time, the amount of time the test has to execute the test is also fixed.

Prior to this change, these tests created a certificate that would expire in 10 seconds; author-, repo- and timestamp-signed a package, waited for certificate expiration, and then verified signatures.  Occasionally, the timestamp would occur so close to certificate expiration time that the timestamp service's [+/- 1 second accuracy](https://github.com/NuGet/NuGet.Client/blob/006c0d1a2fdb07955fa46dfb407bd74d3310e97b/test/TestUtilities/Test.Utility/Signing/TimestampServiceOptions.cs#L25) made the timestamp invalid and the test fail.

This change doubles the certificate validity period, while also making it easy to modify the value in the future.