### PR TITLE
Test:  clean up after test execution

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/SourceCacheContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SourceCacheContext.cs
@@ -148,6 +148,12 @@ namespace NuGet.Protocol.Core.Types
 
         public void Dispose()
         {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
             var currentTempFolder = Interlocked.CompareExchange(ref _generatedTempFolder, value: null, comparand: null);
 
             if (currentTempFolder != null)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/LocalResourceUtilsTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/LocalResourceUtilsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -34,24 +34,27 @@ namespace NuGet.CommandLine.Test
             {
                 // Arrange
                 targetDirectoryPath = targetDirectory.Path;
-                var workingDirectory = TestDirectory.Create();
-                var subDirectoryPath = Path.Combine(workingDirectory.Path, "SubDirectory");
-                var subDirectory = Directory.CreateDirectory(subDirectoryPath);
 
-                Util.CreatePackage(workingDirectory.Path, Guid.NewGuid().ToString("N"), "1.0.0");
-                fileInTargetDirectory = Path.Combine(targetDirectoryPath, "test.txt");
-                File.WriteAllText(fileInTargetDirectory, string.Empty);
+                using (var workingDirectory = TestDirectory.Create())
+                {
+                    var subDirectoryPath = Path.Combine(workingDirectory.Path, "SubDirectory");
+                    var subDirectory = Directory.CreateDirectory(subDirectoryPath);
 
-                Util.CreateJunctionPoint(subDirectory.FullName, targetDirectoryPath, overwrite: true);
+                    Util.CreatePackage(workingDirectory.Path, Guid.NewGuid().ToString("N"), "1.0.0");
+                    fileInTargetDirectory = Path.Combine(targetDirectoryPath, "test.txt");
+                    File.WriteAllText(fileInTargetDirectory, string.Empty);
 
-                // Act
-                LocalResourceUtils.DeleteDirectoryTree(workingDirectory.Path, failedDeletes);
+                    Util.CreateJunctionPoint(subDirectory.FullName, targetDirectoryPath, overwrite: true);
 
-                // Assert
-                Assert.Empty(failedDeletes);
-                Assert.False(Directory.Exists(workingDirectory.Path));
-                Assert.True(Directory.Exists(targetDirectoryPath));
-                Assert.True(File.Exists(fileInTargetDirectory));
+                    // Act
+                    LocalResourceUtils.DeleteDirectoryTree(workingDirectory.Path, failedDeletes);
+
+                    // Assert
+                    Assert.Empty(failedDeletes);
+                    Assert.False(Directory.Exists(workingDirectory.Path));
+                    Assert.True(Directory.Exists(targetDirectoryPath));
+                    Assert.True(File.Exists(fileInTargetDirectory));
+                }
             }
 
             // Verify clean-up

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 using NuGet.Common;
@@ -17,30 +16,30 @@ namespace NuGet.CommandLine.Test
     {
         private class TestInfo : IDisposable
         {
+            private readonly TestDirectory _projectDirectory;
+            private readonly string _msBuildDirectory;
+            private readonly TestNuGetProjectContext _nuGetProjectContext;
+
             public MSBuildProjectSystem MSBuildProjectSystem { get; }
-            private string ProjectDirectory { get; }
-            private string MSBuildDirectory { get; }
-            private TestNuGetProjectContext NuGetProjectContext { get; }
 
             public TestInfo(string projectFileContent, string projectName = "proj1")
             {
-                ProjectDirectory = TestDirectory.Create();
-                MSBuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
-                NuGetProjectContext = new TestNuGetProjectContext();
+                _projectDirectory = TestDirectory.Create();
+                _msBuildDirectory = MsBuildUtility.GetMsBuildToolset(null, null).Path;
+                _nuGetProjectContext = new TestNuGetProjectContext();
 
-                var projectFilePath = Path.Combine(ProjectDirectory, projectName + ".csproj");
+                var projectFilePath = Path.Combine(_projectDirectory, projectName + ".csproj");
                 File.WriteAllText(projectFilePath, projectFileContent);
 
                 MSBuildProjectSystem
-                    = new MSBuildProjectSystem(MSBuildDirectory, projectFilePath, NuGetProjectContext);
+                    = new MSBuildProjectSystem(_msBuildDirectory, projectFilePath, _nuGetProjectContext);
             }
 
             public void Dispose()
             {
-                TestFileSystemUtility.DeleteRandomTestFolder(ProjectDirectory);
+                _projectDirectory.Dispose();
             }
         }
-
 
         [Fact]
         public void MSBuildProjectSystem_AddFile()

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
@@ -479,15 +479,20 @@ namespace NuGet.CommandLine
                     waitForExit: true);
 
                 // Assert
-                var package = new PackageArchiveReader(Path.Combine(workingDirectory, "Assembly.1.0.0.nupkg"));
-                var files = (await package.GetPackageFilesAsync(PackageSaveMode.Files, CancellationToken.None)).ToArray();
+                using (var package = new PackageArchiveReader(Path.Combine(workingDirectory, "Assembly.1.0.0.nupkg")))
+                {
+                    var files = (await package.GetPackageFilesAsync(PackageSaveMode.Files, CancellationToken.None)).ToArray();
 
-                Assert.Equal(0, r.Item1);
-                Array.Sort(files);
-                Assert.Equal(files, new[] {
-                    @"lib/net45/Assembly.dll",
-                    @"lib/net45/Assembly.xml"
-                });
+                    Assert.Equal(0, r.Item1);
+                    Array.Sort(files);
+                    Assert.Equal(
+                        files,
+                        new[]
+                        {
+                            @"lib/net45/Assembly.dll",
+                            @"lib/net45/Assembly.xml"
+                        });
+                }
             }
         }
 
@@ -518,15 +523,20 @@ namespace NuGet.CommandLine
                 // Assert
                 Util.VerifyResultSuccess(r);
 
-                var package = new PackageArchiveReader(Path.Combine(workingDirectory, "Link.1.0.0.nupkg"));
-                var files = (await package.GetPackageFilesAsync(PackageSaveMode.Files, CancellationToken.None)).ToArray();
+                using (var package = new PackageArchiveReader(Path.Combine(workingDirectory, "Link.1.0.0.nupkg")))
+                {
+                    var files = (await package.GetPackageFilesAsync(PackageSaveMode.Files, CancellationToken.None)).ToArray();
 
-                Assert.Equal(0, r.Item1);
-                Array.Sort(files);
-                Assert.Equal(files, new[] {
-                    @"lib/net45/A.dll",
-                    @"lib/net45/Link.dll"
-                });
+                    Assert.Equal(0, r.Item1);
+                    Array.Sort(files);
+                    Assert.Equal(
+                        files,
+                        new[]
+                        {
+                            @"lib/net45/A.dll",
+                            @"lib/net45/Link.dll"
+                        });
+                }
             }
         }
 
@@ -566,16 +576,22 @@ namespace NuGet.CommandLine
 
                 // Assert
                 Util.VerifyResultSuccess(r);
-                var package = new PackageArchiveReader(Path.Combine(workingDirectory, "Link.1.0.0.nupkg"));
-                var files = (await package.GetPackageFilesAsync(PackageSaveMode.Files, CancellationToken.None)).ToArray();
 
-                Assert.Equal(0, r.Item1);
-                Array.Sort(files);
-                Assert.Equal(files, new[] {
-                    @"lib/net45/A.dll",
-                    @"lib/net45/C.dll",
-                    @"lib/net45/Link.dll"
-                });
+                using (var package = new PackageArchiveReader(Path.Combine(workingDirectory, "Link.1.0.0.nupkg")))
+                {
+                    var files = (await package.GetPackageFilesAsync(PackageSaveMode.Files, CancellationToken.None)).ToArray();
+
+                    Assert.Equal(0, r.Item1);
+                    Array.Sort(files);
+                    Assert.Equal(
+                        files,
+                        new[]
+                        {
+                            @"lib/net45/A.dll",
+                            @"lib/net45/C.dll",
+                            @"lib/net45/Link.dll"
+                        });
+                }
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
@@ -1888,7 +1888,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
                 Assert.True(File.Exists(targetFilePath));
 
-                var targetsFile = File.OpenText(targetFilePath).ReadToEnd();
+                var targetsFile = File.ReadAllText(targetFilePath);
                 Assert.True(targetsFile.IndexOf(Path.Combine("build", "uap", "packageA.targets")) > -1);
             }
         }
@@ -1962,7 +1962,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
                 Assert.True(File.Exists(targetFilePath));
 
-                var targetsFile = File.OpenText(targetFilePath).ReadToEnd();
+                var targetsFile = File.ReadAllText(targetFilePath);
                 Assert.True(targetsFile.IndexOf(Path.Combine("build", "uap", "packageA.targets")) > -1);
                 Assert.True(targetsFile.IndexOf(Path.Combine("build", "uap", "packageB.targets")) > -1);
             }
@@ -2070,7 +2070,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
                 Assert.True(File.Exists(targetFilePath));
 
-                var targetsFile = File.OpenText(targetFilePath).ReadToEnd();
+                var targetsFile = File.ReadAllText(targetFilePath);
                 Assert.True(targetsFile.IndexOf(packageAPath) > -1);
                 Assert.True(targetsFile.IndexOf(packageBPath) > -1);
             }
@@ -2145,7 +2145,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
                 Assert.True(File.Exists(targetFilePath));
 
-                var targetsFile = File.OpenText(targetFilePath).ReadToEnd();
+                var targetsFile = File.ReadAllText(targetFilePath);
                 Assert.True(targetsFile.IndexOf(Path.Combine("build", "uap", "packageA.targets")) > -1);
                 Assert.True(targetsFile.IndexOf(Path.Combine("build", "uap", "packageB.targets")) > -1);
             }
@@ -2220,7 +2220,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
                 Assert.True(File.Exists(targetFilePath));
 
-                var targetsFile = File.OpenText(targetFilePath).ReadToEnd();
+                var targetsFile = File.ReadAllText(targetFilePath);
                 Assert.True(targetsFile.IndexOf(Path.Combine("build", "uap", "packageA.targets")) > -1);
                 Assert.True(targetsFile.IndexOf(Path.Combine("build", "uap", "packageB.targets")) > -1);
             }
@@ -2287,7 +2287,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
                 Assert.True(File.Exists(targetFilePath));
 
-                var targetsFile = File.OpenText(targetFilePath).ReadToEnd();
+                var targetsFile = File.ReadAllText(targetFilePath);
                 // Verify the target was added
                 Assert.True(targetsFile.IndexOf(Path.Combine("build", "packageA.targets")) > -1);
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
@@ -49,7 +49,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -137,7 +137,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -278,7 +278,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -404,7 +404,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -556,7 +556,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -646,7 +646,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -780,7 +780,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -904,7 +904,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -1002,7 +1002,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -1096,7 +1096,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -1202,7 +1202,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -1347,7 +1347,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -1511,7 +1511,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -1678,7 +1678,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         new PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, testSolutionManager.TestDirectory);
                     var testNuGetProjectContext = new TestNuGetProjectContext();

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -999,7 +999,11 @@ namespace NuGet.Commands.FuncTest
                 modifiedLockFile.Version = 1000;
 
                 var lockFormat = new LockFileFormat();
