### PR TITLE
Test:  skip flaky test Dotnet.Integration.Test.PackCommandTests.PackCommand_PackProject_PackageReferenceFloatingVersionRange

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -223,7 +223,7 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+        [PlatformFact(Platform.Windows, Skip = "https://github.com/NuGet/Home/issues/8394")]
         public void PackCommand_PackProject_PackageReferenceFloatingVersionRange()
         {
             // Arrange


### PR DESCRIPTION
Progress on https://github.com/NuGet/Home/issues/8394.

Skip this test until it can be made robust or removed.