### PR TITLE
Make PluginManager constructor public again

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
@@ -53,7 +53,7 @@ namespace NuGet.Protocol.Plugins
                 new Lazy<string>(() => SettingsUtility.GetPluginsCacheFolder()));
         }
 
-        internal PluginManager(
+        public PluginManager(
             IEnvironmentVariableReader reader,
             Lazy<IPluginDiscoverer> pluginDiscoverer,
             Func<TimeSpan, IPluginFactory> pluginFactoryCreator,


### PR DESCRIPTION
In https://github.com/NuGet/NuGet.Client/commit/06903595bc47328222a882be9346660b11a7cc00#diff-f2833de1ecaed93179251b95dde8d2a5R56 (related to NuGet/Home#8057), the constructor for `PluginManager` was made internal for seemingly no reason.

This PR makes it available again for those folks integrating with the plugin infrastructure in NuGet client.

**Edit by @nkolev92**

Tracking issue: https://github.com/NuGet/Home/issues/8379