-                lockFormat.Write(File.OpenWrite(lockFilePath), modifiedLockFile);
+
+                using (var stream = File.OpenWrite(lockFilePath))
+                {
+                    lockFormat.Write(stream, modifiedLockFile);
+                }
 
                 request = new TestRestoreRequest(spec, sources, packagesDir, logger)
                 {

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
@@ -161,7 +161,7 @@ namespace NuGet.Commands.FuncTest
                 var result = await command.ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
 
-                var lockFileJson = JObject.Parse(File.OpenText(request.LockFilePath).ReadToEnd());
+                var lockFileJson = JObject.Parse(File.ReadAllText(request.LockFilePath));
 
                 // Assert
                 Assert.Equal(0, result.CompatibilityCheckResults.Sum(checkResult => checkResult.Issues.Count));
@@ -251,7 +251,7 @@ namespace NuGet.Commands.FuncTest
                 var result = await command.ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
 
-                var lockFileJson = JObject.Parse(File.OpenText(request.LockFilePath).ReadToEnd());
+                var lockFileJson = JObject.Parse(File.ReadAllText(request.LockFilePath));
 
                 // Assert
                 Assert.Equal(0, result.CompatibilityCheckResults.Sum(checkResult => checkResult.Issues.Count));
@@ -312,7 +312,7 @@ namespace NuGet.Commands.FuncTest
                 var result = await command.ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
 
-                var lockFileJson = JObject.Parse(File.OpenText(request.LockFilePath).ReadToEnd());
+                var lockFileJson = JObject.Parse(File.ReadAllText(request.LockFilePath));
                 RemovePackageFolders(lockFileJson);
 
                 // Assert
@@ -379,7 +379,7 @@ namespace NuGet.Commands.FuncTest
                 var result = await command.ExecuteAsync();
                 await result.CommitAsync(logger, CancellationToken.None);
 
-                var lockFileJson = JObject.Parse(File.OpenText(request.LockFilePath).ReadToEnd());
+                var lockFileJson = JObject.Parse(File.ReadAllText(request.LockFilePath));
                 RemovePackageFolders(lockFileJson);
 
                 // Assert

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
@@ -83,14 +83,13 @@ namespace NuGet.Protocol.FuncTest
             // Act
             using (var packagesFolder = TestDirectory.Create())
             using (var cacheContext = new SourceCacheContext())
-            {
-                var actual = await downloadResource.GetDownloadResourceResultAsync(
-                    package,
-                    new PackageDownloadContext(cacheContext),
-                    packagesFolder,
-                    NullLogger.Instance,
-                    CancellationToken.None);
-
+            using (var actual = await downloadResource.GetDownloadResourceResultAsync(
+                package,
+                new PackageDownloadContext(cacheContext),
+                packagesFolder,
+                NullLogger.Instance,
+                CancellationToken.None))
+            { 
                 // Assert
                 Assert.NotNull(actual);
                 Assert.Equal(DownloadResourceResultStatus.NotFound, actual.Status);

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.CommandLineUtils;
 using Moq;
 using NuGet.CommandLine.XPlat;
 using NuGet.Protocol;
+using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.XPlat.FuncTest
@@ -15,70 +16,74 @@ namespace NuGet.XPlat.FuncTest
     [Collection("NuGet XPlat Test Collection")]
     public class ListPackageTests
     {
-
         [Fact]
         public void BasicListPackageParsing_Interactive()
         {
             // Arrange
-            var projectPath = Path.Combine(Path.GetTempPath(), "project.csproj");
-            File.Create(projectPath).Dispose();
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectPath = Path.Combine(testDirectory, "project.csproj");
+                File.WriteAllText(projectPath, string.Empty);
 
-            var argList = new List<string>() {
-                "list",
-                "--interactive",
-                projectPath};
+                var argList = new List<string>() {
+                    "list",
+                    "--interactive",
+                    projectPath};
 
-            var logger = new TestCommandOutputLogger();
-            var testApp = new CommandLineApplication();
-            var mockCommandRunner = new Mock<IListPackageCommandRunner>();
-            mockCommandRunner
-                .Setup(m => m.ExecuteCommandAsync(It.IsAny<ListPackageArgs>()))
-                .Returns(Task.CompletedTask);
+                var logger = new TestCommandOutputLogger();
+                var testApp = new CommandLineApplication();
+                var mockCommandRunner = new Mock<IListPackageCommandRunner>();
+                mockCommandRunner
+                    .Setup(m => m.ExecuteCommandAsync(It.IsAny<ListPackageArgs>()))
+                    .Returns(Task.CompletedTask);
 
-            testApp.Name = "dotnet nuget_test";
-            ListPackageCommand.Register(testApp,
-                () => logger,
-                () => mockCommandRunner.Object);
+                testApp.Name = "dotnet nuget_test";
+                ListPackageCommand.Register(testApp,
+                    () => logger,
+                    () => mockCommandRunner.Object);
 
-            // Act
-            var result = testApp.Execute(argList.ToArray());
+                // Act
+                var result = testApp.Execute(argList.ToArray());
 
-            XPlatTestUtils.DisposeTemporaryFile(projectPath);
+                XPlatTestUtils.DisposeTemporaryFile(projectPath);
 
-            // Assert
-            mockCommandRunner.Verify();
-            Assert.NotNull(HttpHandlerResourceV3.CredentialService);
-            Assert.Equal(0, result);
+                // Assert
+                mockCommandRunner.Verify();
+                Assert.NotNull(HttpHandlerResourceV3.CredentialService);
+                Assert.Equal(0, result);
+            }
         }
 
         [Fact]
         public void BasicListPackageParsing_InteractiveTakesNoArguments()
         {
             // Arrange
-            var projectPath = Path.Combine(Path.GetTempPath(), "project.csproj");
-            File.Create(projectPath).Dispose();
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectPath = Path.Combine(testDirectory, "project.csproj");
+                File.WriteAllText(projectPath, string.Empty);
 
+                var argList = new List<string>() {
+                    "list",
+                    "--interactive",
+                    "no",
+                    projectPath};
 
-            var argList = new List<string>() {
-                "list",
-                "--interactive",
-                "no",
-                projectPath};
+                var logger = new TestCommandOutputLogger();
+                var testApp = new CommandLineApplication();
+                var mockCommandRunner = new Mock<IListPackageCommandRunner>();
+                mockCommandRunner
+                    .Setup(m => m.ExecuteCommandAsync(It.IsAny<ListPackageArgs>()))
+                    .Returns(Task.CompletedTask);
 
-            var logger = new TestCommandOutputLogger();
-            var testApp = new CommandLineApplication();
-            var mockCommandRunner = new Mock<IListPackageCommandRunner>();
-            mockCommandRunner
-                .Setup(m => m.ExecuteCommandAsync(It.IsAny<ListPackageArgs>()))
-                .Returns(Task.CompletedTask);
+                testApp.Name = "dotnet nuget_test";
+                ListPackageCommand.Register(testApp,
+                    () => logger,
+                    () => mockCommandRunner.Object);
 
-            testApp.Name = "dotnet nuget_test";
-            ListPackageCommand.Register(testApp,
-                () => logger,
-                () => mockCommandRunner.Object);
-
-            // Act
-            Assert.Throws<CommandParsingException>(() => testApp.Execute(argList.ToArray()));
+                // Act
+                Assert.Throws<CommandParsingException>(() => testApp.Execute(argList.ToArray()));
+            }
         }
     }
 }

