### PR TITLE
Map Xamarin frameworks to NetStandard 2.1

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
@@ -462,27 +462,27 @@ namespace NuGet.Frameworks
                             CreateGenerationAndStandardMappingForAllVersions(
                                 FrameworkConstants.FrameworkIdentifiers.MonoAndroid,
                                 FrameworkConstants.CommonFrameworks.DotNet56,
-                                FrameworkConstants.CommonFrameworks.NetStandard20),
+                                FrameworkConstants.CommonFrameworks.NetStandard21),
 
                             CreateGenerationAndStandardMappingForAllVersions(
                                 FrameworkConstants.FrameworkIdentifiers.MonoMac,
                                 FrameworkConstants.CommonFrameworks.DotNet56,
-                                FrameworkConstants.CommonFrameworks.NetStandard20),
+                                FrameworkConstants.CommonFrameworks.NetStandard21),
 
                             CreateGenerationAndStandardMappingForAllVersions(
                                 FrameworkConstants.FrameworkIdentifiers.MonoTouch,
                                 FrameworkConstants.CommonFrameworks.DotNet56,
-                                FrameworkConstants.CommonFrameworks.NetStandard20),
+                                FrameworkConstants.CommonFrameworks.NetStandard21),
 
                             CreateGenerationAndStandardMappingForAllVersions(
                                 FrameworkConstants.FrameworkIdentifiers.XamarinIOs,
                                 FrameworkConstants.CommonFrameworks.DotNet56,
-                                FrameworkConstants.CommonFrameworks.NetStandard20),
+                                FrameworkConstants.CommonFrameworks.NetStandard21),
 
                             CreateGenerationAndStandardMappingForAllVersions(
                                 FrameworkConstants.FrameworkIdentifiers.XamarinMac,
                                 FrameworkConstants.CommonFrameworks.DotNet56,
-                                FrameworkConstants.CommonFrameworks.NetStandard20),
+                                FrameworkConstants.CommonFrameworks.NetStandard21),
 
                             CreateGenerationAndStandardMappingForAllVersions(
                                 FrameworkConstants.FrameworkIdentifiers.XamarinPlayStation3,
@@ -512,12 +512,12 @@ namespace NuGet.Frameworks
                             CreateGenerationAndStandardMappingForAllVersions(
                                 FrameworkConstants.FrameworkIdentifiers.XamarinTVOS,
                                 FrameworkConstants.CommonFrameworks.DotNet56,
-                                FrameworkConstants.CommonFrameworks.NetStandard20),
+                                FrameworkConstants.CommonFrameworks.NetStandard21),
 
                             CreateGenerationAndStandardMappingForAllVersions(
                                 FrameworkConstants.FrameworkIdentifiers.XamarinWatchOS,
                                 FrameworkConstants.CommonFrameworks.DotNet56,
-                                FrameworkConstants.CommonFrameworks.NetStandard20)
+                                FrameworkConstants.CommonFrameworks.NetStandard21)
                         }.SelectMany(mappings => mappings))
                         .ToArray();
                 }

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityListProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityListProviderTests.cs
@@ -249,28 +249,28 @@ namespace NuGet.Frameworks.Test
             Assert.Contains(".NETCoreApp,Version=v3.0", actual);
             Assert.Contains(".NETStandard,Version=v2.1", actual);
             Assert.Contains("Tizen,Version=v6.0", actual);
+            Assert.Contains("MonoAndroid,Version=v0.0", actual);
+            Assert.Contains("MonoMac,Version=v0.0", actual);
+            Assert.Contains("MonoTouch,Version=v0.0", actual);
+            Assert.Contains("Xamarin.iOS,Version=v0.0", actual);
+            Assert.Contains("Xamarin.Mac,Version=v0.0", actual);
+            Assert.Contains("Xamarin.TVOS,Version=v0.0", actual);
+            Assert.Contains("Xamarin.WatchOS,Version=v0.0", actual);
 
             // negative
             Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // frameworks with no relationship are not returned
             Assert.DoesNotContain(".NETPlatform,Version=v5.6", actual); // frameworks with no relationship are not returned
             Assert.DoesNotContain("DNXCore,Version=v5.0", actual);
             Assert.DoesNotContain("DNX,Version=v4.6.1", actual);
-            Assert.DoesNotContain("MonoAndroid,Version=v0.0", actual);
-            Assert.DoesNotContain("MonoMac,Version=v0.0", actual);
-            Assert.DoesNotContain("MonoTouch,Version=v0.0", actual);
-            Assert.DoesNotContain("Xamarin.iOS,Version=v0.0", actual);
-            Assert.DoesNotContain("Xamarin.Mac,Version=v0.0", actual);
             Assert.DoesNotContain("Xamarin.PlayStation3,Version=v0.0", actual);
             Assert.DoesNotContain("Xamarin.PlayStation4,Version=v0.0", actual);
             Assert.DoesNotContain("Xamarin.PlayStationVita,Version=v0.0", actual);
-            Assert.DoesNotContain("Xamarin.TVOS,Version=v0.0", actual);
-            Assert.DoesNotContain("Xamarin.WatchOS,Version=v0.0", actual);
             Assert.DoesNotContain("Xamarin.Xbox360,Version=v0.0", actual);
             Assert.DoesNotContain("Xamarin.XboxOne,Version=v0.0", actual);
             Assert.DoesNotContain("UAP,Version=v10.0.15064", actual);
 
             // count
-            Assert.Equal(4, actual.Length);
+            Assert.Equal(11, actual.Length);
         }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/mono/mono/issues/15742
Fixes: https://github.com/NuGet/Home/issues/8368
Regression: No
* Last working version:   n/a
* How are we preventing it in future:   n/a

## Fix

Details: Mapped Xamarin frameworks to NS2.1 support so that they can reference a NS2.1 library.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  n/a
Validation:  I ran the tests and copied the NuGet.Frameworks.dll to VSMac and verified correct behavior there.
