### PR TITLE
Allow multiple versions in single PackageDownload tag

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -91,7 +91,7 @@ namespace NuGet.SolutionRestoreManager
                 throw new ArgumentNullException(nameof(projectRestoreInfo));
             }
 
-            if (projectRestoreInfo == null && projectRestoreInfo2 == null)
+            if (projectRestoreInfo != null && projectRestoreInfo2 != null)
             {
                 throw new ArgumentException($"Internal error: Both {nameof(projectRestoreInfo)} and {nameof(projectRestoreInfo2)} cannot have values. Please file an issue at NuGet/Home if you see this exception.");
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -652,19 +652,26 @@ namespace NuGet.Commands
             foreach (var item in GetItemByType(items, "DownloadDependency"))
             {
                 var id = item.GetProperty("Id");
-                var versionRange = GetVersionRange(item);
+                var versionString = item.GetProperty("VersionRange");
 
-                if (!(versionRange.HasLowerAndUpperBounds && versionRange.MinVersion.Equals(versionRange.MaxVersion)))
+                var versions = versionString.Split(';');
+
+                foreach (var version in versions)
                 {
-                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_PackageDownload_OnlyExactVersionsAreAllowed, versionRange.OriginalString));
-                }
+                    var versionRange = GetVersionRange(version);
 
-                var downloadDependency = new DownloadDependency(id, versionRange);
-                var frameworks = GetFrameworks(item);
+                    if (!(versionRange.HasLowerAndUpperBounds && versionRange.MinVersion.Equals(versionRange.MaxVersion)))
+                    {
+                        throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_PackageDownload_OnlyExactVersionsAreAllowed, versionRange.OriginalString));
+                    }
 
-                foreach (var framework in frameworks)
-                {
-                    AddDownloadDependencyIfNotExist(spec, framework, downloadDependency);
+                    var downloadDependency = new DownloadDependency(id, versionRange);
+                    var frameworks = GetFrameworks(item);
+
+                    foreach (var framework in frameworks)
+                    {
+                        AddDownloadDependencyIfNotExist(spec, framework, downloadDependency);
+                    }
                 }
             }
         }
@@ -723,7 +730,11 @@ namespace NuGet.Commands
         private static VersionRange GetVersionRange(IMSBuildItem item)
         {
             var rangeString = item.GetProperty("VersionRange");
+            return GetVersionRange(rangeString);
+        }
 
+        private static VersionRange GetVersionRange(string rangeString)
+        {
             if (!string.IsNullOrEmpty(rangeString))
             {
                 return VersionRange.Parse(rangeString);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -647,31 +647,15 @@ namespace NuGet.Commands
             }
         }
 