--- a/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/GlobalJsonReader_Tests.cs
+++ b/test/NuGet.Core.Tests/Microsoft.Build.NuGetSdkResolver.Tests/GlobalJsonReader_Tests.cs
@@ -42,13 +42,20 @@ namespace Microsoft.Build.NuGetSdkResolver.Test
         {
             using (var testEnvironment = TestEnvironment.Create())
             {
-                var folder = testEnvironment.CreateFolder().FolderPath;
+                TransientTestFolder folder = testEnvironment.CreateFolder();
 
-                File.WriteAllText(Path.Combine(folder, GlobalJsonReader.GlobalJsonFileName), @" { } ");
+                try
+                {
+                    File.WriteAllText(Path.Combine(folder.FolderPath, GlobalJsonReader.GlobalJsonFileName), @" { } ");
 
-                var context = new MockSdkResolverContext(Path.Combine(folder, "foo.proj"));
+                    var context = new MockSdkResolverContext(Path.Combine(folder.FolderPath, "foo.proj"));
 
-                GlobalJsonReader.GetMSBuildSdkVersions(context).Should().BeNull();
+                    GlobalJsonReader.GetMSBuildSdkVersions(context).Should().BeNull();
+                }
+                finally
+                {
+                    folder.Revert();
+                }
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
@@ -165,7 +165,7 @@ namespace NuGet.Commands.Test
             internal TestLogger Logger { get; }
             internal SignCommandRunner Runner { get; }
 
-            internal Test(SignArgs args, TestDirectory directory, X509Certificate2 certificate, TestLogger logger)
+            private Test(SignArgs args, TestDirectory directory, X509Certificate2 certificate, TestLogger logger)
             {
                 Args = args;
                 Directory = directory;
@@ -179,6 +179,7 @@ namespace NuGet.Commands.Test
                 if (!_isDisposed)
                 {
                     Certificate.Dispose();
+                    Directory.Dispose();
 
                     GC.SuppressFinalize(this);
 

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/ProjectJsonPathUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/ProjectJsonPathUtilitiesTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
@@ -240,7 +240,7 @@ namespace NuGet.Common.Test
 
         private static void CreateFile(string path)
         {
-            File.OpenWrite(path).WriteByte(0);
+            File.WriteAllText(path, string.Empty);
         }
 
         private static string ConvertToUnix(string path)

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/SynchronizationTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/SynchronizationTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -279,6 +279,9 @@ namespace NuGet.Common.Test
                 using (Client) { }
 
                 Listener.Stop();
+
+                Reader.Dispose();
+                Writer.Dispose();
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1881,23 +1881,30 @@ namespace NuGet.Configuration.Test
                 File.WriteAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.Config"), configContents);
                 File.SetAttributes(Path.Combine(mockBaseDirectory.Path, "NuGet.Config"), FileAttributes.ReadOnly);
 
-                var settings = Settings.LoadSettings(mockBaseDirectory.Path,
-                                  configFileName: null,
-                                  machineWideSettings: null,
-                                  loadUserWideSettings: true,
-                                  useTestingGlobalPath: true);
-                var packageSourceProvider = new PackageSourceProvider(settings);
+                try
+                {
+                    var settings = Settings.LoadSettings(mockBaseDirectory.Path,
+                        configFileName: null,
+                        machineWideSettings: null,
+                        loadUserWideSettings: true,
+                        useTestingGlobalPath: true);
+                    var packageSourceProvider = new PackageSourceProvider(settings);
 
-                // Act
-                var sources = packageSourceProvider.LoadPackageSources().ToList();
+                    // Act
+                    var sources = packageSourceProvider.LoadPackageSources().ToList();
 
-                sources.Add(new PackageSource("https://test3.net", "test3"));
+                    sources.Add(new PackageSource("https://test3.net", "test3"));
 
-                var ex = Assert.Throws<NuGetConfigurationException>(() => packageSourceProvider.SavePackageSources(sources));
+                    var ex = Assert.Throws<NuGetConfigurationException>(() => packageSourceProvider.SavePackageSources(sources));
 
-                // Assert
-                var path = Path.Combine(mockBaseDirectory, "NuGet.Config");
-                Assert.Equal($"Failed to read NuGet.Config due to unauthorized access. Path: '{path}'.", ex.Message);
+                    // Assert
+                    var path = Path.Combine(mockBaseDirectory, "NuGet.Config");
+                    Assert.Equal($"Failed to read NuGet.Config due to unauthorized access. Path: '{path}'.", ex.Message);
+                }
+                finally
+                {
+                    File.SetAttributes(Path.Combine(mockBaseDirectory.Path, "NuGet.Config"), FileAttributes.Normal);
+                }
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderBuilderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Credentials.Test/SecurePluginCredentialProviderBuilderTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace NuGet.Credentials.Test
 {
-    public class SecurePluginCredentialProviderBuilderTests
+    public class SecurePluginCredentialProviderBuilderTests : IDisposable
     {
         private readonly TestDirectory _testDirectory;
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -75,12 +74,12 @@ namespace NuGet.Test
             // Arrange
             var packageIdentity = new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("1.0.7"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            var projectFolderPaths = new List<string>();
+            var projectDirectories = new List<TestDirectory>();
 
             try
             {
                 using (var settingsDirectory = TestDirectory.Create())
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, settingsDirectory);
                     var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -102,10 +101,10 @@ namespace NuGet.Test
                     // Create projects
                     for (var i = 0; i < 4; i++)
                     {
-                        var folder = TestDirectory.Create();
-                        projectFolderPaths.Add(folder);
+                        var directory = TestDirectory.Create();
+                        projectDirectories.Add(directory);
 
-                        var config = Path.Combine(folder, "project.json");
+                        var config = Path.Combine(directory, "project.json");
 
                         configs.Add(config);
 
@@ -114,7 +113,7 @@ namespace NuGet.Test
                         var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
                             projectTargetFramework,
                             testNuGetProjectContext,
-                            folder,
+                            directory,
                             $"testProjectName{i}");
 
                         var buildIntegratedProject = new TestProjectJsonBuildIntegratedNuGetProject(config, msBuildNuGetProjectSystem);
@@ -132,10 +131,10 @@ namespace NuGet.Test
                     var reference2 = new TestExternalProjectReference(buildIntegratedProjects[2], buildIntegratedProjects[3]);
                     var reference3 = new TestExternalProjectReference(buildIntegratedProjects[3]);
 
-                    var myProjFolder = TestDirectory.Create();
-                    projectFolderPaths.Add(myProjFolder);
+                    var myProjDirectory = TestDirectory.Create();
+                    projectDirectories.Add(myProjDirectory);
 
-                    var myProjPath = Path.Combine(myProjFolder, "myproj.csproj");
+                    var myProjPath = Path.Combine(myProjDirectory, "myproj.csproj");
 
                     var normalProject = new TestNonBuildIntegratedNuGetProject()
                     {
@@ -201,9 +200,9 @@ namespace NuGet.Test
             }
             finally
             {
-                foreach (var folder in projectFolderPaths)
+                foreach (TestDirectory projectDirectory in projectDirectories)
                 {
-                    TestFileSystemUtility.DeleteRandomTestFolder(folder);
+                    projectDirectory.Dispose();
                 }
             }
         }
@@ -216,13 +215,13 @@ namespace NuGet.Test
             var packageIdentity = new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("3.3.0"));
             var packageIdentity2 = new PackageIdentity("NuGet.Configuration", NuGetVersion.Parse("3.3.0"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            var projectFolderPaths = new List<string>();
+            var projectDirectories = new List<TestDirectory>();
             var logger = new TestLogger();
 
             try
             {
                 using (var settingsDirectory = TestDirectory.Create())
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, settingsDirectory);
                     var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -244,10 +243,10 @@ namespace NuGet.Test
                     // Create projects
                     for (var i = 0; i < 4; i++)
                     {
-                        var folder = TestDirectory.Create();
-                        projectFolderPaths.Add(folder);
+                        var directory = TestDirectory.Create();
+                        projectDirectories.Add(directory);
 
-                        var config = Path.Combine(folder, "project.json");
+                        var config = Path.Combine(directory, "project.json");
 
                         configs.Add(config);
 
@@ -256,7 +255,7 @@ namespace NuGet.Test
                         var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
                             projectTargetFramework,
                             testNuGetProjectContext,
-                            folder,
+                            directory,
                             $"testProjectName{i}");
 
                         var buildIntegratedProject = new TestProjectJsonBuildIntegratedNuGetProject(config, msBuildNuGetProjectSystem);
@@ -275,10 +274,10 @@ namespace NuGet.Test
                     var reference2 = new TestExternalProjectReference(buildIntegratedProjects[2], buildIntegratedProjects[3]);
                     var reference3 = new TestExternalProjectReference(buildIntegratedProjects[3]);
 
-                    var myProjFolder = TestDirectory.Create();
-                    projectFolderPaths.Add(myProjFolder);
+                    var myProjDirectory = TestDirectory.Create();
+                    projectDirectories.Add(myProjDirectory);
 
-                    var myProjPath = Path.Combine(myProjFolder, "myproj.csproj");
+                    var myProjPath = Path.Combine(myProjDirectory, "myproj.csproj");
 
                     var normalProject = new TestNonBuildIntegratedNuGetProject()
                     {
@@ -350,9 +349,9 @@ namespace NuGet.Test
             }
             finally
             {
-                foreach (var folder in projectFolderPaths)
+                foreach (TestDirectory projectDirectory in projectDirectories)
                 {
-                    TestFileSystemUtility.DeleteRandomTestFolder(folder);
+                    projectDirectory.Dispose();
                 }
             }
         }
@@ -364,7 +363,7 @@ namespace NuGet.Test
             var packageIdentity = new PackageIdentity("elmah", new NuGetVersion("1.2.2"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -411,7 +410,7 @@ namespace NuGet.Test
             var packageIdentity = new PackageIdentity("nuget.versioning", NuGetVersion.Parse("1.0.7"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -469,7 +468,7 @@ namespace NuGet.Test
             var packageIdentity = new PackageIdentity("nuget.core", NuGetVersion.Parse("91.0.0"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -534,7 +533,7 @@ namespace NuGet.Test
             var packageIdentity = new PackageIdentity("nuget.core", NuGetVersion.Parse("91.0.0"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -600,7 +599,7 @@ namespace NuGet.Test
 
             var lockFiles = new List<string>();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -675,7 +674,7 @@ namespace NuGet.Test
             var packageIdentity2 = new PackageIdentity("newtonsoft.json", NuGetVersion.Parse("6.0.4"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -728,7 +727,7 @@ namespace NuGet.Test
             var versioning105 = new PackageIdentity("nuget.versioning", NuGetVersion.Parse("1.0.5"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -776,7 +775,7 @@ namespace NuGet.Test
             var nugetVersioningId = "Nuget.Versioning";
             var oldJson = new PackageIdentity(nugetVersioningId, NuGetVersion.Parse("3.5.0"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -845,7 +844,7 @@ namespace NuGet.Test
 
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -928,7 +927,7 @@ namespace NuGet.Test
             var oldJson = new PackageIdentity(nugetVersioningId, NuGetVersion.Parse("3.5.0"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1023,7 +1022,7 @@ namespace NuGet.Test
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
             using (var settingsDirectory = TestDirectory.Create())
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, settingsDirectory);
@@ -1122,7 +1121,7 @@ namespace NuGet.Test
             var versioning107 = new PackageIdentity("nuget.versioning", NuGetVersion.Parse("1.0.7"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1190,7 +1189,7 @@ namespace NuGet.Test
 
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1298,7 +1297,7 @@ namespace NuGet.Test
             var versioning101 = new PackageIdentity("nuget.versioning", NuGetVersion.Parse("1.0.1"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1360,7 +1359,7 @@ namespace NuGet.Test
             var packageIdentity = new PackageIdentity("newtonsoft.json", NuGetVersion.Parse("6.0.8"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1409,7 +1408,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1465,7 +1464,7 @@ namespace NuGet.Test
             var packageIdentity = new PackageIdentity("newtonsoft.json", NuGetVersion.Parse("6.0.8"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1525,7 +1524,7 @@ namespace NuGet.Test
             var packageIdentityB = new PackageIdentity("entityframework", NuGetVersion.Parse("6.1.3"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1596,7 +1595,7 @@ namespace NuGet.Test
             var dependencyIdentity = new PackageIdentity("Microsoft.Web.Xdt", NuGetVersion.Parse("2.1.0"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1635,7 +1634,7 @@ namespace NuGet.Test
             var packageIdentity = new PackageIdentity("nuget.core", NuGetVersion.Parse("2.8.3"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1677,7 +1676,7 @@ namespace NuGet.Test
             var dependencyIdentity = new PackageIdentity("Microsoft.Web.Xdt", NuGetVersion.Parse("2.1.0"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1723,7 +1722,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 using (var randomProjectFolderPath = TestDirectory.Create())
                 {
                     var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
@@ -1788,7 +1787,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = CreateSource(packages);
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
                 var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedRestoreUtilityTests.cs
@@ -48,31 +48,33 @@ namespace NuGet.Test
                     new TestNuGetProjectContext());
                 var project = new ProjectJsonNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName);
 
-                var solutionManager = new TestSolutionManager(false);
-                solutionManager.NuGetProjects.Add(project);
+                using (var solutionManager = new TestSolutionManager())
+                {
+                    solutionManager.NuGetProjects.Add(project);
 
-                var testLogger = new TestLogger();
+                    var testLogger = new TestLogger();
 
-                var restoreContext = new DependencyGraphCacheContext(testLogger, NullSettings.Instance);
+                    var restoreContext = new DependencyGraphCacheContext(testLogger, NullSettings.Instance);
 
-                // Act
-                await DependencyGraphRestoreUtility.RestoreAsync(
-                    solutionManager,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
-                    restoreContext,
-                    new RestoreCommandProvidersCache(),
-                    (c) => { },
-                    sources,
-                    Guid.Empty,
-                    false,
-                    true,
-                    testLogger,
-                    CancellationToken.None);
+                    // Act
+                    await DependencyGraphRestoreUtility.RestoreAsync(
+                        solutionManager,
+                        await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                        restoreContext,
+                        new RestoreCommandProvidersCache(),
+                        (c) => { },
+                        sources,
+                        Guid.Empty,
+                        false,
+                        true,
+                        testLogger,
+                        CancellationToken.None);
 
-                // Assert
-                Assert.True(File.Exists(Path.Combine(projectFolder.FullName, "testproj.project.lock.json")));
-                Assert.True(testLogger.Errors == 0);
-                Assert.False(File.Exists(Path.Combine(projectFolder.FullName, "project.lock.json")));
+                    // Assert
+                    Assert.True(File.Exists(Path.Combine(projectFolder.FullName, "testproj.project.lock.json")));
+                    Assert.True(testLogger.Errors == 0);
+                    Assert.False(File.Exists(Path.Combine(projectFolder.FullName, "project.lock.json")));
+                }
             }
         }
 
@@ -101,30 +103,32 @@ namespace NuGet.Test
                     new TestNuGetProjectContext());
                 var project = new ProjectJsonNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName);
 
-                var solutionManager = new TestSolutionManager(false);
-                solutionManager.NuGetProjects.Add(project);
+                using (var solutionManager = new TestSolutionManager())
+                {
+                    solutionManager.NuGetProjects.Add(project);
 
-                var testLogger = new TestLogger();
+                    var testLogger = new TestLogger();
 
-                var restoreContext = new DependencyGraphCacheContext(testLogger, NullSettings.Instance);
+                    var restoreContext = new DependencyGraphCacheContext(testLogger, NullSettings.Instance);
 
-                // Act
-                await DependencyGraphRestoreUtility.RestoreAsync(
-                    solutionManager,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
-                    restoreContext,
-                    new RestoreCommandProvidersCache(),
-                    (c) => { },
-                    sources,
-                    Guid.Empty,
-                    false,
-                    true,
-                    testLogger,
-                    CancellationToken.None);
+                    // Act
+                    await DependencyGraphRestoreUtility.RestoreAsync(
+                        solutionManager,
+                        await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                        restoreContext,
+                        new RestoreCommandProvidersCache(),
+                        (c) => { },
+                        sources,
+                        Guid.Empty,
+                        false,
+                        true,
+                        testLogger,
+                        CancellationToken.None);
 
-                // Assert
-                Assert.True(File.Exists(Path.Combine(projectFolder.FullName, "project.lock.json")));
-                Assert.True(testLogger.Errors == 0);
+                    // Assert
+                    Assert.True(File.Exists(Path.Combine(projectFolder.FullName, "project.lock.json")));
+                    Assert.True(testLogger.Errors == 0);
+                }
             }
         }
 
@@ -134,7 +138,7 @@ namespace NuGet.Test
             // Arrange
             var projectName = "testproj";
 
-            using (var solutionManager = new TestSolutionManager(false))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var projectFolder = new DirectoryInfo(Path.Combine(solutionManager.SolutionDirectory, projectName));
                 projectFolder.Create();

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/DependencyGraphRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/DependencyGraphRestoreUtilityTests.cs
@@ -33,7 +33,8 @@ namespace NuGet.PackageManagement.Test
                 projectFolder.Create();
                 var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
 
-                var sources = new[] {
+                var sources = new[]
+                {
                     Repository.Factory.GetVisualStudio(new PackageSource("https://www.nuget.org/api/v2/"))
                 };
 
@@ -48,26 +49,28 @@ namespace NuGet.PackageManagement.Test
 
                 var projects = new List<IDependencyGraphProject>() { project };
 
-                var solutionManager = new TestSolutionManager(false);
-                solutionManager.NuGetProjects.Add(project);
+                using (var solutionManager = new TestSolutionManager())
+                {
+                    solutionManager.NuGetProjects.Add(project);
 
-                // Act
-                await DependencyGraphRestoreUtility.RestoreAsync(
-                    solutionManager,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
-                    restoreContext,
-                    new RestoreCommandProvidersCache(),
-                    (c) => { },
-                    sources,
-                    Guid.Empty,
-                    false,
-                    true,
-                    logger,
-                    CancellationToken.None);
+                    // Act
+                    await DependencyGraphRestoreUtility.RestoreAsync(
+                        solutionManager,
+                        await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                        restoreContext,
+                        new RestoreCommandProvidersCache(),
+                        (c) => { },
+                        sources,
+                        Guid.Empty,
+                        false,
+                        true,
+                        logger,
+                        CancellationToken.None);
 
-                // Assert
-                Assert.Equal(0, logger.Errors);
-                Assert.Equal(0, logger.Warnings);
+                    // Assert
+                    Assert.Equal(0, logger.Errors);
+                    Assert.Equal(0, logger.Warnings);
+                }
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -99,7 +99,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -165,7 +165,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -230,7 +230,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -268,7 +268,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -329,7 +329,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -380,7 +380,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -429,7 +429,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -476,7 +476,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -527,7 +527,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -572,7 +572,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -633,7 +633,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -704,7 +704,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -775,7 +775,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -825,7 +825,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -873,7 +873,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -921,7 +921,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1003,7 +1003,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1065,7 +1065,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1118,7 +1118,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1187,7 +1187,7 @@ namespace NuGet.Test
 
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1233,7 +1233,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1329,7 +1329,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -1370,7 +1370,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1425,7 +1425,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1489,7 +1489,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1542,7 +1542,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1619,7 +1619,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1683,7 +1683,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1728,7 +1728,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1776,7 +1776,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1824,7 +1824,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1875,7 +1875,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1919,7 +1919,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -1974,7 +1974,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -2044,7 +2044,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -2091,7 +2091,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -2156,7 +2156,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -2202,7 +2202,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -2247,7 +2247,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -2346,7 +2346,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2404,7 +2404,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2462,7 +2462,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2519,7 +2519,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2592,7 +2592,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2669,7 +2669,7 @@ namespace NuGet.Test
             var nuGetProjectB = new TestNuGetProject(installedPackagesB);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2742,7 +2742,7 @@ namespace NuGet.Test
             var nuGetProjectB = new TestNuGetProject("projectB", installedPackagesB);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2827,7 +2827,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2900,7 +2900,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -2969,7 +2969,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -3039,7 +3039,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -3081,7 +3081,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -3154,7 +3154,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -3239,7 +3239,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -3405,7 +3405,7 @@ namespace NuGet.Test
 
             // Create Package Manager
 
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -3449,7 +3449,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -3501,7 +3501,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -3572,7 +3572,7 @@ namespace NuGet.Test
             var packageIdentityB1 = new PackageIdentity("DotNetOpenAuth.Core", new NuGetVersion("4.3.2.13293"));
             var packageIdentityB2 = new PackageIdentity("DotNetOpenAuth.Core", new NuGetVersion("4.3.4.13329"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -3638,7 +3638,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -3686,7 +3686,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -3739,7 +3739,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -3817,7 +3817,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -3898,7 +3898,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -3985,7 +3985,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new List<NuGet.Configuration.PackageSource>());
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4028,7 +4028,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4073,7 +4073,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4122,7 +4122,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4171,7 +4171,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4220,7 +4220,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4269,7 +4269,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4330,7 +4330,7 @@ namespace NuGet.Test
 
             var sourceRepositoryProvider = new SourceRepositoryProvider(packageSourceProvider, resourceProviders);
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4396,7 +4396,7 @@ namespace NuGet.Test
 
             var sourceRepositoryProvider = new SourceRepositoryProvider(packageSourceProvider, resourceProviders);
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4438,7 +4438,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4485,7 +4485,7 @@ namespace NuGet.Test
                 new NuGet.Configuration.PackageSource("https://www.myget.org/F/aspnetvnext/api/v2/"),
             });
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4530,7 +4530,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4578,7 +4578,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4626,7 +4626,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
@@ -4738,7 +4738,7 @@ namespace NuGet.Test
             // Act
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
             var testSettings = NullSettings.Instance;
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
 
@@ -4782,7 +4782,7 @@ namespace NuGet.Test
             // Act
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
             var testSettings = NullSettings.Instance;
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
 
@@ -4810,7 +4810,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -4890,7 +4890,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -5098,7 +5098,7 @@ namespace NuGet.Test
                         new PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -5167,7 +5167,7 @@ namespace NuGet.Test
                         new PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -5253,7 +5253,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -5319,7 +5319,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var actions = new List<NuGetProjectAction>();
                     var testSettings = NullSettings.Instance;
@@ -5394,7 +5394,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -5475,7 +5475,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -5535,7 +5535,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -5604,7 +5604,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -5675,7 +5675,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -5738,7 +5738,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
             using (var settingsdir = TestDirectory.Create())
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var Settings = new Settings(settingsdir);
                 foreach (var source in sourceRepositoryProvider.GetRepositories())
@@ -5840,7 +5840,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -5887,7 +5887,7 @@ namespace NuGet.Test
         {
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var testSettings = NullSettings.Instance;
                 var token = CancellationToken.None;
@@ -5943,7 +5943,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
             using (var settingsdir = TestDirectory.Create())
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var Settings = new Settings(settingsdir);
                 foreach (var source in sourceRepositoryProvider.GetRepositories())
@@ -6033,7 +6033,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6089,7 +6089,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6137,7 +6137,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6195,7 +6195,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6266,7 +6266,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6340,7 +6340,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6423,7 +6423,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6518,7 +6518,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6563,7 +6563,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6618,7 +6618,7 @@ namespace NuGet.Test
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
             using (var settingsdir = TestDirectory.Create())
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var settings = Settings.LoadSpecificSettings(testSolutionManager.SolutionDirectory, "NuGet.Config");
                 foreach (var source in sourceRepositoryProvider.GetRepositories())
@@ -6689,7 +6689,7 @@ namespace NuGet.Test
                         new Configuration.PackageSource(packageSource1.Path)
                     });
 
-                using (var testSolutionManager = new TestSolutionManager(true))
+                using (var testSolutionManager = new TestSolutionManager())
                 {
                     var testSettings = NullSettings.Instance;
                     var token = CancellationToken.None;
@@ -6767,7 +6767,7 @@ namespace NuGet.Test
             var nuGetProject = new TestNuGetProject(installedPackages);
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -6819,7 +6819,7 @@ namespace NuGet.Test
             };
 
             // Create Package Manager
-            using (var solutionManager = new TestSolutionManager(true))
+            using (var solutionManager = new TestSolutionManager())
             {
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/PackagesConfigProjectTests/PackagesLockTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/PackagesConfigProjectTests/PackagesLockTests.cs
@@ -23,7 +23,7 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests.PackagesConfigPr
         {
             // Arrange
             using (var packageSource = TestDirectory.Create())
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
                     new List<PackageSource>()
@@ -71,7 +71,7 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests.PackagesConfigPr
         {
             // Arrange
             using (var packageSource = TestDirectory.Create())
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
                     new List<PackageSource>()
@@ -124,7 +124,7 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests.PackagesConfigPr
         {
             // Arrange
             using (var packageSource = TestDirectory.Create())
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
                     new List<PackageSource>()

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackagePreFetcherTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackagePreFetcherTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -19,7 +19,6 @@ namespace NuGet.PackageManagement.Test
 {
     public class PackagePreFetcherTests
     {
-
         [Fact]
         public async Task PackagePreFetcher_NoActionsInput()
         {
@@ -70,12 +69,12 @@ namespace NuGet.PackageManagement.Test
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var result = await PackagePreFetcher.GetPackagesAsync(
-                    actions,
-                    packagesFolder,
-                    new PackageDownloadContext(cacheContext),
-                    globalPackagesFolder,
-                    logger,
-                    CancellationToken.None);
+                        actions,
+                        packagesFolder,
+                        new PackageDownloadContext(cacheContext),
+                        globalPackagesFolder,
+                        logger,
+                        CancellationToken.None);
 
                     // Assert
                     Assert.Equal(0, result.Count);
@@ -108,24 +107,25 @@ namespace NuGet.PackageManagement.Test
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var result = await PackagePreFetcher.GetPackagesAsync(
-                    actions,
-                    packagesFolder,
-                    new PackageDownloadContext(cacheContext),
-                    globalPackagesFolder,
-                    logger,
-                    CancellationToken.None);
+                        actions,
+                        packagesFolder,
+                        new PackageDownloadContext(cacheContext),
+                        globalPackagesFolder,
+                        logger,
+                        CancellationToken.None);
 
-                    var downloadResult = await result[target].GetResultAsync();
-
-                    // Assert
-                    Assert.Equal(1, result.Count);
-                    Assert.True(result[target].InPackagesFolder);
-                    Assert.Null(result[target].Source);
-                    Assert.Equal(target, result[target].Package);
-                    Assert.True(result[target].IsComplete);
-                    Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
-                    Assert.NotNull(downloadResult.PackageStream);
-                    Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    using (var downloadResult = await result[target].GetResultAsync())
+                    {
+                        // Assert
+                        Assert.Equal(1, result.Count);
+                        Assert.True(result[target].InPackagesFolder);
+                        Assert.Null(result[target].Source);
+                        Assert.Equal(target, result[target].Package);
+                        Assert.True(result[target].IsComplete);
+                        Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
+                        Assert.NotNull(downloadResult.PackageStream);
+                        Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    }
                 }
             }
         }
@@ -163,17 +163,18 @@ namespace NuGet.PackageManagement.Test
                         logger,
                         CancellationToken.None);
 
-                    var downloadResult = await result[target].GetResultAsync();
-
-                    // Assert
-                    Assert.Equal(1, result.Count);
-                    Assert.False(result[target].InPackagesFolder);
-                    Assert.Equal(source.PackageSource, result[target].Source);
-                    Assert.Equal(target, result[target].Package);
-                    Assert.True(result[target].IsComplete);
-                    Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
-                    Assert.NotNull(downloadResult.PackageStream);
-                    Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    using (var downloadResult = await result[target].GetResultAsync())
+                    {
+                        // Assert
+                        Assert.Equal(1, result.Count);
+                        Assert.False(result[target].InPackagesFolder);
+                        Assert.Equal(source.PackageSource, result[target].Source);
+                        Assert.Equal(target, result[target].Package);
+                        Assert.True(result[target].IsComplete);
+                        Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
+                        Assert.NotNull(downloadResult.PackageStream);
+                        Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    }
                 }
             }
         }
@@ -221,43 +222,44 @@ namespace NuGet.PackageManagement.Test
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var result = await PackagePreFetcher.GetPackagesAsync(
-                    actions,
-                    packagesFolder,
-                    new PackageDownloadContext(cacheContext),
-                    globalPackagesFolder,
-                    logger,
-                    CancellationToken.None);
+                        actions,
+                        packagesFolder,
+                        new PackageDownloadContext(cacheContext),
+                        globalPackagesFolder,
+                        logger,
+                        CancellationToken.None);
 
-                    var resultA2 = await result[targetA2].GetResultAsync();
-                    var resultB2 = await result[targetB2].GetResultAsync();
-                    var resultC2 = await result[targetC2].GetResultAsync();
+                    using (var resultA2 = await result[targetA2].GetResultAsync())
+                    using (var resultB2 = await result[targetB2].GetResultAsync())
+                    using (var resultC2 = await result[targetC2].GetResultAsync())
+                    {
+                        // Assert
+                        Assert.Equal(3, result.Count);
 
-                    // Assert
-                    Assert.Equal(3, result.Count);
+                        Assert.True(result[targetA2].InPackagesFolder);
+                        Assert.Null(result[targetA2].Source);
+                        Assert.Equal(targetA2, result[targetA2].Package);
+                        Assert.True(result[targetA2].IsComplete);
+                        Assert.Equal(targetA2, resultA2.PackageReader.GetIdentity());
+                        Assert.NotNull(resultA2.PackageStream);
+                        Assert.Equal(DownloadResourceResultStatus.Available, resultA2.Status);
 
-                    Assert.True(result[targetA2].InPackagesFolder);
-                    Assert.Null(result[targetA2].Source);
-                    Assert.Equal(targetA2, result[targetA2].Package);
-                    Assert.True(result[targetA2].IsComplete);
-                    Assert.Equal(targetA2, resultA2.PackageReader.GetIdentity());
-                    Assert.NotNull(resultA2.PackageStream);
-                    Assert.Equal(DownloadResourceResultStatus.Available, resultA2.Status);
+                        Assert.False(result[targetB2].InPackagesFolder);
+                        Assert.Equal(source.PackageSource, result[targetB2].Source);
+                        Assert.Equal(targetB2, result[targetB2].Package);
+                        Assert.True(result[targetB2].IsComplete);
+                        Assert.Equal(targetB2, resultB2.PackageReader.GetIdentity());
+                        Assert.NotNull(resultB2.PackageStream);
+                        Assert.Equal(DownloadResourceResultStatus.Available, resultB2.Status);
 
-                    Assert.False(result[targetB2].InPackagesFolder);
-                    Assert.Equal(source.PackageSource, result[targetB2].Source);
-                    Assert.Equal(targetB2, result[targetB2].Package);
-                    Assert.True(result[targetB2].IsComplete);
-                    Assert.Equal(targetB2, resultB2.PackageReader.GetIdentity());
-                    Assert.NotNull(resultB2.PackageStream);
-                    Assert.Equal(DownloadResourceResultStatus.Available, resultB2.Status);
-
-                    Assert.False(result[targetC2].InPackagesFolder);
-                    Assert.Equal(source.PackageSource, result[targetC2].Source);
-                    Assert.Equal(targetC2, result[targetC2].Package);
-                    Assert.True(result[targetC2].IsComplete);
-                    Assert.Equal(targetC2, resultC2.PackageReader.GetIdentity());
-                    Assert.NotNull(resultC2.PackageStream);
-                    Assert.Equal(DownloadResourceResultStatus.Available, resultC2.Status);
+                        Assert.False(result[targetC2].InPackagesFolder);
+                        Assert.Equal(source.PackageSource, result[targetC2].Source);
+                        Assert.Equal(targetC2, result[targetC2].Package);
+                        Assert.True(result[targetC2].IsComplete);
+                        Assert.Equal(targetC2, resultC2.PackageReader.GetIdentity());
+                        Assert.NotNull(resultC2.PackageStream);
+                        Assert.Equal(DownloadResourceResultStatus.Available, resultC2.Status);
+                    }
                 }
             }
         }
@@ -288,23 +290,24 @@ namespace NuGet.PackageManagement.Test
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var result = await PackagePreFetcher.GetPackagesAsync(
-                    actions,
-                    packagesFolder,
-                    new PackageDownloadContext(cacheContext),
-                    globalPackagesFolder,
-                    logger,
-                    CancellationToken.None);
+                        actions,
+                        packagesFolder,
+                        new PackageDownloadContext(cacheContext),
+                        globalPackagesFolder,
+                        logger,
+                        CancellationToken.None);
 
-                    var downloadResult = await result[target].GetResultAsync();
-
-                    // Assert
-                    Assert.Equal(1, result.Count);
-                    Assert.True(result[target].InPackagesFolder);
-                    Assert.Null(result[target].Source);
-                    Assert.Equal(target, result[target].Package);
-                    Assert.True(result[target].IsComplete);
-                    Assert.NotNull(downloadResult.PackageStream);
-                    Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    using (var downloadResult = await result[target].GetResultAsync())
+                    {
+                        // Assert
+                        Assert.Equal(1, result.Count);
+                        Assert.True(result[target].InPackagesFolder);
+                        Assert.Null(result[target].Source);
+                        Assert.Equal(target, result[target].Package);
+                        Assert.True(result[target].IsComplete);
+                        Assert.NotNull(downloadResult.PackageStream);
+                        Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    }
                 }
             }
         }
@@ -335,23 +338,24 @@ namespace NuGet.PackageManagement.Test
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var result = await PackagePreFetcher.GetPackagesAsync(
-                    actions,
-                    packagesFolder,
-                    new PackageDownloadContext(cacheContext),
-                    globalPackagesFolder,
-                    logger,
-                    CancellationToken.None);
+                        actions,
+                        packagesFolder,
+                        new PackageDownloadContext(cacheContext),
+                        globalPackagesFolder,
+                        logger,
+                        CancellationToken.None);
 
-                    var downloadResult = await result[target].GetResultAsync();
-
-                    // Assert
-                    Assert.Equal(1, result.Count);
-                    Assert.True(result[target].InPackagesFolder);
-                    Assert.Null(result[target].Source);
-                    Assert.Equal(target, result[target].Package);
-                    Assert.True(result[target].IsComplete);
-                    Assert.NotNull(downloadResult.PackageStream);
-                    Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    using (var downloadResult = await result[target].GetResultAsync())
+                    {
+                        // Assert
+                        Assert.Equal(1, result.Count);
+                        Assert.True(result[target].InPackagesFolder);
+                        Assert.Null(result[target].Source);
+                        Assert.Equal(target, result[target].Package);
+                        Assert.True(result[target].IsComplete);
+                        Assert.NotNull(downloadResult.PackageStream);
+                        Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    }
                 }
             }
         }
@@ -378,24 +382,25 @@ namespace NuGet.PackageManagement.Test
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var result = await PackagePreFetcher.GetPackagesAsync(
-                    actions,
-                    packagesFolder,
-                    new PackageDownloadContext(cacheContext),
-                    globalPackagesFolder,
-                    logger,
-                    CancellationToken.None);
+                        actions,
+                        packagesFolder,
+                        new PackageDownloadContext(cacheContext),
+                        globalPackagesFolder,
+                        logger,
+                        CancellationToken.None);
 
-                    var downloadResult = await result[target].GetResultAsync();
-
-                    // Assert
-                    Assert.Equal(1, result.Count);
-                    Assert.False(result[target].InPackagesFolder);
-                    Assert.Equal(source.PackageSource, result[target].Source);
-                    Assert.Equal(target, result[target].Package);
-                    Assert.True(result[target].IsComplete);
-                    Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
-                    Assert.NotNull(downloadResult.PackageStream);
-                    Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    using (var downloadResult = await result[target].GetResultAsync())
+                    {
+                        // Assert
+                        Assert.Equal(1, result.Count);
+                        Assert.False(result[target].InPackagesFolder);
+                        Assert.Equal(source.PackageSource, result[target].Source);
+                        Assert.Equal(target, result[target].Package);
+                        Assert.True(result[target].IsComplete);
+                        Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
+                        Assert.NotNull(downloadResult.PackageStream);
+                        Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    }
                 }
             }
         }
@@ -421,18 +426,21 @@ namespace NuGet.PackageManagement.Test
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var result = await PackagePreFetcher.GetPackagesAsync(
-                    actions,
-                    packagesFolder,
-                    new PackageDownloadContext(cacheContext),
-                    globalPackagesFolder,
-                    logger,
-                    CancellationToken.None);
+                        actions,
+                        packagesFolder,
+                        new PackageDownloadContext(cacheContext),
+                        globalPackagesFolder,
+                        logger,
+                        CancellationToken.None);
 
                     Exception exception = null;
 
                     try
                     {
-                        var downloadResult = await result[target].GetResultAsync();
+                        using (await result[target].GetResultAsync())
+                        {
+                        }
+
                         Assert.True(false);
                     }
                     catch (Exception ex)

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageRestoreManagerTests.cs
@@ -32,7 +32,7 @@ namespace NuGet.Test
         public async Task TestGetMissingPackagesForSolution()
         {
             // Arrange
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomPackageSourcePath = TestDirectory.Create())
             {
                 var projectA = testSolutionManager.AddNewMSBuildProject();
@@ -84,7 +84,7 @@ namespace NuGet.Test
         public async Task TestGetMissingPackagesForSolution_NoPackagesInstalled()
         {
             // Arrange
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var projectA = testSolutionManager.AddNewMSBuildProject();
                 var projectB = testSolutionManager.AddNewMSBuildProject();
@@ -111,7 +111,7 @@ namespace NuGet.Test
         public async Task TestPackageRestoredEvent()
         {
             // Arrange
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var projectA = testSolutionManager.AddNewMSBuildProject();
                 var projectB = testSolutionManager.AddNewMSBuildProject();
@@ -170,7 +170,7 @@ namespace NuGet.Test
         public async Task TestCheckForMissingPackages()
         {
             // Arrange
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomPackageSourcePath = TestDirectory.Create())
             {
                 var projectA = testSolutionManager.AddNewMSBuildProject();
@@ -228,7 +228,7 @@ namespace NuGet.Test
         public async Task TestRestoreMissingPackages()
         {
             // Arrange
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             {
                 var projectA = testSolutionManager.AddNewMSBuildProject();
                 var projectB = testSolutionManager.AddNewMSBuildProject();
@@ -282,7 +282,7 @@ namespace NuGet.Test
         public async Task Test_PackageRestoreFailure_WithRaisedEvents()
         {
             // Arrange
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomTestPackageSourcePath = TestDirectory.Create())
             {
                 var projectA = testSolutionManager.AddNewMSBuildProject("projectA");

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/BuildIntegratedNuGetProjectTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -10,7 +9,6 @@ using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Configuration;
 using NuGet.Frameworks;
-using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
@@ -517,11 +515,6 @@ namespace ProjectManagement.Test
 
                 return json;
             }
-        }
-
-        private static void CreateFile(string path)
-        {
-            File.OpenWrite(path).WriteByte(0);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/UnzippedPackageInstallTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/UnzippedPackageInstallTests.cs
@@ -34,7 +34,7 @@ namespace NuGet.Test
             // Arrange
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
 
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomPackagesConfigFolderPath = TestDirectory.Create())
             {
                 var testSettings = NullSettings.Instance;

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/V2V3ParityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/V2V3ParityTests.cs
@@ -32,7 +32,7 @@ namespace NuGet.Test
         private async Task<IEnumerable<NuGetProjectAction>> PacManCleanInstall(SourceRepositoryProvider sourceRepositoryProvider, PackageIdentity target)
         {
             // Arrange
-            using (var testSolutionManager = new TestSolutionManager(true))
+            using (var testSolutionManager = new TestSolutionManager())
             using (var randomPackagesConfigFolderPath = TestDirectory.Create())
             {
                 var testSettings = NullSettings.Instance;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
@@ -29,43 +29,45 @@ namespace Commands.Test
                 var version = new NuGetVersion(package.Version);
                 var identity = new PackageIdentity(package.Id, version);
 
-                var packagesDir = TestDirectory.Create();
-                var pathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var token = CancellationToken.None;
-                var logger = NullLogger.Instance;
-                var packageExtractionContext = new PackageExtractionContext(
-                   packageSaveMode: PackageSaveMode.Defaultv3,
-                   xmlDocFileSaveMode: XmlDocFileSaveMode.None,
-                   clientPolicyContext: null,
-                   logger: logger);
-
-                var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
-
-                // Act
-                using (var packageDownloader = new LocalPackageArchiveDownloader(
-                    null,
-                    package.File.FullName,
-                    identity,
-                    logger))
+                using (var packagesDir = TestDirectory.Create())
                 {
-                    await PackageExtractor.InstallFromSourceAsync(
+                    var pathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var token = CancellationToken.None;
+                    var logger = NullLogger.Instance;
+                    var packageExtractionContext = new PackageExtractionContext(
+                        packageSaveMode: PackageSaveMode.Defaultv3,
+                        xmlDocFileSaveMode: XmlDocFileSaveMode.None,
+                        clientPolicyContext: null,
+                        logger: logger);
+
+                    var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    // Act
+                    using (var packageDownloader = new LocalPackageArchiveDownloader(
+                        null,
+                        package.File.FullName,
                         identity,
-                        packageDownloader,
-                        versionFolderPathResolver,
-                        packageExtractionContext,
-                        token);
+                        logger))
+                    {
+                        await PackageExtractor.InstallFromSourceAsync(
+                            identity,
+                            packageDownloader,
+                            versionFolderPathResolver,
+                            packageExtractionContext,
+                            token);
+                    }
+
+                    // Assert
+                    var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
+                    AssertDirectoryExists(packageDir, packageDir + " does not exist");
+
+                    var nupkgPath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
+                    Assert.True(File.Exists(nupkgPath), nupkgPath + " does not exist");
+
+                    var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
+                    Assert.True(File.Exists(dllPath), dllPath + " does not exist");
                 }
-
-                // Assert
-                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
-                AssertDirectoryExists(packageDir, packageDir + " does not exist");
-
-                var nupkgPath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
-                Assert.True(File.Exists(nupkgPath), nupkgPath + " does not exist");
-
-                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
-                Assert.True(File.Exists(dllPath), dllPath + " does not exist");
             }
         }
 
@@ -78,43 +80,45 @@ namespace Commands.Test
                 var version = new NuGetVersion(package.Version);
                 var identity = new PackageIdentity(package.Id, version);
 
-                var packagesDir = TestDirectory.Create();
-                var pathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var token = CancellationToken.None;
-                var logger = NullLogger.Instance;
-                var packageExtractionContext = new PackageExtractionContext(
-                    packageSaveMode: PackageSaveMode.Defaultv3,
-                    xmlDocFileSaveMode: XmlDocFileSaveMode.None,
-                    clientPolicyContext: null,
-                    logger: logger);
-
-                var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
-
-                // Act
-                using (var packageDownloader = new LocalPackageArchiveDownloader(
-                    null,
-                    package.File.FullName,
-                    identity,
-                    logger))
+                using (var packagesDir = TestDirectory.Create())
                 {
-                    await PackageExtractor.InstallFromSourceAsync(
-                         identity,
-                         packageDownloader,
-                         versionFolderPathResolver,
-                         packageExtractionContext,
-                         token);
+                    var pathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var token = CancellationToken.None;
+                    var logger = NullLogger.Instance;
+                    var packageExtractionContext = new PackageExtractionContext(
+                        packageSaveMode: PackageSaveMode.Defaultv3,
+                        xmlDocFileSaveMode: XmlDocFileSaveMode.None,
+                        clientPolicyContext: null,
+                        logger: logger);
+
+                    var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    // Act
+                    using (var packageDownloader = new LocalPackageArchiveDownloader(
+                        null,
+                        package.File.FullName,
+                        identity,
+                        logger))
+                    {
+                        await PackageExtractor.InstallFromSourceAsync(
+                             identity,
+                             packageDownloader,
+                             versionFolderPathResolver,
+                             packageExtractionContext,
+                             token);
+                    }
+
+                    // Assert
+                    var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
+                    AssertDirectoryExists(packageDir, packageDir + " does not exist");
+
+                    var nupkgPath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
+                    Assert.True(File.Exists(nupkgPath), nupkgPath + " does not exist");
+
+                    var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
+                    Assert.True(File.Exists(dllPath), dllPath + " does not exist");
                 }
-
-                // Assert
-                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
-                AssertDirectoryExists(packageDir, packageDir + " does not exist");
-
-                var nupkgPath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
-                Assert.True(File.Exists(nupkgPath), nupkgPath + " does not exist");
-
-                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
-                Assert.True(File.Exists(dllPath), dllPath + " does not exist");
             }
         }
 
@@ -127,54 +131,56 @@ namespace Commands.Test
                 var version = new NuGetVersion(package.Version);
                 var identity = new PackageIdentity(package.Id, version);
 
-                var packagesDir = TestDirectory.Create();
-                var pathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var token = CancellationToken.None;
-                var logger = NullLogger.Instance;
-                var packageExtractionContext = new PackageExtractionContext(
-                    packageSaveMode: PackageSaveMode.Defaultv3,
-                    xmlDocFileSaveMode: XmlDocFileSaveMode.None,
-                    clientPolicyContext: null,
-                    logger: logger);
-
-                var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
-
-                Directory.CreateDirectory(packageDir);
-
-                var nupkgPath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
-                var shaPath = pathResolver.GetNupkgMetadataPath(package.Id, identity.Version);
-
-                File.WriteAllBytes(shaPath, new byte[] { });
-
-                Assert.True(File.Exists(shaPath));
-
-                // Act
-                using (var packageDownloader = new LocalPackageArchiveDownloader(
-                    null,
-                    package.File.FullName,
-                    identity,
-                    logger))
+                using (var packagesDir = TestDirectory.Create())
                 {
-                    await PackageExtractor.InstallFromSourceAsync(
-                          identity,
-                          packageDownloader,
-                          versionFolderPathResolver,
-                          packageExtractionContext,
-                          token);
+                    var pathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var token = CancellationToken.None;
+                    var logger = NullLogger.Instance;
+                    var packageExtractionContext = new PackageExtractionContext(
+                        packageSaveMode: PackageSaveMode.Defaultv3,
+                        xmlDocFileSaveMode: XmlDocFileSaveMode.None,
+                        clientPolicyContext: null,
+                        logger: logger);
+
+                    var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
+
+                    Directory.CreateDirectory(packageDir);
+
+                    var nupkgPath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
+                    var shaPath = pathResolver.GetNupkgMetadataPath(package.Id, identity.Version);
+
+                    File.WriteAllBytes(shaPath, new byte[] { });
+
+                    Assert.True(File.Exists(shaPath));
+
+                    // Act
+                    using (var packageDownloader = new LocalPackageArchiveDownloader(
+                        null,
+                        package.File.FullName,
+                        identity,
+                        logger))
+                    {
+                        await PackageExtractor.InstallFromSourceAsync(
+                              identity,
+                              packageDownloader,
+                              versionFolderPathResolver,
+                              packageExtractionContext,
+                              token);
+                    }
+
+                    // Assert
+                    AssertDirectoryExists(packageDir, packageDir + " does not exist");
+
+                    Assert.False(File.Exists(nupkgPath), nupkgPath + " does not exist");
+
+                    var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
+                    Assert.False(File.Exists(dllPath), dllPath + " does not exist");
+
+                    Assert.Equal(1, Directory.EnumerateFiles(packageDir).Count());
                 }
-
-                // Assert
-                AssertDirectoryExists(packageDir, packageDir + " does not exist");
-
-                Assert.False(File.Exists(nupkgPath), nupkgPath + " does not exist");
-
-                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
-                Assert.False(File.Exists(dllPath), dllPath + " does not exist");
-
-                Assert.Equal(1, Directory.EnumerateFiles(packageDir).Count());
             }
         }
 
@@ -187,58 +193,60 @@ namespace Commands.Test
                 var version = new NuGetVersion(package.Version);
                 var identity = new PackageIdentity(package.Id, version);
 
-                var packagesDir = TestDirectory.Create();
-                var pathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var token = CancellationToken.None;
-                var logger = NullLogger.Instance;
-                var packageExtractionContext = new PackageExtractionContext(
-                    packageSaveMode: PackageSaveMode.Defaultv3,
-                    xmlDocFileSaveMode: XmlDocFileSaveMode.None,
-                    clientPolicyContext: null,
-                    logger: logger);
-
-                var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
-
-                var randomFile = Path.Combine(packageDir, package.Id + "." + package.Version + ".random");
-
-                Directory.CreateDirectory(packageDir);
-                File.WriteAllBytes(randomFile, new byte[] { });
-
-                var randomFolder = Path.Combine(packageDir, "random");
-                Directory.CreateDirectory(randomFolder);
-
-                Assert.True(File.Exists(randomFile), randomFile + " does not exist");
-                AssertDirectoryExists(randomFolder);
-
-                // Act
-                using (var packageDownloader = new LocalPackageArchiveDownloader(
-                    null,
-                    package.File.FullName,
-                    identity,
-                    logger))
+                using (var packagesDir = TestDirectory.Create())
                 {
-                    await PackageExtractor.InstallFromSourceAsync(
-                         identity,
-                         packageDownloader,
-                         versionFolderPathResolver,
-                         packageExtractionContext,
-                         token);
+                    var pathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var token = CancellationToken.None;
+                    var logger = NullLogger.Instance;
+                    var packageExtractionContext = new PackageExtractionContext(
+                        packageSaveMode: PackageSaveMode.Defaultv3,
+                        xmlDocFileSaveMode: XmlDocFileSaveMode.None,
+                        clientPolicyContext: null,
+                        logger: logger);
+
+                    var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
+
+                    var randomFile = Path.Combine(packageDir, package.Id + "." + package.Version + ".random");
+
+                    Directory.CreateDirectory(packageDir);
+                    File.WriteAllBytes(randomFile, new byte[] { });
+
+                    var randomFolder = Path.Combine(packageDir, "random");
+                    Directory.CreateDirectory(randomFolder);
+
+                    Assert.True(File.Exists(randomFile), randomFile + " does not exist");
+                    AssertDirectoryExists(randomFolder);
+
+                    // Act
+                    using (var packageDownloader = new LocalPackageArchiveDownloader(
+                        null,
+                        package.File.FullName,
+                        identity,
+                        logger))
+                    {
+                        await PackageExtractor.InstallFromSourceAsync(
+                             identity,
+                             packageDownloader,
+                             versionFolderPathResolver,
+                             packageExtractionContext,
+                             token);
+                    }
+
+                    // Assert
+                    AssertDirectoryExists(packageDir, packageDir + " does not exist");
+
+                    var filePath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
+                    Assert.True(File.Exists(filePath), filePath + " does not exist");
+
+                    var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
+                    Assert.True(File.Exists(dllPath), dllPath + " does not exist");
+
+                    Assert.False(File.Exists(randomFile), randomFile + " does exist");
+                    Assert.False(Directory.Exists(randomFolder), randomFolder + " does exist");
                 }
-
-                // Assert
-                AssertDirectoryExists(packageDir, packageDir + " does not exist");
-
-                var filePath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
-                Assert.True(File.Exists(filePath), filePath + " does not exist");
-
-                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
-                Assert.True(File.Exists(dllPath), dllPath + " does not exist");
-
-                Assert.False(File.Exists(randomFile), randomFile + " does exist");
-                Assert.False(Directory.Exists(randomFolder), randomFolder + " does exist");
             }
         }
 
@@ -251,62 +259,64 @@ namespace Commands.Test
                 var version = new NuGetVersion(package.Version);
                 var identity = new PackageIdentity(package.Id, version);
 
-                var packagesDir = TestDirectory.Create();
-                var pathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var token = CancellationToken.None;
-                var logger = NullLogger.Instance;
-                var packageExtractionContext = new PackageExtractionContext(
-                    packageSaveMode: PackageSaveMode.Defaultv3,
-                    xmlDocFileSaveMode: XmlDocFileSaveMode.None,
-                    clientPolicyContext: null,
-                    logger: logger);
-
-                var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
-                Assert.False(Directory.Exists(packageDir), packageDir + " exist");
-
-                // Act
-                using (var packageDownloader = new ThrowingPackageArchiveDownloader(
-                    null,
-                    package.File.FullName,
-                    identity,
-                    logger))
+                using (var packagesDir = TestDirectory.Create())
                 {
-                    await Assert.ThrowsAnyAsync<CorruptionException>(async () =>
-                       await PackageExtractor.InstallFromSourceAsync(
-                         identity,
-                         packageDownloader,
-                         versionFolderPathResolver,
-                         packageExtractionContext,
-                         token));
+                    var pathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var token = CancellationToken.None;
+                    var logger = NullLogger.Instance;
+                    var packageExtractionContext = new PackageExtractionContext(
+                        packageSaveMode: PackageSaveMode.Defaultv3,
+                        xmlDocFileSaveMode: XmlDocFileSaveMode.None,
+                        clientPolicyContext: null,
+                        logger: logger);
+
+                    var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
+                    Assert.False(Directory.Exists(packageDir), packageDir + " exist");
+
+                    // Act
+                    using (var packageDownloader = new ThrowingPackageArchiveDownloader(
+                        null,
+                        package.File.FullName,
+                        identity,
+                        logger))
+                    {
+                        await Assert.ThrowsAnyAsync<CorruptionException>(async () =>
+                           await PackageExtractor.InstallFromSourceAsync(
+                             identity,
+                             packageDownloader,
+                             versionFolderPathResolver,
+                             packageExtractionContext,
+                             token));
+                    }
+
+                    AssertDirectoryExists(packageDir, packageDir + " does not exist");
+
+                    Assert.NotEmpty(Directory.EnumerateFiles(packageDir));
+
+                    using (var packageDownloader = new LocalPackageArchiveDownloader(
+                        packagesDir,
+                        package.File.FullName,
+                        identity,
+                        logger))
+                    {
+                        await PackageExtractor.InstallFromSourceAsync(
+                              identity,
+                              packageDownloader,
+                              versionFolderPathResolver,
+                              packageExtractionContext,
+                              token);
+                    }
+
+                    // Assert
+                    var filePath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
+                    Assert.True(File.Exists(filePath), filePath + " does not exist");
+
+                    var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
+                    Assert.True(File.Exists(dllPath), dllPath + " does not exist");
                 }
-
-                AssertDirectoryExists(packageDir, packageDir + " does not exist");
-
-                Assert.NotEmpty(Directory.EnumerateFiles(packageDir));
-
-                using (var packageDownloader = new LocalPackageArchiveDownloader(
-                    packagesDir,
-                    package.File.FullName,
-                    identity,
-                    logger))
-                {
-                    await PackageExtractor.InstallFromSourceAsync(
-                          identity,
-                          packageDownloader,
-                          versionFolderPathResolver,
-                          packageExtractionContext,
-                          token);
-                }
-
-                // Assert
-                var filePath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
-                Assert.True(File.Exists(filePath), filePath + " does not exist");
-
-                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
-                Assert.True(File.Exists(dllPath), dllPath + " does not exist");
             }
         }
 
@@ -319,78 +329,80 @@ namespace Commands.Test
                 var version = new NuGetVersion(package.Version);
                 var identity = new PackageIdentity(package.Id, version);
 
-                var packagesDir = TestDirectory.Create();
-                var pathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var token = CancellationToken.None;
-                var logger = NullLogger.Instance;
-                var packageExtractionContext = new PackageExtractionContext(
-                    packageSaveMode: PackageSaveMode.Defaultv3,
-                    xmlDocFileSaveMode: XmlDocFileSaveMode.None,
-                    clientPolicyContext: null,
-                    logger: logger);
-
-                var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
-
-                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
-                Assert.False(Directory.Exists(packageDir), packageDir + " exist");
-
-                var filePathToLock = Path.Combine(packageDir, "lib", "net40", "two.dll");
-
-                // Act
-                using (var packageDownloader = new LocalPackageArchiveDownloader(
-                    null,
-                    package.File.FullName,
-                    identity,
-                    logger))
+                using (var packagesDir = TestDirectory.Create())
                 {
-                    var cts = new CancellationTokenSource(DefaultTimeOut);
+                    var pathResolver = new VersionFolderPathResolver(packagesDir);
 
-                    Func<CancellationToken, Task<bool>> action = (ct) =>
+                    var token = CancellationToken.None;
+                    var logger = NullLogger.Instance;
+                    var packageExtractionContext = new PackageExtractionContext(
+                        packageSaveMode: PackageSaveMode.Defaultv3,
+                        xmlDocFileSaveMode: XmlDocFileSaveMode.None,
+                        clientPolicyContext: null,
+                        logger: logger);
+
+                    var versionFolderPathResolver = new VersionFolderPathResolver(packagesDir);
+
+                    var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
+                    Assert.False(Directory.Exists(packageDir), packageDir + " exist");
+
+                    var filePathToLock = Path.Combine(packageDir, "lib", "net40", "two.dll");
+
+                    // Act
+                    using (var packageDownloader = new LocalPackageArchiveDownloader(
+                        null,
+                        package.File.FullName,
+                        identity,
+                        logger))
                     {
-                        Assert.ThrowsAnyAsync<IOException>(async () =>
-                            await PackageExtractor.InstallFromSourceAsync(
-                                identity,
-                                packageDownloader,
-                                versionFolderPathResolver,
-                                packageExtractionContext,
-                                token));
+                        var cts = new CancellationTokenSource(DefaultTimeOut);
 
-                        return Task.FromResult(true);
-                    };
+                        Func<CancellationToken, Task<bool>> action = (ct) =>
+                        {
+                            Assert.ThrowsAnyAsync<IOException>(async () =>
+                                await PackageExtractor.InstallFromSourceAsync(
+                                    identity,
+                                    packageDownloader,
+                                    versionFolderPathResolver,
+                                    packageExtractionContext,
+                                    token));
 
-                    await ConcurrencyUtilities.ExecuteWithFileLockedAsync(filePathToLock, action, cts.Token);
+                            return Task.FromResult(true);
+                        };
+
+                        await ConcurrencyUtilities.ExecuteWithFileLockedAsync(filePathToLock, action, cts.Token);
+                    }
+
+                    AssertDirectoryExists(packageDir, packageDir + " does not exist");
+
+                    Assert.NotEmpty(Directory.EnumerateFiles(packageDir));
+
+                    using (var packageDownloader = new LocalPackageArchiveDownloader(
+                        null,
+                        package.File.FullName,
+                        identity,
+                        logger))
+                    {
+                        await PackageExtractor.InstallFromSourceAsync(
+                             identity,
+                             packageDownloader,
+                             versionFolderPathResolver,
+                             packageExtractionContext,
+                             token);
+                    }
+
+                    // Assert
+                    var filePath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
+                    Assert.True(File.Exists(filePath), filePath + " does not exist");
+
+                    var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
+                    Assert.True(File.Exists(dllPath), dllPath + " does not exist");
+
+                    Assert.True(File.Exists(filePathToLock));
+
+                    // Make sure the actual file from the zip was extracted
+                    Assert.Equal(new byte[] { 0 }, File.ReadAllBytes(filePathToLock));
                 }
-
-                AssertDirectoryExists(packageDir, packageDir + " does not exist");
-
-                Assert.NotEmpty(Directory.EnumerateFiles(packageDir));
-
-                using (var packageDownloader = new LocalPackageArchiveDownloader(
-                    null,
-                    package.File.FullName,
-                    identity,
-                    logger))
-                {
-                    await PackageExtractor.InstallFromSourceAsync(
-                         identity,
-                         packageDownloader,
-                         versionFolderPathResolver,
-                         packageExtractionContext,
-                         token);
-                }
-
-                // Assert
-                var filePath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
-                Assert.True(File.Exists(filePath), filePath + " does not exist");
-
-                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
-                Assert.True(File.Exists(dllPath), dllPath + " does not exist");
-
-                Assert.True(File.Exists(filePathToLock));
-
-                // Make sure the actual file from the zip was extracted
-                Assert.Equal(new byte[] { 0 }, File.ReadAllBytes(filePathToLock));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -1501,7 +1501,7 @@ Description is required.");
 #if !IS_CORECLR
             ExceptionAssert.Throws<InvalidOperationException>(
                 () => new PackageBuilder(spec.AsStream(), null),
-                "The element 'metadata' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' has incomplete content. " + 
+                "The element 'metadata' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' has incomplete content. " +
                 "List of possible elements expected: 'authors' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd'. " +
                 "This validation error occurred in a 'metadata' element.");
 #else
@@ -2475,12 +2475,13 @@ Enabling license acceptance requires a license or a licenseUrl to be specified. 
 
                     Assert.Equal(@"test.nuspec", files[4]);
 
-                    var contentTypesReader
-                        = new StreamReader(archive.Entries.Single(file => file.FullName == @"[Content_Types].xml").Open());
-                    var contentTypesXml = XDocument.Parse(contentTypesReader.ReadToEnd());
-                    var node = contentTypesXml.Descendants().Single(e => e.Name.LocalName == "Override");
+                    using (var contentTypesReader = new StreamReader(archive.Entries.Single(file => file.FullName == @"[Content_Types].xml").Open()))
+                    {
+                        var contentTypesXml = XDocument.Parse(contentTypesReader.ReadToEnd());
+                        var node = contentTypesXml.Descendants().Single(e => e.Name.LocalName == "Override");
 
-                    Assert.StartsWith(@"<Override PartName=""/myfile"" ContentType=""application/octet""", node.ToString());
+                        Assert.StartsWith(@"<Override PartName=""/myfile"" ContentType=""application/octet""", node.ToString());
+                    }
                 }
             }
         }
@@ -2528,18 +2529,18 @@ Enabling license acceptance requires a license or a licenseUrl to be specified. 
                 builder.Authors.Add("test");
                 builder.AddFiles(directory.Path, "**", "Content");
 
-                using (MemoryStream stream = new MemoryStream())
+                using (var stream = new MemoryStream())
                 {
                     builder.Save(stream);
 
                     // Assert
                     using (var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true))
                     {
-                        foreach(var entry in archive.Entries)
+                        foreach (var entry in archive.Entries)
                         {
                             var path = directory.Path + Path.DirectorySeparatorChar + entry.Name;
                             // Only checks the entries that originated from files in test directory
-                            if(File.Exists(path))
+                            if (File.Exists(path))
                             {
                                 Assert.Equal(entry.LastWriteTime.DateTime, File.GetLastWriteTimeUtc(path));
                             }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
@@ -175,9 +175,8 @@ namespace NuGet.Packaging.Test
         public void GetStream_ReturnsReadableStream()
         {
             using (var test = PackageReaderTest.Create(TestPackagesCore.GetPackageCoreReaderTestPackage()))
+            using (var stream = test.Reader.GetStream("Aa.nuspec"))
             {
-                var stream = test.Reader.GetStream("Aa.nuspec");
-
                 Assert.NotNull(stream);
                 Assert.True(stream.CanRead);
             }
@@ -187,9 +186,8 @@ namespace NuGet.Packaging.Test
         public async Task GetStreamAsync_ReturnsReadableStream()
         {
             using (var test = PackageReaderTest.Create(TestPackagesCore.GetPackageCoreReaderTestPackage()))
+            using (var stream = await test.Reader.GetStreamAsync("Aa.nuspec", CancellationToken.None))
             {
-                var stream = await test.Reader.GetStreamAsync("Aa.nuspec", CancellationToken.None);
-
                 Assert.NotNull(stream);
                 Assert.True(stream.CanRead);
             }
@@ -278,9 +276,8 @@ namespace NuGet.Packaging.Test
         public void GetNuspec_ReturnsReadableStream()
         {
             using (var test = PackageReaderTest.Create(TestPackagesCore.GetPackageCoreReaderTestPackage()))
+            using (var stream = test.Reader.GetNuspec())
             {
-                var stream = test.Reader.GetNuspec();
-
                 Assert.NotNull(stream);
                 Assert.True(stream.CanRead);
             }
@@ -290,9 +287,8 @@ namespace NuGet.Packaging.Test
         public async Task GetNuspecAsync_ReturnsReadableStream()
         {
             using (var test = PackageReaderTest.Create(TestPackagesCore.GetPackageCoreReaderTestPackage()))
+            using (var stream = await test.Reader.GetNuspecAsync(CancellationToken.None))
             {
-                var stream = await test.Reader.GetNuspecAsync(CancellationToken.None);
-
                 Assert.NotNull(stream);
                 Assert.True(stream.CanRead);
             }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagesConfigWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagesConfigWriterTests.cs
@@ -375,31 +375,32 @@ namespace NuGet.Packaging.Test
                     }
                 }
 
-                var stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite);
-
-                using (var writer = new PackagesConfigWriter(stream, false))
+                using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite))
                 {
-                    // Act
-                    var packageIdentityA1 = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
-                    var packageReferenceA1 = new PackageReference(packageIdentityA1, NuGetFramework.Parse("win81"),
-                        userInstalled: true, developmentDependency: false, requireReinstallation: false);
+                    using (var writer = new PackagesConfigWriter(stream, false))
+                    {
+                        // Act
+                        var packageIdentityA1 = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+                        var packageReferenceA1 = new PackageReference(packageIdentityA1, NuGetFramework.Parse("win81"),
+                            userInstalled: true, developmentDependency: false, requireReinstallation: false);
 
-                    var packageIdentityA2 = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.1"));
-                    var packageReferenceA2 = new PackageReference(packageIdentityA2, NuGetFramework.Parse("net45"));
+                        var packageIdentityA2 = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.1"));
+                        var packageReferenceA2 = new PackageReference(packageIdentityA2, NuGetFramework.Parse("net45"));
 
-                    writer.UpdatePackageEntry(packageReferenceA1, packageReferenceA2);
+                        writer.UpdatePackageEntry(packageReferenceA1, packageReferenceA2);
+                    }
+
+                    // Assert
+                    stream.Seek(0, SeekOrigin.Begin);
+
+                    var xml = XDocument.Load(stream);
+
+                    // Assert
+                    Assert.Equal("utf-8", xml.Declaration.Encoding);
+
+                    var packageNode = xml.Descendants(PackagesConfig.PackageNodeName).FirstOrDefault();
+                    Assert.Equal(packageNode.ToString(), "<package id=\"packageA\" version=\"1.0.1\" targetFramework=\"net45\" userInstalled=\"true\" protocolVersion=\"V2\" />");
                 }
-
-                // Assert
-                stream.Seek(0, SeekOrigin.Begin);
-
-                var xml = XDocument.Load(stream);
-
-                // Assert
-                Assert.Equal("utf-8", xml.Declaration.Encoding);
-
-                var packageNode = xml.Descendants(PackagesConfig.PackageNodeName).FirstOrDefault();
-                Assert.Equal(packageNode.ToString(), "<package id=\"packageA\" version=\"1.0.1\" targetFramework=\"net45\" userInstalled=\"true\" protocolVersion=\"V2\" />");
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningOptionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningOptionsTests.cs
@@ -190,8 +190,8 @@ namespace NuGet.Packaging.Test
         {
             using (var directory = TestDirectory.Create())
             {
-                var inputPackageFilePath = Path.Combine(Path.GetTempPath(), "a");
-                var outputPackageFilePath = Path.Combine(Path.GetTempPath(), "b");
+                var inputPackageFilePath = Path.Combine(directory, "a");
+                var outputPackageFilePath = Path.Combine(directory, "b");
                 var overwrite = false;
                 var signatureProvider = Mock.Of<ISignatureProvider>();
                 var logger = Mock.Of<ILogger>();

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceV2FeedTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -36,14 +36,13 @@ namespace NuGet.Protocol.Tests
             // Act
             using (var packagesFolder = TestDirectory.Create())
             using (var sourceCacheContext = new SourceCacheContext())
+            using (var actual = await downloadResource.GetDownloadResourceResultAsync(
+                new PackageIdentity("xunit", new NuGetVersion("1.0.0-notfound")),
+                new PackageDownloadContext(sourceCacheContext),
+                packagesFolder,
+                NullLogger.Instance,
+                CancellationToken.None))
             {
-                var actual = await downloadResource.GetDownloadResourceResultAsync(
-                    new PackageIdentity("xunit", new NuGetVersion("1.0.0-notfound")),
-                    new PackageDownloadContext(sourceCacheContext),
-                    packagesFolder,
-                    NullLogger.Instance,
-                    CancellationToken.None);
-
                 // Assert
                 Assert.NotNull(actual);
                 Assert.Equal(DownloadResourceResultStatus.NotFound, actual.Status);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalFolderUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalFolderUtilityTests.cs
@@ -212,7 +212,10 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(a, foundA.Identity);
                 Assert.Equal(a, foundA.Nuspec.GetIdentity());
                 Assert.True(foundA.IsNupkg);
-                Assert.Equal(a, foundA.GetReader().GetIdentity());
+                using (var reader = foundA.GetReader())
+                {
+                    Assert.Equal(a, reader.GetIdentity());
+                }
                 Assert.Contains("a.1.0.0.nupkg", foundA.Path);
                 Assert.Equal(0, testLogger.Messages.Count);
             }
@@ -287,7 +290,10 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(a, foundA.Identity);
                 Assert.Equal(a, foundA.Nuspec.GetIdentity());
                 Assert.True(foundA.IsNupkg);
-                Assert.Equal(a, foundA.GetReader().GetIdentity());
+                using (var reader = foundA.GetReader())
+                {
+                    Assert.Equal(a, reader.GetIdentity());
+                }
                 Assert.Contains("a.1.0.01.0.nupkg", foundA.Path);
             }
         }
@@ -315,7 +321,10 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(a, foundA.Identity);
                 Assert.Equal(a, foundA.Nuspec.GetIdentity());
                 Assert.True(foundA.IsNupkg);
-                Assert.Equal(a, foundA.GetReader().GetIdentity());
+                using (var reader = foundA.GetReader())
+                {
+                    Assert.Equal(a, reader.GetIdentity());
+                }
                 Assert.Contains("a.1.0.1.nupkg", foundA.Path);
             }
         }
@@ -704,7 +713,10 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(a, foundA.Identity);
                 Assert.Equal(a, foundA.Nuspec.GetIdentity());
                 Assert.True(foundA.IsNupkg);
-                Assert.Equal(a, foundA.GetReader().GetIdentity());
+                using (var reader = foundA.GetReader())
+                {
+                    Assert.Equal(a, reader.GetIdentity());
+                }
                 Assert.Contains("a.1.0.0.nupkg", foundA.Path);
             }
         }
@@ -886,7 +898,10 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(a, foundA.Identity);
                 Assert.Equal(a, foundA.Nuspec.GetIdentity());
                 Assert.True(foundA.IsNupkg);
-                Assert.Equal(a, foundA.GetReader().GetIdentity());
+                using (var reader = foundA.GetReader())
+                {
+                    Assert.Equal(a, reader.GetIdentity());
+                }
                 Assert.Contains("a.1.0.0.nupkg", foundA.Path);
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/FindLocalPackagesResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/FindLocalPackagesResourceTests.cs
@@ -68,7 +68,13 @@ namespace NuGet.Protocol.Tests
 
                     // Assert
                     Assert.True(expected.SetEquals(result.Select(p => p.Identity)));
-                    Assert.True(expected.SetEquals(result.Select(p => p.GetReader().GetIdentity())));
+                    Assert.True(expected.SetEquals(result.Select(p =>
+                    {
+                        using (var reader = p.GetReader())
+                        {
+                            return reader.GetIdentity();
+                        }
+                    })));
                     Assert.True(expected.SetEquals(result.Select(p => p.Nuspec.GetIdentity())));
                     Assert.True(result.All(p => p.IsNupkg));
                 }
