### PR TITLE
Add insert_final_newline to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,7 @@ indent_style = space
 ; (Please don't specify an indent_size here; that has too many unintended consequences.)
 charset = utf-8
 trim_trailing_whitespace = true
+insert_final_newline = true
 
 ; Code files
 [*.{cs}]


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8350
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: insert_final_newline = true

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  no code changes
Validation:  
