### PR TITLE
Fix for "Locked-mode restore fails with sha512 errors & installs new packages when a project's RuntimeIdentifier is changed"

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -46,12 +46,32 @@ namespace NuGet.ProjectModel
             return path;
         }
 
+        /// <summary>
+        /// The lock file will get invalidated if one or more of the below are true
+        ///     1. The target frameworks list of the current project was updated.
+        ///     2. The runtime list of the current project waw updated.
+        ///     3. The packages of the current project were updated.
+        ///     4. The packages of the dependent projects were updated.
+        ///     5. The framework list of the dependent projects were updated with frameworks incompatible with the main project framework.
+        /// </summary>
+        /// <param name="dgSpec">The <see cref="DependencyGraphSpec"/> for the new project defintion.</param>
+        /// <param name="nuGetLockFile">The current <see cref="PackagesLockFile"/>.</param>
+        /// <returns></returns>
         public static bool IsLockFileStillValid(DependencyGraphSpec dgSpec, PackagesLockFile nuGetLockFile)
         {
             var uniqueName = dgSpec.Restore.First();
             var project = dgSpec.GetProjectSpec(uniqueName);
 
             // Validate all the direct dependencies
+            var lockFileFrameworks = nuGetLockFile.Targets
+                .Where(t => t.TargetFramework != null)
+                .Select(t => t.TargetFramework)
+                .Distinct();
+            if (project.TargetFrameworks.Count != lockFileFrameworks.Count())
+            {
+                return false;
+            }
+
             foreach (var framework in project.TargetFrameworks)
             {
                 var target = nuGetLockFile.Targets.FirstOrDefault(
@@ -70,6 +90,15 @@ namespace NuGet.ProjectModel
                     // lock file is out of sync
                     return false;
                 }
+            }
+
+            // Validate the runtimes for the current project did not change.
+            var projectRuntimesKeys = project.RuntimeGraph.Runtimes.Select(r => r.Key).Where(k => k != null);
+            var lockFileRuntimes = nuGetLockFile.Targets.Select(t => t.RuntimeIdentifier).Where(r => r != null);
+
+            if (!projectRuntimesKeys.SequenceEqual(lockFileRuntimes))
+            {
+                return false;
             }
 
             // Validate all P2P references

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -103,7 +103,7 @@ namespace NuGet.ProjectModel
 
             // Validate the runtimes for the current project did not change.
             var projectRuntimesKeys = project.RuntimeGraph.Runtimes.Select(r => r.Key).Where(k => k != null);
-            var lockFileRuntimes = nuGetLockFile.Targets.Select(t => t.RuntimeIdentifier).Where(r => r != null);
+            var lockFileRuntimes = nuGetLockFile.Targets.Select(t => t.RuntimeIdentifier).Where(r => r != null).Distinct();
 
             if (!projectRuntimesKeys.SequenceEqual(lockFileRuntimes))
             {

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -65,7 +65,7 @@ namespace NuGet.ProjectModel
         /// </summary>
         /// <param name="dgSpec">The <see cref="DependencyGraphSpec"/> for the new project defintion.</param>
         /// <param name="nuGetLockFile">The current <see cref="PackagesLockFile"/>.</param>
-        /// <returns></returns>
+        /// <returns>True if the lock file is valid false otherwise. </returns>
         public static bool IsLockFileStillValid(DependencyGraphSpec dgSpec, PackagesLockFile nuGetLockFile)
         {
             var uniqueName = dgSpec.Restore.First();

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -94,7 +94,7 @@ namespace NuGet.ProjectModel
 
             // Validate the runtimes for the current project did not change.
             var projectRuntimesKeys = project.RuntimeGraph.Runtimes.Select(r => r.Key).Where(k => k != null);
-            var lockFileRuntimes = nuGetLockFile.Targets.Select(t => t.RuntimeIdentifier).Where(r => r != null);
+            var lockFileRuntimes = nuGetLockFile.Targets.Select(t => t.RuntimeIdentifier).Where(r => r != null).Distinct();
 
             if (!projectRuntimesKeys.SequenceEqual(lockFileRuntimes))
             {

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -55,12 +55,32 @@ namespace NuGet.ProjectModel
             return Path.Combine(baseDirectory, PackagesLockFileFormat.LockFileName);
         }
 
+        /// <summary>
+        /// The lock file will get invalidated if one or more of the below are true
+        ///     1. The target frameworks list of the current project was updated.
+        ///     2. The runtime list of the current project waw updated.
+        ///     3. The packages of the current project were updated.
+        ///     4. The packages of the dependent projects were updated.
+        ///     5. The framework list of the dependent projects were updated with frameworks incompatible with the main project framework.
+        /// </summary>
+        /// <param name="dgSpec">The <see cref="DependencyGraphSpec"/> for the new project defintion.</param>
+        /// <param name="nuGetLockFile">The current <see cref="PackagesLockFile"/>.</param>
+        /// <returns></returns>
         public static bool IsLockFileStillValid(DependencyGraphSpec dgSpec, PackagesLockFile nuGetLockFile)
         {
             var uniqueName = dgSpec.Restore.First();
             var project = dgSpec.GetProjectSpec(uniqueName);
 
             // Validate all the direct dependencies
+            var lockFileFrameworks = nuGetLockFile.Targets
+                .Where(t => t.TargetFramework != null)
+                .Select(t => t.TargetFramework)
+                .Distinct();
+            if (project.TargetFrameworks.Count != lockFileFrameworks.Count())
+            {
+                return false;
+            }
+
             foreach (var framework in project.TargetFrameworks)
             {
                 var target = nuGetLockFile.Targets.FirstOrDefault(
@@ -79,6 +99,15 @@ namespace NuGet.ProjectModel
                     // lock file is out of sync
                     return false;
                 }
+            }
+
+            // Validate the runtimes for the current project did not change.
+            var projectRuntimesKeys = project.RuntimeGraph.Runtimes.Select(r => r.Key).Where(k => k != null);
+            var lockFileRuntimes = nuGetLockFile.Targets.Select(t => t.RuntimeIdentifier).Where(r => r != null);
+
+            if (!projectRuntimesKeys.SequenceEqual(lockFileRuntimes))
+            {
+                return false;
             }
 
             // Validate all P2P references

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -8568,8 +8568,7 @@ namespace NuGet.CommandLine.Test
                    pathContext.SolutionRoot,
                    new NuGetFramework[]{ NuGetFramework.Parse(tfm) });
 
-                projectA.Properties.Add("RestorePackagesWithLockFile", "true");
-                projectA.Properties.Add("RestoreLockedMode", "true");
+                projectA.Properties.Add("RestorePackagesWithLockFile", "true");             
                 projectA.Properties.Add("RuntimeIdentifiers", string.Join(";", intitialRuntimes));
 
                 solution.Projects.Add(projectA);
@@ -8588,6 +8587,7 @@ namespace NuGet.CommandLine.Test
                 intitialRuntimes.ShouldBeEquivalentTo(lockRuntimes);
 
                 // Setup - change runtimes
+                projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.Properties.Remove("RuntimeIdentifiers");
                 projectA.Properties.Add("RuntimeIdentifiers", string.Join(";", updatedRuntimes));
                 projectA.Save();
@@ -8623,7 +8623,6 @@ namespace NuGet.CommandLine.Test
                    intitialFrameworks.Select(tfm => NuGetFramework.Parse(tfm)).ToArray());
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
-                projectA.Properties.Add("RestoreLockedMode", "true");
                 solution.Projects.Add(projectA);
                 solution.Create(pathContext.SolutionRoot);
 
@@ -8644,6 +8643,7 @@ namespace NuGet.CommandLine.Test
                 lockFrameworkTransformed.ShouldBeEquivalentTo(lockFrameworks);
 
                 // Setup - change frameworks
+                projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.Frameworks = updatedFrameworks.Select(tfm => new SimpleTestProjectFrameworkContext(NuGetFramework.Parse(tfm))).ToList();
                 projectA.Save();
 
@@ -8683,7 +8683,6 @@ namespace NuGet.CommandLine.Test
                    NuGetFramework.Parse(netcoreapp20));
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
-                projectA.Properties.Add("RestoreLockedMode", "true");
 
                 // Set up the package and source
                 var packages = initialPackageIdAndVersion.Select(p =>
@@ -8720,6 +8719,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
 
                 // Setup - change project's packages
+                projectA.Properties.Add("RestoreLockedMode", "true");
                 projectA.CleanPackagesFromAllFrameworks();
                 packages = updatedPackageIdAndVersion.Select(p =>
                 {
@@ -8775,7 +8775,6 @@ namespace NuGet.CommandLine.Test
                    NuGetFramework.Parse(netcoreapp20));
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
-                projectA.Properties.Add("RestoreLockedMode", "true");
 
                 var projectB = SimpleTestProjectContext.CreateNETCore(
                    "b",
@@ -8819,6 +8818,8 @@ namespace NuGet.CommandLine.Test
                 Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
 
                 // Setup - change project's packages
+                projectA.Properties.Add("RestoreLockedMode", "true");
+                projectA.Save();
                 projectB.CleanPackagesFromAllFrameworks();
                 packages = updatedPackageIdAndVersion.Select(p =>
                 {
@@ -8874,7 +8875,6 @@ namespace NuGet.CommandLine.Test
                    NuGetFramework.Parse(netcoreapp20));
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
-                projectA.Properties.Add("RestoreLockedMode", "true");
 
                 var projectB = SimpleTestProjectContext.CreateNETCore(
                    "b",
@@ -8895,6 +8895,8 @@ namespace NuGet.CommandLine.Test
                 Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
 
                 // Setup - change package version
+                projectA.Properties.Add("RestoreLockedMode", "true");
+                projectA.Save();
                 projectB.Frameworks = updatedFrameworks.Select(tfm => new SimpleTestProjectFrameworkContext(NuGetFramework.Parse(tfm))).ToList();
                 projectB.Save();
 
@@ -8930,7 +8932,6 @@ namespace NuGet.CommandLine.Test
                    NuGetFramework.Parse(netcoreapp20));
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
-                projectA.Properties.Add("RestoreLockedMode", "true");
 
                 var projectB = SimpleTestProjectContext.CreateNETCore(
                    "b",
@@ -8951,6 +8952,8 @@ namespace NuGet.CommandLine.Test
                 Assert.True(File.Exists(projectA.NuGetLockFileOutputPath));
 
                 // Setup - change package version
+                projectA.Properties.Add("RestoreLockedMode", "true");
+                projectA.Save();
                 projectB.Frameworks = updatedFrameworks.Select(tfm => new SimpleTestProjectFrameworkContext(NuGetFramework.Parse(tfm))).ToList();
                 projectB.Save();
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -8551,7 +8551,7 @@ namespace NuGet.CommandLine.Test
         [InlineData(new string[] { "win7-x86" }, new string[] { "win-x64" })]
         [InlineData(new string[] { "win7-x86", "net46" }, new string[] { "win-x64" })]
         [InlineData(new string[] { "win7-x86" }, new string[] { "win7-x86", "win-x64" })]
-        public void RestoreNetCoreSDK_PackagesLockFile_WithProjectChangeRuntimeAndLockedMode_FailsRestore(string[] intitialRuntimes, string[] updatedRuntimes)
+        public void RestoreNetCore_PackagesLockFile_WithProjectChangeRuntimeAndLockedMode_FailsRestore(string[] intitialRuntimes, string[] updatedRuntimes)
         {
             // A project with RestoreLockedMode should fail restore if the project's runtime is changed between restores.
             using (var pathContext = new SimpleTestPathContext())
@@ -8560,10 +8560,9 @@ namespace NuGet.CommandLine.Test
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
                 var tfm = "net45";
 
-                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectA = SimpleTestProjectContext.CreateNETCore(
                    "a",
                    pathContext.SolutionRoot,
-                   true,
                    new NuGetFramework[]{ NuGetFramework.Parse(tfm) });
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
@@ -8607,7 +8606,7 @@ namespace NuGet.CommandLine.Test
         [InlineData(new string[] { "net45" }, new string[] { "net46" })]
         [InlineData(new string[] { "net45", "net46" }, new string[] { "net46" })]
         [InlineData(new string[] { "net45" }, new string[] { "net45", "net46" })]
-        public void RestoreNetCoreSDK_PackagesLockFile_WithProjectChangeFramweorksAndLockedMode_FailsRestore(string[] intitialFrameworks, string[] updatedFrameworks)
+        public void RestoreNetCore_PackagesLockFile_WithProjectChangeFramweorksAndLockedMode_FailsRestore(string[] intitialFrameworks, string[] updatedFrameworks)
         {
             // A project with RestoreLockedMode should fail restore if the project's frameworks list is changed between restores.
             using (var pathContext = new SimpleTestPathContext())
@@ -8615,10 +8614,9 @@ namespace NuGet.CommandLine.Test
                 // Set up solution, project, and packages
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
 
-                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectA = SimpleTestProjectContext.CreateNETCore(
                    "a",
                    pathContext.SolutionRoot,
-                   true,
                    intitialFrameworks.Select(tfm => NuGetFramework.Parse(tfm)).ToArray());
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
@@ -8658,11 +8656,11 @@ namespace NuGet.CommandLine.Test
 
 
         [Theory]
-        [InlineData(new string[] { "x/1.0.0" }, new string[] { "x/2.0.0" })]
-        [InlineData(new string[] { "x/1.0.0" }, new string[] { "y/1.0.0" })]
-        [InlineData(new string[] { "x/1.0.0" }, new string[] { "x/1.0.0", "y/1.0.0" })]
-        [InlineData(new string[] { "x/1.0.0", "y/1.0.0" }, new string[] { "y/1.0.0" })]
-        public async Task RestoreNetCoreSDK_PackagesLockFile_WithProjectChangePackageDependencyAndLockedMode_FailsRestore(
+        [InlineData(new string[] { "x_lockmodedepch/1.0.0" }, new string[] { "x_lockmodedepch/2.0.0" })]
+        [InlineData(new string[] { "x_lockmodedepch/1.0.0" }, new string[] { "y_lockmodedepch/1.0.0" })]
+        [InlineData(new string[] { "x_lockmodewdepch/1.0.0" }, new string[] { "x_lockmodedepch/1.0.0", "y_lockmodedepch/1.0.0" })]
+        [InlineData(new string[] { "x_lockmodedepch/1.0.0", "y_lockmodedepch/1.0.0" }, new string[] { "y_lockmodedepch/1.0.0" })]
+        public async Task RestoreNetCore_PackagesLockFile_WithProjectChangePackageDependencyAndLockedMode_FailsRestore(
             string[] initialPackageIdAndVersion,
             string[] updatedPackageIdAndVersion)
         {
@@ -8673,10 +8671,9 @@ namespace NuGet.CommandLine.Test
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
                 var netcoreapp20 = "netcoreapp2.0";
 
-                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectA = SimpleTestProjectContext.CreateNETCore(
                    "a",
                    pathContext.SolutionRoot,
-                   true,
                    NuGetFramework.Parse(netcoreapp20));
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
@@ -8751,11 +8748,11 @@ namespace NuGet.CommandLine.Test
         }
 
         [Theory]
-        [InlineData(new string[] { "x/1.0.0" }, new string[] { "x/2.0.0" })]
-        [InlineData(new string[] { "x/1.0.0" }, new string[] { "y/1.0.0" })]
-        [InlineData(new string[] { "x/1.0.0" }, new string[] { "x/1.0.0", "y/1.0.0" })]
-        [InlineData(new string[] { "x/1.0.0", "y/1.0.0" }, new string[] { "y/1.0.0" })]
-        public async Task RestoreNetCoreSDK_PackagesLockFile_WithDependentProjectChangeIfPackageDependencyAndLockedMode_FailsRestore(
+        [InlineData(new string[] { "x_lockmodetdepch/1.0.0" }, new string[] { "x_lockmodetdepch/2.0.0" })]
+        [InlineData(new string[] { "x_lockmodetdepch/1.0.0" }, new string[] { "y_lockmodetdepch/1.0.0" })]
+        [InlineData(new string[] { "x_lockmodetdepch/1.0.0" }, new string[] { "x_lockmodetdepch/1.0.0", "y_lockmodetdepch/1.0.0" })]
+        [InlineData(new string[] { "x_lockmodetdepch/1.0.0", "y_lockmodetdepch/1.0.0" }, new string[] { "y_lockmodetdepch/1.0.0" })]
+        public async Task RestoreNetCore_PackagesLockFile_WithDependentProjectChangeIfPackageDependencyAndLockedMode_FailsRestore(
            string[] initialPackageIdAndVersion,
            string[] updatedPackageIdAndVersion)
         {
@@ -8766,19 +8763,17 @@ namespace NuGet.CommandLine.Test
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
                 var netcoreapp20 = "netcoreapp2.0";
 
-                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectA = SimpleTestProjectContext.CreateNETCore(
                    "a",
                    pathContext.SolutionRoot,
-                   true,
                    NuGetFramework.Parse(netcoreapp20));
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
 
-                var projectB = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectB = SimpleTestProjectContext.CreateNETCore(
                    "b",
                    pathContext.SolutionRoot,
-                   true,
                    NuGetFramework.Parse(netcoreapp20));
 
                 // Set up the package and source
@@ -8811,7 +8806,7 @@ namespace NuGet.CommandLine.Test
 
                 // Act
                 var r = Util.RestoreSolution(pathContext);
-
+              
                 // Assert
                 r.Success.Should().BeTrue();
                 Assert.True(File.Exists(projectA.AssetsFileOutputPath));
@@ -8855,7 +8850,7 @@ namespace NuGet.CommandLine.Test
         [Theory]
         [InlineData("netcoreapp2.0", new string[] { "netcoreapp2.0" }, new string[] { "netcoreapp2.2" })]
         [InlineData("netcoreapp2.0", new string[] { "netcoreapp2.0", "netcoreapp2.2" }, new string[] { "netcoreapp2.2" })]
-        public void RestoreNetCoreSDK_PackagesLockFile_WithDependentProjectChangeOfNotCompatibleFrameworksAndLockedMode_FailsRestore(
+        public void RestoreNetCore_PackagesLockFile_WithDependentProjectChangeOfNotCompatibleFrameworksAndLockedMode_FailsRestore(
            string mainProjectFramework,
            string[] initialFrameworks,
            string[] updatedFrameworks)
@@ -8868,19 +8863,17 @@ namespace NuGet.CommandLine.Test
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
                 var netcoreapp20 = mainProjectFramework;
 
-                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectA = SimpleTestProjectContext.CreateNETCore(
                    "a",
                    pathContext.SolutionRoot,
-                   true,
                    NuGetFramework.Parse(netcoreapp20));
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
 
-                var projectB = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectB = SimpleTestProjectContext.CreateNETCore(
                    "b",
                    pathContext.SolutionRoot,
-                   true,
                    initialFrameworks.Select(tfm => NuGetFramework.Parse(tfm)).ToArray());
 
                 projectA.AddProjectToAllFrameworks(projectB);
@@ -8913,7 +8906,7 @@ namespace NuGet.CommandLine.Test
         [InlineData("netcoreapp2.2", new string[] { "netcoreapp2.2" }, new string[] { "netcoreapp2.0", "netcoreapp2.2" })]
         [InlineData("netcoreapp2.2", new string[] { "netcoreapp2.0", "netcoreapp2.2" }, new string[] { "netcoreapp2.2" })]
         [InlineData("netcoreapp2.2", new string[] { "netcoreapp2.0"}, new string[] { "netcoreapp2.2" })]
-        public void RestoreNetCoreSDK_PackagesLockFile_WithDependentProjectChangeOfCompatibleFrameworksAndLockedMode_PassRestore(
+        public void RestoreNetCore_PackagesLockFile_WithDependentProjectChangeOfCompatibleFrameworksAndLockedMode_PassRestore(
            string mainProjectFramework,
            string[] initialFrameworks,
            string[] updatedFrameworks)
@@ -8926,19 +8919,17 @@ namespace NuGet.CommandLine.Test
                 var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
                 var netcoreapp20 = mainProjectFramework;
 
-                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectA = SimpleTestProjectContext.CreateNETCore(
                    "a",
                    pathContext.SolutionRoot,
-                   true,
                    NuGetFramework.Parse(netcoreapp20));
 
                 projectA.Properties.Add("RestorePackagesWithLockFile", "true");
                 projectA.Properties.Add("RestoreLockedMode", "true");
 
-                var projectB = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                var projectB = SimpleTestProjectContext.CreateNETCore(
                    "b",
                    pathContext.SolutionRoot,
-                   true,
                    initialFrameworks.Select(tfm => NuGetFramework.Parse(tfm)).ToArray());
 
                 projectA.AddProjectToAllFrameworks(projectB);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -8910,7 +8910,7 @@ namespace NuGet.CommandLine.Test
         [Theory]
         [InlineData("netcoreapp2.2", new string[] { "netcoreapp2.2" }, new string[] { "netcoreapp2.0", "netcoreapp2.2" })]
         [InlineData("netcoreapp2.2", new string[] { "netcoreapp2.0", "netcoreapp2.2" }, new string[] { "netcoreapp2.2" })]
-        [InlineData("netcoreapp2.2", new string[] { "netcoreapp2.0"}, new string[] { "netcoreapp2.2" })]
+        [InlineData("netcoreapp2.2", new string[] { "netcoreapp2.0" }, new string[] { "netcoreapp2.2" })]
         public void RestoreNetCore_PackagesLockFile_WithDependentProjectChangeOfCompatibleFrameworksAndLockedMode_PassRestore(
            string mainProjectFramework,
            string[] initialFrameworks,

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -279,7 +279,7 @@ namespace NuGet.Test.Utility
         {
             foreach (var framework in Frameworks)
             {
-                framework.PackageReferences = new List<SimpleTestPackageContext>();
+                framework.PackageReferences.Clear();
             }
         }
 

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -5,15 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Xml.Linq;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
-using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
+using NuGet.RuntimeModel;
 using NuGet.Versioning;
 
 namespace NuGet.Test.Utility
@@ -273,6 +272,14 @@ namespace NuGet.Test.Utility
             foreach (var framework in Frameworks)
             {
                 framework.PackageReferences.AddRange(packages);
+            }
+        }
+
+        public void CleanPackagesFromAllFrameworks()
+        {
+            foreach (var framework in Frameworks)
+            {
+                framework.PackageReferences = new List<SimpleTestPackageContext>();
             }
         }
 


### PR DESCRIPTION
## Bug
[Locked-mode restore fails with sha512 errors & installs new packages when a project's RuntimeIdentifier is changed](https://github.com/NuGet/Home/issues/8260)

See comments in the [previous pull request](https://github.com/NuGet/NuGet.Client/pull/2920)

Fixes: https://github.com/NuGet/Home/issues/8260
Regression: No  
* Last working version:  N/A 
* How are we preventing it in future: 
More unit tests.  

## Fix

Added verification to detect runtime changes. 

## Testing/Validation

Tests Added: Yes

Validation:  
Unit test and manual validation.