@@ -154,7 +160,13 @@ namespace NuGet.Protocol.Tests
 
                     // Assert
                     Assert.True(expected.SetEquals(result.Select(p => p.Identity)));
-                    Assert.True(expected.SetEquals(result.Select(p => p.GetReader().GetIdentity())));
+                    Assert.True(expected.SetEquals(result.Select(p =>
+                    {
+                        using (var reader = p.GetReader())
+                        {
+                            return reader.GetIdentity();
+                        }
+                    })));
                     Assert.True(expected.SetEquals(result.Select(p => p.Nuspec.GetIdentity())));
                     Assert.True(result.All(p => p.IsNupkg));
                 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalDownloadResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalDownloadResourceTests.cs
@@ -51,23 +51,18 @@ namespace NuGet.Protocol.Tests
 
                 // Act
                 using (var cacheContext = new SourceCacheContext())
+                using (var result = await resource.GetDownloadResourceResultAsync(
+                    packageA.Identity,
+                    new PackageDownloadContext(cacheContext),
+                    packagesFolder,
+                    testLogger,
+                    CancellationToken.None))
                 {
-                    var result = await resource.GetDownloadResourceResultAsync(
-                        packageA.Identity,
-                        new PackageDownloadContext(cacheContext),
-                        packagesFolder,
-                        testLogger,
-                        CancellationToken.None);
-
-                    using (var reader = result.PackageReader)
-                    using (var stream = result.PackageStream)
-                    {
-                        // Assert
-                        Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
-                        Assert.Equal("a", reader.GetIdentity().Id);
-                        Assert.Equal("1.0.0", reader.GetIdentity().Version.ToFullString());
-                        Assert.True(stream.CanSeek);
-                    }
+                    // Assert
+                    Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
+                    Assert.Equal("a", result.PackageReader.GetIdentity().Id);
+                    Assert.Equal("1.0.0", result.PackageReader.GetIdentity().Version.ToFullString());
+                    Assert.True(result.PackageStream.CanSeek);
                 }
             }
         }
