### PR TITLE
Disable MSBuild Node Reuse in Linux Build phase

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -530,7 +530,7 @@ phases:
     displayName: "Run Tests"
     continueOnError: "true"
     inputs:
-      scriptPath: "scripts/funcTests/runFuncTests.sh"
+      scriptPath: "MSBUILDDISABLENODEREUSE=1 scripts/funcTests/runFuncTests.sh"
       disableAutoCwd: "true"
       cwd: "$(Build.Repository.LocalPath)"
 

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -531,7 +531,7 @@ phases:
     inputs:
       targetType: "inline"
       script: |
-        SET $env:MSBUILDDISABLENODEREUSE=1"
+        SET $env:MSBUILDDISABLENODEREUSE="1"
       failOnStderr: "true"
     condition: "always()"
 

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -510,6 +510,7 @@ phases:
   dependsOn: Initialize_Build
   variables:
     FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+    MSBUILDDISABLENODEREUSE: 1
   condition: "and(succeeded(),eq(variables['RunTestsOnLinux'], 'true')) "
   queue:
     name: DDNuGet-Linux
@@ -517,21 +518,13 @@ phases:
     demands: sh
 
   steps:
+  - bash: echo $(MSBUILDDISABLENODEREUSE)
   - task: PowerShell@2
     displayName: "Update Build Number"
     inputs:
       targetType: "inline"
       script: |
         Write-Host "##vso[build.updatebuildnumber]$env:FULLVSTSBUILDNUMBER"
-      failOnStderr: "true"
-    condition: "always()"
-
-  - task: PowerShell@2
-    displayName: "Set Environment Variables"
-    inputs:
-      targetType: "inline"
-      script: |
-        SET $env:MSBUILDDISABLENODEREUSE="1"
       failOnStderr: "true"
     condition: "always()"
 

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -56,455 +56,455 @@ phases:
         Write-Host "##vso[build.addbuildtag]$env:BUILD_SOURCEVERSIONAUTHOR"
         Write-Host "##vso[build.addbuildtag]$env:BUILD_SOURCEBRANCHNAME"
 
-- phase: Build_and_UnitTest
-  dependsOn: Initialize_Build
-  variables:
-    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-  queue:
-    name: VSEng-MicroBuildVS2019
-    timeoutInMinutes: 90
-    parallel: 2
-    matrix:
-      RTM:
-        BuildRTM: "true"
-      NonRTM:
-        BuildRTM: "false"
-    demands: 
-      - DotNetFramework
-      - msbuild
+# - phase: Build_and_UnitTest
+#   dependsOn: Initialize_Build
+#   variables:
+#     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+#     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+#   queue:
+#     name: VSEng-MicroBuildVS2019
+#     timeoutInMinutes: 90
+#     parallel: 2
+#     matrix:
+#       RTM:
+#         BuildRTM: "true"
+#       NonRTM:
+#         BuildRTM: "false"
+#     demands: 
+#       - DotNetFramework
+#       - msbuild
 
-  steps:
-  - task: PowerShell@1
-    displayName: "Update Build Number"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
-        gci env:* | sort-object name
+#   steps:
+#   - task: PowerShell@1
+#     displayName: "Update Build Number"
+#     inputs:
+#       scriptType: "inlineScript"
+#       inlineScript: |
+#         Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
+#         gci env:* | sort-object name
 
-  - task: PowerShell@1
-    displayName: "Define variables"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        Write-Host "##vso[task.setvariable variable=ManifestFilePath]$(Build.Repository.LocalPath)\artifacts\manifests\nuget.client.xml"
+#   - task: PowerShell@1
+#     displayName: "Define variables"
+#     inputs:
+#       scriptType: "inlineScript"
+#       inlineScript: |
+#         Write-Host "##vso[task.setvariable variable=ManifestFilePath]$(Build.Repository.LocalPath)\artifacts\manifests\nuget.client.xml"
 
-  - task: NuGetToolInstaller@0
-    displayName: "Use NuGet 5.0.0"
-    inputs:
-      versionSpec: "5.0.0"
+#   - task: NuGetToolInstaller@0
+#     displayName: "Use NuGet 5.0.0"
+#     inputs:
+#       versionSpec: "5.0.0"
 
-  - task: PowerShell@1
-    inputs:
-      scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
-      arguments: "-Force"
-    displayName: "Run Configure.ps1"
+#   - task: PowerShell@1
+#     inputs:
+#       scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
+#       arguments: "-Force"
+#     displayName: "Run Configure.ps1"
 
-  - task: PowerShell@1
-    inputs:
-      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
-      arguments: "-BuildCounterFile $(BuildCounterFile) -BuildInfoJsonFile $(BuildInfoJsonFile) -BuildRTM $(BuildRTM) -SkipUpdateBuildNumber"
-    displayName: "Configure VSTS CI Environment"
+#   - task: PowerShell@1
+#     inputs:
+#       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
+#       arguments: "-BuildCounterFile $(BuildCounterFile) -BuildInfoJsonFile $(BuildInfoJsonFile) -BuildRTM $(BuildRTM) -SkipUpdateBuildNumber"
+#     displayName: "Configure VSTS CI Environment"
 
-  - task: PowerShell@1
-    displayName: "Print Environment Variables"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        gci env:* | sort-object name
+#   - task: PowerShell@1
+#     displayName: "Print Environment Variables"
+#     inputs:
+#       scriptType: "inlineScript"
+#       inlineScript: |
+#         gci env:* | sort-object name
 
-  - task: MicroBuildLocalizationPlugin@1
-    displayName: "Install Localization Plugin"
+#   - task: MicroBuildLocalizationPlugin@1
+#     displayName: "Install Localization Plugin"
 
-  - task: MicroBuildSigningPlugin@1
-    inputs:
-      signType: "$(SigningType)"
-      esrpSigning: "true"
-    displayName: "Install Signing Plugin"
+#   - task: MicroBuildSigningPlugin@1
+#     inputs:
+#       signType: "$(SigningType)"
+#       esrpSigning: "true"
+#     displayName: "Install Signing Plugin"
 
-  - task: MicroBuildSwixPlugin@1
-    displayName: "Install Swix Plugin"
+#   - task: MicroBuildSwixPlugin@1
+#     displayName: "Install Swix Plugin"
 
-  - task: MSBuild@1
-    displayName: "Restore for VS2019"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=$(BuildRTM) /v:m"
+#   - task: MSBuild@1
+#     displayName: "Restore for VS2019"
+#     inputs:
+#       solution: "build\\build.proj"
+#       msbuildVersion: "16.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=$(BuildRTM) /v:m"
 
-  - task: MSBuild@1
-    displayName: "Build for VS2019"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:BuildNoVSIX /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
+#   - task: MSBuild@1
+#     displayName: "Build for VS2019"
+#     inputs:
+#       solution: "build\\build.proj"
+#       msbuildVersion: "16.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/t:BuildNoVSIX /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
 
-  - task: MSBuild@1
-    displayName: "Ensure msbuild.exe can parse nuget.sln"
-    continueOnError: "false"
-    inputs:
-      solution: "nuget.sln"
-      msbuildVersion: "16.0"
-      msbuildArguments: "/t:EnsureNewtonsoftJsonVersion"
-    condition: "succeeded()"
+#   - task: MSBuild@1
+#     displayName: "Ensure msbuild.exe can parse nuget.sln"
+#     continueOnError: "false"
+#     inputs:
+#       solution: "nuget.sln"
+#       msbuildVersion: "16.0"
+#       msbuildArguments: "/t:EnsureNewtonsoftJsonVersion"
+#     condition: "succeeded()"
 
-  - task: MSBuild@1
-    displayName: "Run unit tests"
-    continueOnError: "true"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml"
-    condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
+#   - task: MSBuild@1
+#     displayName: "Run unit tests"
+#     continueOnError: "true"
+#     inputs:
+#       solution: "build\\build.proj"
+#       msbuildVersion: "16.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml"
+#     condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
-  - task: PublishTestResults@2
-    displayName: "Publish Test Results"
-    inputs:
-      testRunner: "XUnit"
-      testResultsFiles: "*.xml"
-      testRunTitle: "NuGet.Client Unit Tests On Windows"
-      searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
-      mergeTestResults: "true"
-      publishRunAttachments: "false"
-    condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
+#   - task: PublishTestResults@2
+#     displayName: "Publish Test Results"
+#     inputs:
+#       testRunner: "XUnit"
+#       testResultsFiles: "*.xml"
+#       testRunTitle: "NuGet.Client Unit Tests On Windows"
+#       searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
+#       mergeTestResults: "true"
+#       publishRunAttachments: "false"
+#     condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
 
-  - task: PowerShell@1
-    displayName: "Initialize Git Commit Status on GitHub"
-    inputs:
-      scriptType: "inlineScript"
-      arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
-      inlineScript: |
-        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
-        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Unit Tests On Windows"
-    condition: "and(always(),eq(variables['BuildRTM'], 'true'))"
+#   - task: PowerShell@1
+#     displayName: "Initialize Git Commit Status on GitHub"
+#     inputs:
+#       scriptType: "inlineScript"
+#       arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
+#       inlineScript: |
+#         . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
+#         SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Unit Tests On Windows"
+#     condition: "and(always(),eq(variables['BuildRTM'], 'true'))"
 
-  - task: PublishBuildArtifacts@1
-    displayName: "Publish NuGet.CommandLine.Test as artifact"
-    inputs:
-      PathtoPublish: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472\\win7-x64"
-      ArtifactName: "NuGet.CommandLine.Test"
-      ArtifactType: "Container"
-    condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
+#   - task: PublishBuildArtifacts@1
+#     displayName: "Publish NuGet.CommandLine.Test as artifact"
+#     inputs:
+#       PathtoPublish: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472\\win7-x64"
+#       ArtifactName: "NuGet.CommandLine.Test"
+#       ArtifactType: "Container"
+#     condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
-  - task: MSBuild@1
-    displayName: "Localize Assemblies"
-    inputs:
-      solution: "build\\loc.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:AfterBuild"
-    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+#   - task: MSBuild@1
+#     displayName: "Localize Assemblies"
+#     inputs:
+#       solution: "build\\loc.proj"
+#       msbuildVersion: "16.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/t:AfterBuild"
+#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
-  - task: MSBuild@1
-    displayName: "Sign Assemblies"
-    inputs:
-      solution: "build\\sign.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:AfterBuild"
+#   - task: MSBuild@1
+#     displayName: "Sign Assemblies"
+#     inputs:
+#       solution: "build\\sign.proj"
+#       msbuildVersion: "16.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/t:AfterBuild"
 
-  - task: MSBuild@1
-    displayName: "Pack Nupkgs"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
+#   - task: MSBuild@1
+#     displayName: "Pack Nupkgs"
+#     inputs:
+#       solution: "build\\build.proj"
+#       msbuildVersion: "16.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
 
-  - task: MSBuild@1
-    displayName: "Pack VSIX"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:BuildVSIX /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:IsCIBuild=true"
-    condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+#   - task: MSBuild@1
+#     displayName: "Pack VSIX"
+#     inputs:
+#       solution: "build\\build.proj"
+#       msbuildVersion: "16.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/t:BuildVSIX /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:IsCIBuild=true"
+#     condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
-  - task: MSBuild@1
-    displayName: "Generate Build Tools package"
-    inputs:
-      solution: "setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true"
-    condition: " and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+#   - task: MSBuild@1
+#     displayName: "Generate Build Tools package"
+#     inputs:
+#       solution: "setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
+#       msbuildVersion: "16.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true"
+#     condition: " and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-  - task: MSBuild@1
-    displayName: "Sign Nupkgs and VSIX"
-    inputs:
-      solution: "build\\sign.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:AfterBuild /p:SignPackages=true"
+#   - task: MSBuild@1
+#     displayName: "Sign Nupkgs and VSIX"
+#     inputs:
+#       solution: "build\\sign.proj"
+#       msbuildVersion: "16.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/t:AfterBuild /p:SignPackages=true"
 
-  - task: NuGetCommand@2
-    displayName: "Verify Nupkg Signatures"
-    inputs:
-      command: "custom"
-      arguments: "verify -Signatures $(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)\\*.nupkg"
+#   - task: NuGetCommand@2
+#     displayName: "Verify Nupkg Signatures"
+#     inputs:
+#       command: "custom"
+#       arguments: "verify -Signatures $(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)\\*.nupkg"
 
-  - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
-    displayName: Verify Assembly Signatures and StrongName for the nupkgs
-    inputs:
-      TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
+#   - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
+#     displayName: Verify Assembly Signatures and StrongName for the nupkgs
+#     inputs:
+#       TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
 
-  - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
-    displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
-    inputs:
-      TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
-      WhiteListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
-      WhiteListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
+#   - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
+#     displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
+#     inputs:
+#       TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
+#       WhiteListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
+#       WhiteListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
 
-  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-    displayName: 'Component Detection'
-    condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
+#   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+#     displayName: 'Component Detection'
+#     condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
-  - task: CopyFiles@2
-    displayName: "Copy Nupkgs"
-    inputs:
-      SourceFolder: "artifacts\\$(NupkgOutputDir)"
-      Contents: "*.nupkg"
-      TargetFolder: "$(BuildOutputTargetPath)\\artifacts\\$(VsixPublishDir)\\$(NupkgOutputDir)"
+#   - task: CopyFiles@2
+#     displayName: "Copy Nupkgs"
+#     inputs:
+#       SourceFolder: "artifacts\\$(NupkgOutputDir)"
+#       Contents: "*.nupkg"
+#       TargetFolder: "$(BuildOutputTargetPath)\\artifacts\\$(VsixPublishDir)\\$(NupkgOutputDir)"
 
