### PR TITLE
Fix the deadlock that can happen during the initialization of the VSSettings

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSMachineWideSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSMachineWideSettings.cs
@@ -40,8 +40,8 @@ namespace NuGet.PackageManagement.VisualStudio
                         "VisualStudio",
                         version,
                         sku);
-                }, 
-                ThreadHelper.JoinableTaskFactory);
+                },
+                NuGetUIThreadHelper.JoinableTaskFactory);
         }
 
         public Configuration.ISettings Settings => NuGetUIThreadHelper.JoinableTaskFactory.Run(_settings.GetValueAsync);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSMachineWideSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSMachineWideSettings.cs
@@ -40,7 +40,7 @@ namespace NuGet.PackageManagement.VisualStudio
                         "VisualStudio",
                         version,
                         sku);
-                },
+                }, 
                 ThreadHelper.JoinableTaskFactory);
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSMachineWideSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSMachineWideSettings.cs
@@ -41,7 +41,7 @@ namespace NuGet.PackageManagement.VisualStudio
                         version,
                         sku);
                 },
-                NuGetUIThreadHelper.JoinableTaskFactory);
+                ThreadHelper.JoinableTaskFactory);
         }
 
         public Configuration.ISettings Settings => NuGetUIThreadHelper.JoinableTaskFactory.Run(_settings.GetValueAsync);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
@@ -79,7 +79,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 _solutionSettings = new Tuple<string, AsyncLazy<ISettings>>(
                     item1: root,
-                    item2: new AsyncLazy<ISettings>(() =>
+                    item2: new AsyncLazy<ISettings>(async () =>
                         {
                             ISettings settings = null;
                             try
@@ -88,12 +88,12 @@ namespace NuGet.PackageManagement.VisualStudio
                             }
                             catch (NuGetConfigurationException ex)
                             {
-                                //ExceptionHelper.WriteErrorToActivityLog(ex);
-                                MessageHelper.ShowErrorMessage(Common.ExceptionUtilities.DisplayMessage(ex), Strings.ConfigErrorDialogBoxTitle);
                                 settings = NullSettings.Instance;
+                                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                                MessageHelper.ShowErrorMessage(Common.ExceptionUtilities.DisplayMessage(ex), Strings.ConfigErrorDialogBoxTitle);
                             }
 
-                            return Task.FromResult(settings);
+                            return settings;
 
                         }, NuGetUIThreadHelper.JoinableTaskFactory));
                 return true;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
@@ -31,7 +31,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     ResetSolutionSettingsIfNeeded();
                 }
 
-                return NuGetUIThreadHelper.JoinableTaskFactory.Run(async () => await _solutionSettings.Item2.GetValueAsync());
+                return NuGetUIThreadHelper.JoinableTaskFactory.Run(_solutionSettings.Item2.GetValueAsync);
             }
         }
 


### PR DESCRIPTION
## Bug

