### PR TITLE
Report framework name in exception

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -166,7 +166,7 @@ namespace NuGet.Frameworks
                     throw new FrameworkException(string.Format(
                         CultureInfo.CurrentCulture,
                         Strings.InvalidFrameworkIdentifier,
-                        shortFramework));
+                        framework.Framework));
                 }
 
                 // add framework


### PR DESCRIPTION
## Bug

Fixes: The exception is only thrown when the shortFramework is null or empty
Regression: No  

## Fix

Details: Report the full framework name in case there is some other error happening  

## Testing/Validation

Tests Added: No  
Reason for not adding tests: Diagnostic improvement
Validation:  N/A