-  - task: MSBuild@1
-    displayName: "Generate VSMAN file for NuGet Core VSIX"
-    inputs:
-      solution: "setup\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+#   - task: MSBuild@1
+#     displayName: "Generate VSMAN file for NuGet Core VSIX"
+#     inputs:
+#       solution: "setup\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
+#       msbuildVersion: "16.0"
+#       configuration: "$(BuildConfiguration)"
+#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
-  - task: MSBuild@1
-    displayName: "Generate VSMAN file for Build Tools VSIX"
-    inputs:
-      solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+#   - task: MSBuild@1
+#     displayName: "Generate VSMAN file for Build Tools VSIX"
+#     inputs:
+#       solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
+#       msbuildVersion: "16.0"
+#       configuration: "$(BuildConfiguration)"
+#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
-  - task: PowerShell@1
-    displayName: "Create EndToEnd Test Package"
-    inputs:
-      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\CreateEndToEndTestPackage.ps1"
-      arguments: "-c $(BuildConfiguration) -tv 16 -out $(Build.Repository.LocalPath)\\artifacts\\VS15"
-      failOnStandardError: "true"
-    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+#   - task: PowerShell@1
+#     displayName: "Create EndToEnd Test Package"
+#     inputs:
+#       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\CreateEndToEndTestPackage.ps1"
+#       arguments: "-c $(BuildConfiguration) -tv 16 -out $(Build.Repository.LocalPath)\\artifacts\\VS15"
+#       failOnStandardError: "true"
+#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
-  - task: CopyFiles@2
-    displayName: "Copy NuGet.exe, VSIX and EndToEnd"
-    inputs:
-      SourceFolder: "artifacts"
-      Contents: |
-        $(VsixPublishDir)\\NuGet.exe
-        $(VsixPublishDir)\\NuGet.pdb
-        $(VsixPublishDir)\\NuGet.Mssign.exe
-        $(VsixPublishDir)\\NuGet.Mssign.pdb
-        $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.Core.json
-        $(VsixPublishDir)\\NuGet.Tools.vsix
-        $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.BuildTools.vsix
-        $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.BuildTools.json
-        $(VsixPublishDir)\\EndToEnd.zip
-      TargetFolder: "$(BuildOutputTargetPath)\\artifacts"
+#   - task: CopyFiles@2
+#     displayName: "Copy NuGet.exe, VSIX and EndToEnd"
+#     inputs:
+#       SourceFolder: "artifacts"
+#       Contents: |
+#         $(VsixPublishDir)\\NuGet.exe
+#         $(VsixPublishDir)\\NuGet.pdb
+#         $(VsixPublishDir)\\NuGet.Mssign.exe
+#         $(VsixPublishDir)\\NuGet.Mssign.pdb
+#         $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.Core.json
+#         $(VsixPublishDir)\\NuGet.Tools.vsix
+#         $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.BuildTools.vsix
+#         $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.BuildTools.json
+#         $(VsixPublishDir)\\EndToEnd.zip
+#       TargetFolder: "$(BuildOutputTargetPath)\\artifacts"
 
-  - task: PublishBuildArtifacts@1
-    displayName: "Publish NuGet.exe VSIX and EndToEnd.zip as artifact"
-    inputs:
-      PathtoPublish: "$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)"
-      ArtifactName: "VS15"
-      ArtifactType: "Container"
-    condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+#   - task: PublishBuildArtifacts@1
+#     displayName: "Publish NuGet.exe VSIX and EndToEnd.zip as artifact"
+#     inputs:
+#       PathtoPublish: "$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)"
+#       ArtifactName: "VS15"
+#       ArtifactType: "Container"
+#     condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
-  - task: CopyFiles@2
-    displayName: "Copy LCG Files"
-    inputs:
-      SourceFolder: "artifacts\\"
-      Contents: "**\\*.lcg"
-      TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
-    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
+#   - task: CopyFiles@2
+#     displayName: "Copy LCG Files"
+#     inputs:
+#       SourceFolder: "artifacts\\"
+#       Contents: "**\\*.lcg"
+#       TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
+#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
 
-  - task: PowerShell@1
-    displayName: "Publish Artifacts to MyGet"
-    continueOnError: "true"
-    inputs:
-      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\PublishArtifactsFromVsts.ps1"
-      arguments: "-NuGetBuildFeedUrl $(NuGetBuildFeed) -NuGetBuildSymbolsFeedUrl $(NuGetBuildSymbolsFeed) -DotnetCoreFeedUrl $(DotnetCoreBuildFeed) -DotnetCoreSymbolsFeedUrl $(DotnetCoreSymbolsFeed) -NuGetBuildFeedApiKey $(NuGetBuildApiKey) -DotnetCoreFeedApiKey $(DotnetCoreFeedApiKey)"
-      failOnStandardError: "true"
-    condition: " and(succeeded(),eq(variables['PublishArtifactsToMyGet'], 'true'), eq(variables['BuildRTM'], 'false')) "
+#   - task: PowerShell@1
+#     displayName: "Publish Artifacts to MyGet"
+#     continueOnError: "true"
+#     inputs:
+#       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\PublishArtifactsFromVsts.ps1"
+#       arguments: "-NuGetBuildFeedUrl $(NuGetBuildFeed) -NuGetBuildSymbolsFeedUrl $(NuGetBuildSymbolsFeed) -DotnetCoreFeedUrl $(DotnetCoreBuildFeed) -DotnetCoreSymbolsFeedUrl $(DotnetCoreSymbolsFeed) -NuGetBuildFeedApiKey $(NuGetBuildApiKey) -DotnetCoreFeedApiKey $(DotnetCoreFeedApiKey)"
+#       failOnStandardError: "true"
+#     condition: " and(succeeded(),eq(variables['PublishArtifactsToMyGet'], 'true'), eq(variables['BuildRTM'], 'false')) "
 
-  - task: MSBuild@1
-    displayName: "Collect Build Symbols"
-    inputs:
-      solution: "build\\symbols.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/p:IsSymbolBuild=true"
-    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
+#   - task: MSBuild@1
+#     displayName: "Collect Build Symbols"
+#     inputs:
+#       solution: "build\\symbols.proj"
+#       msbuildVersion: "16.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/p:IsSymbolBuild=true"
+#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
 
-  - task: CopyFiles@2
-    displayName: "Copy Symbols"
-    inputs:
-      SourceFolder: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
-      Contents: "**\\*"
-      TargetFolder: "$(BuildOutputTargetPath)\\symbols"
-    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
+#   - task: CopyFiles@2
+#     displayName: "Copy Symbols"
+#     inputs:
+#       SourceFolder: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
+#       Contents: "**\\*"
+#       TargetFolder: "$(BuildOutputTargetPath)\\symbols"
+#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
 
-  - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
-    displayName: "Publish Symbols on Symweb"
-    inputs:
-      symbolServiceURI: "https://microsoft.artifacts.visualstudio.com/DefaultCollection"
-      requestName: "CollectionId/$(System.CollectionId)/ProjectId/$(System.TeamProjectId)/$(TeamName)/BuildId/$(Build.BuildId)"
-      sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
-      detailedLog: "true"
-      expirationInDays: "45"
-      usePat: "false"
-    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
+#   - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
+#     displayName: "Publish Symbols on Symweb"
+#     inputs:
+#       symbolServiceURI: "https://microsoft.artifacts.visualstudio.com/DefaultCollection"
+#       requestName: "CollectionId/$(System.CollectionId)/ProjectId/$(System.TeamProjectId)/$(TeamName)/BuildId/$(Build.BuildId)"
+#       sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
+#       detailedLog: "true"
+#       expirationInDays: "45"
+#       usePat: "false"
+#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
 
-  - task: MicroBuildUploadVstsDropFolder@1
-    displayName: "Upload VSTS Drop"
-    inputs:
-      DropFolder: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
-    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+#   - task: MicroBuildUploadVstsDropFolder@1
+#     displayName: "Upload VSTS Drop"
+#     inputs:
+#       DropFolder: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
+#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
-  - task: PowerShell@1
-    displayName: "Validate VSIX Localization"
-    inputs:
-      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
-      arguments: "-BuildRTM $(BuildRTM) -BuildOutputTargetPath $(BuildOutputTargetPath) -ValidateVsix"
-    condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
+#   - task: PowerShell@1
+#     displayName: "Validate VSIX Localization"
+#     inputs:
+#       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
+#       arguments: "-BuildRTM $(BuildRTM) -BuildOutputTargetPath $(BuildOutputTargetPath) -ValidateVsix"
+#     condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
 
-  - task: PowerShell@1
-    displayName: "Validate Repository Artifacts Localization"
-    inputs:
-      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
-      arguments: "-BuildRTM $(BuildRTM) -BuildOutputTargetPath $(BuildOutputTargetPath)"
-    condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
+#   - task: PowerShell@1
+#     displayName: "Validate Repository Artifacts Localization"
+#     inputs:
+#       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
+#       arguments: "-BuildRTM $(BuildRTM) -BuildOutputTargetPath $(BuildOutputTargetPath)"
+#     condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
 
-    # Use dotnet msbuild instead of MSBuild CLI.
-    # Using MSBuild CLI results in an assembly binding failure for NuGet.Common.dll 4.4.0.3 because Microsoft.DotNet.Build.Tasks.Feed.dll references SleetLib.dll which references NuGet.Common 4.4.0.3.
-    # The Microsoft.DotNet.Build.Tasks.Feed package includes NuGet.Common 4.9.0.6 and a binding redirection in Microsoft.DotNet.Build.Tasks.Feed.dll.config but the binding redirection is not processed.
-    # This would probably solve it:  https://github.com/Microsoft/msbuild/issues/1309
-  - task: CmdLine@2
-    displayName: "Publish the packages to the .NET Core build asset registry (BAR)"
-    inputs:
-      script: dotnet msbuild ..\build\publish.proj /t:PublishPackagesToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:FeedUrl=$(DotNetFeedUrl) /p:BuildId=$(Build.BuildNumber) /p:RepoBranch=$(Build.SourceBranchName) /p:RepoCommit=$(Build.SourceVersion) /p:RepoUri=$(Build.Repository.Uri) /p:ManifestFilePath=$(ManifestFilePath) /p:AccountKey=$(dotnetfeed-storage-access-key-1)
-      workingDirectory: cli
-      failOnStderr: true
-    env:
-      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-      DOTNET_MULTILEVEL_LOOKUP: true
-    condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
+#     # Use dotnet msbuild instead of MSBuild CLI.
+#     # Using MSBuild CLI results in an assembly binding failure for NuGet.Common.dll 4.4.0.3 because Microsoft.DotNet.Build.Tasks.Feed.dll references SleetLib.dll which references NuGet.Common 4.4.0.3.
+#     # The Microsoft.DotNet.Build.Tasks.Feed package includes NuGet.Common 4.9.0.6 and a binding redirection in Microsoft.DotNet.Build.Tasks.Feed.dll.config but the binding redirection is not processed.
+#     # This would probably solve it:  https://github.com/Microsoft/msbuild/issues/1309
+#   - task: CmdLine@2
+#     displayName: "Publish the packages to the .NET Core build asset registry (BAR)"
+#     inputs:
+#       script: dotnet msbuild ..\build\publish.proj /t:PublishPackagesToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:FeedUrl=$(DotNetFeedUrl) /p:BuildId=$(Build.BuildNumber) /p:RepoBranch=$(Build.SourceBranchName) /p:RepoCommit=$(Build.SourceVersion) /p:RepoUri=$(Build.Repository.Uri) /p:ManifestFilePath=$(ManifestFilePath) /p:AccountKey=$(dotnetfeed-storage-access-key-1)
+#       workingDirectory: cli
+#       failOnStderr: true
+#     env:
+#       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+#       DOTNET_MULTILEVEL_LOOKUP: true
+#     condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
 
-  - task: PowerShell@1
-    displayName: "Upload the build manifest file as a build artifact"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        Write-Host "##vso[task.uploadfile]$(ManifestFilePath)"
-    condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
+#   - task: PowerShell@1
+#     displayName: "Upload the build manifest file as a build artifact"
+#     inputs:
+#       scriptType: "inlineScript"
+#       inlineScript: |
+#         Write-Host "##vso[task.uploadfile]$(ManifestFilePath)"
+#     condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
 
-  - task: MSBuild@1
-    displayName: "Publish the build manifest file to the .NET Core build asset registry (BAR)"
-    inputs:
-      solution: 'build\\publish.proj'
-      msbuildVersion: 16.0
-      configuration: '$(BuildConfiguration)'
-      msbuildArguments: '/t:PublishManifestToBuildAssetRegistry /p:MaestroApiEndpoint=$(MaestroApiEndpoint) /p:ManifestsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\manifests /p:MaestroAccessToken=$(MaestroAccessToken)'
-    condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
+#   - task: MSBuild@1
+#     displayName: "Publish the build manifest file to the .NET Core build asset registry (BAR)"
+#     inputs:
+#       solution: 'build\\publish.proj'
+#       msbuildVersion: 16.0
+#       configuration: '$(BuildConfiguration)'
+#       msbuildArguments: '/t:PublishManifestToBuildAssetRegistry /p:MaestroApiEndpoint=$(MaestroApiEndpoint) /p:ManifestsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\manifests /p:MaestroAccessToken=$(MaestroAccessToken)'
+#     condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
 
-  - task: MicroBuildCleanup@1
-    displayName: "Perform Cleanup Tasks"
+#   - task: MicroBuildCleanup@1
+#     displayName: "Perform Cleanup Tasks"
 
-  - task: PowerShell@1
-    displayName: "Cleanup on Failure"
-    inputs:
-      scriptType: "inlineScript"
-      arguments: "-BuildOutputTargetPath $(BuildOutputTargetPath)"
-      inlineScript: |
-        param([string]$BuildOutputTargetPath)
-        Get-ChildItem $(BuildOutputTargetPath) -Recurse | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue
-        Remove-Item -Path $(BuildOutputTargetPath) -Force -Recurse -ErrorAction SilentlyContinue
-    condition: "eq(variables['Agent.JobStatus'], 'Failed')"
+#   - task: PowerShell@1
+#     displayName: "Cleanup on Failure"
+#     inputs:
+#       scriptType: "inlineScript"
+#       arguments: "-BuildOutputTargetPath $(BuildOutputTargetPath)"
+#       inlineScript: |
+#         param([string]$BuildOutputTargetPath)
+#         Get-ChildItem $(BuildOutputTargetPath) -Recurse | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue
+#         Remove-Item -Path $(BuildOutputTargetPath) -Force -Recurse -ErrorAction SilentlyContinue
+#     condition: "eq(variables['Agent.JobStatus'], 'Failed')"
 