Fixes: [940108]( https://devdiv.visualstudio.com/DevDiv/_workitems/edit/940108/)
Fixes: https://github.com/NuGet/Home/issues/8320
Regression: No  
* Last working version:  5.1 P2.
* How are we preventing it in future:   

## Fix

Details: 

There is ongoing thread for everyone on the client team. 

A couple of the previous fixes that are fixing UI delays have caused a regression that can result in a deadlock.
https://github.com/NuGet/NuGet.Client/commit/ec48ee474965d3d5f41ed7e5b4199af79868351a#diff-6545c160a4f64189999990c5a6961eb6
https://github.com/NuGet/NuGet.Client/commit/787181546ebd1b2ff5a20fd5e7dc0ae45a3839e4#diff-6545c160a4f64189999990c5a6961eb6
https://github.com/NuGet/NuGet.Client/commit/7fee43eeb1b5dbe0de3cb93ad0cb80b3a321e4a9#diff-6545c160a4f64189999990c5a6961eb6 

Specifically the stack trace is: 

```
user32.dll!MsgWaitForMultipleObjectsEx
vslog.dll!VSResponsiveness::Detours::DetourMsgWaitForMultipleObjectsEx
combase.dll!CCliModalLoop::BlockFn
combase.dll!ClassicSTAThreadWaitForHandles
combase.dll!CoWaitForMultipleHandles
vslog.dll!VSResponsiveness::Detours::DetourCoWaitForMultipleHandles
clr.dll!MsgWaitHelper
clr.dll!Thread::DoAppropriateWaitWorker
clr.dll!Thread::DoAppropriateWait
clr.dll!CLREventBase::WaitEx
clr.dll!CLREventBase::Wait
clr.dll!AwareLock::EnterEpilogHelper
clr.dll!AwareLock::EnterEpilog
clr.dll!AwareLock::Enter
mscorlib.dll!System.Lazy`[System.__Canon].LazyInitValue
mscorlib.dll!System.Lazy`[System.__Canon].get_Value
nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.VisualStudio.VSSettings.get_SolutionSettings
nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.VisualStudio.VSSettings.GetSection
nuget.configuration.dll!NuGet.Configuration.SettingsUtility.GetValueForAddItem
nuget.configuration.dll!NuGet.Configuration.SettingsUtility.GetRepositoryPath
nuget.packagemanagement.dll!NuGet.PackageManagement.PackagesFolderPathUtility.GetPackagesFolderPath
nuget.packagemanagement.dll!NuGet.PackageManagement.PackagesFolderPathUtility.GetPackagesFolderPath
nuget.packagemanagement.dll!NuGet.PackageManagement.NuGetPackageManager..ctor
nuget.visualstudio.implementation.dll!NuGet.VisualStudio.VsPackageInstallerServices.InitializePackageManagerAndPackageFolderPath
nuget.visualstudio.implementation.dll!NuGet.VisualStudio.VsPackageInstallerServices+<>c__DisplayClass_0+<b__>d.MoveNext
?!System.Runtime.CompilerServices.AsyncTaskMethodBuilder`[System.__Canon].Start
nuget.visualstudio.implementation.dll!NuGet.VisualStudio.VsPackageInstallerServices+<>c__DisplayClass_0.b__
?!?
nuget.visualstudio.implementation.dll!NuGet.VisualStudio.VsPackageInstallerServices.GetInstalledPackages
microsoft.visualstudio.languageservices.dll!Microsoft.VisualStudio.LanguageServices.Packaging.PackageInstallerService.ProcessProjectChange
microsoft.visualstudio.languageservices.dll!Microsoft.VisualStudio.LanguageServices.Packaging.PackageInstallerService.ProcessBatchedChangesOnForeground
microsoft.visualstudio.languageservices.dll!Microsoft.VisualStudio.LanguageServices.Packaging.PackageInstallerService+<>c__DisplayClass_0+<b__>d.MoveNext
mscorlib.dll!System.Runtime.CompilerServices.AsyncMethodBuilderCore+MoveNextRunner.InvokeMoveNext
mscorlib.dll!System.Threading.ExecutionContext.RunInternal
mscorlib.dll!System.Threading.ExecutionContext.Run
mscorlib.dll!System.Runtime.CompilerServices.AsyncMethodBuilderCore+MoveNextRunner.Run
?!?
windowsbase.dll!System.Windows.Threading.ExceptionWrapper.TryCatchWhen
windowsbase.dll!System.Windows.Threading.DispatcherOperation.InvokeImpl
windowsbase.dll!System.Windows.Threading.DispatcherOperation.InvokeInSecurityContext
windowsbase.dll!System.Windows.Threading.Dispatcher.ProcessQueue
windowsbase.dll!System.Windows.Threading.Dispatcher.WndProcHook
windowsbase.dll!MS.Win32.HwndWrapper.WndProc
windowsbase.dll!MS.Win32.HwndSubclass.DispatcherCallbackOperation
windowsbase.dll!System.Windows.Threading.ExceptionWrapper.InternalRealCall
windowsbase.dll!System.Windows.Threading.ExceptionWrapper.TryCatchWhen
windowsbase.dll!System.Windows.Threading.Dispatcher.LegacyInvokeImpl
windowsbase.dll!MS.Win32.HwndSubclass.SubclassWndProc
?!?
user32.dll!_InternalCallWinProc
user32.dll!UserCallWinProcCheckWow
user32.dll!DispatchMessageWorker
user32.dll!DispatchMessageW
msenv.dll!MainMessageLoop::ProcessMessage
msenv.dll!CMsoCMHandler::EnvironmentMsgLoop
msenv.dll!CMsoCMHandler::FPushMessageLoop
msenv.dll!SCM::FPushMessageLoop
msenv.dll!SCM_MsoCompMgr::FPushMessageLoop
msenv.dll!CMsoComponent::PushMsgLoop
msenv.dll!VStudioMainLogged
msenv.dll!VStudioMain
devenv.exe!util_CallVsMain
devenv.exe!CDevEnvAppId::Run
devenv.exe!WinMain
devenv.exe!__scrt_common_main_seh
kernel32.dll!BaseThreadInitThunk
ntdll.dll!__RtlUserThreadStart
ntdll.dll!_RtlUserThreadStart
```

The root cause of the issue is that NuGet’s Settings initialization is being called on the UI thread. 

Basically this lazy ends up getting initialized on the UI thread. 
https://github.com/NuGet/NuGet.Client/blob/1d7c528af797a507abbe6f51ce9a1e7872a38889/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs#L82

https://github.com/NuGet/NuGet.Client/blob/1d7c528af797a507abbe6f51ce9a1e7872a38889/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs#L86 reads the configs on disk and in VS potentially initializes the vs machine wide settings.
If user-wide configs on disk are valid, then it will potentially initialize the VS Machine Wide Settings.
https://github.com/NuGet/NuGet.Client/blob/1d7c528af797a507abbe6f51ce9a1e7872a38889/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSMachineWideSettings.cs#L28-L43

The VSMachineWideSettings initialization is VS Threading AsyncLazy with JTF. There we switch to the UI thread first and then switch to a background thread to read the machine wide settings from disk. 

If either of the config processing throws, we land at https://github.com/NuGet/NuGet.Client/blob/1d7c528af797a507abbe6f51ce9a1e7872a38889/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs#L90, which itself calls https://github.com/NuGet/NuGet.Client/blob/1d7c528af797a507abbe6f51ce9a1e7872a38889/src/NuGet.Clients/NuGet.VisualStudio.Common/MessageHelper.cs#L45

VsShellUtilities.ShowMessageBox

The VSShellUtilities.ShowMEssageBox has STA requirements so it needs to run on the UI thread. 

How the deadlock can usually occur is if there are 2 different threads trying to access the VSSettings lazy, one of which is the UI thread.
When a non-UI thread ends up initializing the lazy, the VSMachineWideSettings initialization will try to switch to the UI thread (with JTF). 
However, the UI thread call to Lazy is holding the lock to the UI thread and since it's not JTF aware, it won't let the JTF call in VSMachineWideSettings to switch to the UI thread. 

@AArnott Mind taking a look?

//cc 
@RyanMolden who helped me understand the scenario better :) 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  Manual by simulating the issues.
