### PR TITLE
Linux Tests now has TMP Cleanup

### DIFF
--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -157,4 +157,7 @@ esac
 
 popd
 
+# Cleanup TMP directory
+rm "/tmp/"dotnet.* -rf
+
 exit $RESULTCODE

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -54,6 +54,10 @@ cli/dotnet-install.sh -i cli -c $DOTNET_BRANCH
 # Display current version
 $DOTNET --version
 
+# Cleanup TMP directory
+echo "Cleaning TMP directory"
+rm "/tmp/"dotnet.* -rf
+
 echo "================="
 
 # init the repo
@@ -156,8 +160,5 @@ esac
 
 
 popd
-
-# Cleanup TMP directory
-rm "/tmp/"dotnet.* -rf
 
 exit $RESULTCODE


### PR DESCRIPTION
## Bug

Fixes: DDNuGet-Linux machines have been running out of space due to a lot of "dotnet." output to the TMP directory.

## Fix

Details: Remove all dotnet.* from TMP/ during each build as the last step in the script, **runFuncTests.sh**.

## Testing/Validation

Tests Added: No
Validation:  

1. Executed a Build
2. Run `ls /tmp/dotnet* -l` and observe dotnet.* files being created.
3. After script completes, run `ls /tmp/dotnet* -l` and observe all dotnet.* files have been removed.
