### PR TITLE
Support restoring packages.config with restore task

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
@@ -26,6 +26,8 @@ namespace NuGet.Build.Tasks
 
         public string RestorePackagesPath { get; set; }
 
+        public string RestoreRepositoryPath { get; set; }
+
         public string[] RestoreFallbackFolders { get; set; }
 
         public string RestoreConfigFile { get; set; }
@@ -46,6 +48,8 @@ namespace NuGet.Build.Tasks
         /// Command line value of RestorePackagesPath
         /// </summary>
         public string RestorePackagesPathOverride { get; set; }
+
+        public string RestoreRepositoryPathOverride { get; set; }
 
         /// <summary>
         /// Command line value of RestoreSources
@@ -73,6 +77,9 @@ namespace NuGet.Build.Tasks
         public string OutputPackagesPath { get; set; }
 
         [Output]
+        public string OutputRepositoryPath { get; set; }
+
+        [Output]
         public string[] OutputFallbackFolders { get; set; }
 
         [Output]
@@ -88,6 +95,7 @@ namespace NuGet.Build.Tasks
             BuildTasksUtility.LogInputParam(log, nameof(ProjectUniqueName), ProjectUniqueName);
             BuildTasksUtility.LogInputParam(log, nameof(RestoreSources), RestoreSources);
             BuildTasksUtility.LogInputParam(log, nameof(RestorePackagesPath), RestorePackagesPath);
+            BuildTasksUtility.LogInputParam(log, nameof(RestoreRepositoryPath), RestoreRepositoryPath);
             BuildTasksUtility.LogInputParam(log, nameof(RestoreFallbackFolders), RestoreFallbackFolders);
             BuildTasksUtility.LogInputParam(log, nameof(RestoreConfigFile), RestoreConfigFile);
             BuildTasksUtility.LogInputParam(log, nameof(RestoreSolutionDirectory), RestoreSolutionDirectory);
@@ -127,6 +135,11 @@ namespace NuGet.Build.Tasks
                     () => GetGlobalAbsolutePath(RestorePackagesPathOverride),
                     () => string.IsNullOrEmpty(RestorePackagesPath) ? null : UriUtility.GetAbsolutePathFromFile(ProjectUniqueName, RestorePackagesPath),
                     () => SettingsUtility.GetGlobalPackagesFolder(settings));
