### PR TITLE
Add lock file arguments to nuget.exe

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -676,7 +676,8 @@ namespace NuGet.CommandLine
 
             Console.LogVerbose($"MSBuild P2P timeout [ms]: {scaleTimeout}");
 
-            var restoreLockProperties = new RestoreLockProperties(UseLockFile.ToString(), LockFilePath, LockedMode);
+            string restorePackagesWithLockFile = UseLockFile ? bool.TrueString : null;
+            var restoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile, LockFilePath, LockedMode);
 
             // Call MSBuild to resolve P2P references.
             return await MsBuildUtility.GetProjectReferencesAsync(

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -60,10 +60,10 @@ namespace NuGet.CommandLine
         public bool Force { get; set; }
 
         [Option(typeof(NuGetCommand), "RestoreCommandUseLockFile")]
-        public bool? UseLockFile { get; set; }
+        public bool UseLockFile { get; set; }
 
         [Option(typeof(NuGetCommand), "RestoreCommandLockedMode")]
-        public bool? LockedMode { get; set; }
+        public bool LockedMode { get; set; }
 
         [Option(typeof(NuGetCommand), "RestoreCommandLockFilePath")]
         public string LockFilePath { get; set; }
@@ -676,7 +676,7 @@ namespace NuGet.CommandLine
 
             Console.LogVerbose($"MSBuild P2P timeout [ms]: {scaleTimeout}");
 
-            var restoreLockProperties = new RestoreLockProperties(UseLockFile?.ToString(), LockFilePath?.ToString(), LockedMode ?? false);
+            var restoreLockProperties = new RestoreLockProperties(UseLockFile.ToString(), LockFilePath, LockedMode);
 
             // Call MSBuild to resolve P2P references.
             return await MsBuildUtility.GetProjectReferencesAsync(
@@ -928,9 +928,9 @@ namespace NuGet.CommandLine
 
                 var projectFile = dgSpec?.FilePath ?? pcFile;
                 var projectTfm = dgSpec?.TargetFrameworks.SingleOrDefault()?.FrameworkName ?? NuGetFramework.AnyFramework;
-                var restoreLockedMode = LockedMode ?? dgSpec?.RestoreMetadata?.RestoreLockProperties?.RestoreLockedMode ?? false;
+                var restoreLockedMode = LockedMode || (dgSpec?.RestoreMetadata?.RestoreLockProperties?.RestoreLockedMode ?? false);
                 var lockFilePath = LockFilePath ?? dgSpec?.RestoreMetadata?.RestoreLockProperties?.NuGetLockFilePath;
-                var useLockFile = UseLockFile?.ToString() ?? dgSpec?.RestoreMetadata?.RestoreLockProperties?.RestorePackagesWithLockFile;
+                var useLockFile = UseLockFile ? bool.TrueString : dgSpec?.RestoreMetadata?.RestoreLockProperties?.RestorePackagesWithLockFile;
 
                 IReadOnlyList<IRestoreLogMessage> result = PackagesConfigLockFileUtility.ValidatePackagesConfigLockFiles(
                     projectFile,

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -77,7 +77,8 @@ namespace NuGet.CommandLine
             string solutionName,
             string restoreConfigFile,
             string[] sources,
-            string packagesDirectory)
+            string packagesDirectory,
+            RestoreLockProperties restoreLockProperties)
         {
             var msbuildPath = GetMsbuild(msbuildToolset.Path);
 
@@ -121,7 +122,7 @@ namespace NuGet.CommandLine
                 inputTargetXML.Save(inputTargetPath);
 
                 // Create msbuild parameters and include global properties that cannot be set in the input targets path
-                var arguments = GetMSBuildArguments(entryPointTargetPath, inputTargetPath, nugetExePath, solutionDirectory, solutionName, restoreConfigFile, sources, packagesDirectory, msbuildToolset);
+                var arguments = GetMSBuildArguments(entryPointTargetPath, inputTargetPath, nugetExePath, solutionDirectory, solutionName, restoreConfigFile, sources, packagesDirectory, msbuildToolset, restoreLockProperties);
 
                 var processStartInfo = new ProcessStartInfo
                 {
@@ -226,7 +227,8 @@ namespace NuGet.CommandLine
             string restoreConfigFile,
             string[] sources,
             string packagesDirectory,
-            MsBuildToolset toolset)
+            MsBuildToolset toolset,
+            RestoreLockProperties restoreLockProperties)
         {
             // args for MSBuild.exe
             var args = new List<string>()
@@ -279,6 +281,13 @@ namespace NuGet.CommandLine
             if (!string.IsNullOrEmpty(msbuildAdditionalArgs))
             {
                 args.Add(msbuildAdditionalArgs);
+            }
+
+            AddPropertyIfHasValue(args, "RestorePackagesWithLockFile", restoreLockProperties.RestorePackagesWithLockFile);
+            AddPropertyIfHasValue(args, "NuGetLockFilePath", restoreLockProperties.NuGetLockFilePath);
+            if (restoreLockProperties.RestoreLockedMode)
+            {
+                AddProperty(args, "RestoreLockedMode", bool.TrueString);
             }
 
             return string.Join(" ", args);

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -9982,6 +9982,33 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Forces restore to reevaluate all dependencies even if a lock file already exists..
+        /// </summary>
+        internal static string RestoreCommandForceEvaluate {
+            get {
+                return ResourceManager.GetString("RestoreCommandForceEvaluate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Don&apos;t allow updating project lock file..
+        /// </summary>
+        internal static string RestoreCommandLockedMode {
+            get {
+                return ResourceManager.GetString("RestoreCommandLockedMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Output location where project lock file is written. By default, this is &apos;PROJECT_ROOT\packages.lock.json&apos;..
+        /// </summary>
+        internal static string RestoreCommandLockFilePath {
+            get {
+                return ResourceManager.GetString("RestoreCommandLockFilePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to 禁止使用计算机缓存作为第一个程序包源。.
         /// </summary>
         internal static string RestoreCommandNoCache_chs {
@@ -10869,6 +10896,15 @@ namespace NuGet.CommandLine {
         internal static string RestoreCommandUsageSummary_trk {
             get {
                 return ResourceManager.GetString("RestoreCommandUsageSummary_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables project lock file to be generated and used with restore..
+        /// </summary>
+        internal static string RestoreCommandUseLockFile {
+            get {
+                return ResourceManager.GetString("RestoreCommandUseLockFile", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5529,4 +5529,16 @@ nuget-trusted-signers Remove -Name TrustedRepo</value>
   <data name="PushCommandSkipDuplicateDescription" xml:space="preserve">
     <value>If a package and version already exists, skip it and continue with the next package in the push, if any.</value>
   </data>
+  <data name="RestoreCommandForceEvaluate" xml:space="preserve">
+    <value>Forces restore to reevaluate all dependencies even if a lock file already exists.</value>
+  </data>
+  <data name="RestoreCommandLockedMode" xml:space="preserve">
+    <value>Don't allow updating project lock file.</value>
+  </data>
+  <data name="RestoreCommandLockFilePath" xml:space="preserve">
+    <value>Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</value>
+  </data>
+  <data name="RestoreCommandUseLockFile" xml:space="preserve">
+    <value>Enables project lock file to be generated and used with restore.</value>
+  </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -188,15 +188,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
-
-                var lockFile = PackagesLockFileFormat.Read(projectA.NuGetLockFileOutputPath);
-                Assert.Equal(4, lockFile.Targets.Count);
-
-                var targets = lockFile.Targets.Where(t => t.Dependencies.Count > 0).ToList();
-                Assert.Equal(1, targets.Count);
-                Assert.Equal(".NETFramework,Version=v4.6.1", targets[0].Name);
-                Assert.Equal(1, targets[0].Dependencies.Count);
-                Assert.Equal("x", targets[0].Dependencies[0].Id);
             }
         }
 
@@ -239,15 +230,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 // Assert
                 var expectedLockFileName = Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "custom.lock.json");
                 Assert.True(File.Exists(expectedLockFileName));
-
-                var lockFile = PackagesLockFileFormat.Read(expectedLockFileName);
-                Assert.Equal(4, lockFile.Targets.Count);
-
-                var targets = lockFile.Targets.Where(t => t.Dependencies.Count > 0).ToList();
-                Assert.Equal(1, targets.Count);
-                Assert.Equal(".NETFramework,Version=v4.6.1", targets[0].Name);
-                Assert.Equal(1, targets[0].Dependencies.Count);
-                Assert.Equal("x", targets[0].Dependencies[0].Id);
             }
         }
 
@@ -406,15 +388,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
-
-                var lockFile = PackagesLockFileFormat.Read(projectA.NuGetLockFileOutputPath);
-                Assert.Equal(1, lockFile.Targets.Count);
-
-                var targets = lockFile.Targets.Where(t => t.Dependencies.Count > 0).ToList();
-                Assert.Equal(1, targets.Count);
-                Assert.Equal(".NETFramework,Version=v4.6.1", targets[0].Name);
-                Assert.Equal(1, targets[0].Dependencies.Count);
-                Assert.Equal("x", targets[0].Dependencies[0].Id);
             }
         }
 
@@ -461,15 +434,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 // Assert
                 var expectedLockFileName = Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "custom.lock.json");
                 Assert.True(File.Exists(expectedLockFileName));
-
-                var lockFile = PackagesLockFileFormat.Read(expectedLockFileName);
-                Assert.Equal(1, lockFile.Targets.Count);
-
-                var targets = lockFile.Targets.Where(t => t.Dependencies.Count > 0).ToList();
-                Assert.Equal(1, targets.Count);
-                Assert.Equal(".NETFramework,Version=v4.6.1", targets[0].Name);
-                Assert.Equal(1, targets[0].Dependencies.Count);
-                Assert.Equal("x", targets[0].Dependencies[0].Id);
             }
         }
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using NuGet.CommandLine.Test;
 using NuGet.Frameworks;
@@ -16,6 +17,9 @@ namespace NuGet.CommandLine.FuncTest.Commands
 {
     public class RestoreCommandTests
     {
+        private const int _successExitCode = 0;
+        private const int _failureExitCode = 1;
+
         [Fact]
         public async Task Restore_LegacyPackageReference_WithNuGetLockFile()
         {
@@ -143,6 +147,285 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 Assert.Equal(PackageDependencyType.Transitive, targets[0].Dependencies[1].Type);
                 Assert.Equal("b", targets[0].Dependencies[2].Id);
                 Assert.Equal(PackageDependencyType.Project, targets[0].Dependencies[2].Type);
+            }
+        }
+
+        [Fact]
+        public async Task Restore_LegacyPackageReference_WithNuGetLockFileArgument()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    net461);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Act
+                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile", "true");
+
+                // Assert
+                Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
+
+                var lockFile = PackagesLockFileFormat.Read(projectA.NuGetLockFileOutputPath);
+                Assert.Equal(4, lockFile.Targets.Count);
+
+                var targets = lockFile.Targets.Where(t => t.Dependencies.Count > 0).ToList();
+                Assert.Equal(1, targets.Count);
+                Assert.Equal(".NETFramework,Version=v4.6.1", targets[0].Name);
+                Assert.Equal(1, targets[0].Dependencies.Count);
+                Assert.Equal("x", targets[0].Dependencies[0].Id);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Restore_LegacyPackageReference_ForceEvaluateNuGetLockFile(bool forceEvaluate)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    net461);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile", "true");
+                Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
+
+                // Act
+                result = forceEvaluate
+                    ? RunRestore(pathContext, _successExitCode, "-UseLockFile", "true", "-ForceEvaluate")
+                    : RunRestore(pathContext, _successExitCode, "-UseLockFile", "true");
+
+                // Assert
+                Assert.Contains("Assets file has not changed.", result.AllOutput);
+                if (forceEvaluate)
+                {
+                    Assert.Contains("Writing packages lock file at disk.", result.AllOutput);
+                }
+                else
+                {
+                    Assert.Contains("No-Op restore.", result.AllOutput);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Restore_LegacyPackagesConfig_WithNuGetLockFileArgument()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    net461);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
+
+                Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+@"<packages>
+  <package id=""x"" version=""1.0.0"" targetFramework=""net461"" />
+</packages>");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Act
+                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile", "true");
+
+                // Assert
+                Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
+
+                var lockFile = PackagesLockFileFormat.Read(projectA.NuGetLockFileOutputPath);
+                Assert.Equal(1, lockFile.Targets.Count);
+
+                var targets = lockFile.Targets.Where(t => t.Dependencies.Count > 0).ToList();
+                Assert.Equal(1, targets.Count);
+                Assert.Equal(".NETFramework,Version=v4.6.1", targets[0].Name);
+                Assert.Equal(1, targets[0].Dependencies.Count);
+                Assert.Equal("x", targets[0].Dependencies[0].Id);
+            }
+        }
+
+        [Fact]
+        public async Task Restore_LegacyPackagesConfig_WithCustomNamedNuGetLockFile()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    net461);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
+
+                Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+@"<packages>
+  <package id=""x"" version=""1.0.0"" targetFramework=""net461"" />
+</packages>");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Act
+                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile", "true", "-LockFilePath", "custom.lock.json");
+
+                // Assert
+                var expectedLockFileName = Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "custom.lock.json");
+                Assert.True(File.Exists(expectedLockFileName));
+
+                var lockFile = PackagesLockFileFormat.Read(expectedLockFileName);
+                Assert.Equal(1, lockFile.Targets.Count);
+
+                var targets = lockFile.Targets.Where(t => t.Dependencies.Count > 0).ToList();
+                Assert.Equal(1, targets.Count);
+                Assert.Equal(".NETFramework,Version=v4.6.1", targets[0].Name);
+                Assert.Equal(1, targets[0].Dependencies.Count);
+                Assert.Equal("x", targets[0].Dependencies[0].Id);
+            }
+        }
+
+        [Fact]
+        public async Task Restore_LegacyPackagesConfig_WithNuGetLockFileLockedMode()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    net461);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/x.dll");
+
+                var packageY = new SimpleTestPackageContext()
+                {
+                    Id = "y",
+                    Version = "1.0.0"
+                };
+                packageY.Files.Clear();
+                packageY.AddFile("lib/net461/y.dll");
+
+                Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+@"<packages>
+  <package id=""x"" version=""1.0.0"" targetFramework=""net461"" />
+</packages>");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX,
+                    packageY);
+
+                // Restore to set up lock file
+                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile", "true");
+                Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
+
+                // Change packages to cause lock file difference
+                Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+@"<packages>
+  <package id=""y"" version=""1.0.0"" targetFramework=""net461"" />
+</packages>");
+
+                // Act
+                result = RunRestore(pathContext, _failureExitCode, "-UseLockFile", "true", "-LockedMode", "true");
+
+                // Assert
+                Assert.Contains("NU1004:", result.Errors);
             }
         }
 
@@ -451,7 +734,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        public static CommandRunnerResult RunRestore(SimpleTestPathContext pathContext, int expectedExitCode = 0)
+        public static CommandRunnerResult RunRestore(SimpleTestPathContext pathContext, int expectedExitCode = 0, params string[] additionalArguments)
         {
             var nugetExe = Util.GetNuGetExePath();
 
@@ -461,13 +744,15 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 { "NUGET_HTTP_CACHE_PATH", pathContext.HttpCacheFolder }
             };
 
-            var args = new string[]
+            var args = new string[4 + additionalArguments.Length];
+            args[0] = "restore";
+            args[1] = pathContext.SolutionRoot;
+            args[2] = "-Verbosity";
+            args[3] = "detailed";
+            for (int i = 0; i < additionalArguments.Length; i++)
             {
-                "restore",
-                pathContext.SolutionRoot,
-                "-Verbosity",
-                "detailed"
-            };
+                args[4 + i] = additionalArguments[i];
+            }
 
             // Act
             var r = CommandRunner.Run(

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -184,7 +184,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     packageX);
 
                 // Act
-                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile", "true");
+                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile");
 
                 // Assert
                 Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8038
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Add command line arguments for lock file features to nuget.exe

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