-        private static void AddPackageDownloads(PackageSpec spec, IEnumerable<IMSBuildItem> items)
+        internal static void AddPackageDownloads(PackageSpec spec, IEnumerable<IMSBuildItem> items)
         {
+            var splitChars = new[] { ';' };
+
             foreach (var item in GetItemByType(items, "DownloadDependency"))
             {
                 var id = item.GetProperty("Id");
                 var versionString = item.GetProperty("VersionRange");
-
-                // If there are multiple package download elements in the project for the same package id, only the first is used.
-                // But, the project might multi-target, and the package download is for one target, so we must check each tfm.
-                var frameworks = GetFrameworks(item).ToList();
-                for (int i = 0; i < frameworks.Count; i++)
-                {
-                    if (spec.GetTargetFramework(frameworks[i]).DownloadDependencies.Any(d => d.Name == id))
-                    {
-                        frameworks.RemoveAt(i);
-                        i--;
-                    }
-                }
-
-                if (frameworks.Count == 0)
-                {
-                    continue;
-                }
-
-                var versions = versionString.Split(';');
+                var versions = versionString.Split(splitChars, StringSplitOptions.RemoveEmptyEntries);
 
                 foreach (var version in versions)
                 {
@@ -684,6 +668,7 @@ namespace NuGet.Commands
 
                     var downloadDependency = new DownloadDependency(id, versionRange);
 
+                    var frameworks = GetFrameworks(item);
                     foreach (var framework in frameworks)
                     {
                         AddDownloadDependencyIfNotExist(spec, framework, downloadDependency);

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -852,6 +852,10 @@ namespace NuGet.ProjectModel
 
         private static void PopulateDownloadDependencies(IList<DownloadDependency> downloadDependencies, JObject properties, string packageSpecPath)
         {
+            var splitChars = new[] { ';' };
+
+            var seenIds = new HashSet<string>();
+
             var downloadDependenciesProperty = properties["downloadDependencies"] as JArray;
             if (downloadDependenciesProperty != null)
             {
@@ -865,6 +869,11 @@ namespace NuGet.ProjectModel
                             packageSpecPath);
                     }
                     var name = dependency["name"].Value<string>();
+                    if (!seenIds.Add(name))
+                    {
+                        // package ID already seen, only use first definition.
+                        continue;
+                    }
 
                     string versionValue = null;
 
@@ -879,7 +888,7 @@ namespace NuGet.ProjectModel
 
                     if (!string.IsNullOrEmpty(versionValue))
                     {
-                        var versions = versionValue.Split(';');
+                        var versions = versionValue.Split(splitChars, StringSplitOptions.RemoveEmptyEntries);
                         foreach (var singleVersionValue in versions)
                         {
                             try

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -879,16 +879,21 @@ namespace NuGet.ProjectModel
 
                     if (!string.IsNullOrEmpty(versionValue))
                     {
-                        try
+                        var versions = versionValue.Split(';');
+                        foreach (var singleVersionValue in versions)
                         {
-                            version = VersionRange.Parse(versionValue);
-                        }
-                        catch (Exception ex)
-                        {
-                            throw FileFormatException.Create(
-                                ex,
-                                dependencyVersionToken,
-                                packageSpecPath);
+                            try
+                            {
+                                version = VersionRange.Parse(singleVersionValue);
+                                downloadDependencies.Add(new DownloadDependency(name, version));
+                            }
+                            catch (Exception ex)
+                            {
+                                throw FileFormatException.Create(
+                                    ex,
+                                    dependencyVersionToken,
+                                    packageSpecPath);
+                            }
                         }
                     }
                     else
@@ -898,8 +903,6 @@ namespace NuGet.ProjectModel
                                 dependencyVersionToken,
                                 packageSpecPath);
                     }
-
-                    downloadDependencies.Add(new DownloadDependency(name, version));
                 }
             }
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -473,11 +473,13 @@ namespace NuGet.ProjectModel
 
             writer.WriteArrayStart("downloadDependencies");
 
-            foreach (var dependency in downloadDependencies.OrderBy(dep => dep))
+            foreach (var dependency in downloadDependencies.GroupBy(dep => dep.Name).OrderBy(dep => dep.Key))
             {
+                var version = string.Join(";", dependency.Select(dep => dep.VersionRange).OrderBy(dep => dep.MinVersion).Select(dep => dep.ToNormalizedString()));
+
                 writer.WriteObjectInArrayStart();
-                SetValue(writer, "name", dependency.Name);
-                SetValue(writer, "version", dependency.VersionRange.ToNormalizedString());
+                SetValue(writer, "name", dependency.Key);
+                SetValue(writer, "version", version);
                 writer.WriteObjectEnd();
 
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -6949,9 +6949,9 @@ namespace NuGet.CommandLine.Test
                 Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.Count);
                 Assert.Equal(2, lockFile.PackageSpec.TargetFrameworks.First().DownloadDependencies.Count);
                 Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().Name);
-                Assert.Equal($"[{packageX2.Version}, {packageX2.Version}]", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().VersionRange.ToNormalizedString());
+                Assert.Equal($"[{packageX1.Version}, {packageX1.Version}]", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().VersionRange.ToNormalizedString());
                 Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.Last().Name);