-- phase: Functional_Tests_On_Windows
-  dependsOn: Initialize_Build
-  variables:
-    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-  condition: "and(succeeded(),eq(variables['RunFunctionalTestsOnWindows'], 'true')) "
-  queue:
-    name: VSEng-MicroBuildSxS
-    timeoutInMinutes: 150
-    demands: 
-        - DotNetFramework
-        - msbuild
+# - phase: Functional_Tests_On_Windows
+#   dependsOn: Initialize_Build
+#   variables:
+#     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+#     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+#   condition: "and(succeeded(),eq(variables['RunFunctionalTestsOnWindows'], 'true')) "
+#   queue:
+#     name: VSEng-MicroBuildSxS
+#     timeoutInMinutes: 150
+#     demands: 
+#         - DotNetFramework
+#         - msbuild
 
-  steps:
-  - task: PowerShell@1
-    displayName: "Print Environment Variables"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
-        gci env:* | sort-object name
+#   steps:
+#   - task: PowerShell@1
+#     displayName: "Print Environment Variables"
+#     inputs:
+#       scriptType: "inlineScript"
+#       inlineScript: |
+#         Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
+#         gci env:* | sort-object name
 
-  - task: PowerShell@1
-    displayName: "Download Config Files"
-    enabled: "false"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        $url = $(VstsConfigFileRootUrl) -f 'NuGet.Core.FuncTests.Config'
-        Invoke-RestMethod -Method Get -Uri $url -UseDefaultCredentials -OutFile $(Build.Repository.LocalPath)\\NuGet.Core.FuncTests.Config
-        $url = $(VstsConfigFileRootUrl) -f 'NuGet.Protocol.FuncTest.Config'
-        Invoke-RestMethod -Method Get -Uri $url -UseDefaultCredentials -OutFile $(Build.Repository.LocalPath)\\NuGet.Protocol.FuncTest.Config
+#   - task: PowerShell@1
+#     displayName: "Download Config Files"
+#     enabled: "false"
+#     inputs:
+#       scriptType: "inlineScript"
+#       inlineScript: |
+#         $url = $(VstsConfigFileRootUrl) -f 'NuGet.Core.FuncTests.Config'
+#         Invoke-RestMethod -Method Get -Uri $url -UseDefaultCredentials -OutFile $(Build.Repository.LocalPath)\\NuGet.Core.FuncTests.Config
+#         $url = $(VstsConfigFileRootUrl) -f 'NuGet.Protocol.FuncTest.Config'
+#         Invoke-RestMethod -Method Get -Uri $url -UseDefaultCredentials -OutFile $(Build.Repository.LocalPath)\\NuGet.Protocol.FuncTest.Config
 
-  - task: PowerShell@1
-    displayName: "Run Configure.ps1"
-    inputs:
-      scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
-      arguments: "-Force -CleanCache"
+#   - task: PowerShell@1
+#     displayName: "Run Configure.ps1"
+#     inputs:
+#       scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
+#       arguments: "-Force -CleanCache"
 
-  - task: MSBuild@1
-    displayName: "Restore for VS2019"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=false /v:m"
+#   - task: MSBuild@1
+#     displayName: "Restore for VS2019"
+#     inputs:
+#       solution: "build\\build.proj"
+#       msbuildVersion: "16.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=false /v:m"
 
-  - task: MSBuild@1
-    displayName: "Run Functional Tests"
-    continueOnError: "true"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:CoreFuncTests /p:BuildRTM=false /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml"
+#   - task: MSBuild@1
+#     displayName: "Run Functional Tests"
+#     continueOnError: "true"
+#     inputs:
+#       solution: "build\\build.proj"
+#       msbuildVersion: "16.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/t:CoreFuncTests /p:BuildRTM=false /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml"
 
-  - task: PublishTestResults@2
-    displayName: "Publish Test Results"
-    continueOnError: "true"
-    inputs:
-      testRunner: "XUnit"
-      testResultsFiles: "*.xml"
-      searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
-      mergeTestResults: "true"
-      testRunTitle: "NuGet.Client Functional Tests On Windows"
-    condition: "succeededOrFailed()"
+#   - task: PublishTestResults@2
+#     displayName: "Publish Test Results"
+#     continueOnError: "true"
+#     inputs:
+#       testRunner: "XUnit"
+#       testResultsFiles: "*.xml"
+#       searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
+#       mergeTestResults: "true"
+#       testRunTitle: "NuGet.Client Functional Tests On Windows"
+#     condition: "succeededOrFailed()"
 
-  - task: PowerShell@1
-    displayName: "Initialize Git Commit Status on GitHub"
-    inputs:
-      scriptType: "inlineScript"
-      arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
-      inlineScript: |
-        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
-        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -TestName "Functional Tests On Windows"
-    condition: "always()"
+#   - task: PowerShell@1
+#     displayName: "Initialize Git Commit Status on GitHub"
+#     inputs:
+#       scriptType: "inlineScript"
+#       arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
+#       inlineScript: |
+#         . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
+#         SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -TestName "Functional Tests On Windows"
+#     condition: "always()"
 
 - phase: Tests_On_Linux
   dependsOn: Initialize_Build
@@ -554,292 +554,292 @@ phases:
       failOnStderr: "true"
     condition: "always()"
 
-- phase: Tests_On_Mac
-  dependsOn:
-  - Build_and_UnitTest
-  - Initialize_Build
-  variables:
-    FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-  condition: "and(succeeded(),eq(variables['RunTestsOnMac'], 'true')) "
-  queue:
-    name: VSEng-MicroBuildMacSierra
-    timeoutInMinutes: 75
-    demands: sh
+# - phase: Tests_On_Mac
+#   dependsOn:
+#   - Build_and_UnitTest
+#   - Initialize_Build
+#   variables:
+#     FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+#   condition: "and(succeeded(),eq(variables['RunTestsOnMac'], 'true')) "
+#   queue:
+#     name: VSEng-MicroBuildMacSierra
+#     timeoutInMinutes: 75
+#     demands: sh
 
-  steps:
-  - task: PowerShell@2
-    displayName: "Update Build Number"
-    inputs:
-      targetType: "inline"
-      script: |
-        Write-Host "##vso[build.updatebuildnumber]$env:FULLVSTSBUILDNUMBER"
-      failOnStderr: "true"
-    condition: "always()"
+#   steps:
+#   - task: PowerShell@2
+#     displayName: "Update Build Number"
+#     inputs:
+#       targetType: "inline"
+#       script: |
+#         Write-Host "##vso[build.updatebuildnumber]$env:FULLVSTSBUILDNUMBER"
+#       failOnStderr: "true"
+#     condition: "always()"
 
-  - task: DownloadBuildArtifacts@0
-    displayName: "Download NuGet.ComamandLine.Test artifacts"
-    inputs:
-      artifactName: "NuGet.CommandLine.Test"
-      downloadPath: "$(Build.Repository.LocalPath)/artifacts"
+#   - task: DownloadBuildArtifacts@0
+#     displayName: "Download NuGet.ComamandLine.Test artifacts"
+#     inputs:
+#       artifactName: "NuGet.CommandLine.Test"
+#       downloadPath: "$(Build.Repository.LocalPath)/artifacts"
 
-  - task: ShellScript@2
-    displayName: "Run Tests"
-    continueOnError: "true"
-    inputs:
-      scriptPath: "scripts/funcTests/runFuncTests.sh"
-      disableAutoCwd: "true"
-      cwd: "$(Build.Repository.LocalPath)"
+#   - task: ShellScript@2
+#     displayName: "Run Tests"
+#     continueOnError: "true"
+#     inputs:
+#       scriptPath: "scripts/funcTests/runFuncTests.sh"
+#       disableAutoCwd: "true"
+#       cwd: "$(Build.Repository.LocalPath)"
 
-  - task: PublishTestResults@2
-    displayName: "Publish Test Results"
-    inputs:
-      testRunner: "XUnit"
-      testResultsFiles: "*.xml"
-      searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
-      mergeTestResults: "true"
-      testRunTitle: "NuGet.Client Tests On Mac"
-    condition: "succeededOrFailed()"
+#   - task: PublishTestResults@2
+#     displayName: "Publish Test Results"
+#     inputs:
+#       testRunner: "XUnit"
+#       testResultsFiles: "*.xml"
+#       searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
+#       mergeTestResults: "true"
+#       testRunTitle: "NuGet.Client Tests On Mac"
+#     condition: "succeededOrFailed()"
 
-  - task: PowerShell@2
-    displayName: "Initialize Git Commit Status on GitHub"
-    inputs:
-      targetType: "inline"
-      arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
-      script: |
-        . $(Build.Repository.LocalPath)/scripts/utils/PostGitCommitStatus.ps1
-        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Tests On Mac"
-      failOnStderr: "true"
-    condition: "always()"
+#   - task: PowerShell@2
+#     displayName: "Initialize Git Commit Status on GitHub"
+#     inputs:
+#       targetType: "inline"
+#       arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
+#       script: |
+#         . $(Build.Repository.LocalPath)/scripts/utils/PostGitCommitStatus.ps1
+#         SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Tests On Mac"
+#       failOnStderr: "true"
+#     condition: "always()"
 
-- phase: End_To_End_Tests_On_Windows
-  dependsOn:
-  - Build_and_UnitTest
-  - Initialize_Build
-  variables:
-    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-  condition: "and(succeeded(),eq(variables['RunEndToEndTests'], 'true')) "
-  queue:
-    timeoutInMinutes: 90
-    name: DDNuGet-Windows
-    demands: DotNetFramework
+# - phase: End_To_End_Tests_On_Windows
+#   dependsOn:
+#   - Build_and_UnitTest
+#   - Initialize_Build
+#   variables:
+#     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+#   condition: "and(succeeded(),eq(variables['RunEndToEndTests'], 'true')) "
+#   queue:
+#     timeoutInMinutes: 90
+#     name: DDNuGet-Windows
+#     demands: DotNetFramework
 
-  steps:
-  - task: PowerShell@1
-    displayName: "Print Environment Variables"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
-        gci env:* | sort-object name
+#   steps:
+#   - task: PowerShell@1
+#     displayName: "Print Environment Variables"
+#     inputs:
+#       scriptType: "inlineScript"
+#       inlineScript: |
+#         Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
+#         gci env:* | sort-object name
 
-  - task: DownloadBuildArtifacts@0
-    displayName: "Download Build artifacts"
-    inputs:
-      artifactName: "VS15"
-      downloadPath: "$(Build.Repository.LocalPath)/artifacts"
+#   - task: DownloadBuildArtifacts@0
+#     displayName: "Download Build artifacts"
+#     inputs:
+#       artifactName: "VS15"
+#       downloadPath: "$(Build.Repository.LocalPath)/artifacts"
 
-  - task: PowerShell@1
-    displayName: "Bootstrap.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
-      arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
+#   - task: PowerShell@1
+#     displayName: "Bootstrap.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
+#       arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
 
-  - task: PowerShell@1
-    displayName: "SetupFunctionalTests.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
+#   - task: PowerShell@1
+#     displayName: "SetupFunctionalTests.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
 
-  - task: PowerShell@1
-    displayName: "SetupMachine.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupMachine.ps1"
+#   - task: PowerShell@1
+#     displayName: "SetupMachine.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupMachine.ps1"
 
-  - task: PowerShell@1
-    displayName: "InstallNuGetVSIX.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
-      arguments: "-NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 16.0"
-      failOnStandardError: "false"
+#   - task: PowerShell@1
+#     displayName: "InstallNuGetVSIX.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
+#       arguments: "-NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 16.0"
+#       failOnStandardError: "false"
 
-  - task: PowerShell@1
-    displayName: "Collect VS Logs"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        Invoke-WebRequest -Uri $(CollectExeUrl) -OutFile $(System.DefaultWorkingDirectory)\\VSCollect.exe
-        $(System.DefaultWorkingDirectory)\\VSCollect.exe -zip:$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\e2e-collectlogs.zip
-    condition: "failed()"
+#   - task: PowerShell@1
+#     displayName: "Collect VS Logs"
+#     inputs:
+#       scriptType: "inlineScript"
+#       inlineScript: |
+#         Invoke-WebRequest -Uri $(CollectExeUrl) -OutFile $(System.DefaultWorkingDirectory)\\VSCollect.exe
+#         $(System.DefaultWorkingDirectory)\\VSCollect.exe -zip:$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\e2e-collectlogs.zip
+#     condition: "failed()"
 
-  - task: PowerShell@1
-    displayName: "RunFunctionalTests.ps1"    
-    timeoutInMinutes: 75
-    continueOnError: "true"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
-      arguments: "-PMCCommand $(EndToEndTestCommandToRun) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 16.0"
+#   - task: PowerShell@1
+#     displayName: "RunFunctionalTests.ps1"    
+#     timeoutInMinutes: 75
+#     continueOnError: "true"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
+#       arguments: "-PMCCommand $(EndToEndTestCommandToRun) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 16.0"
 
-  - task: PublishTestResults@2
-    displayName: "Publish Test Results"
-    inputs:
-      testRunner: "JUnit"
-      testResultsFiles: "*.xml"
-      searchFolder: "$(System.DefaultWorkingDirectory)\\testresults"
-      mergeTestResults: "true"
-      testRunTitle: "NuGet.Client EndToEnd Tests On Windows"
-    condition: "succeededOrFailed()"
+#   - task: PublishTestResults@2
+#     displayName: "Publish Test Results"
+#     inputs:
+#       testRunner: "JUnit"
+#       testResultsFiles: "*.xml"
+#       searchFolder: "$(System.DefaultWorkingDirectory)\\testresults"
+#       mergeTestResults: "true"
+#       testRunTitle: "NuGet.Client EndToEnd Tests On Windows"
+#     condition: "succeededOrFailed()"
 
