### PR TITLE
[Do not review] Merge packages.config content hash enforcement

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -59,6 +59,18 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "ForceRestoreCommand")]
         public bool Force { get; set; }
 
+        [Option(typeof(NuGetCommand), "RestoreCommandUseLockFile")]
+        public bool UseLockFile { get; set; }
+
+        [Option(typeof(NuGetCommand), "RestoreCommandLockedMode")]
+        public bool LockedMode { get; set; }
+
+        [Option(typeof(NuGetCommand), "RestoreCommandLockFilePath")]
+        public string LockFilePath { get; set; }
+
+        [Option(typeof(NuGetCommand), "RestoreCommandForceEvaluate")]
+        public bool ForceEvaluate { get; set; }
+
         [ImportingConstructor]
         public RestoreCommand()
         {
@@ -148,6 +160,7 @@ namespace NuGet.CommandLine
                     restoreContext.MachineWideSettings = MachineWideSettings;
                     restoreContext.Log = Console;
                     restoreContext.CachingSourceProvider = GetSourceRepositoryProvider();
+                    restoreContext.RestoreForceEvaluate = ForceEvaluate;
 
                     var packageSaveMode = EffectivePackageSaveMode;
                     if (packageSaveMode != Packaging.PackageSaveMode.None)
@@ -663,6 +676,9 @@ namespace NuGet.CommandLine
 
             Console.LogVerbose($"MSBuild P2P timeout [ms]: {scaleTimeout}");
 
+            string restorePackagesWithLockFile = UseLockFile ? bool.TrueString : null;
+            var restoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile, LockFilePath, LockedMode);
+
             // Call MSBuild to resolve P2P references.
             return await MsBuildUtility.GetProjectReferencesAsync(
                 MsBuildDirectory.Value,
@@ -674,7 +690,8 @@ namespace NuGet.CommandLine
                 solutionName,
                 configFile,
                 Source.ToArray(),
-                PackagesDirectory
+                PackagesDirectory,
+                restoreLockProperties
                 );
         }
 
@@ -912,14 +929,16 @@ namespace NuGet.CommandLine
 
                 var projectFile = dgSpec?.FilePath ?? pcFile;
                 var projectTfm = dgSpec?.TargetFrameworks.SingleOrDefault()?.FrameworkName ?? NuGetFramework.AnyFramework;