-                Assert.Equal($"[{packageX1.Version}, {packageX1.Version}]", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.Last().VersionRange.ToNormalizedString());
+                Assert.Equal($"[{packageX2.Version}, {packageX2.Version}]", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.Last().VersionRange.ToNormalizedString());
 
                 Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX1.Identity.Id, packageX1.Version)), $"{packageX1.ToString()} is not installed");
                 Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX2.Identity.Id, packageX2.Version)), $"{packageX2.ToString()} is not installed");

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -6831,7 +6831,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public async Task RestoreNetCore_SingleTFM_SameIdMultiPackageDownload()
+        public async Task RestoreNetCore_SingleTFM_InstallFirstPackageDownload()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -6888,81 +6888,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public async Task RestoreNetCore_SingleTFM_SameIdSameVersionMultiDeclaration_SinglePackageDownload()
-        {
-            // Arrange
-            using (var pathContext = new SimpleTestPathContext())
-            {
-                // Set up solution, project, and packages
-                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-                var projectFrameworks = "net46";
-
-                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
-                            projectName: "a",
-                            solutionRoot: pathContext.SolutionRoot,
-                            frameworks: MSBuildStringUtility.Split(projectFrameworks));
-
-                var packageX1 = new SimpleTestPackageContext()
-                {
-                    Id = "x",
-                    Version = "1.0.0"
-                };
-
-                var packageX2 = new SimpleTestPackageContext()
-                {
-                    Id = "x",
-                    Version = "2.0.0"
-                };
-
-                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    pathContext.PackageSource,
-                    packageX1,
-                    packageX2);
-
-                projectA.AddPackageDownloadToAllFrameworks(packageX1);
-                projectA.AddPackageDownloadToAllFrameworks(packageX2);
-
-                solution.Projects.Add(projectA);
-                solution.Create(pathContext.SolutionRoot);
-
-                // Add one more - Adding them through the Test Context adds only exact versions.
-
-                var xml = projectA.GetXML();
-
-                var props = new Dictionary<string, string>();
-                var attributes = new Dictionary<string, string>();
-                attributes.Add("Version", "[1.0.0, 1.0.0]");
-                ProjectFileUtils.AddItem(
-                                    xml,
-                                    "PackageDownload",
-                                    packageX1.Id,
-                                    NuGetFramework.AnyFramework,
-                                    props,
-                                    attributes);
-
-                xml.Save(projectA.ProjectPath);
-
-                // Act
-                var r = Util.RestoreSolution(pathContext);
-
-                // Assert
-                Assert.True(r.Success, r.AllOutput);
-                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.AllOutput);
-
-                var lockFile = LockFileUtilities.GetLockFile(projectA.AssetsFileOutputPath, Common.NullLogger.Instance);
-                Assert.Equal(0, lockFile.Libraries.Count);
-                Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.Count);
-                Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks[0].DownloadDependencies.Count);
-                Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks[0].DownloadDependencies[0].Name);
-                Assert.Equal($"[{packageX1.Version}, {packageX1.Version}]", lockFile.PackageSpec.TargetFrameworks[0].DownloadDependencies[0].VersionRange.ToNormalizedString());
-
-                Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX1.Identity.Id, packageX1.Version)), $"{packageX1.ToString()} is not installed");
-                Assert.False(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX2.Identity.Id, packageX2.Version)), $"{packageX2.ToString()} should not be installed");
-            }
-        }
-
-        [Fact]
-        public async Task RestoreNetCore_SingleTFM_SameIdMultipleVersionsSingleDeclaration_MultiPackageDownload()
+        public async Task RestoreNetCore_SingleTFM_SameIdMultipleVersions_MultiPackageDownload()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -6878,19 +6878,17 @@ namespace NuGet.CommandLine.Test
                 var lockFile = LockFileUtilities.GetLockFile(projectA.AssetsFileOutputPath, Common.NullLogger.Instance);
                 Assert.Equal(0, lockFile.Libraries.Count);
                 Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.Count);
-                Assert.Equal(2, lockFile.PackageSpec.TargetFrameworks.First().DownloadDependencies.Count);
-                Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().Name);
-                Assert.Equal($"[{packageX2.Version}, {packageX2.Version}]", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().VersionRange.ToNormalizedString());
-                Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.Last().Name);
-                Assert.Equal($"[{packageX1.Version}, {packageX1.Version}]", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.Last().VersionRange.ToNormalizedString());
+                Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks[0].DownloadDependencies.Count);
+                Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks[0].DownloadDependencies[0].Name);
+                Assert.Equal($"[{packageX1.Version}, {packageX1.Version}]", lockFile.PackageSpec.TargetFrameworks[0].DownloadDependencies[0].VersionRange.ToNormalizedString());
 
                 Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX1.Identity.Id, packageX1.Version)), $"{packageX1.ToString()} is not installed");