+
+                OutputRepositoryPath = RestoreSettingsUtils.GetValue(
+                    () => GetGlobalAbsolutePath(RestoreRepositoryPathOverride),
+                    () => string.IsNullOrEmpty(RestoreRepositoryPath) ? null : UriUtility.GetAbsolutePathFromFile(ProjectUniqueName, RestoreRepositoryPath),
+                    () => SettingsUtility.GetRepositoryPath(settings));
 
                 // Sources
                 var currentSources = RestoreSettingsUtils.GetValue(
@@ -169,6 +182,7 @@ namespace NuGet.Build.Tasks
 
             // Log Outputs
             BuildTasksUtility.LogOutputParam(log, nameof(OutputPackagesPath), OutputPackagesPath);
+            BuildTasksUtility.LogOutputParam(log, nameof(OutputRepositoryPath), OutputRepositoryPath);
             BuildTasksUtility.LogOutputParam(log, nameof(OutputSources), OutputSources);
             BuildTasksUtility.LogOutputParam(log, nameof(OutputFallbackFolders), OutputFallbackFolders);
             BuildTasksUtility.LogOutputParam(log, nameof(OutputConfigFilePaths), OutputConfigFilePaths);

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
+    <ProjectReference Include="..\NuGet.PackageManagement\NuGet.PackageManagement.csproj" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.Build.Framework" />
   </ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -435,6 +435,14 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- If this is not a PackageReference project check if project.json or projectName.project.json exists. -->
       <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND '$(_CurrentProjectJsonPath)' != '' ">ProjectJson</RestoreProjectStyle>
       <!-- This project is either a packages.config project or one that does not use NuGet at all. -->
+      <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND
+                           ('$(MSBuildProjectExtension)' == '.csproj'
+                           OR '$(MSBuildProjectExtension)' == '.vbproj'
+                           OR '$(MSBuildProjectExtension)' == '.fsproj'
+                           OR '$(MSBuildProjectExtension)' == '.sfproj'
+                           OR '$(MSBuildProjectExtension)' == '.vcxproj')
+                           AND Exists('$(MSBuildProjectDirectory)\packages.config')">PackagesConfig</RestoreProjectStyle>
+      <!-- This project is either a packages.config project or one that does not use NuGet at all. -->
       <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' ">Unknown</RestoreProjectStyle>
     </PropertyGroup>
     <PropertyGroup>
@@ -517,21 +525,23 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GetRestoreSettings"
-          Condition=" '$(RestoreProjectStyle)' == 'PackageReference' OR '$(RestoreProjectStyle)' == 'ProjectJson' OR '$(RestoreProjectStyle)' == 'DotnetToolReference' "
+          Condition=" '$(RestoreProjectStyle)' == 'PackageReference' OR '$(RestoreProjectStyle)' == 'ProjectJson' OR '$(RestoreProjectStyle)' == 'DotnetToolReference' OR '$(RestoreProjectStyle)' == 'PackagesConfig'"
           DependsOnTargets="_GetRestoreSettingsOverrides;_GetRestoreSettingsCurrentProject;_GetRestoreSettingsAllFrameworks"
-          Returns="$(_OutputSources);$(_OutputPackagesPath);$(_OutputFallbackFolders);$(_OutputConfigFilePaths)">
+          Returns="$(_OutputSources);$(_OutputPackagesPath);$(_OutputRepositoryPath);$(_OutputFallbackFolders);$(_OutputConfigFilePaths)">
 
     <!-- For transitive project styles, we rely on evaluating all the settings and including them in the dg spec to faciliate no-op restore-->
     <GetRestoreSettingsTask
      ProjectUniqueName="$(MSBuildProjectFullPath)"
      RestoreSources="$(RestoreSources)"
      RestorePackagesPath="$(RestorePackagesPath)"
+     RestoreRepositoryPath="$(RestoreRepositoryPath)"
      RestoreFallbackFolders="$(RestoreFallbackFolders)"
      RestoreConfigFile="$(RestoreConfigFile)"
      RestoreRootConfigDirectory="$(RestoreRootConfigDirectory)"
      RestoreSolutionDirectory="$(RestoreSolutionDirectory)"
      RestoreSettingsPerFramework="@(_RestoreSettingsPerFramework)"
      RestorePackagesPathOverride="$(_RestorePackagesPathOverride)"
+     RestoreRepositoryPathOverride="$(RestoreRepositoryPathOverride)"
      RestoreSourcesOverride="$(_RestoreSourcesOverride)"
      RestoreFallbackFoldersOverride="$(_RestoreFallbackFoldersOverride)"
      MSBuildStartupDirectory="$(MSBuildStartupDirectory)">
@@ -541,6 +551,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
         TaskParameter="OutputPackagesPath"
         PropertyName="_OutputPackagesPath" />
+      <Output
+        TaskParameter="OutputRepositoryPath"
+        PropertyName="_OutputRepositoryPath" />
       <Output
         TaskParameter="OutputFallbackFolders"
         PropertyName="_OutputFallbackFolders" />
@@ -704,6 +717,22 @@ Copyright (c) .NET Foundation. All rights reserved.
         <ProjectJsonPath>$(_CurrentProjectJsonPath)</ProjectJsonPath>
         <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
         <ConfigFilePaths>$(_OutputConfigFilePaths)</ConfigFilePaths>
+      </_RestoreGraphEntry>
+    </ItemGroup>
+
+    <!-- Non-NuGet type -->
+    <ItemGroup Condition=" '$(RestoreProjectStyle)' == 'PackagesConfig' ">
+      <_RestoreGraphEntry Include="$([System.Guid]::NewGuid())">
+        <Type>ProjectSpec</Type>
+        <ProjectUniqueName>$(MSBuildProjectFullPath)</ProjectUniqueName>
+        <ProjectPath>$(MSBuildProjectFullPath)</ProjectPath>
+        <ProjectName>$(_RestoreProjectName)</ProjectName>
+        <Sources>$(_OutputSources)</Sources>
+        <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
+        <RepositoryPath>$(_OutputRepositoryPath)</RepositoryPath>
+        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
+        <ConfigFilePaths>$(_OutputConfigFilePaths)</ConfigFilePaths>
+        <PackagesPath>$(_OutputPackagesPath)</PackagesPath>
       </_RestoreGraphEntry>
     </ItemGroup>
 
@@ -1107,7 +1136,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GetRestoreSettingsOverrides"
-          Returns="$(_RestorePackagesPathOverride);$(_RestoreSourcesOverride);$(_RestoreFallbackFoldersOverride)">
+          Returns="$(_RestorePackagesPathOverride);$(_RestoreRepositoryPathOverride);$(_RestoreSourcesOverride);$(_RestoreFallbackFoldersOverride)">
 
     <!-- RestorePackagesPathOverride -->
     <MsBuild
@@ -1119,6 +1148,18 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
           TaskParameter="TargetOutputs"
           PropertyName="_RestorePackagesPathOverride" />
+    </MsBuild>
+
+    <!-- RestoreRepositoryPathOverride -->
+    <MsBuild
+      BuildInParallel="$(RestoreBuildInParallel)"
+      Condition=" '$(RestoreRepositoryPathOverride)' != '' "
+      Projects="$(MSBuildThisFileFullPath)"
+      Targets="_GetRestoreRepositoryPathOverride">
+
+      <Output
+        TaskParameter="TargetOutputs"
+        PropertyName="_RestoreRepositoryPathOverride" />
     </MsBuild>
 
     <!-- RestoreSourcesOverride -->
@@ -1155,6 +1196,18 @@ Copyright (c) .NET Foundation. All rights reserved.
           Returns="$(_RestorePackagesPathOverride)">
     <PropertyGroup>
       <_RestorePackagesPathOverride>$(RestorePackagesPath)</_RestorePackagesPathOverride>
+    </PropertyGroup>
+  </Target>
+
+  <!--
+    ============================================================
+    _GetRestoreRepositoryPathOverride
+    ============================================================
+  -->
+  <Target Name="_GetRestoreRepositoryPathOverride"
+          Returns="$(_RestoreRepositoryPathOverride)">
+    <PropertyGroup>
+      <_RestorePackagesPathOverride>$(RestoreRepositoryPath)</_RestorePackagesPathOverride>
     </PropertyGroup>
   </Target>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -2,21 +2,42 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+#if IS_DESKTOP
+using System.Collections.Concurrent;
+#endif
 using System.Collections.Generic;
 using System.Diagnostics;
+#if IS_DESKTOP
+using System.IO;
+#endif
 using System.Linq;
+#if IS_CORECLR
 using System.Runtime.InteropServices;
+#endif
 using System.Threading;
 using System.Threading.Tasks;
+#if IS_DESKTOP
+using System.Xml;
+using System.Xml.Linq;
+#endif
 using Microsoft.Build.Framework;
-using Newtonsoft.Json;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Credentials;
+#if IS_DESKTOP
+using NuGet.Packaging;
+using NuGet.Packaging.PackageExtraction;
+using NuGet.Packaging.Signing;
+using NuGet.PackageManagement;
+using NuGet.ProjectManagement;
+#endif
 using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
+#if IS_DESKTOP
+using NuGet.Shared;
+#endif
 
 namespace NuGet.Build.Tasks
 {
@@ -136,80 +157,131 @@ namespace NuGet.Build.Tasks
                 log.LogWarning(Strings.NoProjectsProvidedToTask);
                 return true;
             }
+            var restoreSummaries = new List<RestoreSummary>();
 
             // Set user agent and connection settings.
             ConfigureProtocol();
 
-            // Convert to the internal wrapper
-            var wrappedItems = RestoreGraphItems.Select(MSBuildUtility.WrapMSBuildItem);
+            var dgFile = MSBuildRestoreUtility.GetDependencySpec(RestoreGraphItems.Select(MSBuildUtility.WrapMSBuildItem));
 
-            //var graphLines = RestoreGraphItems;
-            var providerCache = new RestoreCommandProvidersCache();
-
-            using (var cacheContext = new SourceCacheContext())
+            try
             {
-                cacheContext.NoCache = RestoreNoCache;
-                cacheContext.IgnoreFailedSources = RestoreIgnoreFailedSources;
-
-                // Pre-loaded request provider containing the graph file
-                var providers = new List<IPreLoadedRestoreRequestProvider>();
-
-                var dgFile = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
-
-                if (dgFile.Restore.Count < 1)
+#if IS_DESKTOP
+                if (dgFile.Projects.Any(i => i.RestoreMetadata.ProjectStyle == ProjectStyle.PackagesConfig))
                 {
-                    // Restore will fail if given no inputs, but here we should skip it and provide a friendly message.
-                    log.LogMinimal(Strings.NoProjectsToRestore);
-                    return true;
+                    var v2RestoreResult = await PerformNuGetV2RestoreAsync(log, dgFile);
+                    restoreSummaries.Add(v2RestoreResult);
+
+                    // TODO: Message if no packages needed to be restored?
+                    //var message = string.Format(
+                    //    CultureInfo.CurrentCulture,
+                    //    LocalizedResourceManager.GetString("InstallCommandNothingToInstall"),
+                    //    "packages.config");
+
+                    //Console.LogMinimal(message);
+
+                    if (!v2RestoreResult.Success)
+                    {
+                        v2RestoreResult
+                            .Errors
+                            .Where(l => l.Level == LogLevel.Warning)
+                            .ForEach(message =>
+                            {
+                                if (message.Code > NuGetLogCode.Undefined && message.Code.TryGetName(out var codeString))
+                                {
+                                    Log.LogWarning(
+                                        null,
+                                        codeString,
+                                        null,
+                                        message.FilePath,
+                                        message.StartLineNumber,
+                                        message.StartColumnNumber,
+                                        message.EndLineNumber,
+                                        message.EndColumnNumber,
+                                        message.Message);
+                                }
+                                else
+                                {
+                                    Log.LogWarning(message.Message);
+                                }
+                            });
+                    }
                 }
+#endif
+                var providerCache = new RestoreCommandProvidersCache();
 
-                // Add all child projects
-                if (RestoreRecursive)
+                using (var cacheContext = new SourceCacheContext())
                 {
-                    BuildTasksUtility.AddAllProjectsForRestore(dgFile);
+                    cacheContext.NoCache = RestoreNoCache;
+                    cacheContext.IgnoreFailedSources = RestoreIgnoreFailedSources;
+
+                    // Pre-loaded request provider containing the graph file
+                    var providers = new List<IPreLoadedRestoreRequestProvider>();
+
+                    if (dgFile.Restore.Count < 1)
+                    {
+                        if (restoreSummaries.Count < 1)
+                        {
+                            // Restore will fail if given no inputs, but here we should skip it and provide a friendly message.
+                            log.LogMinimal(Strings.NoProjectsToRestore);
+                        }
+                        return true;
+                    }
+
+                    // Add all child projects
+                    if (RestoreRecursive)
+                    {
+                        BuildTasksUtility.AddAllProjectsForRestore(dgFile);
+                    }
+
+                    providers.Add(new DependencyGraphSpecRequestProvider(providerCache, dgFile));
+
+                    var restoreContext = new RestoreArgs()
+                    {
+                        CacheContext = cacheContext,
+                        LockFileVersion = LockFileFormat.Version,
+                        DisableParallel = RestoreDisableParallel,
+                        Log = log,
+                        MachineWideSettings = new XPlatMachineWideSetting(),
+                        PreLoadedRequestProviders = providers,
+                        AllowNoOp = !RestoreForce,
+                        HideWarningsAndErrors = HideWarningsAndErrors,
+                        RestoreForceEvaluate = RestoreForceEvaluate
+                    };
+
+                    // 'dotnet restore' fails on slow machines (https://github.com/NuGet/Home/issues/6742)
+                    // The workaround is to pass the '--disable-parallel' option.
+                    // We apply the workaround by default when the system has 1 cpu.
+                    // This will fix restore failures on VMs with 1 CPU and containers with less or equal to 1 CPU assigned.
+                    if (Environment.ProcessorCount == 1)
+                    {
+                        restoreContext.DisableParallel = true;
+                    }
+
+                    if (restoreContext.DisableParallel)
+                    {
+                        HttpSourceResourceProvider.Throttle = SemaphoreSlimThrottle.CreateBinarySemaphore();
+                    }
+
+                    DefaultCredentialServiceUtility.SetupDefaultCredentialService(log, !Interactive);
+
+                    _cts.Token.ThrowIfCancellationRequested();
+
+                    restoreSummaries.AddRange(await RestoreRunner.RunAsync(restoreContext, _cts.Token));
                 }
-
-                providers.Add(new DependencyGraphSpecRequestProvider(providerCache, dgFile));
-
-                var restoreContext = new RestoreArgs()
-                {
-                    CacheContext = cacheContext,
-                    LockFileVersion = LockFileFormat.Version,
-                    DisableParallel = RestoreDisableParallel,
-                    Log = log,
-                    MachineWideSettings = new XPlatMachineWideSetting(),
-                    PreLoadedRequestProviders = providers,
-                    AllowNoOp = !RestoreForce,
-                    HideWarningsAndErrors = HideWarningsAndErrors,
-                    RestoreForceEvaluate = RestoreForceEvaluate
-                };
-
-                // 'dotnet restore' fails on slow machines (https://github.com/NuGet/Home/issues/6742)
-                // The workaround is to pass the '--disable-parallel' option.
-                // We apply the workaround by default when the system has 1 cpu.
-                // This will fix restore failures on VMs with 1 CPU and containers with less or equal to 1 CPU assigned.
-                if (Environment.ProcessorCount == 1)
-                {
-                    restoreContext.DisableParallel = true;
-                }
-
-                if (restoreContext.DisableParallel)
-                {
-                    HttpSourceResourceProvider.Throttle = SemaphoreSlimThrottle.CreateBinarySemaphore();
-                }
-
-                DefaultCredentialServiceUtility.SetupDefaultCredentialService(log, !Interactive);
-
-                _cts.Token.ThrowIfCancellationRequested();
-
-                var restoreSummaries = await RestoreRunner.RunAsync(restoreContext, _cts.Token);
-
-                // Summary
-                RestoreSummary.Log(log, restoreSummaries);
-
-                return restoreSummaries.All(x => x.Success);
             }
+            finally
+            {
+                if (restoreSummaries.Any(x => x.InstallCount > 0))
+                {
+                    // Summary
+                    RestoreSummary.Log(log, restoreSummaries);
+                }
+            }
+
+            return restoreSummaries.All(x => x.Success);
         }