-                var restoreLockedMode = dgSpec?.RestoreMetadata?.RestoreLockProperties?.RestoreLockedMode ?? false;
+                var restoreLockedMode = LockedMode || (dgSpec?.RestoreMetadata?.RestoreLockProperties?.RestoreLockedMode ?? false);
+                var lockFilePath = LockFilePath ?? dgSpec?.RestoreMetadata?.RestoreLockProperties?.NuGetLockFilePath;
+                var useLockFile = UseLockFile ? bool.TrueString : dgSpec?.RestoreMetadata?.RestoreLockProperties?.RestorePackagesWithLockFile;
 
                 IReadOnlyList<IRestoreLogMessage> result = PackagesConfigLockFileUtility.ValidatePackagesConfigLockFiles(
                     projectFile,
                     pcFile,
                     dgSpec?.Name,
-                    dgSpec?.RestoreMetadata?.RestoreLockProperties?.NuGetLockFilePath,
-                    dgSpec?.RestoreMetadata?.RestoreLockProperties?.RestorePackagesWithLockFile,
+                    lockFilePath,
+                    useLockFile,
                     projectTfm,
                     packagesFolderPath,
                     restoreLockedMode,

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -77,7 +77,8 @@ namespace NuGet.CommandLine
             string solutionName,
             string restoreConfigFile,
             string[] sources,
-            string packagesDirectory)
+            string packagesDirectory,
+            RestoreLockProperties restoreLockProperties)
         {
             var msbuildPath = GetMsbuild(msbuildToolset.Path);
 
@@ -121,7 +122,7 @@ namespace NuGet.CommandLine
                 inputTargetXML.Save(inputTargetPath);
 
                 // Create msbuild parameters and include global properties that cannot be set in the input targets path
-                var arguments = GetMSBuildArguments(entryPointTargetPath, inputTargetPath, nugetExePath, solutionDirectory, solutionName, restoreConfigFile, sources, packagesDirectory, msbuildToolset);
+                var arguments = GetMSBuildArguments(entryPointTargetPath, inputTargetPath, nugetExePath, solutionDirectory, solutionName, restoreConfigFile, sources, packagesDirectory, msbuildToolset, restoreLockProperties);
 
                 var processStartInfo = new ProcessStartInfo
                 {
@@ -226,7 +227,8 @@ namespace NuGet.CommandLine
             string restoreConfigFile,
             string[] sources,
             string packagesDirectory,
-            MsBuildToolset toolset)
+            MsBuildToolset toolset,
+            RestoreLockProperties restoreLockProperties)
         {
             // args for MSBuild.exe
             var args = new List<string>()
@@ -279,6 +281,13 @@ namespace NuGet.CommandLine
             if (!string.IsNullOrEmpty(msbuildAdditionalArgs))
             {
                 args.Add(msbuildAdditionalArgs);
+            }
+
+            AddPropertyIfHasValue(args, "RestorePackagesWithLockFile", restoreLockProperties.RestorePackagesWithLockFile);
+            AddPropertyIfHasValue(args, "NuGetLockFilePath", restoreLockProperties.NuGetLockFilePath);
+            if (restoreLockProperties.RestoreLockedMode)
+            {
+                AddProperty(args, "RestoreLockedMode", bool.TrueString);
             }
 
             return string.Join(" ", args);

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -9982,6 +9982,33 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Forces restore to reevaluate all dependencies even if a lock file already exists..
+        /// </summary>
+        internal static string RestoreCommandForceEvaluate {
+            get {
+                return ResourceManager.GetString("RestoreCommandForceEvaluate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Don&apos;t allow updating project lock file..
+        /// </summary>
+        internal static string RestoreCommandLockedMode {
+            get {
+                return ResourceManager.GetString("RestoreCommandLockedMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Output location where project lock file is written. By default, this is &apos;PROJECT_ROOT\packages.lock.json&apos;..
+        /// </summary>
+        internal static string RestoreCommandLockFilePath {
+            get {
+                return ResourceManager.GetString("RestoreCommandLockFilePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to 禁止使用计算机缓存作为第一个程序包源。.
         /// </summary>
         internal static string RestoreCommandNoCache_chs {
@@ -10869,6 +10896,15 @@ namespace NuGet.CommandLine {
         internal static string RestoreCommandUsageSummary_trk {
             get {
                 return ResourceManager.GetString("RestoreCommandUsageSummary_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables project lock file to be generated and used with restore..
+        /// </summary>
+        internal static string RestoreCommandUseLockFile {
+            get {
+                return ResourceManager.GetString("RestoreCommandUseLockFile", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5529,4 +5529,16 @@ nuget trusted-signers Remove -Name TrustedRepo</value>
   <data name="PushCommandSkipDuplicateDescription" xml:space="preserve">
     <value>If a package and version already exists, skip it and continue with the next package in the push, if any.</value>
   </data>
+  <data name="RestoreCommandForceEvaluate" xml:space="preserve">
+    <value>Forces restore to reevaluate all dependencies even if a lock file already exists.</value>
+  </data>
+  <data name="RestoreCommandLockedMode" xml:space="preserve">
+    <value>Don't allow updating project lock file.</value>
+  </data>
+  <data name="RestoreCommandLockFilePath" xml:space="preserve">
+    <value>Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</value>
+  </data>
+  <data name="RestoreCommandUseLockFile" xml:space="preserve">
+    <value>Enables project lock file to be generated and used with restore.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
@@ -18,7 +18,9 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using NuGet.Common;
 using NuGet.Frameworks;
+using NuGet.PackageManagement.Utility;
 using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
 using NuGet.VisualStudio;
 using PathUtility = NuGet.Common.PathUtility;
 using Task = System.Threading.Tasks.Task;
@@ -203,12 +205,15 @@ namespace NuGet.PackageManagement.VisualStudio
             // it into the project.
             // Other exceptions are 'web.config' and 'app.config'
             var fileName = Path.GetFileName(path);
+            var lockFileFullPath = PackagesConfigLockFileUtility.GetPackagesLockFilePath(ProjectFullPath, GetPropertyValue("NuGetLockFilePath")?.ToString(), ProjectName);
             if (File.Exists(Path.Combine(ProjectFullPath, path))
                 && !fileExistsInProject
                 && !fileName.Equals(ProjectManagement.Constants.PackageReferenceFile)
                 && !fileName.Equals("packages." + ProjectName + ".config")
                 && !fileName.Equals(EnvDTEProjectInfoUtility.WebConfig)
-                && !fileName.Equals(EnvDTEProjectInfoUtility.AppConfig))
+                && !fileName.Equals(EnvDTEProjectInfoUtility.AppConfig)
+                && !fileName.Equals(Path.GetFileName(lockFileFullPath))
+                )
             {
                 NuGetProjectContext.Log(ProjectManagement.MessageLevel.Warning, Strings.Warning_FileAlreadyExists, path);
             }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ScriptPackageFile.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ScriptPackageFile.cs
@@ -1,7 +1,9 @@
-﻿using System;
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Runtime.Versioning;
 using NuGet.Frameworks;
-using Utility = System.IO;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -19,7 +21,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 throw new ArgumentNullException("ScriptPackageFileTargetFramework");
             }
 
-            Path = path.Replace(Utility.Path.AltDirectorySeparatorChar, Utility.Path.DirectorySeparatorChar);
+            Path = path.Replace(System.IO.Path.AltDirectorySeparatorChar, System.IO.Path.DirectorySeparatorChar);
             TargetFramework = new FrameworkName(targetFramework.DotNetFrameworkName); ;
         }
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -434,6 +434,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND @(PackageReference) != '' ">PackageReference</RestoreProjectStyle>
       <!-- If this is not a PackageReference project check if project.json or projectName.project.json exists. -->
       <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND '$(_CurrentProjectJsonPath)' != '' ">ProjectJson</RestoreProjectStyle>
+      <!-- If this is not a PackageReference or ProjectJson project check if packages.config or packages.ProjectName.config exists -->
+      <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND (Exists('$(MSBuildProjectDirectory)\packages.config') Or Exists('$(MSBuildProjectDirectory)\packages.$(MSBuildProjectName).config'))">PackagesConfig</RestoreProjectStyle>
       <!-- This project is either a packages.config project or one that does not use NuGet at all. -->
       <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' ">Unknown</RestoreProjectStyle>
     </PropertyGroup>
@@ -704,6 +706,23 @@ Copyright (c) .NET Foundation. All rights reserved.
         <ProjectJsonPath>$(_CurrentProjectJsonPath)</ProjectJsonPath>
         <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
         <ConfigFilePaths>$(_OutputConfigFilePaths)</ConfigFilePaths>
+      </_RestoreGraphEntry>
+    </ItemGroup>
+
+    <!-- Use packages.config -->
+    <ItemGroup Condition=" '$(RestoreProjectStyle)' == 'PackagesConfig' ">
+      <_RestoreGraphEntry Include="$([System.Guid]::NewGuid())">
+        <Type>ProjectSpec</Type>
+        <ProjectUniqueName>$(MSBuildProjectFullPath)</ProjectUniqueName>
+        <ProjectPath>$(MSBuildProjectFullPath)</ProjectPath>
+        <ProjectName>$(_RestoreProjectName)</ProjectName>
+        <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
+        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
+        <PackagesConfigPath Condition="Exists('$(MSBuildProjectDirectory)\packages.$(MSBuildProjectName).config')">$(MSBuildProjectDirectory)\packages.$(MSBuildProjectName).config</PackagesConfigPath>
+        <PackagesConfigPath Condition="Exists('$(MSBuildProjectDirectory)\packages.config')">$(MSBuildProjectDirectory)\packages.config</PackagesConfigPath>
+        <RestorePackagesWithLockFile>$(RestorePackagesWithLockFile)</RestorePackagesWithLockFile>
+        <NuGetLockFilePath>$(NuGetLockFilePath)</NuGetLockFilePath>
+        <RestoreLockedMode>$(RestoreLockedMode)</RestoreLockedMode>
       </_RestoreGraphEntry>
     </ItemGroup>
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -402,7 +402,7 @@ namespace NuGet.Commands
         {
             var librariesLookUp = lockFile.Targets
                 .SelectMany(t => t.Dependencies.Where(dep => dep.Type != PackageDependencyType.Project))
-                .Distinct(new LockFileDependencyIdVersionComparer())
+                .Distinct(LockFileDependencyIdVersionComparer.Default)
                 .ToDictionary(dep => new PackageIdentity(dep.Id, dep.ResolvedVersion), val => val.ContentHash);
 
             foreach (var library in assetsFile.Libraries.Where(lib => lib.Type == LibraryType.Package))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
@@ -20,23 +20,23 @@ namespace NuGet.Commands
 
         public string InputPath { get; }
 
-        public IList<string> ConfigFiles { get; }
+        public IReadOnlyList<string> ConfigFiles { get; }
 
-        public IList<string> FeedsUsed { get; }
+        public IReadOnlyList<string> FeedsUsed { get; }
 
         public int InstallCount { get; }
 
-        public IList<IRestoreLogMessage> Errors { get; }
+        public IReadOnlyList<IRestoreLogMessage> Errors { get; }
 
         public RestoreSummary(bool success)
         {
             Success = success;
             NoOpRestore = false;
             InputPath = null;
-            ConfigFiles = new List<string>().AsReadOnly();
-            FeedsUsed = new List<string>().AsReadOnly();
+            ConfigFiles = Array.Empty<string>();
+            FeedsUsed = Array.Empty<string>();
             InstallCount = 0;
-            Errors = new List<IRestoreLogMessage>().AsReadOnly();
+            Errors = Array.Empty<IRestoreLogMessage>();
         }
 
         public RestoreSummary(
@@ -61,17 +61,17 @@ namespace NuGet.Commands
         public RestoreSummary(
             bool success,
             string inputPath,
-            IEnumerable<string> configFiles,
-            IEnumerable<string> feedsUsed,
+            IReadOnlyList<string> configFiles,
+            IReadOnlyList<string> feedsUsed,
             int installCount,
-            IEnumerable<IRestoreLogMessage> errors)
+            IReadOnlyList<IRestoreLogMessage> errors)
         {
             Success = success;
             InputPath = inputPath;
-            ConfigFiles = configFiles.ToList().AsReadOnly();
-            FeedsUsed = feedsUsed.ToList().AsReadOnly();
+            ConfigFiles = configFiles;
+            FeedsUsed = feedsUsed;
             InstallCount = installCount;
-            Errors = errors.ToArray();
+            Errors = errors;
         }
 
         public static void Log(ILogger logger, IEnumerable<RestoreSummary> restoreSummaries, bool logErrors = false)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -173,7 +173,7 @@ namespace NuGet.Commands
                 else
                 {
                     // Read msbuild data for both non-nuget and .NET Core
-                    result = GetBaseSpec(specItem);
+                    result = GetBaseSpec(specItem, restoreType);
                 }
 
                 // Applies to all types
@@ -272,6 +272,14 @@ namespace NuGet.Commands
 
                     // Packages lock file properties
                     result.RestoreMetadata.RestoreLockProperties = GetRestoreLockProperites(specItem);
+                }
+
+                if (restoreType == ProjectStyle.PackagesConfig)
+                {
+                    var pcRestoreMetadata = (PackagesConfigProjectRestoreMetadata)result.RestoreMetadata;
+                    // Packages lock file properties
+                    pcRestoreMetadata.PackagesConfigPath = specItem.GetProperty("PackagesConfigPath");
+                    pcRestoreMetadata.RestoreLockProperties = GetRestoreLockProperites(specItem);
                 }
 
                 if (restoreType == ProjectStyle.ProjectJson)
@@ -740,7 +748,7 @@ namespace NuGet.Commands
             return result;
         }
 
-        private static PackageSpec GetBaseSpec(IMSBuildItem specItem)
+        private static PackageSpec GetBaseSpec(IMSBuildItem specItem, ProjectStyle projectStyle)
         {
             var frameworkInfo = GetFrameworks(specItem)
                 .Select(framework => new TargetFrameworkInformation()
@@ -750,7 +758,9 @@ namespace NuGet.Commands
                 .ToList();
 
             var spec = new PackageSpec(frameworkInfo);
-            spec.RestoreMetadata = new ProjectRestoreMetadata();
+            spec.RestoreMetadata = projectStyle == ProjectStyle.PackagesConfig
+                ? new PackagesConfigProjectRestoreMetadata()
+                : new ProjectRestoreMetadata();
             spec.FilePath = specItem.GetProperty("ProjectPath");
             spec.RestoreMetadata.ProjectName = specItem.GetProperty("ProjectName");
 

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -277,7 +277,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid restore input where RestorePackagesWithLockFile property is set to false and also exist a packages lock file at {0}..
+        ///   Looks up a localized string similar to Invalid restore input where RestorePackagesWithLockFile property is set to false but a packages lock file exists at {0}..
         /// </summary>
         internal static string Error_InvalidLockFileInput {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -421,7 +421,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package {0} sha512 validation failed. The package is different than the last restore..
+        ///   Looks up a localized string similar to The package {0} content hash validation failed. The package is different than the last restore..
         /// </summary>
         internal static string Error_PackageValidationFailed {
             get {
@@ -502,7 +502,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The packages lock file is inconsistent with the project dependencies so restore can&apos;t be run in locked mode. Please disable RestoreLockedMode MSBuild property or pass explicit --force-evaluate flag to run restore to update the lock file..
+        ///   Looks up a localized string similar to The packages lock file is inconsistent with the project dependencies so restore can&apos;t be run in locked mode. Disable the RestoreLockedMode MSBuild property or pass an explicit --force-evaluate option to run restore to update the lock file..
         /// </summary>
         internal static string Error_RestoreInLockedMode {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -709,7 +709,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <comment>{0} - package id and version</comment>
   </data>
   <data name="Error_InvalidLockFileInput" xml:space="preserve">
-    <value>Invalid restore input where RestorePackagesWithLockFile property is set to false and also exist a packages lock file at {0}.</value>
+    <value>Invalid restore input where RestorePackagesWithLockFile property is set to false but a packages lock file exists at {0}.</value>
     <comment>{0} - packages lock file path</comment>
   </data>
   <data name="Log_WritingPackagesLockFile" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -702,10 +702,10 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <comment>Do not localize snupkg and symbols.nupkg</comment>
   </data>
   <data name="Error_RestoreInLockedMode" xml:space="preserve">
-    <value>The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode. Please disable RestoreLockedMode MSBuild property or pass explicit --force-evaluate flag to run restore to update the lock file.</value>
+    <value>The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode. Disable the RestoreLockedMode MSBuild property or pass an explicit --force-evaluate option to run restore to update the lock file.</value>
   </data>
   <data name="Error_PackageValidationFailed" xml:space="preserve">
-    <value>The package {0} sha512 validation failed. The package is different than the last restore.</value>
+    <value>The package {0} content hash validation failed. The package is different than the last restore.</value>
     <comment>{0} - package id and version</comment>
   </data>
   <data name="Error_InvalidLockFileInput" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.Common/MsBuildStringUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/MsBuildStringUtility.cs
@@ -101,6 +101,19 @@ namespace NuGet.Common
         }
 
         /// <summary>
+        /// Convert the provided string to a boolean, or return null if the value can't be parsed as a boolean.
+        /// </summary>
+        public static bool? GetBooleanOrNull(string value)
+        {
+            if (bool.TryParse(value, out var result))
+            {
+                return result;
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Convert the provided string to MSBuild style.
         /// </summary>
         public static string Convert(string value)

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -14,6 +14,7 @@ using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
+using NuGet.PackageManagement.Utility;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
@@ -2336,6 +2337,10 @@ namespace NuGet.PackageManagement
                             await msbuildProject.ProjectSystem.EndProcessingAsync();
                         }
                     }
+
+                    PackagesConfigLockFileUtility.UpdateLockFile(msbuildProject,
+                        actionsList,
+                        token);
 
                     // Post process
                     await nuGetProject.PostProcessAsync(nuGetProjectContext, token);

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/NuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/NuGetProject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -98,6 +98,21 @@ namespace NuGet.ProjectManagement
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Get metadata value, or return null if it doesn't exist.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public object GetMetadataOrNull(string key)
+        {
+            if (Metadata.TryGetValue(key, out var value))
+            {
+                return value;
+            }
+
+            return null;
         }
 
         public Task SaveAsync(CancellationToken token)

--- a/src/NuGet.Core/NuGet.PackageManagement/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Properties/AssemblyInfo.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+#if SIGNED_BUILD
+[assembly: InternalsVisibleTo("NuGet.PackageManagement.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+#else
+[assembly: InternalsVisibleTo("NuGet.PackageManagement.Test")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+#endif

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -367,6 +367,15 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid restore input where RestorePackagesWithLockFile property is set to false but a packages lock file exists at {0}..
+        /// </summary>
+        internal static string Error_InvalidLockFileInput {
+            get {
+                return ResourceManager.GetString("Error_InvalidLockFileInput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An error occurred while reading file &apos;{0}&apos;: {1}.
         /// </summary>
         internal static string ErrorLoadingPackagesConfig {

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -367,11 +367,47 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Directory {0} does not exist..
+        /// </summary>
+        internal static string Error_DirectoryDoesNotExist {
+            get {
+                return ResourceManager.GetString("Error_DirectoryDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File {0} does not exist..
+        /// </summary>
+        internal static string Error_FileDoesNotExist {
+            get {
+                return ResourceManager.GetString("Error_FileDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid restore input where RestorePackagesWithLockFile property is set to false but a packages lock file exists at {0}..
         /// </summary>
         internal static string Error_InvalidLockFileInput {
             get {
                 return ResourceManager.GetString("Error_InvalidLockFileInput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The package {0} content hash validation failed. The package is different than the last restore..
+        /// </summary>
+        internal static string Error_PackageValidationFailed {
+            get {
+                return ResourceManager.GetString("Error_PackageValidationFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The packages lock file is inconsistent with the project dependencies so restore can&apos;t be run in locked mode. Run restore without using restore locked mode to update the lock file..
+        /// </summary>
+        internal static string Error_RestoreInLockedModePackagesConfig {
+            get {
+                return ResourceManager.GetString("Error_RestoreInLockedModePackagesConfig", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -491,4 +491,8 @@
     <value>Signed package validation failed with multiple errors:{0}</value>
     <comment>0 - new line separated list of errors</comment>
   </data>
+  <data name="Error_InvalidLockFileInput" xml:space="preserve">
+    <value>Invalid restore input where RestorePackagesWithLockFile property is set to false but a packages lock file exists at {0}.</value>
+    <comment>{0} - packages lock file path</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -495,4 +495,19 @@
     <value>Invalid restore input where RestorePackagesWithLockFile property is set to false but a packages lock file exists at {0}.</value>
     <comment>{0} - packages lock file path</comment>
   </data>
+  <data name="Error_PackageValidationFailed" xml:space="preserve">
+    <value>The package {0} content hash validation failed. The package is different than the last restore.</value>
+    <comment>{0} - package id and version</comment>
+  </data>
+  <data name="Error_RestoreInLockedModePackagesConfig" xml:space="preserve">
+    <value>The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode. Run restore without using restore locked mode to update the lock file.</value>
+  </data>
+  <data name="Error_DirectoryDoesNotExist" xml:space="preserve">
+    <value>Directory {0} does not exist.</value>
+    <comment>{0} is the directory name.</comment>
+  </data>
+  <data name="Error_FileDoesNotExist" xml:space="preserve">
+    <value>File {0} does not exist.</value>
+    <comment>{0} is the filename.</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/IPackagesConfigContentHashProvider.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/IPackagesConfigContentHashProvider.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using NuGet.Packaging.Core;
+
+namespace NuGet.PackageManagement
+{
+    internal interface IPackagesConfigContentHashProvider
+    {
+        string GetContentHash(PackageIdentity packageIdentity, CancellationToken token);
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/PackagesConfigContentHashProvider.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/PackagesConfigContentHashProvider.cs
@@ -1,0 +1,94 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+
+namespace NuGet.PackageManagement
+{
+    internal class PackagesConfigContentHashProvider : IPackagesConfigContentHashProvider
+    {
+        private readonly FolderNuGetProject _packagesFolder;
+
+        internal PackagesConfigContentHashProvider(FolderNuGetProject packagesFolder)
+        {
+            _packagesFolder = packagesFolder;
+        }
+
+        public string GetContentHash(PackageIdentity packageIdentity, CancellationToken token)
+        {
+            var nupkgPath = GetNupkgPath(packageIdentity, token);
+            var result = TryGetNupkgMetadata(nupkgPath);
+
+            if (!result.Found)
+            {
+                var contentHash = GetContentHashFromNupkg(nupkgPath, token);
+
+                WriteNupkgMetadata(nupkgPath, result.ContentHash);
+            }
+
+            return result.ContentHash;
+        }
+
+        private string GetNupkgPath(PackageIdentity packageIdentity, CancellationToken token)
+        {
+            var packagePath = _packagesFolder.GetInstalledPackageFilePath(packageIdentity);
+            return packagePath;
+        }
+
+        private Result TryGetNupkgMetadata(string nupkgPath)
+        {
+            var metadataPath = Path.Combine(Path.GetDirectoryName(nupkgPath), PackagingCoreConstants.NupkgMetadataFileExtension);
+            if (File.Exists(metadataPath))
+            {
+                var metadata = NupkgMetadataFileFormat.Read(metadataPath);
+                return new Result(true, metadata.ContentHash);
+            }
+
+            return Result.NotFound;
+        }
+
+        private string GetNupkgMetadataPath(string nupkgPath)
+        {
+            return Path.Combine(Path.GetDirectoryName(nupkgPath), PackagingCoreConstants.NupkgMetadataFileExtension);
+        }
+
+        private string GetContentHashFromNupkg(string filePath, CancellationToken token)
+        {
+            using (var reader = new PackageArchiveReader(filePath))
+            {
+                var hash = reader.GetContentHash(token);
+                return hash;
+            }
+        }
+
+        private void WriteNupkgMetadata(string nupkgPath, string contentHash)
+        {
+            var metadataPath = GetNupkgMetadataPath(nupkgPath);
+
+            var metadata = new NupkgMetadataFile()
+            {
+                ContentHash = contentHash
+            };
+
+            NupkgMetadataFileFormat.Write(metadataPath, metadata);
+        }
+
+        private struct Result
+        {
+            public static readonly Result NotFound = new Result(false, null);
+
+            public Result(bool found, string contentHash)
+            {
+                Found = found;
+                ContentHash = contentHash;
+            }
+
+            public bool Found { get; }
+            public string ContentHash { get; }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/PackagesConfigContentHashProvider.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/PackagesConfigContentHashProvider.cs
@@ -26,6 +26,7 @@ namespace NuGet.PackageManagement
             if (!result.Found)
             {
                 var contentHash = GetContentHashFromNupkg(nupkgPath, token);
+                result = new Result(found: true, contentHash: contentHash);
 
                 WriteNupkgMetadata(nupkgPath, result.ContentHash);
             }
@@ -45,7 +46,7 @@ namespace NuGet.PackageManagement
             if (File.Exists(metadataPath))
             {
                 var metadata = NupkgMetadataFileFormat.Read(metadataPath);
-                return new Result(true, metadata.ContentHash);
+                return new Result(found: true, contentHash: metadata.ContentHash);
             }
 
             return Result.NotFound;
@@ -79,7 +80,7 @@ namespace NuGet.PackageManagement
 
         private struct Result
         {
-            public static readonly Result NotFound = new Result(false, null);
+            public static readonly Result NotFound = new Result(found: false, contentHash: null);
 
             public Result(bool found, string contentHash)
             {

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/PackagesConfigLockFileUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/PackagesConfigLockFileUtility.cs
@@ -1,0 +1,207 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+
+namespace NuGet.PackageManagement.Utility
+{
+    public class PackagesConfigLockFileUtility
+    {
+        private static readonly IComparer _dependencyComparer = new DependencyComparer();
+
+        internal static void UpdateLockFile(
+            MSBuildNuGetProject msbuildProject,
+            List<NuGetProjectAction> actionsList,
+            CancellationToken token)
+        {
+            if (msbuildProject == null)
+            {
+                // probably a `nuget.exe install` command, which doesn't support lock files until lock file arguments are implemented
+                return;
+            }
+
+            var lockFileName = GetPackagesLockFilePath(msbuildProject);
+            var lockFileExists = File.Exists(lockFileName);
+            var enableLockFile = IsRestorePackagesWithLockFileEnabled(msbuildProject);
+            if (enableLockFile == false && lockFileExists)
+            {
+                var message = string.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidLockFileInput, lockFileName);
+                throw new InvalidOperationException(message);
+            }
+            else if (enableLockFile == true || lockFileExists)
+            {
+                var lockFile = GetLockFile(lockFileExists, lockFileName);
+                lockFile.Targets[0].TargetFramework = msbuildProject.ProjectSystem.TargetFramework;
+                var contentHashUtil = new PackagesConfigContentHashProvider(msbuildProject.FolderNuGetProject);
+                ApplyChanges(lockFile, actionsList, contentHashUtil, token);
+                PackagesLockFileFormat.Write(lockFileName, lockFile);
+
+                // Add lock file to msbuild project, so it appears in solution explorer and is added to TFS source control.
+                if (msbuildProject != null)
+                {
+                    var projectUri = new Uri(msbuildProject.MSBuildProjectPath);
+                    var lockFileUri = new Uri(lockFileName);
+                    var lockFileRelativePath = projectUri.MakeRelativeUri(lockFileUri).OriginalString;
+                    if (Path.DirectorySeparatorChar != '/')
+                    {
+                        lockFileRelativePath.Replace('/', Path.DirectorySeparatorChar);
+                    }
+                    msbuildProject.ProjectSystem.AddExistingFile(lockFileRelativePath);
+                }
+            }
+        }
+
+        internal static string GetPackagesLockFilePath(MSBuildNuGetProject msbuildProject)
+        {
+            var directory = (string)msbuildProject.Metadata["FullPath"];
+            var msbuildProperty = msbuildProject?.ProjectSystem?.GetPropertyValue("NuGetLockFilePath");
+            var projectName = (string)msbuildProject.Metadata["UniqueName"];
+
+            return GetPackagesLockFilePath(directory, msbuildProperty, projectName);
+        }
+
+        public static string GetPackagesLockFilePath(string projectPath, string nuGetLockFilePath, string projectName)
+        {
+            if (!string.IsNullOrWhiteSpace(nuGetLockFilePath))
+            {
+                return Path.Combine(projectPath, nuGetLockFilePath);
+            }
+
+            return PackagesLockFileUtilities.GetNuGetLockFilePath(projectPath, projectName);
+        }
+
+        private static bool? IsRestorePackagesWithLockFileEnabled(MSBuildNuGetProject msbuildProject)
+        {
+            var msbuildProperty = msbuildProject?.ProjectSystem?.GetPropertyValue("RestorePackagesWithLockFile");
+            if (msbuildProperty is string restorePackagesWithLockFileValue)
+            {
+                if (bool.TryParse(restorePackagesWithLockFileValue, out var useLockFile))
+                {
+                    return useLockFile;
+                }
+            }
+
+            return null;
+        }
+
+        internal static PackagesLockFile GetLockFile(bool lockFileExists, string lockFileName)
+        {
+            PackagesLockFile lockFile;
+
+            if (lockFileExists)
+            {
+                lockFile = PackagesLockFileFormat.Read(lockFileName);
+                lockFile.Version = PackagesLockFileFormat.Version;
+                if (lockFile.Targets.Count == 0)
+                {
+                    lockFile.Targets.Add(new PackagesLockFileTarget());
+                }
+                else if (lockFile.Targets.Count > 1)
+                {
+                    // merge lists
+                    while (lockFile.Targets.Count > 1)
+                    {
+                        var target = lockFile.Targets[1];
+
+                        for (var i = 0; i < target.Dependencies.Count; i++)
+                        {
+                            lockFile.Targets[0].Dependencies.Add(target.Dependencies[i]);
+                        }
+
+                        lockFile.Targets.RemoveAt(1);
+                    }
+                }
+            }
+            else
+            {
+                lockFile = new PackagesLockFile();
+                lockFile.Targets.Add(new PackagesLockFileTarget());
+            }
+
+            return lockFile;
+        }
+
+        internal static void ApplyChanges(
+            PackagesLockFile lockFile,
+            List<NuGetProjectAction> actionsList,
+            IPackagesConfigContentHashProvider contentHashUtil,
+            CancellationToken token)
+        {
+            RemoveUninstalledPackages(lockFile,
+                actionsList.Where(a => a.NuGetProjectActionType == NuGetProjectActionType.Uninstall));
+            AddInstalledPackages(lockFile,
+                actionsList.Where(a => a.NuGetProjectActionType == NuGetProjectActionType.Install),
+                contentHashUtil,
+                token);
+            ArrayList.Adapter((IList)lockFile.Targets[0].Dependencies).Sort(_dependencyComparer);
+        }
+
+        private static void RemoveUninstalledPackages(PackagesLockFile lockFile, IEnumerable<NuGetProjectAction> actionsList)
+        {
+            var dependencies = lockFile.Targets[0].Dependencies;
+            foreach (var toUninstall in actionsList)
+            {
+                Debug.Assert(toUninstall.NuGetProjectActionType == NuGetProjectActionType.Uninstall);
+
+                var toUninstallId = toUninstall.PackageIdentity.Id;
+
+                for (var i = 0; i < dependencies.Count; i++)
+                {
+                    if (string.Equals(toUninstallId, dependencies[i].Id, StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        dependencies.RemoveAt(i);
+                        break;
+                    }
+                }
+            }
+        }
+
+        private static void AddInstalledPackages(
+            PackagesLockFile lockFile,
+            IEnumerable<NuGetProjectAction> actionsList,
+            IPackagesConfigContentHashProvider contentHashUtil,
+            CancellationToken token)
+        {
+            foreach (var toInstall in actionsList)
+            {
+                Debug.Assert(toInstall.NuGetProjectActionType == NuGetProjectActionType.Install);
+
+                var newDependency = new LockFileDependency
+                {
+                    Id = toInstall.PackageIdentity.Id,
+                    ContentHash = contentHashUtil.GetContentHash(toInstall.PackageIdentity, token),
+                    RequestedVersion = new VersionRange(toInstall.PackageIdentity.Version, true, toInstall.PackageIdentity.Version, true),
+                    ResolvedVersion = toInstall.PackageIdentity.Version,
+                    Type = PackageDependencyType.Direct
+                };
+
+                lockFile.Targets[0].Dependencies.Add(newDependency);
+            }
+        }
+
+        private class DependencyComparer : IComparer<LockFileDependency>, IComparer
+        {
+            public int Compare(LockFileDependency x, LockFileDependency y)
+            {
+                if (x == null && y == null) return 0;
+                if (x == null || y == null) return x == null ? -1 : 1;
+                return string.Compare(x.Id, y.Id, StringComparison.InvariantCultureIgnoreCase);
+            }
+
+            public int Compare(object x, object y)
+            {
+                return Compare(x as LockFileDependency, y as LockFileDependency);
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -204,19 +204,26 @@ namespace NuGet.ProjectModel
                 return null;
             }
 
-            var msbuildMetadata = new ProjectRestoreMetadata();
+            var projectStyleString = rawMSBuildMetadata.GetValue<string>("projectStyle");
+
+            ProjectStyle? projectStyle = null;
+            if (!string.IsNullOrEmpty(projectStyleString)
+                && Enum.TryParse<ProjectStyle>(projectStyleString, ignoreCase: true, result: out var projectStyleValue))
+            {
+                projectStyle = projectStyleValue;
+            }
+
+            var msbuildMetadata = projectStyle == ProjectStyle.PackagesConfig
+                ? new PackagesConfigProjectRestoreMetadata()
+                : new ProjectRestoreMetadata();
+
+            if (projectStyle.HasValue)
+            {
+                msbuildMetadata.ProjectStyle = projectStyle.Value;
+            }
 
             msbuildMetadata.ProjectUniqueName = rawMSBuildMetadata.GetValue<string>("projectUniqueName");
             msbuildMetadata.OutputPath = rawMSBuildMetadata.GetValue<string>("outputPath");
-
-            var projectStyleString = rawMSBuildMetadata.GetValue<string>("projectStyle");
-
-            ProjectStyle projectStyle;
-            if (!string.IsNullOrEmpty(projectStyleString)
-                && Enum.TryParse<ProjectStyle>(projectStyleString, ignoreCase: true, result: out projectStyle))
-            {
-                msbuildMetadata.ProjectStyle = projectStyle;
-            }
 
             msbuildMetadata.PackagesPath = rawMSBuildMetadata.GetValue<string>("packagesPath");
             msbuildMetadata.ProjectJsonPath = rawMSBuildMetadata.GetValue<string>("projectJsonPath");
@@ -337,6 +344,11 @@ namespace NuGet.ProjectModel
                     restoreLockProperties.GetValue<string>("restorePackagesWithLockFile"),
                     restoreLockProperties.GetValue<string>("nuGetLockFilePath"),
                     GetBoolOrFalse(restoreLockProperties, "restoreLockedMode", packageSpec.FilePath));
+            }
+
+            if (msbuildMetadata is PackagesConfigProjectRestoreMetadata pcMsbuildMetadata)
+            {
+                pcMsbuildMetadata.PackagesConfigPath = rawMSBuildMetadata.GetValue<string>("packagesConfigPath");
             }
 
             return msbuildMetadata;

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -159,6 +159,11 @@ namespace NuGet.ProjectModel
             // write NuGet lock file msbuild properties
             WriteNuGetLockFileProperties(writer, msbuildMetadata);
 
+            if (msbuildMetadata is PackagesConfigProjectRestoreMetadata pcMsbuildMetadata)
+            {
+                SetValue(writer, "packagesConfigPath", pcMsbuildMetadata.PackagesConfigPath);
+            }
+
             writer.WriteObjectEnd();
         }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/PackagesConfigProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackagesConfigProjectRestoreMetadata.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Common;
+using NuGet.Shared;
+
+namespace NuGet.ProjectModel
+{
+    public class PackagesConfigProjectRestoreMetadata : ProjectRestoreMetadata
+    {
+        /// <summary>
+        /// Full path to the packages.config file, if it exists. Only valid when ProjectStyle is PackagesConfig.
+        /// </summary>
+        public string PackagesConfigPath { get; set; }
+
+        public override int GetHashCode()
+        {
+            var hashCode = new HashCodeCombiner();
+
+            hashCode.AddObject(base.GetHashCode());
+            hashCode.AddObject(PackagesConfigPath);
+
+            return hashCode.CombinedHash;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as PackagesConfigProjectRestoreMetadata);
+        }
+
+        public bool Equals(PackagesConfigProjectRestoreMetadata obj)
+        {
+            return base.Equals(obj) &&
+                PathUtility.GetStringComparerBasedOnOS().Equals(PackagesConfigPath, obj.PackagesConfigPath);
+        }
+
+        public override ProjectRestoreMetadata Clone()
+        {
+            var clone = new PackagesConfigProjectRestoreMetadata();
+            FillClone(clone);
+            clone.PackagesConfigPath =  PackagesConfigPath;
+            return clone;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependency.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependency.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using NuGet.Common;
 using NuGet.Packaging.Core;
+using NuGet.ProjectModel.ProjectLockFile;
 using NuGet.Shared;
 using NuGet.Versioning;
 
@@ -37,12 +36,8 @@ namespace NuGet.ProjectModel
                 return true;
             }
 
-            return StringComparer.OrdinalIgnoreCase.Equals(Id, other.Id) &&
-                EqualityUtility.EqualsWithNullCheck(ResolvedVersion, other.ResolvedVersion) &&
-                EqualityUtility.EqualsWithNullCheck(RequestedVersion, other.RequestedVersion) &&
-                EqualityUtility.SequenceEqualWithNullCheck(Dependencies, other.Dependencies) &&
-                ContentHash == other.ContentHash &&
-                Type == other.Type;
+            return LockFileDependencyComparerWithoutContentHash.Default.Equals(this, other) &&
+                ContentHash == other.ContentHash;
         }
 
         public override bool Equals(object obj)
@@ -53,14 +48,8 @@ namespace NuGet.ProjectModel
         public override int GetHashCode()
         {
             var combiner = new HashCodeCombiner();
-
-            combiner.AddObject(Id);
-            combiner.AddObject(ResolvedVersion);
-            combiner.AddObject(RequestedVersion);
-            combiner.AddSequence(Dependencies);
+            combiner.AddObject(LockFileDependencyComparerWithoutContentHash.Default.GetHashCode(this));
             combiner.AddObject(ContentHash);
-            combiner.AddObject(Type);
-
             return combiner.CombinedHash;
         }
     }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependencyComparerWithoutContentHash.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependencyComparerWithoutContentHash.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Shared;
+
+namespace NuGet.ProjectModel.ProjectLockFile
+{
+    public class LockFileDependencyComparerWithoutContentHash : IEqualityComparer<LockFileDependency>
+    {
+        public static LockFileDependencyComparerWithoutContentHash Default { get; } = new LockFileDependencyComparerWithoutContentHash();
+
+        public bool Equals(LockFileDependency x, LockFileDependency y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x == null || y == null)
+            {
+                return false;
+            }
+
+            return LockFileDependencyIdVersionComparer.Default.Equals(x, y) &&
+                x.Type == y.Type &&
+                EqualityUtility.EqualsWithNullCheck(x.RequestedVersion, y.RequestedVersion) &&
+                EqualityUtility.SequenceEqualWithNullCheck(x.Dependencies, y.Dependencies);
+        }
+
+        public int GetHashCode(LockFileDependency obj)
+        {
+            var combiner = new HashCodeCombiner();
+            combiner.AddObject(LockFileDependencyIdVersionComparer.Default.GetHashCode(obj));
+            combiner.AddObject(obj.RequestedVersion);
+            combiner.AddSequence(obj.Dependencies);
+            combiner.AddObject(obj.Type);
+            return combiner.CombinedHash;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependencyIdVersionComparer.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/LockFileDependencyIdVersionComparer.cs
@@ -1,13 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
-using System.Text;
-using NuGet.Common;
 using NuGet.Shared;
 
 namespace NuGet.ProjectModel
 {
     public class LockFileDependencyIdVersionComparer : IEqualityComparer<LockFileDependency>
     {
+        public static LockFileDependencyIdVersionComparer Default { get; } = new LockFileDependencyIdVersionComparer();
+
         public bool Equals(LockFileDependency x, LockFileDependency y)
         {
             if (ReferenceEquals(x, y))
@@ -15,8 +18,7 @@ namespace NuGet.ProjectModel
                 return true;
             }
 
-            if (ReferenceEquals(x, null)
-                || ReferenceEquals(y, null))
+            if (x == null || y == null)
             {
                 return false;
             }
@@ -28,10 +30,8 @@ namespace NuGet.ProjectModel
         public int GetHashCode(LockFileDependency obj)
         {
             var combiner = new HashCodeCombiner();
-
             combiner.AddObject(obj.Id);
             combiner.AddObject(obj.ResolvedVersion);
-
             return combiner.CombinedHash;
         }
     }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -36,14 +36,22 @@ namespace NuGet.ProjectModel
             }
 
             var projectName = Path.GetFileNameWithoutExtension(project.RestoreMetadata.ProjectPath);
-            path = Path.Combine(project.BaseDirectory, "packages." + projectName.Replace(' ', '_') + ".lock.json");
+            return GetNuGetLockFilePath(project.BaseDirectory, projectName);
+        }
 
-            if (!File.Exists(path))
+        public static string GetNuGetLockFilePath(string baseDirectory, string projectName)
+        {
+            if (!string.IsNullOrEmpty(projectName))
             {
-                path = Path.Combine(project.BaseDirectory, PackagesLockFileFormat.LockFileName);
+                var path = Path.Combine(baseDirectory, "packages." + projectName.Replace(' ', '_') + ".lock.json");
+
+                if (File.Exists(path))
+                {
+                    return path;
+                }
             }
 
-            return path;
+            return Path.Combine(baseDirectory, PackagesLockFileFormat.LockFileName);
         }
 
         public static bool IsLockFileStillValid(DependencyGraphSpec dgSpec, PackagesLockFile nuGetLockFile)

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -178,31 +178,35 @@ namespace NuGet.ProjectModel
                    EqualityUtility.EqualsWithNullCheck(RestoreLockProperties, other.RestoreLockProperties);
         }
 
-        public ProjectRestoreMetadata Clone()
+        public virtual ProjectRestoreMetadata Clone()
         {
-            return new ProjectRestoreMetadata
-            {
-                ProjectStyle = ProjectStyle,
-                ProjectPath = ProjectPath,
-                ProjectJsonPath = ProjectJsonPath,
-                OutputPath = OutputPath,
-                ProjectName = ProjectName,
-                ProjectUniqueName = ProjectUniqueName,
-                PackagesPath = PackagesPath,
-                CacheFilePath = CacheFilePath,
-                CrossTargeting = CrossTargeting,
-                LegacyPackagesDirectory = LegacyPackagesDirectory,
-                SkipContentFileWrite = SkipContentFileWrite,
-                ValidateRuntimeAssets = ValidateRuntimeAssets,
-                FallbackFolders = FallbackFolders != null ? new List<string>(FallbackFolders) : null,
-                ConfigFilePaths = ConfigFilePaths != null ? new List<string>(ConfigFilePaths) : null,
-                OriginalTargetFrameworks = OriginalTargetFrameworks != null ? new List<string>(OriginalTargetFrameworks) : null,
-                Sources = Sources?.Select(c => c.Clone()).ToList(),
-                TargetFrameworks = TargetFrameworks?.Select(c => c.Clone()).ToList(),
-                Files = Files?.Select(c => c.Clone()).ToList(),
-                ProjectWideWarningProperties = ProjectWideWarningProperties?.Clone(),
-                RestoreLockProperties = RestoreLockProperties?.Clone()
-            };
+            var clone = new ProjectRestoreMetadata();
+            FillClone(clone);
+            return clone;
+        }
+
+        protected void FillClone(ProjectRestoreMetadata clone)
+        {
+            clone.ProjectStyle = ProjectStyle;
+            clone.ProjectPath = ProjectPath;
+            clone.ProjectJsonPath = ProjectJsonPath;
+            clone.OutputPath = OutputPath;
+            clone.ProjectName = ProjectName;
+            clone.ProjectUniqueName = ProjectUniqueName;
+            clone.PackagesPath = PackagesPath;
+            clone.CacheFilePath = CacheFilePath;
+            clone.CrossTargeting = CrossTargeting;
+            clone.LegacyPackagesDirectory = LegacyPackagesDirectory;
+            clone.SkipContentFileWrite = SkipContentFileWrite;
+            clone.ValidateRuntimeAssets = ValidateRuntimeAssets;
+            clone.FallbackFolders = FallbackFolders != null ? new List<string>(FallbackFolders) : null;
+            clone.ConfigFilePaths = ConfigFilePaths != null ? new List<string>(ConfigFilePaths) : null;
+            clone.OriginalTargetFrameworks = OriginalTargetFrameworks != null ? new List<string>(OriginalTargetFrameworks) : null;
+            clone.Sources = Sources?.Select(c => c.Clone()).ToList();
+            clone.TargetFrameworks = TargetFrameworks?.Select(c => c.Clone()).ToList();
+            clone.Files = Files?.Select(c => c.Clone()).ToList();
+            clone.ProjectWideWarningProperties = ProjectWideWarningProperties?.Clone();
+            clone.RestoreLockProperties = RestoreLockProperties?.Clone();
         }
     }
 }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -325,13 +325,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile", "true");
+                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile");
                 Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
 
                 // Act
                 result = forceEvaluate
-                    ? RunRestore(pathContext, _successExitCode, "-UseLockFile", "true", "-ForceEvaluate")
-                    : RunRestore(pathContext, _successExitCode, "-UseLockFile", "true");
+                    ? RunRestore(pathContext, _successExitCode, "-UseLockFile", "-ForceEvaluate")
+                    : RunRestore(pathContext, _successExitCode, "-UseLockFile");
 
                 // Assert
                 Assert.Contains("Assets file has not changed.", result.AllOutput);
@@ -384,7 +384,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     packageX);
 
                 // Act
-                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile", "true");
+                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile");
 
                 // Assert
                 Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
@@ -429,7 +429,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     packageX);
 
                 // Act
-                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile", "true", "-LockFilePath", "custom.lock.json");
+                var result = RunRestore(pathContext, _successExitCode, "-UseLockFile", "-LockFilePath", "custom.lock.json");
 
                 // Assert
                 var expectedLockFileName = Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "custom.lock.json");

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -1798,6 +1798,48 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
+        public void MSBuildRestoreUtility_GetPackageSpec_PackagesConfigProject()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var projectPath = Path.Combine(workingDir, "a.csproj");
+                var packagesConfigPath = Path.Combine(workingDir, "packages.config");
+
+                var items = new List<IDictionary<string, string>>();
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectPath", projectPath },
+                    { "ProjectStyle", "PackagesConfig" },
+                    { "TargetFramework", "net462" },
+                    { "ProjectName", "a" },
+                    { "PackagesConfigPath", packagesConfigPath },
+                    { "RestorePackagesWithLockFile", "true" },
+                    { "NuGetLockFilePath", "custom.lock.json" },
+                    { "RestoreLockedMode", "true" }
+                });
+
+                // Act
+                var spec = MSBuildRestoreUtility.GetPackageSpec(items.Select(CreateItems));
+
+                // Assert
+                Assert.Equal(projectPath, spec.FilePath);
+                Assert.Equal("a", spec.Name);
+                Assert.IsType(typeof(PackagesConfigProjectRestoreMetadata), spec.RestoreMetadata);
+                var restoreMetadata = (PackagesConfigProjectRestoreMetadata)spec.RestoreMetadata;
+                Assert.Equal(ProjectStyle.PackagesConfig, restoreMetadata.ProjectStyle);
+                Assert.Equal("482C20DE-DFF9-4BD0-B90A-BD3201AA351A", restoreMetadata.ProjectUniqueName);
+                Assert.Equal(projectPath, restoreMetadata.ProjectPath);
+                Assert.Equal(packagesConfigPath, restoreMetadata.PackagesConfigPath);
+                Assert.Equal("true", restoreMetadata.RestoreLockProperties.RestorePackagesWithLockFile);
+                Assert.Equal("custom.lock.json", restoreMetadata.RestoreLockProperties.NuGetLockFilePath);
+                Assert.True(restoreMetadata.RestoreLockProperties.RestoreLockedMode);
+            }
+        }
+
+        [Fact]
         public void MSBuildRestoreUtility_GetPackageSpec_NonNuGetProject()
         {
             using (var workingDir = TestDirectory.Create())

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/MSBuildStringUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/MSBuildStringUtilityTests.cs
@@ -93,5 +93,19 @@ namespace NuGet.Common.Test
             // Assert
             Assert.Equal(0, result.Count());
         }
+
+        [Theory]
+        [InlineData("true", true)]
+        [InlineData("false", false)]
+        [InlineData("", null)]
+        [InlineData(null, null)]
+        public void GetBooleanOrNullTests(string value, bool? expected)
+        {
+            // Act
+            bool? result = MSBuildStringUtility.GetBooleanOrNull(value);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGet.PackageManagement.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGet.PackageManagement.Test.csproj
@@ -28,12 +28,6 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="$(SharedDirectory)\HashCodeCombiner.cs">
-      <Link>HashCodeCombiner.cs</Link>
-    </Compile>
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/PackagesConfigProjectTests/PackagesLockTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/PackagesConfigProjectTests/PackagesLockTests.cs
@@ -1,0 +1,176 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests.PackagesConfigProjectTests
+{
+    public class PackagesLockTests
+    {
+        [Fact]
+        public async Task DoNotCreateLockFileWhenFeatureDisabled()
+        {
+            // Arrange
+            using (var packageSource = TestDirectory.Create())
+            using (var testSolutionManager = new TestSolutionManager(true))
+            {
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<PackageSource>()
+                    {
+                        new PackageSource(packageSource.Path)
+                    });
+
+                var testSettings = NullSettings.Instance;
+                var token = CancellationToken.None;
+                var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                var nuGetPackageManager = new NuGetPackageManager(
+                    sourceRepositoryProvider,
+                    testSettings,
+                    testSolutionManager,
+                    deleteOnRestartManager);
+                var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(testSolutionManager, testSettings);
+
+                var packageContext = new SimpleTestPackageContext("packageA");
+                packageContext.AddFile("lib/net45/a.dll");
+                SimpleTestPackageUtility.CreateOPCPackage(packageContext, packageSource);
+
+                var msBuildNuGetProject = testSolutionManager.AddNewMSBuildProject();
+                var msBuildNuGetProjectSystem = msBuildNuGetProject.ProjectSystem as TestMSBuildNuGetProjectSystem;
+                msBuildNuGetProjectSystem.SetPropertyValue("RestorePackagesWithLockFile", "false");
+                var packagesConfigPath = msBuildNuGetProject.PackagesConfigNuGetProject.FullPath;
+                var packagesLockPath = packagesConfigPath.Replace("packages.config", "packages.lock.json");
+                var packageIdentity = packageContext.Identity;
+
+                // Pre-Assert
+                // Check that the packages.lock.json file does not exist
+                Assert.False(File.Exists(packagesLockPath));
+
+                // Act
+                await nuGetPackageManager.InstallPackageAsync(msBuildNuGetProject, packageIdentity,
+                    new ResolutionContext(), new TestNuGetProjectContext(), sourceRepositoryProvider.GetRepositories().First(), null, token);
+
+                // Assert
+                // Check that the packages.lock.json still does not exist after the installation
+                Assert.False(File.Exists(packagesLockPath));
+            }
+        }
+
+        [Fact]
+        public async Task InstallingPackageShouldCreateLockFile_PackagesLockJson()
+        {
+            // Arrange
+            using (var packageSource = TestDirectory.Create())
+            using (var testSolutionManager = new TestSolutionManager(true))
+            {
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<PackageSource>()
+                    {
+                        new PackageSource(packageSource.Path)
+                    });
+
+                var testSettings = NullSettings.Instance;
+                var token = CancellationToken.None;
+                var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                var nuGetPackageManager = new NuGetPackageManager(
+                    sourceRepositoryProvider,
+                    testSettings,
+                    testSolutionManager,
+                    deleteOnRestartManager);
+                var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(testSolutionManager, testSettings);
+
+                var packageContext = new SimpleTestPackageContext("packageA");
+                packageContext.AddFile("lib/net45/a.dll");
+                SimpleTestPackageUtility.CreateOPCPackage(packageContext, packageSource);
+
+                var msBuildNuGetProject = testSolutionManager.AddNewMSBuildProject();
+                var msBuildNuGetProjectSystem = msBuildNuGetProject.ProjectSystem as TestMSBuildNuGetProjectSystem;
+                msBuildNuGetProjectSystem.SetPropertyValue("RestorePackagesWithLockFile", "true");
+                var packagesConfigPath = msBuildNuGetProject.PackagesConfigNuGetProject.FullPath;
+                var packagesLockPath = packagesConfigPath.Replace("packages.config", "packages.lock.json");
+                var packageIdentity = packageContext.Identity;
+
+                // Pre-Assert
+                // Check that the packages.lock.json file does not exist
+                Assert.False(File.Exists(packagesLockPath));
+
+                // Act
+                await nuGetPackageManager.InstallPackageAsync(msBuildNuGetProject, packageIdentity,
+                    new ResolutionContext(), new TestNuGetProjectContext(), sourceRepositoryProvider.GetRepositories().First(), null, token);
+
+                // Assert
+                // Check that the packages.lock.json file exists after the installation
+                Assert.True(File.Exists(packagesLockPath));
+                Assert.True(msBuildNuGetProjectSystem.FileExistsInProject("packages.lock.json"));
+                // Check the number of target frameworks and dependencies in the lock file
+                var lockFile = PackagesLockFileFormat.Read(packagesLockPath);
+                Assert.Equal(1, lockFile.Targets.Count);
+                Assert.Equal(1, lockFile.Targets[0].Dependencies.Count);
+            }
+        }
+
+        [Fact]
+        public async Task InstallingPackageShouldCreateLockFile_CustomLockFileName()
+        {
+            // Arrange
+            using (var packageSource = TestDirectory.Create())
+            using (var testSolutionManager = new TestSolutionManager(true))
+            {
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<PackageSource>()
+                    {
+                        new PackageSource(packageSource.Path)
+                    });
+
+                var testSettings = NullSettings.Instance;
+                var token = CancellationToken.None;
+                var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                var nuGetPackageManager = new NuGetPackageManager(
+                    sourceRepositoryProvider,
+                    testSettings,
+                    testSolutionManager,
+                    deleteOnRestartManager);
+                var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(testSolutionManager, testSettings);
+
+                var packageContext = new SimpleTestPackageContext("packageA");
+                packageContext.AddFile("lib/net45/a.dll");
+                SimpleTestPackageUtility.CreateOPCPackage(packageContext, packageSource);
+
+                var msBuildNuGetProject = testSolutionManager.AddNewMSBuildProject();
+                var msBuildNuGetProjectSystem = msBuildNuGetProject.ProjectSystem as TestMSBuildNuGetProjectSystem;
+                msBuildNuGetProjectSystem.SetPropertyValue("RestorePackagesWithLockFile", "true");
+                msBuildNuGetProjectSystem.SetPropertyValue("NuGetLockFilePath", "my.lock.json");
+                var packagesConfigPath = msBuildNuGetProject.PackagesConfigNuGetProject.FullPath;
+                var packagesLockPath = packagesConfigPath.Replace("packages.config", "my.lock.json");
+                var packageIdentity = packageContext.Identity;
+
+                // Pre-Assert
+                // Check that the packages.lock.json file does not exist
+                Assert.False(File.Exists(packagesLockPath));
+
+                // Act
+                await nuGetPackageManager.InstallPackageAsync(msBuildNuGetProject, packageIdentity,
+                    new ResolutionContext(), new TestNuGetProjectContext(), sourceRepositoryProvider.GetRepositories().First(), null, token);
+
+                // Assert
+                // Check that the packages.lock.json file exists after the installation
+                Assert.True(File.Exists(packagesLockPath));
+                Assert.True(msBuildNuGetProjectSystem.FileExistsInProject("my.lock.json"));
+                // Check the number of target frameworks and dependencies in the lock file
+                var lockFile = PackagesLockFileFormat.Read(packagesLockPath);
+                Assert.Equal(1, lockFile.Targets.Count);
+                Assert.Equal(1, lockFile.Targets[0].Dependencies.Count);
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetProjectTests.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Test;
+using Xunit;
+
+namespace NuGet.PackageManagement.Test
+{
+    public class NuGetProjectTests
+    {
+        [Theory]
+        [InlineData("Name", "test")]
+        [InlineData("DoesNotExist", null)]
+        public void GetMetadataOrNull_TestProject_HasExpectedValue(string key, string expected)
+        {
+            // Arrange
+            var project = new TestNuGetProject("test", null);
+
+            // Act
+            var result = project.GetMetadataOrNull(key);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/Utility/PackagesConfigLockFileUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/Utility/PackagesConfigLockFileUtilityTests.cs
@@ -1,0 +1,327 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using Moq;
+using NuGet.Frameworks;
+using NuGet.PackageManagement.Utility;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.PackageManagement.Test.Utility
+{
+    public class PackagesConfigLockFileUtilityTests
+    {
+        [Fact]
+        public void GetPackagesLockFilePath_MsbuildProperty()
+        {
+            // Arrage
+            var projectName = "testproj";
+            var logger = new TestLogger();
+            var expected = "somewhere\\my.lock.json";
+
+            using (var rootFolder = TestDirectory.Create())
+            {
+                var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
+                var targetFramework = NuGetFramework.Parse("net46");
+
+                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(targetFramework, new TestNuGetProjectContext(), projectFolder.FullName);
+                var project = new TestMSBuildNuGetProject(msBuildNuGetProjectSystem, rootFolder, projectFolder.FullName);
+                msBuildNuGetProjectSystem.SetPropertyValue("NuGetLockFilePath", expected);
+
+                // Act
+                var lockFile = PackagesConfigLockFileUtility.GetPackagesLockFilePath(project);
+
+                // Assert
+                Assert.Equal(Path.Combine(projectFolder.FullName, expected), lockFile);
+            }
+        }
+
+        [Fact]
+        public void GetPackagesLockFilePath_PackagesProjectLockJson()
+        {
+            // Arrange
+            var projectName = "testproj";
+            var logger = new TestLogger();
+            var expected = $"packages.{projectName}.lock.json";
+
+            using (var rootFolder = TestDirectory.Create())
+            {
+                var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
+                var targetFramework = NuGetFramework.Parse("net46");
+                projectFolder.Create();
+                File.WriteAllText(Path.Combine(projectFolder.FullName, expected), string.Empty);
+
+                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(targetFramework, new TestNuGetProjectContext(), projectFolder.FullName, projectName: projectName);
+                var project = new TestMSBuildNuGetProject(msBuildNuGetProjectSystem, rootFolder, projectFolder.FullName);
+
+                // Act
+                var lockFile = PackagesConfigLockFileUtility.GetPackagesLockFilePath(project);
+
+                //Assert
+                Assert.Equal(Path.Combine(projectFolder.FullName, expected), lockFile);
+            }
+        }
+
+        [Fact]
+        public void GetPackagesLockFilePath_PackagesLockJson()
+        {
+            // Arrange
+            var projectName = "testproj";
+            var logger = new TestLogger();
+
+            using (var rootFolder = TestDirectory.Create())
+            {
+                var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
+                var targetFramework = NuGetFramework.Parse("net46");
+
+                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(targetFramework, new TestNuGetProjectContext(), projectFolder.FullName);
+                var project = new TestMSBuildNuGetProject(msBuildNuGetProjectSystem, rootFolder, projectFolder.FullName);
+
+                // Act
+                var lockFile = PackagesConfigLockFileUtility.GetPackagesLockFilePath(project);
+
+                // Assert
+                Assert.Equal(Path.Combine(projectFolder.FullName, "packages.lock.json"), lockFile);
+            }
+        }
+
+        [Fact]
+        public void ApplyChanges_AddInstalledPackage()
+        {
+            // Arrange
+            var lockFile = new PackagesLockFile
+            {
+                Targets = new List<PackagesLockFileTarget>
+                {
+                    new PackagesLockFileTarget()
+                }
+            };
+
+            var actionList = new List<NuGetProjectAction>
+            {
+                NuGetProjectAction.CreateInstallProjectAction(new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), null, null)
+            };
+
+            var contentHashUtility = new Mock<IPackagesConfigContentHashProvider>();
+
+            // Act
+            PackagesConfigLockFileUtility.ApplyChanges(lockFile, actionList, contentHashUtility.Object, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(1, lockFile.Targets[0].Dependencies.Count);
+            Assert.Equal(actionList[0].PackageIdentity.Id, lockFile.Targets[0].Dependencies[0].Id);
+            Assert.Equal(actionList[0].PackageIdentity.Version, lockFile.Targets[0].Dependencies[0].ResolvedVersion);
+        }
+
+        [Fact]
+        public void ApplyChanges_RemoveUninstalledPackage()
+        {
+            // Arrange
+            var lockFile = new PackagesLockFile
+            {
+                Targets = new List<PackagesLockFileTarget>
+                {
+                    new PackagesLockFileTarget
+                    {
+                        Dependencies = new List<LockFileDependency>
+                        {
+                            new LockFileDependency
+                            {
+                                Id = "packageA",
+                                ResolvedVersion = NuGetVersion.Parse("1.0.0")
+                            }
+                        }
+                    }
+                }
+            };
+
+            var actionList = new List<NuGetProjectAction>
+            {
+                NuGetProjectAction.CreateUninstallProjectAction(new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), null)
+            };
+
+            var contentHashUtility = new Mock<IPackagesConfigContentHashProvider>();
+
+            // Act
+            PackagesConfigLockFileUtility.ApplyChanges(lockFile, actionList, contentHashUtility.Object, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(0, lockFile.Targets[0].Dependencies.Count);
+        }
+
+        [Fact]
+        public void ApplyChanges_UpgradeInstalledPackage()
+        {
+            // Arrange
+            var lockFile = new PackagesLockFile
+            {
+                Targets = new List<PackagesLockFileTarget>
+                {
+                    new PackagesLockFileTarget
+                    {
+                        Dependencies = new List<LockFileDependency>
+                        {
+                            new LockFileDependency
+                            {
+                                Id = "packageA",
+                                ResolvedVersion = NuGetVersion.Parse("1.0.0")
+                            }
+                        }
+                    }
+                }
+            };
+
+            var actionList = new List<NuGetProjectAction>
+            {
+                NuGetProjectAction.CreateUninstallProjectAction(new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), null),
+                NuGetProjectAction.CreateInstallProjectAction(new PackageIdentity("packageA", NuGetVersion.Parse("2.0.0")), null, null)
+            };
+
+            var contentHashUtility = new Mock<IPackagesConfigContentHashProvider>();
+
+            // Act
+            PackagesConfigLockFileUtility.ApplyChanges(lockFile, actionList, contentHashUtility.Object, CancellationToken.None);
+
+             // Assert
+            Assert.Equal(1, lockFile.Targets[0].Dependencies.Count);
+            Assert.Equal(actionList[0].PackageIdentity.Id, lockFile.Targets[0].Dependencies[0].Id);
+            Assert.Equal(NuGetVersion.Parse("2.0.0"), lockFile.Targets[0].Dependencies[0].ResolvedVersion);
+        }
+
+        [Fact]
+        public void ApplyChanges_SortPackages_FirstPackage()
+        {
+            // Arrange
+            var lockFile = new PackagesLockFile
+            {
+                Targets = new List<PackagesLockFileTarget>
+                {
+                    new PackagesLockFileTarget
+                    {
+                        Dependencies = new List<LockFileDependency>
+                        {
+                            new LockFileDependency
+                            {
+                                Id = "packageB",
+                                ResolvedVersion = NuGetVersion.Parse("1.0.0")
+                            },
+                            new LockFileDependency
+                            {
+                                Id = "packageD",
+                                ResolvedVersion = NuGetVersion.Parse("1.0.0")
+                            }
+                        }
+                    }
+                }
+            };
+
+            var actionList = new List<NuGetProjectAction>
+            {
+                NuGetProjectAction.CreateInstallProjectAction(new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), null, null)
+            };
+
+            var contentHashUtility = new Mock<IPackagesConfigContentHashProvider>();
+
+            // Act
+            PackagesConfigLockFileUtility.ApplyChanges(lockFile, actionList, contentHashUtility.Object, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(3, lockFile.Targets[0].Dependencies.Count);
+            Assert.Equal("packageA", lockFile.Targets[0].Dependencies[0].Id);
+            Assert.Equal("packageB", lockFile.Targets[0].Dependencies[1].Id);
+            Assert.Equal("packageD", lockFile.Targets[0].Dependencies[2].Id);
+        }
+
+        [Fact]
+        public void ApplyChanges_SortPackages_MiddleOfList()
+        {
+            // Arrange
+            var lockFile = new PackagesLockFile
+            {
+                Targets = new List<PackagesLockFileTarget>
+                {
+                    new PackagesLockFileTarget
+                    {
+                        Dependencies = new List<LockFileDependency>
+                        {
+                            new LockFileDependency
+                            {
+                                Id = "packageB",
+                                ResolvedVersion = NuGetVersion.Parse("1.0.0")
+                            },
+                            new LockFileDependency
+                            {
+                                Id = "packageD",
+                                ResolvedVersion = NuGetVersion.Parse("1.0.0")
+                            }
+                        }
+                    }
+                }
+            };
+
+            var actionList = new List<NuGetProjectAction>
+            {
+                NuGetProjectAction.CreateInstallProjectAction(new PackageIdentity("packageC", NuGetVersion.Parse("1.0.0")), null, null)
+            };
+
+            var contentHashUtility = new Mock<IPackagesConfigContentHashProvider>();
+
+            // Act
+            PackagesConfigLockFileUtility.ApplyChanges(lockFile, actionList, contentHashUtility.Object, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(3, lockFile.Targets[0].Dependencies.Count);
+            Assert.Equal("packageB", lockFile.Targets[0].Dependencies[0].Id);
+            Assert.Equal("packageC", lockFile.Targets[0].Dependencies[1].Id);
+            Assert.Equal("packageD", lockFile.Targets[0].Dependencies[2].Id);
+        }
+
+        [Fact]
+        public void ApplyChanges_SortPackages_LastPackage()
+        {
+            // Arrange
+            var lockFile = new PackagesLockFile
+            {
+                Targets = new List<PackagesLockFileTarget>
+                {
+                    new PackagesLockFileTarget
+                    {
+                        Dependencies = new List<LockFileDependency>
+                        {
+                            new LockFileDependency
+                            {
+                                Id = "packageB",
+                                ResolvedVersion = NuGetVersion.Parse("1.0.0")
+                            },
+                            new LockFileDependency
+                            {
+                                Id = "packageD",
+                                ResolvedVersion = NuGetVersion.Parse("1.0.0")
+                            }
+                        }
+                    }
+                }
+            };
+
+            var actionList = new List<NuGetProjectAction>
+            {
+                NuGetProjectAction.CreateInstallProjectAction(new PackageIdentity("packageE", NuGetVersion.Parse("1.0.0")), null, null)
+            };
+
+            var contentHashUtility = new Mock<IPackagesConfigContentHashProvider>();
+
+            // Act
+            PackagesConfigLockFileUtility.ApplyChanges(lockFile, actionList, contentHashUtility.Object, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(3, lockFile.Targets[0].Dependencies.Count);
+            Assert.Equal("packageB", lockFile.Targets[0].Dependencies[0].Id);
+            Assert.Equal("packageD", lockFile.Targets[0].Dependencies[1].Id);
+            Assert.Equal("packageE", lockFile.Targets[0].Dependencies[2].Id);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Builders/LockFileDependencyBuilder.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Builders/LockFileDependencyBuilder.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Versioning;
+
+namespace NuGet.ProjectModel.Test.Builders
+{
+    internal class LockFileDependencyBuilder
+    {
+        private string _id = "PackageA";
+        private VersionRange _requestedVersion = new VersionRange(new NuGetVersion(1, 0, 0));
+        private NuGetVersion _resolvedVersion = new NuGetVersion(1, 0, 0);
+        private PackageDependencyType _type = PackageDependencyType.Direct;
+        private string _contentHash = "ABC";
+
+        public LockFileDependencyBuilder WithId(string id)
+        {
+            _id = id;
+            return this;
+        }
+
+        public LockFileDependencyBuilder WithRequestedVersion(VersionRange requestedVersion)
+        {
+            _requestedVersion = requestedVersion;
+            return this;
+        }
+
+        public LockFileDependencyBuilder WithResolvedVersion(NuGetVersion resolvedVersion)
+        {
+            _resolvedVersion = resolvedVersion;
+            return this;
+        }
+
+        public LockFileDependencyBuilder WithType(PackageDependencyType type)
+        {
+            _type = type;
+            return this;
+        }
+
+        public LockFileDependencyBuilder WithContentHash(string contentHash)
+        {
+            _contentHash = contentHash;
+            return this;
+        }
+
+        public LockFileDependency Build()
+        {
+            return new LockFileDependency()
+            {
+                Id = _id,
+                RequestedVersion = _requestedVersion,
+                ResolvedVersion = _resolvedVersion,
+                Type = _type,
+                ContentHash = _contentHash
+            };
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Builders/PackagesLockFileBuilder.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Builders/PackagesLockFileBuilder.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.ProjectModel.Test.Builders
+{
+    internal class PackagesLockFileBuilder
+    {
+        private int _version = PackagesLockFileFormat.Version;
+        private List<PackagesLockFileTarget> _targets = new List<PackagesLockFileTarget>();
+
+        public PackagesLockFileBuilder WithVersion(int version)
+        {
+            _version = version;
+            return this;
+        }
+
+        public PackagesLockFileBuilder WithTarget(Action<PackagesLockFileTargetBuilder> action)
+        {
+            var target = new PackagesLockFileTargetBuilder();
+            action(target);
+            _targets.Add(target.Build());
+            return this;
+        }
+
+        public PackagesLockFile Build()
+        {
+            return new PackagesLockFile
+            {
+                Version = _version,
+                Targets = _targets
+            };
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Builders/PackagesLockFileTargetBuilder.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/Builders/PackagesLockFileTargetBuilder.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Frameworks;
+
+namespace NuGet.ProjectModel.Test.Builders
+{
+    internal class PackagesLockFileTargetBuilder
+    {
+        private NuGetFramework _framework;
+        private List<LockFileDependency> _dependencies = new List<LockFileDependency>();
+
+        public PackagesLockFileTargetBuilder WithFramework(NuGetFramework framework)
+        {
+            _framework = framework;
+            return this;
+        }
+
+        public PackagesLockFileTargetBuilder WithDependency(Action<LockFileDependencyBuilder> action)
+        {
+            var dep = new LockFileDependencyBuilder();
+            action(dep);
+            _dependencies.Add(dep.Build());
+            return this;
+        }
+
+        public PackagesLockFileTarget Build()
+        {
+            return new PackagesLockFileTarget()
+            {
+                TargetFramework = _framework,
+                Dependencies = _dependencies
+            };
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileDependencyComparerWithoutContentHashTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileDependencyComparerWithoutContentHashTests.cs
@@ -1,0 +1,145 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.ProjectModel.ProjectLockFile;
+using NuGet.ProjectModel.Test.Builders;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test.ProjectLockFile
+{
+    public class LockFileDependencyComparerWithoutContentHashTests
+    {
+        [Fact]
+        public void Equals_WhenBothArgumentsAreNull_ReturnsTrue()
+        {
+            LockFileDependency x = null;
+            LockFileDependency y = null;
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(x, y);
+
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenOneArgumentIsNull_ReturnsFalse()
+        {
+            LockFileDependency isNull = null;
+            var notNull = new LockFileDependencyBuilder().Build();
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(isNull, notNull);
+            Assert.False(actual);
+
+            actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(notNull, isNull);
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenSameReference_ReturnsTrue()
+        {
+            var dep = new LockFileDependencyBuilder().Build();
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(dep, dep);
+
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenSameValue_ReturnsTrue()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder().Build();
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(x, y);
+            Assert.True(actual);
+
+            actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(y, x);
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenContentHashIsDifferent_ReturnsTrue()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithContentHash("XYZ")
+                .Build();
+
+            Assert.NotEqual(x.ContentHash, y.ContentHash);
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(x, y);
+            Assert.True(actual);
+
+            actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(y, x);
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenPackageIdIsDifferent_ReturnsFalse()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithId("PackageB")
+                .Build();
+
+            Assert.NotEqual(x.Id, y.Id);
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(x, y);
+            Assert.False(actual);
+
+            actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(y, x);
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenResolvedVersionsAreDifferent_ReturnsFalse()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithResolvedVersion(new NuGetVersion(1, 0, 1))
+                .Build();
+
+            Assert.NotEqual(x.ResolvedVersion, y.ResolvedVersion);
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(x, y);
+            Assert.False(actual);
+
+            actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(y, x);
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenRequestedVersionsAreDifferent_ReturnsFalse()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithRequestedVersion(new VersionRange(new NuGetVersion(1, 0, 1)))
+                .Build();
+
+            Assert.NotEqual(x.RequestedVersion, y.RequestedVersion);
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(x, y);
+            Assert.False(actual);
+
+            actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(y, x);
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenDependencyTypesAreDifferent_ReturnFalse()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithType(PackageDependencyType.Transitive)
+                .Build();
+
+            Assert.NotEqual(x.Type, y.Type);
+
+            var actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(x, y);
+            Assert.False(actual);
+
+            actual = LockFileDependencyComparerWithoutContentHash.Default.Equals(y, x);
+            Assert.False(actual);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileDependencyIdVersionComparerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileDependencyIdVersionComparerTests.cs
@@ -1,0 +1,144 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.ProjectModel.Test.Builders;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test.ProjectLockFile
+{
+    public class LockFileDependencyIdVersionComparerTests
+    {
+        [Fact]
+        public void Equals_WhenBothArgumentsAreNull_ReturnsTrue()
+        {
+            LockFileDependency x = null;
+            LockFileDependency y = null;
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(x, y);
+
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenOneArgumentIsNull_ReturnsFalse()
+        {
+            LockFileDependency isNull = null;
+            var notNull = new LockFileDependencyBuilder().Build();
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(isNull, notNull);
+            Assert.False(actual);
+
+            actual = LockFileDependencyIdVersionComparer.Default.Equals(notNull, isNull);
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenSameReference_ReturnsTrue()
+        {
+            var dep = new LockFileDependencyBuilder().Build();
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(dep, dep);
+
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenSameValue_ReturnsTrue()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder().Build();
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(x, y);
+            Assert.True(actual);
+
+            actual = LockFileDependencyIdVersionComparer.Default.Equals(y, x);
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenContentHashIsDifferent_ReturnsTrue()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithContentHash("XYZ")
+                .Build();
+
+            Assert.NotEqual(x.ContentHash, y.ContentHash);
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(x, y);
+            Assert.True(actual);
+
+            actual = LockFileDependencyIdVersionComparer.Default.Equals(y, x);
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenPackageIdIsDifferent_ReturnsFalse()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithId("PackageB")
+                .Build();
+
+            Assert.NotEqual(x.Id, y.Id);
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(x, y);
+            Assert.False(actual);
+
+            actual = LockFileDependencyIdVersionComparer.Default.Equals(y, x);
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenResolvedVersionsAreDifferent_ReturnsFalse()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithResolvedVersion(new NuGetVersion(1, 0, 1))
+                .Build();
+
+            Assert.NotEqual(x.ResolvedVersion, y.ResolvedVersion);
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(x, y);
+            Assert.False(actual);
+
+            actual = LockFileDependencyIdVersionComparer.Default.Equals(y, x);
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenRequestedVersionsAreDifferent_ReturnsTrue()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithRequestedVersion(new VersionRange(new NuGetVersion(1, 0, 1)))
+                .Build();
+
+            Assert.NotEqual(x.RequestedVersion, y.RequestedVersion);
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(x, y);
+            Assert.True(actual);
+
+            actual = LockFileDependencyIdVersionComparer.Default.Equals(y, x);
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_WhenDependencyTypesAreDifferent_ReturnTrue()
+        {
+            var x = new LockFileDependencyBuilder().Build();
+            var y = new LockFileDependencyBuilder()
+                .WithType(PackageDependencyType.Transitive)
+                .Build();
+
+            Assert.NotEqual(x.Type, y.Type);
+
+            var actual = LockFileDependencyIdVersionComparer.Default.Equals(x, y);
+            Assert.True(actual);
+
+            actual = LockFileDependencyIdVersionComparer.Default.Equals(y, x);
+            Assert.True(actual);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectLockFile/LockFileUtilitiesTests.cs
@@ -1,0 +1,153 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Xunit;
+using static NuGet.Frameworks.FrameworkConstants;
+using PackagesLockFileBuilder = NuGet.ProjectModel.Test.Builders.PackagesLockFileBuilder;
+
+namespace NuGet.ProjectModel.Test.ProjectLockFile
+{
+    public class LockFileUtilitiesTests
+    {
+        [Fact]
+        public void IsLockFileStillValid_DifferentVersions_AreNotEqual()
+        {
+            var x = new PackagesLockFileBuilder().Build();
+            var y = new PackagesLockFileBuilder()
+                .WithVersion(2)
+                .Build();
+
+            var actual = PackagesLockFileUtilities.IsLockFileStillValid(x, y);
+            Assert.False(actual.IsValid);
+
+            actual = PackagesLockFileUtilities.IsLockFileStillValid(y, x);
+            Assert.False(actual.IsValid);
+        }
+
+        [Fact]
+        public void IsLockFileStillValid_DifferentTargetCounts_AreNotEqual()
+        {
+            var x = new PackagesLockFileBuilder()
+                .WithTarget(target => target.WithFramework(CommonFrameworks.NetStandard20))
+                .WithTarget(target => target.WithFramework(CommonFrameworks.NetCoreApp22))
+                .Build();
+            var y = new PackagesLockFileBuilder()
+                .WithTarget(target => target.WithFramework(CommonFrameworks.NetStandard20))
+                .Build();
+
+            var actual = PackagesLockFileUtilities.IsLockFileStillValid(x, y);
+            Assert.False(actual.IsValid);
+
+            actual = PackagesLockFileUtilities.IsLockFileStillValid(y, x);
+            Assert.False(actual.IsValid);
+        }
+
+        [Fact]
+        public void IsLockFileStillValid_DifferentTargets_AreNotEqual()
+        {
+            var x = new PackagesLockFileBuilder()
+                .WithTarget(target => target.WithFramework(CommonFrameworks.NetStandard20))
+                .Build();
+            var y = new PackagesLockFileBuilder()
+                .WithTarget(target => target.WithFramework(CommonFrameworks.NetCoreApp22))
+                .Build();
+
+            var actual = PackagesLockFileUtilities.IsLockFileStillValid(x, y);
+            Assert.False(actual.IsValid);
+
+            actual = PackagesLockFileUtilities.IsLockFileStillValid(y, x);
+            Assert.False(actual.IsValid);
+        }
+
+        [Fact]
+        public void IsLockFileStillValid_DifferentDependencyCounts_AreNotEqual()
+        {
+            var x = new PackagesLockFileBuilder()
+                .WithTarget(target => target
+                    .WithFramework(CommonFrameworks.NetStandard20)
+                    .WithDependency(dep => dep.WithId("PackageA")))
+                .Build();
+            var y = new PackagesLockFileBuilder()
+                .WithTarget(target => target
+                    .WithFramework(CommonFrameworks.NetStandard20)
+                    .WithDependency(dep => dep.WithId("PackageA"))
+                    .WithDependency(dep => dep.WithId("PackageB")))
+                .Build();
+
+            var actual = PackagesLockFileUtilities.IsLockFileStillValid(x, y);
+            Assert.False(actual.IsValid);
+
+            actual = PackagesLockFileUtilities.IsLockFileStillValid(y, x);
+            Assert.False(actual.IsValid);
+        }
+
+        [Fact]
+        public void IsLockFileStillValid_DifferentDependency_AreNotEqual()
+        {
+            var x = new PackagesLockFileBuilder()
+                .WithTarget(target => target
+                    .WithFramework(CommonFrameworks.NetStandard20)
+                    .WithDependency(dep => dep.WithId("PackageA")))
+                .Build();
+            var y = new PackagesLockFileBuilder()
+                .WithTarget(target => target
+                    .WithFramework(CommonFrameworks.NetStandard20)
+                    .WithDependency(dep => dep.WithId("PackageB")))
+                .Build();
+
+            var actual = PackagesLockFileUtilities.IsLockFileStillValid(x, y);
+            Assert.False(actual.IsValid);
+
+            actual = PackagesLockFileUtilities.IsLockFileStillValid(y, x);
+            Assert.False(actual.IsValid);
+        }
+
+        [Fact]
+        public void IsLockFileStillValid_MatchesDependencies_AreEqual()
+        {
+            var x = new PackagesLockFileBuilder()
+                .WithTarget(target => target
+                    .WithFramework(CommonFrameworks.NetStandard20)
+                    .WithDependency(dep => dep
+                        .WithId("PackageA")
+                        .WithContentHash("ABC"))
+                    .WithDependency(dep => dep
+                        .WithId("PackageB")
+                        .WithContentHash("123")))
+                .Build();
+            var y = new PackagesLockFileBuilder()
+                .WithTarget(target => target
+                    .WithFramework(CommonFrameworks.NetStandard20)
+                    .WithDependency(dep => dep
+                        .WithId("PackageA")
+                        .WithContentHash("XYZ"))
+                    .WithDependency(dep => dep
+                        .WithId("PackageB")
+                        .WithContentHash("890")))
+                .Build();
+
+            var actual = PackagesLockFileUtilities.IsLockFileStillValid(x, y);
+            Assert.True(actual.IsValid);
+            Assert.NotNull(actual.MatchedDependencies);
+            Assert.Equal(2, actual.MatchedDependencies.Count);
+            var depKvp = actual.MatchedDependencies.Single(d => d.Key.Id == "PackageA");
+            Assert.Equal("ABC", depKvp.Key.ContentHash);
+            Assert.Equal("XYZ", depKvp.Value.ContentHash);
+            depKvp = actual.MatchedDependencies.Single(d => d.Key.Id == "PackageB");
+            Assert.Equal("123", depKvp.Key.ContentHash);
+            Assert.Equal("890", depKvp.Value.ContentHash);
+
+            actual = PackagesLockFileUtilities.IsLockFileStillValid(y, x);
+            Assert.True(actual.IsValid);
+            Assert.NotNull(actual.MatchedDependencies);
+            Assert.Equal(2, actual.MatchedDependencies.Count);
+            depKvp = actual.MatchedDependencies.Single(d => d.Key.Id == "PackageA");
+            Assert.Equal("ABC", depKvp.Value.ContentHash);
+            Assert.Equal("XYZ", depKvp.Key.ContentHash);
+            depKvp = actual.MatchedDependencies.Single(d => d.Key.Id == "PackageB");
+            Assert.Equal("123", depKvp.Value.ContentHash);
+            Assert.Equal("890", depKvp.Key.ContentHash);
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#7281
Regression: No  

## Fix

Details: Implement content hash validation for packages.config projects

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
