### PR TITLE
Fix potential NullReferenceException in ProjectPackagesPrintUtility

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/ProjectPackagesPrintUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/ProjectPackagesPrintUtility.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
 
 namespace NuGet.CommandLine.XPlat.Utility
 {
@@ -128,8 +129,14 @@ namespace NuGet.CommandLine.XPlat.Utility
                        p => "",
                        p => p.Name,
                        p => "",
-                       p => PrintVersion(p.ResolvedPackageMetadata),
-                       p => p.LatestPackageMetadata == null ? Strings.ListPkg_NotFoundAtSources : PrintVersion(p.LatestPackageMetadata));
+                       p => PrintVersion(
+                                p.ResolvedPackageMetadata.Identity.Version,
+                                p.ResolvedPackageMetadata.DeprecationMetadata != null),
+                       p => p.LatestPackageMetadata?.Identity?.Version == null
+                            ? Strings.ListPkg_NotFoundAtSources
+                            : PrintVersion(
+                                p.LatestPackageMetadata.Identity.Version,
+                                p.LatestPackageMetadata.DeprecationMetadata != null));
             }
             else if (outdated && !printingTransitive)
             {
@@ -148,8 +155,14 @@ namespace NuGet.CommandLine.XPlat.Utility
                            return "";
                        },
                        p => p.OriginalRequestedVersion,
-                       p => PrintVersion(p.ResolvedPackageMetadata),
-                       p => p.LatestPackageMetadata == null ? Strings.ListPkg_NotFoundAtSources : PrintVersion(p.LatestPackageMetadata));
+                       p => PrintVersion(
+                                p.ResolvedPackageMetadata.Identity.Version,
+                                p.ResolvedPackageMetadata.DeprecationMetadata != null),
+                       p => p.LatestPackageMetadata?.Identity?.Version == null
+                            ? Strings.ListPkg_NotFoundAtSources
+                            : PrintVersion(
+                                p.LatestPackageMetadata.Identity.Version,
+                                p.LatestPackageMetadata.DeprecationMetadata != null));
             }
             else if (!outdated && printingTransitive)
             {
@@ -159,7 +172,9 @@ namespace NuGet.CommandLine.XPlat.Utility
                         p => "",
                         p => p.Name,
                         p => "",
-                        p => PrintVersion(p.ResolvedPackageMetadata));
+                        p => PrintVersion(
+                                p.ResolvedPackageMetadata.Identity.Version,
+                                p.ResolvedPackageMetadata.DeprecationMetadata != null));
             }
             else
             {
@@ -178,7 +193,9 @@ namespace NuGet.CommandLine.XPlat.Utility
                            return "";
                        },
                        p => p.OriginalRequestedVersion,
-                       p => PrintVersion(p.ResolvedPackageMetadata));
+                       p => PrintVersion(
+                                p.ResolvedPackageMetadata.Identity.Version,
+                                p.ResolvedPackageMetadata.DeprecationMetadata != null));
             }
 
             //Handle printing with colors
@@ -195,11 +212,11 @@ namespace NuGet.CommandLine.XPlat.Utility
             return new PrintPackagesResult(autoReferenceFound, deprecatedFound);
         }
 
-        private static string PrintVersion(IPackageSearchMetadata metadata)
+        private static string PrintVersion(NuGetVersion version, bool isDeprecated)
         {
-            var output = metadata.Identity.Version.ToString();
+            var output = version.ToString();
 
-            if (metadata.DeprecationMetadata != null)
+            if (isDeprecated)
             {
                 output += " (D)";
             }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/ProjectPackagesPrintUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/ProjectPackagesPrintUtility.cs
@@ -207,7 +207,7 @@ namespace NuGet.CommandLine.XPlat.Utility
 
             Console.WriteLine();
 
-            deprecatedFound = packages.Any(p => p.LatestPackageMetadata.DeprecationMetadata != null || p.ResolvedPackageMetadata.DeprecationMetadata != null);
+            deprecatedFound = packages.Any(p => p.LatestPackageMetadata?.DeprecationMetadata != null || p.ResolvedPackageMetadata?.DeprecationMetadata != null);
 
             return new PrintPackagesResult(autoReferenceFound, deprecatedFound);
         }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8378
Regression: Yes  

Stacktrace:

```
[xUnit.net 00:02:19.8051101]     Dotnet.Integration.Test.DotnetListPackageTests.DotnetListPackage_Succeed [FAIL]
    X Dotnet.Integration.Test.DotnetListPackageTests.DotnetListPackage_Succeed [4s 848ms]
##[warning]EXEC(0,0): Warning Message: 
EXEC : warning Message:  [E:\A\_work\235\s\build\build.proj]
  The previous error was converted to a warning because the task was called with ContinueOnError=true.
     dotnet.exe list E:\A\_work\235\s\.test\work\421f7497\5b75e207\solution\test_project_listpkg\test_project_listpkg.csproj package command failed with following log information :
   Project 'test_project_listpkg' has the following package references
     [net46]: 
     Top-level Package      Requested   Resolved
     > packageX             1.0.0       1.0.0   
  
##[warning]EXEC(0,0): Warning : Object reference not set to an instance of an object.
EXEC : warning : Object reference not set to an instance of an object. [E:\A\_work\235\s\build\build.proj]
  The previous error was converted to a warning because the task was called with ContinueOnError=true.
  
  
  Expected: True
  Actual:   False
    Stack Trace:
       at Dotnet.Integration.Test.DotnetListPackageTests.DotnetListPackage_Succeed() in E:\A\_work\235\s\test\NuGet.Core.FuncTests\Dotnet.Integration.Test\DotnetListPackageTests.cs:line 50
```

## Fix

Details: A `NullReferenceException` was thrown as part of functional test failures covering `dotnet list package` commands.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Existing tests uncovered the bug