-  - task: PowerShell@1
-    displayName: "Initialize Git Commit Status on GitHub"
-    inputs:
-      scriptType: "inlineScript"
-      arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
-      inlineScript: |
-        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
-        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "EndToEnd Tests On Windows"
-    condition: "always()"
+#   - task: PowerShell@1
+#     displayName: "Initialize Git Commit Status on GitHub"
+#     inputs:
+#       scriptType: "inlineScript"
+#       arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
+#       inlineScript: |
+#         . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
+#         SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "EndToEnd Tests On Windows"
+#     condition: "always()"
 
-  - task: PowerShell@1
-    displayName: "Kill running instances of DevEnv"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        . $(Build.Repository.LocalPath)\\scripts\\e2etests\\VSUtils.ps1
-        KillRunningInstancesOfVS
-    condition: "always()"
+#   - task: PowerShell@1
+#     displayName: "Kill running instances of DevEnv"
+#     inputs:
+#       scriptType: "inlineScript"
+#       inlineScript: |
+#         . $(Build.Repository.LocalPath)\\scripts\\e2etests\\VSUtils.ps1
+#         KillRunningInstancesOfVS
+#     condition: "always()"
 
-- phase: Apex_Tests_On_Windows
-  dependsOn:
-  - Build_and_UnitTest
-  - Initialize_Build
-  variables:
-    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-  condition: "and(succeeded(),eq(variables['RunApexTests'], 'true')) "
-  queue:
-    name: DDNuGet-Windows
-    demands: DotNetFramework
+# - phase: Apex_Tests_On_Windows
+#   dependsOn:
+#   - Build_and_UnitTest
+#   - Initialize_Build
+#   variables:
+#     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+#     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+#   condition: "and(succeeded(),eq(variables['RunApexTests'], 'true')) "
+#   queue:
+#     name: DDNuGet-Windows
+#     demands: DotNetFramework
 
-  steps:
-  - checkout: self
-    clean: true
-    submodules: true
+#   steps:
+#   - checkout: self
+#     clean: true
+#     submodules: true
     
-  - task: PowerShell@1
-    displayName: "Print Environment Variables"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
-        gci env:* | sort-object name
+#   - task: PowerShell@1
+#     displayName: "Print Environment Variables"
+#     inputs:
+#       scriptType: "inlineScript"
+#       inlineScript: |
+#         Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
+#         gci env:* | sort-object name
 
-  - task: DownloadBuildArtifacts@0
-    displayName: "Download Build artifacts"
-    inputs:
-      artifactName: "VS15"
-      downloadPath: "$(Build.Repository.LocalPath)/artifacts"
+#   - task: DownloadBuildArtifacts@0
+#     displayName: "Download Build artifacts"
+#     inputs:
+#       artifactName: "VS15"
+#       downloadPath: "$(Build.Repository.LocalPath)/artifacts"
         
-  - task: NuGetToolInstaller@0
-    displayName: "Use NuGet 4.5.0"
-    inputs:
-      versionSpec: "4.5.0"
+#   - task: NuGetToolInstaller@0
+#     displayName: "Use NuGet 4.5.0"
+#     inputs:
+#       versionSpec: "4.5.0"
 
-  - task: NuGetCommand@2
-    displayName: "Download packages.config packages"
-    inputs:
-      restoreSolution: ".nuget/packages.config"
-      feedsToUse: "config"
-      nugetConfigPath: "NuGet.Config"
-      restoreDirectory: "$(System.DefaultWorkingDirectory)/packages"
+#   - task: NuGetCommand@2
+#     displayName: "Download packages.config packages"
+#     inputs:
+#       restoreSolution: ".nuget/packages.config"
+#       feedsToUse: "config"
+#       nugetConfigPath: "NuGet.Config"
+#       restoreDirectory: "$(System.DefaultWorkingDirectory)/packages"
 
-  - task: PowerShell@1
-    displayName: "Bootstrap.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
-      arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
+#   - task: PowerShell@1
+#     displayName: "Bootstrap.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
+#       arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
 
-  - task: PowerShell@1
-    displayName: "SetupFunctionalTests.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
-      arguments: "-VSVersion 16.0"
+#   - task: PowerShell@1
+#     displayName: "SetupFunctionalTests.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
+#       arguments: "-VSVersion 16.0"
 
-  - task: PowerShell@1
-    displayName: "InstallNuGetVSIX.ps1"
-    inputs:
-      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
-      arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 16.0"
-      failOnStandardError: "false"
+#   - task: PowerShell@1
+#     displayName: "InstallNuGetVSIX.ps1"
+#     inputs:
+#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
+#       arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 16.0"
+#       failOnStandardError: "false"
 
-  # - task: PowerShell@1
-  #   displayName: "Collect VS Logs"
-  #   inputs:
-  #     scriptType: "inlineScript"
-  #     inlineScript: |
-  #       Invoke-WebRequest -Uri $(CollectExeUrl) -OutFile $(System.DefaultWorkingDirectory)\\VSCollect.exe
-  #       if(-not (Test-Path $(EndToEndResultsDropPath)))
-  #         {
-  #           New-Item -Path $(EndToEndResultsDropPath) -ItemType Directory -Force
-  #         }
-  #       $(System.DefaultWorkingDirectory)\\VSCollect.exe -zip:$(EndToEndResultsDropPath)\\apex-collectlogs.zip
-  #   condition: "failed()"
+#   # - task: PowerShell@1
+#   #   displayName: "Collect VS Logs"
+#   #   inputs:
+#   #     scriptType: "inlineScript"
+#   #     inlineScript: |
+#   #       Invoke-WebRequest -Uri $(CollectExeUrl) -OutFile $(System.DefaultWorkingDirectory)\\VSCollect.exe
+#   #       if(-not (Test-Path $(EndToEndResultsDropPath)))
+#   #         {
+#   #           New-Item -Path $(EndToEndResultsDropPath) -ItemType Directory -Force
+#   #         }
+#   #       $(System.DefaultWorkingDirectory)\\VSCollect.exe -zip:$(EndToEndResultsDropPath)\\apex-collectlogs.zip
+#   #   condition: "failed()"
 
-  - task: MSBuild@1
-    displayName: "Restore for VS2019"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber)"
+#   - task: MSBuild@1
+#     displayName: "Restore for VS2019"
+#     inputs:
+#       solution: "build\\build.proj"
+#       msbuildVersion: "16.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber)"
 
-  - task: NuGetCommand@2
-    displayName: "Add Apex Feed Source"
-    inputs:
-      command: "custom"
-      arguments: "sources add -Name ApexFeed -Source $(ApexPackageFeedUrl) -UserName $(ApexPackageFeedUsername) -Password $(ApexPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\\NuGet.config"
+#   - task: NuGetCommand@2
+#     displayName: "Add Apex Feed Source"
+#     inputs:
+#       command: "custom"
+#       arguments: "sources add -Name ApexFeed -Source $(ApexPackageFeedUrl) -UserName $(ApexPackageFeedUsername) -Password $(ApexPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\\NuGet.config"
 
-  - task: MSBuild@1
-    displayName: "Restore Apex Tests"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:RestoreApex /p:BuildNumber=$(BuildNumber)"
+#   - task: MSBuild@1
+#     displayName: "Restore Apex Tests"
+#     inputs:
+#       solution: "build\\build.proj"
+#       msbuildVersion: "16.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/t:RestoreApex /p:BuildNumber=$(BuildNumber)"
 
-  - task: MSBuild@1
-    displayName: "Run Apex Tests"
-    timeoutInMinutes: 45
-    continueOnError: "true"
-    inputs:
-      solution: "build\\build.proj"
-      msbuildVersion: "16.0"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml /p:BuildNumber=$(BuildNumber)"
+#   - task: MSBuild@1
+#     displayName: "Run Apex Tests"
+#     timeoutInMinutes: 45
+#     continueOnError: "true"
+#     inputs:
+#       solution: "build\\build.proj"
+#       msbuildVersion: "16.0"
+#       configuration: "$(BuildConfiguration)"
+#       msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml /p:BuildNumber=$(BuildNumber)"
 
-  - task: PublishTestResults@2
-    displayName: "Publish Test Results"
-    inputs:
-      testRunner: "XUnit"
-      testResultsFiles: "*.xml"
-      searchFolder: "$(System.DefaultWorkingDirectory)\\build\\TestResults"
-      mergeTestResults: "true"
-      testRunTitle: "NuGet.Client Apex Tests On Windows"
-    condition: "succeededOrFailed()"
+#   - task: PublishTestResults@2
+#     displayName: "Publish Test Results"
+#     inputs:
+#       testRunner: "XUnit"
+#       testResultsFiles: "*.xml"
+#       searchFolder: "$(System.DefaultWorkingDirectory)\\build\\TestResults"
+#       mergeTestResults: "true"
+#       testRunTitle: "NuGet.Client Apex Tests On Windows"
+#     condition: "succeededOrFailed()"
 
-  - task: PowerShell@1
-    displayName: "Initialize Git Commit Status on GitHub"
-    inputs:
-      arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
-      scriptType: "inlineScript"
-      inlineScript: |
-        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
-        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Apex Tests On Windows"
-    condition: "always()"
+#   - task: PowerShell@1
+#     displayName: "Initialize Git Commit Status on GitHub"
+#     inputs:
+#       arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
+#       scriptType: "inlineScript"
+#       inlineScript: |
+#         . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
+#         SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Apex Tests On Windows"
+#     condition: "always()"
 
-  - task: PowerShell@1
-    displayName: "Kill running instances of DevEnv"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        . $(Build.Repository.LocalPath)\\scripts\\e2etests\\VSUtils.ps1
-        KillRunningInstancesOfVS
-    condition: "always()"
+#   - task: PowerShell@1
+#     displayName: "Kill running instances of DevEnv"
+#     inputs:
+#       scriptType: "inlineScript"
+#       inlineScript: |
+#         . $(Build.Repository.LocalPath)\\scripts\\e2etests\\VSUtils.ps1
+#         KillRunningInstancesOfVS
+#     condition: "always()"

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -518,7 +518,7 @@ phases:
     demands: sh
 
   steps:
-  - bash: echo $(MSBUILDDISABLENODEREUSE)
+  - bash: echo MSBUILDDISABLENODEREUSE=$(MSBUILDDISABLENODEREUSE)
   - task: PowerShell@2
     displayName: "Update Build Number"
     inputs:

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -56,455 +56,455 @@ phases:
         Write-Host "##vso[build.addbuildtag]$env:BUILD_SOURCEVERSIONAUTHOR"
         Write-Host "##vso[build.addbuildtag]$env:BUILD_SOURCEBRANCHNAME"
 
-# - phase: Build_and_UnitTest
-#   dependsOn: Initialize_Build
-#   variables:
-#     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-#     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-#   queue:
-#     name: VSEng-MicroBuildVS2019
-#     timeoutInMinutes: 90
-#     parallel: 2
-#     matrix:
-#       RTM:
-#         BuildRTM: "true"
-#       NonRTM:
-#         BuildRTM: "false"
-#     demands: 
-#       - DotNetFramework
-#       - msbuild
+- phase: Build_and_UnitTest
+  dependsOn: Initialize_Build
+  variables:
+    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+  queue:
+    name: VSEng-MicroBuildVS2019
+    timeoutInMinutes: 90
+    parallel: 2
+    matrix:
+      RTM:
+        BuildRTM: "true"
+      NonRTM:
+        BuildRTM: "false"
+    demands: 
+      - DotNetFramework
+      - msbuild
 
-#   steps:
-#   - task: PowerShell@1
-#     displayName: "Update Build Number"
-#     inputs:
-#       scriptType: "inlineScript"
-#       inlineScript: |
-#         Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
-#         gci env:* | sort-object name
+  steps:
+  - task: PowerShell@1
+    displayName: "Update Build Number"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
+        gci env:* | sort-object name
 
-#   - task: PowerShell@1
-#     displayName: "Define variables"
-#     inputs:
-#       scriptType: "inlineScript"
-#       inlineScript: |
-#         Write-Host "##vso[task.setvariable variable=ManifestFilePath]$(Build.Repository.LocalPath)\artifacts\manifests\nuget.client.xml"
+  - task: PowerShell@1
+    displayName: "Define variables"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        Write-Host "##vso[task.setvariable variable=ManifestFilePath]$(Build.Repository.LocalPath)\artifacts\manifests\nuget.client.xml"
 
-#   - task: NuGetToolInstaller@0
-#     displayName: "Use NuGet 5.0.0"
-#     inputs:
-#       versionSpec: "5.0.0"
+  - task: NuGetToolInstaller@0
+    displayName: "Use NuGet 5.0.0"
+    inputs:
+      versionSpec: "5.0.0"
 
-#   - task: PowerShell@1
-#     inputs:
-#       scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
-#       arguments: "-Force"
-#     displayName: "Run Configure.ps1"
+  - task: PowerShell@1
+    inputs:
+      scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
+      arguments: "-Force"
+    displayName: "Run Configure.ps1"
 
-#   - task: PowerShell@1
-#     inputs:
-#       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
-#       arguments: "-BuildCounterFile $(BuildCounterFile) -BuildInfoJsonFile $(BuildInfoJsonFile) -BuildRTM $(BuildRTM) -SkipUpdateBuildNumber"
-#     displayName: "Configure VSTS CI Environment"
+  - task: PowerShell@1
+    inputs:
+      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
+      arguments: "-BuildCounterFile $(BuildCounterFile) -BuildInfoJsonFile $(BuildInfoJsonFile) -BuildRTM $(BuildRTM) -SkipUpdateBuildNumber"
+    displayName: "Configure VSTS CI Environment"
 
-#   - task: PowerShell@1
-#     displayName: "Print Environment Variables"
-#     inputs:
-#       scriptType: "inlineScript"
-#       inlineScript: |
-#         gci env:* | sort-object name
+  - task: PowerShell@1
+    displayName: "Print Environment Variables"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        gci env:* | sort-object name
 
-#   - task: MicroBuildLocalizationPlugin@1
-#     displayName: "Install Localization Plugin"
+  - task: MicroBuildLocalizationPlugin@1
+    displayName: "Install Localization Plugin"
 
