### PR TITLE
Decrease the number of UI refreshes when installing through the PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -654,7 +654,8 @@ namespace NuGet.PackageManagement.UI
                     useCacheForUpdates: useCacheForUpdates,
                     pSearchCallback: null,
                     searchTask: null);
-            });
+            })
+            .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(PackageManagerControl), nameof(SearchPackagesAndRefreshUpdateCount)));
         }
 
         /// <summary>
@@ -747,7 +748,8 @@ namespace NuGet.PackageManagement.UI
                 };
 
                 _topPanel._labelUpgradeAvailable.Count = Model.CachedUpdates.Packages.Count;
-            });
+            })
+            .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(PackageManagerControl), nameof(RefreshAvailableUpdatesCount)));
         }
 
         private void RefreshConsolidatablePackagesCount()
@@ -776,7 +778,9 @@ namespace NuGet.PackageManagement.UI
 
         private void PackageList_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(UpdateDetailPaneAsync);
+            NuGetUIThreadHelper.JoinableTaskFactory
+                .RunAsync(UpdateDetailPaneAsync)
+                .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(PackageManagerControl), nameof(PackageList_SelectionChanged)));
         }
 
         /// <summary>
@@ -924,7 +928,8 @@ namespace NuGet.PackageManagement.UI
                     var installedPackages = await PackageCollection.FromProjectsAsync(Model.Context.Projects,
                         CancellationToken.None);
                     _packageList.UpdatePackageStatus(installedPackages.ToArray());
-                });
+                })
+                .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(PackageManagerControl), nameof(Refresh)));
 
                 RefreshAvailableUpdatesCount();
             }
@@ -1035,7 +1040,8 @@ namespace NuGet.PackageManagement.UI
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 _windowSearchHost.Activate();
-            });
+            })
+            .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(PackageManagerControl), nameof(FocusOnSearchBox_Executed)));
         }
 
         public void Search(string searchText)
@@ -1138,7 +1144,8 @@ namespace NuGet.PackageManagement.UI
                         _uiRefreshRequired = false;
                     }
                 }
-            });
+            })
+            .FileAndForget(TelemetryUtility.CreateFileAndForgetEventName(nameof(PackageManagerControl), nameof(ExecuteAction)));
         }
 
         private void ExecuteUninstallPackageCommand(object sender, ExecutedRoutedEventArgs e)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -218,7 +218,6 @@ namespace NuGet.PackageManagement.UI
                     var projects = solutionModel.Projects.Select(p => p.NuGetProject);
                     Model.Context.Projects = projects;
 
-                    // refresh UI
                     RefreshWhenNotExecutingAction();
                 }
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -46,7 +46,7 @@ namespace NuGet.PackageManagement.UI
 
         // When executing a UI operation, we disable the PM UI and ignore any refresh requests.
         // This tells the operation execution part that it needs to trigger a refresh when done.
-        private bool _usRefreshRequired;
+        private bool _isRefreshRequired;
 
         // Signifies where an action is being executed. Should be updated in a coordinated fashion with IsEnabled
         private bool _isExecutingAction;
@@ -288,7 +288,7 @@ namespace NuGet.PackageManagement.UI
             }
             else
             {
-                _usRefreshRequired = true;
+                _isRefreshRequired = true;
             }
         }
 
@@ -1137,10 +1137,10 @@ namespace NuGet.PackageManagement.UI
                     NuGetEventTrigger.Instance.TriggerEvent(NuGetEvent.PackageOperationEnd);
                     IsEnabled = true;
                     _isExecutingAction = false;
-                    if (_usRefreshRequired)
+                    if (_isRefreshRequired)
                     {
                         Refresh();
-                        _usRefreshRequired = false;
+                        _isRefreshRequired = false;
                     }
                 }
             })

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -46,11 +46,10 @@ namespace NuGet.PackageManagement.UI
 
         // When executing a UI operation, we disable the PM UI and ignore any refresh requests.
         // This tells the operation execution part that it needs to trigger a refresh when done.
-
-        private bool _uiRefreshRequired;
+        private bool _usRefreshRequired;
 
         // Signifies where an action is being executed. Should be updated in a coordinated fashion with IsEnabled
