### PR TITLE
Fix for "Locked-mode restore fails with sha512 errors & installs new packages when a project's RuntimeIdentifier is changed" 

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -66,8 +66,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <NUGET_PFX_PATH>$(MSBuildThisFileDirectory)\..\keys\NuGetKey.snk</NUGET_PFX_PATH>
-    <MS_PFX_PATH>$(MSBuildThisFileDirectory)\..\keys\35MSSharedLib1024.snk</MS_PFX_PATH>
+    <NUGET_PFX_PATH>$(MSBuildThisFileDirectory)..\keys\NuGetKey.snk</NUGET_PFX_PATH>
+    <MS_PFX_PATH>$(MSBuildThisFileDirectory)..\keys\35MSSharedLib1024.snk</MS_PFX_PATH>
   </PropertyGroup>
 
   <Target Name="GetSemanticVersion">

--- a/scripts/e2etests/SetupFunctionalTests.ps1
+++ b/scripts/e2etests/SetupFunctionalTests.ps1
@@ -42,6 +42,16 @@ function DisableTextTemplateSecurityWarning([string]$VSVersion)
     Write-Host -ForegroundColor Cyan $Message
 }
 
+Function SuppressNuGetUI([Parameter(Mandatory = $True)] [string] $registryValueName)
+{
+    $success = SetRegistryKey -RegKey 'HKCU:\Software\NuGet' -RegName $registryValueName -ExpectedValue '1' -FriendlyKeyName $registryValueName
+
+    If (!$success)
+    {
+        Exit 1
+    }
+}
+
 trap
 {
     Write-Host $_.Exception -ForegroundColor Red
@@ -69,6 +79,8 @@ Write-Host
 Write-Host 'Trying to set some registry keys to avoid dialog boxes popping during the functional test run...'
 
 DisableTextTemplateSecurityWarning $VSVersion
+SuppressNuGetUI -registryValueName 'DoNotShowPreviewWindow'
+SuppressNuGetUI -registryValueName 'SuppressUILegalDisclaimer'
 
 $net35x86 = "C:\windows\Microsoft.NET\Framework\v3.5\msbuild.exe"
 $net35x64 = "C:\windows\Microsoft.NET\Framework64\v3.5\msbuild.exe"

--- a/scripts/e2etests/Utils.ps1
+++ b/scripts/e2etests/Utils.ps1
@@ -75,7 +75,11 @@ function SetRegistryKey
             return $false
         }
 
-        New-Item -Path $RegKey -Force | Out-Null
+        If (!(Test-Path $RegKey))
+        {
+            New-Item -Path $RegKey -Force | Out-Null
+        }
+
         New-ItemProperty -Path $RegKey -Name $RegName -Value $ExpectedValue -Force | Out-Null
     }
 

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -77,7 +77,8 @@ namespace NuGet.CommandLine
             string solutionName,
             string restoreConfigFile,
             string[] sources,