@@ -116,35 +111,29 @@ namespace NuGet.Protocol.Tests
                 {
                     var downloadContext = new PackageDownloadContext(cacheContext);
 
-                    var result1 = await resource.GetDownloadResourceResultAsync(
+                    using (var result1 = await resource.GetDownloadResourceResultAsync(
                         packageA1.Identity,
                         downloadContext,
                         packagesFolder,
                         testLogger,
-                        CancellationToken.None);
-
-                    var result2 = await resource.GetDownloadResourceResultAsync(
+                        CancellationToken.None))
+                    using (var result2 = await resource.GetDownloadResourceResultAsync(
                         packageA2.Identity,
                         downloadContext,
                         packagesFolder,
                         testLogger,
-                        CancellationToken.None);
-
-                    var result3 = await resource.GetDownloadResourceResultAsync(
+                        CancellationToken.None))
+                    using (var result3 = await resource.GetDownloadResourceResultAsync(
                         packageA3.Identity,
                         downloadContext,
                         packagesFolder,
                         testLogger,
-                        CancellationToken.None);
-
-                    using (var reader1 = result1.PackageReader)
-                    using (var reader2 = result2.PackageReader)
-                    using (var reader3 = result3.PackageReader)
+                        CancellationToken.None))
                     {
                         // Assert
-                        Assert.Equal("1.0", reader1.GetIdentity().Version.ToString());
-                        Assert.Equal("1.0.0", reader2.GetIdentity().Version.ToString());
-                        Assert.Equal("1.0.0.0", reader3.GetIdentity().Version.ToString());
+                        Assert.Equal("1.0", result1.PackageReader.GetIdentity().Version.ToString());
+                        Assert.Equal("1.0.0", result2.PackageReader.GetIdentity().Version.ToString());
+                        Assert.Equal("1.0.0.0", result3.PackageReader.GetIdentity().Version.ToString());
                     }
                 }
             }
