### PR TITLE
Test:  skip flaky test NuGet.PackageManagement.UI.Test.PackageItemLoaderTests.EmitsSearchTelemetryEvents

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
@@ -72,7 +72,7 @@ namespace NuGet.PackageManagement.UI.Test
             Assert.NotEmpty(loaded);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/8393")]
         public async Task EmitsSearchTelemetryEvents()
         {
             // Arrange


### PR DESCRIPTION
Progress on https://github.com/NuGet/Home/issues/8393.

Skip this test until it can be made robust or removed.