+
         private static void ConfigureProtocol()
         {
             // Set connection limit
@@ -242,5 +314,243 @@ namespace NuGet.Build.Tasks
         {
             _cts.Dispose();
         }
+
+#if IS_DESKTOP
+        private async Task<RestoreSummary> PerformNuGetV2RestoreAsync(Common.ILogger log, DependencyGraphSpec dgFile)
+        {
+            string globalPackageFolder = null;
+            string repositoryPath = null;
+            string firstPackagesConfigPath = null;
+            IList<PackageSource> packageSources = null;
+
+            var installedPackageReferences = new HashSet<Packaging.PackageReference>(new PackageReferenceComparer());
+
+            ISettings settings = null;
+
+            foreach (PackageSpec packageSpec in dgFile.Projects.Where(i => i.RestoreMetadata.ProjectStyle == ProjectStyle.PackagesConfig))
+            {
+                globalPackageFolder = globalPackageFolder ?? packageSpec.RestoreMetadata.PackagesPath;
+                repositoryPath = repositoryPath ?? packageSpec.RestoreMetadata.RepositoryPath;
+
+                if (packageSources == null)
+                {
+                    packageSources = new List<PackageSource>();
+                    if (!RestoreNoCache)
+                    {
+                        if (!string.IsNullOrEmpty(globalPackageFolder) && Directory.Exists(globalPackageFolder))
+                        {
+                            packageSources.Add(new FeedTypePackageSource(globalPackageFolder, FeedType.FileSystemV3));
+                        }
+                    }
+
+                    packageSources.AddRange(packageSpec.RestoreMetadata.Sources);
+                }
+
+                settings = settings ?? Settings.LoadSettingsGivenConfigPaths(packageSpec.RestoreMetadata.ConfigFilePaths);
+
+                var packagesConfigPath = Path.Combine(Path.GetDirectoryName(packageSpec.RestoreMetadata.ProjectPath), NuGetConstants.PackageReferenceFile);
+
+                firstPackagesConfigPath = firstPackagesConfigPath ?? packagesConfigPath;
+
+                installedPackageReferences.AddRange(GetInstalledPackageReferences(packagesConfigPath, allowDuplicatePackageIds: true));
+            }
+
+            PackageSourceProvider packageSourceProvider = new PackageSourceProvider(settings);
+            var sourceRepositoryProvider = new CommandLineSourceRepositoryProvider(packageSourceProvider);
+            var nuGetPackageManager = new NuGetPackageManager(sourceRepositoryProvider, settings, repositoryPath);
+
+            // TODO: different default?  Allow user to specify?
+            var packageSaveMode = Packaging.PackageSaveMode.Defaultv2;
+
+            var missingPackageReferences = installedPackageReferences.Where(reference =>
+                !nuGetPackageManager.PackageExistsInPackagesFolder(reference.PackageIdentity, packageSaveMode)).ToArray();
+
+            if (missingPackageReferences.Length == 0)
+            {
+                return new RestoreSummary(true);
+            }
+            var packageRestoreData = missingPackageReferences.Select(reference =>
+                new PackageRestoreData(
+                    reference,
+                    new[] { firstPackagesConfigPath },
+                    isMissing: true));
+
+            var repositories = packageSources
+                .Select(sourceRepositoryProvider.CreateRepository)
+                .ToArray();
+
+            var installCount = 0;
+            var failedEvents = new ConcurrentQueue<PackageRestoreFailedEventArgs>();
+            var collectorLogger = new RestoreCollectorLogger(new MSBuildLogger(Log));
+
+            var packageRestoreContext = new PackageRestoreContext(
+                nuGetPackageManager,
+                packageRestoreData,
+                CancellationToken.None,
+                packageRestoredEvent: (sender, args) => { Interlocked.Add(ref installCount, args.Restored ? 1 : 0); },
+                packageRestoreFailedEvent: (sender, args) => { failedEvents.Enqueue(args); },
+                sourceRepositories: repositories,
+                maxNumberOfParallelTasks: RestoreDisableParallel
+                    ? 1
+                    : PackageManagementConstants.DefaultMaxDegreeOfParallelism,
+                logger: collectorLogger);
+
+            // TODO: Check require consent?
+            // CheckRequireConsent();
+
+            var clientPolicyContext = ClientPolicyContext.GetClientPolicy(settings, collectorLogger);
+            var projectContext = new ConsoleProjectContext(collectorLogger)
+            {
+                PackageExtractionContext = new PackageExtractionContext(
+                    Packaging.PackageSaveMode.Defaultv2,
+                    PackageExtractionBehavior.XmlDocFileSaveMode,
+                    clientPolicyContext,
+                    collectorLogger)
+            };
+
+            // if (EffectivePackageSaveMode != Packaging.PackageSaveMode.None)
+            {
+                projectContext.PackageExtractionContext.PackageSaveMode = packageSaveMode;
+            }
+
+            using (var cacheContext = new SourceCacheContext())
+            {
+                cacheContext.NoCache = RestoreNoCache;
+
+                // TODO: Direct download?
+                // //cacheContext.DirectDownload = DirectDownload;
+
+                var downloadContext = new PackageDownloadContext(cacheContext, repositoryPath, directDownload: false)
+                {
+                    ClientPolicyContext = clientPolicyContext
+                };
+
+                DefaultCredentialServiceUtility.SetupDefaultCredentialService(log, !Interactive);
+
+                var result = await PackageRestoreManager.RestoreMissingPackagesAsync(
+                    packageRestoreContext,
+                    projectContext,
+                    downloadContext);
+
+                if (downloadContext.DirectDownload)
+                {
+                    GetDownloadResultUtility.CleanUpDirectDownloads(downloadContext);
+                }
+
+                return new RestoreSummary(
+                    result.Restored,
+                    "packages.config projects",
+                    settings.GetConfigFilePaths(),
+                    packageSources.Select(x => x.Source),
+                    installCount,
+                    collectorLogger.Errors.Concat(ProcessFailedEventsIntoRestoreLogs(failedEvents)));
+            }
+        }
+
+        private IEnumerable<Packaging.PackageReference> GetInstalledPackageReferences(string projectConfigFilePath, bool allowDuplicatePackageIds)
+        {
+            if (File.Exists(projectConfigFilePath))
+            {
+                try
+                {
+                    var xDocument = XDocument.Load(projectConfigFilePath);
+                    var reader = new PackagesConfigReader(xDocument);
+                    return reader.GetPackages(allowDuplicatePackageIds);
+                }
+                catch (XmlException)
+                {
+                    // TODO: Log an error?
+                    //var message = string.Format(
+                    //    CultureInfo.CurrentCulture,
+                    //    ResourceManager.GetString("Error_PackagesConfigParseError"),
+                    //    projectConfigFilePath,
+                    //    ex.Message);
+
+                    //Log.LogError(message);
+                }
+            }
+
+            return Enumerable.Empty<Packaging.PackageReference>();
+        }
+
+        private static IEnumerable<RestoreLogMessage> ProcessFailedEventsIntoRestoreLogs(ConcurrentQueue<PackageRestoreFailedEventArgs> failedEvents)
+        {
+            var result = new List<RestoreLogMessage>();
+
+            foreach (var failedEvent in failedEvents)
+            {
+                if (failedEvent.Exception is SignatureException)
+                {
+                    var signatureException = failedEvent.Exception as SignatureException;
+
+                    var errorsAndWarnings = signatureException
+                        .Results.SelectMany(r => r.Issues)
+                        .Where(i => i.Level == LogLevel.Error || i.Level == LogLevel.Warning)
+                        .Select(i => i.AsRestoreLogMessage());
+
+                    result.AddRange(errorsAndWarnings);
+                }
+                else
+                {
+                    result.Add(new RestoreLogMessage(LogLevel.Error, NuGetLogCode.Undefined, failedEvent.Exception.Message));
+                }
+            }
+
+            return result;
+        }
+#endif
     }