-                Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX2.Identity.Id, packageX2.Version)), $"{packageX2.ToString()} is not installed");
+                Assert.False(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX2.Identity.Id, packageX2.Version)), $"{packageX2.ToString()} should not be installed");
             }
         }
 
         [Fact]
-        public async Task RestoreNetCore_SingleTFM_SameIdSameVersionMultiDeclaration_MultiPackageDownload()
+        public async Task RestoreNetCore_SingleTFM_SameIdSameVersionMultiDeclaration_SinglePackageDownload()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -6954,14 +6952,12 @@ namespace NuGet.CommandLine.Test
                 var lockFile = LockFileUtilities.GetLockFile(projectA.AssetsFileOutputPath, Common.NullLogger.Instance);
                 Assert.Equal(0, lockFile.Libraries.Count);
                 Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.Count);
-                Assert.Equal(2, lockFile.PackageSpec.TargetFrameworks.First().DownloadDependencies.Count);
-                Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().Name);
-                Assert.Equal($"[{packageX2.Version}, {packageX2.Version}]", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.First().VersionRange.ToNormalizedString());
-                Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.Last().Name);
-                Assert.Equal($"[{packageX1.Version}, {packageX1.Version}]", lockFile.PackageSpec.TargetFrameworks.Last().DownloadDependencies.Last().VersionRange.ToNormalizedString());
+                Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks[0].DownloadDependencies.Count);
+                Assert.Equal("x", lockFile.PackageSpec.TargetFrameworks[0].DownloadDependencies[0].Name);
+                Assert.Equal($"[{packageX1.Version}, {packageX1.Version}]", lockFile.PackageSpec.TargetFrameworks[0].DownloadDependencies[0].VersionRange.ToNormalizedString());
 
                 Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX1.Identity.Id, packageX1.Version)), $"{packageX1.ToString()} is not installed");
-                Assert.True(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX2.Identity.Id, packageX2.Version)), $"{packageX2.ToString()} is not installed");
+                Assert.False(Directory.Exists(Path.Combine(pathContext.UserPackagesFolder, packageX2.Identity.Id, packageX2.Version)), $"{packageX2.ToString()} should not be installed");
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -1287,7 +1287,7 @@ namespace NuGet.SolutionRestoreManager.Test
         }
 
         [Fact]
-        public async Task NominateProjectAsync_PackageDownload_AllowsDuplicateIds()
+        public async Task NominateProjectAsync_PackageDownload_IgnoreDuplicateIds()
         {
             var consoleAppProjectJson = @"{
     ""frameworks"": {
@@ -1336,13 +1336,13 @@ namespace NuGet.SolutionRestoreManager.Test
             AssertPackages(actualTfi,
                 "NuGet.Protocol:5.1.0");
             AssertDownloadPackages(actualTfi,
-                "NetCoreTargetingPack:[1.0.0]",
-                "NetCoreTargetingPack:[2.0.0]"
-                );
+                "NetCoreTargetingPack:[1.0.0]");
         }
 
-        [Fact]
-        public async Task NominateProjectAsync_PackageDownload_AllowsVersionList()
+        [Theory]
+        [InlineData("[1.0.0];[2.0.0]")]
+        [InlineData(";[1.0.0];;[2.0.0];")]
+        public async Task NominateProjectAsync_PackageDownload_AllowsVersionList(string versionString)
         {
             var consoleAppProjectJson = @"{
     ""frameworks"": {
@@ -1354,7 +1354,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 },
             },
             ""downloadDependencies"": [
-                {""name"" : ""NetCoreTargetingPack"", ""version"" : ""[1.0.0];[2.0.0]""}
+                {""name"" : ""NetCoreTargetingPack"", ""version"" : """ + versionString + @"""}
             ]
             }
         }