@@ -185,23 +174,18 @@ namespace NuGet.Protocol.Tests
 
                 // Act
                 using (var cacheContext = new SourceCacheContext())
+                using (var result = await resource.GetDownloadResourceResultAsync(
+                    packageA.Identity,
+                    new PackageDownloadContext(cacheContext),
+                    packagesFolder,
+                    testLogger,
+                    CancellationToken.None))
                 {
-                    var result = await resource.GetDownloadResourceResultAsync(
-                        packageA.Identity,
-                        new PackageDownloadContext(cacheContext),
-                        packagesFolder,
-                        testLogger,
-                        CancellationToken.None);
-
-                    using (var reader = result.PackageReader)
-                    using (var stream = result.PackageStream)
-                    {
-                        // Assert
-                        Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
-                        Assert.Equal("a", reader.GetIdentity().Id);
-                        Assert.Equal("1.0.0-alpha.1.2+b", reader.GetIdentity().Version.ToFullString());
-                        Assert.True(stream.CanSeek);
-                    }
+                    // Assert
+                    Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
+                    Assert.Equal("a", result.PackageReader.GetIdentity().Id);
+                    Assert.Equal("1.0.0-alpha.1.2+b", result.PackageReader.GetIdentity().Version.ToFullString());
+                    Assert.True(result.PackageStream.CanSeek);
                 }
             }
         }