-#   - task: MicroBuildSigningPlugin@1
-#     inputs:
-#       signType: "$(SigningType)"
-#       esrpSigning: "true"
-#     displayName: "Install Signing Plugin"
+  - task: MicroBuildSigningPlugin@1
+    inputs:
+      signType: "$(SigningType)"
+      esrpSigning: "true"
+    displayName: "Install Signing Plugin"
 
-#   - task: MicroBuildSwixPlugin@1
-#     displayName: "Install Swix Plugin"
+  - task: MicroBuildSwixPlugin@1
+    displayName: "Install Swix Plugin"
 
-#   - task: MSBuild@1
-#     displayName: "Restore for VS2019"
-#     inputs:
-#       solution: "build\\build.proj"
-#       msbuildVersion: "16.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=$(BuildRTM) /v:m"
+  - task: MSBuild@1
+    displayName: "Restore for VS2019"
+    inputs:
+      solution: "build\\build.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=$(BuildRTM) /v:m"
 
-#   - task: MSBuild@1
-#     displayName: "Build for VS2019"
-#     inputs:
-#       solution: "build\\build.proj"
-#       msbuildVersion: "16.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/t:BuildNoVSIX /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
+  - task: MSBuild@1
+    displayName: "Build for VS2019"
+    inputs:
+      solution: "build\\build.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:BuildNoVSIX /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
 
-#   - task: MSBuild@1
-#     displayName: "Ensure msbuild.exe can parse nuget.sln"
-#     continueOnError: "false"
-#     inputs:
-#       solution: "nuget.sln"
-#       msbuildVersion: "16.0"
-#       msbuildArguments: "/t:EnsureNewtonsoftJsonVersion"
-#     condition: "succeeded()"
+  - task: MSBuild@1
+    displayName: "Ensure msbuild.exe can parse nuget.sln"
+    continueOnError: "false"
+    inputs:
+      solution: "nuget.sln"
+      msbuildVersion: "16.0"
+      msbuildArguments: "/t:EnsureNewtonsoftJsonVersion"
+    condition: "succeeded()"
 
-#   - task: MSBuild@1
-#     displayName: "Run unit tests"
-#     continueOnError: "true"
-#     inputs:
-#       solution: "build\\build.proj"
-#       msbuildVersion: "16.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml"
-#     condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
+  - task: MSBuild@1
+    displayName: "Run unit tests"
+    continueOnError: "true"
+    inputs:
+      solution: "build\\build.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml"
+    condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
-#   - task: PublishTestResults@2
-#     displayName: "Publish Test Results"
-#     inputs:
-#       testRunner: "XUnit"
-#       testResultsFiles: "*.xml"
-#       testRunTitle: "NuGet.Client Unit Tests On Windows"
-#       searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
-#       mergeTestResults: "true"
-#       publishRunAttachments: "false"
-#     condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
+  - task: PublishTestResults@2
+    displayName: "Publish Test Results"
+    inputs:
+      testRunner: "XUnit"
+      testResultsFiles: "*.xml"
+      testRunTitle: "NuGet.Client Unit Tests On Windows"
+      searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
+      mergeTestResults: "true"
+      publishRunAttachments: "false"
+    condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
 
-#   - task: PowerShell@1
-#     displayName: "Initialize Git Commit Status on GitHub"
-#     inputs:
-#       scriptType: "inlineScript"
-#       arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
-#       inlineScript: |
-#         . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
-#         SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Unit Tests On Windows"
-#     condition: "and(always(),eq(variables['BuildRTM'], 'true'))"
+  - task: PowerShell@1
+    displayName: "Initialize Git Commit Status on GitHub"
+    inputs:
+      scriptType: "inlineScript"
+      arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
+      inlineScript: |
+        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
+        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Unit Tests On Windows"
+    condition: "and(always(),eq(variables['BuildRTM'], 'true'))"
 
-#   - task: PublishBuildArtifacts@1
-#     displayName: "Publish NuGet.CommandLine.Test as artifact"
-#     inputs:
-#       PathtoPublish: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472\\win7-x64"
-#       ArtifactName: "NuGet.CommandLine.Test"
-#       ArtifactType: "Container"
-#     condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
+  - task: PublishBuildArtifacts@1
+    displayName: "Publish NuGet.CommandLine.Test as artifact"
+    inputs:
+      PathtoPublish: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472\\win7-x64"
+      ArtifactName: "NuGet.CommandLine.Test"
+      ArtifactType: "Container"
+    condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
-#   - task: MSBuild@1
-#     displayName: "Localize Assemblies"
-#     inputs:
-#       solution: "build\\loc.proj"
-#       msbuildVersion: "16.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/t:AfterBuild"
-#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+  - task: MSBuild@1
+    displayName: "Localize Assemblies"
+    inputs:
+      solution: "build\\loc.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:AfterBuild"
+    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
-#   - task: MSBuild@1
-#     displayName: "Sign Assemblies"
-#     inputs:
-#       solution: "build\\sign.proj"
-#       msbuildVersion: "16.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/t:AfterBuild"
+  - task: MSBuild@1
+    displayName: "Sign Assemblies"
+    inputs:
+      solution: "build\\sign.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:AfterBuild"
 
-#   - task: MSBuild@1
-#     displayName: "Pack Nupkgs"
-#     inputs:
-#       solution: "build\\build.proj"
-#       msbuildVersion: "16.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
+  - task: MSBuild@1
+    displayName: "Pack Nupkgs"
+    inputs:
+      solution: "build\\build.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
 
-#   - task: MSBuild@1
-#     displayName: "Pack VSIX"
-#     inputs:
-#       solution: "build\\build.proj"
-#       msbuildVersion: "16.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/t:BuildVSIX /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:IsCIBuild=true"
-#     condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+  - task: MSBuild@1
+    displayName: "Pack VSIX"
+    inputs:
+      solution: "build\\build.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:BuildVSIX /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:IsCIBuild=true"
+    condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
-#   - task: MSBuild@1
-#     displayName: "Generate Build Tools package"
-#     inputs:
-#       solution: "setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
-#       msbuildVersion: "16.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true"
-#     condition: " and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  - task: MSBuild@1
+    displayName: "Generate Build Tools package"
+    inputs:
+      solution: "setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true"
+    condition: " and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-#   - task: MSBuild@1
-#     displayName: "Sign Nupkgs and VSIX"
-#     inputs:
-#       solution: "build\\sign.proj"
-#       msbuildVersion: "16.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/t:AfterBuild /p:SignPackages=true"
+  - task: MSBuild@1
+    displayName: "Sign Nupkgs and VSIX"
+    inputs:
+      solution: "build\\sign.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:AfterBuild /p:SignPackages=true"
 
-#   - task: NuGetCommand@2
-#     displayName: "Verify Nupkg Signatures"
-#     inputs:
-#       command: "custom"
-#       arguments: "verify -Signatures $(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)\\*.nupkg"
+  - task: NuGetCommand@2
+    displayName: "Verify Nupkg Signatures"
+    inputs:
+      command: "custom"
+      arguments: "verify -Signatures $(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)\\*.nupkg"
 
-#   - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
-#     displayName: Verify Assembly Signatures and StrongName for the nupkgs
-#     inputs:
-#       TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
+  - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
+    displayName: Verify Assembly Signatures and StrongName for the nupkgs
+    inputs:
+      TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
 
-#   - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
-#     displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
-#     inputs:
-#       TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
-#       WhiteListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
-#       WhiteListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
+  - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@1
+    displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
+    inputs:
+      TargetFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)'
+      WhiteListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
+      WhiteListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
 
-#   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-#     displayName: 'Component Detection'
-#     condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'
+    condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
-#   - task: CopyFiles@2
-#     displayName: "Copy Nupkgs"
-#     inputs:
-#       SourceFolder: "artifacts\\$(NupkgOutputDir)"
-#       Contents: "*.nupkg"
-#       TargetFolder: "$(BuildOutputTargetPath)\\artifacts\\$(VsixPublishDir)\\$(NupkgOutputDir)"
+  - task: CopyFiles@2
+    displayName: "Copy Nupkgs"
+    inputs:
+      SourceFolder: "artifacts\\$(NupkgOutputDir)"
+      Contents: "*.nupkg"
+      TargetFolder: "$(BuildOutputTargetPath)\\artifacts\\$(VsixPublishDir)\\$(NupkgOutputDir)"
 
-#   - task: MSBuild@1
-#     displayName: "Generate VSMAN file for NuGet Core VSIX"
-#     inputs:
-#       solution: "setup\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
-#       msbuildVersion: "16.0"
-#       configuration: "$(BuildConfiguration)"
-#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+  - task: MSBuild@1
+    displayName: "Generate VSMAN file for NuGet Core VSIX"
+    inputs:
+      solution: "setup\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
-#   - task: MSBuild@1
-#     displayName: "Generate VSMAN file for Build Tools VSIX"
-#     inputs:
-#       solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
-#       msbuildVersion: "16.0"
-#       configuration: "$(BuildConfiguration)"
-#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+  - task: MSBuild@1
+    displayName: "Generate VSMAN file for Build Tools VSIX"
+    inputs:
+      solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
-#   - task: PowerShell@1
-#     displayName: "Create EndToEnd Test Package"
-#     inputs:
-#       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\CreateEndToEndTestPackage.ps1"
-#       arguments: "-c $(BuildConfiguration) -tv 16 -out $(Build.Repository.LocalPath)\\artifacts\\VS15"
-#       failOnStandardError: "true"
-#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+  - task: PowerShell@1
+    displayName: "Create EndToEnd Test Package"
+    inputs:
+      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\CreateEndToEndTestPackage.ps1"
+      arguments: "-c $(BuildConfiguration) -tv 16 -out $(Build.Repository.LocalPath)\\artifacts\\VS15"
+      failOnStandardError: "true"
+    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
-#   - task: CopyFiles@2
-#     displayName: "Copy NuGet.exe, VSIX and EndToEnd"
-#     inputs:
-#       SourceFolder: "artifacts"
-#       Contents: |
-#         $(VsixPublishDir)\\NuGet.exe
-#         $(VsixPublishDir)\\NuGet.pdb
-#         $(VsixPublishDir)\\NuGet.Mssign.exe
-#         $(VsixPublishDir)\\NuGet.Mssign.pdb
-#         $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.Core.json
-#         $(VsixPublishDir)\\NuGet.Tools.vsix
-#         $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.BuildTools.vsix
-#         $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.BuildTools.json
-#         $(VsixPublishDir)\\EndToEnd.zip
-#       TargetFolder: "$(BuildOutputTargetPath)\\artifacts"
+  - task: CopyFiles@2
+    displayName: "Copy NuGet.exe, VSIX and EndToEnd"
+    inputs:
+      SourceFolder: "artifacts"
+      Contents: |
+        $(VsixPublishDir)\\NuGet.exe
+        $(VsixPublishDir)\\NuGet.pdb
+        $(VsixPublishDir)\\NuGet.Mssign.exe
+        $(VsixPublishDir)\\NuGet.Mssign.pdb
+        $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.Core.json
+        $(VsixPublishDir)\\NuGet.Tools.vsix
+        $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.BuildTools.vsix
+        $(VsixPublishDir)\\Microsoft.VisualStudio.NuGet.BuildTools.json
+        $(VsixPublishDir)\\EndToEnd.zip
+      TargetFolder: "$(BuildOutputTargetPath)\\artifacts"
 
-#   - task: PublishBuildArtifacts@1
-#     displayName: "Publish NuGet.exe VSIX and EndToEnd.zip as artifact"
-#     inputs:
-#       PathtoPublish: "$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)"
-#       ArtifactName: "VS15"
-#       ArtifactType: "Container"
-#     condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+  - task: PublishBuildArtifacts@1
+    displayName: "Publish NuGet.exe VSIX and EndToEnd.zip as artifact"
+    inputs:
+      PathtoPublish: "$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)"
+      ArtifactName: "VS15"
+      ArtifactType: "Container"
+    condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
-#   - task: CopyFiles@2
-#     displayName: "Copy LCG Files"
-#     inputs:
-#       SourceFolder: "artifacts\\"
-#       Contents: "**\\*.lcg"
-#       TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
-#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
+  - task: CopyFiles@2
+    displayName: "Copy LCG Files"
+    inputs:
+      SourceFolder: "artifacts\\"
+      Contents: "**\\*.lcg"
+      TargetFolder: "$(CIRoot)\\PLOC\\$(Build.SourceBranchName)\\$(Build.BuildNumber)"
+    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
 
-#   - task: PowerShell@1
-#     displayName: "Publish Artifacts to MyGet"
-#     continueOnError: "true"
-#     inputs:
-#       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\PublishArtifactsFromVsts.ps1"
-#       arguments: "-NuGetBuildFeedUrl $(NuGetBuildFeed) -NuGetBuildSymbolsFeedUrl $(NuGetBuildSymbolsFeed) -DotnetCoreFeedUrl $(DotnetCoreBuildFeed) -DotnetCoreSymbolsFeedUrl $(DotnetCoreSymbolsFeed) -NuGetBuildFeedApiKey $(NuGetBuildApiKey) -DotnetCoreFeedApiKey $(DotnetCoreFeedApiKey)"
-#       failOnStandardError: "true"
-#     condition: " and(succeeded(),eq(variables['PublishArtifactsToMyGet'], 'true'), eq(variables['BuildRTM'], 'false')) "
+  - task: PowerShell@1
+    displayName: "Publish Artifacts to MyGet"
+    continueOnError: "true"
+    inputs:
+      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\PublishArtifactsFromVsts.ps1"
+      arguments: "-NuGetBuildFeedUrl $(NuGetBuildFeed) -NuGetBuildSymbolsFeedUrl $(NuGetBuildSymbolsFeed) -DotnetCoreFeedUrl $(DotnetCoreBuildFeed) -DotnetCoreSymbolsFeedUrl $(DotnetCoreSymbolsFeed) -NuGetBuildFeedApiKey $(NuGetBuildApiKey) -DotnetCoreFeedApiKey $(DotnetCoreFeedApiKey)"
+      failOnStandardError: "true"
+    condition: " and(succeeded(),eq(variables['PublishArtifactsToMyGet'], 'true'), eq(variables['BuildRTM'], 'false')) "
 
