### PR TITLE
Add -verbose to running CommandLine tests on Mac

### DIFF
--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -146,11 +146,11 @@ case "$(uname -s)" in
 			fi
 			;;
 		Darwin)
-			echo "mono $XunitConsole "$TestDir/NuGet.CommandLine.Test.dll" -notrait Platform=Windows -notrait Platform=Linux -xml build/TestResults/monoomac.xml"
-			mono $XunitConsole "$TestDir/NuGet.CommandLine.Test.dll" -notrait Platform=Windows -notrait Platform=Linux -xml "build/TestResults/monoonmac.xml"
+			echo "mono $XunitConsole "$TestDir/NuGet.CommandLine.Test.dll" -notrait Platform=Windows -notrait Platform=Linux -xml build/TestResults/monoomac.xml -verbose"
+			mono $XunitConsole "$TestDir/NuGet.CommandLine.Test.dll" -notrait Platform=Windows -notrait Platform=Linux -xml "build/TestResults/monoonmac.xml" -verbose
 			if [ $? -ne '0' ]; then
 				RESULTCODE=$?
-				echo "Mono tests failed!"				
+				echo "Mono tests failed!"
 				exit 1
 			fi
 			;;


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8384
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: add `-verbose` flag to xunit.console.exe, so we know what test was running when the timeout happened.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  build script change
Validation:  
