### PR TITLE
Test:  skip flaky test NuGet.CommandLine.Test.NetworkCallCountTest.NetworkCallCount_RestoreLargePackagesConfigWithMultipleSourcesWithPartialMissingPackages

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
@@ -127,7 +127,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/7878")]
         public void NetworkCallCount_RestoreLargePackagesConfigWithMultipleSourcesWithPartialMissingPackages()
         {
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
@@ -127,7 +127,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/7878")]
+        [SkipMono(Skip = "https://github.com/NuGet/Home/issues/7878")]
         public void NetworkCallCount_RestoreLargePackagesConfigWithMultipleSourcesWithPartialMissingPackages()
         {
             // Arrange


### PR DESCRIPTION
Progress on https://github.com/NuGet/Home/issues/7878.

Skip this test until it can be made robust or removed.