-#   - task: MSBuild@1
-#     displayName: "Collect Build Symbols"
-#     inputs:
-#       solution: "build\\symbols.proj"
-#       msbuildVersion: "16.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/p:IsSymbolBuild=true"
-#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
+  - task: MSBuild@1
+    displayName: "Collect Build Symbols"
+    inputs:
+      solution: "build\\symbols.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/p:IsSymbolBuild=true"
+    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
 
-#   - task: CopyFiles@2
-#     displayName: "Copy Symbols"
-#     inputs:
-#       SourceFolder: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
-#       Contents: "**\\*"
-#       TargetFolder: "$(BuildOutputTargetPath)\\symbols"
-#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
+  - task: CopyFiles@2
+    displayName: "Copy Symbols"
+    inputs:
+      SourceFolder: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
+      Contents: "**\\*"
+      TargetFolder: "$(BuildOutputTargetPath)\\symbols"
+    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
 
-#   - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
-#     displayName: "Publish Symbols on Symweb"
-#     inputs:
-#       symbolServiceURI: "https://microsoft.artifacts.visualstudio.com/DefaultCollection"
-#       requestName: "CollectionId/$(System.CollectionId)/ProjectId/$(System.TeamProjectId)/$(TeamName)/BuildId/$(Build.BuildId)"
-#       sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
-#       detailedLog: "true"
-#       expirationInDays: "45"
-#       usePat: "false"
-#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
+  - task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
+    displayName: "Publish Symbols on Symweb"
+    inputs:
+      symbolServiceURI: "https://microsoft.artifacts.visualstudio.com/DefaultCollection"
+      requestName: "CollectionId/$(System.CollectionId)/ProjectId/$(System.TeamProjectId)/$(TeamName)/BuildId/$(Build.BuildId)"
+      sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
+      detailedLog: "true"
+      expirationInDays: "45"
+      usePat: "false"
+    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true')) "
 
-#   - task: MicroBuildUploadVstsDropFolder@1
-#     displayName: "Upload VSTS Drop"
-#     inputs:
-#       DropFolder: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
-#     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+  - task: MicroBuildUploadVstsDropFolder@1
+    displayName: "Upload VSTS Drop"
+    inputs:
+      DropFolder: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
+    condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
-#   - task: PowerShell@1
-#     displayName: "Validate VSIX Localization"
-#     inputs:
-#       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
-#       arguments: "-BuildRTM $(BuildRTM) -BuildOutputTargetPath $(BuildOutputTargetPath) -ValidateVsix"
-#     condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
+  - task: PowerShell@1
+    displayName: "Validate VSIX Localization"
+    inputs:
+      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
+      arguments: "-BuildRTM $(BuildRTM) -BuildOutputTargetPath $(BuildOutputTargetPath) -ValidateVsix"
+    condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
 
-#   - task: PowerShell@1
-#     displayName: "Validate Repository Artifacts Localization"
-#     inputs:
-#       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
-#       arguments: "-BuildRTM $(BuildRTM) -BuildOutputTargetPath $(BuildOutputTargetPath)"
-#     condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
+  - task: PowerShell@1
+    displayName: "Validate Repository Artifacts Localization"
+    inputs:
+      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
+      arguments: "-BuildRTM $(BuildRTM) -BuildOutputTargetPath $(BuildOutputTargetPath)"
+    condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
 
-#     # Use dotnet msbuild instead of MSBuild CLI.
-#     # Using MSBuild CLI results in an assembly binding failure for NuGet.Common.dll 4.4.0.3 because Microsoft.DotNet.Build.Tasks.Feed.dll references SleetLib.dll which references NuGet.Common 4.4.0.3.
-#     # The Microsoft.DotNet.Build.Tasks.Feed package includes NuGet.Common 4.9.0.6 and a binding redirection in Microsoft.DotNet.Build.Tasks.Feed.dll.config but the binding redirection is not processed.
-#     # This would probably solve it:  https://github.com/Microsoft/msbuild/issues/1309
-#   - task: CmdLine@2
-#     displayName: "Publish the packages to the .NET Core build asset registry (BAR)"
-#     inputs:
-#       script: dotnet msbuild ..\build\publish.proj /t:PublishPackagesToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:FeedUrl=$(DotNetFeedUrl) /p:BuildId=$(Build.BuildNumber) /p:RepoBranch=$(Build.SourceBranchName) /p:RepoCommit=$(Build.SourceVersion) /p:RepoUri=$(Build.Repository.Uri) /p:ManifestFilePath=$(ManifestFilePath) /p:AccountKey=$(dotnetfeed-storage-access-key-1)
-#       workingDirectory: cli
-#       failOnStderr: true
-#     env:
-#       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-#       DOTNET_MULTILEVEL_LOOKUP: true
-#     condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
+    # Use dotnet msbuild instead of MSBuild CLI.
+    # Using MSBuild CLI results in an assembly binding failure for NuGet.Common.dll 4.4.0.3 because Microsoft.DotNet.Build.Tasks.Feed.dll references SleetLib.dll which references NuGet.Common 4.4.0.3.
+    # The Microsoft.DotNet.Build.Tasks.Feed package includes NuGet.Common 4.9.0.6 and a binding redirection in Microsoft.DotNet.Build.Tasks.Feed.dll.config but the binding redirection is not processed.
+    # This would probably solve it:  https://github.com/Microsoft/msbuild/issues/1309
+  - task: CmdLine@2
+    displayName: "Publish the packages to the .NET Core build asset registry (BAR)"
+    inputs:
+      script: dotnet msbuild ..\build\publish.proj /t:PublishPackagesToBuildAssetRegistry /p:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /p:FeedUrl=$(DotNetFeedUrl) /p:BuildId=$(Build.BuildNumber) /p:RepoBranch=$(Build.SourceBranchName) /p:RepoCommit=$(Build.SourceVersion) /p:RepoUri=$(Build.Repository.Uri) /p:ManifestFilePath=$(ManifestFilePath) /p:AccountKey=$(dotnetfeed-storage-access-key-1)
+      workingDirectory: cli
+      failOnStderr: true
+    env:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      DOTNET_MULTILEVEL_LOOKUP: true
+    condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
 
-#   - task: PowerShell@1
-#     displayName: "Upload the build manifest file as a build artifact"
-#     inputs:
-#       scriptType: "inlineScript"
-#       inlineScript: |
-#         Write-Host "##vso[task.uploadfile]$(ManifestFilePath)"
-#     condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
+  - task: PowerShell@1
+    displayName: "Upload the build manifest file as a build artifact"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        Write-Host "##vso[task.uploadfile]$(ManifestFilePath)"
+    condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
 
-#   - task: MSBuild@1
-#     displayName: "Publish the build manifest file to the .NET Core build asset registry (BAR)"
-#     inputs:
-#       solution: 'build\\publish.proj'
-#       msbuildVersion: 16.0
-#       configuration: '$(BuildConfiguration)'
-#       msbuildArguments: '/t:PublishManifestToBuildAssetRegistry /p:MaestroApiEndpoint=$(MaestroApiEndpoint) /p:ManifestsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\manifests /p:MaestroAccessToken=$(MaestroAccessToken)'
-#     condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
+  - task: MSBuild@1
+    displayName: "Publish the build manifest file to the .NET Core build asset registry (BAR)"
+    inputs:
+      solution: 'build\\publish.proj'
+      msbuildVersion: 16.0
+      configuration: '$(BuildConfiguration)'
+      msbuildArguments: '/t:PublishManifestToBuildAssetRegistry /p:MaestroApiEndpoint=$(MaestroApiEndpoint) /p:ManifestsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\manifests /p:MaestroAccessToken=$(MaestroAccessToken)'
+    condition: " and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false')) "
 
-#   - task: MicroBuildCleanup@1
-#     displayName: "Perform Cleanup Tasks"
+  - task: MicroBuildCleanup@1
+    displayName: "Perform Cleanup Tasks"
 
-#   - task: PowerShell@1
-#     displayName: "Cleanup on Failure"
-#     inputs:
-#       scriptType: "inlineScript"
-#       arguments: "-BuildOutputTargetPath $(BuildOutputTargetPath)"
-#       inlineScript: |
-#         param([string]$BuildOutputTargetPath)
-#         Get-ChildItem $(BuildOutputTargetPath) -Recurse | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue
-#         Remove-Item -Path $(BuildOutputTargetPath) -Force -Recurse -ErrorAction SilentlyContinue
-#     condition: "eq(variables['Agent.JobStatus'], 'Failed')"
+  - task: PowerShell@1
+    displayName: "Cleanup on Failure"
+    inputs:
+      scriptType: "inlineScript"
+      arguments: "-BuildOutputTargetPath $(BuildOutputTargetPath)"
+      inlineScript: |
+        param([string]$BuildOutputTargetPath)
+        Get-ChildItem $(BuildOutputTargetPath) -Recurse | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue
+        Remove-Item -Path $(BuildOutputTargetPath) -Force -Recurse -ErrorAction SilentlyContinue
+    condition: "eq(variables['Agent.JobStatus'], 'Failed')"
 
-# - phase: Functional_Tests_On_Windows
-#   dependsOn: Initialize_Build
-#   variables:
-#     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-#     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-#   condition: "and(succeeded(),eq(variables['RunFunctionalTestsOnWindows'], 'true')) "
-#   queue:
-#     name: VSEng-MicroBuildSxS
-#     timeoutInMinutes: 150
-#     demands: 
-#         - DotNetFramework
-#         - msbuild
+- phase: Functional_Tests_On_Windows
+  dependsOn: Initialize_Build
+  variables:
+    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+  condition: "and(succeeded(),eq(variables['RunFunctionalTestsOnWindows'], 'true')) "
+  queue:
+    name: VSEng-MicroBuildSxS
+    timeoutInMinutes: 150
+    demands: 
+        - DotNetFramework
+        - msbuild
 
-#   steps:
-#   - task: PowerShell@1
-#     displayName: "Print Environment Variables"
-#     inputs:
-#       scriptType: "inlineScript"
-#       inlineScript: |
-#         Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
-#         gci env:* | sort-object name
+  steps:
+  - task: PowerShell@1
+    displayName: "Print Environment Variables"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
+        gci env:* | sort-object name
 
-#   - task: PowerShell@1
-#     displayName: "Download Config Files"
-#     enabled: "false"
-#     inputs:
-#       scriptType: "inlineScript"
-#       inlineScript: |
-#         $url = $(VstsConfigFileRootUrl) -f 'NuGet.Core.FuncTests.Config'
-#         Invoke-RestMethod -Method Get -Uri $url -UseDefaultCredentials -OutFile $(Build.Repository.LocalPath)\\NuGet.Core.FuncTests.Config
-#         $url = $(VstsConfigFileRootUrl) -f 'NuGet.Protocol.FuncTest.Config'
-#         Invoke-RestMethod -Method Get -Uri $url -UseDefaultCredentials -OutFile $(Build.Repository.LocalPath)\\NuGet.Protocol.FuncTest.Config
+  - task: PowerShell@1
+    displayName: "Download Config Files"
+    enabled: "false"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        $url = $(VstsConfigFileRootUrl) -f 'NuGet.Core.FuncTests.Config'
+        Invoke-RestMethod -Method Get -Uri $url -UseDefaultCredentials -OutFile $(Build.Repository.LocalPath)\\NuGet.Core.FuncTests.Config
+        $url = $(VstsConfigFileRootUrl) -f 'NuGet.Protocol.FuncTest.Config'
+        Invoke-RestMethod -Method Get -Uri $url -UseDefaultCredentials -OutFile $(Build.Repository.LocalPath)\\NuGet.Protocol.FuncTest.Config
 
-#   - task: PowerShell@1
-#     displayName: "Run Configure.ps1"
-#     inputs:
-#       scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
-#       arguments: "-Force -CleanCache"
+  - task: PowerShell@1
+    displayName: "Run Configure.ps1"
+    inputs:
+      scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
+      arguments: "-Force -CleanCache"
 
-#   - task: MSBuild@1
-#     displayName: "Restore for VS2019"
-#     inputs:
-#       solution: "build\\build.proj"
-#       msbuildVersion: "16.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=false /v:m"
+  - task: MSBuild@1
+    displayName: "Restore for VS2019"
+    inputs:
+      solution: "build\\build.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber) /p:BuildRTM=false /v:m"
 
-#   - task: MSBuild@1
-#     displayName: "Run Functional Tests"
-#     continueOnError: "true"
-#     inputs:
-#       solution: "build\\build.proj"
-#       msbuildVersion: "16.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/t:CoreFuncTests /p:BuildRTM=false /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml"
+  - task: MSBuild@1
+    displayName: "Run Functional Tests"
+    continueOnError: "true"
+    inputs:
+      solution: "build\\build.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:CoreFuncTests /p:BuildRTM=false /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml"
 
-#   - task: PublishTestResults@2
-#     displayName: "Publish Test Results"
-#     continueOnError: "true"
-#     inputs:
-#       testRunner: "XUnit"
-#       testResultsFiles: "*.xml"
-#       searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
-#       mergeTestResults: "true"
-#       testRunTitle: "NuGet.Client Functional Tests On Windows"
-#     condition: "succeededOrFailed()"
+  - task: PublishTestResults@2
+    displayName: "Publish Test Results"
+    continueOnError: "true"
+    inputs:
+      testRunner: "XUnit"
+      testResultsFiles: "*.xml"
+      searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
+      mergeTestResults: "true"
+      testRunTitle: "NuGet.Client Functional Tests On Windows"
+    condition: "succeededOrFailed()"
 
-#   - task: PowerShell@1
-#     displayName: "Initialize Git Commit Status on GitHub"
-#     inputs:
-#       scriptType: "inlineScript"
-#       arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
-#       inlineScript: |
-#         . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
-#         SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -TestName "Functional Tests On Windows"
-#     condition: "always()"
+  - task: PowerShell@1
+    displayName: "Initialize Git Commit Status on GitHub"
+    inputs:
+      scriptType: "inlineScript"
+      arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
+      inlineScript: |
+        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
+        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -CommitSha $(Build.SourceVersion) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -TestName "Functional Tests On Windows"
+    condition: "always()"
 
 - phase: Tests_On_Linux
   dependsOn: Initialize_Build