@@ -1391,8 +1391,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 "NuGet.Protocol:5.1.0");
             AssertDownloadPackages(actualTfi,
                 "NetCoreTargetingPack:[1.0.0]",
-                "NetCoreTargetingPack:[2.0.0]"
-                );
+                "NetCoreTargetingPack:[2.0.0]");
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestorePackageDownloadsTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestorePackageDownloadsTaskTests.cs
@@ -1,0 +1,165 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xunit;
+
+namespace NuGet.Build.Tasks.Test
+{
+    public class GetRestorePackageDownloadsTaskTests
+    {
+        [Fact]
+        public void Execute_CheckAllMetadata()
+        {
+            // Arrange
+            var buildEngine = new TestBuildEngine();
+
+            var packageX = new TaskItem();
+            packageX.ItemSpec = "x";
+            packageX.SetMetadata("Version", "[1.0.0]");
+
+            var packageDownloads = new List<ITaskItem>()
+            {
+                packageX
+            };
+
+            var task = new GetRestorePackageDownloadsTask()
+            {
+                BuildEngine = buildEngine,
+                ProjectUniqueName = "MyProj",
+                TargetFrameworks = "netstandard2.0",
+                PackageDownloads = packageDownloads.ToArray()
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result, "Task failed");
+            Assert.Equal(1, task.RestoreGraphItems.Length);
+            Assert.Equal("x", task.RestoreGraphItems[0].GetMetadata("Id"));
+            Assert.Equal(task.ProjectUniqueName, task.RestoreGraphItems[0].GetMetadata("ProjectUniqueName"));
+            Assert.Equal("DownloadDependency", task.RestoreGraphItems[0].GetMetadata("Type"));
+            Assert.Equal("[1.0.0]", task.RestoreGraphItems[0].GetMetadata("VersionRange"));
+            Assert.Equal("netstandard2.0", task.RestoreGraphItems[0].GetMetadata("TargetFrameworks"));
+        }
+
+        [Fact]
+        public void Execute_UseFirstVersionPerId()
+        {
+            // Arrange
+            var buildEngine = new TestBuildEngine();
+
+            var packageX1 = new TaskItem();
+            packageX1.ItemSpec = "x";
+            packageX1.SetMetadata("Version", "[1.0.0]");
+
+            var packageX2 = new TaskItem();
+            packageX2.ItemSpec = "x";
+            packageX2.SetMetadata("Version", "[2.0.0]");
+
+            var packageDownloads = new List<ITaskItem>()
+            {
+                packageX1,
+                packageX2
+            };
+
+            var task = new GetRestorePackageDownloadsTask()
+            {
+                BuildEngine = buildEngine,
+                ProjectUniqueName = "MyProj",
+                TargetFrameworks = "netstandard2.0",
+                PackageDownloads = packageDownloads.ToArray()
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result, "Task failed");
+            Assert.Equal(1, task.RestoreGraphItems.Length);
+            Assert.Equal("x", task.RestoreGraphItems[0].GetMetadata("Id"));
+            Assert.Equal("[1.0.0]", task.RestoreGraphItems[0].GetMetadata("VersionRange"));
+        }
+
+        [Fact]
+        public void Execute_AllowMultiRangeVersion()
+        {
+            // Arrange
+            var buildEngine = new TestBuildEngine();
+
+            var packageX = new TaskItem();
+            packageX.ItemSpec = "x";
+            packageX.SetMetadata("Version", "[1.0.0];[2.0.0]");
+
+            var packageDownloads = new List<ITaskItem>()
+            {
+                packageX
+            };
+
+            var task = new GetRestorePackageDownloadsTask()
+            {
+                BuildEngine = buildEngine,
+                ProjectUniqueName = "MyProj",
+                TargetFrameworks = "netstandard2.0",
+                PackageDownloads = packageDownloads.ToArray()
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result, "Task failed");
+            Assert.Equal(1, task.RestoreGraphItems.Length);
+            Assert.Equal("x", task.RestoreGraphItems[0].GetMetadata("Id"));
+            Assert.Equal("[1.0.0];[2.0.0]", task.RestoreGraphItems[0].GetMetadata("VersionRange"));
+        }
+
+        [Fact]
+        public void Execute_AllowMultiplePackages()
+        {
+            // Arrange
+            var buildEngine = new TestBuildEngine();
+
+            var packageX = new TaskItem();
+            packageX.ItemSpec = "x";
+            packageX.SetMetadata("Version", "[1.0.0]");
+
+            var packageY = new TaskItem();
+            packageY.ItemSpec = "y";
+            packageY.SetMetadata("Version", "[2.0.0]");
+
+            var packageDownloads = new List<ITaskItem>()
+            {
+                packageX,
+                packageY
+            };
+
+            var task = new GetRestorePackageDownloadsTask()
+            {
+                BuildEngine = buildEngine,
+                ProjectUniqueName = "MyProj",
+                TargetFrameworks = "netstandard2.0",
+                PackageDownloads = packageDownloads.ToArray()
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result, "Task failed");
+            Assert.Equal(2, task.RestoreGraphItems.Length);
+
+            var package = task.RestoreGraphItems.SingleOrDefault(i => i.GetMetadata("Id") == "x");
+            Assert.NotNull(package);
+            Assert.Equal("[1.0.0]", package.GetMetadata("VersionRange"));
+
+            package = task.RestoreGraphItems.SingleOrDefault(i => i.GetMetadata("Id") == "y");
+            Assert.NotNull(package);
+            Assert.Equal("[2.0.0]", package.GetMetadata("VersionRange"));
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
@@ -938,11 +938,9 @@ namespace NuGet.Commands.Test
                     Assert.Equal("x", lockFile.Targets.First().Libraries.First().Name);
                     Assert.Equal(0, lockFile.LogMessages.Count);
                     Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.Count);
-                    Assert.Equal(2, lockFile.PackageSpec.TargetFrameworks.First().DownloadDependencies.Count);
+                    Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.First().DownloadDependencies.Count);
                     Assert.Equal("y", lockFile.PackageSpec.TargetFrameworks.First().DownloadDependencies.First().Name);
-                    Assert.Equal("y", lockFile.PackageSpec.TargetFrameworks.First().DownloadDependencies.Last().Name);
                     Assert.True(Directory.Exists(Path.Combine(globalPackagesFolder.FullName, "y", "1.0.0"))); // Y 1.0.0 is installed
-                    Assert.True(Directory.Exists(Path.Combine(globalPackagesFolder.FullName, "y", "2.0.0"))); // Y 2.0.0 is installed
                     Assert.True(File.Exists(targetsPath));
                     Assert.True(File.Exists(propsPath));
                 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
@@ -863,8 +863,7 @@ namespace NuGet.Commands.Test
                         ""x"": ""1.0.0""
                     },
                     ""downloadDependencies"": [
-                       {""name"" : ""y"", ""version"" : ""[1.0.0]""},
-                       {""name"" : ""y"", ""version"" : ""[2.0.0]""}
+                       {""name"" : ""y"", ""version"" : ""[1.0.0];[2.0.0]""}
                     ]
                 }
               }