-        private bool _executingAction;
+        private bool _isExecutingAction;
 
         private PackageRestoreBar _restoreBar;
 
@@ -220,7 +219,7 @@ namespace NuGet.PackageManagement.UI
                     Model.Context.Projects = projects;
 
                     // refresh UI
-                    RefreshIfNeeded();
+                    RefreshWhenNotExecutingAction();
                 }
             }
         }
@@ -232,7 +231,7 @@ namespace NuGet.PackageManagement.UI
             {
                 if (Model.IsSolution)
                 {
-                    RefreshIfNeeded();
+                    RefreshWhenNotExecutingAction();
                 }
                 else
                 {
@@ -244,7 +243,7 @@ namespace NuGet.PackageManagement.UI
                     if (e.Actions.Any(action =>
                         NuGetProject.GetUniqueNameOrName(action.Project) == projectName))
                     {
-                        RefreshIfNeeded();
+                        RefreshWhenNotExecutingAction();
                     }
                 }
             }
@@ -257,7 +256,7 @@ namespace NuGet.PackageManagement.UI
             {
                 if (Model.IsSolution)
                 {
-                    RefreshIfNeeded();
+                    RefreshWhenNotExecutingAction();
                 }
                 else
                 {
@@ -274,22 +273,22 @@ namespace NuGet.PackageManagement.UI
                     // We also refresh the UI if projectFullPath is not present.
                     if (!projectContainsFullPath || projectFullName == eventProjectFullName)
                     {
-                        RefreshIfNeeded();
+                        RefreshWhenNotExecutingAction();
                     }
                 }
             }
         }
 
-        private void RefreshIfNeeded()
+        private void RefreshWhenNotExecutingAction()
         {
-            // Only refresh there is no executing action. Tell the operation execution to refresh when done otherwise.
-            if (!_executingAction)
+            // Only refresh if there is no executing action. Tell the operation execution to refresh when done otherwise.
+            if (!_isExecutingAction)
             {
                 Refresh();
             }
             else
             {
-                _uiRefreshRequired = true;
+                _usRefreshRequired = true;
             }
         }
 
@@ -1112,7 +1111,7 @@ namespace NuGet.PackageManagement.UI
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async delegate
             {
                 IsEnabled = false;
-                _executingAction = true;
+                _isExecutingAction = true;
 
                 NuGetEventTrigger.Instance.TriggerEvent(NuGetEvent.PackageOperationBegin);
                 try
@@ -1137,11 +1136,11 @@ namespace NuGet.PackageManagement.UI
                     _actionCompleted?.Invoke(this, EventArgs.Empty);
                     NuGetEventTrigger.Instance.TriggerEvent(NuGetEvent.PackageOperationEnd);
                     IsEnabled = true;
-                    _executingAction = false;
-                    if (_uiRefreshRequired)
+                    _isExecutingAction = false;
+                    if (_usRefreshRequired)
                     {
                         Refresh();
-                        _uiRefreshRequired = false;
+                        _usRefreshRequired = false;
                     }
                 }
             })


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8358
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
Whenever a package operation is run in the PM UI, there is a chance that we trigger lots of unnecessary refreshes. 
The problem is specifically with the SDK based projects. 

Refer to https://user-images.githubusercontent.com/2878341/61335124-34fd3380-a7e1-11e9-9e3e-d5c93cbaa73f.png. 

When installing a package into 20 projects, we're going to get 20 cache update events, and 1 actions executed event.

It's challenging to synchronize all the expected cache updates because the ordering of the events is not guaranteed. The actions executed event might be in between the cache update events. 

The simplest solution is not allow any refreshes when an operation is running and just run one if needed when the operation completes.

We can alternatively count the projects for which we are listening for updates, but the ordering of the events make that challenging and error project. 

**Note**

I have also added file and forget telemetry events for every single RunAsync call. 

See: 
https://github.com/Microsoft/vs-threading/blob/master/doc/cookbook_vs.md#how-to-write-a-fire-and-forget-method-responsibly

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation: Manual
