### PR TITLE
Parallelize Functional_Tests_On_Windows

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -130,7 +130,7 @@
     Build, Pack, Core Tests, Unit tests for VS
     ============================================================
   -->
-  <Target Name="RunVS"  DependsOnTargets="BuildVS;Pack;CoreUnitTests;UnitTestsVS">
+  <Target Name="RunVS" DependsOnTargets="BuildVS;Pack;CoreUnitTests;UnitTestsVS">
     <Message Text="Running NuGet Build for VS $(VisualStudioVersion)" Importance="high" />
   </Target>
 
@@ -354,40 +354,47 @@
     <MakeDir Directories="$(TestResultsDirectory)" />
 
     <PropertyGroup>
+      <TestResultOutputFormat Condition=" '$(TestResultOutputFormat)' == '' ">xml</TestResultOutputFormat>
+      <TestResultsXunit Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)\$(TestResultsFileName)-xunit.$(TestResultOutputFormat)</TestResultsXunit>
+      <TestResultsVsts Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)\$(TestResultsFileName)-vsts.$(TestResultOutputFormat)</TestResultsVsts>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(SkipDesktopAssemblies)' != 'true' ">
       <!-- Sort assemblies -->
       <DesktopInputTestAssemblies>@(TestAssemblyPath->WithMetadataValue("IsDesktop", "true"))</DesktopInputTestAssemblies>
       <DesktopInputTestAssembliesSpaced>$(DesktopInputTestAssemblies.Replace(';', ' '))</DesktopInputTestAssembliesSpaced>
-      <CoreInputTestAssemblies>@(TestAssemblyPath->WithMetadataValue("IsCore", "true"))</CoreInputTestAssemblies>
-      <CoreInputTestAssembliesSpaced>$(CoreInputTestAssemblies.Replace(';', ' '))</CoreInputTestAssembliesSpaced>
       
-      <TestResultOutputFormat Condition="'$(TestResultOutputFormat)' == ''">xml</TestResultOutputFormat>
       <!-- Build exe commands -->
-      <TestResultsXunit Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)\$(TestResultsFileName)-xunit.$(TestResultOutputFormat)</TestResultsXunit>
-      <TestResultsVsts Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)\$(TestResultsFileName)-vsts.$(TestResultOutputFormat)</TestResultsVsts>
-      <VsTestLogger>--TestAdapterPath:$(XunitXmlLoggerDirectory) --logger:xunit;LogFileName=$(TestResultsFileName)-vsts.$(TestResultOutputFormat)</VsTestLogger>
-      <VSTestCommand>$(DotnetExePath) vstest $(CoreInputTestAssembliesSpaced) $(VsTestLogger)</VSTestCommand>
       <DesktopTestCommand>$(XunitConsoleExePath) $(DesktopInputTestAssembliesSpaced)</DesktopTestCommand>
       <DesktopTestCommand Condition=" '$(TestResultsXunit)' != '' ">$(DesktopTestCommand) -$(TestResultOutputFormat) $(TestResultsXunit) $(Verbosity)</DesktopTestCommand>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(SkipCoreAssemblies)' != 'true' ">
+      <CoreInputTestAssemblies>@(TestAssemblyPath->WithMetadataValue("IsCore", "true"))</CoreInputTestAssemblies>
+      <CoreInputTestAssembliesSpaced>$(CoreInputTestAssemblies.Replace(';', ' '))</CoreInputTestAssembliesSpaced>
+
+      <VsTestLogger>--TestAdapterPath:$(XunitXmlLoggerDirectory) --logger:xunit;LogFileName=$(TestResultsFileName)-vsts.$(TestResultOutputFormat)</VsTestLogger>      
+      <VSTestCommand>$(DotnetExePath) vstest $(CoreInputTestAssembliesSpaced) $(VsTestLogger)</VSTestCommand>
     </PropertyGroup>
 
     <!-- Desktop -->
     <Exec Command="$(DesktopTestCommand)"
           ContinueOnError="true"
