### PR TITLE
Prevent NuGetFrameworkException from nomination API

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -130,15 +130,9 @@ namespace NuGet.SolutionRestoreManager
                 return restoreTask;
             }
             catch (Exception e)
-            when (e is InvalidOperationException || e is ArgumentException || e is FormatException)
             {
                 _logger.LogError(e.ToString());
                 return Task.FromResult(false);
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e.ToString());
-                throw;
             }
         }
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -129,6 +129,10 @@ namespace NuGet.SolutionRestoreManager
 
                 return restoreTask;
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
                 _logger.LogError(e.ToString());

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -1776,7 +1776,7 @@ namespace NuGet.SolutionRestoreManager.Test
             restoreWorker.Setup(x => x.ScheduleRestoreAsync(
                     It.IsAny<SolutionRestoreRequest>(),
                     It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(false)); // framework is invalid, restore fails
+                .Returns(Task.FromResult(false)); // version is invalid, restore fails
 
             var logger = new Mock<ILogger>();
 
@@ -1805,7 +1805,7 @@ namespace NuGet.SolutionRestoreManager.Test
             var result = await service.NominateProjectAsync(@"f:\project\project.csproj", projectRestoreInfo, CancellationToken.None);
 
             // Assert
-            // As per IVsSolutionRestoreService* xmldoc, result signifies restore result, not nomination failure. We expect false since the TFM is invalid.
+            // As per IVsSolutionRestoreService* xmldoc, result signifies restore result, not nomination failure. We expect false since the version string is invalid.
             Assert.False(result);
             // https://github.com/NuGet/Home/issues/7717
             logger.Verify(l => l.LogError(It.Is<string>(s => s.Contains("'foo' is not a valid version string"))), Times.Once);

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -1838,13 +1838,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 {
                     new VsTargetFrameworkInfo2(
                         targetFrameworkMoniker: FrameworkConstants.CommonFrameworks.NetStandard20.ToString(),
-                        packageReferences: new[]
-                        {
-                            new VsReferenceItem("packageId", new VsReferenceProperties(new []
-                            {
-                                new VsReferenceProperty("Version", "foo")
-                            }))
-                        },
+                        packageReferences: emptyReferenceItems,
                         projectReferences: emptyReferenceItems,
                         packageDownloads: emptyReferenceItems,
                         frameworkReferences: emptyReferenceItems,


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8385
Regression: Not caused by NuGet
* Last working version:  15.x or maybe 16.0
* How are we preventing it in future:  catching all exceptions prevents any exceptions leaking out :)

## Fix

Details: catch all exceptions. Some errors, such as bad TFM in the `<TargetFramework>` element in the `csproj`, will be reported in the VS error list by other components. However, some errors (like unparsable version number in a `PackageReference`) will be completely silent to the user (but still logged to the activity log xml). NuGet/Home#7717 will solve that.

Note: silently failing restore for unparsable version number is the same behaviour as 15.9. This fix will stop the Watson reports which is currently very noisy, and it will stop the yellow bar in VS which tells the user that reloading the project may resolve the issue, when we know that will not solve the issue.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  VS COM interface
Validation:  