@@ -241,14 +225,13 @@ namespace NuGet.Protocol.Tests
 
                 // Act
                 using (var cacheContext = new SourceCacheContext())
+                using (var result = await resource.GetDownloadResourceResultAsync(
+                    new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.1.2.3+a.b")),
+                    new PackageDownloadContext(cacheContext),
+                    packagesFolder,
+                    testLogger,
+                    CancellationToken.None))
                 {
-                    var result = await resource.GetDownloadResourceResultAsync(
-                        new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.1.2.3+a.b")),
-                        new PackageDownloadContext(cacheContext),
-                        packagesFolder,
-                        testLogger,
-                        CancellationToken.None);
-
                     // Assert
                     Assert.Equal(DownloadResourceResultStatus.NotFound, result.Status);
                 }
@@ -269,14 +252,13 @@ namespace NuGet.Protocol.Tests
 
                 // Act
                 using (var cacheContext = new SourceCacheContext())
+                using (var result = await resource.GetDownloadResourceResultAsync(
+                    new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.1.2.3+a.b")),
+                    new PackageDownloadContext(cacheContext),
+                    packagesFolder,
+                    testLogger,
+                    CancellationToken.None))
                 {
-                    var result = await resource.GetDownloadResourceResultAsync(
-                        new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.1.2.3+a.b")),
-                        new PackageDownloadContext(cacheContext),
-                        packagesFolder,
-                        testLogger,
-                        CancellationToken.None);
-
                     // Assert
                     Assert.Equal(DownloadResourceResultStatus.NotFound, result.Status);
                 }
