### PR TITLE
Fix encoding of source name for credentials in nuget.config

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Utility/XmlUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/XmlUtility.cs
@@ -35,7 +35,7 @@ namespace NuGet.Configuration
             }
             catch (XmlException)
             {
-                return XmlConvert.EncodeName(name);
+                return XmlConvert.EncodeLocalName(name);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/CredentialsItemTests.cs
@@ -511,6 +511,22 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void CredentialsItem_AsXNode_WithUrlInName_ReturnsCorrectElementName()
+        {
+            // Arrange
+            var credentialsItem = new CredentialsItem("https://nuget.contoso.com/v3/index.json", "username", "password", isPasswordClearText: false, validAuthenticationTypes: null);
+
+            // Act
+            var xnode = credentialsItem.AsXNode();
+
+            // Assert
+            xnode.Should().BeOfType<XElement>();
+            var xelement = xnode as XElement;
+
+            xelement.Name.LocalName.Should().Be("https_x003A__x002F__x002F_nuget.contoso.com_x002F_v3_x002F_index.json");
+        }
+
+        [Fact]
         public void CredentialsItem_AsXNode_WithUsernameAndPassword_ReturnsCorrectElement()
         {
             // Arrange


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#7948
Regression: Yes
* Last working version:   4.8.x
* How are we preventing it in future:   unit test

## Fix

Details: Use EncodeLocalName so that `http` doesn't get treated as an XML namespace

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