-            string packagesDirectory)
+            string packagesDirectory,
+            RestoreLockProperties restoreLockProperties)
         {
             var msbuildPath = GetMsbuild(msbuildToolset.Path);
 
@@ -121,7 +122,7 @@ namespace NuGet.CommandLine
                 inputTargetXML.Save(inputTargetPath);
 
                 // Create msbuild parameters and include global properties that cannot be set in the input targets path
-                var arguments = GetMSBuildArguments(entryPointTargetPath, inputTargetPath, nugetExePath, solutionDirectory, solutionName, restoreConfigFile, sources, packagesDirectory, msbuildToolset);
+                var arguments = GetMSBuildArguments(entryPointTargetPath, inputTargetPath, nugetExePath, solutionDirectory, solutionName, restoreConfigFile, sources, packagesDirectory, msbuildToolset, restoreLockProperties);
 
                 var processStartInfo = new ProcessStartInfo
                 {
@@ -226,7 +227,8 @@ namespace NuGet.CommandLine
             string restoreConfigFile,
             string[] sources,
             string packagesDirectory,
-            MsBuildToolset toolset)
+            MsBuildToolset toolset,
+            RestoreLockProperties restoreLockProperties)
         {
             // args for MSBuild.exe
             var args = new List<string>()
@@ -279,6 +281,13 @@ namespace NuGet.CommandLine
             if (!string.IsNullOrEmpty(msbuildAdditionalArgs))
             {
                 args.Add(msbuildAdditionalArgs);
+            }
+
+            AddPropertyIfHasValue(args, "RestorePackagesWithLockFile", restoreLockProperties.RestorePackagesWithLockFile);
+            AddPropertyIfHasValue(args, "NuGetLockFilePath", restoreLockProperties.NuGetLockFilePath);
+            if (restoreLockProperties.RestoreLockedMode)
+            {
+                AddProperty(args, "RestoreLockedMode", bool.TrueString);
             }
 
             return string.Join(" ", args);

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -9982,6 +9982,33 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Forces restore to reevaluate all dependencies even if a lock file already exists..
+        /// </summary>
+        internal static string RestoreCommandForceEvaluate {
+            get {
+                return ResourceManager.GetString("RestoreCommandForceEvaluate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Don&apos;t allow updating project lock file..
+        /// </summary>
+        internal static string RestoreCommandLockedMode {
+            get {
+                return ResourceManager.GetString("RestoreCommandLockedMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Output location where project lock file is written. By default, this is &apos;PROJECT_ROOT\packages.lock.json&apos;..
+        /// </summary>
+        internal static string RestoreCommandLockFilePath {
+            get {
+                return ResourceManager.GetString("RestoreCommandLockFilePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to 禁止使用计算机缓存作为第一个程序包源。.
         /// </summary>
         internal static string RestoreCommandNoCache_chs {
@@ -10869,6 +10896,15 @@ namespace NuGet.CommandLine {
         internal static string RestoreCommandUsageSummary_trk {
             get {
                 return ResourceManager.GetString("RestoreCommandUsageSummary_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables project lock file to be generated and used with restore..
+        /// </summary>
+        internal static string RestoreCommandUseLockFile {
+            get {
+                return ResourceManager.GetString("RestoreCommandUseLockFile", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5529,4 +5529,16 @@ nuget trusted-signers Remove -Name TrustedRepo</value>
   <data name="PushCommandSkipDuplicateDescription" xml:space="preserve">
     <value>If a package and version already exists, skip it and continue with the next package in the push, if any.</value>
   </data>
+  <data name="RestoreCommandForceEvaluate" xml:space="preserve">
+    <value>Forces restore to reevaluate all dependencies even if a lock file already exists.</value>
+  </data>
+  <data name="RestoreCommandLockedMode" xml:space="preserve">
+    <value>Don't allow updating project lock file.</value>
+  </data>
+  <data name="RestoreCommandLockFilePath" xml:space="preserve">
+    <value>Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</value>
+  </data>
+  <data name="RestoreCommandUseLockFile" xml:space="preserve">
+    <value>Enables project lock file to be generated and used with restore.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
@@ -339,7 +339,6 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         /// <summary>
         /// Return package identity parsed from path to .nupkg file
         /// </summary>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1031")]
         private IEnumerable<PackageIdentity> CreatePackageIdentityFromNupkgPath()
         {
@@ -347,7 +346,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
             try
             {
-                // Example: install-package https://az320820.vo.msecnd.net/packages/microsoft.aspnet.mvc.4.0.20505.nupkg
+                // Example: Install-Package https://globalcdn.nuget.org/packages/microsoft.aspnet.mvc.4.0.20505.nupkg
                 if (_isHttp)
                 {
                     identity = ParsePackageIdentityFromNupkgPath(Id, @"/");
@@ -395,10 +394,8 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
         /// <summary>
         /// Parse package identity from path to .nupkg file, such as
-        /// https://az320820.vo.msecnd.net/packages/microsoft.aspnet.mvc.4.0.20505.nupkg
+        /// https://globalcdn.nuget.org/packages/microsoft.aspnet.mvc.4.0.20505.nupkg
         /// </summary>
-        /// <param name="sourceUrl"></param>
-        /// <returns></returns>
         private PackageIdentity ParsePackageIdentityFromNupkgPath(string path, string divider)
         {
             if (!string.IsNullOrEmpty(path))

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DeprecationControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DeprecationControl.xaml
@@ -15,30 +15,25 @@
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
   </UserControl.Resources>
-  <Grid>
-    <Expander
-      Margin="0,12,0,16"
-      IsExpanded="True"
-      Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}">
-      <Expander.Header>
+  <Grid
+    Margin="0,12,0,16">
+      <StackPanel
+        Orientation="Vertical">
         <StackPanel
           Orientation="Horizontal"
           VerticalAlignment="Center">
-          <TextBlock
-            FontWeight="Bold"
-            AutomationProperties.Name="{x:Static nuget:Resources.Label_Deprecated}"
-            Text="{x:Static nuget:Resources.Label_Deprecated}"/>
           <imaging:CrispImage
             x:Name="_deprecationWarning"
-            Margin="5,0,0,0"
+            Margin="0,0,5,0"
             Width="13"
             Height="13"
             ToolTip="{x:Static nuget:Resources.Label_Deprecated}"
             Moniker="{x:Static catalog:KnownMonikers.StatusWarning}" />
-        </StackPanel>
-      </Expander.Header>
-      <StackPanel
-        Orientation="Vertical">
+        <TextBlock
+            FontWeight="Bold"
+            AutomationProperties.Name="{x:Static nuget:Resources.Label_Deprecated}"
+            Text="{x:Static nuget:Resources.Label_Deprecated}"/>
+      </StackPanel>
         <TextBox
           Style="{DynamicResource SelectableTextBlockStyle}" 
           Margin="0,8,0,0"
@@ -67,6 +62,5 @@
           </StackPanel>
         </StackPanel>
       </StackPanel>
-    </Expander>
   </Grid>
 </UserControl>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
@@ -18,7 +18,9 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using NuGet.Common;
 using NuGet.Frameworks;
+using NuGet.PackageManagement.Utility;
 using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
 using NuGet.VisualStudio;
 using PathUtility = NuGet.Common.PathUtility;
 using Task = System.Threading.Tasks.Task;
@@ -203,12 +205,15 @@ namespace NuGet.PackageManagement.VisualStudio
             // it into the project.
             // Other exceptions are 'web.config' and 'app.config'
             var fileName = Path.GetFileName(path);
+            var lockFileFullPath = PackagesConfigLockFileUtility.GetPackagesLockFilePath(ProjectFullPath, GetPropertyValue("NuGetLockFilePath")?.ToString(), ProjectName);
             if (File.Exists(Path.Combine(ProjectFullPath, path))
                 && !fileExistsInProject
                 && !fileName.Equals(ProjectManagement.Constants.PackageReferenceFile)
                 && !fileName.Equals("packages." + ProjectName + ".config")
                 && !fileName.Equals(EnvDTEProjectInfoUtility.WebConfig)
-                && !fileName.Equals(EnvDTEProjectInfoUtility.AppConfig))
+                && !fileName.Equals(EnvDTEProjectInfoUtility.AppConfig)
+                && !fileName.Equals(Path.GetFileName(lockFileFullPath))
+                )
             {
                 NuGetProjectContext.Log(ProjectManagement.MessageLevel.Warning, Strings.Warning_FileAlreadyExists, path);
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
@@ -5,9 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
-using NuGet.Common;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
 using NuGet.Configuration;
-using NuGet.Shared;
 using NuGet.VisualStudio;
 
 namespace NuGet.PackageManagement.VisualStudio
@@ -19,7 +19,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private const string NuGetSolutionSettingsFolder = ".nuget";
 
         // to initialize SolutionSettings first time outside MEF constructor
-        private Tuple<string, Lazy<ISettings>> _solutionSettings;
+        private Tuple<string, AsyncLazy<ISettings>> _solutionSettings;
 
         private ISettings SolutionSettings
         {
@@ -31,7 +31,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     ResetSolutionSettingsIfNeeded();
                 }
 
-                return _solutionSettings.Item2.Value;
+                return NuGetUIThreadHelper.JoinableTaskFactory.Run(_solutionSettings.Item2.GetValueAsync);
             }
         }
 
@@ -77,20 +77,25 @@ namespace NuGet.PackageManagement.VisualStudio
             // That however is not the case for solution close and  same session close -> open events. Those will be on the UI thread.
             if (_solutionSettings == null || !string.Equals(root, _solutionSettings.Item1))
             {
-                _solutionSettings = new Tuple<string, Lazy<ISettings>>(
+                _solutionSettings = new Tuple<string, AsyncLazy<ISettings>>(
                     item1: root,
-                    item2: new Lazy<ISettings>(() =>
+                    item2: new AsyncLazy<ISettings>(async () =>
                         {
+                            ISettings settings = null;
                             try
                             {
-                                return Settings.LoadDefaultSettings(root, configFileName: null, machineWideSettings: MachineWideSettings);
+                                settings = Settings.LoadDefaultSettings(root, configFileName: null, machineWideSettings: MachineWideSettings);
                             }
                             catch (NuGetConfigurationException ex)
                             {
-                                MessageHelper.ShowErrorMessage(ExceptionUtilities.DisplayMessage(ex), Strings.ConfigErrorDialogBoxTitle);
-                                return NullSettings.Instance;
+                                settings = NullSettings.Instance;
+                                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                                MessageHelper.ShowErrorMessage(Common.ExceptionUtilities.DisplayMessage(ex), Strings.ConfigErrorDialogBoxTitle);
                             }
-                        }));
+
+                            return settings;
+
+                        }, NuGetUIThreadHelper.JoinableTaskFactory));
                 return true;
             }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ScriptPackageFile.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ScriptPackageFile.cs
@@ -1,7 +1,9 @@
-﻿using System;
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Runtime.Versioning;
 using NuGet.Frameworks;
-using Utility = System.IO;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -19,7 +21,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 throw new ArgumentNullException("ScriptPackageFileTargetFramework");
             }
 
-            Path = path.Replace(Utility.Path.AltDirectorySeparatorChar, Utility.Path.DirectorySeparatorChar);
+            Path = path.Replace(System.IO.Path.AltDirectorySeparatorChar, System.IO.Path.DirectorySeparatorChar);
             TargetFramework = new FrameworkName(targetFramework.DotNetFrameworkName); ;
         }
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -434,6 +434,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND @(PackageReference) != '' ">PackageReference</RestoreProjectStyle>
       <!-- If this is not a PackageReference project check if project.json or projectName.project.json exists. -->
       <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND '$(_CurrentProjectJsonPath)' != '' ">ProjectJson</RestoreProjectStyle>
+      <!-- If this is not a PackageReference or ProjectJson project check if packages.config or packages.ProjectName.config exists -->
+      <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND (Exists('$(MSBuildProjectDirectory)\packages.config') Or Exists('$(MSBuildProjectDirectory)\packages.$(MSBuildProjectName).config'))">PackagesConfig</RestoreProjectStyle>
       <!-- This project is either a packages.config project or one that does not use NuGet at all. -->
       <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' ">Unknown</RestoreProjectStyle>
     </PropertyGroup>
@@ -704,6 +706,23 @@ Copyright (c) .NET Foundation. All rights reserved.
         <ProjectJsonPath>$(_CurrentProjectJsonPath)</ProjectJsonPath>
         <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
         <ConfigFilePaths>$(_OutputConfigFilePaths)</ConfigFilePaths>
+      </_RestoreGraphEntry>
+    </ItemGroup>
+
+    <!-- Use packages.config -->
+    <ItemGroup Condition=" '$(RestoreProjectStyle)' == 'PackagesConfig' ">
+      <_RestoreGraphEntry Include="$([System.Guid]::NewGuid())">
+        <Type>ProjectSpec</Type>
+        <ProjectUniqueName>$(MSBuildProjectFullPath)</ProjectUniqueName>
+        <ProjectPath>$(MSBuildProjectFullPath)</ProjectPath>
+        <ProjectName>$(_RestoreProjectName)</ProjectName>
+        <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
+        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
+        <PackagesConfigPath Condition="Exists('$(MSBuildProjectDirectory)\packages.$(MSBuildProjectName).config')">$(MSBuildProjectDirectory)\packages.$(MSBuildProjectName).config</PackagesConfigPath>
+        <PackagesConfigPath Condition="Exists('$(MSBuildProjectDirectory)\packages.config')">$(MSBuildProjectDirectory)\packages.config</PackagesConfigPath>
+        <RestorePackagesWithLockFile>$(RestorePackagesWithLockFile)</RestorePackagesWithLockFile>
+        <NuGetLockFilePath>$(NuGetLockFilePath)</NuGetLockFilePath>
+        <RestoreLockedMode>$(RestoreLockedMode)</RestoreLockedMode>
       </_RestoreGraphEntry>
     </ItemGroup>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -234,6 +234,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                    '%(RestoreGraphProjectInputItems.Extension)' == '.vbproj' Or
                    '%(RestoreGraphProjectInputItems.Extension)' == '.fsproj' Or
                    '%(RestoreGraphProjectInputItems.Extension)' == '.nuproj' Or
+                   '%(RestoreGraphProjectInputItems.Extension)' == '.proj' Or
                    '%(RestoreGraphProjectInputItems.Extension)' == '.msbuildproj' Or
                    '%(RestoreGraphProjectInputItems.Extension)' == '.vcxproj' " />
     </ItemGroup>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -402,7 +402,7 @@ namespace NuGet.Commands
         {
             var librariesLookUp = lockFile.Targets
                 .SelectMany(t => t.Dependencies.Where(dep => dep.Type != PackageDependencyType.Project))
-                .Distinct(new LockFileDependencyIdVersionComparer())
+                .Distinct(LockFileDependencyIdVersionComparer.Default)
                 .ToDictionary(dep => new PackageIdentity(dep.Id, dep.ResolvedVersion), val => val.ContentHash);
 
             foreach (var library in assetsFile.Libraries.Where(lib => lib.Type == LibraryType.Package))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
@@ -20,23 +20,23 @@ namespace NuGet.Commands
 
         public string InputPath { get; }
 
-        public IList<string> ConfigFiles { get; }
+        public IReadOnlyList<string> ConfigFiles { get; }
 
-        public IList<string> FeedsUsed { get; }
+        public IReadOnlyList<string> FeedsUsed { get; }
 
         public int InstallCount { get; }
 
-        public IList<IRestoreLogMessage> Errors { get; }
+        public IReadOnlyList<IRestoreLogMessage> Errors { get; }
 
         public RestoreSummary(bool success)
         {
             Success = success;
             NoOpRestore = false;
             InputPath = null;
-            ConfigFiles = new List<string>().AsReadOnly();
-            FeedsUsed = new List<string>().AsReadOnly();
+            ConfigFiles = Array.Empty<string>();
+            FeedsUsed = Array.Empty<string>();
             InstallCount = 0;
-            Errors = new List<IRestoreLogMessage>().AsReadOnly();
+            Errors = Array.Empty<IRestoreLogMessage>();
         }
 
         public RestoreSummary(
@@ -61,17 +61,17 @@ namespace NuGet.Commands
         public RestoreSummary(
             bool success,
             string inputPath,
-            IEnumerable<string> configFiles,
-            IEnumerable<string> feedsUsed,
+            IReadOnlyList<string> configFiles,
+            IReadOnlyList<string> feedsUsed,
             int installCount,
-            IEnumerable<IRestoreLogMessage> errors)
+            IReadOnlyList<IRestoreLogMessage> errors)
         {
             Success = success;
             InputPath = inputPath;
-            ConfigFiles = configFiles.ToList().AsReadOnly();
-            FeedsUsed = feedsUsed.ToList().AsReadOnly();
+            ConfigFiles = configFiles;
+            FeedsUsed = feedsUsed;
             InstallCount = installCount;
-            Errors = errors.ToArray();
+            Errors = errors;
         }
 
         public static void Log(ILogger logger, IEnumerable<RestoreSummary> restoreSummaries, bool logErrors = false)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -173,7 +173,7 @@ namespace NuGet.Commands
                 else
                 {
                     // Read msbuild data for both non-nuget and .NET Core
-                    result = GetBaseSpec(specItem);
+                    result = GetBaseSpec(specItem, restoreType);
                 }
 
                 // Applies to all types
@@ -272,6 +272,14 @@ namespace NuGet.Commands
 
                     // Packages lock file properties
                     result.RestoreMetadata.RestoreLockProperties = GetRestoreLockProperites(specItem);
+                }
+
+                if (restoreType == ProjectStyle.PackagesConfig)
+                {
+                    var pcRestoreMetadata = (PackagesConfigProjectRestoreMetadata)result.RestoreMetadata;
+                    // Packages lock file properties
+                    pcRestoreMetadata.PackagesConfigPath = specItem.GetProperty("PackagesConfigPath");
+                    pcRestoreMetadata.RestoreLockProperties = GetRestoreLockProperites(specItem);
                 }
 
                 if (restoreType == ProjectStyle.ProjectJson)
@@ -740,7 +748,7 @@ namespace NuGet.Commands
             return result;
         }
 
-        private static PackageSpec GetBaseSpec(IMSBuildItem specItem)
+        private static PackageSpec GetBaseSpec(IMSBuildItem specItem, ProjectStyle projectStyle)
         {
             var frameworkInfo = GetFrameworks(specItem)
                 .Select(framework => new TargetFrameworkInformation()
@@ -750,7 +758,9 @@ namespace NuGet.Commands
                 .ToList();
 
             var spec = new PackageSpec(frameworkInfo);
-            spec.RestoreMetadata = new ProjectRestoreMetadata();
+            spec.RestoreMetadata = projectStyle == ProjectStyle.PackagesConfig
+                ? new PackagesConfigProjectRestoreMetadata()
+                : new ProjectRestoreMetadata();
             spec.FilePath = specItem.GetProperty("ProjectPath");
             spec.RestoreMetadata.ProjectName = specItem.GetProperty("ProjectName");
 

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -277,7 +277,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid restore input where RestorePackagesWithLockFile property is set to false and also exist a packages lock file at {0}..
+        ///   Looks up a localized string similar to Invalid restore input where RestorePackagesWithLockFile property is set to false but a packages lock file exists at {0}..
         /// </summary>
         internal static string Error_InvalidLockFileInput {
             get {
@@ -421,7 +421,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package {0} sha512 validation failed. The package is different than the last restore..
+        ///   Looks up a localized string similar to The package {0} content hash validation failed. The package is different than the last restore..
         /// </summary>
         internal static string Error_PackageValidationFailed {
             get {
@@ -502,7 +502,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The packages lock file is inconsistent with the project dependencies so restore can&apos;t be run in locked mode. Please disable RestoreLockedMode MSBuild property or pass explicit --force-evaluate flag to run restore to update the lock file..
+        ///   Looks up a localized string similar to The packages lock file is inconsistent with the project dependencies so restore can&apos;t be run in locked mode. Disable the RestoreLockedMode MSBuild property or pass an explicit --force-evaluate option to run restore to update the lock file..
         /// </summary>
         internal static string Error_RestoreInLockedMode {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -702,14 +702,14 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <comment>Do not localize snupkg and symbols.nupkg</comment>
   </data>
   <data name="Error_RestoreInLockedMode" xml:space="preserve">
-    <value>The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode. Please disable RestoreLockedMode MSBuild property or pass explicit --force-evaluate flag to run restore to update the lock file.</value>
+    <value>The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode. Disable the RestoreLockedMode MSBuild property or pass an explicit --force-evaluate option to run restore to update the lock file.</value>
   </data>
   <data name="Error_PackageValidationFailed" xml:space="preserve">
-    <value>The package {0} sha512 validation failed. The package is different than the last restore.</value>
+    <value>The package {0} content hash validation failed. The package is different than the last restore.</value>
     <comment>{0} - package id and version</comment>
   </data>
   <data name="Error_InvalidLockFileInput" xml:space="preserve">
-    <value>Invalid restore input where RestorePackagesWithLockFile property is set to false and also exist a packages lock file at {0}.</value>
+    <value>Invalid restore input where RestorePackagesWithLockFile property is set to false but a packages lock file exists at {0}.</value>
     <comment>{0} - packages lock file path</comment>
   </data>
   <data name="Log_WritingPackagesLockFile" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.Common/MsBuildStringUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/MsBuildStringUtility.cs
@@ -101,6 +101,19 @@ namespace NuGet.Common
         }
 
         /// <summary>
+        /// Convert the provided string to a boolean, or return null if the value can't be parsed as a boolean.
+        /// </summary>
+        public static bool? GetBooleanOrNull(string value)
+        {
+            if (bool.TryParse(value, out var result))
+            {
+                return result;
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Convert the provided string to MSBuild style.
         /// </summary>
         public static string Convert(string value)

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -14,6 +14,7 @@ using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
+using NuGet.PackageManagement.Utility;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
@@ -2336,6 +2337,10 @@ namespace NuGet.PackageManagement
                             await msbuildProject.ProjectSystem.EndProcessingAsync();
                         }
                     }
+
+                    PackagesConfigLockFileUtility.UpdateLockFile(msbuildProject,
+                        actionsList,
+                        token);
 
                     // Post process
                     await nuGetProject.PostProcessAsync(nuGetProjectContext, token);

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/NuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/NuGetProject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -98,6 +98,21 @@ namespace NuGet.ProjectManagement
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Get metadata value, or return null if it doesn't exist.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public object GetMetadataOrNull(string key)
+        {
+            if (Metadata.TryGetValue(key, out var value))
+            {
+                return value;
+            }
+
+            return null;
         }
 
         public Task SaveAsync(CancellationToken token)

--- a/src/NuGet.Core/NuGet.PackageManagement/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Properties/AssemblyInfo.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+#if SIGNED_BUILD
+[assembly: InternalsVisibleTo("NuGet.PackageManagement.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+#else
+[assembly: InternalsVisibleTo("NuGet.PackageManagement.Test")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+#endif

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -367,6 +367,51 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Directory {0} does not exist..
+        /// </summary>
+        internal static string Error_DirectoryDoesNotExist {
+            get {
+                return ResourceManager.GetString("Error_DirectoryDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File {0} does not exist..
+        /// </summary>
+        internal static string Error_FileDoesNotExist {
+            get {
+                return ResourceManager.GetString("Error_FileDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid restore input where RestorePackagesWithLockFile property is set to false but a packages lock file exists at {0}..
+        /// </summary>
+        internal static string Error_InvalidLockFileInput {
+            get {
+                return ResourceManager.GetString("Error_InvalidLockFileInput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The package {0} content hash validation failed. The package is different than the last restore..
+        /// </summary>
+        internal static string Error_PackageValidationFailed {
+            get {
+                return ResourceManager.GetString("Error_PackageValidationFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The packages lock file is inconsistent with the project dependencies so restore can&apos;t be run in locked mode. Run restore without using restore locked mode to update the lock file..
+        /// </summary>
+        internal static string Error_RestoreInLockedModePackagesConfig {
+            get {
+                return ResourceManager.GetString("Error_RestoreInLockedModePackagesConfig", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An error occurred while reading file &apos;{0}&apos;: {1}.
         /// </summary>
         internal static string ErrorLoadingPackagesConfig {

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -491,4 +491,23 @@
     <value>Signed package validation failed with multiple errors:{0}</value>
     <comment>0 - new line separated list of errors</comment>
   </data>
+  <data name="Error_InvalidLockFileInput" xml:space="preserve">
+    <value>Invalid restore input where RestorePackagesWithLockFile property is set to false but a packages lock file exists at {0}.</value>
+    <comment>{0} - packages lock file path</comment>
+  </data>
+  <data name="Error_PackageValidationFailed" xml:space="preserve">
+    <value>The package {0} content hash validation failed. The package is different than the last restore.</value>
+    <comment>{0} - package id and version</comment>
+  </data>
+  <data name="Error_RestoreInLockedModePackagesConfig" xml:space="preserve">
+    <value>The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode. Run restore without using restore locked mode to update the lock file.</value>
+  </data>
+  <data name="Error_DirectoryDoesNotExist" xml:space="preserve">
+    <value>Directory {0} does not exist.</value>
+    <comment>{0} is the directory name.</comment>
+  </data>
+  <data name="Error_FileDoesNotExist" xml:space="preserve">
+    <value>File {0} does not exist.</value>
+    <comment>{0} is the filename.</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/IPackagesConfigContentHashProvider.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/IPackagesConfigContentHashProvider.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using NuGet.Packaging.Core;
+
+namespace NuGet.PackageManagement
+{
+    internal interface IPackagesConfigContentHashProvider
+    {
+        string GetContentHash(PackageIdentity packageIdentity, CancellationToken token);
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/PackagesConfigContentHashProvider.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/PackagesConfigContentHashProvider.cs
@@ -1,0 +1,95 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+
+namespace NuGet.PackageManagement
+{
+    internal class PackagesConfigContentHashProvider : IPackagesConfigContentHashProvider
+    {
+        private readonly FolderNuGetProject _packagesFolder;
+
+        internal PackagesConfigContentHashProvider(FolderNuGetProject packagesFolder)
+        {
+            _packagesFolder = packagesFolder;
+        }
+
+        public string GetContentHash(PackageIdentity packageIdentity, CancellationToken token)
+        {
+            var nupkgPath = GetNupkgPath(packageIdentity, token);
+            var result = TryGetNupkgMetadata(nupkgPath);
+
+            if (!result.Found)
+            {
+                var contentHash = GetContentHashFromNupkg(nupkgPath, token);
+                result = new Result(found: true, contentHash: contentHash);
+
+                WriteNupkgMetadata(nupkgPath, result.ContentHash);
+            }
+
+            return result.ContentHash;
+        }
+
+        private string GetNupkgPath(PackageIdentity packageIdentity, CancellationToken token)
+        {
+            var packagePath = _packagesFolder.GetInstalledPackageFilePath(packageIdentity);
+            return packagePath;
+        }
+
+        private Result TryGetNupkgMetadata(string nupkgPath)
+        {
+            var metadataPath = Path.Combine(Path.GetDirectoryName(nupkgPath), PackagingCoreConstants.NupkgMetadataFileExtension);
+            if (File.Exists(metadataPath))
+            {
+                var metadata = NupkgMetadataFileFormat.Read(metadataPath);
+                return new Result(found: true, contentHash: metadata.ContentHash);
+            }
+
+            return Result.NotFound;
+        }
+
+        private string GetNupkgMetadataPath(string nupkgPath)
+        {
+            return Path.Combine(Path.GetDirectoryName(nupkgPath), PackagingCoreConstants.NupkgMetadataFileExtension);
+        }
+
+        private string GetContentHashFromNupkg(string filePath, CancellationToken token)
+        {
+            using (var reader = new PackageArchiveReader(filePath))
+            {
+                var hash = reader.GetContentHash(token);
+                return hash;
+            }
+        }
+
+        private void WriteNupkgMetadata(string nupkgPath, string contentHash)
+        {
+            var metadataPath = GetNupkgMetadataPath(nupkgPath);
+
+            var metadata = new NupkgMetadataFile()
+            {
+                ContentHash = contentHash
+            };
+
+            NupkgMetadataFileFormat.Write(metadataPath, metadata);
+        }
+
+        private struct Result
+        {
+            public static readonly Result NotFound = new Result(found: false, contentHash: null);
+
+            public Result(bool found, string contentHash)
+            {
+                Found = found;
+                ContentHash = contentHash;
+            }
+
+            public bool Found { get; }
+            public string ContentHash { get; }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/PackagesConfigLockFileUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/PackagesConfigLockFileUtility.cs
@@ -1,0 +1,353 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+
+namespace NuGet.PackageManagement.Utility
+{
+    public static class PackagesConfigLockFileUtility
+    {
+        private static readonly IComparer _dependencyComparer = new DependencyComparer();
+
+        internal static void UpdateLockFile(
+            MSBuildNuGetProject msbuildProject,
+            List<NuGetProjectAction> actionsList,
+            CancellationToken token)
+        {
+            if (msbuildProject == null)
+            {
+                // probably a `nuget.exe install` command, which doesn't support lock files until lock file arguments are implemented
+                return;
+            }
+
+            var lockFileName = GetPackagesLockFilePath(msbuildProject);
+            var lockFileExists = File.Exists(lockFileName);
+            var enableLockFile = IsRestorePackagesWithLockFileEnabled(msbuildProject);
+            if (enableLockFile == false && lockFileExists)
+            {
+                var message = string.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidLockFileInput, lockFileName);
+                throw new InvalidOperationException(message);
+            }
+            else if (enableLockFile == true || lockFileExists)
+            {
+                var lockFile = GetLockFile(lockFileExists, lockFileName);
+                lockFile.Targets[0].TargetFramework = msbuildProject.ProjectSystem.TargetFramework;
+                var contentHashUtil = new PackagesConfigContentHashProvider(msbuildProject.FolderNuGetProject);
+                ApplyChanges(lockFile, actionsList, contentHashUtil, token);
+                PackagesLockFileFormat.Write(lockFileName, lockFile);
+
+                // Add lock file to msbuild project, so it appears in solution explorer and is added to TFS source control.
+                if (msbuildProject != null)
+                {
+                    var projectUri = new Uri(msbuildProject.MSBuildProjectPath);
+                    var lockFileUri = new Uri(lockFileName);
+                    var lockFileRelativePath = projectUri.MakeRelativeUri(lockFileUri).OriginalString;
+                    if (Path.DirectorySeparatorChar != '/')
+                    {
+                        lockFileRelativePath.Replace('/', Path.DirectorySeparatorChar);
+                    }
+                    msbuildProject.ProjectSystem.AddExistingFile(lockFileRelativePath);
+                }
+            }
+        }
+
+        internal static string GetPackagesLockFilePath(MSBuildNuGetProject msbuildProject)
+        {
+            var directory = (string)msbuildProject.Metadata["FullPath"];
+            var msbuildProperty = msbuildProject?.ProjectSystem?.GetPropertyValue("NuGetLockFilePath");
+            var projectName = (string)msbuildProject.Metadata["UniqueName"];
+
+            return GetPackagesLockFilePath(directory, msbuildProperty, projectName);
+        }
+
+        public static string GetPackagesLockFilePath(string projectPath, string nuGetLockFilePath, string projectName)
+        {
+            if (!string.IsNullOrWhiteSpace(nuGetLockFilePath))
+            {
+                return Path.Combine(projectPath, nuGetLockFilePath);
+            }
+
+            return PackagesLockFileUtilities.GetNuGetLockFilePath(projectPath, projectName);
+        }
+
+        public static IReadOnlyList<IRestoreLogMessage> ValidatePackagesConfigLockFiles(
+            string projectFile,
+            string packagesConfigFile,
+            string projectName,
+            string nuGetLockFilePath,
+            string restorePackagesWithLockFile,
+            NuGetFramework projectTfm,
+            string packagesFolderPath,
+            bool restoreLockedMode,
+            CancellationToken token)
+        {
+            var lockFilePath = GetPackagesLockFilePath(Path.GetDirectoryName(packagesConfigFile), nuGetLockFilePath, projectName);
+            var lockFileExists = File.Exists(lockFilePath);
+            var lockFileOptIn = MSBuildStringUtility.GetBooleanOrNull(restorePackagesWithLockFile);
+            var useLockFile = lockFileOptIn == true || lockFileExists;
+
+            if (lockFileOptIn == false && lockFileExists)
+            {
+                var message = string.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidLockFileInput, lockFilePath);
+                var errors = new List<IRestoreLogMessage>();
+                var log = RestoreLogMessage.CreateError(NuGetLogCode.NU1005, message, packagesConfigFile);
+                log.ProjectPath = projectFile ?? packagesConfigFile;
+                errors.Add(log);
+                return errors;
+            }
+
+            if (useLockFile)
+            {
+                PackagesLockFile projectLockFileEquivalent = PackagesConfigLockFileUtility.FromPackagesConfigFile(packagesConfigFile,
+                    projectTfm,
+                    packagesFolderPath,
+                    token);
+
+                if (!lockFileExists)
+                {
+                    PackagesLockFileFormat.Write(lockFilePath, projectLockFileEquivalent);
+                    return null;
+                }
+                else
+                {
+                    PackagesLockFile lockFile = PackagesLockFileFormat.Read(lockFilePath);
+                    PackagesLockFileUtilities.LockFileValidityWithMatchedResults comparisonResult = PackagesLockFileUtilities.IsLockFileStillValid(projectLockFileEquivalent, lockFile);
+                    if (comparisonResult.IsValid)
+                    {
+                        // check sha hashes
+                        bool allContentHashesMatch = comparisonResult.MatchedDependencies.All(pair => pair.Key.ContentHash == pair.Value.ContentHash);
+                        if (allContentHashesMatch)
+                        {
+                            return null;
+                        }
+                        else
+                        {
+                            var errors = new List<IRestoreLogMessage>();
+                            foreach (var difference in comparisonResult.MatchedDependencies.Where(kvp => kvp.Key.ContentHash != kvp.Value.ContentHash))
+                            {
+                                var message = string.Format(CultureInfo.CurrentCulture, Strings.Error_PackageValidationFailed, difference.Key.Id + "." + difference.Key.ResolvedVersion);
+                                var log = RestoreLogMessage.CreateError(NuGetLogCode.NU1403, message, packagesConfigFile);
+                                log.ProjectPath = projectFile ?? packagesConfigFile;
+                                errors.Add(log);
+                            }
+                            return errors;
+                        }
+                    }
+                    else
+                    {
+                        if (restoreLockedMode)
+                        {
+                            var errors = new List<IRestoreLogMessage>();
+                            var log = RestoreLogMessage.CreateError(NuGetLogCode.NU1004, Strings.Error_RestoreInLockedModePackagesConfig, packagesConfigFile);
+                            log.ProjectPath = projectFile ?? packagesConfigFile;
+                            errors.Add(log);
+                            return errors;
+                        }
+                        else
+                        {
+                            PackagesLockFileFormat.Write(lockFilePath, projectLockFileEquivalent);
+                            return null;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+
+        private static bool? IsRestorePackagesWithLockFileEnabled(MSBuildNuGetProject msbuildProject)
+        {
+            var msbuildProperty = msbuildProject?.ProjectSystem?.GetPropertyValue("RestorePackagesWithLockFile");
+            if (msbuildProperty is string restorePackagesWithLockFileValue)
+            {
+                if (bool.TryParse(restorePackagesWithLockFileValue, out var useLockFile))
+                {
+                    return useLockFile;
+                }
+            }
+
+            return null;
+        }
+
+        internal static PackagesLockFile GetLockFile(bool lockFileExists, string lockFileName)
+        {
+            PackagesLockFile lockFile;
+
+            if (lockFileExists)
+            {
+                lockFile = PackagesLockFileFormat.Read(lockFileName);
+                lockFile.Version = PackagesLockFileFormat.Version;
+                if (lockFile.Targets.Count == 0)
+                {
+                    lockFile.Targets.Add(new PackagesLockFileTarget());
+                }
+                else if (lockFile.Targets.Count > 1)
+                {
+                    // merge lists
+                    while (lockFile.Targets.Count > 1)
+                    {
+                        var target = lockFile.Targets[1];
+
+                        for (var i = 0; i < target.Dependencies.Count; i++)
+                        {
+                            lockFile.Targets[0].Dependencies.Add(target.Dependencies[i]);
+                        }
+
+                        lockFile.Targets.RemoveAt(1);
+                    }
+                }
+            }
+            else
+            {
+                lockFile = new PackagesLockFile();
+                lockFile.Targets.Add(new PackagesLockFileTarget());
+            }
+
+            return lockFile;
+        }
+
+        internal static void ApplyChanges(
+            PackagesLockFile lockFile,
+            List<NuGetProjectAction> actionsList,
+            IPackagesConfigContentHashProvider contentHashUtil,
+            CancellationToken token)
+        {
+            RemoveUninstalledPackages(lockFile,
+                actionsList.Where(a => a.NuGetProjectActionType == NuGetProjectActionType.Uninstall));
+            AddInstalledPackages(lockFile,
+                actionsList.Where(a => a.NuGetProjectActionType == NuGetProjectActionType.Install),
+                contentHashUtil,
+                token);
+            ArrayList.Adapter((IList)lockFile.Targets[0].Dependencies).Sort(_dependencyComparer);
+        }
+
+        private static void RemoveUninstalledPackages(PackagesLockFile lockFile, IEnumerable<NuGetProjectAction> actionsList)
+        {
+            var dependencies = lockFile.Targets[0].Dependencies;
+            foreach (var toUninstall in actionsList)
+            {
+                Debug.Assert(toUninstall.NuGetProjectActionType == NuGetProjectActionType.Uninstall);
+
+                var toUninstallId = toUninstall.PackageIdentity.Id;
+
+                for (var i = 0; i < dependencies.Count; i++)
+                {
+                    if (string.Equals(toUninstallId, dependencies[i].Id, StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        dependencies.RemoveAt(i);
+                        break;
+                    }
+                }
+            }
+        }
+
+        private static void AddInstalledPackages(
+            PackagesLockFile lockFile,
+            IEnumerable<NuGetProjectAction> actionsList,
+            IPackagesConfigContentHashProvider contentHashUtil,
+            CancellationToken token)
+        {
+            foreach (var toInstall in actionsList)
+            {
+                Debug.Assert(toInstall.NuGetProjectActionType == NuGetProjectActionType.Install);
+
+                var newDependency = new LockFileDependency
+                {
+                    Id = toInstall.PackageIdentity.Id,
+                    ContentHash = contentHashUtil.GetContentHash(toInstall.PackageIdentity, token),
+                    RequestedVersion = new VersionRange(toInstall.PackageIdentity.Version, includeMinVersion: true, toInstall.PackageIdentity.Version, includeMaxVersion: true),
+                    ResolvedVersion = toInstall.PackageIdentity.Version,
+                    Type = PackageDependencyType.Direct
+                };
+
+                lockFile.Targets[0].Dependencies.Add(newDependency);
+            }
+        }
+
+        public static PackagesLockFile FromPackagesConfigFile(
+            string pcFile,
+            NuGetFramework projectTfm,
+            string packagesFolderPath,
+            CancellationToken token)
+        {
+            if (pcFile == null)
+            {
+                throw new ArgumentNullException(nameof(pcFile));
+            }
+            if (!File.Exists(pcFile))
+            {
+                throw new FileNotFoundException(string.Format(Strings.Error_FileDoesNotExist, pcFile), pcFile);
+            }
+            if (projectTfm == null)
+            {
+                throw new ArgumentNullException(nameof(projectTfm));
+            }
+            if (packagesFolderPath == null)
+            {
+                throw new ArgumentNullException(nameof(packagesFolderPath));
+            }
+            if (!Directory.Exists(packagesFolderPath))
+            {
+                throw new DirectoryNotFoundException(string.Format(Strings.Error_DirectoryDoesNotExist, packagesFolderPath));
+            }
+
+            var lockFile = new PackagesLockFile();
+            var target = new PackagesLockFileTarget();
+            lockFile.Targets.Add(target);
+            target.TargetFramework = projectTfm;
+
+            using (var stream = File.OpenRead(pcFile))
+            {
+                var contentHashUtil = new PackagesConfigContentHashProvider(new FolderNuGetProject(packagesFolderPath));
+
+                var reader = new PackagesConfigReader(stream);
+                foreach (var package in reader.GetPackages(allowDuplicatePackageIds: true))
+                {
+                    var dependency = new LockFileDependency
+                    {
+                        Id = package.PackageIdentity.Id,
+                        ContentHash = contentHashUtil.GetContentHash(package.PackageIdentity, token),
+                        RequestedVersion = new VersionRange(package.PackageIdentity.Version, includeMinVersion: true, package.PackageIdentity.Version, includeMaxVersion: true),
+                        ResolvedVersion = package.PackageIdentity.Version,
+                        Type = PackageDependencyType.Direct
+                    };
+
+                    target.Dependencies.Add(dependency);
+                }
+            }
+
+            return lockFile;
+        }
+
+        private class DependencyComparer : IComparer<LockFileDependency>, IComparer
+        {
+            public int Compare(LockFileDependency x, LockFileDependency y)
+            {
+                if (x == null && y == null) return 0;
+                if (x == null || y == null) return x == null ? -1 : 1;
+                return string.Compare(x.Id, y.Id, StringComparison.InvariantCultureIgnoreCase);
+            }
+
+            public int Compare(object x, object y)
+            {
+                return Compare(x as LockFileDependency, y as LockFileDependency);
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -204,19 +204,26 @@ namespace NuGet.ProjectModel
                 return null;
             }
 
-            var msbuildMetadata = new ProjectRestoreMetadata();
+            var projectStyleString = rawMSBuildMetadata.GetValue<string>("projectStyle");
+
+            ProjectStyle? projectStyle = null;
+            if (!string.IsNullOrEmpty(projectStyleString)
+                && Enum.TryParse<ProjectStyle>(projectStyleString, ignoreCase: true, result: out var projectStyleValue))
+            {
+                projectStyle = projectStyleValue;
+            }
+
+            var msbuildMetadata = projectStyle == ProjectStyle.PackagesConfig
+                ? new PackagesConfigProjectRestoreMetadata()
+                : new ProjectRestoreMetadata();
+
+            if (projectStyle.HasValue)
+            {
+                msbuildMetadata.ProjectStyle = projectStyle.Value;
+            }
 
             msbuildMetadata.ProjectUniqueName = rawMSBuildMetadata.GetValue<string>("projectUniqueName");
             msbuildMetadata.OutputPath = rawMSBuildMetadata.GetValue<string>("outputPath");
-
-            var projectStyleString = rawMSBuildMetadata.GetValue<string>("projectStyle");
-
-            ProjectStyle projectStyle;
-            if (!string.IsNullOrEmpty(projectStyleString)
-                && Enum.TryParse<ProjectStyle>(projectStyleString, ignoreCase: true, result: out projectStyle))
-            {
-                msbuildMetadata.ProjectStyle = projectStyle;
-            }
 
             msbuildMetadata.PackagesPath = rawMSBuildMetadata.GetValue<string>("packagesPath");
             msbuildMetadata.ProjectJsonPath = rawMSBuildMetadata.GetValue<string>("projectJsonPath");
@@ -337,6 +344,11 @@ namespace NuGet.ProjectModel
                     restoreLockProperties.GetValue<string>("restorePackagesWithLockFile"),
                     restoreLockProperties.GetValue<string>("nuGetLockFilePath"),
                     GetBoolOrFalse(restoreLockProperties, "restoreLockedMode", packageSpec.FilePath));
+            }
+
+            if (msbuildMetadata is PackagesConfigProjectRestoreMetadata pcMsbuildMetadata)
+            {
+                pcMsbuildMetadata.PackagesConfigPath = rawMSBuildMetadata.GetValue<string>("packagesConfigPath");
             }
 
             return msbuildMetadata;

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -159,6 +159,11 @@ namespace NuGet.ProjectModel
             // write NuGet lock file msbuild properties
             WriteNuGetLockFileProperties(writer, msbuildMetadata);
 
+            if (msbuildMetadata is PackagesConfigProjectRestoreMetadata pcMsbuildMetadata)
+            {
+                SetValue(writer, "packagesConfigPath", pcMsbuildMetadata.PackagesConfigPath);
+            }
+
             writer.WriteObjectEnd();
         }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/PackagesConfigProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackagesConfigProjectRestoreMetadata.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Common;
+using NuGet.Shared;
+
+namespace NuGet.ProjectModel
+{
+    public class PackagesConfigProjectRestoreMetadata : ProjectRestoreMetadata
+    {
+        /// <summary>
+        /// Full path to the packages.config file, if it exists. Only valid when ProjectStyle is PackagesConfig.
+        /// </summary>
+        public string PackagesConfigPath { get; set; }
+
+        public override int GetHashCode()
+        {
+            var hashCode = new HashCodeCombiner();
+
+            hashCode.AddObject(base.GetHashCode());
+            hashCode.AddObject(PackagesConfigPath);
+
+            return hashCode.CombinedHash;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as PackagesConfigProjectRestoreMetadata);
+        }
+
+        public bool Equals(PackagesConfigProjectRestoreMetadata obj)
+        {
+            return base.Equals(obj) &&
+                PathUtility.GetStringComparerBasedOnOS().Equals(PackagesConfigPath, obj.PackagesConfigPath);
+        }
+
+        public override ProjectRestoreMetadata Clone()
+        {
+            var clone = new PackagesConfigProjectRestoreMetadata();
+            FillClone(clone);
+            clone.PackagesConfigPath =  PackagesConfigPath;
+            return clone;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependency.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependency.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using NuGet.Common;
 using NuGet.Packaging.Core;
+using NuGet.ProjectModel.ProjectLockFile;
 using NuGet.Shared;
 using NuGet.Versioning;
 
@@ -37,12 +36,8 @@ namespace NuGet.ProjectModel
                 return true;
             }
 
-            return StringComparer.OrdinalIgnoreCase.Equals(Id, other.Id) &&
-                EqualityUtility.EqualsWithNullCheck(ResolvedVersion, other.ResolvedVersion) &&
-                EqualityUtility.EqualsWithNullCheck(RequestedVersion, other.RequestedVersion) &&
-                EqualityUtility.SequenceEqualWithNullCheck(Dependencies, other.Dependencies) &&
-                ContentHash == other.ContentHash &&
-                Type == other.Type;
+            return LockFileDependencyComparerWithoutContentHash.Default.Equals(this, other) &&
+                ContentHash == other.ContentHash;
         }
 
         public override bool Equals(object obj)
@@ -53,14 +48,8 @@ namespace NuGet.ProjectModel
         public override int GetHashCode()
         {
             var combiner = new HashCodeCombiner();
-
-            combiner.AddObject(Id);
-            combiner.AddObject(ResolvedVersion);
-            combiner.AddObject(RequestedVersion);
-            combiner.AddSequence(Dependencies);
+            combiner.AddObject(LockFileDependencyComparerWithoutContentHash.Default.GetHashCode(this));
             combiner.AddObject(ContentHash);
-            combiner.AddObject(Type);
-
             return combiner.CombinedHash;
         }
     }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependencyComparerWithoutContentHash.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependencyComparerWithoutContentHash.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Shared;
+
+namespace NuGet.ProjectModel.ProjectLockFile
+{
+    public class LockFileDependencyComparerWithoutContentHash : IEqualityComparer<LockFileDependency>
+    {
+        public static LockFileDependencyComparerWithoutContentHash Default { get; } = new LockFileDependencyComparerWithoutContentHash();
+
+        public bool Equals(LockFileDependency x, LockFileDependency y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x == null || y == null)
+            {
+                return false;
+            }
+
+            return LockFileDependencyIdVersionComparer.Default.Equals(x, y) &&
+                x.Type == y.Type &&
+                EqualityUtility.EqualsWithNullCheck(x.RequestedVersion, y.RequestedVersion) &&
+                EqualityUtility.SequenceEqualWithNullCheck(x.Dependencies, y.Dependencies);
+        }
+
+        public int GetHashCode(LockFileDependency obj)
+        {
+            var combiner = new HashCodeCombiner();
+            combiner.AddObject(LockFileDependencyIdVersionComparer.Default.GetHashCode(obj));
+            combiner.AddObject(obj.RequestedVersion);
+            combiner.AddSequence(obj.Dependencies);
+            combiner.AddObject(obj.Type);
+            return combiner.CombinedHash;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependencyIdVersionComparer.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependencyIdVersionComparer.cs
@@ -1,13 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
-using System.Text;
-using NuGet.Common;
 using NuGet.Shared;
 
 namespace NuGet.ProjectModel
 {
     public class LockFileDependencyIdVersionComparer : IEqualityComparer<LockFileDependency>
     {
+        public static LockFileDependencyIdVersionComparer Default { get; } = new LockFileDependencyIdVersionComparer();
+
         public bool Equals(LockFileDependency x, LockFileDependency y)
         {
             if (ReferenceEquals(x, y))
@@ -15,8 +18,7 @@ namespace NuGet.ProjectModel
                 return true;
             }
 
-            if (ReferenceEquals(x, null)
-                || ReferenceEquals(y, null))
+            if (x == null || y == null)
             {
                 return false;
             }
@@ -28,10 +30,8 @@ namespace NuGet.ProjectModel
         public int GetHashCode(LockFileDependency obj)
         {
             var combiner = new HashCodeCombiner();
-
             combiner.AddObject(obj.Id);
             combiner.AddObject(obj.ResolvedVersion);
-
             return combiner.CombinedHash;
         }
     }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -46,12 +46,32 @@ namespace NuGet.ProjectModel
             return path;
         }
 
+        /// <summary>
+        /// The lock file will get invalidated if one or more of the below are true
+        ///     1. The target frameworks list of the current project was updated.
+        ///     2. The runtime list of the current project waw updated.
+        ///     3. The packages of the current project were updated.
+        ///     4. The packages of the dependent projects were updated.
+        ///     5. The framework list of the dependent projects were updated with frameworks incompatible with the main project framework.
+        /// </summary>
+        /// <param name="dgSpec">The <see cref="DependencyGraphSpec"/> for the new project defintion.</param>
+        /// <param name="nuGetLockFile">The current <see cref="PackagesLockFile"/>.</param>
+        /// <returns></returns>
         public static bool IsLockFileStillValid(DependencyGraphSpec dgSpec, PackagesLockFile nuGetLockFile)
         {
             var uniqueName = dgSpec.Restore.First();
             var project = dgSpec.GetProjectSpec(uniqueName);
 
             // Validate all the direct dependencies
+            var lockFileFrameworks = nuGetLockFile.Targets
+                .Where(t => t.TargetFramework != null)
+                .Select(t => t.TargetFramework)
+                .Distinct();
+            if (project.TargetFrameworks.Count != lockFileFrameworks.Count())
+            {
+                return false;
+            }
+
             foreach (var framework in project.TargetFrameworks)
             {
                 var target = nuGetLockFile.Targets.FirstOrDefault(
@@ -70,6 +90,15 @@ namespace NuGet.ProjectModel
                     // lock file is out of sync
                     return false;
                 }
+            }
+
+            // Validate the runtimes for the current project did not change.
+            var projectRuntimesKeys = project.RuntimeGraph.Runtimes.Select(r => r.Key).Where(k => k != null);
+            var lockFileRuntimes = nuGetLockFile.Targets.Select(t => t.RuntimeIdentifier).Where(r => r != null);
+
+            if (!projectRuntimesKeys.SequenceEqual(lockFileRuntimes))
+            {
+                return false;
             }
 
             // Validate all P2P references

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -103,7 +103,7 @@ namespace NuGet.ProjectModel
 
             // Validate the runtimes for the current project did not change.
             var projectRuntimesKeys = project.RuntimeGraph.Runtimes.Select(r => r.Key).Where(k => k != null);
-            var lockFileRuntimes = nuGetLockFile.Targets.Select(t => t.RuntimeIdentifier).Where(r => r != null);
+            var lockFileRuntimes = nuGetLockFile.Targets.Select(t => t.RuntimeIdentifier).Where(r => r != null).Distinct();
 
             if (!projectRuntimesKeys.SequenceEqual(lockFileRuntimes))
             {

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.ProjectModel.ProjectLockFile;
 using NuGet.Shared;
 
 namespace NuGet.ProjectModel
@@ -36,14 +37,22 @@ namespace NuGet.ProjectModel
             }
 
             var projectName = Path.GetFileNameWithoutExtension(project.RestoreMetadata.ProjectPath);
-            path = Path.Combine(project.BaseDirectory, "packages." + projectName.Replace(' ', '_') + ".lock.json");
+            return GetNuGetLockFilePath(project.BaseDirectory, projectName);
+        }
 
-            if (!File.Exists(path))
+        public static string GetNuGetLockFilePath(string baseDirectory, string projectName)
+        {
+            if (!string.IsNullOrEmpty(projectName))
             {
-                path = Path.Combine(project.BaseDirectory, PackagesLockFileFormat.LockFileName);
+                var path = Path.Combine(baseDirectory, "packages." + projectName.Replace(' ', '_') + ".lock.json");
+
+                if (File.Exists(path))
+                {
+                    return path;
+                }
             }
 
-            return path;
+            return Path.Combine(baseDirectory, PackagesLockFileFormat.LockFileName);
         }
 
         public static bool IsLockFileStillValid(DependencyGraphSpec dgSpec, PackagesLockFile nuGetLockFile)
@@ -164,6 +173,104 @@ namespace NuGet.ProjectModel
             return true;
         }
 
+        /// <summary>Compares two lock files to check if the structure is the same (all values are the same, other
+        /// than SHA hash), and matches dependencies so the caller can easily compare SHA hashes.</summary>
+        /// <param name="expected">The expected lock file structure. Usuaully generated from the project.</param>
+        /// <param name="actual">The lock file that was loaded from the file on disk.</param>
+        /// <returns>A <see cref="LockFileValidityWithMatchedResults"/>.</returns>
+        public static LockFileValidityWithMatchedResults IsLockFileStillValid(PackagesLockFile expected, PackagesLockFile actual)
+        {
+            if (expected == null)
+            {
+                throw new ArgumentNullException(nameof(expected));
+            }
+            if (actual == null)
+            {
+                throw new ArgumentNullException(nameof(actual));
+            }
+
+            // do quick checks for obvious structure differences
+            if (expected.Version != actual.Version)
+            {
+                return LockFileValidityWithMatchedResults.Invalid;
+            }
+
+            if (expected.Targets.Count != actual.Targets.Count)
+            {
+                return LockFileValidityWithMatchedResults.Invalid;
+            }
+
+            foreach (var expectedTarget in expected.Targets)
+            {
+                PackagesLockFileTarget actualTarget = null;
+
+                for (var i = 0; i < actual.Targets.Count; i++)
+                {
+                    if (actual.Targets[i].TargetFramework == expectedTarget.TargetFramework)
+                    {
+                        if (actualTarget == null)
+                        {
+                            actualTarget = actual.Targets[i];
+                        }
+                        else
+                        {
+                            // more than 1? possible bug or bad hand edited lock file.
+                            return LockFileValidityWithMatchedResults.Invalid;
+                        }
+                    }
+
+                    if (actualTarget == null)
+                    {
+                        return LockFileValidityWithMatchedResults.Invalid;
+                    }
+
+                    if (actualTarget.Dependencies.Count != expectedTarget.Dependencies.Count)
+                    {
+                        return LockFileValidityWithMatchedResults.Invalid;
+                    }
+                }
+            }
+
+            // no obvious structure difference, so start trying to match individual dependencies
+            var matchedDependencies = new List<KeyValuePair<LockFileDependency, LockFileDependency>>();
+            var isLockFileStillValid = true;
+            var dependencyComparer = LockFileDependencyComparerWithoutContentHash.Default;
+
+            foreach (PackagesLockFileTarget expectedTarget in expected.Targets)
+            {
+                PackagesLockFileTarget actualTarget = actual.Targets.Single(t => t.TargetFramework == expectedTarget.TargetFramework);
+
+                // Duplicate dependencies list so we can remove matches to validate that all dependencies were matched
+                var actualDependencies = new Dictionary<LockFileDependency, LockFileDependency>(
+                    actualTarget.Dependencies.Count, 
+                    dependencyComparer);
+                foreach (LockFileDependency actualDependency in actualTarget.Dependencies)
+                {
+                    actualDependencies.Add(actualDependency, actualDependency);
+                }
+
+                foreach (LockFileDependency expectedDependency in expectedTarget.Dependencies)
+                {
+                    if (actualDependencies.TryGetValue(expectedDependency, out var actualDependency))
+                    {
+                        matchedDependencies.Add(new KeyValuePair<LockFileDependency, LockFileDependency>(expectedDependency, actualDependency));
+                        actualDependencies.Remove(actualDependency);
+                    }
+                    else
+                    {
+                        return LockFileValidityWithMatchedResults.Invalid;
+                    }
+                }
+
+                if (actualDependencies.Count != 0)
+                {
+                    return LockFileValidityWithMatchedResults.Invalid;
+                }
+            }
+
+            return new LockFileValidityWithMatchedResults(isLockFileStillValid, matchedDependencies);
+        }
+
         private static bool HasProjectDependencyChanged(IEnumerable<LibraryDependency> newDependencies, IEnumerable<LockFileDependency> lockFileDependencies)
         {
             // If the count is not the same, something has changed.
@@ -234,5 +341,29 @@ namespace NuGet.ProjectModel
             return false;
         }
 
+        /// <summary>
+        /// A class to return information about lock file validity
+        /// </summary>
+        public class LockFileValidityWithMatchedResults
+        {
+            /// <summary>
+            /// True if the lock file had the expected structure (all values expected, other than content hash)
+            /// </summary>
+            public bool IsValid { get; }
+
+            /// <summary>
+            /// A list of matched dependencies, so content sha can easily be checked.
+            /// </summary>
+            public IReadOnlyList<KeyValuePair<LockFileDependency, LockFileDependency>> MatchedDependencies { get; }
+
+            public LockFileValidityWithMatchedResults(bool isValid, IReadOnlyList<KeyValuePair<LockFileDependency, LockFileDependency>> matchedDependencies)
+            {
+                IsValid = isValid;
+                MatchedDependencies = matchedDependencies;
+            }
+
+            public static readonly LockFileValidityWithMatchedResults Invalid =
+                new LockFileValidityWithMatchedResults(isValid: false, matchedDependencies: null);
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -94,7 +94,7 @@ namespace NuGet.ProjectModel
 
             // Validate the runtimes for the current project did not change.
             var projectRuntimesKeys = project.RuntimeGraph.Runtimes.Select(r => r.Key).Where(k => k != null);
-            var lockFileRuntimes = nuGetLockFile.Targets.Select(t => t.RuntimeIdentifier).Where(r => r != null);
+            var lockFileRuntimes = nuGetLockFile.Targets.Select(t => t.RuntimeIdentifier).Where(r => r != null).Distinct();
 
             if (!projectRuntimesKeys.SequenceEqual(lockFileRuntimes))
             {

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -55,12 +55,32 @@ namespace NuGet.ProjectModel
             return Path.Combine(baseDirectory, PackagesLockFileFormat.LockFileName);
         }
 
+        /// <summary>
+        /// The lock file will get invalidated if one or more of the below are true
+        ///     1. The target frameworks list of the current project was updated.
+        ///     2. The runtime list of the current project waw updated.
+        ///     3. The packages of the current project were updated.
+        ///     4. The packages of the dependent projects were updated.
+        ///     5. The framework list of the dependent projects were updated with frameworks incompatible with the main project framework.
+        /// </summary>
+        /// <param name="dgSpec">The <see cref="DependencyGraphSpec"/> for the new project defintion.</param>
+        /// <param name="nuGetLockFile">The current <see cref="PackagesLockFile"/>.</param>
+        /// <returns></returns>
         public static bool IsLockFileStillValid(DependencyGraphSpec dgSpec, PackagesLockFile nuGetLockFile)
         {
             var uniqueName = dgSpec.Restore.First();
             var project = dgSpec.GetProjectSpec(uniqueName);
 
             // Validate all the direct dependencies
+            var lockFileFrameworks = nuGetLockFile.Targets
+                .Where(t => t.TargetFramework != null)
+                .Select(t => t.TargetFramework)
+                .Distinct();
+            if (project.TargetFrameworks.Count != lockFileFrameworks.Count())
+            {
+                return false;
+            }
+
             foreach (var framework in project.TargetFrameworks)
             {
                 var target = nuGetLockFile.Targets.FirstOrDefault(
@@ -79,6 +99,15 @@ namespace NuGet.ProjectModel
                     // lock file is out of sync
                     return false;
                 }
+            }
+
+            // Validate the runtimes for the current project did not change.
+            var projectRuntimesKeys = project.RuntimeGraph.Runtimes.Select(r => r.Key).Where(k => k != null);
+            var lockFileRuntimes = nuGetLockFile.Targets.Select(t => t.RuntimeIdentifier).Where(r => r != null);
+
+            if (!projectRuntimesKeys.SequenceEqual(lockFileRuntimes))
+            {
+                return false;
             }
 
             // Validate all P2P references

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -178,31 +178,35 @@ namespace NuGet.ProjectModel
                    EqualityUtility.EqualsWithNullCheck(RestoreLockProperties, other.RestoreLockProperties);
         }
 
-        public ProjectRestoreMetadata Clone()
+        public virtual ProjectRestoreMetadata Clone()
         {
-            return new ProjectRestoreMetadata
-            {
-                ProjectStyle = ProjectStyle,
-                ProjectPath = ProjectPath,
-                ProjectJsonPath = ProjectJsonPath,
-                OutputPath = OutputPath,
-                ProjectName = ProjectName,
-                ProjectUniqueName = ProjectUniqueName,
-                PackagesPath = PackagesPath,
-                CacheFilePath = CacheFilePath,
-                CrossTargeting = CrossTargeting,
-                LegacyPackagesDirectory = LegacyPackagesDirectory,
-                SkipContentFileWrite = SkipContentFileWrite,
-                ValidateRuntimeAssets = ValidateRuntimeAssets,
-                FallbackFolders = FallbackFolders != null ? new List<string>(FallbackFolders) : null,
-                ConfigFilePaths = ConfigFilePaths != null ? new List<string>(ConfigFilePaths) : null,
-                OriginalTargetFrameworks = OriginalTargetFrameworks != null ? new List<string>(OriginalTargetFrameworks) : null,
-                Sources = Sources?.Select(c => c.Clone()).ToList(),
-                TargetFrameworks = TargetFrameworks?.Select(c => c.Clone()).ToList(),
-                Files = Files?.Select(c => c.Clone()).ToList(),
-                ProjectWideWarningProperties = ProjectWideWarningProperties?.Clone(),
-                RestoreLockProperties = RestoreLockProperties?.Clone()
-            };
+            var clone = new ProjectRestoreMetadata();
+            FillClone(clone);
+            return clone;
+        }
+
+        protected void FillClone(ProjectRestoreMetadata clone)
+        {
+            clone.ProjectStyle = ProjectStyle;
+            clone.ProjectPath = ProjectPath;
+            clone.ProjectJsonPath = ProjectJsonPath;
+            clone.OutputPath = OutputPath;
+            clone.ProjectName = ProjectName;
+            clone.ProjectUniqueName = ProjectUniqueName;
+            clone.PackagesPath = PackagesPath;
+            clone.CacheFilePath = CacheFilePath;
+            clone.CrossTargeting = CrossTargeting;
+            clone.LegacyPackagesDirectory = LegacyPackagesDirectory;
+            clone.SkipContentFileWrite = SkipContentFileWrite;
+            clone.ValidateRuntimeAssets = ValidateRuntimeAssets;
+            clone.FallbackFolders = FallbackFolders != null ? new List<string>(FallbackFolders) : null;
+            clone.ConfigFilePaths = ConfigFilePaths != null ? new List<string>(ConfigFilePaths) : null;
+            clone.OriginalTargetFrameworks = OriginalTargetFrameworks != null ? new List<string>(OriginalTargetFrameworks) : null;
+            clone.Sources = Sources?.Select(c => c.Clone()).ToList();
+            clone.TargetFrameworks = TargetFrameworks?.Select(c => c.Clone()).ToList();
+            clone.Files = Files?.Select(c => c.Clone()).ToList();
+            clone.ProjectWideWarningProperties = ProjectWideWarningProperties?.Clone();
+            clone.RestoreLockProperties = RestoreLockProperties?.Clone();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/SourceCacheContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SourceCacheContext.cs
@@ -148,6 +148,12 @@ namespace NuGet.Protocol.Core.Types
 
         public void Dispose()
         {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
             var currentTempFolder = Interlocked.CompareExchange(ref _generatedTempFolder, value: null, comparand: null);
 
             if (currentTempFolder != null)

--- a/test/EndToEnd/tests/InstallPackageTest.ps1
+++ b/test/EndToEnd/tests/InstallPackageTest.ps1
@@ -2848,7 +2848,7 @@ function Test-InstallPackagesNupkgOnline
     $p = New-ClassLibrary
 
     # Act
-    $p | Install-package https://az320820.vo.msecnd.net/packages/microsoft.aspnet.mvc.4.0.20505.nupkg
+    $p | Install-package https://globalcdn.nuget.org/packages/microsoft.aspnet.mvc.4.0.20505.nupkg
 
     # Assert
     Assert-Package $p microsoft.aspnet.mvc 4.0.20505.0

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using NuGet.CommandLine.Test;
 using NuGet.Frameworks;
@@ -16,6 +17,9 @@ namespace NuGet.CommandLine.FuncTest.Commands
 {
     public class RestoreCommandTests
     {
+        private const int _successExitCode = 0;
+        private const int _failureExitCode = 1;
+
         [Fact]
         public async Task Restore_LegacyPackageReference_WithNuGetLockFile()
         {
@@ -143,6 +147,357 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 Assert.Equal(PackageDependencyType.Transitive, targets[0].Dependencies[1].Type);
                 Assert.Equal("b", targets[0].Dependencies[2].Id);
                 Assert.Equal(PackageDependencyType.Project, targets[0].Dependencies[2].Type);
+            }
+        }
+
+        [Fact]
+        public async Task Restore_LegacyPackageReference_WithNuGetLockFileArgument()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    net461);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Act
+                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile");
+
+                // Assert
+                Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
+            }
+        }
+
+        [Fact]
+        public async Task Restore_LegacyPackageReference_WithCustomNameNuGetLockFileArgument()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    net461);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Act
+                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile", "-LockFilePath", "custom.lock.json");
+
+                // Assert
+                var expectedLockFileName = Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "custom.lock.json");
+                Assert.True(File.Exists(expectedLockFileName));
+            }
+        }
+
+        [Fact]
+        public async Task Restore_LegacyPackageReference_WithNuGetLockFileLockedMode()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    net461);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
+
+                var packageY = new SimpleTestPackageContext()
+                {
+                    Id = "y",
+                    Version = "1.0.0"
+                };
+                packageY.Files.Clear();
+                packageY.AddFile("lib/net461/y.dll");
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX,
+                    packageY);
+
+                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile");
+                Assert.True(result.Success);
+                Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
+
+                projectA.AddPackageToAllFrameworks(packageY);
+                projectA.Save();
+
+                // Act
+                result = RunRestore(pathContext, _failureExitCode, "-LockedMode");
+
+                // Assert
+                Assert.Contains("NU1004:", result.Errors);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Restore_LegacyPackageReference_ForceEvaluateNuGetLockFile(bool forceEvaluate)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    net461);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile");
+                Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
+
+                // Act
+                result = forceEvaluate
+                    ? RunRestore(pathContext, _successExitCode, "-UseLockFile", "-ForceEvaluate")
+                    : RunRestore(pathContext, _successExitCode, "-UseLockFile");
+
+                // Assert
+                Assert.Contains("Assets file has not changed.", result.AllOutput);
+                if (forceEvaluate)
+                {
+                    Assert.Contains("Writing packages lock file at disk.", result.AllOutput);
+                }
+                else
+                {
+                    Assert.Contains("No-Op restore.", result.AllOutput);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Restore_LegacyPackagesConfig_WithNuGetLockFileArgument()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    net461);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
+
+                Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+@"<packages>
+  <package id=""x"" version=""1.0.0"" targetFramework=""net461"" />
+</packages>");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Act
+                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile");
+
+                // Assert
+                Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
+            }
+        }
+
+        [Fact]
+        public async Task Restore_LegacyPackagesConfig_WithCustomNamedNuGetLockFile()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    net461);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
+
+                Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+@"<packages>
+  <package id=""x"" version=""1.0.0"" targetFramework=""net461"" />
+</packages>");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Act
+                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile", "-LockFilePath", "custom.lock.json");
+
+                // Assert
+                var expectedLockFileName = Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "custom.lock.json");
+                Assert.True(File.Exists(expectedLockFileName));
+            }
+        }
+
+        [Fact]
+        public async Task Restore_LegacyPackagesConfig_WithNuGetLockFileLockedMode()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net461 = NuGetFramework.Parse("net461");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    net461);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/x.dll");
+
+                var packageY = new SimpleTestPackageContext()
+                {
+                    Id = "y",
+                    Version = "1.0.0"
+                };
+                packageY.Files.Clear();
+                packageY.AddFile("lib/net461/y.dll");
+
+                Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+@"<packages>
+  <package id=""x"" version=""1.0.0"" targetFramework=""net461"" />
+</packages>");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX,
+                    packageY);
+
+                // Restore to set up lock file
+                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile");
+                Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
+
+                // Change packages to cause lock file difference
+                Util.CreateFile(Path.GetDirectoryName(projectA.ProjectPath), "packages.config",
+@"<packages>
+  <package id=""y"" version=""1.0.0"" targetFramework=""net461"" />
+</packages>");
+
+                // Act
+                result = RunRestore(pathContext, _failureExitCode, "-UseLockFile", "-LockedMode");
+
+                // Assert
+                Assert.Contains("NU1004:", result.Errors);
             }
         }
 
@@ -451,7 +806,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
             }
         }
 
-        public static CommandRunnerResult RunRestore(SimpleTestPathContext pathContext, int expectedExitCode = 0)
+        public static CommandRunnerResult RunRestore(SimpleTestPathContext pathContext, int expectedExitCode = 0, params string[] additionalArguments)
         {
             var nugetExe = Util.GetNuGetExePath();
 
@@ -461,13 +816,15 @@ namespace NuGet.CommandLine.FuncTest.Commands
                 { "NUGET_HTTP_CACHE_PATH", pathContext.HttpCacheFolder }
             };
 
-            var args = new string[]
+            var args = new string[4 + additionalArguments.Length];
+            args[0] = "restore";
+            args[1] = pathContext.SolutionRoot;
+            args[2] = "-Verbosity";
+            args[3] = "detailed";
+            for (int i = 0; i < additionalArguments.Length; i++)
             {
-                "restore",
-                pathContext.SolutionRoot,
-                "-Verbosity",
-                "detailed"
-            };
+                args[4 + i] = additionalArguments[i];
+            }
 
             // Act
             var r = CommandRunner.Run(

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/LocalResourceUtilsTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/LocalResourceUtilsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -34,24 +34,27 @@ namespace NuGet.CommandLine.Test
             {
                 // Arrange
                 targetDirectoryPath = targetDirectory.Path;
-                var workingDirectory = TestDirectory.Create();
-                var subDirectoryPath = Path.Combine(workingDirectory.Path, "SubDirectory");
-                var subDirectory = Directory.CreateDirectory(subDirectoryPath);
 
-                Util.CreatePackage(workingDirectory.Path, Guid.NewGuid().ToString("N"), "1.0.0");
-                fileInTargetDirectory = Path.Combine(targetDirectoryPath, "test.txt");
-                File.WriteAllText(fileInTargetDirectory, string.Empty);
+                using (var workingDirectory = TestDirectory.Create())
+                {
+                    var subDirectoryPath = Path.Combine(workingDirectory.Path, "SubDirectory");
+                    var subDirectory = Directory.CreateDirectory(subDirectoryPath);
 
-                Util.CreateJunctionPoint(subDirectory.FullName, targetDirectoryPath, overwrite: true);
+                    Util.CreatePackage(workingDirectory.Path, Guid.NewGuid().ToString("N"), "1.0.0");
+                    fileInTargetDirectory = Path.Combine(targetDirectoryPath, "test.txt");
+                    File.WriteAllText(fileInTargetDirectory, string.Empty);
 
-                // Act
-                LocalResourceUtils.DeleteDirectoryTree(workingDirectory.Path, failedDeletes);
+                    Util.CreateJunctionPoint(subDirectory.FullName, targetDirectoryPath, overwrite: true);
 
-                // Assert
-                Assert.Empty(failedDeletes);
-                Assert.False(Directory.Exists(workingDirectory.Path));
-                Assert.True(Directory.Exists(targetDirectoryPath));
-                Assert.True(File.Exists(fileInTargetDirectory));
+                    // Act
+                    LocalResourceUtils.DeleteDirectoryTree(workingDirectory.Path, failedDeletes);
+
+                    // Assert
+                    Assert.Empty(failedDeletes);
+                    Assert.False(Directory.Exists(workingDirectory.Path));
+                    Assert.True(Directory.Exists(targetDirectoryPath));
+                    Assert.True(File.Exists(fileInTargetDirectory));
+                }
             }
 
             // Verify clean-up

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 using NuGet.Common;
@@ -17,30 +16,30 @@ namespace NuGet.CommandLine.Test
     {
         private class TestInfo : IDisposable
         {
+            private readonly TestDirectory _projectDirectory;
+            private readonly string _msBuildDirectory;
+            private readonly TestNuGetProjectContext _nuGetProjectContext;
+
             public MSBuildProjectSystem MSBuildProjectSystem { get; }
-            private string ProjectDirectory { get; }
-            private string MSBuildDirectory { get; }
-            private TestNuGetProjectContext NuGetProjectContext { get; }
 
             public TestInfo(string projectFileContent, string projectName = "proj1")
             {
-                ProjectDirectory = TestDirectory.Create();
-                MSBuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
-                NuGetProjectContext = new TestNuGetProjectContext();
+                _projectDirectory = TestDirectory.Create();
+                _msBuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
+                _nuGetProjectContext = new TestNuGetProjectContext();
 
-                var projectFilePath = Path.Combine(ProjectDirectory, projectName + ".csproj");
+                var projectFilePath = Path.Combine(_projectDirectory, projectName + ".csproj");
                 File.WriteAllText(projectFilePath, projectFileContent);
 
                 MSBuildProjectSystem
-                    = new MSBuildProjectSystem(MSBuildDirectory, projectFilePath, NuGetProjectContext);
+                    = new MSBuildProjectSystem(_msBuildDirectory, projectFilePath, _nuGetProjectContext);
             }
 
             public void Dispose()
             {
-                TestFileSystemUtility.DeleteRandomTestFolder(ProjectDirectory);
+                _projectDirectory.Dispose();
             }
         }
-
 
         [Fact]
         public void MSBuildProjectSystem_AddFile()

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
@@ -479,15 +479,20 @@ namespace NuGet.CommandLine
                     waitForExit: true);
 
                 // Assert
-                var package = new PackageArchiveReader(Path.Combine(workingDirectory, "Assembly.1.0.0.nupkg"));
-                var files = (await package.GetPackageFilesAsync(PackageSaveMode.Files, CancellationToken.None)).ToArray();
+                using (var package = new PackageArchiveReader(Path.Combine(workingDirectory, "Assembly.1.0.0.nupkg")))
+                {
+                    var files = (await package.GetPackageFilesAsync(PackageSaveMode.Files, CancellationToken.None)).ToArray();
 
-                Assert.Equal(0, r.Item1);
-                Array.Sort(files);
-                Assert.Equal(files, new[] {
-                    @"lib/net45/Assembly.dll",
-                    @"lib/net45/Assembly.xml"
-                });
+                    Assert.Equal(0, r.Item1);
+                    Array.Sort(files);
+                    Assert.Equal(
+                        files,
+                        new[]
+                        {
+                            @"lib/net45/Assembly.dll",
+                            @"lib/net45/Assembly.xml"
+                        });
+                }
             }
         }
 
@@ -518,15 +523,20 @@ namespace NuGet.CommandLine
                 // Assert
                 Util.VerifyResultSuccess(r);
 
-                var package = new PackageArchiveReader(Path.Combine(workingDirectory, "Link.1.0.0.nupkg"));
-                var files = (await package.GetPackageFilesAsync(PackageSaveMode.Files, CancellationToken.None)).ToArray();
+                using (var package = new PackageArchiveReader(Path.Combine(workingDirectory, "Link.1.0.0.nupkg")))
+                {
+                    var files = (await package.GetPackageFilesAsync(PackageSaveMode.Files, CancellationToken.None)).ToArray();
 
-                Assert.Equal(0, r.Item1);
-                Array.Sort(files);
-                Assert.Equal(files, new[] {
-                    @"lib/net45/A.dll",
-                    @"lib/net45/Link.dll"
-                });
+                    Assert.Equal(0, r.Item1);
+                    Array.Sort(files);
+                    Assert.Equal(
+                        files,
+                        new[]
+                        {
+                            @"lib/net45/A.dll",
+                            @"lib/net45/Link.dll"
+                        });
+                }
             }
         }
 
@@ -566,16 +576,22 @@ namespace NuGet.CommandLine
 
                 // Assert
                 Util.VerifyResultSuccess(r);
-                var package = new PackageArchiveReader(Path.Combine(workingDirectory, "Link.1.0.0.nupkg"));
-                var files = (await package.GetPackageFilesAsync(PackageSaveMode.Files, CancellationToken.None)).ToArray();
 
-                Assert.Equal(0, r.Item1);
-                Array.Sort(files);
-                Assert.Equal(files, new[] {
-                    @"lib/net45/A.dll",
-                    @"lib/net45/C.dll",
-                    @"lib/net45/Link.dll"
-                });
+                using (var package = new PackageArchiveReader(Path.Combine(workingDirectory, "Link.1.0.0.nupkg")))
+                {
+                    var files = (await package.GetPackageFilesAsync(PackageSaveMode.Files, CancellationToken.None)).ToArray();
+
+                    Assert.Equal(0, r.Item1);
+                    Array.Sort(files);
+                    Assert.Equal(
+                        files,
+                        new[]
+                        {
+                            @"lib/net45/A.dll",
+                            @"lib/net45/C.dll",
+                            @"lib/net45/Link.dll"
+                        });
+                }
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -8551,7 +8551,7 @@ namespace NuGet.CommandLine.Test
         [InlineData(new string[] { "win7-x86" }, new string[] { "win-x64" })]
         [InlineData(new string[] { "win7-x86", "net46" }, new string[] { "win-x64" })]
         [InlineData(new string[] { "win7-x86" }, new string[] { "win7-x86", "win-x64" })]
-        public void RestoreNetCoreSDK_PackagesLockFile_WithProjectChangeRuntimeAndLockedMode_FailsRestore(string[] intitialRuntimes, string[] updatedRuntimes)
+        public void RestoreNetCore_PackagesLockFile_WithProjectChangeRuntimeAndLockedMode_FailsRestore(string[] intitialRuntimes, string[] updatedRuntimes)
         {
             // A project with RestoreLockedMode should fail restore if the project's runtime is changed between restores.
             using (var pathContext = new SimpleTestPathContext())
@@ -8560,10 +8560,9 @@ namespace NuGet.CommandLine.Test
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
                 var tfm = "net45";
 
-                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectA = SimpleTestProjectContext.CreateNETCore(
                    "a",
                    pathContext.SolutionRoot,
-                   true,
                    new NuGetFramework[]{ NuGetFramework.Parse(tfm) });
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
@@ -8607,7 +8606,7 @@ namespace NuGet.CommandLine.Test
         [InlineData(new string[] { "net45" }, new string[] { "net46" })]
         [InlineData(new string[] { "net45", "net46" }, new string[] { "net46" })]
         [InlineData(new string[] { "net45" }, new string[] { "net45", "net46" })]
-        public void RestoreNetCoreSDK_PackagesLockFile_WithProjectChangeFramweorksAndLockedMode_FailsRestore(string[] intitialFrameworks, string[] updatedFrameworks)
+        public void RestoreNetCore_PackagesLockFile_WithProjectChangeFramweorksAndLockedMode_FailsRestore(string[] intitialFrameworks, string[] updatedFrameworks)
         {
             // A project with RestoreLockedMode should fail restore if the project's frameworks list is changed between restores.
             using (var pathContext = new SimpleTestPathContext())
@@ -8615,10 +8614,9 @@ namespace NuGet.CommandLine.Test
                 // Set up solution, project, and packages
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
 
-                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectA = SimpleTestProjectContext.CreateNETCore(
                    "a",
                    pathContext.SolutionRoot,
-                   true,
                    intitialFrameworks.Select(tfm => NuGetFramework.Parse(tfm)).ToArray());
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
@@ -8658,11 +8656,11 @@ namespace NuGet.CommandLine.Test
 
 
         [Theory]
-        [InlineData(new string[] { "x/1.0.0" }, new string[] { "x/2.0.0" })]
-        [InlineData(new string[] { "x/1.0.0" }, new string[] { "y/1.0.0" })]
-        [InlineData(new string[] { "x/1.0.0" }, new string[] { "x/1.0.0", "y/1.0.0" })]
-        [InlineData(new string[] { "x/1.0.0", "y/1.0.0" }, new string[] { "y/1.0.0" })]
-        public async Task RestoreNetCoreSDK_PackagesLockFile_WithProjectChangePackageDependencyAndLockedMode_FailsRestore(
+        [InlineData(new string[] { "x_lockmodedepch/1.0.0" }, new string[] { "x_lockmodedepch/2.0.0" })]
+        [InlineData(new string[] { "x_lockmodedepch/1.0.0" }, new string[] { "y_lockmodedepch/1.0.0" })]
+        [InlineData(new string[] { "x_lockmodewdepch/1.0.0" }, new string[] { "x_lockmodedepch/1.0.0", "y_lockmodedepch/1.0.0" })]
+        [InlineData(new string[] { "x_lockmodedepch/1.0.0", "y_lockmodedepch/1.0.0" }, new string[] { "y_lockmodedepch/1.0.0" })]
+        public async Task RestoreNetCore_PackagesLockFile_WithProjectChangePackageDependencyAndLockedMode_FailsRestore(
             string[] initialPackageIdAndVersion,
             string[] updatedPackageIdAndVersion)
         {
@@ -8673,10 +8671,9 @@ namespace NuGet.CommandLine.Test
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
                 var netcoreapp20 = "netcoreapp2.0";
 
-                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectA = SimpleTestProjectContext.CreateNETCore(
                    "a",
                    pathContext.SolutionRoot,
-                   true,
                    NuGetFramework.Parse(netcoreapp20));
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
@@ -8751,11 +8748,11 @@ namespace NuGet.CommandLine.Test
         }
 
         [Theory]
-        [InlineData(new string[] { "x/1.0.0" }, new string[] { "x/2.0.0" })]
-        [InlineData(new string[] { "x/1.0.0" }, new string[] { "y/1.0.0" })]
-        [InlineData(new string[] { "x/1.0.0" }, new string[] { "x/1.0.0", "y/1.0.0" })]
-        [InlineData(new string[] { "x/1.0.0", "y/1.0.0" }, new string[] { "y/1.0.0" })]
-        public async Task RestoreNetCoreSDK_PackagesLockFile_WithDependentProjectChangeIfPackageDependencyAndLockedMode_FailsRestore(
+        [InlineData(new string[] { "x_lockmodetdepch/1.0.0" }, new string[] { "x_lockmodetdepch/2.0.0" })]
+        [InlineData(new string[] { "x_lockmodetdepch/1.0.0" }, new string[] { "y_lockmodetdepch/1.0.0" })]
+        [InlineData(new string[] { "x_lockmodetdepch/1.0.0" }, new string[] { "x_lockmodetdepch/1.0.0", "y_lockmodetdepch/1.0.0" })]
+        [InlineData(new string[] { "x_lockmodetdepch/1.0.0", "y_lockmodetdepch/1.0.0" }, new string[] { "y_lockmodetdepch/1.0.0" })]
+        public async Task RestoreNetCore_PackagesLockFile_WithDependentProjectChangeIfPackageDependencyAndLockedMode_FailsRestore(
            string[] initialPackageIdAndVersion,
            string[] updatedPackageIdAndVersion)
         {
@@ -8766,19 +8763,17 @@ namespace NuGet.CommandLine.Test
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
                 var netcoreapp20 = "netcoreapp2.0";
 
-                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectA = SimpleTestProjectContext.CreateNETCore(
                    "a",
                    pathContext.SolutionRoot,
-                   true,
                    NuGetFramework.Parse(netcoreapp20));
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
 
-                var projectB = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectB = SimpleTestProjectContext.CreateNETCore(
                    "b",
                    pathContext.SolutionRoot,
-                   true,
                    NuGetFramework.Parse(netcoreapp20));
 
                 // Set up the package and source
@@ -8811,7 +8806,7 @@ namespace NuGet.CommandLine.Test
 
                 // Act
                 var r = Util.RestoreSolution(pathContext);
-
+              
                 // Assert
                 r.Success.Should().BeTrue();
                 Assert.True(File.Exists(projectA.AssetsFileOutputPath));
@@ -8855,7 +8850,7 @@ namespace NuGet.CommandLine.Test
         [Theory]
         [InlineData("netcoreapp2.0", new string[] { "netcoreapp2.0" }, new string[] { "netcoreapp2.2" })]
         [InlineData("netcoreapp2.0", new string[] { "netcoreapp2.0", "netcoreapp2.2" }, new string[] { "netcoreapp2.2" })]
-        public void RestoreNetCoreSDK_PackagesLockFile_WithDependentProjectChangeOfNotCompatibleFrameworksAndLockedMode_FailsRestore(
+        public void RestoreNetCore_PackagesLockFile_WithDependentProjectChangeOfNotCompatibleFrameworksAndLockedMode_FailsRestore(
            string mainProjectFramework,
            string[] initialFrameworks,
            string[] updatedFrameworks)
@@ -8868,19 +8863,17 @@ namespace NuGet.CommandLine.Test
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
                 var netcoreapp20 = mainProjectFramework;
 
-                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectA = SimpleTestProjectContext.CreateNETCore(
                    "a",
                    pathContext.SolutionRoot,
-                   true,
                    NuGetFramework.Parse(netcoreapp20));
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
 
-                var projectB = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectB = SimpleTestProjectContext.CreateNETCore(
                    "b",
                    pathContext.SolutionRoot,
-                   true,
                    initialFrameworks.Select(tfm => NuGetFramework.Parse(tfm)).ToArray());
 
                 projectA.AddProjectToAllFrameworks(projectB);
@@ -8913,7 +8906,7 @@ namespace NuGet.CommandLine.Test
         [InlineData("netcoreapp2.2", new string[] { "netcoreapp2.2" }, new string[] { "netcoreapp2.0", "netcoreapp2.2" })]
         [InlineData("netcoreapp2.2", new string[] { "netcoreapp2.0", "netcoreapp2.2" }, new string[] { "netcoreapp2.2" })]
         [InlineData("netcoreapp2.2", new string[] { "netcoreapp2.0"}, new string[] { "netcoreapp2.2" })]
-        public void RestoreNetCoreSDK_PackagesLockFile_WithDependentProjectChangeOfCompatibleFrameworksAndLockedMode_PassRestore(
+        public void RestoreNetCore_PackagesLockFile_WithDependentProjectChangeOfCompatibleFrameworksAndLockedMode_PassRestore(
            string mainProjectFramework,
            string[] initialFrameworks,
            string[] updatedFrameworks)
@@ -8926,19 +8919,17 @@ namespace NuGet.CommandLine.Test
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
                 var netcoreapp20 = mainProjectFramework;
 
-                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectA = SimpleTestProjectContext.CreateNETCore(
                    "a",
                    pathContext.SolutionRoot,
-                   true,
                    NuGetFramework.Parse(netcoreapp20));
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
 
-                var projectB = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectB = SimpleTestProjectContext.CreateNETCore(
                    "b",
                    pathContext.SolutionRoot,
-                   true,
                    initialFrameworks.Select(tfm => NuGetFramework.Parse(tfm)).ToArray());
 
                 projectA.AddProjectToAllFrameworks(projectB);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -8910,7 +8910,7 @@ namespace NuGet.CommandLine.Test
         [Theory]
         [InlineData("netcoreapp2.2", new string[] { "netcoreapp2.2" }, new string[] { "netcoreapp2.0", "netcoreapp2.2" })]
         [InlineData("netcoreapp2.2", new string[] { "netcoreapp2.0", "netcoreapp2.2" }, new string[] { "netcoreapp2.2" })]
-        [InlineData("netcoreapp2.2", new string[] { "netcoreapp2.0"}, new string[] { "netcoreapp2.2" })]
+        [InlineData("netcoreapp2.2", new string[] { "netcoreapp2.0" }, new string[] { "netcoreapp2.2" })]
         public void RestoreNetCore_PackagesLockFile_WithDependentProjectChangeOfCompatibleFrameworksAndLockedMode_PassRestore(
            string mainProjectFramework,
            string[] initialFrameworks,

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
@@ -1888,7 +1888,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
                 Assert.True(File.Exists(targetFilePath));
 
-                var targetsFile = File.OpenText(targetFilePath).ReadToEnd();
+                var targetsFile = File.ReadAllText(targetFilePath);
                 Assert.True(targetsFile.IndexOf(Path.Combine("build", "uap", "packageA.targets")) > -1);
             }
         }
@@ -1962,7 +1962,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
                 Assert.True(File.Exists(targetFilePath));
 
-                var targetsFile = File.OpenText(targetFilePath).ReadToEnd();
+                var targetsFile = File.ReadAllText(targetFilePath);
                 Assert.True(targetsFile.IndexOf(Path.Combine("build", "uap", "packageA.targets")) > -1);
                 Assert.True(targetsFile.IndexOf(Path.Combine("build", "uap", "packageB.targets")) > -1);
             }
@@ -2070,7 +2070,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
                 Assert.True(File.Exists(targetFilePath));
 
-                var targetsFile = File.OpenText(targetFilePath).ReadToEnd();
+                var targetsFile = File.ReadAllText(targetFilePath);
                 Assert.True(targetsFile.IndexOf(packageAPath) > -1);
                 Assert.True(targetsFile.IndexOf(packageBPath) > -1);
             }
@@ -2145,7 +2145,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
                 Assert.True(File.Exists(targetFilePath));
 
-                var targetsFile = File.OpenText(targetFilePath).ReadToEnd();
+                var targetsFile = File.ReadAllText(targetFilePath);
                 Assert.True(targetsFile.IndexOf(Path.Combine("build", "uap", "packageA.targets")) > -1);
                 Assert.True(targetsFile.IndexOf(Path.Combine("build", "uap", "packageB.targets")) > -1);
             }
@@ -2220,7 +2220,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
                 Assert.True(File.Exists(targetFilePath));
 
-                var targetsFile = File.OpenText(targetFilePath).ReadToEnd();
+                var targetsFile = File.ReadAllText(targetFilePath);
                 Assert.True(targetsFile.IndexOf(Path.Combine("build", "uap", "packageA.targets")) > -1);
                 Assert.True(targetsFile.IndexOf(Path.Combine("build", "uap", "packageB.targets")) > -1);
             }
@@ -2287,7 +2287,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
                 Assert.True(File.Exists(targetFilePath));
 
-                var targetsFile = File.OpenText(targetFilePath).ReadToEnd();
+                var targetsFile = File.ReadAllText(targetFilePath);
                 // Verify the target was added
                 Assert.True(targetsFile.IndexOf(Path.Combine("build", "packageA.targets")) > -1);
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
@@ -49,7 +49,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -137,7 +137,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -278,7 +278,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -404,7 +404,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -556,7 +556,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -646,7 +646,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -780,7 +780,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -904,7 +904,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -1002,7 +1002,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -1096,7 +1096,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -1202,7 +1202,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -1347,7 +1347,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -1511,7 +1511,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -1678,7 +1678,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -999,7 +999,11 @@ namespace NuGet.Commands.FuncTest
                 modifiedLockFile.Version = 1000;
 
                 var lockFormat = new LockFileFormat();
-                lockFormat.Write(File.OpenWrite(lockFilePath), modifiedLockFile);
+
+                using (var stream = File.OpenWrite(lockFilePath))
+                {
+                    lockFormat.Write(stream, modifiedLockFile);
+                }
 
                 request = new TestRestoreRequest(spec, sources, packagesDir, logger)
                 {

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
@@ -161,7 +161,7 @@ namespace NuGet.Commands.FuncTest
                 var result = await command.ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
 
-                var lockFileJson = JObject.Parse(File.OpenText(request.LockFilePath).ReadToEnd());
+                var lockFileJson = JObject.Parse(File.ReadAllText(request.LockFilePath));
 
                 // Assert
                 Assert.Equal(0, result.CompatibilityCheckResults.Sum(checkResult => checkResult.Issues.Count));
@@ -251,7 +251,7 @@ namespace NuGet.Commands.FuncTest
                 var result = await command.ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
 
-                var lockFileJson = JObject.Parse(File.OpenText(request.LockFilePath).ReadToEnd());
+                var lockFileJson = JObject.Parse(File.ReadAllText(request.LockFilePath));
 
                 // Assert
                 Assert.Equal(0, result.CompatibilityCheckResults.Sum(checkResult => checkResult.Issues.Count));
@@ -312,7 +312,7 @@ namespace NuGet.Commands.FuncTest
                 var result = await command.ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
 
-                var lockFileJson = JObject.Parse(File.OpenText(request.LockFilePath).ReadToEnd());
+                var lockFileJson = JObject.Parse(File.ReadAllText(request.LockFilePath));
                 RemovePackageFolders(lockFileJson);
 
                 // Assert
@@ -379,7 +379,7 @@ namespace NuGet.Commands.FuncTest
                 var result = await command.ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
 
-                var lockFileJson = JObject.Parse(File.OpenText(request.LockFilePath).ReadToEnd());
+                var lockFileJson = JObject.Parse(File.ReadAllText(request.LockFilePath));
                 RemovePackageFolders(lockFileJson);
 
                 // Assert

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
@@ -265,6 +265,7 @@ namespace NuGet.Packaging.FuncTest
                     RepositoryRequest?.Dispose();
                     _authorCertificate?.Dispose();
                     _repositoryCertificate?.Dispose();
+                    Options.Dispose();
                     _directory?.Dispose();
 
                     GC.SuppressFinalize(this);

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
@@ -83,14 +83,13 @@ namespace NuGet.Protocol.FuncTest
             // Act
             using (var packagesFolder = TestDirectory.Create())
             using (var cacheContext = new SourceCacheContext())
-            {
-                var actual = await downloadResource.GetDownloadResourceResultAsync(
-                    package,
-                    new PackageDownloadContext(cacheContext),
-                    packagesFolder,
-                    NullLogger.Instance,
-                    CancellationToken.None);
-
+            using (var actual = await downloadResource.GetDownloadResourceResultAsync(
+                package,
+                new PackageDownloadContext(cacheContext),
+                packagesFolder,
+                NullLogger.Instance,
+                CancellationToken.None))
+            { 
                 // Assert
                 Assert.NotNull(actual);
                 Assert.Equal(DownloadResourceResultStatus.NotFound, actual.Status);

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.CommandLineUtils;
 using Moq;
 using NuGet.CommandLine.XPlat;
 using NuGet.Protocol;
+using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.XPlat.FuncTest
@@ -15,70 +16,74 @@ namespace NuGet.XPlat.FuncTest
     [Collection("NuGet XPlat Test Collection")]
     public class ListPackageTests
     {
-
         [Fact]
         public void BasicListPackageParsing_Interactive()
         {
             // Arrange
-            var projectPath = Path.Combine(Path.GetTempPath(), "project.csproj");
-            File.Create(projectPath).Dispose();
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectPath = Path.Combine(testDirectory, "project.csproj");
+                File.WriteAllText(projectPath, string.Empty);
 
-            var argList = new List<string>() {
-                "list",
-                "--interactive",
-                projectPath};
+                var argList = new List<string>() {
+                    "list",
+                    "--interactive",
+                    projectPath};
 
-            var logger = new TestCommandOutputLogger();
-            var testApp = new CommandLineApplication();
-            var mockCommandRunner = new Mock<IListPackageCommandRunner>();
-            mockCommandRunner
-                .Setup(m => m.ExecuteCommandAsync(It.IsAny<ListPackageArgs>()))
-                .Returns(Task.CompletedTask);
+                var logger = new TestCommandOutputLogger();
+                var testApp = new CommandLineApplication();
+                var mockCommandRunner = new Mock<IListPackageCommandRunner>();
+                mockCommandRunner
+                    .Setup(m => m.ExecuteCommandAsync(It.IsAny<ListPackageArgs>()))
+                    .Returns(Task.CompletedTask);
 
-            testApp.Name = "dotnet nuget_test";
-            ListPackageCommand.Register(testApp,
-                () => logger,
-                () => mockCommandRunner.Object);
+                testApp.Name = "dotnet nuget_test";
+                ListPackageCommand.Register(testApp,
+                    () => logger,
+                    () => mockCommandRunner.Object);
 
-            // Act
-            var result = testApp.Execute(argList.ToArray());
+                // Act
+                var result = testApp.Execute(argList.ToArray());
 
-            XPlatTestUtils.DisposeTemporaryFile(projectPath);
+                XPlatTestUtils.DisposeTemporaryFile(projectPath);
 
-            // Assert
-            mockCommandRunner.Verify();
-            Assert.NotNull(HttpHandlerResourceV3.CredentialService);
-            Assert.Equal(0, result);
+                // Assert
+                mockCommandRunner.Verify();
+                Assert.NotNull(HttpHandlerResourceV3.CredentialService);
+                Assert.Equal(0, result);
+            }
         }
 
         [Fact]
         public void BasicListPackageParsing_InteractiveTakesNoArguments()
         {
             // Arrange
-            var projectPath = Path.Combine(Path.GetTempPath(), "project.csproj");
-            File.Create(projectPath).Dispose();
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectPath = Path.Combine(testDirectory, "project.csproj");
+                File.WriteAllText(projectPath, string.Empty);
 
+                var argList = new List<string>() {
+                    "list",
+                    "--interactive",
+                    "no",
+                    projectPath};
 
-            var argList = new List<string>() {
-                "list",
-                "--interactive",
-                "no",
-                projectPath};
+                var logger = new TestCommandOutputLogger();
+                var testApp = new CommandLineApplication();
+                var mockCommandRunner = new Mock<IListPackageCommandRunner>();
+                mockCommandRunner
+                    .Setup(m => m.ExecuteCommandAsync(It.IsAny<ListPackageArgs>()))
+                    .Returns(Task.CompletedTask);
 
-            var logger = new TestCommandOutputLogger();
-            var testApp = new CommandLineApplication();
-            var mockCommandRunner = new Mock<IListPackageCommandRunner>();
-            mockCommandRunner
-                .Setup(m => m.ExecuteCommandAsync(It.IsAny<ListPackageArgs>()))
-                .Returns(Task.CompletedTask);
+                testApp.Name = "dotnet nuget_test";
+                ListPackageCommand.Register(testApp,
+                    () => logger,
+                    () => mockCommandRunner.Object);
 
-            testApp.Name = "dotnet nuget_test";
-            ListPackageCommand.Register(testApp,
-                () => logger,
-                () => mockCommandRunner.Object);
-
-            // Act
-            Assert.Throws<CommandParsingException>(() => testApp.Execute(argList.ToArray()));
+                // Act
+                Assert.Throws<CommandParsingException>(() => testApp.Execute(argList.ToArray()));
+            }
         }
     }
 }

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/GlobalJsonReader_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/GlobalJsonReader_Tests.cs
@@ -42,13 +42,20 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         {
             using (var testEnvironment = TestEnvironment.Create())
             {
-                var folder = testEnvironment.CreateFolder().FolderPath;
+                TransientTestFolder folder = testEnvironment.CreateFolder();
 
-                File.WriteAllText(Path.Combine(folder, GlobalJsonReader.GlobalJsonFileName), @" { } ");
+                try
+                {
+                    File.WriteAllText(Path.Combine(folder.FolderPath, GlobalJsonReader.GlobalJsonFileName), @" { } ");
 
-                var context = new MockSdkResolverContext(Path.Combine(folder, "foo.proj"));
+                    var context = new MockSdkResolverContext(Path.Combine(folder.FolderPath, "foo.proj"));
 
-                GlobalJsonReader.GetMSBuildSdkVersions(context).Should().BeNull();
+                    GlobalJsonReader.GetMSBuildSdkVersions(context).Should().BeNull();
+                }
+                finally
+                {
+                    folder.Revert();
+                }
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -1798,6 +1798,48 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
+        public void MSBuildRestoreUtility_GetPackageSpec_PackagesConfigProject()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var projectPath = Path.Combine(workingDir, "a.csproj");
+                var packagesConfigPath = Path.Combine(workingDir, "packages.config");
+
+                var items = new List<IDictionary<string, string>>();
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectPath", projectPath },
+                    { "ProjectStyle", "PackagesConfig" },
+                    { "TargetFramework", "net462" },
+                    { "ProjectName", "a" },
+                    { "PackagesConfigPath", packagesConfigPath },
+                    { "RestorePackagesWithLockFile", "true" },
+                    { "NuGetLockFilePath", "custom.lock.json" },
+                    { "RestoreLockedMode", "true" }
+                });
+
+                // Act
+                var spec = MSBuildRestoreUtility.GetPackageSpec(items.Select(CreateItems));
+
+                // Assert
+                Assert.Equal(projectPath, spec.FilePath);
+                Assert.Equal("a", spec.Name);
+                Assert.IsType(typeof(PackagesConfigProjectRestoreMetadata), spec.RestoreMetadata);
+                var restoreMetadata = (PackagesConfigProjectRestoreMetadata)spec.RestoreMetadata;
+                Assert.Equal(ProjectStyle.PackagesConfig, restoreMetadata.ProjectStyle);
+                Assert.Equal("482C20DE-DFF9-4BD0-B90A-BD3201AA351A", restoreMetadata.ProjectUniqueName);
+                Assert.Equal(projectPath, restoreMetadata.ProjectPath);
+                Assert.Equal(packagesConfigPath, restoreMetadata.PackagesConfigPath);
+                Assert.Equal("true", restoreMetadata.RestoreLockProperties.RestorePackagesWithLockFile);
+                Assert.Equal("custom.lock.json", restoreMetadata.RestoreLockProperties.NuGetLockFilePath);
+                Assert.True(restoreMetadata.RestoreLockProperties.RestoreLockedMode);
+            }
+        }
+
+        [Fact]
         public void MSBuildRestoreUtility_GetPackageSpec_NonNuGetProject()
         {
             using (var workingDir = TestDirectory.Create())

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
@@ -165,7 +165,7 @@ namespace NuGet.Commands.Test
             internal TestLogger Logger { get; }
             internal SignCommandRunner Runner { get; }
 
-            internal Test(SignArgs args, TestDirectory directory, X509Certificate2 certificate, TestLogger logger)
+            private Test(SignArgs args, TestDirectory directory, X509Certificate2 certificate, TestLogger logger)
             {
                 Args = args;
                 Directory = directory;
@@ -179,6 +179,7 @@ namespace NuGet.Commands.Test
                 if (!_isDisposed)
                 {
                     Certificate.Dispose();
+                    Directory.Dispose();
 
                     GC.SuppressFinalize(this);
 

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/MSBuildStringUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/MSBuildStringUtilityTests.cs
@@ -93,5 +93,19 @@ namespace NuGet.Common.Test
             // Assert
             Assert.Equal(0, result.Count());
         }
+
+        [Theory]
+        [InlineData("true", true)]
+        [InlineData("false", false)]
+        [InlineData("", null)]
+        [InlineData(null, null)]
+        public void GetBooleanOrNullTests(string value, bool? expected)
+        {
+            // Act
+            bool? result = MSBuildStringUtility.GetBooleanOrNull(value);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/ProjectJsonPathUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/ProjectJsonPathUtilitiesTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
@@ -240,7 +240,7 @@ namespace NuGet.Common.Test
 
         private static void CreateFile(string path)
         {
-            File.OpenWrite(path).WriteByte(0);
+            File.WriteAllText(path, string.Empty);
         }
 
         private static string ConvertToUnix(string path)

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/SynchronizationTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/SynchronizationTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -279,6 +279,9 @@ namespace NuGet.Common.Test
                 using (Client) { }
 
                 Listener.Stop();
+
+                Reader.Dispose();
+                Writer.Dispose();
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1881,23 +1881,30 @@ namespace NuGet.Configuration.Test
                 File.WriteAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.Config"), configContents);
                 File.SetAttributes(Path.Combine(mockBaseDirectory.Path, "NuGet.Config"), FileAttributes.ReadOnly);
 
-                var settings = Settings.LoadSettings(mockBaseDirectory.Path,
-                                  configFileName: null,
-                                  machineWideSettings: null,
-                                  loadUserWideSettings: true,
-                                  useTestingGlobalPath: true);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                try
+                {
+                    var settings = Settings.LoadSettings(mockBaseDirectory.Path,
+                        configFileName: null,
+                        machineWideSettings: null,
+                        loadUserWideSettings: true,
+                        useTestingGlobalPath: true);
+                    var packageSourceProvider = new PackageSourceProvider(settings);
 
-                // Act
-                var sources = packageSourceProvider.LoadPackageSources().ToList();
+                    // Act
+                    var sources = packageSourceProvider.LoadPackageSources().ToList();
 
-                sources.Add(new PackageSource("https://test3.net", "test3"));
+                    sources.Add(new PackageSource("https://test3.net", "test3"));
 
-                var ex = Assert.Throws<NuGetConfigurationException>(() => packageSourceProvider.SavePackageSources(sources));
+                    var ex = Assert.Throws<NuGetConfigurationException>(() => packageSourceProvider.SavePackageSources(sources));
 
-                // Assert
-                var path = Path.Combine(mockBaseDirectory, "NuGet.Config");
-                Assert.Equal($"Failed to read NuGet.Config due to unauthorized access. Path: '{path}'.", ex.Message);
+                    // Assert
+                    var path = Path.Combine(mockBaseDirectory, "NuGet.Config");
+                    Assert.Equal($"Failed to read NuGet.Config due to unauthorized access. Path: '{path}'.", ex.Message);
+                }
+                finally
+                {
+                    File.SetAttributes(Path.Combine(mockBaseDirectory.Path, "NuGet.Config"), FileAttributes.Normal);
+                }
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderBuilderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderBuilderTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace NuGet.Credentials.Test
 {
-    public class SecurePluginCredentialProviderBuilderTests
+    public class SecurePluginCredentialProviderBuilderTests : IDisposable
     {
         private readonly TestDirectory _testDirectory;
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -75,12 +74,12 @@ namespace NuGet.Test
             // Arrange
             var packageIdentity = new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("1.0.7"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            var projectFolderPaths = new List<string>();
+            var projectDirectories = new List<TestDirectory>();
 
             try
             {
                 using (var settingsDirectory = TestDirectory.Create())
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, settingsDirectory);
                     var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -102,10 +101,10 @@ namespace NuGet.Test
                     // Create projects
                     for (var i = 0; i < 4; i++)
                     {
-                        var folder = TestDirectory.Create();
-                        projectFolderPaths.Add(folder);
+                        var directory = TestDirectory.Create();
+                        projectDirectories.Add(directory);
 
-                        var config = Path.Combine(folder, "project.json");
+                        var config = Path.Combine(directory, "project.json");
 
                         configs.Add(config);
 
@@ -114,7 +113,7 @@ namespace NuGet.Test
                         var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
                             projectTargetFramework,
                             testNuGetProjectContext,
-                            folder,
+                            directory,
                             $"testProjectName{i}");
 
                         var buildIntegratedProject = new TestProjectJsonBuildIntegratedNuGetProject(config, msBuildNuGetProjectSystem);
@@ -132,10 +131,10 @@ namespace NuGet.Test
                     var reference2 = new TestExternalProjectReference(buildIntegratedProjects[2], buildIntegratedProjects[3]);
                     var reference3 = new TestExternalProjectReference(buildIntegratedProjects[3]);
 
-                    var myProjFolder = TestDirectory.Create();
-                    projectFolderPaths.Add(myProjFolder);
+                    var myProjDirectory = TestDirectory.Create();
+                    projectDirectories.Add(myProjDirectory);
 
-                    var myProjPath = Path.Combine(myProjFolder, "myproj.csproj");
+                    var myProjPath = Path.Combine(myProjDirectory, "myproj.csproj");
 
                     var normalProject = new TestNonBuildIntegratedNuGetProject()
                     {
@@ -201,9 +200,9 @@ namespace NuGet.Test
             }
             finally
             {
-                foreach (var folder in projectFolderPaths)
+                foreach (TestDirectory projectDirectory in projectDirectories)
                 {
-                    TestFileSystemUtility.DeleteRandomTestFolder(folder);
+                    projectDirectory.Dispose();
                 }
             }
         }
@@ -216,13 +215,13 @@ namespace NuGet.Test
             var packageIdentity = new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("3.3.0"));
             var packageIdentity2 = new PackageIdentity("NuGet.Configuration", NuGetVersion.Parse("3.3.0"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            var projectFolderPaths = new List<string>();
+            var projectDirectories = new List<TestDirectory>();
             var logger = new TestLogger();
 
             try
             {
                 using (var settingsDirectory = TestDirectory.Create())
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, settingsDirectory);
                     var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -244,10 +243,10 @@ namespace NuGet.Test
                     // Create projects
                     for (var i = 0; i < 4; i++)
                     {
-                        var folder = TestDirectory.Create();
-                        projectFolderPaths.Add(folder);
+                        var directory = TestDirectory.Create();
+                        projectDirectories.Add(directory);
 
-                        var config = Path.Combine(folder, "project.json");
+                        var config = Path.Combine(directory, "project.json");
 
                         configs.Add(config);
 
@@ -256,7 +255,7 @@ namespace NuGet.Test
                         var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
                             projectTargetFramework,
                             testNuGetProjectContext,
-                            folder,
+                            directory,
                             $"testProjectName{i}");
 
                         var buildIntegratedProject = new TestProjectJsonBuildIntegratedNuGetProject(config, msBuildNuGetProjectSystem);
@@ -275,10 +274,10 @@ namespace NuGet.Test
                     var reference2 = new TestExternalProjectReference(buildIntegratedProjects[2], buildIntegratedProjects[3]);
                     var reference3 = new TestExternalProjectReference(buildIntegratedProjects[3]);
 
-                    var myProjFolder = TestDirectory.Create();
-                    projectFolderPaths.Add(myProjFolder);
+                    var myProjDirectory = TestDirectory.Create();
+                    projectDirectories.Add(myProjDirectory);
 
-                    var myProjPath = Path.Combine(myProjFolder, "myproj.csproj");
+                    var myProjPath = Path.Combine(myProjDirectory, "myproj.csproj");
 
                     var normalProject = new TestNonBuildIntegratedNuGetProject()
                     {
@@ -350,9 +349,9 @@ namespace NuGet.Test
             }
             finally
             {
-                foreach (var folder in projectFolderPaths)
+                foreach (TestDirectory projectDirectory in projectDirectories)
                 {
-                    TestFileSystemUtility.DeleteRandomTestFolder(folder);
+                    projectDirectory.Dispose();
                 }
             }
         }
@@ -364,7 +363,7 @@ namespace NuGet.Test
             var packageIdentity = new PackageIdentity("elmah", new NuGetVersion("1.2.2"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -411,7 +410,7 @@ namespace NuGet.Test
             var packageIdentity = new PackageIdentity("nuget.versioning", NuGetVersion.Parse("1.0.7"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -469,7 +468,7 @@ namespace NuGet.Test
             var packageIdentity = new PackageIdentity("nuget.core", NuGetVersion.Parse("91.0.0"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -534,7 +533,7 @@ namespace NuGet.Test
             var packageIdentity = new PackageIdentity("nuget.core", NuGetVersion.Parse("91.0.0"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -600,7 +599,7 @@ namespace NuGet.Test
 
             var lockFiles = new List<string>();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -675,7 +674,7 @@ namespace NuGet.Test
             var packageIdentity2 = new PackageIdentity("newtonsoft.json", NuGetVersion.Parse("6.0.4"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -728,7 +727,7 @@ namespace NuGet.Test
             var versioning105 = new PackageIdentity("nuget.versioning", NuGetVersion.Parse("1.0.5"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -776,7 +775,7 @@ namespace NuGet.Test
             var nugetVersioningId = "Nuget.Versioning";
             var oldJson = new PackageIdentity(nugetVersioningId, NuGetVersion.Parse("3.5.0"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -845,7 +844,7 @@ namespace NuGet.Test
 
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -928,7 +927,7 @@ namespace NuGet.Test
             var oldJson = new PackageIdentity(nugetVersioningId, NuGetVersion.Parse("3.5.0"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1023,7 +1022,7 @@ namespace NuGet.Test
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
             using (var settingsDirectory = TestDirectory.Create())
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, settingsDirectory);
@@ -1122,7 +1121,7 @@ namespace NuGet.Test
             var versioning107 = new PackageIdentity("nuget.versioning", NuGetVersion.Parse("1.0.7"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1190,7 +1189,7 @@ namespace NuGet.Test
 
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1298,7 +1297,7 @@ namespace NuGet.Test
             var versioning101 = new PackageIdentity("nuget.versioning", NuGetVersion.Parse("1.0.1"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1360,7 +1359,7 @@ namespace NuGet.Test
             var packageIdentity = new PackageIdentity("newtonsoft.json", NuGetVersion.Parse("6.0.8"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1409,7 +1408,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1465,7 +1464,7 @@ namespace NuGet.Test
             var packageIdentity = new PackageIdentity("newtonsoft.json", NuGetVersion.Parse("6.0.8"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1525,7 +1524,7 @@ namespace NuGet.Test
             var packageIdentityB = new PackageIdentity("entityframework", NuGetVersion.Parse("6.1.3"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1596,7 +1595,7 @@ namespace NuGet.Test
             var dependencyIdentity = new PackageIdentity("Microsoft.Web.Xdt", NuGetVersion.Parse("2.1.0"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1635,7 +1634,7 @@ namespace NuGet.Test
             var packageIdentity = new PackageIdentity("nuget.core", NuGetVersion.Parse("2.8.3"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1677,7 +1676,7 @@ namespace NuGet.Test
             var dependencyIdentity = new PackageIdentity("Microsoft.Web.Xdt", NuGetVersion.Parse("2.1.0"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1723,7 +1722,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 using (var randomProjectFolderPath = TestDirectory.Create())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1788,7 +1787,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = CreateSource(packages);
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedRestoreUtilityTests.cs
@@ -48,31 +48,33 @@ namespace NuGet.Test
                     new TestNuGetProjectContext());
                 var project = new ProjectJsonNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName);
 
-                var solutionManager = new TestSolutionManager(false);
-                solutionManager.NuGetProjects.Add(project);
+                using (var solutionManager = new TestSolutionManager())
+                {
+                    solutionManager.NuGetProjects.Add(project);
 
-                var testLogger = new TestLogger();
+                    var testLogger = new TestLogger();
 
-                var restoreContext = new DependencyGraphCacheContext(testLogger, NullSettings.Instance);
+                    var restoreContext = new DependencyGraphCacheContext(testLogger, NullSettings.Instance);
 
-                // Act
-                await DependencyGraphRestoreUtility.RestoreAsync(
-                    solutionManager,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
-                    restoreContext,
-                    new RestoreCommandProvidersCache(),
-                    (c) => { },
-                    sources,
-                    Guid.Empty,
-                    false,
-                    true,
-                    testLogger,
-                    CancellationToken.None);
+                    // Act
+                    await DependencyGraphRestoreUtility.RestoreAsync(
+                        solutionManager,
+                        await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                        restoreContext,
+                        new RestoreCommandProvidersCache(),
+                        (c) => { },
+                        sources,
+                        Guid.Empty,
+                        false,
+                        true,
+                        testLogger,
+                        CancellationToken.None);
 
-                // Assert
-                Assert.True(File.Exists(Path.Combine(projectFolder.FullName, "testproj.project.lock.json")));
-                Assert.True(testLogger.Errors == 0);
-                Assert.False(File.Exists(Path.Combine(projectFolder.FullName, "project.lock.json")));
+                    // Assert
+                    Assert.True(File.Exists(Path.Combine(projectFolder.FullName, "testproj.project.lock.json")));
+                    Assert.True(testLogger.Errors == 0);
+                    Assert.False(File.Exists(Path.Combine(projectFolder.FullName, "project.lock.json")));
+                }
             }
         }
 
@@ -101,30 +103,32 @@ namespace NuGet.Test
                     new TestNuGetProjectContext());
                 var project = new ProjectJsonNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName);
 
-                var solutionManager = new TestSolutionManager(false);
-                solutionManager.NuGetProjects.Add(project);
+                using (var solutionManager = new TestSolutionManager())
+                {
+                    solutionManager.NuGetProjects.Add(project);
 
-                var testLogger = new TestLogger();
+                    var testLogger = new TestLogger();
 
-                var restoreContext = new DependencyGraphCacheContext(testLogger, NullSettings.Instance);
+                    var restoreContext = new DependencyGraphCacheContext(testLogger, NullSettings.Instance);
 
-                // Act
-                await DependencyGraphRestoreUtility.RestoreAsync(
-                    solutionManager,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
-                    restoreContext,
-                    new RestoreCommandProvidersCache(),
-                    (c) => { },
-                    sources,
-                    Guid.Empty,
-                    false,
-                    true,
-                    testLogger,
-                    CancellationToken.None);
+                    // Act
+                    await DependencyGraphRestoreUtility.RestoreAsync(
+                        solutionManager,
+                        await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                        restoreContext,
+                        new RestoreCommandProvidersCache(),
+                        (c) => { },
+                        sources,
+                        Guid.Empty,
+                        false,
+                        true,
+                        testLogger,
+                        CancellationToken.None);
 
-                // Assert
-                Assert.True(File.Exists(Path.Combine(projectFolder.FullName, "project.lock.json")));
-                Assert.True(testLogger.Errors == 0);
+                    // Assert
+                    Assert.True(File.Exists(Path.Combine(projectFolder.FullName, "project.lock.json")));
+                    Assert.True(testLogger.Errors == 0);
+                }
             }
         }
 
@@ -134,7 +138,7 @@ namespace NuGet.Test
             // Arrange
             var projectName = "testproj";
 
-            using (var solutionManager = new TestSolutionManager(false))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var projectFolder = new DirectoryInfo(Path.Combine(solutionManager.SolutionDirectory, projectName));
                 projectFolder.Create();

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/DependencyGraphRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/DependencyGraphRestoreUtilityTests.cs
@@ -33,7 +33,8 @@ namespace NuGet.PackageManagement.Test
                 projectFolder.Create();
                 var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
 
-                var sources = new[] {
+                var sources = new[]
+                {
                     Repository.Factory.GetVisualStudio(new PackageSource("https://www.nuget.org/api/v2/"))
                 };
 
@@ -48,26 +49,28 @@ namespace NuGet.PackageManagement.Test
 
                 var projects = new List<IDependencyGraphProject>() { project };
 
-                var solutionManager = new TestSolutionManager(false);
-                solutionManager.NuGetProjects.Add(project);
+                using (var solutionManager = new TestSolutionManager())
+                {
+                    solutionManager.NuGetProjects.Add(project);
 
-                // Act
-                await DependencyGraphRestoreUtility.RestoreAsync(
-                    solutionManager,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
-                    restoreContext,
-                    new RestoreCommandProvidersCache(),
-                    (c) => { },
-                    sources,
-                    Guid.Empty,
-                    false,
-                    true,
-                    logger,
-                    CancellationToken.None);
+                    // Act
+                    await DependencyGraphRestoreUtility.RestoreAsync(
+                        solutionManager,
+                        await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                        restoreContext,
+                        new RestoreCommandProvidersCache(),
+                        (c) => { },
+                        sources,
+                        Guid.Empty,
+                        false,
+                        true,
+                        logger,
+                        CancellationToken.None);
 
-                // Assert
-                Assert.Equal(0, logger.Errors);
-                Assert.Equal(0, logger.Warnings);
+                    // Assert
+                    Assert.Equal(0, logger.Errors);
+                    Assert.Equal(0, logger.Warnings);
+                }
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGet.PackageManagement.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGet.PackageManagement.Test.csproj
@@ -28,12 +28,6 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="$(SharedDirectory)\HashCodeCombiner.cs">
-      <Link>HashCodeCombiner.cs</Link>
-    </Compile>
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -99,7 +99,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -165,7 +165,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -230,7 +230,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -268,7 +268,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -329,7 +329,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -380,7 +380,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -429,7 +429,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -476,7 +476,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -527,7 +527,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -572,7 +572,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -633,7 +633,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -704,7 +704,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -775,7 +775,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -825,7 +825,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -873,7 +873,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -921,7 +921,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1003,7 +1003,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1065,7 +1065,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1118,7 +1118,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1187,7 +1187,7 @@ namespace NuGet.Test
 
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1233,7 +1233,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1329,7 +1329,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -1370,7 +1370,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1425,7 +1425,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1489,7 +1489,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1542,7 +1542,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1619,7 +1619,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1683,7 +1683,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1728,7 +1728,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1776,7 +1776,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1824,7 +1824,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1875,7 +1875,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1919,7 +1919,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1974,7 +1974,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -2044,7 +2044,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -2091,7 +2091,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -2156,7 +2156,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -2202,7 +2202,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -2247,7 +2247,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -2346,7 +2346,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2404,7 +2404,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2462,7 +2462,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2519,7 +2519,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2592,7 +2592,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2669,7 +2669,7 @@ namespace NuGet.Test
             var nuGetProjectB = new TestNuGetProject(installedPackagesB);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2742,7 +2742,7 @@ namespace NuGet.Test
             var nuGetProjectB = new TestNuGetProject("projectB", installedPackagesB);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2827,7 +2827,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2900,7 +2900,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2969,7 +2969,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -3039,7 +3039,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -3081,7 +3081,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -3154,7 +3154,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -3239,7 +3239,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -3405,7 +3405,7 @@ namespace NuGet.Test
 
             // Create Package Manager
 
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -3449,7 +3449,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -3501,7 +3501,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -3572,7 +3572,7 @@ namespace NuGet.Test
             var packageIdentityB1 = new PackageIdentity("DotNetOpenAuth.Core", new NuGetVersion("4.3.2.13293"));
             var packageIdentityB2 = new PackageIdentity("DotNetOpenAuth.Core", new NuGetVersion("4.3.4.13329"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -3638,7 +3638,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -3686,7 +3686,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -3739,7 +3739,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -3817,7 +3817,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -3898,7 +3898,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -3985,7 +3985,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new List<NuGet.Configuration.PackageSource>());
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4028,7 +4028,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4073,7 +4073,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4122,7 +4122,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4171,7 +4171,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4220,7 +4220,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4269,7 +4269,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4330,7 +4330,7 @@ namespace NuGet.Test
 
             var sourceRepositoryProvider = new SourceRepositoryProvider(packageSourceProvider, resourceProviders);
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4396,7 +4396,7 @@ namespace NuGet.Test
 
             var sourceRepositoryProvider = new SourceRepositoryProvider(packageSourceProvider, resourceProviders);
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4438,7 +4438,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4485,7 +4485,7 @@ namespace NuGet.Test
                 new NuGet.Configuration.PackageSource("https://www.myget.org/F/aspnetvnext/api/v2/"),
             });
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4530,7 +4530,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4578,7 +4578,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4626,7 +4626,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4738,7 +4738,7 @@ namespace NuGet.Test
             // Act
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
             var testSettings = NullSettings.Instance;
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
 
@@ -4782,7 +4782,7 @@ namespace NuGet.Test
             // Act
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
             var testSettings = NullSettings.Instance;
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
 
@@ -4810,7 +4810,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -4890,7 +4890,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -5098,7 +5098,7 @@ namespace NuGet.Test
                         new PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -5167,7 +5167,7 @@ namespace NuGet.Test
                         new PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -5253,7 +5253,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -5319,7 +5319,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var actions = new List<NuGetProjectAction>();
                     var testSettings = NullSettings.Instance;
@@ -5394,7 +5394,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -5475,7 +5475,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -5535,7 +5535,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -5604,7 +5604,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -5675,7 +5675,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -5738,7 +5738,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
             using (var settingsdir = TestDirectory.Create())
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var Settings = new Settings(settingsdir);
                 foreach (var source in sourceRepositoryProvider.GetRepositories())
@@ -5840,7 +5840,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -5887,7 +5887,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -5943,7 +5943,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
             using (var settingsdir = TestDirectory.Create())
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var Settings = new Settings(settingsdir);
                 foreach (var source in sourceRepositoryProvider.GetRepositories())
@@ -6033,7 +6033,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6089,7 +6089,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6137,7 +6137,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6195,7 +6195,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6266,7 +6266,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6340,7 +6340,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6423,7 +6423,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6518,7 +6518,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6563,7 +6563,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6618,7 +6618,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             using (var settingsdir = TestDirectory.Create())
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var settings = Settings.LoadSpecificSettings(testSolutionManager.SolutionDirectory, "NuGet.Config");
                 foreach (var source in sourceRepositoryProvider.GetRepositories())
@@ -6689,7 +6689,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource1.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -6767,7 +6767,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6819,7 +6819,7 @@ namespace NuGet.Test
             };
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/PackagesConfigProjectTests/PackagesLockTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/PackagesConfigProjectTests/PackagesLockTests.cs
@@ -1,0 +1,176 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests.PackagesConfigProjectTests
+{
+    public class PackagesLockTests
+    {
+        [Fact]
+        public async Task DoNotCreateLockFileWhenFeatureDisabled()
+        {
+            // Arrange
+            using (var packageSource = TestDirectory.Create())
+            using (var testSolutionManager = new TestSolutionManager(true))
+            {
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<PackageSource>()
+                    {
+                        new PackageSource(packageSource.Path)
+                    });
+
+                var testSettings = NullSettings.Instance;
+                var token = CancellationToken.None;
+                var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                var nuGetPackageManager = new NuGetPackageManager(
+                    sourceRepositoryProvider,
+                    testSettings,
+                    testSolutionManager,
+                    deleteOnRestartManager);
+                var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(testSolutionManager, testSettings);
+
+                var packageContext = new SimpleTestPackageContext("packageA");
+                packageContext.AddFile("lib/net45/a.dll");
+                SimpleTestPackageUtility.CreateOPCPackage(packageContext, packageSource);
+
+                var msBuildNuGetProject = testSolutionManager.AddNewMSBuildProject();
+                var msBuildNuGetProjectSystem = msBuildNuGetProject.ProjectSystem as TestMSBuildNuGetProjectSystem;
+                msBuildNuGetProjectSystem.SetPropertyValue("RestorePackagesWithLockFile", "false");
+                var packagesConfigPath = msBuildNuGetProject.PackagesConfigNuGetProject.FullPath;
+                var packagesLockPath = packagesConfigPath.Replace("packages.config", "packages.lock.json");
+                var packageIdentity = packageContext.Identity;
+
+                // Pre-Assert
+                // Check that the packages.lock.json file does not exist
+                Assert.False(File.Exists(packagesLockPath));
+
+                // Act
+                await nuGetPackageManager.InstallPackageAsync(msBuildNuGetProject, packageIdentity,
+                    new ResolutionContext(), new TestNuGetProjectContext(), sourceRepositoryProvider.GetRepositories().First(), null, token);
+
+                // Assert
+                // Check that the packages.lock.json still does not exist after the installation
+                Assert.False(File.Exists(packagesLockPath));
+            }
+        }
+
+        [Fact]
+        public async Task InstallingPackageShouldCreateLockFile_PackagesLockJson()
+        {
+            // Arrange
+            using (var packageSource = TestDirectory.Create())
+            using (var testSolutionManager = new TestSolutionManager(true))
+            {
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<PackageSource>()
+                    {
+                        new PackageSource(packageSource.Path)
+                    });
+
+                var testSettings = NullSettings.Instance;
+                var token = CancellationToken.None;
+                var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                var nuGetPackageManager = new NuGetPackageManager(
+                    sourceRepositoryProvider,
+                    testSettings,
+                    testSolutionManager,
+                    deleteOnRestartManager);
+                var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(testSolutionManager, testSettings);
+
+                var packageContext = new SimpleTestPackageContext("packageA");
+                packageContext.AddFile("lib/net45/a.dll");
+                SimpleTestPackageUtility.CreateOPCPackage(packageContext, packageSource);
+
+                var msBuildNuGetProject = testSolutionManager.AddNewMSBuildProject();
+                var msBuildNuGetProjectSystem = msBuildNuGetProject.ProjectSystem as TestMSBuildNuGetProjectSystem;
+                msBuildNuGetProjectSystem.SetPropertyValue("RestorePackagesWithLockFile", "true");
+                var packagesConfigPath = msBuildNuGetProject.PackagesConfigNuGetProject.FullPath;
+                var packagesLockPath = packagesConfigPath.Replace("packages.config", "packages.lock.json");
+                var packageIdentity = packageContext.Identity;
+
+                // Pre-Assert
+                // Check that the packages.lock.json file does not exist
+                Assert.False(File.Exists(packagesLockPath));
+
+                // Act
+                await nuGetPackageManager.InstallPackageAsync(msBuildNuGetProject, packageIdentity,
+                    new ResolutionContext(), new TestNuGetProjectContext(), sourceRepositoryProvider.GetRepositories().First(), null, token);
+
+                // Assert
+                // Check that the packages.lock.json file exists after the installation
+                Assert.True(File.Exists(packagesLockPath));
+                Assert.True(msBuildNuGetProjectSystem.FileExistsInProject("packages.lock.json"));
+                // Check the number of target frameworks and dependencies in the lock file
+                var lockFile = PackagesLockFileFormat.Read(packagesLockPath);
+                Assert.Equal(1, lockFile.Targets.Count);
+                Assert.Equal(1, lockFile.Targets[0].Dependencies.Count);
+            }
+        }
+
+        [Fact]
+        public async Task InstallingPackageShouldCreateLockFile_CustomLockFileName()
+        {
+            // Arrange
+            using (var packageSource = TestDirectory.Create())
+            using (var testSolutionManager = new TestSolutionManager(true))
+            {
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<PackageSource>()
+                    {
+                        new PackageSource(packageSource.Path)
+                    });
+
+                var testSettings = NullSettings.Instance;
+                var token = CancellationToken.None;
+                var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                var nuGetPackageManager = new NuGetPackageManager(
+                    sourceRepositoryProvider,
+                    testSettings,
+                    testSolutionManager,
+                    deleteOnRestartManager);
+                var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(testSolutionManager, testSettings);
+
+                var packageContext = new SimpleTestPackageContext("packageA");
+                packageContext.AddFile("lib/net45/a.dll");
+                SimpleTestPackageUtility.CreateOPCPackage(packageContext, packageSource);
+
+                var msBuildNuGetProject = testSolutionManager.AddNewMSBuildProject();
+                var msBuildNuGetProjectSystem = msBuildNuGetProject.ProjectSystem as TestMSBuildNuGetProjectSystem;
+                msBuildNuGetProjectSystem.SetPropertyValue("RestorePackagesWithLockFile", "true");
+                msBuildNuGetProjectSystem.SetPropertyValue("NuGetLockFilePath", "my.lock.json");
+                var packagesConfigPath = msBuildNuGetProject.PackagesConfigNuGetProject.FullPath;
+                var packagesLockPath = packagesConfigPath.Replace("packages.config", "my.lock.json");
+                var packageIdentity = packageContext.Identity;
+
+                // Pre-Assert
+                // Check that the packages.lock.json file does not exist
+                Assert.False(File.Exists(packagesLockPath));
+
+                // Act
+                await nuGetPackageManager.InstallPackageAsync(msBuildNuGetProject, packageIdentity,
+                    new ResolutionContext(), new TestNuGetProjectContext(), sourceRepositoryProvider.GetRepositories().First(), null, token);
+
+                // Assert
+                // Check that the packages.lock.json file exists after the installation
+                Assert.True(File.Exists(packagesLockPath));
+                Assert.True(msBuildNuGetProjectSystem.FileExistsInProject("my.lock.json"));
+                // Check the number of target frameworks and dependencies in the lock file
+                var lockFile = PackagesLockFileFormat.Read(packagesLockPath);
+                Assert.Equal(1, lockFile.Targets.Count);
+                Assert.Equal(1, lockFile.Targets[0].Dependencies.Count);
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/PackagesConfigProjectTests/PackagesLockTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/PackagesConfigProjectTests/PackagesLockTests.cs
@@ -23,7 +23,7 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests.PackagesConfigPr
         {
             // Arrange
             using (var packageSource = TestDirectory.Create())
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
                     new List<PackageSource>()
@@ -71,7 +71,7 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests.PackagesConfigPr
         {
             // Arrange
             using (var packageSource = TestDirectory.Create())
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
                     new List<PackageSource>()
@@ -124,7 +124,7 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests.PackagesConfigPr
         {
             // Arrange
             using (var packageSource = TestDirectory.Create())
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
                     new List<PackageSource>()

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetProjectTests.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Test;
+using Xunit;
+
+namespace NuGet.PackageManagement.Test
+{
+    public class NuGetProjectTests
+    {
+        [Theory]
+        [InlineData("Name", "test")]
+        [InlineData("DoesNotExist", null)]
+        public void GetMetadataOrNull_TestProject_HasExpectedValue(string key, string expected)
+        {
+            // Arrange
+            var project = new TestNuGetProject("test", null);
+
+            // Act
+            var result = project.GetMetadataOrNull(key);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackagePreFetcherTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackagePreFetcherTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -19,7 +19,6 @@ namespace NuGet.PackageManagement.Test
 {
     public class PackagePreFetcherTests
     {
-
         [Fact]
         public async Task PackagePreFetcher_NoActionsInput()
         {
@@ -70,12 +69,12 @@ namespace NuGet.PackageManagement.Test
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var result = await PackagePreFetcher.GetPackagesAsync(
-                    actions,
-                    packagesFolder,
-                    new PackageDownloadContext(cacheContext),
-                    globalPackagesFolder,
-                    logger,
-                    CancellationToken.None);
+                        actions,
+                        packagesFolder,
+                        new PackageDownloadContext(cacheContext),
+                        globalPackagesFolder,
+                        logger,
+                        CancellationToken.None);
 
                     // Assert
                     Assert.Equal(0, result.Count);
@@ -108,24 +107,25 @@ namespace NuGet.PackageManagement.Test
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var result = await PackagePreFetcher.GetPackagesAsync(
-                    actions,
-                    packagesFolder,
-                    new PackageDownloadContext(cacheContext),
-                    globalPackagesFolder,
-                    logger,
-                    CancellationToken.None);
+                        actions,
+                        packagesFolder,
+                        new PackageDownloadContext(cacheContext),
+                        globalPackagesFolder,
+                        logger,
+                        CancellationToken.None);
 
-                    var downloadResult = await result[target].GetResultAsync();
-
-                    // Assert
-                    Assert.Equal(1, result.Count);
-                    Assert.True(result[target].InPackagesFolder);
-                    Assert.Null(result[target].Source);
-                    Assert.Equal(target, result[target].Package);
-                    Assert.True(result[target].IsComplete);
-                    Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
-                    Assert.NotNull(downloadResult.PackageStream);
-                    Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    using (var downloadResult = await result[target].GetResultAsync())
+                    {
+                        // Assert
+                        Assert.Equal(1, result.Count);
+                        Assert.True(result[target].InPackagesFolder);
+                        Assert.Null(result[target].Source);
+                        Assert.Equal(target, result[target].Package);
+                        Assert.True(result[target].IsComplete);
+                        Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
+                        Assert.NotNull(downloadResult.PackageStream);
+                        Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    }
                 }
             }
         }
@@ -163,17 +163,18 @@ namespace NuGet.PackageManagement.Test
                         logger,
                         CancellationToken.None);
 
-                    var downloadResult = await result[target].GetResultAsync();
-
-                    // Assert
-                    Assert.Equal(1, result.Count);
-                    Assert.False(result[target].InPackagesFolder);
-                    Assert.Equal(source.PackageSource, result[target].Source);
-                    Assert.Equal(target, result[target].Package);
-                    Assert.True(result[target].IsComplete);
-                    Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
-                    Assert.NotNull(downloadResult.PackageStream);
-                    Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    using (var downloadResult = await result[target].GetResultAsync())
+                    {
+                        // Assert
+                        Assert.Equal(1, result.Count);
+                        Assert.False(result[target].InPackagesFolder);
+                        Assert.Equal(source.PackageSource, result[target].Source);
+                        Assert.Equal(target, result[target].Package);
+                        Assert.True(result[target].IsComplete);
+                        Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
+                        Assert.NotNull(downloadResult.PackageStream);
+                        Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    }
                 }
             }
         }
@@ -221,43 +222,44 @@ namespace NuGet.PackageManagement.Test
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var result = await PackagePreFetcher.GetPackagesAsync(
-                    actions,
-                    packagesFolder,
-                    new PackageDownloadContext(cacheContext),
-                    globalPackagesFolder,
-                    logger,
-                    CancellationToken.None);
+                        actions,
+                        packagesFolder,
+                        new PackageDownloadContext(cacheContext),
+                        globalPackagesFolder,
+                        logger,
+                        CancellationToken.None);
 
-                    var resultA2 = await result[targetA2].GetResultAsync();
-                    var resultB2 = await result[targetB2].GetResultAsync();
-                    var resultC2 = await result[targetC2].GetResultAsync();
+                    using (var resultA2 = await result[targetA2].GetResultAsync())
+                    using (var resultB2 = await result[targetB2].GetResultAsync())
+                    using (var resultC2 = await result[targetC2].GetResultAsync())
+                    {
+                        // Assert
+                        Assert.Equal(3, result.Count);
 
-                    // Assert
-                    Assert.Equal(3, result.Count);
+                        Assert.True(result[targetA2].InPackagesFolder);
+                        Assert.Null(result[targetA2].Source);
+                        Assert.Equal(targetA2, result[targetA2].Package);
+                        Assert.True(result[targetA2].IsComplete);
+                        Assert.Equal(targetA2, resultA2.PackageReader.GetIdentity());
+                        Assert.NotNull(resultA2.PackageStream);
+                        Assert.Equal(DownloadResourceResultStatus.Available, resultA2.Status);
 
-                    Assert.True(result[targetA2].InPackagesFolder);
-                    Assert.Null(result[targetA2].Source);
-                    Assert.Equal(targetA2, result[targetA2].Package);
-                    Assert.True(result[targetA2].IsComplete);
-                    Assert.Equal(targetA2, resultA2.PackageReader.GetIdentity());
-                    Assert.NotNull(resultA2.PackageStream);
-                    Assert.Equal(DownloadResourceResultStatus.Available, resultA2.Status);
+                        Assert.False(result[targetB2].InPackagesFolder);
+                        Assert.Equal(source.PackageSource, result[targetB2].Source);
+                        Assert.Equal(targetB2, result[targetB2].Package);
+                        Assert.True(result[targetB2].IsComplete);
+                        Assert.Equal(targetB2, resultB2.PackageReader.GetIdentity());
+                        Assert.NotNull(resultB2.PackageStream);
+                        Assert.Equal(DownloadResourceResultStatus.Available, resultB2.Status);
 
-                    Assert.False(result[targetB2].InPackagesFolder);
-                    Assert.Equal(source.PackageSource, result[targetB2].Source);
-                    Assert.Equal(targetB2, result[targetB2].Package);
-                    Assert.True(result[targetB2].IsComplete);
-                    Assert.Equal(targetB2, resultB2.PackageReader.GetIdentity());
-                    Assert.NotNull(resultB2.PackageStream);
-                    Assert.Equal(DownloadResourceResultStatus.Available, resultB2.Status);
-
-                    Assert.False(result[targetC2].InPackagesFolder);
-                    Assert.Equal(source.PackageSource, result[targetC2].Source);
-                    Assert.Equal(targetC2, result[targetC2].Package);
-                    Assert.True(result[targetC2].IsComplete);
-                    Assert.Equal(targetC2, resultC2.PackageReader.GetIdentity());
-                    Assert.NotNull(resultC2.PackageStream);
-                    Assert.Equal(DownloadResourceResultStatus.Available, resultC2.Status);
+                        Assert.False(result[targetC2].InPackagesFolder);
+                        Assert.Equal(source.PackageSource, result[targetC2].Source);
+                        Assert.Equal(targetC2, result[targetC2].Package);
+                        Assert.True(result[targetC2].IsComplete);
+                        Assert.Equal(targetC2, resultC2.PackageReader.GetIdentity());
+                        Assert.NotNull(resultC2.PackageStream);
+                        Assert.Equal(DownloadResourceResultStatus.Available, resultC2.Status);
+                    }
                 }
             }
         }
@@ -288,23 +290,24 @@ namespace NuGet.PackageManagement.Test
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var result = await PackagePreFetcher.GetPackagesAsync(
-                    actions,
-                    packagesFolder,
-                    new PackageDownloadContext(cacheContext),
-                    globalPackagesFolder,
-                    logger,
-                    CancellationToken.None);
+                        actions,
+                        packagesFolder,
+                        new PackageDownloadContext(cacheContext),
+                        globalPackagesFolder,
+                        logger,
+                        CancellationToken.None);
 
-                    var downloadResult = await result[target].GetResultAsync();
-
-                    // Assert
-                    Assert.Equal(1, result.Count);
-                    Assert.True(result[target].InPackagesFolder);
-                    Assert.Null(result[target].Source);
-                    Assert.Equal(target, result[target].Package);
-                    Assert.True(result[target].IsComplete);
-                    Assert.NotNull(downloadResult.PackageStream);
-                    Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    using (var downloadResult = await result[target].GetResultAsync())
+                    {
+                        // Assert
+                        Assert.Equal(1, result.Count);
+                        Assert.True(result[target].InPackagesFolder);
+                        Assert.Null(result[target].Source);
+                        Assert.Equal(target, result[target].Package);
+                        Assert.True(result[target].IsComplete);
+                        Assert.NotNull(downloadResult.PackageStream);
+                        Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    }
                 }
             }
         }
@@ -335,23 +338,24 @@ namespace NuGet.PackageManagement.Test
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var result = await PackagePreFetcher.GetPackagesAsync(
-                    actions,
-                    packagesFolder,
-                    new PackageDownloadContext(cacheContext),
-                    globalPackagesFolder,
-                    logger,
-                    CancellationToken.None);
+                        actions,
+                        packagesFolder,
+                        new PackageDownloadContext(cacheContext),
+                        globalPackagesFolder,
+                        logger,
+                        CancellationToken.None);
 
-                    var downloadResult = await result[target].GetResultAsync();
-
-                    // Assert
-                    Assert.Equal(1, result.Count);
-                    Assert.True(result[target].InPackagesFolder);
-                    Assert.Null(result[target].Source);
-                    Assert.Equal(target, result[target].Package);
-                    Assert.True(result[target].IsComplete);
-                    Assert.NotNull(downloadResult.PackageStream);
-                    Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    using (var downloadResult = await result[target].GetResultAsync())
+                    {
+                        // Assert
+                        Assert.Equal(1, result.Count);
+                        Assert.True(result[target].InPackagesFolder);
+                        Assert.Null(result[target].Source);
+                        Assert.Equal(target, result[target].Package);
+                        Assert.True(result[target].IsComplete);
+                        Assert.NotNull(downloadResult.PackageStream);
+                        Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    }
                 }
             }
         }
@@ -378,24 +382,25 @@ namespace NuGet.PackageManagement.Test
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var result = await PackagePreFetcher.GetPackagesAsync(
-                    actions,
-                    packagesFolder,
-                    new PackageDownloadContext(cacheContext),
-                    globalPackagesFolder,
-                    logger,
-                    CancellationToken.None);
+                        actions,
+                        packagesFolder,
+                        new PackageDownloadContext(cacheContext),
+                        globalPackagesFolder,
+                        logger,
+                        CancellationToken.None);
 
-                    var downloadResult = await result[target].GetResultAsync();
-
-                    // Assert
-                    Assert.Equal(1, result.Count);
-                    Assert.False(result[target].InPackagesFolder);
-                    Assert.Equal(source.PackageSource, result[target].Source);
-                    Assert.Equal(target, result[target].Package);
-                    Assert.True(result[target].IsComplete);
-                    Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
-                    Assert.NotNull(downloadResult.PackageStream);
-                    Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    using (var downloadResult = await result[target].GetResultAsync())
+                    {
+                        // Assert
+                        Assert.Equal(1, result.Count);
+                        Assert.False(result[target].InPackagesFolder);
+                        Assert.Equal(source.PackageSource, result[target].Source);
+                        Assert.Equal(target, result[target].Package);
+                        Assert.True(result[target].IsComplete);
+                        Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
+                        Assert.NotNull(downloadResult.PackageStream);
+                        Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    }
                 }
             }
         }
@@ -421,18 +426,21 @@ namespace NuGet.PackageManagement.Test
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var result = await PackagePreFetcher.GetPackagesAsync(
-                    actions,
-                    packagesFolder,
-                    new PackageDownloadContext(cacheContext),
-                    globalPackagesFolder,
-                    logger,
-                    CancellationToken.None);
+                        actions,
+                        packagesFolder,
+                        new PackageDownloadContext(cacheContext),
+                        globalPackagesFolder,
+                        logger,
+                        CancellationToken.None);
 
                     Exception exception = null;
 
                     try
                     {
-                        var downloadResult = await result[target].GetResultAsync();
+                        using (await result[target].GetResultAsync())
+                        {
+                        }
+
                         Assert.True(false);
                     }
                     catch (Exception ex)

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
@@ -32,7 +32,7 @@ namespace NuGet.Test
         public async Task TestGetMissingPackagesForSolution()
         {
             // Arrange
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomPackageSourcePath = TestDirectory.Create())
             {
                 var projectA = testSolutionManager.AddNewMSBuildProject();
@@ -84,7 +84,7 @@ namespace NuGet.Test
         public async Task TestGetMissingPackagesForSolution_NoPackagesInstalled()
         {
             // Arrange
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var projectA = testSolutionManager.AddNewMSBuildProject();
                 var projectB = testSolutionManager.AddNewMSBuildProject();
@@ -111,7 +111,7 @@ namespace NuGet.Test
         public async Task TestPackageRestoredEvent()
         {
             // Arrange
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var projectA = testSolutionManager.AddNewMSBuildProject();
                 var projectB = testSolutionManager.AddNewMSBuildProject();
@@ -170,7 +170,7 @@ namespace NuGet.Test
         public async Task TestCheckForMissingPackages()
         {
             // Arrange
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomPackageSourcePath = TestDirectory.Create())
             {
                 var projectA = testSolutionManager.AddNewMSBuildProject();
@@ -228,7 +228,7 @@ namespace NuGet.Test
         public async Task TestRestoreMissingPackages()
         {
             // Arrange
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var projectA = testSolutionManager.AddNewMSBuildProject();
                 var projectB = testSolutionManager.AddNewMSBuildProject();
@@ -282,7 +282,7 @@ namespace NuGet.Test
         public async Task Test_PackageRestoreFailure_WithRaisedEvents()
         {
             // Arrange
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomTestPackageSourcePath = TestDirectory.Create())
             {
                 var projectA = testSolutionManager.AddNewMSBuildProject("projectA");

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/BuildIntegratedNuGetProjectTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -10,7 +9,6 @@ using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Configuration;
 using NuGet.Frameworks;
-using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
@@ -517,11 +515,6 @@ namespace ProjectManagement.Test
 
                 return json;
             }
-        }
-
-        private static void CreateFile(string path)
-        {
-            File.OpenWrite(path).WriteByte(0);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/UnzippedPackageInstallTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/UnzippedPackageInstallTests.cs
@@ -34,7 +34,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomPackagesConfigFolderPath = TestDirectory.Create())
             {
                 var testSettings = NullSettings.Instance;

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/Utility/PackagesConfigLockFileUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/Utility/PackagesConfigLockFileUtilityTests.cs
@@ -1,0 +1,327 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using Moq;
+using NuGet.Frameworks;
+using NuGet.PackageManagement.Utility;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.PackageManagement.Test.Utility
+{
+    public class PackagesConfigLockFileUtilityTests
+    {
+        [Fact]
+        public void GetPackagesLockFilePath_MsbuildProperty()
+        {
+            // Arrage
+            var projectName = "testproj";
+            var logger = new TestLogger();
+            var expected = "somewhere\\my.lock.json";
+
+            using (var rootFolder = TestDirectory.Create())
+            {
+                var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
+                var targetFramework = NuGetFramework.Parse("net46");
+
+                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(targetFramework, new TestNuGetProjectContext(), projectFolder.FullName);
+                var project = new TestMSBuildNuGetProject(msBuildNuGetProjectSystem, rootFolder, projectFolder.FullName);
+                msBuildNuGetProjectSystem.SetPropertyValue("NuGetLockFilePath", expected);
+
+                // Act
+                var lockFile = PackagesConfigLockFileUtility.GetPackagesLockFilePath(project);
+
+                // Assert
+                Assert.Equal(Path.Combine(projectFolder.FullName, expected), lockFile);
+            }
+        }
+
+        [Fact]
+        public void GetPackagesLockFilePath_PackagesProjectLockJson()
+        {
+            // Arrange
+            var projectName = "testproj";
+            var logger = new TestLogger();
+            var expected = $"packages.{projectName}.lock.json";
+
+            using (var rootFolder = TestDirectory.Create())
+            {
+                var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
+                var targetFramework = NuGetFramework.Parse("net46");
+                projectFolder.Create();
+                File.WriteAllText(Path.Combine(projectFolder.FullName, expected), string.Empty);
+
+                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(targetFramework, new TestNuGetProjectContext(), projectFolder.FullName, projectName: projectName);
+                var project = new TestMSBuildNuGetProject(msBuildNuGetProjectSystem, rootFolder, projectFolder.FullName);
+
+                // Act
+                var lockFile = PackagesConfigLockFileUtility.GetPackagesLockFilePath(project);
+
+                //Assert
+                Assert.Equal(Path.Combine(projectFolder.FullName, expected), lockFile);
+            }
+        }
+
+        [Fact]
+        public void GetPackagesLockFilePath_PackagesLockJson()
+        {
+            // Arrange
+            var projectName = "testproj";
+            var logger = new TestLogger();
+
+            using (var rootFolder = TestDirectory.Create())
+            {
+                var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
+                var targetFramework = NuGetFramework.Parse("net46");
+
+                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(targetFramework, new TestNuGetProjectContext(), projectFolder.FullName);
+                var project = new TestMSBuildNuGetProject(msBuildNuGetProjectSystem, rootFolder, projectFolder.FullName);
+
+                // Act
+                var lockFile = PackagesConfigLockFileUtility.GetPackagesLockFilePath(project);
+
+                // Assert
+                Assert.Equal(Path.Combine(projectFolder.FullName, "packages.lock.json"), lockFile);
+            }
+        }
+
+        [Fact]
+        public void ApplyChanges_AddInstalledPackage()
+        {
+            // Arrange
+            var lockFile = new PackagesLockFile
+            {
+                Targets = new List<PackagesLockFileTarget>
+                {
+                    new PackagesLockFileTarget()
+                }
+            };
+
+            var actionList = new List<NuGetProjectAction>
+            {
+                NuGetProjectAction.CreateInstallProjectAction(new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), null, null)
+            };
+
+            var contentHashUtility = new Mock<IPackagesConfigContentHashProvider>();
+
+            // Act
+            PackagesConfigLockFileUtility.ApplyChanges(lockFile, actionList, contentHashUtility.Object, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(1, lockFile.Targets[0].Dependencies.Count);
+            Assert.Equal(actionList[0].PackageIdentity.Id, lockFile.Targets[0].Dependencies[0].Id);
+            Assert.Equal(actionList[0].PackageIdentity.Version, lockFile.Targets[0].Dependencies[0].ResolvedVersion);
+        }
+
+        [Fact]
+        public void ApplyChanges_RemoveUninstalledPackage()
+        {
+            // Arrange
+            var lockFile = new PackagesLockFile
+            {
+                Targets = new List<PackagesLockFileTarget>
+                {
+                    new PackagesLockFileTarget
+                    {
+                        Dependencies = new List<LockFileDependency>
+                        {
+                            new LockFileDependency
+                            {
+                                Id = "packageA",
+                                ResolvedVersion = NuGetVersion.Parse("1.0.0")
+                            }
+                        }
+                    }
+                }
+            };
+
+            var actionList = new List<NuGetProjectAction>
+            {
+                NuGetProjectAction.CreateUninstallProjectAction(new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), null)
+            };
+
+            var contentHashUtility = new Mock<IPackagesConfigContentHashProvider>();
+
+            // Act
+            PackagesConfigLockFileUtility.ApplyChanges(lockFile, actionList, contentHashUtility.Object, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(0, lockFile.Targets[0].Dependencies.Count);
+        }
+
+        [Fact]
+        public void ApplyChanges_UpgradeInstalledPackage()
+        {
+            // Arrange
+            var lockFile = new PackagesLockFile
+            {
+                Targets = new List<PackagesLockFileTarget>
+                {
+                    new PackagesLockFileTarget
+                    {
+                        Dependencies = new List<LockFileDependency>
+                        {
+                            new LockFileDependency
+                            {
+                                Id = "packageA",
+                                ResolvedVersion = NuGetVersion.Parse("1.0.0")
+                            }
+                        }
+                    }
+                }
+            };
+
+            var actionList = new List<NuGetProjectAction>
+            {
+                NuGetProjectAction.CreateUninstallProjectAction(new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), null),
+                NuGetProjectAction.CreateInstallProjectAction(new PackageIdentity("packageA", NuGetVersion.Parse("2.0.0")), null, null)
+            };
+
+            var contentHashUtility = new Mock<IPackagesConfigContentHashProvider>();
+
+            // Act
+            PackagesConfigLockFileUtility.ApplyChanges(lockFile, actionList, contentHashUtility.Object, CancellationToken.None);
+
+             // Assert
+            Assert.Equal(1, lockFile.Targets[0].Dependencies.Count);
+            Assert.Equal(actionList[0].PackageIdentity.Id, lockFile.Targets[0].Dependencies[0].Id);
+            Assert.Equal(NuGetVersion.Parse("2.0.0"), lockFile.Targets[0].Dependencies[0].ResolvedVersion);
+        }
+
+        [Fact]
+        public void ApplyChanges_SortPackages_FirstPackage()
+        {
+            // Arrange
+            var lockFile = new PackagesLockFile
+            {
+                Targets = new List<PackagesLockFileTarget>
+                {
+                    new PackagesLockFileTarget
+                    {
+                        Dependencies = new List<LockFileDependency>
+                        {
+                            new LockFileDependency
+                            {
+                                Id = "packageB",
+                                ResolvedVersion = NuGetVersion.Parse("1.0.0")
+                            },
+                            new LockFileDependency
+                            {
+                                Id = "packageD",
+                                ResolvedVersion = NuGetVersion.Parse("1.0.0")
+                            }
+                        }
+                    }
+                }
+            };
+
+            var actionList = new List<NuGetProjectAction>
+            {
+                NuGetProjectAction.CreateInstallProjectAction(new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), null, null)
+            };
+
+            var contentHashUtility = new Mock<IPackagesConfigContentHashProvider>();
+
+            // Act
+            PackagesConfigLockFileUtility.ApplyChanges(lockFile, actionList, contentHashUtility.Object, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(3, lockFile.Targets[0].Dependencies.Count);
+            Assert.Equal("packageA", lockFile.Targets[0].Dependencies[0].Id);
+            Assert.Equal("packageB", lockFile.Targets[0].Dependencies[1].Id);
+            Assert.Equal("packageD", lockFile.Targets[0].Dependencies[2].Id);
+        }
+
+        [Fact]
+        public void ApplyChanges_SortPackages_MiddleOfList()
+        {
+            // Arrange
+            var lockFile = new PackagesLockFile
+            {
+                Targets = new List<PackagesLockFileTarget>
+                {
+                    new PackagesLockFileTarget
+                    {
+                        Dependencies = new List<LockFileDependency>
+                        {
+                            new LockFileDependency
+                            {
+                                Id = "packageB",
+                                ResolvedVersion = NuGetVersion.Parse("1.0.0")
+                            },
+                            new LockFileDependency
+                            {
+                                Id = "packageD",
+                                ResolvedVersion = NuGetVersion.Parse("1.0.0")
+                            }
+                        }
+                    }
+                }
+            };
+
+            var actionList = new List<NuGetProjectAction>
+            {
+                NuGetProjectAction.CreateInstallProjectAction(new PackageIdentity("packageC", NuGetVersion.Parse("1.0.0")), null, null)
+            };
+
+            var contentHashUtility = new Mock<IPackagesConfigContentHashProvider>();
+
+            // Act
+            PackagesConfigLockFileUtility.ApplyChanges(lockFile, actionList, contentHashUtility.Object, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(3, lockFile.Targets[0].Dependencies.Count);
+            Assert.Equal("packageB", lockFile.Targets[0].Dependencies[0].Id);
+            Assert.Equal("packageC", lockFile.Targets[0].Dependencies[1].Id);
+            Assert.Equal("packageD", lockFile.Targets[0].Dependencies[2].Id);
+        }
+
+        [Fact]
+        public void ApplyChanges_SortPackages_LastPackage()
+        {
+            // Arrange
+            var lockFile = new PackagesLockFile
+            {
+                Targets = new List<PackagesLockFileTarget>
+                {
+                    new PackagesLockFileTarget
+                    {
+                        Dependencies = new List<LockFileDependency>
+                        {
+                            new LockFileDependency
+                            {
+                                Id = "packageB",
+                                ResolvedVersion = NuGetVersion.Parse("1.0.0")
+                            },
+                            new LockFileDependency
+                            {
+                                Id = "packageD",
+                                ResolvedVersion = NuGetVersion.Parse("1.0.0")
+                            }
+                        }
+                    }
+                }
+            };
+
+            var actionList = new List<NuGetProjectAction>
+            {
+                NuGetProjectAction.CreateInstallProjectAction(new PackageIdentity("packageE", NuGetVersion.Parse("1.0.0")), null, null)
+            };
+
+            var contentHashUtility = new Mock<IPackagesConfigContentHashProvider>();
+
+            // Act
+            PackagesConfigLockFileUtility.ApplyChanges(lockFile, actionList, contentHashUtility.Object, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(3, lockFile.Targets[0].Dependencies.Count);
+            Assert.Equal("packageB", lockFile.Targets[0].Dependencies[0].Id);
+            Assert.Equal("packageD", lockFile.Targets[0].Dependencies[1].Id);
+            Assert.Equal("packageE", lockFile.Targets[0].Dependencies[2].Id);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/V2V3ParityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/V2V3ParityTests.cs
@@ -32,7 +32,7 @@ namespace NuGet.Test
         private async Task<IEnumerable<NuGetProjectAction>> PacManCleanInstall(SourceRepositoryProvider sourceRepositoryProvider, PackageIdentity target)
         {
             // Arrange
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomPackagesConfigFolderPath = TestDirectory.Create())
             {
                 var testSettings = NullSettings.Instance;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
@@ -29,43 +29,45 @@ namespace Commands.Test
                 var version = new NuGetVersion(package.Version);
                 var identity = new PackageIdentity(package.Id, version);
 
-                var packagesDir = TestDirectory.Create();
-                var pathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var token = CancellationToken.None;
-                var logger = NullLogger.Instance;
-                var packageExtractionContext = new PackageExtractionContext(
-                   packageSaveMode: PackageSaveMode.Defaultv3,
-                   xmlDocFileSaveMode: XmlDocFileSaveMode.None,
-                   clientPolicyContext: null,
-                   logger: logger);
-
-                var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
-
-                // Act
-                using (var packageDownloader = new LocalPackageArchiveDownloader(
-                    null,
-                    package.File.FullName,
-                    identity,
-                    logger))
+                using (var packagesDir = TestDirectory.Create())
                 {
-                    await PackageExtractor.InstallFromSourceAsync(
+                    var pathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var token = CancellationToken.None;
+                    var logger = NullLogger.Instance;
+                    var packageExtractionContext = new PackageExtractionContext(
+                        packageSaveMode: PackageSaveMode.Defaultv3,
+                        xmlDocFileSaveMode: XmlDocFileSaveMode.None,
+                        clientPolicyContext: null,
+                        logger: logger);
+
+                    var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    // Act
+                    using (var packageDownloader = new LocalPackageArchiveDownloader(
+                        null,
+                        package.File.FullName,
                         identity,
-                        packageDownloader,
-                        versionFolderPathResolver,
-                        packageExtractionContext,
-                        token);
+                        logger))
+                    {
+                        await PackageExtractor.InstallFromSourceAsync(
+                            identity,
+                            packageDownloader,
+                            versionFolderPathResolver,
+                            packageExtractionContext,
+                            token);
+                    }
+
+                    // Assert
+                    var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
+                    AssertDirectoryExists(packageDir, packageDir + " does not exist");
+
+                    var nupkgPath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
+                    Assert.True(File.Exists(nupkgPath), nupkgPath + " does not exist");
+
+                    var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
+                    Assert.True(File.Exists(dllPath), dllPath + " does not exist");
                 }
-
-                // Assert
-                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
-                AssertDirectoryExists(packageDir, packageDir + " does not exist");
-
-                var nupkgPath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
-                Assert.True(File.Exists(nupkgPath), nupkgPath + " does not exist");
-
-                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
-                Assert.True(File.Exists(dllPath), dllPath + " does not exist");
             }
         }
 
@@ -78,43 +80,45 @@ namespace Commands.Test
                 var version = new NuGetVersion(package.Version);
                 var identity = new PackageIdentity(package.Id, version);
 
-                var packagesDir = TestDirectory.Create();
-                var pathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var token = CancellationToken.None;
-                var logger = NullLogger.Instance;
-                var packageExtractionContext = new PackageExtractionContext(
-                    packageSaveMode: PackageSaveMode.Defaultv3,
-                    xmlDocFileSaveMode: XmlDocFileSaveMode.None,
-                    clientPolicyContext: null,
-                    logger: logger);
-
-                var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
-
-                // Act
-                using (var packageDownloader = new LocalPackageArchiveDownloader(
-                    null,
-                    package.File.FullName,
-                    identity,
-                    logger))
+                using (var packagesDir = TestDirectory.Create())
                 {
-                    await PackageExtractor.InstallFromSourceAsync(
-                         identity,
-                         packageDownloader,
-                         versionFolderPathResolver,
-                         packageExtractionContext,
-                         token);
+                    var pathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var token = CancellationToken.None;
+                    var logger = NullLogger.Instance;
+                    var packageExtractionContext = new PackageExtractionContext(
+                        packageSaveMode: PackageSaveMode.Defaultv3,
+                        xmlDocFileSaveMode: XmlDocFileSaveMode.None,
+                        clientPolicyContext: null,
+                        logger: logger);
+
+                    var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    // Act
+                    using (var packageDownloader = new LocalPackageArchiveDownloader(
+                        null,
+                        package.File.FullName,
+                        identity,
+                        logger))
+                    {
+                        await PackageExtractor.InstallFromSourceAsync(
+                             identity,
+                             packageDownloader,
+                             versionFolderPathResolver,
+                             packageExtractionContext,
+                             token);
+                    }
+
+                    // Assert
+                    var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
+                    AssertDirectoryExists(packageDir, packageDir + " does not exist");
+
+                    var nupkgPath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
+                    Assert.True(File.Exists(nupkgPath), nupkgPath + " does not exist");
+
+                    var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
+                    Assert.True(File.Exists(dllPath), dllPath + " does not exist");
                 }
-
-                // Assert
-                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
-                AssertDirectoryExists(packageDir, packageDir + " does not exist");
-
-                var nupkgPath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
-                Assert.True(File.Exists(nupkgPath), nupkgPath + " does not exist");
-
-                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
-                Assert.True(File.Exists(dllPath), dllPath + " does not exist");
             }
         }
 
@@ -127,54 +131,56 @@ namespace Commands.Test
                 var version = new NuGetVersion(package.Version);
                 var identity = new PackageIdentity(package.Id, version);
 
-                var packagesDir = TestDirectory.Create();
-                var pathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var token = CancellationToken.None;
-                var logger = NullLogger.Instance;
-                var packageExtractionContext = new PackageExtractionContext(
-                    packageSaveMode: PackageSaveMode.Defaultv3,
-                    xmlDocFileSaveMode: XmlDocFileSaveMode.None,
-                    clientPolicyContext: null,
-                    logger: logger);
-
-                var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
-
-                Directory.CreateDirectory(packageDir);
-
-                var nupkgPath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
-                var shaPath = pathResolver.GetNupkgMetadataPath(package.Id, identity.Version);
-
-                File.WriteAllBytes(shaPath, new byte[] { });
-
-                Assert.True(File.Exists(shaPath));
-
-                // Act
-                using (var packageDownloader = new LocalPackageArchiveDownloader(
-                    null,
-                    package.File.FullName,
-                    identity,
-                    logger))
+                using (var packagesDir = TestDirectory.Create())
                 {
-                    await PackageExtractor.InstallFromSourceAsync(
-                          identity,
-                          packageDownloader,
-                          versionFolderPathResolver,
-                          packageExtractionContext,
-                          token);
+                    var pathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var token = CancellationToken.None;
+                    var logger = NullLogger.Instance;
+                    var packageExtractionContext = new PackageExtractionContext(
+                        packageSaveMode: PackageSaveMode.Defaultv3,
+                        xmlDocFileSaveMode: XmlDocFileSaveMode.None,
+                        clientPolicyContext: null,
+                        logger: logger);
+
+                    var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
+
+                    Directory.CreateDirectory(packageDir);
+
+                    var nupkgPath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
+                    var shaPath = pathResolver.GetNupkgMetadataPath(package.Id, identity.Version);
+
+                    File.WriteAllBytes(shaPath, new byte[] { });
+
+                    Assert.True(File.Exists(shaPath));
+
+                    // Act
+                    using (var packageDownloader = new LocalPackageArchiveDownloader(
+                        null,
+                        package.File.FullName,
+                        identity,
+                        logger))
+                    {
+                        await PackageExtractor.InstallFromSourceAsync(
+                              identity,
+                              packageDownloader,
+                              versionFolderPathResolver,
+                              packageExtractionContext,
+                              token);
+                    }
+
+                    // Assert
+                    AssertDirectoryExists(packageDir, packageDir + " does not exist");
+
+                    Assert.False(File.Exists(nupkgPath), nupkgPath + " does not exist");
+
+                    var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
+                    Assert.False(File.Exists(dllPath), dllPath + " does not exist");
+
+                    Assert.Equal(1, Directory.EnumerateFiles(packageDir).Count());
                 }
-
-                // Assert
-                AssertDirectoryExists(packageDir, packageDir + " does not exist");
-
-                Assert.False(File.Exists(nupkgPath), nupkgPath + " does not exist");
-
-                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
-                Assert.False(File.Exists(dllPath), dllPath + " does not exist");
-
-                Assert.Equal(1, Directory.EnumerateFiles(packageDir).Count());
             }
         }
 
@@ -187,58 +193,60 @@ namespace Commands.Test
                 var version = new NuGetVersion(package.Version);
                 var identity = new PackageIdentity(package.Id, version);
 
-                var packagesDir = TestDirectory.Create();
-                var pathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var token = CancellationToken.None;
-                var logger = NullLogger.Instance;
-                var packageExtractionContext = new PackageExtractionContext(
-                    packageSaveMode: PackageSaveMode.Defaultv3,
-                    xmlDocFileSaveMode: XmlDocFileSaveMode.None,
-                    clientPolicyContext: null,
-                    logger: logger);
-
-                var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
-
-                var randomFile = Path.Combine(packageDir, package.Id + "." + package.Version + ".random");
-
-                Directory.CreateDirectory(packageDir);
-                File.WriteAllBytes(randomFile, new byte[] { });
-
-                var randomFolder = Path.Combine(packageDir, "random");
-                Directory.CreateDirectory(randomFolder);
-
-                Assert.True(File.Exists(randomFile), randomFile + " does not exist");
-                AssertDirectoryExists(randomFolder);
-
-                // Act
-                using (var packageDownloader = new LocalPackageArchiveDownloader(
-                    null,
-                    package.File.FullName,
-                    identity,
-                    logger))
+                using (var packagesDir = TestDirectory.Create())
                 {
-                    await PackageExtractor.InstallFromSourceAsync(
-                         identity,
-                         packageDownloader,
-                         versionFolderPathResolver,
-                         packageExtractionContext,
-                         token);
+                    var pathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var token = CancellationToken.None;
+                    var logger = NullLogger.Instance;
+                    var packageExtractionContext = new PackageExtractionContext(
+                        packageSaveMode: PackageSaveMode.Defaultv3,
+                        xmlDocFileSaveMode: XmlDocFileSaveMode.None,
+                        clientPolicyContext: null,
+                        logger: logger);
+
+                    var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
+
+                    var randomFile = Path.Combine(packageDir, package.Id + "." + package.Version + ".random");
+
+                    Directory.CreateDirectory(packageDir);
+                    File.WriteAllBytes(randomFile, new byte[] { });
+
+                    var randomFolder = Path.Combine(packageDir, "random");
+                    Directory.CreateDirectory(randomFolder);
+
+                    Assert.True(File.Exists(randomFile), randomFile + " does not exist");
+                    AssertDirectoryExists(randomFolder);
+
+                    // Act
+                    using (var packageDownloader = new LocalPackageArchiveDownloader(
+                        null,
+                        package.File.FullName,
+                        identity,
+                        logger))
+                    {
+                        await PackageExtractor.InstallFromSourceAsync(
+                             identity,
+                             packageDownloader,
+                             versionFolderPathResolver,
+                             packageExtractionContext,
+                             token);
+                    }
+
+                    // Assert
+                    AssertDirectoryExists(packageDir, packageDir + " does not exist");
+
+                    var filePath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
+                    Assert.True(File.Exists(filePath), filePath + " does not exist");
+
+                    var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
+                    Assert.True(File.Exists(dllPath), dllPath + " does not exist");
+
+                    Assert.False(File.Exists(randomFile), randomFile + " does exist");
+                    Assert.False(Directory.Exists(randomFolder), randomFolder + " does exist");
                 }
-
-                // Assert
-                AssertDirectoryExists(packageDir, packageDir + " does not exist");
-
-                var filePath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
-                Assert.True(File.Exists(filePath), filePath + " does not exist");
-
-                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
-                Assert.True(File.Exists(dllPath), dllPath + " does not exist");
-
-                Assert.False(File.Exists(randomFile), randomFile + " does exist");
-                Assert.False(Directory.Exists(randomFolder), randomFolder + " does exist");
             }
         }
 
@@ -251,62 +259,64 @@ namespace Commands.Test
                 var version = new NuGetVersion(package.Version);
                 var identity = new PackageIdentity(package.Id, version);
 
-                var packagesDir = TestDirectory.Create();
-                var pathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var token = CancellationToken.None;
-                var logger = NullLogger.Instance;
-                var packageExtractionContext = new PackageExtractionContext(
-                    packageSaveMode: PackageSaveMode.Defaultv3,
-                    xmlDocFileSaveMode: XmlDocFileSaveMode.None,
-                    clientPolicyContext: null,
-                    logger: logger);
-
-                var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
-                Assert.False(Directory.Exists(packageDir), packageDir + " exist");
-
-                // Act
-                using (var packageDownloader = new ThrowingPackageArchiveDownloader(
-                    null,
-                    package.File.FullName,
-                    identity,
-                    logger))
+                using (var packagesDir = TestDirectory.Create())
                 {
-                    await Assert.ThrowsAnyAsync<CorruptionException>(async () =>
-                       await PackageExtractor.InstallFromSourceAsync(
-                         identity,
-                         packageDownloader,
-                         versionFolderPathResolver,
-                         packageExtractionContext,
-                         token));
+                    var pathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var token = CancellationToken.None;
+                    var logger = NullLogger.Instance;
+                    var packageExtractionContext = new PackageExtractionContext(
+                        packageSaveMode: PackageSaveMode.Defaultv3,
+                        xmlDocFileSaveMode: XmlDocFileSaveMode.None,
+                        clientPolicyContext: null,
+                        logger: logger);
+
+                    var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
+                    Assert.False(Directory.Exists(packageDir), packageDir + " exist");
+
+                    // Act
+                    using (var packageDownloader = new ThrowingPackageArchiveDownloader(
+                        null,
+                        package.File.FullName,
+                        identity,
+                        logger))
+                    {
+                        await Assert.ThrowsAnyAsync<CorruptionException>(async () =>
+                           await PackageExtractor.InstallFromSourceAsync(
+                             identity,
+                             packageDownloader,
+                             versionFolderPathResolver,
+                             packageExtractionContext,
+                             token));
+                    }
+
+                    AssertDirectoryExists(packageDir, packageDir + " does not exist");
+
+                    Assert.NotEmpty(Directory.EnumerateFiles(packageDir));
+
+                    using (var packageDownloader = new LocalPackageArchiveDownloader(
+                        packagesDir,
+                        package.File.FullName,
+                        identity,
+                        logger))
+                    {
+                        await PackageExtractor.InstallFromSourceAsync(
+                              identity,
+                              packageDownloader,
+                              versionFolderPathResolver,
+                              packageExtractionContext,
+                              token);
+                    }
+
+                    // Assert
+                    var filePath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
+                    Assert.True(File.Exists(filePath), filePath + " does not exist");
+
+                    var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
+                    Assert.True(File.Exists(dllPath), dllPath + " does not exist");
                 }
-
-                AssertDirectoryExists(packageDir, packageDir + " does not exist");
-
-                Assert.NotEmpty(Directory.EnumerateFiles(packageDir));
-
-                using (var packageDownloader = new LocalPackageArchiveDownloader(
-                    packagesDir,
-                    package.File.FullName,
-                    identity,
-                    logger))
-                {
-                    await PackageExtractor.InstallFromSourceAsync(
-                          identity,
-                          packageDownloader,
-                          versionFolderPathResolver,
-                          packageExtractionContext,
-                          token);
-                }
-
-                // Assert
-                var filePath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
-                Assert.True(File.Exists(filePath), filePath + " does not exist");
-
-                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
-                Assert.True(File.Exists(dllPath), dllPath + " does not exist");
             }
         }
 
@@ -319,78 +329,80 @@ namespace Commands.Test
                 var version = new NuGetVersion(package.Version);
                 var identity = new PackageIdentity(package.Id, version);
 
-                var packagesDir = TestDirectory.Create();
-                var pathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var token = CancellationToken.None;
-                var logger = NullLogger.Instance;
-                var packageExtractionContext = new PackageExtractionContext(
-                    packageSaveMode: PackageSaveMode.Defaultv3,
-                    xmlDocFileSaveMode: XmlDocFileSaveMode.None,
-                    clientPolicyContext: null,
-                    logger: logger);
-
-                var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
-                Assert.False(Directory.Exists(packageDir), packageDir + " exist");
-
-                var filePathToLock = Path.Combine(packageDir, "lib", "net40", "two.dll");
-
-                // Act
-                using (var packageDownloader = new LocalPackageArchiveDownloader(
-                    null,
-                    package.File.FullName,
-                    identity,
-                    logger))
+                using (var packagesDir = TestDirectory.Create())
                 {
-                    var cts = new CancellationTokenSource(DefaultTimeOut);
+                    var pathResolver = new VersionFolderPathResolver(packagesDir);
 
-                    Func<CancellationToken, Task<bool>> action = (ct) =>
+                    var token = CancellationToken.None;
+                    var logger = NullLogger.Instance;
+                    var packageExtractionContext = new PackageExtractionContext(
+                        packageSaveMode: PackageSaveMode.Defaultv3,
+                        xmlDocFileSaveMode: XmlDocFileSaveMode.None,
+                        clientPolicyContext: null,
+                        logger: logger);
+
+                    var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
+                    Assert.False(Directory.Exists(packageDir), packageDir + " exist");
+
+                    var filePathToLock = Path.Combine(packageDir, "lib", "net40", "two.dll");
+
+                    // Act
+                    using (var packageDownloader = new LocalPackageArchiveDownloader(
+                        null,
+                        package.File.FullName,
+                        identity,
+                        logger))
                     {
-                        Assert.ThrowsAnyAsync<IOException>(async () =>
-                            await PackageExtractor.InstallFromSourceAsync(
-                                identity,
-                                packageDownloader,
-                                versionFolderPathResolver,
-                                packageExtractionContext,
-                                token));
+                        var cts = new CancellationTokenSource(DefaultTimeOut);
 
-                        return Task.FromResult(true);
-                    };
+                        Func<CancellationToken, Task<bool>> action = (ct) =>
+                        {
+                            Assert.ThrowsAnyAsync<IOException>(async () =>
+                                await PackageExtractor.InstallFromSourceAsync(
+                                    identity,
+                                    packageDownloader,
+                                    versionFolderPathResolver,
+                                    packageExtractionContext,
+                                    token));
 
-                    await ConcurrencyUtilities.ExecuteWithFileLockedAsync(filePathToLock, action, cts.Token);
+                            return Task.FromResult(true);
+                        };
+
+                        await ConcurrencyUtilities.ExecuteWithFileLockedAsync(filePathToLock, action, cts.Token);
+                    }
+
+                    AssertDirectoryExists(packageDir, packageDir + " does not exist");
+
+                    Assert.NotEmpty(Directory.EnumerateFiles(packageDir));
+
+                    using (var packageDownloader = new LocalPackageArchiveDownloader(
+                        null,
+                        package.File.FullName,
+                        identity,
+                        logger))
+                    {
+                        await PackageExtractor.InstallFromSourceAsync(
+                             identity,
+                             packageDownloader,
+                             versionFolderPathResolver,
+                             packageExtractionContext,
+                             token);
+                    }
+
+                    // Assert
+                    var filePath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
+                    Assert.True(File.Exists(filePath), filePath + " does not exist");
+
+                    var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
+                    Assert.True(File.Exists(dllPath), dllPath + " does not exist");
+
+                    Assert.True(File.Exists(filePathToLock));
+
+                    // Make sure the actual file from the zip was extracted
+                    Assert.Equal(new byte[] { 0 }, File.ReadAllBytes(filePathToLock));
                 }
-
-                AssertDirectoryExists(packageDir, packageDir + " does not exist");
-
-                Assert.NotEmpty(Directory.EnumerateFiles(packageDir));
-
-                using (var packageDownloader = new LocalPackageArchiveDownloader(
-                    null,
-                    package.File.FullName,
-                    identity,
-                    logger))
-                {
-                    await PackageExtractor.InstallFromSourceAsync(
-                         identity,
-                         packageDownloader,
-                         versionFolderPathResolver,
-                         packageExtractionContext,
-                         token);
-                }
-
-                // Assert
-                var filePath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
-                Assert.True(File.Exists(filePath), filePath + " does not exist");
-
-                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
-                Assert.True(File.Exists(dllPath), dllPath + " does not exist");
-
-                Assert.True(File.Exists(filePathToLock));
-
-                // Make sure the actual file from the zip was extracted
-                Assert.Equal(new byte[] { 0 }, File.ReadAllBytes(filePathToLock));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -1501,7 +1501,7 @@ Description is required.");
 #if !IS_CORECLR
             ExceptionAssert.Throws<InvalidOperationException>(
                 () => new PackageBuilder(spec.AsStream(), null),
-                "The element 'metadata' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' has incomplete content. " + 
+                "The element 'metadata' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' has incomplete content. " +
                 "List of possible elements expected: 'authors' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd'. " +
                 "This validation error occurred in a 'metadata' element.");
 #else
@@ -2475,12 +2475,13 @@ Enabling license acceptance requires a license or a licenseUrl to be specified. 
 
                     Assert.Equal(@"test.nuspec", files[4]);
 
-                    var contentTypesReader
-                        = new StreamReader(archive.Entries.Single(file => file.FullName == @"[Content_Types].xml").Open());
-                    var contentTypesXml = XDocument.Parse(contentTypesReader.ReadToEnd());
-                    var node = contentTypesXml.Descendants().Single(e => e.Name.LocalName == "Override");
+                    using (var contentTypesReader = new StreamReader(archive.Entries.Single(file => file.FullName == @"[Content_Types].xml").Open()))
+                    {
+                        var contentTypesXml = XDocument.Parse(contentTypesReader.ReadToEnd());
+                        var node = contentTypesXml.Descendants().Single(e => e.Name.LocalName == "Override");
 
-                    Assert.StartsWith(@"<Override PartName=""/myfile"" ContentType=""application/octet""", node.ToString());
+                        Assert.StartsWith(@"<Override PartName=""/myfile"" ContentType=""application/octet""", node.ToString());
+                    }
                 }
             }
         }
@@ -2528,18 +2529,18 @@ Enabling license acceptance requires a license or a licenseUrl to be specified. 
                 builder.Authors.Add("test");
                 builder.AddFiles(directory.Path, "**", "Content");
 
-                using (MemoryStream stream = new MemoryStream())
+                using (var stream = new MemoryStream())
                 {
                     builder.Save(stream);
 
                     // Assert
                     using (var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true))
                     {
-                        foreach(var entry in archive.Entries)
+                        foreach (var entry in archive.Entries)
                         {
                             var path = directory.Path + Path.DirectorySeparatorChar + entry.Name;
                             // Only checks the entries that originated from files in test directory
-                            if(File.Exists(path))
+                            if (File.Exists(path))
                             {
                                 Assert.Equal(entry.LastWriteTime.DateTime, File.GetLastWriteTimeUtc(path));
                             }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
@@ -175,9 +175,8 @@ namespace NuGet.Packaging.Test
         public void GetStream_ReturnsReadableStream()
         {
             using (var test = PackageReaderTest.Create(TestPackagesCore.GetPackageCoreReaderTestPackage()))
+            using (var stream = test.Reader.GetStream("Aa.nuspec"))
             {
-                var stream = test.Reader.GetStream("Aa.nuspec");
-
                 Assert.NotNull(stream);
                 Assert.True(stream.CanRead);
             }
@@ -187,9 +186,8 @@ namespace NuGet.Packaging.Test
         public async Task GetStreamAsync_ReturnsReadableStream()
         {
             using (var test = PackageReaderTest.Create(TestPackagesCore.GetPackageCoreReaderTestPackage()))
+            using (var stream = await test.Reader.GetStreamAsync("Aa.nuspec", CancellationToken.None))
             {
-                var stream = await test.Reader.GetStreamAsync("Aa.nuspec", CancellationToken.None);
-
                 Assert.NotNull(stream);
                 Assert.True(stream.CanRead);
             }
@@ -278,9 +276,8 @@ namespace NuGet.Packaging.Test
         public void GetNuspec_ReturnsReadableStream()
         {
             using (var test = PackageReaderTest.Create(TestPackagesCore.GetPackageCoreReaderTestPackage()))
+            using (var stream = test.Reader.GetNuspec())
             {
-                var stream = test.Reader.GetNuspec();
-
                 Assert.NotNull(stream);
                 Assert.True(stream.CanRead);
             }
@@ -290,9 +287,8 @@ namespace NuGet.Packaging.Test
         public async Task GetNuspecAsync_ReturnsReadableStream()
         {
             using (var test = PackageReaderTest.Create(TestPackagesCore.GetPackageCoreReaderTestPackage()))
+            using (var stream = await test.Reader.GetNuspecAsync(CancellationToken.None))
             {
-                var stream = await test.Reader.GetNuspecAsync(CancellationToken.None);
-
                 Assert.NotNull(stream);
                 Assert.True(stream.CanRead);
             }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagesConfigWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagesConfigWriterTests.cs
@@ -375,31 +375,32 @@ namespace NuGet.Packaging.Test
                     }
                 }
 
-                var stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite);
-
-                using (var writer = new PackagesConfigWriter(stream, false))
+                using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite))
                 {
-                    // Act
-                    var packageIdentityA1 = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
-                    var packageReferenceA1 = new PackageReference(packageIdentityA1, NuGetFramework.Parse("win81"),
-                        userInstalled: true, developmentDependency: false, requireReinstallation: false);
+                    using (var writer = new PackagesConfigWriter(stream, false))
+                    {
+                        // Act
+                        var packageIdentityA1 = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+                        var packageReferenceA1 = new PackageReference(packageIdentityA1, NuGetFramework.Parse("win81"),
+                            userInstalled: true, developmentDependency: false, requireReinstallation: false);
 
-                    var packageIdentityA2 = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.1"));
-                    var packageReferenceA2 = new PackageReference(packageIdentityA2, NuGetFramework.Parse("net45"));
+                        var packageIdentityA2 = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.1"));
+                        var packageReferenceA2 = new PackageReference(packageIdentityA2, NuGetFramework.Parse("net45"));
 
-                    writer.UpdatePackageEntry(packageReferenceA1, packageReferenceA2);
+                        writer.UpdatePackageEntry(packageReferenceA1, packageReferenceA2);
+                    }
+
+                    // Assert
+                    stream.Seek(0, SeekOrigin.Begin);
+
+                    var xml = XDocument.Load(stream);
+
+                    // Assert
+                    Assert.Equal("utf-8", xml.Declaration.Encoding);
+
+                    var packageNode = xml.Descendants(PackagesConfig.PackageNodeName).FirstOrDefault();
+                    Assert.Equal(packageNode.ToString(), "<package id=\"packageA\" version=\"1.0.1\" targetFramework=\"net45\" userInstalled=\"true\" protocolVersion=\"V2\" />");
                 }
-
-                // Assert
-                stream.Seek(0, SeekOrigin.Begin);
-
-                var xml = XDocument.Load(stream);
-
-                // Assert
-                Assert.Equal("utf-8", xml.Declaration.Encoding);
-
-                var packageNode = xml.Descendants(PackagesConfig.PackageNodeName).FirstOrDefault();
-                Assert.Equal(packageNode.ToString(), "<package id=\"packageA\" version=\"1.0.1\" targetFramework=\"net45\" userInstalled=\"true\" protocolVersion=\"V2\" />");
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/AttributeUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/AttributeUtilityTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET46
+#if IS_DESKTOP
 using System;
 using System.Linq;
 using System.Security.Cryptography;
@@ -170,7 +170,7 @@ namespace NuGet.Packaging.Test
         {
             using (var certificate = _fixture.GetDefaultCertificate())
             {
-                var attributes = CreateAttributeCollection(certificate, _fixture.DefaultKeyPair.Private,
+                var attributes = CreateAttributeCollection(certificate, _fixture.Key,
                     vector =>
                     {
                         vector.Add(
@@ -200,7 +200,7 @@ namespace NuGet.Packaging.Test
         {
             using (var certificate = _fixture.GetDefaultCertificate())
             {
-                var attributes = CreateAttributeCollection(certificate, _fixture.DefaultKeyPair.Private,
+                var attributes = CreateAttributeCollection(certificate, _fixture.Key,
                     vector =>
                     {
                         vector.Add(
@@ -340,7 +340,7 @@ namespace NuGet.Packaging.Test
         {
             using (var certificate = _fixture.GetDefaultCertificate())
             {
-                var attributes = CreateAttributeCollection(certificate, _fixture.DefaultKeyPair.Private,
+                var attributes = CreateAttributeCollection(certificate, _fixture.Key,
                     vector =>
                     {
                         vector.Add(
@@ -398,7 +398,7 @@ namespace NuGet.Packaging.Test
         {
             using (var certificate = _fixture.GetDefaultCertificate())
             {
-                var attributes = CreateAttributeCollection(certificate, _fixture.DefaultKeyPair.Private,
+                var attributes = CreateAttributeCollection(certificate, _fixture.Key,
                     vector =>
                     {
                         vector.Add(
@@ -498,7 +498,7 @@ namespace NuGet.Packaging.Test
         {
             using (var certificate = _fixture.GetDefaultCertificate())
             {
-                var attributes = CreateAttributeCollection(certificate, _fixture.DefaultKeyPair.Private,
+                var attributes = CreateAttributeCollection(certificate, _fixture.Key,
                     vector =>
                     {
                         var attribute = new BcAttribute(
@@ -521,7 +521,7 @@ namespace NuGet.Packaging.Test
         {
             using (var certificate = _fixture.GetDefaultCertificate())
             {
-                var attributes = CreateAttributeCollection(certificate, _fixture.DefaultKeyPair.Private,
+                var attributes = CreateAttributeCollection(certificate, _fixture.Key,
                     vector =>
                     {
                         var value = new DerIA5String("https://test.test");
@@ -622,7 +622,7 @@ namespace NuGet.Packaging.Test
         {
             using (var certificate = _fixture.GetDefaultCertificate())
             {
-                var attributes = CreateAttributeCollection(certificate, _fixture.DefaultKeyPair.Private,
+                var attributes = CreateAttributeCollection(certificate, _fixture.Key,
                     vector =>
                     {
                         var attribute = new BcAttribute(
@@ -649,7 +649,7 @@ namespace NuGet.Packaging.Test
         {
             using (var certificate = _fixture.GetDefaultCertificate())
             {
-                var attributes = CreateAttributeCollection(certificate, _fixture.DefaultKeyPair.Private,
+                var attributes = CreateAttributeCollection(certificate, _fixture.Key,
                     vector =>
                     {
                         var value = new DerSequence(
@@ -702,7 +702,7 @@ namespace NuGet.Packaging.Test
 
         private static CryptographicAttributeObjectCollection CreateAttributeCollection(
             X509Certificate2 certificate,
-            AsymmetricKeyParameter privateKey,
+            RSA privateKey,
             Action<Asn1EncodableVector> addAttributes)
         {
             var content = new CmsProcessableByteArray(new byte[0]);
@@ -714,9 +714,10 @@ namespace NuGet.Packaging.Test
             var unsignedAttributes = new AttributeTable(DerSet.Empty);
 
             var generator = new CmsSignedDataGenerator();
+            var keyPair = DotNetUtilities.GetRsaKeyPair(privateKey);
 
             generator.AddSigner(
-                privateKey,
+                keyPair.Private,
                 DotNetUtilities.FromX509Certificate(certificate),
                 Oids.Sha256,
                 signedAttributes,

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificatesFixture.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificatesFixture.cs
@@ -23,12 +23,12 @@ namespace NuGet.Packaging.Test
 
         private bool _isDisposed;
 
-        internal RSA DefaultKeyPair { get; }
+        internal RSA Key { get; }
 
         public CertificatesFixture()
         {
-            DefaultKeyPair = RSA.Create(keySizeInBits: 2048);
-            _defaultCertificate = SigningTestUtility.GenerateCertificate("test", DefaultKeyPair);
+            Key = RSA.Create(keySizeInBits: 2048);
+            _defaultCertificate = SigningTestUtility.GenerateCertificate("test", Key);
             _rsaSsaPssCertificate = SigningTestUtility.GenerateCertificate("test",
                 generator => { },
                 hashAlgorithm: Common.HashAlgorithmName.SHA256,
@@ -82,7 +82,7 @@ namespace NuGet.Packaging.Test
                 _selfIssuedCertificate.Dispose();
                 _rootCertificate.Dispose();
                 _cyclicChain.Dispose();
-                DefaultKeyPair.Dispose();
+                Key.Dispose();
 
                 GC.SuppressFinalize(this);
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/PrimarySignatureTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/PrimarySignatureTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET46
+#if IS_DESKTOP
 using System;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/RepositoryCountersignatureTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/RepositoryCountersignatureTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET46
+#if IS_DESKTOP
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureUtilityTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET46
+#if IS_DESKTOP
 using System;
 using System.IO;
 using System.Threading;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningOptionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningOptionsTests.cs
@@ -190,8 +190,8 @@ namespace NuGet.Packaging.Test
         {
             using (var directory = TestDirectory.Create())
             {
-                var inputPackageFilePath = Path.Combine(Path.GetTempPath(), "a");
-                var outputPackageFilePath = Path.Combine(Path.GetTempPath(), "b");
+                var inputPackageFilePath = Path.Combine(directory, "a");
+                var outputPackageFilePath = Path.Combine(directory, "b");
                 var overwrite = false;
                 var signatureProvider = Mock.Of<ISignatureProvider>();
                 var logger = Mock.Of<ILogger>();

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningOptionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningOptionsTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET46
+#if IS_DESKTOP
 using System;
 using System.IO;
 using Moq;

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Builders/LockFileDependencyBuilder.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Builders/LockFileDependencyBuilder.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Versioning;
+
+namespace NuGet.ProjectModel.Test.Builders
+{
+    internal class LockFileDependencyBuilder
+    {
+        private string _id = "PackageA";
+        private VersionRange _requestedVersion = new VersionRange(new NuGetVersion(1, 0, 0));
+        private NuGetVersion _resolvedVersion = new NuGetVersion(1, 0, 0);
+        private PackageDependencyType _type = PackageDependencyType.Direct;
+        private string _contentHash = "ABC";
+
+        public LockFileDependencyBuilder WithId(string id)
+        {
+            _id = id;
+            return this;
+        }
+
+        public LockFileDependencyBuilder WithRequestedVersion(VersionRange requestedVersion)
+        {
+            _requestedVersion = requestedVersion;
+            return this;
+        }
+
+        public LockFileDependencyBuilder WithResolvedVersion(NuGetVersion resolvedVersion)
+        {
+            _resolvedVersion = resolvedVersion;
+            return this;
+        }
+
+        public LockFileDependencyBuilder WithType(PackageDependencyType type)
+        {
+            _type = type;
+            return this;
+        }
+
+        public LockFileDependencyBuilder WithContentHash(string contentHash)
+        {
+            _contentHash = contentHash;
+            return this;
+        }
+
+        public LockFileDependency Build()
+        {
+            return new LockFileDependency()
+            {
+                Id = _id,
+                RequestedVersion = _requestedVersion,
+                ResolvedVersion = _resolvedVersion,
+                Type = _type,
+                ContentHash = _contentHash
+            };
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Builders/PackagesLockFileBuilder.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Builders/PackagesLockFileBuilder.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.ProjectModel.Test.Builders
+{
+    internal class PackagesLockFileBuilder
+    {
+        private int _version = PackagesLockFileFormat.Version;
+        private List<PackagesLockFileTarget> _targets = new List<PackagesLockFileTarget>();
+
+        public PackagesLockFileBuilder WithVersion(int version)
+        {
+            _version = version;
+            return this;
+        }
+
+        public PackagesLockFileBuilder WithTarget(Action<PackagesLockFileTargetBuilder> action)
+        {
+            var target = new PackagesLockFileTargetBuilder();
+            action(target);
+            _targets.Add(target.Build());
+            return this;
+        }
+
+        public PackagesLockFile Build()
+        {
+            return new PackagesLockFile
+            {
+                Version = _version,
+                Targets = _targets
+            };
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Builders/PackagesLockFileTargetBuilder.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Builders/PackagesLockFileTargetBuilder.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Frameworks;
+
+namespace NuGet.ProjectModel.Test.Builders
+{
+    internal class PackagesLockFileTargetBuilder
+    {
+        private NuGetFramework _framework;
+        private List<LockFileDependency> _dependencies = new List<LockFileDependency>();
+
+        public PackagesLockFileTargetBuilder WithFramework(NuGetFramework framework)
+        {
+            _framework = framework;
+            return this;
+        }
+
+        public PackagesLockFileTargetBuilder WithDependency(Action<LockFileDependencyBuilder> action)
+        {
+            var dep = new LockFileDependencyBuilder();
+            action(dep);
+            _dependencies.Add(dep.Build());
+            return this;
+        }
+
+        public PackagesLockFileTarget Build()
+        {
+            return new PackagesLockFileTarget()
+            {
+                TargetFramework = _framework,
+                Dependencies = _dependencies
+            };
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileDependencyComparerWithoutContentHashTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileDependencyComparerWithoutContentHashTests.cs
@@ -1,0 +1,145 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.ProjectModel.ProjectLockFile;
+using NuGet.ProjectModel.Test.Builders;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test.ProjectLockFile
+{
+    public class LockFileDependencyComparerWithoutContentHashTests
+    {
+        [Fact]
+        public void Equals_WhenBothArgumentsAreNull_ReturnsTrue()
+        {
+            LockFileDependency x = null;
+            LockFileDependency y = null;
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(x, y);
+
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenOneArgumentIsNull_ReturnsFalse()
+        {
+            LockFileDependency isNull = null;
+            var notNull = new LockFileDependencyBuilder().Build();
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(isNull, notNull);
+            Assert.False(actual);
+
+            actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(notNull, isNull);
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenSameReference_ReturnsTrue()
+        {
+            var dep = new LockFileDependencyBuilder().Build();
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(dep, dep);
+
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenSameValue_ReturnsTrue()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder().Build();
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(x, y);
+            Assert.True(actual);
+
+            actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(y, x);
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenContentHashIsDifferent_ReturnsTrue()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithContentHash("XYZ")
+                .Build();
+
+            Assert.NotEqual(x.ContentHash, y.ContentHash);
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(x, y);
+            Assert.True(actual);
+
+            actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(y, x);
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenPackageIdIsDifferent_ReturnsFalse()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithId("PackageB")
+                .Build();
+
+            Assert.NotEqual(x.Id, y.Id);
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(x, y);
+            Assert.False(actual);
+
+            actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(y, x);
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenResolvedVersionsAreDifferent_ReturnsFalse()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithResolvedVersion(new NuGetVersion(1, 0, 1))
+                .Build();
+
+            Assert.NotEqual(x.ResolvedVersion, y.ResolvedVersion);
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(x, y);
+            Assert.False(actual);
+
+            actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(y, x);
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenRequestedVersionsAreDifferent_ReturnsFalse()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithRequestedVersion(new VersionRange(new NuGetVersion(1, 0, 1)))
+                .Build();
+
+            Assert.NotEqual(x.RequestedVersion, y.RequestedVersion);
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(x, y);
+            Assert.False(actual);
+
+            actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(y, x);
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenDependencyTypesAreDifferent_ReturnFalse()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithType(PackageDependencyType.Transitive)
+                .Build();
+
+            Assert.NotEqual(x.Type, y.Type);
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(x, y);
+            Assert.False(actual);
+
+            actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(y, x);
+            Assert.False(actual);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileDependencyIdVersionComparerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileDependencyIdVersionComparerTests.cs
@@ -1,0 +1,144 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.ProjectModel.Test.Builders;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test.ProjectLockFile
+{
+    public class LockFileDependencyIdVersionComparerTests
+    {
+        [Fact]
+        public void Equals_WhenBothArgumentsAreNull_ReturnsTrue()
+        {
+            LockFileDependency x = null;
+            LockFileDependency y = null;
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(x, y);
+
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenOneArgumentIsNull_ReturnsFalse()
+        {
+            LockFileDependency isNull = null;
+            var notNull = new LockFileDependencyBuilder().Build();
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(isNull, notNull);
+            Assert.False(actual);
+
+            actual = LockFileDependencyIdVersionComparer.Default.Equals(notNull, isNull);
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenSameReference_ReturnsTrue()
+        {
+            var dep = new LockFileDependencyBuilder().Build();
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(dep, dep);
+
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenSameValue_ReturnsTrue()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder().Build();
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(x, y);
+            Assert.True(actual);
+
+            actual = LockFileDependencyIdVersionComparer.Default.Equals(y, x);
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenContentHashIsDifferent_ReturnsTrue()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithContentHash("XYZ")
+                .Build();
+
+            Assert.NotEqual(x.ContentHash, y.ContentHash);
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(x, y);
+            Assert.True(actual);
+
+            actual = LockFileDependencyIdVersionComparer.Default.Equals(y, x);
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenPackageIdIsDifferent_ReturnsFalse()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithId("PackageB")
+                .Build();
+
+            Assert.NotEqual(x.Id, y.Id);
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(x, y);
+            Assert.False(actual);
+
+            actual = LockFileDependencyIdVersionComparer.Default.Equals(y, x);
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenResolvedVersionsAreDifferent_ReturnsFalse()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithResolvedVersion(new NuGetVersion(1, 0, 1))
+                .Build();
+
+            Assert.NotEqual(x.ResolvedVersion, y.ResolvedVersion);
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(x, y);
+            Assert.False(actual);
+
+            actual = LockFileDependencyIdVersionComparer.Default.Equals(y, x);
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenRequestedVersionsAreDifferent_ReturnsTrue()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithRequestedVersion(new VersionRange(new NuGetVersion(1, 0, 1)))
+                .Build();
+
+            Assert.NotEqual(x.RequestedVersion, y.RequestedVersion);
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(x, y);
+            Assert.True(actual);
+
+            actual = LockFileDependencyIdVersionComparer.Default.Equals(y, x);
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenDependencyTypesAreDifferent_ReturnTrue()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithType(PackageDependencyType.Transitive)
+                .Build();
+
+            Assert.NotEqual(x.Type, y.Type);
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(x, y);
+            Assert.True(actual);
+
+            actual = LockFileDependencyIdVersionComparer.Default.Equals(y, x);
+            Assert.True(actual);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileUtilitiesTests.cs
@@ -1,0 +1,153 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Xunit;
+using static NuGet.Frameworks.FrameworkConstants;
+using PackagesLockFileBuilder = NuGet.ProjectModel.Test.Builders.PackagesLockFileBuilder;
+
+namespace NuGet.ProjectModel.Test.ProjectLockFile
+{
+    public class LockFileUtilitiesTests
+    {
+        [Fact]
+        public void IsLockFileStillValid_DifferentVersions_AreNotEqual()
+        {
+            var x = new PackagesLockFileBuilder().Build();
+            var y = new PackagesLockFileBuilder()
+                .WithVersion(2)
+                .Build();
+
+            var actual = PackagesLockFileUtilities.IsLockFileStillValid(x, y);
+            Assert.False(actual.IsValid);
+
+            actual = PackagesLockFileUtilities.IsLockFileStillValid(y, x);
+            Assert.False(actual.IsValid);
+        }
+
+        [Fact]
+        public void IsLockFileStillValid_DifferentTargetCounts_AreNotEqual()
+        {
+            var x = new PackagesLockFileBuilder()
+                .WithTarget(target => target.WithFramework(CommonFrameworks.NetStandard20))
+                .WithTarget(target => target.WithFramework(CommonFrameworks.NetCoreApp22))
+                .Build();
+            var y = new PackagesLockFileBuilder()
+                .WithTarget(target => target.WithFramework(CommonFrameworks.NetStandard20))
+                .Build();
+
+            var actual = PackagesLockFileUtilities.IsLockFileStillValid(x, y);
+            Assert.False(actual.IsValid);
+
+            actual = PackagesLockFileUtilities.IsLockFileStillValid(y, x);
+            Assert.False(actual.IsValid);
+        }
+
+        [Fact]
+        public void IsLockFileStillValid_DifferentTargets_AreNotEqual()
+        {
+            var x = new PackagesLockFileBuilder()
+                .WithTarget(target => target.WithFramework(CommonFrameworks.NetStandard20))
+                .Build();
+            var y = new PackagesLockFileBuilder()
+                .WithTarget(target => target.WithFramework(CommonFrameworks.NetCoreApp22))
+                .Build();
+
+            var actual = PackagesLockFileUtilities.IsLockFileStillValid(x, y);
+            Assert.False(actual.IsValid);
+
+            actual = PackagesLockFileUtilities.IsLockFileStillValid(y, x);
+            Assert.False(actual.IsValid);
+        }
+
+        [Fact]
+        public void IsLockFileStillValid_DifferentDependencyCounts_AreNotEqual()
+        {
+            var x = new PackagesLockFileBuilder()
+                .WithTarget(target => target
+                    .WithFramework(CommonFrameworks.NetStandard20)
+                    .WithDependency(dep => dep.WithId("PackageA")))
+                .Build();
+            var y = new PackagesLockFileBuilder()
+                .WithTarget(target => target
+                    .WithFramework(CommonFrameworks.NetStandard20)
+                    .WithDependency(dep => dep.WithId("PackageA"))
+                    .WithDependency(dep => dep.WithId("PackageB")))
+                .Build();
+
+            var actual = PackagesLockFileUtilities.IsLockFileStillValid(x, y);
+            Assert.False(actual.IsValid);
+
+            actual = PackagesLockFileUtilities.IsLockFileStillValid(y, x);
+            Assert.False(actual.IsValid);
+        }
+
+        [Fact]
+        public void IsLockFileStillValid_DifferentDependency_AreNotEqual()
+        {
+            var x = new PackagesLockFileBuilder()
+                .WithTarget(target => target
+                    .WithFramework(CommonFrameworks.NetStandard20)
+                    .WithDependency(dep => dep.WithId("PackageA")))
+                .Build();
+            var y = new PackagesLockFileBuilder()
+                .WithTarget(target => target
+                    .WithFramework(CommonFrameworks.NetStandard20)
+                    .WithDependency(dep => dep.WithId("PackageB")))
+                .Build();
+
+            var actual = PackagesLockFileUtilities.IsLockFileStillValid(x, y);
+            Assert.False(actual.IsValid);
+
+            actual = PackagesLockFileUtilities.IsLockFileStillValid(y, x);
+            Assert.False(actual.IsValid);
+        }
+
+        [Fact]
+        public void IsLockFileStillValid_MatchesDependencies_AreEqual()
+        {
+            var x = new PackagesLockFileBuilder()
+                .WithTarget(target => target
+                    .WithFramework(CommonFrameworks.NetStandard20)
+                    .WithDependency(dep => dep
+                        .WithId("PackageA")
+                        .WithContentHash("ABC"))
+                    .WithDependency(dep => dep
+                        .WithId("PackageB")
+                        .WithContentHash("123")))
+                .Build();
+            var y = new PackagesLockFileBuilder()
+                .WithTarget(target => target
+                    .WithFramework(CommonFrameworks.NetStandard20)
+                    .WithDependency(dep => dep
+                        .WithId("PackageA")
+                        .WithContentHash("XYZ"))
+                    .WithDependency(dep => dep
+                        .WithId("PackageB")
+                        .WithContentHash("890")))
+                .Build();
+
+            var actual = PackagesLockFileUtilities.IsLockFileStillValid(x, y);
+            Assert.True(actual.IsValid);
+            Assert.NotNull(actual.MatchedDependencies);
+            Assert.Equal(2, actual.MatchedDependencies.Count);
+            var depKvp = actual.MatchedDependencies.Single(d => d.Key.Id == "PackageA");
+            Assert.Equal("ABC", depKvp.Key.ContentHash);
+            Assert.Equal("XYZ", depKvp.Value.ContentHash);
+            depKvp = actual.MatchedDependencies.Single(d => d.Key.Id == "PackageB");
+            Assert.Equal("123", depKvp.Key.ContentHash);
+            Assert.Equal("890", depKvp.Value.ContentHash);
+
+            actual = PackagesLockFileUtilities.IsLockFileStillValid(y, x);
+            Assert.True(actual.IsValid);
+            Assert.NotNull(actual.MatchedDependencies);
+            Assert.Equal(2, actual.MatchedDependencies.Count);
+            depKvp = actual.MatchedDependencies.Single(d => d.Key.Id == "PackageA");
+            Assert.Equal("ABC", depKvp.Value.ContentHash);
+            Assert.Equal("XYZ", depKvp.Key.ContentHash);
+            depKvp = actual.MatchedDependencies.Single(d => d.Key.Id == "PackageB");
+            Assert.Equal("123", depKvp.Value.ContentHash);
+            Assert.Equal("890", depKvp.Key.ContentHash);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceV2FeedTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -36,14 +36,13 @@ namespace NuGet.Protocol.Tests
             // Act
             using (var packagesFolder = TestDirectory.Create())
             using (var sourceCacheContext = new SourceCacheContext())
+            using (var actual = await downloadResource.GetDownloadResourceResultAsync(
+                new PackageIdentity("xunit", new NuGetVersion("1.0.0-notfound")),
+                new PackageDownloadContext(sourceCacheContext),
+                packagesFolder,
+                NullLogger.Instance,
+                CancellationToken.None))
             {
-                var actual = await downloadResource.GetDownloadResourceResultAsync(
-                    new PackageIdentity("xunit", new NuGetVersion("1.0.0-notfound")),
-                    new PackageDownloadContext(sourceCacheContext),
-                    packagesFolder,
-                    NullLogger.Instance,
-                    CancellationToken.None);
-
                 // Assert
                 Assert.NotNull(actual);
                 Assert.Equal(DownloadResourceResultStatus.NotFound, actual.Status);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalFolderUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalFolderUtilityTests.cs
@@ -212,7 +212,10 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(a, foundA.Identity);
                 Assert.Equal(a, foundA.Nuspec.GetIdentity());
                 Assert.True(foundA.IsNupkg);
-                Assert.Equal(a, foundA.GetReader().GetIdentity());
+                using (var reader = foundA.GetReader())
+                {
+                    Assert.Equal(a, reader.GetIdentity());
+                }
                 Assert.Contains("a.1.0.0.nupkg", foundA.Path);
                 Assert.Equal(0, testLogger.Messages.Count);
             }
@@ -287,7 +290,10 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(a, foundA.Identity);
                 Assert.Equal(a, foundA.Nuspec.GetIdentity());
                 Assert.True(foundA.IsNupkg);
-                Assert.Equal(a, foundA.GetReader().GetIdentity());
+                using (var reader = foundA.GetReader())
+                {
+                    Assert.Equal(a, reader.GetIdentity());
+                }
                 Assert.Contains("a.1.0.01.0.nupkg", foundA.Path);
             }
         }
@@ -315,7 +321,10 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(a, foundA.Identity);
                 Assert.Equal(a, foundA.Nuspec.GetIdentity());
                 Assert.True(foundA.IsNupkg);
-                Assert.Equal(a, foundA.GetReader().GetIdentity());
+                using (var reader = foundA.GetReader())
+                {
+                    Assert.Equal(a, reader.GetIdentity());
+                }
                 Assert.Contains("a.1.0.1.nupkg", foundA.Path);
             }
         }
@@ -704,7 +713,10 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(a, foundA.Identity);
                 Assert.Equal(a, foundA.Nuspec.GetIdentity());
                 Assert.True(foundA.IsNupkg);
-                Assert.Equal(a, foundA.GetReader().GetIdentity());
+                using (var reader = foundA.GetReader())
+                {
+                    Assert.Equal(a, reader.GetIdentity());
+                }
                 Assert.Contains("a.1.0.0.nupkg", foundA.Path);
             }
         }
@@ -886,7 +898,10 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(a, foundA.Identity);
                 Assert.Equal(a, foundA.Nuspec.GetIdentity());
                 Assert.True(foundA.IsNupkg);
-                Assert.Equal(a, foundA.GetReader().GetIdentity());
+                using (var reader = foundA.GetReader())
+                {
+                    Assert.Equal(a, reader.GetIdentity());
+                }
                 Assert.Contains("a.1.0.0.nupkg", foundA.Path);
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/FindLocalPackagesResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/FindLocalPackagesResourceTests.cs
@@ -68,7 +68,13 @@ namespace NuGet.Protocol.Tests
 
                     // Assert
                     Assert.True(expected.SetEquals(result.Select(p => p.Identity)));
-                    Assert.True(expected.SetEquals(result.Select(p => p.GetReader().GetIdentity())));
+                    Assert.True(expected.SetEquals(result.Select(p =>
+                    {
+                        using (var reader = p.GetReader())
+                        {
+                            return reader.GetIdentity();
+                        }
+                    })));
                     Assert.True(expected.SetEquals(result.Select(p => p.Nuspec.GetIdentity())));
                     Assert.True(result.All(p => p.IsNupkg));
                 }
@@ -154,7 +160,13 @@ namespace NuGet.Protocol.Tests
 
                     // Assert
                     Assert.True(expected.SetEquals(result.Select(p => p.Identity)));
-                    Assert.True(expected.SetEquals(result.Select(p => p.GetReader().GetIdentity())));
+                    Assert.True(expected.SetEquals(result.Select(p =>
+                    {
+                        using (var reader = p.GetReader())
+                        {
+                            return reader.GetIdentity();
+                        }
+                    })));
                     Assert.True(expected.SetEquals(result.Select(p => p.Nuspec.GetIdentity())));
                     Assert.True(result.All(p => p.IsNupkg));
                 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalDownloadResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalDownloadResourceTests.cs
@@ -51,23 +51,18 @@ namespace NuGet.Protocol.Tests
 
                 // Act
                 using (var cacheContext = new SourceCacheContext())
+                using (var result = await resource.GetDownloadResourceResultAsync(
+                    packageA.Identity,
+                    new PackageDownloadContext(cacheContext),
+                    packagesFolder,
+                    testLogger,
+                    CancellationToken.None))
                 {
-                    var result = await resource.GetDownloadResourceResultAsync(
-                        packageA.Identity,
-                        new PackageDownloadContext(cacheContext),
-                        packagesFolder,
-                        testLogger,
-                        CancellationToken.None);
-
-                    using (var reader = result.PackageReader)
-                    using (var stream = result.PackageStream)
-                    {
-                        // Assert
-                        Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
-                        Assert.Equal("a", reader.GetIdentity().Id);
-                        Assert.Equal("1.0.0", reader.GetIdentity().Version.ToFullString());
-                        Assert.True(stream.CanSeek);
-                    }
+                    // Assert
+                    Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
+                    Assert.Equal("a", result.PackageReader.GetIdentity().Id);
+                    Assert.Equal("1.0.0", result.PackageReader.GetIdentity().Version.ToFullString());
+                    Assert.True(result.PackageStream.CanSeek);
                 }
             }
         }
@@ -116,35 +111,29 @@ namespace NuGet.Protocol.Tests
                 {
                     var downloadContext = new PackageDownloadContext(cacheContext);
 
-                    var result1 = await resource.GetDownloadResourceResultAsync(
+                    using (var result1 = await resource.GetDownloadResourceResultAsync(
                         packageA1.Identity,
                         downloadContext,
                         packagesFolder,
                         testLogger,
-                        CancellationToken.None);
-
-                    var result2 = await resource.GetDownloadResourceResultAsync(
+                        CancellationToken.None))
+                    using (var result2 = await resource.GetDownloadResourceResultAsync(
                         packageA2.Identity,
                         downloadContext,
                         packagesFolder,
                         testLogger,
-                        CancellationToken.None);
-
-                    var result3 = await resource.GetDownloadResourceResultAsync(
+                        CancellationToken.None))
+                    using (var result3 = await resource.GetDownloadResourceResultAsync(
                         packageA3.Identity,
                         downloadContext,
                         packagesFolder,
                         testLogger,
-                        CancellationToken.None);
-
-                    using (var reader1 = result1.PackageReader)
-                    using (var reader2 = result2.PackageReader)
-                    using (var reader3 = result3.PackageReader)
+                        CancellationToken.None))
                     {
                         // Assert
-                        Assert.Equal("1.0", reader1.GetIdentity().Version.ToString());
-                        Assert.Equal("1.0.0", reader2.GetIdentity().Version.ToString());
-                        Assert.Equal("1.0.0.0", reader3.GetIdentity().Version.ToString());
+                        Assert.Equal("1.0", result1.PackageReader.GetIdentity().Version.ToString());
+                        Assert.Equal("1.0.0", result2.PackageReader.GetIdentity().Version.ToString());
+                        Assert.Equal("1.0.0.0", result3.PackageReader.GetIdentity().Version.ToString());
                     }
                 }
             }
@@ -185,23 +174,18 @@ namespace NuGet.Protocol.Tests
 
                 // Act
                 using (var cacheContext = new SourceCacheContext())
+                using (var result = await resource.GetDownloadResourceResultAsync(
+                    packageA.Identity,
+                    new PackageDownloadContext(cacheContext),
+                    packagesFolder,
+                    testLogger,
+                    CancellationToken.None))
                 {
-                    var result = await resource.GetDownloadResourceResultAsync(
-                        packageA.Identity,
-                        new PackageDownloadContext(cacheContext),
-                        packagesFolder,
-                        testLogger,
-                        CancellationToken.None);
-
-                    using (var reader = result.PackageReader)
-                    using (var stream = result.PackageStream)
-                    {
-                        // Assert
-                        Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
-                        Assert.Equal("a", reader.GetIdentity().Id);
-                        Assert.Equal("1.0.0-alpha.1.2+b", reader.GetIdentity().Version.ToFullString());
-                        Assert.True(stream.CanSeek);
-                    }
+                    // Assert
+                    Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
+                    Assert.Equal("a", result.PackageReader.GetIdentity().Id);
+                    Assert.Equal("1.0.0-alpha.1.2+b", result.PackageReader.GetIdentity().Version.ToFullString());
+                    Assert.True(result.PackageStream.CanSeek);
                 }
             }
         }
@@ -241,14 +225,13 @@ namespace NuGet.Protocol.Tests
 
                 // Act
                 using (var cacheContext = new SourceCacheContext())
+                using (var result = await resource.GetDownloadResourceResultAsync(
+                    new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.1.2.3+a.b")),
+                    new PackageDownloadContext(cacheContext),
+                    packagesFolder,
+                    testLogger,
+                    CancellationToken.None))
                 {
-                    var result = await resource.GetDownloadResourceResultAsync(
-                        new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.1.2.3+a.b")),
-                        new PackageDownloadContext(cacheContext),
-                        packagesFolder,
-                        testLogger,
-                        CancellationToken.None);
-
                     // Assert
                     Assert.Equal(DownloadResourceResultStatus.NotFound, result.Status);
                 }
@@ -269,14 +252,13 @@ namespace NuGet.Protocol.Tests
 
                 // Act
                 using (var cacheContext = new SourceCacheContext())
+                using (var result = await resource.GetDownloadResourceResultAsync(
+                    new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.1.2.3+a.b")),
+                    new PackageDownloadContext(cacheContext),
+                    packagesFolder,
+                    testLogger,
+                    CancellationToken.None))
                 {
-                    var result = await resource.GetDownloadResourceResultAsync(
-                        new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.1.2.3+a.b")),
-                        new PackageDownloadContext(cacheContext),
-                        packagesFolder,
-                        testLogger,
-                        CancellationToken.None);
-
                     // Assert
                     Assert.Equal(DownloadResourceResultStatus.NotFound, result.Status);
                 }
@@ -299,14 +281,13 @@ namespace NuGet.Protocol.Tests
 
                 // Act
                 using (var cacheContext = new SourceCacheContext())
-                {
-                    var result = await resource.GetDownloadResourceResultAsync(
+                using (var result = await resource.GetDownloadResourceResultAsync(
                     new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.1.2.3+a.b")),
                     new PackageDownloadContext(cacheContext),
                     packagesFolder,
                     testLogger,
-                    CancellationToken.None);
-
+                    CancellationToken.None))
+                {
                     // Assert
                     Assert.Equal(DownloadResourceResultStatus.NotFound, result.Status);
                 }
@@ -330,24 +311,19 @@ namespace NuGet.Protocol.Tests
 
                 // Act
                 using (var cacheContext = new SourceCacheContext())
+                using (var result = await resource.GetDownloadResourceResultAsync(
+                    id,
+                    new PackageDownloadContext(cacheContext),
+                    packagesFolder,
+                    testLogger,
+                    CancellationToken.None))
                 {
-                    var result = await resource.GetDownloadResourceResultAsync(
-                        id,
-                        new PackageDownloadContext(cacheContext),
-                        packagesFolder,
-                        testLogger,
-                        CancellationToken.None);
-
-                    using (var reader = result.PackageReader)
-                    using (var stream = result.PackageStream)
-                    {
-                        // Assert
-                        Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
-                        Assert.Equal("a", reader.GetIdentity().Id);
-                        Assert.Equal("1.0.0", reader.GetIdentity().Version.ToFullString());
-                        Assert.True(stream.CanSeek);
-                        Assert.True(reader is PackageFolderReader);
-                    }
+                    // Assert
+                    Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
+                    Assert.Equal("a", result.PackageReader.GetIdentity().Id);
+                    Assert.Equal("1.0.0", result.PackageReader.GetIdentity().Version.ToFullString());
+                    Assert.True(result.PackageStream.CanSeek);
+                    Assert.True(result.PackageReader is PackageFolderReader);
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.IO;
 using NuGet.Test.Utility;
 using Xunit;
@@ -28,7 +31,7 @@ namespace NuGet.Protocol.Plugins.Tests
 
                 // Create plugin Directory and name
                 Directory.CreateDirectory(pluginDirectoryPath);
-                File.Create(fullPluginFilePath);
+                File.WriteAllText(fullPluginFilePath, string.Empty);
 
                 // Act
                 var results = PluginDiscoveryUtility.GetConventionBasedPlugins(new string[] { test.Path });

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Utility/GetDownloadResultUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Utility/GetDownloadResultUtilityTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -126,11 +126,17 @@ namespace NuGet.Protocol.Tests
                     Assert.EndsWith(".nugetdirectdownload", Path.GetFileName(files[0]));
                     Assert.EndsWith(".nugetdirectdownload", Path.GetFileName(files[1]));
 
-                    var actualContentA = new StreamReader(resultA.PackageStream).ReadToEnd();
-                    Assert.Equal(expectedContent, actualContentA);
+                    using (var reader = new StreamReader(resultA.PackageStream))
+                    {
+                        var actualContentA = reader.ReadToEnd();
+                        Assert.Equal(expectedContent, actualContentA);
+                    }
 
-                    var actualContentB = new StreamReader(resultB.PackageStream).ReadToEnd();
-                    Assert.Equal(expectedContent, actualContentB);
+                    using (var reader = new StreamReader(resultB.PackageStream))
+                    {
+                        var actualContentB = reader.ReadToEnd();
+                        Assert.Equal(expectedContent, actualContentB);
+                    }
                 }
 
                 Assert.Equal(0, Directory.EnumerateFileSystemEntries(downloadDirectory).Count());

--- a/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
+++ b/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
@@ -43,7 +43,7 @@ namespace Test.Utility
   </config>
 </configuration>";
 
-        public TestSolutionManager(bool foo)
+        public TestSolutionManager()
         {
             TestDirectory = TestDirectory.Create();
             SolutionDirectory = TestDirectory;

--- a/test/TestUtilities/Test.Utility/Protocol/TestSourceCacheContext.cs
+++ b/test/TestUtilities/Test.Utility/Protocol/TestSourceCacheContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Protocol.Core.Types;
@@ -9,12 +9,12 @@ namespace NuGet.Protocol.Test
     /// <summary>
     /// This is a test source cache context that should be used in places where it is not convenient to dispose the
     /// <see cref="SourceCacheContext"/>. Since <see cref="SourceCacheContext.GeneratedTempFolder"/> must be called
-    /// before <see cref="SourceCacheContext.Dispose"/> does anything meaningful, this implementation disables that
+    /// before <see cref="SourceCacheContext.Dispose()"/> does anything meaningful, this implementation disables that
     /// property.
     /// </summary>
-    public class TestSourceCacheContext : SourceCacheContext
+    public sealed class TestSourceCacheContext : SourceCacheContext
     {
-        private string _testDirectory;
+        private TestDirectory _testDirectory;
 
         public override string GeneratedTempFolder
         {
@@ -27,6 +27,13 @@ namespace NuGet.Protocol.Test
 
                 return _testDirectory;
             }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _testDirectory?.Dispose();
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/Signing/CertificateRevocationList.cs
+++ b/test/TestUtilities/Test.Utility/Signing/CertificateRevocationList.cs
@@ -76,10 +76,13 @@ namespace Test.Utility.Signing
 
         public void ExportCrl()
         {
-            var pemWriter = new PemWriter(new StreamWriter(File.Open(CrlLocalPath, FileMode.Create)));
-            pemWriter.WriteObject(Crl);
-            pemWriter.Writer.Flush();
-            pemWriter.Writer.Close();
+            using (var streamWriter = new StreamWriter(File.Open(CrlLocalPath, FileMode.Create)))
+            {
+                var pemWriter = new PemWriter(streamWriter);
+                pemWriter.WriteObject(Crl);
+                pemWriter.Writer.Flush();
+                pemWriter.Writer.Close();
+            }
         }
 
         private void UpdateVersion()

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -335,9 +335,7 @@ namespace Test.Utility.Signing
         /// <summary>
         /// Create a self signed certificate.
         /// </summary>
-        public static X509Certificate2 GenerateCertificate(
-            string subjectName,
-            RSA algorithm)
+        public static X509Certificate2 GenerateCertificate(string subjectName, RSA key)
         {
             if (string.IsNullOrEmpty(subjectName))
             {
@@ -346,7 +344,7 @@ namespace Test.Utility.Signing
 
             var subjectDN = new X500DistinguishedName($"CN={subjectName}");
             var hashAlgorithm = System.Security.Cryptography.HashAlgorithmName.SHA256;
-            var request = new CertificateRequest(subjectDN, algorithm, hashAlgorithm, RSASignaturePadding.Pkcs1);
+            var request = new CertificateRequest(subjectDN, key, hashAlgorithm, RSASignaturePadding.Pkcs1);
 
             request.CertificateExtensions.Add(
                 new X509SubjectKeyIdentifierExtension(request.PublicKey, critical: false));

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -279,7 +279,7 @@ namespace NuGet.Test.Utility
         {
             foreach (var framework in Frameworks)
             {
-                framework.PackageReferences = new List<SimpleTestPackageContext>();
+                framework.PackageReferences.Clear();
             }
         }
 

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -5,15 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Xml.Linq;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
-using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
+using NuGet.RuntimeModel;
 using NuGet.Versioning;
 
 namespace NuGet.Test.Utility
@@ -273,6 +272,14 @@ namespace NuGet.Test.Utility
             foreach (var framework in Frameworks)
             {
                 framework.PackageReferences.AddRange(packages);
+            }
+        }
+
+        public void CleanPackagesFromAllFrameworks()
+        {
+            foreach (var framework in Frameworks)
+            {
+                framework.PackageReferences = new List<SimpleTestPackageContext>();
             }
         }
 


### PR DESCRIPTION
## Bug
[Locked-mode restore fails with sha512 errors & installs new packages when a project's RuntimeIdentifier is changed](https://github.com/NuGet/Home/issues/8260)

Fixes: https://github.com/NuGet/Home/issues/8260
Regression: No  
* Last working version:  N/A 
* How are we preventing it in future: 
More unit tests.  

## Fix

Added verification to detect runtime changes. 

## Testing/Validation

Tests Added: Yes

Validation:  
Unit test and manual validation.