@@ -299,14 +281,13 @@ namespace NuGet.Protocol.Tests
 
                 // Act
                 using (var cacheContext = new SourceCacheContext())
-                {
-                    var result = await resource.GetDownloadResourceResultAsync(
+                using (var result = await resource.GetDownloadResourceResultAsync(
                     new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.1.2.3+a.b")),
                     new PackageDownloadContext(cacheContext),
                     packagesFolder,
                     testLogger,
-                    CancellationToken.None);
-
+                    CancellationToken.None))
+                {
                     // Assert
                     Assert.Equal(DownloadResourceResultStatus.NotFound, result.Status);
                 }
@@ -330,24 +311,19 @@ namespace NuGet.Protocol.Tests
 
                 // Act
                 using (var cacheContext = new SourceCacheContext())
+                using (var result = await resource.GetDownloadResourceResultAsync(
+                    id,
+                    new PackageDownloadContext(cacheContext),
+                    packagesFolder,
+                    testLogger,
+                    CancellationToken.None))
                 {
-                    var result = await resource.GetDownloadResourceResultAsync(
-                        id,
-                        new PackageDownloadContext(cacheContext),
-                        packagesFolder,
-                        testLogger,
-                        CancellationToken.None);
-
-                    using (var reader = result.PackageReader)
-                    using (var stream = result.PackageStream)
-                    {
-                        // Assert
-                        Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
-                        Assert.Equal("a", reader.GetIdentity().Id);
-                        Assert.Equal("1.0.0", reader.GetIdentity().Version.ToFullString());
-                        Assert.True(stream.CanSeek);
-                        Assert.True(reader is PackageFolderReader);
-                    }
+                    // Assert
+                    Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
+                    Assert.Equal("a", result.PackageReader.GetIdentity().Id);
+                    Assert.Equal("1.0.0", result.PackageReader.GetIdentity().Version.ToFullString());
+                    Assert.True(result.PackageStream.CanSeek);
+                    Assert.True(result.PackageReader is PackageFolderReader);
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryUtilityTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.IO;
 using NuGet.Test.Utility;
 using Xunit;
@@ -28,7 +31,7 @@ namespace NuGet.Protocol.Plugins.Tests
 
                 // Create plugin Directory and name
                 Directory.CreateDirectory(pluginDirectoryPath);
-                File.Create(fullPluginFilePath);
+                File.WriteAllText(fullPluginFilePath, string.Empty);
 
                 // Act
                 var results = PluginDiscoveryUtility.GetConventionBasedPlugins(new string[] { test.Path });

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Utility/GetDownloadResultUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Utility/GetDownloadResultUtilityTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -126,11 +126,17 @@ namespace NuGet.Protocol.Tests
                     Assert.EndsWith(".nugetdirectdownload", Path.GetFileName(files[0]));
                     Assert.EndsWith(".nugetdirectdownload", Path.GetFileName(files[1]));
 
-                    var actualContentA = new StreamReader(resultA.PackageStream).ReadToEnd();
-                    Assert.Equal(expectedContent, actualContentA);
+                    using (var reader = new StreamReader(resultA.PackageStream))
+                    {
+                        var actualContentA = reader.ReadToEnd();
+                        Assert.Equal(expectedContent, actualContentA);
+                    }
 
-                    var actualContentB = new StreamReader(resultB.PackageStream).ReadToEnd();
-                    Assert.Equal(expectedContent, actualContentB);
+                    using (var reader = new StreamReader(resultB.PackageStream))
+                    {
+                        var actualContentB = reader.ReadToEnd();
+                        Assert.Equal(expectedContent, actualContentB);
+                    }
                 }
 
                 Assert.Equal(0, Directory.EnumerateFileSystemEntries(downloadDirectory).Count());

--- a/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
+++ b/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
@@ -43,7 +43,7 @@ namespace Test.Utility
   </config>
 </configuration>";
 
-        public TestSolutionManager(bool foo)
+        public TestSolutionManager()
         {
             TestDirectory = TestDirectory.Create();
             SolutionDirectory = TestDirectory;

--- a/test/TestUtilities/Test.Utility/Protocol/TestSourceCacheContext.cs
+++ b/test/TestUtilities/Test.Utility/Protocol/TestSourceCacheContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Protocol.Core.Types;
@@ -9,12 +9,12 @@ namespace NuGet.Protocol.Test
     /// <summary>
     /// This is a test source cache context that should be used in places where it is not convenient to dispose the
     /// <see cref="SourceCacheContext"/>. Since <see cref="SourceCacheContext.GeneratedTempFolder"/> must be called
-    /// before <see cref="SourceCacheContext.Dispose"/> does anything meaningful, this implementation disables that
+    /// before <see cref="SourceCacheContext.Dispose()"/> does anything meaningful, this implementation disables that
     /// property.
     /// </summary>
-    public class TestSourceCacheContext : SourceCacheContext
+    public sealed class TestSourceCacheContext : SourceCacheContext
     {
-        private string _testDirectory;
+        private TestDirectory _testDirectory;
 
         public override string GeneratedTempFolder
         {
@@ -27,6 +27,13 @@ namespace NuGet.Protocol.Test
 
                 return _testDirectory;
             }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _testDirectory?.Dispose();
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/Signing/CertificateRevocationList.cs
+++ b/test/TestUtilities/Test.Utility/Signing/CertificateRevocationList.cs
@@ -76,10 +76,13 @@ namespace Test.Utility.Signing
 
         public void ExportCrl()
         {
-            var pemWriter = new PemWriter(new StreamWriter(File.Open(CrlLocalPath, FileMode.Create)));
-            pemWriter.WriteObject(Crl);
-            pemWriter.Writer.Flush();
-            pemWriter.Writer.Close();
+            using (var streamWriter = new StreamWriter(File.Open(CrlLocalPath, FileMode.Create)))
+            {
+                var pemWriter = new PemWriter(streamWriter);
+                pemWriter.WriteObject(Crl);
+                pemWriter.Writer.Flush();
+                pemWriter.Writer.Close();
+            }
         }
 
         private void UpdateVersion()


### PR DESCRIPTION
Resolve https://github.com/NuGet/Home/issues/8328.

Basically, call `IDisposable.Dispose()` wherever possible.

This PR cleans up a lot of test files/folders under `%TEMP%\NuGetScratch` and `<RepositoryRoot>\.test`.