### PR TITLE
Removed expander on DeprecationControl

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DeprecationControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/DeprecationControl.xaml
@@ -15,30 +15,25 @@
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
   </UserControl.Resources>
-  <Grid>
-    <Expander
-      Margin="0,12,0,16"
-      IsExpanded="True"
-      Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}">
-      <Expander.Header>
+  <Grid
+    Margin="0,12,0,16">
+      <StackPanel
+        Orientation="Vertical">
         <StackPanel
           Orientation="Horizontal"
           VerticalAlignment="Center">
-          <TextBlock
-            FontWeight="Bold"
-            AutomationProperties.Name="{x:Static nuget:Resources.Label_Deprecated}"
-            Text="{x:Static nuget:Resources.Label_Deprecated}"/>
           <imaging:CrispImage
             x:Name="_deprecationWarning"
-            Margin="5,0,0,0"
+            Margin="0,0,5,0"
             Width="13"
             Height="13"
             ToolTip="{x:Static nuget:Resources.Label_Deprecated}"
             Moniker="{x:Static catalog:KnownMonikers.StatusWarning}" />
-        </StackPanel>
-      </Expander.Header>
-      <StackPanel
-        Orientation="Vertical">
+        <TextBlock
+            FontWeight="Bold"
+            AutomationProperties.Name="{x:Static nuget:Resources.Label_Deprecated}"
+            Text="{x:Static nuget:Resources.Label_Deprecated}"/>
+      </StackPanel>
         <TextBox
           Style="{DynamicResource SelectableTextBlockStyle}" 
           Margin="0,8,0,0"
@@ -67,6 +62,5 @@
           </StackPanel>
         </StackPanel>
       </StackPanel>
-    </Expander>
   </Grid>
 </UserControl>


### PR DESCRIPTION
As [per UX feedback](https://github.com/NuGet/NuGet.Client/pull/2899#issuecomment-510161887), the expander control has been removed and the expander icon is replaced by the warning icon in the deprecation section.

![image](https://user-images.githubusercontent.com/880728/61049290-54acea00-a3e4-11e9-928c-78607cf1d1d7.png)
