### PR TITLE
Escape the strings when setting env variables used for tracking

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -54,8 +54,8 @@ phases:
     inputs:
       scriptType: "inlineScript"
       inlineScript: |
-        Write-Host "##vso[build.addbuildtag]$env:BUILD_SOURCEVERSIONAUTHOR"
-        Write-Host "##vso[build.addbuildtag]$env:BUILD_SOURCEBRANCHNAME"
+        Write-Host "##vso[build.addbuildtag]${env:BUILD_SOURCEVERSIONAUTHOR}"
+        Write-Host "##vso[build.addbuildtag]${env:BUILD_SOURCEBRANCHNAME}"
 
 - phase: Build_and_UnitTest
   dependsOn: Initialize_Build

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -50,6 +50,7 @@ phases:
 
   - task: PowerShell@1
     displayName: "Add Build Tags"
+    continueOnError: "false"
     inputs:
       scriptType: "inlineScript"
       inlineScript: |

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -50,7 +50,6 @@ phases:
 
   - task: PowerShell@1
     displayName: "Add Build Tags"
-    continueOnError: "false"
     inputs:
       scriptType: "inlineScript"
       inlineScript: |


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8367
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

Escape the build tags as they might contain special characters such as  the ones described in the issue. 

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