+
+#if IS_DESKTOP
+    public class CommandLineSourceRepositoryProvider : ISourceRepositoryProvider
+    {
+        private readonly Configuration.IPackageSourceProvider _packageSourceProvider;
+        private readonly List<Lazy<INuGetResourceProvider>> _resourceProviders;
+        private readonly List<SourceRepository> _repositories = new List<SourceRepository>();
+
+        // There should only be one instance of the source repository for each package source.
+        private static readonly ConcurrentDictionary<Configuration.PackageSource, SourceRepository> _cachedSources
+            = new ConcurrentDictionary<Configuration.PackageSource, SourceRepository>();
+
+        public CommandLineSourceRepositoryProvider(Configuration.IPackageSourceProvider packageSourceProvider)
+        {
+            _packageSourceProvider = packageSourceProvider;
+
+            _resourceProviders = new List<Lazy<INuGetResourceProvider>>();
+            _resourceProviders.AddRange(FactoryExtensionsV3.GetCoreV3(Repository.Provider));
+
+            // Create repositories
+            _repositories = _packageSourceProvider.LoadPackageSources()
+                .Where(s => s.IsEnabled)
+                .Select(CreateRepository)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Retrieve repositories that have been cached.
+        /// </summary>
+        public IEnumerable<SourceRepository> GetRepositories()
+        {
+            return _repositories;
+        }
+
+        /// <summary>
+        /// Create a repository and add it to the cache.
+        /// </summary>
+        public SourceRepository CreateRepository(Configuration.PackageSource source)
+        {
+            return CreateRepository(source, FeedType.Undefined);
+        }
+
+        public SourceRepository CreateRepository(Configuration.PackageSource source, FeedType type)
+        {
+            return _cachedSources.GetOrAdd(source, new SourceRepository(source, _resourceProviders, type));
+        }
+
+        public Configuration.IPackageSourceProvider PackageSourceProvider
+        {
+            get { return _packageSourceProvider; }
+        }
+    }
+#endif
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -195,7 +195,8 @@ namespace NuGet.Commands
                     || restoreType == ProjectStyle.Standalone
                     || restoreType == ProjectStyle.DotnetCliTool
                     || restoreType == ProjectStyle.ProjectJson
-                    || restoreType == ProjectStyle.DotnetToolReference)
+                    || restoreType == ProjectStyle.DotnetToolReference
+                    || restoreType == ProjectStyle.PackagesConfig)
                 {
 
                     foreach (var source in MSBuildStringUtility.Split(specItem.GetProperty("Sources")))
@@ -216,7 +217,7 @@ namespace NuGet.Commands
                     }
 
                     result.RestoreMetadata.PackagesPath = specItem.GetProperty("PackagesPath");