@@ -938,9 +937,11 @@ namespace NuGet.Commands.Test
                     Assert.Equal("x", lockFile.Targets.First().Libraries.First().Name);
                     Assert.Equal(0, lockFile.LogMessages.Count);
                     Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.Count);
-                    Assert.Equal(1, lockFile.PackageSpec.TargetFrameworks.First().DownloadDependencies.Count);
+                    Assert.Equal(2, lockFile.PackageSpec.TargetFrameworks.First().DownloadDependencies.Count);
                     Assert.Equal("y", lockFile.PackageSpec.TargetFrameworks.First().DownloadDependencies.First().Name);
+                    Assert.Equal("y", lockFile.PackageSpec.TargetFrameworks.First().DownloadDependencies.Last().Name);
                     Assert.True(Directory.Exists(Path.Combine(globalPackagesFolder.FullName, "y", "1.0.0"))); // Y 1.0.0 is installed
+                    Assert.True(Directory.Exists(Path.Combine(globalPackagesFolder.FullName, "y", "2.0.0"))); // Y 2.0.0 is installed
                     Assert.True(File.Exists(targetsPath));
                     Assert.True(File.Exists(propsPath));
                 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -60,9 +60,8 @@ namespace NuGet.ProjectModel.Test
                             }
                         },
                         ""downloadDependencies"": [
-                            {""name"" : ""a"", ""version"" : ""[1.0.0, )""},
-                            {""name"" : ""b"", ""version"" : ""[2.0.0, )""},
-                            {""name"" : ""b"", ""version"" : ""[2.0.0, )""}
+                            {""name"" : ""a"", ""version"" : ""[1.0.0, 1.0.0]""},
+                            {""name"" : ""b"", ""version"" : ""[1.0.0, 1.0.0];[2.0.0, 2.0.0]""}
                         ]
                     }
                   }


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8074
Regression: No  
* Last working version:  
* How are we preventing it in future:   

## Fix

Details: split version by `;`, then create a download dependency for each.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