@@ -555,292 +555,292 @@ phases:
       failOnStderr: "true"
     condition: "always()"
 
-# - phase: Tests_On_Mac
-#   dependsOn:
-#   - Build_and_UnitTest
-#   - Initialize_Build
-#   variables:
-#     FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-#   condition: "and(succeeded(),eq(variables['RunTestsOnMac'], 'true')) "
-#   queue:
-#     name: VSEng-MicroBuildMacSierra
-#     timeoutInMinutes: 75
-#     demands: sh
+- phase: Tests_On_Mac
+  dependsOn:
+  - Build_and_UnitTest
+  - Initialize_Build
+  variables:
+    FULLVSTSBUILDNUMBER: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+  condition: "and(succeeded(),eq(variables['RunTestsOnMac'], 'true')) "
+  queue:
+    name: VSEng-MicroBuildMacSierra
+    timeoutInMinutes: 75
+    demands: sh
 
-#   steps:
-#   - task: PowerShell@2
-#     displayName: "Update Build Number"
-#     inputs:
-#       targetType: "inline"
-#       script: |
-#         Write-Host "##vso[build.updatebuildnumber]$env:FULLVSTSBUILDNUMBER"
-#       failOnStderr: "true"
-#     condition: "always()"
+  steps:
+  - task: PowerShell@2
+    displayName: "Update Build Number"
+    inputs:
+      targetType: "inline"
+      script: |
+        Write-Host "##vso[build.updatebuildnumber]$env:FULLVSTSBUILDNUMBER"
+      failOnStderr: "true"
+    condition: "always()"
 
-#   - task: DownloadBuildArtifacts@0
-#     displayName: "Download NuGet.ComamandLine.Test artifacts"
-#     inputs:
-#       artifactName: "NuGet.CommandLine.Test"
-#       downloadPath: "$(Build.Repository.LocalPath)/artifacts"
+  - task: DownloadBuildArtifacts@0
+    displayName: "Download NuGet.ComamandLine.Test artifacts"
+    inputs:
+      artifactName: "NuGet.CommandLine.Test"
+      downloadPath: "$(Build.Repository.LocalPath)/artifacts"
 
-#   - task: ShellScript@2
-#     displayName: "Run Tests"
-#     continueOnError: "true"
-#     inputs:
-#       scriptPath: "scripts/funcTests/runFuncTests.sh"
-#       disableAutoCwd: "true"
-#       cwd: "$(Build.Repository.LocalPath)"
+  - task: ShellScript@2
+    displayName: "Run Tests"
+    continueOnError: "true"
+    inputs:
+      scriptPath: "scripts/funcTests/runFuncTests.sh"
+      disableAutoCwd: "true"
+      cwd: "$(Build.Repository.LocalPath)"
 
-#   - task: PublishTestResults@2
-#     displayName: "Publish Test Results"
-#     inputs:
-#       testRunner: "XUnit"
-#       testResultsFiles: "*.xml"
-#       searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
-#       mergeTestResults: "true"
-#       testRunTitle: "NuGet.Client Tests On Mac"
-#     condition: "succeededOrFailed()"
+  - task: PublishTestResults@2
+    displayName: "Publish Test Results"
+    inputs:
+      testRunner: "XUnit"
+      testResultsFiles: "*.xml"
+      searchFolder: "$(Build.Repository.LocalPath)/build/TestResults"
+      mergeTestResults: "true"
+      testRunTitle: "NuGet.Client Tests On Mac"
+    condition: "succeededOrFailed()"
 
-#   - task: PowerShell@2
-#     displayName: "Initialize Git Commit Status on GitHub"
-#     inputs:
-#       targetType: "inline"
-#       arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
-#       script: |
-#         . $(Build.Repository.LocalPath)/scripts/utils/PostGitCommitStatus.ps1
-#         SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Tests On Mac"
-#       failOnStderr: "true"
-#     condition: "always()"
+  - task: PowerShell@2
+    displayName: "Initialize Git Commit Status on GitHub"
+    inputs:
+      targetType: "inline"
+      arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
+      script: |
+        . $(Build.Repository.LocalPath)/scripts/utils/PostGitCommitStatus.ps1
+        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Tests On Mac"
+      failOnStderr: "true"
+    condition: "always()"
 
-# - phase: End_To_End_Tests_On_Windows
-#   dependsOn:
-#   - Build_and_UnitTest
-#   - Initialize_Build
-#   variables:
-#     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-#   condition: "and(succeeded(),eq(variables['RunEndToEndTests'], 'true')) "
-#   queue:
-#     timeoutInMinutes: 90
-#     name: DDNuGet-Windows
-#     demands: DotNetFramework
+- phase: End_To_End_Tests_On_Windows
+  dependsOn:
+  - Build_and_UnitTest
+  - Initialize_Build
+  variables:
+    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+  condition: "and(succeeded(),eq(variables['RunEndToEndTests'], 'true')) "
+  queue:
+    timeoutInMinutes: 90
+    name: DDNuGet-Windows
+    demands: DotNetFramework
 
-#   steps:
-#   - task: PowerShell@1
-#     displayName: "Print Environment Variables"
-#     inputs:
-#       scriptType: "inlineScript"
-#       inlineScript: |
-#         Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
-#         gci env:* | sort-object name
+  steps:
+  - task: PowerShell@1
+    displayName: "Print Environment Variables"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
+        gci env:* | sort-object name
 
-#   - task: DownloadBuildArtifacts@0
-#     displayName: "Download Build artifacts"
-#     inputs:
-#       artifactName: "VS15"
-#       downloadPath: "$(Build.Repository.LocalPath)/artifacts"
+  - task: DownloadBuildArtifacts@0
+    displayName: "Download Build artifacts"
+    inputs:
+      artifactName: "VS15"
+      downloadPath: "$(Build.Repository.LocalPath)/artifacts"
 
-#   - task: PowerShell@1
-#     displayName: "Bootstrap.ps1"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
-#       arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
+  - task: PowerShell@1
+    displayName: "Bootstrap.ps1"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
+      arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
 
-#   - task: PowerShell@1
-#     displayName: "SetupFunctionalTests.ps1"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
+  - task: PowerShell@1
+    displayName: "SetupFunctionalTests.ps1"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
 
-#   - task: PowerShell@1
-#     displayName: "SetupMachine.ps1"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupMachine.ps1"
+  - task: PowerShell@1
+    displayName: "SetupMachine.ps1"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupMachine.ps1"
 
-#   - task: PowerShell@1
-#     displayName: "InstallNuGetVSIX.ps1"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
-#       arguments: "-NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 16.0"
-#       failOnStandardError: "false"
+  - task: PowerShell@1
+    displayName: "InstallNuGetVSIX.ps1"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
+      arguments: "-NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 16.0"
+      failOnStandardError: "false"
 
-#   - task: PowerShell@1
-#     displayName: "Collect VS Logs"
-#     inputs:
-#       scriptType: "inlineScript"
-#       inlineScript: |
-#         Invoke-WebRequest -Uri $(CollectExeUrl) -OutFile $(System.DefaultWorkingDirectory)\\VSCollect.exe
-#         $(System.DefaultWorkingDirectory)\\VSCollect.exe -zip:$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\e2e-collectlogs.zip
-#     condition: "failed()"
+  - task: PowerShell@1
+    displayName: "Collect VS Logs"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        Invoke-WebRequest -Uri $(CollectExeUrl) -OutFile $(System.DefaultWorkingDirectory)\\VSCollect.exe
+        $(System.DefaultWorkingDirectory)\\VSCollect.exe -zip:$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\e2e-collectlogs.zip
+    condition: "failed()"
 
-#   - task: PowerShell@1
-#     displayName: "RunFunctionalTests.ps1"    
-#     timeoutInMinutes: 75
-#     continueOnError: "true"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
-#       arguments: "-PMCCommand $(EndToEndTestCommandToRun) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 16.0"
+  - task: PowerShell@1
+    displayName: "RunFunctionalTests.ps1"    
+    timeoutInMinutes: 75
+    continueOnError: "true"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\RunFunctionalTests.ps1"
+      arguments: "-PMCCommand $(EndToEndTestCommandToRun) -PMCLaunchWaitTimeInSecs 30 -EachTestTimoutInSecs 600 -NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -RunCounter $(Build.BuildNumber) -VSVersion 16.0"
 
-#   - task: PublishTestResults@2
-#     displayName: "Publish Test Results"
-#     inputs:
-#       testRunner: "JUnit"
-#       testResultsFiles: "*.xml"
-#       searchFolder: "$(System.DefaultWorkingDirectory)\\testresults"
-#       mergeTestResults: "true"
-#       testRunTitle: "NuGet.Client EndToEnd Tests On Windows"
-#     condition: "succeededOrFailed()"
+  - task: PublishTestResults@2
+    displayName: "Publish Test Results"
+    inputs:
+      testRunner: "JUnit"
+      testResultsFiles: "*.xml"
+      searchFolder: "$(System.DefaultWorkingDirectory)\\testresults"
+      mergeTestResults: "true"
+      testRunTitle: "NuGet.Client EndToEnd Tests On Windows"
+    condition: "succeededOrFailed()"
 
-#   - task: PowerShell@1
-#     displayName: "Initialize Git Commit Status on GitHub"
-#     inputs:
-#       scriptType: "inlineScript"
-#       arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
-#       inlineScript: |
-#         . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
-#         SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "EndToEnd Tests On Windows"
-#     condition: "always()"
+  - task: PowerShell@1
+    displayName: "Initialize Git Commit Status on GitHub"
+    inputs:
+      scriptType: "inlineScript"
+      arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
+      inlineScript: |
+        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
+        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "EndToEnd Tests On Windows"
+    condition: "always()"
 
-#   - task: PowerShell@1
-#     displayName: "Kill running instances of DevEnv"
-#     inputs:
-#       scriptType: "inlineScript"
-#       inlineScript: |
-#         . $(Build.Repository.LocalPath)\\scripts\\e2etests\\VSUtils.ps1
-#         KillRunningInstancesOfVS
-#     condition: "always()"
+  - task: PowerShell@1
+    displayName: "Kill running instances of DevEnv"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        . $(Build.Repository.LocalPath)\\scripts\\e2etests\\VSUtils.ps1
+        KillRunningInstancesOfVS
+    condition: "always()"
 
-# - phase: Apex_Tests_On_Windows
-#   dependsOn:
-#   - Build_and_UnitTest
-#   - Initialize_Build
-#   variables:
-#     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-#     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-#   condition: "and(succeeded(),eq(variables['RunApexTests'], 'true')) "
-#   queue:
-#     name: DDNuGet-Windows
-#     demands: DotNetFramework
+- phase: Apex_Tests_On_Windows
+  dependsOn:
+  - Build_and_UnitTest
+  - Initialize_Build
+  variables:
+    BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
+    FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+  condition: "and(succeeded(),eq(variables['RunApexTests'], 'true')) "
+  queue:
+    name: DDNuGet-Windows
+    demands: DotNetFramework
 
-#   steps:
-#   - checkout: self
-#     clean: true
-#     submodules: true
+  steps:
+  - checkout: self
+    clean: true
+    submodules: true
     
-#   - task: PowerShell@1
-#     displayName: "Print Environment Variables"
-#     inputs:
-#       scriptType: "inlineScript"
-#       inlineScript: |
-#         Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
-#         gci env:* | sort-object name
+  - task: PowerShell@1
+    displayName: "Print Environment Variables"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        Write-Host "##vso[build.updatebuildnumber]$env:FullVstsBuildNumber"
+        gci env:* | sort-object name
 
-#   - task: DownloadBuildArtifacts@0
-#     displayName: "Download Build artifacts"
-#     inputs:
-#       artifactName: "VS15"
-#       downloadPath: "$(Build.Repository.LocalPath)/artifacts"
+  - task: DownloadBuildArtifacts@0
+    displayName: "Download Build artifacts"
+    inputs:
+      artifactName: "VS15"
+      downloadPath: "$(Build.Repository.LocalPath)/artifacts"
         
-#   - task: NuGetToolInstaller@0
-#     displayName: "Use NuGet 4.5.0"
-#     inputs:
-#       versionSpec: "4.5.0"
+  - task: NuGetToolInstaller@0
+    displayName: "Use NuGet 4.5.0"
+    inputs:
+      versionSpec: "4.5.0"
 
-#   - task: NuGetCommand@2
-#     displayName: "Download packages.config packages"
-#     inputs:
-#       restoreSolution: ".nuget/packages.config"
-#       feedsToUse: "config"
-#       nugetConfigPath: "NuGet.Config"
-#       restoreDirectory: "$(System.DefaultWorkingDirectory)/packages"
+  - task: NuGetCommand@2
+    displayName: "Download packages.config packages"
+    inputs:
+      restoreSolution: ".nuget/packages.config"
+      feedsToUse: "config"
+      nugetConfigPath: "NuGet.Config"
+      restoreDirectory: "$(System.DefaultWorkingDirectory)/packages"
 
-#   - task: PowerShell@1
-#     displayName: "Bootstrap.ps1"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
-#       arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
+  - task: PowerShell@1
+    displayName: "Bootstrap.ps1"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
+      arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
 
-#   - task: PowerShell@1
-#     displayName: "SetupFunctionalTests.ps1"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
-#       arguments: "-VSVersion 16.0"
+  - task: PowerShell@1
+    displayName: "SetupFunctionalTests.ps1"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\SetupFunctionalTests.ps1"
+      arguments: "-VSVersion 16.0"
 
-#   - task: PowerShell@1
-#     displayName: "InstallNuGetVSIX.ps1"
-#     inputs:
-#       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
-#       arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 16.0"
-#       failOnStandardError: "false"
+  - task: PowerShell@1
+    displayName: "InstallNuGetVSIX.ps1"
+    inputs:
+      scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
+      arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 16.0"
+      failOnStandardError: "false"
 