-          Condition=" '$(DesktopInputTestAssemblies)' != '' AND '$(SkipDesktopTests)' != 'true' ">
+          Condition=" '$(SkipDesktopAssemblies)' != 'true' AND '$(DesktopInputTestAssemblies)' != '' AND '$(SkipDesktopTests)' != 'true' ">
       <Output TaskParameter="ExitCode" PropertyName="DesktopTestErrorCode"/>
     </Exec>
 
     <!-- VSTest/NETCore -->
     <Exec Command="$(VSTestCommand)"
           ContinueOnError="true"
-          Condition=" '$(CoreInputTestAssemblies)' != '' AND '$(SkipCoreTests)' != 'true' ">
+          Condition=" '$(SkipCoreAssemblies)' != 'true' AND '$(CoreInputTestAssemblies)' != '' AND '$(SkipCoreTests)' != 'true' ">
       <Output TaskParameter="ExitCode" PropertyName="VSTestErrorCode"/>
     </Exec>
 
-    <Error Text="Desktop $(TestResultsFileName) tests failed! Results: $(TestResultsXunit)" Condition=" '$(DesktopTestErrorCode)' != '0' AND '$(DesktopTestErrorCode)' != '' " />
-    <Error Text="NETCore $(TestResultsFileName) tests failed! Results: $(TestResultsVsts)" Condition=" '$(VSTestErrorCode)' != '0' AND '$(VSTestErrorCode)' != '' " />
+    <Error Text="Desktop $(TestResultsFileName) tests failed! Results: $(TestResultsXunit)" Condition=" '$(SkipDesktopAssemblies)' != 'true' AND '$(DesktopTestErrorCode)' != '0' AND '$(DesktopTestErrorCode)' != '' " />
+    <Error Text="NETCore $(TestResultsFileName) tests failed! Results: $(TestResultsVsts)" Condition=" '$(SkipCoreAssemblies)' != 'true' AND '$(VSTestErrorCode)' != '0' AND '$(VSTestErrorCode)' != '' " />
 
-    <Message Text="Desktop $(TestResultsFileName) tests passed! Results: $(TestResultsXunit)" Condition=" '$(DesktopTestErrorCode)' == '0' " Importance="High" />
-    <Message Text="NETCore $(TestResultsFileName) tests passed! Results: $(TestResultsVsts)" Condition=" '$(VSTestErrorCode)' == '0' " Importance="High" />
+    <Message Text="Desktop $(TestResultsFileName) tests passed! Results: $(TestResultsXunit)" Condition=" '$(SkipDesktopAssemblies)' != 'true' AND '$(DesktopTestErrorCode)' == '0' " Importance="High" />
+    <Message Text="NETCore $(TestResultsFileName) tests passed! Results: $(TestResultsVsts)" Condition=" '$(SkipCoreAssemblies)' != 'true' AND '$(VSTestErrorCode)' == '0' " Importance="High" />
   </Target>
 </Project>

--- a/build/build.proj
+++ b/build/build.proj
@@ -380,14 +380,14 @@
     <!-- Desktop -->
     <Exec Command="$(DesktopTestCommand)"
           ContinueOnError="true"
-          Condition=" '$(SkipDesktopAssemblies)' != 'true' AND '$(DesktopInputTestAssemblies)' != '' AND '$(SkipDesktopTests)' != 'true' ">
+          Condition=" '$(SkipDesktopAssemblies)' != 'true' AND '$(DesktopInputTestAssemblies)' != '' ">
       <Output TaskParameter="ExitCode" PropertyName="DesktopTestErrorCode"/>
     </Exec>
 
     <!-- VSTest/NETCore -->
     <Exec Command="$(VSTestCommand)"
           ContinueOnError="true"
-          Condition=" '$(SkipCoreAssemblies)' != 'true' AND '$(CoreInputTestAssemblies)' != '' AND '$(SkipCoreTests)' != 'true' ">
+          Condition=" '$(SkipCoreAssemblies)' != 'true' AND '$(CoreInputTestAssemblies)' != '' ">
       <Output TaskParameter="ExitCode" PropertyName="VSTestErrorCode"/>
     </Exec>
 

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -441,7 +441,12 @@ phases:
     demands: 
         - DotNetFramework
         - msbuild
