### PR TITLE
Test:  fix flaky Apex test

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/ApexTestUIProject.cs
+++ b/test/NuGet.Tests.Apex/NuGet.PackageManagement.UI.TestContract/ApexTestUIProject.cs
@@ -13,9 +13,9 @@ namespace NuGet.PackageManagement.UI.TestContract
     {
         private PackageManagerControl _packageManagerControl;
 
-        internal ApexTestUIProject(PackageManagerControl project)
+        internal ApexTestUIProject(PackageManagerControl pmc)
         {
-            _packageManagerControl = project;
+            _packageManagerControl = pmc ?? throw new ArgumentNullException(nameof(pmc));
         }
 
         public IEnumerable<PackageItemListViewModel> PackageItems


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/8348.

The install command in the Apex OM does not block until installation completes.  This is a cheap and effective way to ensure install/uninstall actions complete before proceeding to the next step.