-#   # - task: PowerShell@1
-#   #   displayName: "Collect VS Logs"
-#   #   inputs:
-#   #     scriptType: "inlineScript"
-#   #     inlineScript: |
-#   #       Invoke-WebRequest -Uri $(CollectExeUrl) -OutFile $(System.DefaultWorkingDirectory)\\VSCollect.exe
-#   #       if(-not (Test-Path $(EndToEndResultsDropPath)))
-#   #         {
-#   #           New-Item -Path $(EndToEndResultsDropPath) -ItemType Directory -Force
-#   #         }
-#   #       $(System.DefaultWorkingDirectory)\\VSCollect.exe -zip:$(EndToEndResultsDropPath)\\apex-collectlogs.zip
-#   #   condition: "failed()"
+  # - task: PowerShell@1
+  #   displayName: "Collect VS Logs"
+  #   inputs:
+  #     scriptType: "inlineScript"
+  #     inlineScript: |
+  #       Invoke-WebRequest -Uri $(CollectExeUrl) -OutFile $(System.DefaultWorkingDirectory)\\VSCollect.exe
+  #       if(-not (Test-Path $(EndToEndResultsDropPath)))
+  #         {
+  #           New-Item -Path $(EndToEndResultsDropPath) -ItemType Directory -Force
+  #         }
+  #       $(System.DefaultWorkingDirectory)\\VSCollect.exe -zip:$(EndToEndResultsDropPath)\\apex-collectlogs.zip
+  #   condition: "failed()"
 
-#   - task: MSBuild@1
-#     displayName: "Restore for VS2019"
-#     inputs:
-#       solution: "build\\build.proj"
-#       msbuildVersion: "16.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber)"
+  - task: MSBuild@1
+    displayName: "Restore for VS2019"
+    inputs:
+      solution: "build\\build.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:RestoreVS /p:BuildNumber=$(BuildNumber)"
 
-#   - task: NuGetCommand@2
-#     displayName: "Add Apex Feed Source"
-#     inputs:
-#       command: "custom"
-#       arguments: "sources add -Name ApexFeed -Source $(ApexPackageFeedUrl) -UserName $(ApexPackageFeedUsername) -Password $(ApexPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\\NuGet.config"
+  - task: NuGetCommand@2
+    displayName: "Add Apex Feed Source"
+    inputs:
+      command: "custom"
+      arguments: "sources add -Name ApexFeed -Source $(ApexPackageFeedUrl) -UserName $(ApexPackageFeedUsername) -Password $(ApexPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\\NuGet.config"
 
-#   - task: MSBuild@1
-#     displayName: "Restore Apex Tests"
-#     inputs:
-#       solution: "build\\build.proj"
-#       msbuildVersion: "16.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/t:RestoreApex /p:BuildNumber=$(BuildNumber)"
+  - task: MSBuild@1
+    displayName: "Restore Apex Tests"
+    inputs:
+      solution: "build\\build.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:RestoreApex /p:BuildNumber=$(BuildNumber)"
 
-#   - task: MSBuild@1
-#     displayName: "Run Apex Tests"
-#     timeoutInMinutes: 45
-#     continueOnError: "true"
-#     inputs:
-#       solution: "build\\build.proj"
-#       msbuildVersion: "16.0"
-#       configuration: "$(BuildConfiguration)"
-#       msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml /p:BuildNumber=$(BuildNumber)"
+  - task: MSBuild@1
+    displayName: "Run Apex Tests"
+    timeoutInMinutes: 45
+    continueOnError: "true"
+    inputs:
+      solution: "build\\build.proj"
+      msbuildVersion: "16.0"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/t:ApexTestsStandalone /p:TestResultOutputFormat=xml /p:BuildNumber=$(BuildNumber)"
 
-#   - task: PublishTestResults@2
-#     displayName: "Publish Test Results"
-#     inputs:
-#       testRunner: "XUnit"
-#       testResultsFiles: "*.xml"
-#       searchFolder: "$(System.DefaultWorkingDirectory)\\build\\TestResults"
-#       mergeTestResults: "true"
-#       testRunTitle: "NuGet.Client Apex Tests On Windows"
-#     condition: "succeededOrFailed()"
+  - task: PublishTestResults@2
+    displayName: "Publish Test Results"
+    inputs:
+      testRunner: "XUnit"
+      testResultsFiles: "*.xml"
+      searchFolder: "$(System.DefaultWorkingDirectory)\\build\\TestResults"
+      mergeTestResults: "true"
+      testRunTitle: "NuGet.Client Apex Tests On Windows"
+    condition: "succeededOrFailed()"
 
-#   - task: PowerShell@1
-#     displayName: "Initialize Git Commit Status on GitHub"
-#     inputs:
-#       arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
-#       scriptType: "inlineScript"
-#       inlineScript: |
-#         . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
-#         SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Apex Tests On Windows"
-#     condition: "always()"
+  - task: PowerShell@1
+    displayName: "Initialize Git Commit Status on GitHub"
+    inputs:
+      arguments: "-VstsPersonalAccessToken $(VstsPersonalAccessToken)"
+      scriptType: "inlineScript"
+      inlineScript: |
+        . $(Build.Repository.LocalPath)\\scripts\\utils\\PostGitCommitStatus.ps1
+        SetCommitStatusForTestResult -PersonalAccessToken $(NuGetLurkerPersonalAccessToken) -VstsPersonalAccessToken $(VstsPersonalAccessToken) -CommitSha $(Build.SourceVersion) -TestName "Apex Tests On Windows"
+    condition: "always()"
 
-#   - task: PowerShell@1
-#     displayName: "Kill running instances of DevEnv"
-#     inputs:
-#       scriptType: "inlineScript"
-#       inlineScript: |
-#         . $(Build.Repository.LocalPath)\\scripts\\e2etests\\VSUtils.ps1
-#         KillRunningInstancesOfVS
-#     condition: "always()"
+  - task: PowerShell@1
+    displayName: "Kill running instances of DevEnv"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        . $(Build.Repository.LocalPath)\\scripts\\e2etests\\VSUtils.ps1
+        KillRunningInstancesOfVS
+    condition: "always()"

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -518,7 +518,6 @@ phases:
     demands: sh
 
   steps:
-  - bash: echo MSBUILDDISABLENODEREUSE=$(MSBUILDDISABLENODEREUSE)
   - task: PowerShell@2
     displayName: "Update Build Number"
     inputs:

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -526,11 +526,20 @@ phases:
       failOnStderr: "true"
     condition: "always()"
 
+  - task: PowerShell@2
+    displayName: "Set Environment Variables"
+    inputs:
+      targetType: "inline"
+      script: |
+        SET $env:MSBUILDDISABLENODEREUSE=1"
+      failOnStderr: "true"
+    condition: "always()"
+
   - task: ShellScript@2
     displayName: "Run Tests"
     continueOnError: "true"
     inputs:
-      scriptPath: "MSBUILDDISABLENODEREUSE=1 scripts/funcTests/runFuncTests.sh"
+      scriptPath: "scripts/funcTests/runFuncTests.sh"
       disableAutoCwd: "true"
       cwd: "$(Build.Repository.LocalPath)"
 

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -536,7 +536,6 @@ phases:
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
-    condition: "succeededOrFailed()"
     inputs:
       testRunner: "XUnit"
       testResultsFiles: "*.xml"

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -75,8 +75,8 @@ then
 fi
 
 # restore packages
-echo "$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /flp:Verbosity=detailed"
-$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /flp:Verbosity=detailed
+echo "$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /flp:Verbosity=detailed /nr:false"
+$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /flp:Verbosity=detailed /nr:false
 if [ $? -ne 0 ]; then
 	echo "Restore failed!!"
 	exit 1

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -160,7 +160,4 @@ esac
 
 popd
 
-# Cleanup TMP directory
-rm "/tmp/"dotnet.* -rf
-
 exit $RESULTCODE

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -42,11 +42,11 @@ cli/dotnet-install.sh -i cli -c 1.0
 
 DOTNET="$(pwd)/cli/dotnet"
 
-echo "$DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting /nr:false"
+echo "$DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting /nodeReuse:false"
 
 # run it twice so dotnet cli can expand and decompress without affecting the result of the target
-$DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting /nr:false
-DOTNET_BRANCH="$($DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting /nr:false)"
+$DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting /nodeReuse:false
+DOTNET_BRANCH="$($DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting /nodeReuse:false)"
 
 echo $DOTNET_BRANCH
 cli/dotnet-install.sh -i cli -c $DOTNET_BRANCH
@@ -75,16 +75,16 @@ then
 fi
 
 # restore packages
-echo "$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /flp:Verbosity=detailed /nr:false"
-$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /flp:Verbosity=detailed /nr:false
+echo "$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /flp:Verbosity=detailed /nodeReuse:false"
+$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /flp:Verbosity=detailed /nodeReuse:false
 if [ $? -ne 0 ]; then
 	echo "Restore failed!!"
 	exit 1
 fi
 
 # Unit tests
-echo "$DOTNET msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /nr:false"
-$DOTNET msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /nr:false
+echo "$DOTNET msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /nodeReuse:false"
+$DOTNET msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /nodeReuse:false
 
 if [ $? -ne 0 ]; then
 	echo "CoreUnitTests failed!!"
@@ -103,8 +103,8 @@ else
 fi
 
 # Func tests
-echo "$DOTNET msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /nr:false"
-$DOTNET msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /nr:false
+echo "$DOTNET msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /nodeReuse:false"
+$DOTNET msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /nodeReuse:false
 
 if [ $? -ne 0 ]; then
 	RESULTCODE='1'

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -75,7 +75,7 @@ then
 fi
 
 # restore packages
-echo "$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta"
+echo "$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /flp:Verbosity=detailed"
 $DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta
 if [ $? -ne 0 ]; then
 	echo "Restore failed!!"

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -160,4 +160,7 @@ esac
 
 popd
 
+# Cleanup TMP directory
+rm "/tmp/"dotnet.* -rf
+
 exit $RESULTCODE

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -76,7 +76,7 @@ fi
 
 # restore packages
 echo "$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /flp:Verbosity=detailed"
-$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta
+$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /flp:Verbosity=detailed
 if [ $? -ne 0 ]; then
 	echo "Restore failed!!"
 	exit 1

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -75,8 +75,8 @@ then
 fi
 
 # restore packages
-echo "$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /flp:Verbosity=detailed"
-$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /flp:Verbosity=detailed
+echo "$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta"
+$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta
 if [ $? -ne 0 ]; then
 	echo "Restore failed!!"
 	exit 1

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -42,11 +42,11 @@ cli/dotnet-install.sh -i cli -c 1.0
 
 DOTNET="$(pwd)/cli/dotnet"
 
-echo "$DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting /nodeReuse:false"
+echo "$DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting"
 
 # run it twice so dotnet cli can expand and decompress without affecting the result of the target
-$DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting /nodeReuse:false
-DOTNET_BRANCH="$($DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting /nodeReuse:false)"
+$DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting
+DOTNET_BRANCH="$($DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting)"
 
 echo $DOTNET_BRANCH
 cli/dotnet-install.sh -i cli -c $DOTNET_BRANCH
@@ -75,16 +75,16 @@ then
 fi
 
 # restore packages
-echo "$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /flp:Verbosity=detailed /nodeReuse:false"
-$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /flp:Verbosity=detailed /nodeReuse:false
+echo "$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /flp:Verbosity=detailed"
+$DOTNET msbuild build/build.proj /t:Restore /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /flp:Verbosity=detailed
 if [ $? -ne 0 ]; then
 	echo "Restore failed!!"
 	exit 1
 fi
 
 # Unit tests
-echo "$DOTNET msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /nodeReuse:false"
-$DOTNET msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /nodeReuse:false
+echo "$DOTNET msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta"
+$DOTNET msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta
 
 if [ $? -ne 0 ]; then
 	echo "CoreUnitTests failed!!"
@@ -103,8 +103,8 @@ else
 fi
 
 # Func tests
-echo "$DOTNET msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /nodeReuse:false"
-$DOTNET msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /nodeReuse:false
+echo "$DOTNET msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta"
+$DOTNET msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta
 
 if [ $? -ne 0 ]; then
 	RESULTCODE='1'

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -42,11 +42,11 @@ cli/dotnet-install.sh -i cli -c 1.0
 
 DOTNET="$(pwd)/cli/dotnet"
 
-echo "$DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting"
+echo "$DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting /nr:false"
 
 # run it twice so dotnet cli can expand and decompress without affecting the result of the target
-$DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting
-DOTNET_BRANCH="$($DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting)"
+$DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting /nr:false
+DOTNET_BRANCH="$($DOTNET msbuild build/config.props /v:m /nologo /t:GetCliBranchForTesting /nr:false)"
 
 echo $DOTNET_BRANCH
 cli/dotnet-install.sh -i cli -c $DOTNET_BRANCH
@@ -83,8 +83,8 @@ if [ $? -ne 0 ]; then
 fi
 
 # Unit tests
-echo "$DOTNET msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta"
-$DOTNET msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta
+echo "$DOTNET msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /nr:false"
+$DOTNET msbuild build/build.proj /t:CoreUnitTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /nr:false
 
 if [ $? -ne 0 ]; then
 	echo "CoreUnitTests failed!!"
@@ -103,8 +103,8 @@ else
 fi
 
 # Func tests
-echo "$DOTNET msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta"
-$DOTNET msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta
+echo "$DOTNET msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /nr:false"
+$DOTNET msbuild build/build.proj /t:CoreFuncTests /p:VisualStudioVersion=15.0 /p:Configuration=Release /p:BuildNumber=1 /p:ReleaseLabel=beta /nr:false
 
 if [ $? -ne 0 ]; then
 	RESULTCODE='1'


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8381
Regression: No

## Fix

Details: Modified CI to disable Node Reuse (`MSBUILDDISABLENODEREUSE=1`) which avoids an MSBuild bug that was causing our Linux Builds to timeout.

MSBuild tracking issue: https://github.com/dotnet/cli/issues/11560
Our [Issue to revert](https://github.com/NuGet/Home/issues/8382) **this PR's work** once MSBuild resolves the source of the problem .

Bonus fix: Test Results should always be published.