-
+    matrix:
+      IsDesktop:
+        SkipCoreAssemblies: "true"
+      IsCore:
+        SkipDesktopAssemblies: "true"
+        
   steps:
   - task: PowerShell@1
     displayName: "Print Environment Variables"
@@ -483,7 +488,7 @@ phases:
       solution: "build\\build.proj"
       msbuildVersion: "16.0"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:CoreFuncTests /p:BuildRTM=false /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml"
+      msbuildArguments: "/t:CoreFuncTests /p:BuildRTM=false /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipDesktopAssemblies=$(SkipDesktopAssemblies) /p:SkipCoreAssemblies=$(SkipCoreAssemblies)"
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
@@ -503,7 +508,7 @@ phases:
       arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
       inlineScript: |
         . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
-        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -TestName "Functional Tests On Windows"
+        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -TestName "$env:AGENT_JOBNAME"
     condition: "always()"
 
 - phase: Tests_On_Linux

--- a/scripts/utils/PostGitCommitStatus.ps1
+++ b/scripts/utils/PostGitCommitStatus.ps1
@@ -14,7 +14,7 @@ Function Update-GitCommitStatus {
         [Parameter(Mandatory = $True)]
         [string]$PersonalAccessToken,
         [Parameter(Mandatory = $True)]
-        [ValidateSet( "Unit Tests On Windows", "Tests On Mac", "Tests On Linux", "Functional Tests On Windows", "EndToEnd Tests On Windows", "Apex Tests On Windows", "Rebuild")]
+        [ValidateSet( "Unit Tests On Windows", "Tests On Mac", "Tests On Linux", "Functional_Tests_On_Windows IsDesktop", "Functional_Tests_On_Windows IsCore", "EndToEnd Tests On Windows", "Apex Tests On Windows", "Rebuild")]
         [string]$TestName,
         [Parameter(Mandatory = $True)]
         [ValidateSet( "pending", "success", "error", "failure")]
@@ -58,11 +58,14 @@ Function InitializeAllTestsToPending {
     Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Unit Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
     if($env:RunFunctionalTestsOnWindows -eq "true")
     {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional Tests On Windows" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+        # Setup individual states for the matrixing of jobs in "Functional Tests On Windows".
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional_Tests_On_Windows IsDesktop" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional_Tests_On_Windows IsCore" -Status "pending" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "in progress"
     } 
     else 
     {
-        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional Tests On Windows" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional_Tests_On_Windows IsDesktop" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
+        Update-GitCommitStatus -PersonalAccessToken $PersonalAccessToken -TestName "Functional_Tests_On_Windows IsCore" -Status "success" -CommitSha $CommitSha -TargetUrl $env:BUILDURL -Description "skipped"
     }
     if($env:RunTestsOnMac -eq "true")
     {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8063
Regression: No

## Fix

The Build Phase, "Functional_Tests_On_Windows" has been split up by assembly based on their IsDesktop and IsCore flags. 

Two new phases:
- "Functional_Tests_On_Windows IsDesktop"
- "Functional_Tests_On_Windows IsCore"

The existing phase ran in just under/over 2 hours (eg, [Build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2844806) ran this phase for 1hr 45m. The two new phases can run in parallel, which achieved total runtime of an 1hr 12m (eg, [Build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2847379) ran the new IsDesktop phase for 1hr 12m and the new IsCore phase for 1hr 3m, running simultaneously). There's overhead with splitting the phases, but this seems like a good first step in keeping our CI manageable.   

@heng-liu  is currently [working on](https://github.com/NuGet/Home/issues/8043) adding another TFM which will lengthen the runtime of the Core tests. This work will increase the occurrence of the current timeouts.

The CI status embedded in GitHub's commit view will reflect both phases.

~~Additionally, the Test Result XML files from each phase are now available as an Artifact. This XML includes the runtimes of each Assembly, Test Collection, and individual test during the build.~~

Perhaps more insight into how to further improve the runtime will be apparent once this runs on Dev for a while without so many timeouts.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  CI modified
Validation:  Functional Tests on Windows now has 2 phases in our CI, and both completed successfully. GitHub status reflected new phases as In Progress and Succeeded, when expected.