-
+                    result.RestoreMetadata.RepositoryPath = specItem.GetProperty("RepositoryPath");
                     result.RestoreMetadata.OutputPath = specItem.GetProperty("OutputPath");
                 }
 

--- a/src/NuGet.Core/NuGet.PackageManagement/ConsoleProjectContext.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/ConsoleProjectContext.cs
@@ -6,9 +6,8 @@ using System.Globalization;
 using System.Xml.Linq;
 using NuGet.Common;
 using NuGet.Packaging;
-using NuGet.ProjectManagement;
 
-namespace NuGet.CommandLine
+namespace NuGet.ProjectManagement
 {
     public class ConsoleProjectContext : INuGetProjectContext
     {

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -53,6 +53,11 @@ namespace NuGet.ProjectModel
         public string PackagesPath { get; set; }
 
         /// <summary>
+        /// User packages repository path.
+        /// </summary>
+        public string RepositoryPath { get; set; }
+
+        /// <summary>
         /// Cache file path
         /// </summary>
         public string CacheFilePath { get; set; }


### PR DESCRIPTION
This enable msbuild /t:Restore to restore projects with packages.config as well as PackageReference.

There are two project types that still don't support `PackageReference`, Service Fabric (`.sfproj`) and Visual C++ (`.vcxproj`).  When you have a code base with one or more of these project types, you must either restore twice (once with msbuild and once with nuget.exe) or restore with nuget.exe against a Visual Studio solution file.  It does not work well for large code bases to do either of those.

It is fully understood that `packages.config` is deprecated, however there are large code bases that cannot move away from `.vcxproj` or `.sfproj`.  Until those project types support `PackageReference`, there needs to be a way to restore them.  

Another point is that everything works as expected in Visual Studio.  Packages are restored for all projects regardless of whether or not they are using `packages.config` or `PackageReference`.  So this really just brings parity back.

I've only made this work for .NET Framework and the feature is disabled for .NET Core.  The only scenario that won't work as expected is a `.csproj` still using `packages.config` (the other project types, `.vcxproj` and `.sfproj` do not build in .NET Core anyway).  But I don't want to enable restoring `packages.config` for scenarios where people could just migrate to `PackageReference`.