### PR TITLE
new error code 5037 to notify users of missing nuspec file during restore

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -646,6 +646,11 @@ namespace NuGet.Common
         NU5036 = 5036,
 
         /// <summary>
+        /// Error_MissingNuspecFile
+        /// </summary>
+        NU5037 = 5037,
+
+        /// <summary>
         /// AssemblyOutsideLibWarning
         /// </summary>
         NU5100 = 5100,

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -778,7 +778,7 @@ namespace NuGet.Common
         /// <summary>
         /// No ref or lib folder in the package
         /// </summary>
-        NU5127 = 5127,       
+        NU5127 = 5127,
 
         /// <summary>
         /// TFM dependencies in the lib or ref folder don't have exact matches in the nuspec
@@ -803,6 +803,6 @@ namespace NuGet.Common
         /// <summary>
         /// Undefined package warning
         /// </summary>
-        NU5500 = 5500
+        NU5500 = 5500,
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -778,7 +778,7 @@ namespace NuGet.Common
         /// <summary>
         /// No ref or lib folder in the package
         /// </summary>
-        NU5127 = 5127,
+        NU5127 = 5127,       
 
         /// <summary>
         /// TFM dependencies in the lib or ref folder don't have exact matches in the nuspec

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
@@ -69,9 +70,10 @@ namespace NuGet.Packaging
 
             if (nuspecFiles.Length == 0)
             {
-                throw new PackagingException(NuGetLogCode.NU5128, string.Format(
+                throw new PackagingException(NuGetLogCode.NU5036, string.Format(
                                             CultureInfo.CurrentCulture,
                                             Strings.Error_MissingRequiredFiles,
+                                            NuGetConstants.ManifestExtension,
                                             _root.FullName));              
             }
             else if (nuspecFiles.Length > 1)

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -71,7 +71,7 @@ namespace NuGet.Packaging
             {
                 throw new PackagingException(NuGetLogCode.NU5128, string.Format(
                                             CultureInfo.CurrentCulture,
-                                            Strings.MissingRequiredFiles,
+                                            Strings.Error_MissingRequiredFiles,
                                             _root.FullName));              
             }
             else if (nuspecFiles.Length > 1)

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -71,7 +71,7 @@ namespace NuGet.Packaging
             if (nuspecFiles.Length == 0)
             {
                 var message = new StringBuilder();
-                message.AppendFormat(CultureInfo.CurrentCulture, Strings.Error_MissingNuspecFile);
+                message.Append(Strings.Error_MissingNuspecFile);
                 message.AppendFormat(CultureInfo.CurrentCulture, Strings.Message_Path, _root.FullName);
                 throw new PackagingException(NuGetLogCode.NU5037, message.ToString());
             }

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -72,8 +72,7 @@ namespace NuGet.Packaging
             {
                 throw new PackagingException(NuGetLogCode.NU5036, string.Format(
                                             CultureInfo.CurrentCulture,
-                                            Strings.Error_MissingRequiredFiles,
-                                            NuGetConstants.ManifestExtension,
+                                            Strings.Error_MissingNuspecFile,
                                             _root.FullName));              
             }
             else if (nuspecFiles.Length > 1)

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -70,7 +70,7 @@ namespace NuGet.Packaging
 
             if (nuspecFiles.Length == 0)
             {
-                throw new PackagingException(NuGetLogCode.NU5036, string.Format(
+                throw new PackagingException(NuGetLogCode.NU5037, string.Format(
                                             CultureInfo.CurrentCulture,
                                             Strings.Error_MissingNuspecFile,
                                             string.Format(

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -73,7 +73,11 @@ namespace NuGet.Packaging
                 throw new PackagingException(NuGetLogCode.NU5036, string.Format(
                                             CultureInfo.CurrentCulture,
                                             Strings.Error_MissingNuspecFile,
-                                            _root.FullName));              
+                                            string.Format(
+                                                CultureInfo.CurrentCulture,
+                                                Strings.Message_Path,
+                                                _root.FullName))
+                                            );              
             }
             else if (nuspecFiles.Length > 1)
             {

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -68,7 +69,10 @@ namespace NuGet.Packaging
 
             if (nuspecFiles.Length == 0)
             {
-                throw new PackagingException(Strings.MissingNuspec);
+                throw new PackagingException(NuGetLogCode.NU5128, string.Format(
+                                            CultureInfo.CurrentCulture,
+                                            Strings.MissingRequiredFiles,
+                                            _root.FullName));              
             }
             else if (nuspecFiles.Length > 1)
             {

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -6,10 +6,10 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
@@ -70,14 +70,10 @@ namespace NuGet.Packaging
 
             if (nuspecFiles.Length == 0)
             {
-                throw new PackagingException(NuGetLogCode.NU5037, string.Format(
-                                            CultureInfo.CurrentCulture,
-                                            Strings.Error_MissingNuspecFile,
-                                            string.Format(
-                                                CultureInfo.CurrentCulture,
-                                                Strings.Message_Path,
-                                                _root.FullName))
-                                            );              
+                var message = new StringBuilder();
+                message.AppendFormat(CultureInfo.CurrentCulture, Strings.Error_MissingNuspecFile);
+                message.AppendFormat(CultureInfo.CurrentCulture, Strings.Message_Path, _root.FullName);
+                throw new PackagingException(NuGetLogCode.NU5037, message.ToString());
             }
             else if (nuspecFiles.Length > 1)
             {

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -527,7 +527,13 @@ namespace NuGet.Packaging
 
             if (nuspecPaths.Count == 0)
             {
-                throw new PackagingException(Strings.MissingNuspec);
+                // Find the package directory name by inspecting first file in the folder
+                FileInfo file = new FileInfo(files.ElementAtOrDefault(0));
+
+                throw new PackagingException(NuGetLogCode.NU5128, string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.MissingRequiredFiles,
+                            file.DirectoryName));
             }
             else if (nuspecPaths.Count > 1)
             {

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -526,13 +526,9 @@ namespace NuGet.Packaging
 
             if (nuspecPaths.Count == 0)
             {
-                // Find the package directory name by inspecting first file in the folder if it exists
-                string directory = files.Count() > 0 ? new FileInfo(files.First()).DirectoryName : string.Empty;
-
                 throw new PackagingException(NuGetLogCode.NU5036, string.Format(
                             CultureInfo.CurrentCulture,
-                            Strings.Error_MissingNuspecFile,
-                            directory));                
+                            Strings.Error_MissingNuspecFile));                
             }
             else if (nuspecPaths.Count > 1)
             {

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -531,8 +531,7 @@ namespace NuGet.Packaging
 
                 throw new PackagingException(NuGetLogCode.NU5036, string.Format(
                             CultureInfo.CurrentCulture,
-                            Strings.Error_MissingRequiredFiles,
-                            NuGetConstants.ManifestExtension,
+                            Strings.Error_MissingNuspecFile,
                             directory));                
             }
             else if (nuspecPaths.Count > 1)

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -526,7 +526,7 @@ namespace NuGet.Packaging
 
             if (nuspecPaths.Count == 0)
             {
-                throw new PackagingException(NuGetLogCode.NU5036, string.Format(
+                throw new PackagingException(NuGetLogCode.NU5037, string.Format(
                             CultureInfo.CurrentCulture,
                             Strings.Error_MissingNuspecFile,
                             string.Empty));

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -532,7 +532,7 @@ namespace NuGet.Packaging
 
                 throw new PackagingException(NuGetLogCode.NU5128, string.Format(
                             CultureInfo.CurrentCulture,
-                            Strings.MissingRequiredFiles,
+                            Strings.Error_MissingRequiredFiles,
                             file.DirectoryName));
             }
             else if (nuspecPaths.Count > 1)
@@ -559,7 +559,7 @@ namespace NuGet.Packaging
                     Strings.ErrorUnsafePackageEntry,
                     packageIdentity));
             }
-        }
+        }        
 
         protected string NormalizeDirectoryPath(string path)
         {

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -8,9 +8,8 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
@@ -527,13 +526,14 @@ namespace NuGet.Packaging
 
             if (nuspecPaths.Count == 0)
             {
-                // Find the package directory name by inspecting first file in the folder
-                FileInfo file = new FileInfo(files.ElementAtOrDefault(0));
+                // Find the package directory name by inspecting first file in the folder if it exists
+                string directory = files.Count() > 0 ? new FileInfo(files.First()).DirectoryName : string.Empty;
 
-                throw new PackagingException(NuGetLogCode.NU5128, string.Format(
+                throw new PackagingException(NuGetLogCode.NU5036, string.Format(
                             CultureInfo.CurrentCulture,
                             Strings.Error_MissingRequiredFiles,
-                            file.DirectoryName));
+                            NuGetConstants.ManifestExtension,
+                            directory));                
             }
             else if (nuspecPaths.Count > 1)
             {
@@ -559,7 +559,7 @@ namespace NuGet.Packaging
                     Strings.ErrorUnsafePackageEntry,
                     packageIdentity));
             }
-        }        
+        }
 
         protected string NormalizeDirectoryPath(string path)
         {

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -528,7 +528,8 @@ namespace NuGet.Packaging
             {
                 throw new PackagingException(NuGetLogCode.NU5036, string.Format(
                             CultureInfo.CurrentCulture,
-                            Strings.Error_MissingNuspecFile));                
+                            Strings.Error_MissingNuspecFile,
+                            string.Empty));
             }
             else if (nuspecPaths.Count > 1)
             {

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -526,9 +526,7 @@ namespace NuGet.Packaging
 
             if (nuspecPaths.Count == 0)
             {
-                throw new PackagingException(NuGetLogCode.NU5037, string.Format(
-                            CultureInfo.CurrentCulture,
-                            Strings.Error_MissingNuspecFile));
+                throw new PackagingException(NuGetLogCode.NU5037, Strings.Error_MissingNuspecFile);
             }
             else if (nuspecPaths.Count > 1)
             {

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -528,8 +528,7 @@ namespace NuGet.Packaging
             {
                 throw new PackagingException(NuGetLogCode.NU5037, string.Format(
                             CultureInfo.CurrentCulture,
-                            Strings.Error_MissingNuspecFile,
-                            string.Empty));
+                            Strings.Error_MissingNuspecFile));
             }
             else if (nuspecPaths.Count > 1)
             {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -223,7 +223,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The global package folder is missing one or more files. Delete package folder and run the restore again: {0}.
+        ///   Looks up a localized string similar to The package doesn&apos;t contain {0} file: {1}.
         /// </summary>
         internal static string Error_MissingRequiredFiles {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -223,6 +223,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The global package folder is missing one or more files. Delete package folder and run the restore again: {0}.
+        /// </summary>
+        internal static string Error_MissingRequiredFiles {
+            get {
+                return ResourceManager.GetString("Error_MissingRequiredFiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to signatureValidationMode is set to require, so packages are allowed only if signed by trusted signers; however, no trusted signers were specified..
         /// </summary>
         internal static string Error_NoClientAllowList {
@@ -750,15 +759,6 @@ namespace NuGet.Packaging {
         internal static string MissingPackageTypeName {
             get {
                 return ResourceManager.GetString("MissingPackageTypeName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The global package folder copy of package &apos;{0}&apos; is missing one or more files..
-        /// </summary>
-        internal static string MissingRequiredFiles {
-            get {
-                return ResourceManager.GetString("MissingRequiredFiles", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -223,7 +223,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package doesn&apos;t contain nuspec file. {0}.
+        ///   Looks up a localized string similar to The package is missing the required nuspec file. {0}.
         /// </summary>
         internal static string Error_MissingNuspecFile {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -745,20 +745,20 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Nuspec file does not exist in package..
-        /// </summary>
-        internal static string MissingNuspec {
-            get {
-                return ResourceManager.GetString("MissingNuspec", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Nuspec file contains a package type that is missing the name attribute..
         /// </summary>
         internal static string MissingPackageTypeName {
             get {
                 return ResourceManager.GetString("MissingPackageTypeName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The global package folder copy of package &apos;{0}&apos; is missing one or more files..
+        /// </summary>
+        internal static string MissingRequiredFiles {
+            get {
+                return ResourceManager.GetString("MissingRequiredFiles", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -223,7 +223,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package is missing the required nuspec file. {0}.
+        ///   Looks up a localized string similar to The package is missing the required nuspec file. .
         /// </summary>
         internal static string Error_MissingNuspecFile {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -223,7 +223,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package doesn&apos;t contain .nuspec file: {0}.
+        ///   Looks up a localized string similar to The package doesn&apos;t contain .nuspec file. {0}.
         /// </summary>
         internal static string Error_MissingNuspecFile {
             get {
@@ -732,6 +732,15 @@ namespace NuGet.Packaging {
         internal static string Log_InstallingPackage {
             get {
                 return ResourceManager.GetString("Log_InstallingPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path: {0}.
+        /// </summary>
+        internal static string Message_Path {
+            get {
+                return ResourceManager.GetString("Message_Path", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -223,11 +223,11 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package doesn&apos;t contain {0} file: {1}.
+        ///   Looks up a localized string similar to The package doesn&apos;t contain .nuspec file: {0}.
         /// </summary>
-        internal static string Error_MissingRequiredFiles {
+        internal static string Error_MissingNuspecFile {
             get {
-                return ResourceManager.GetString("Error_MissingRequiredFiles", resourceCulture);
+                return ResourceManager.GetString("Error_MissingNuspecFile", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -223,7 +223,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package doesn&apos;t contain .nuspec file. {0}.
+        ///   Looks up a localized string similar to The package doesn&apos;t contain nuspec file. {0}.
         /// </summary>
         internal static string Error_MissingNuspecFile {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -149,8 +149,8 @@
   <data name="MinClientVersionAlreadyExist" xml:space="preserve">
     <value>MinClientVersion already exists in packages.config</value>
   </data>
-  <data name="MissingRequiredFiles" xml:space="preserve">
-    <value>The global package folder copy of package '{0}' is missing one or more files.</value>
+  <data name="Error_MissingRequiredFiles" xml:space="preserve">
+    <value>The global package folder is missing one or more files. Delete package folder and run the restore again: {0}</value>
     <comment>{0} is the folder name in which required files such as .nuspec etc., are missing</comment>
   </data>
   <data name="PackageEntryAlreadyExist" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -150,7 +150,7 @@
     <value>MinClientVersion already exists in packages.config</value>
   </data>
   <data name="Error_MissingNuspecFile" xml:space="preserve">
-    <value>The package is missing the required nuspec file. {0}</value>
+    <value>The package is missing the required nuspec file. </value>
     <comment>0 - package folder</comment>
   </data>
   <data name="PackageEntryAlreadyExist" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -151,7 +151,7 @@
   </data>
   <data name="Error_MissingNuspecFile" xml:space="preserve">
     <value>The package is missing the required nuspec file. {0}</value>
-    <comment>0 - package folder which doesn't contain .nuspec file</comment>
+    <comment>0 - package folder</comment>
   </data>
   <data name="PackageEntryAlreadyExist" xml:space="preserve">
     <value>Package entry already exists in packages.config. Id: {0}</value>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -150,7 +150,7 @@
     <value>MinClientVersion already exists in packages.config</value>
   </data>
   <data name="Error_MissingNuspecFile" xml:space="preserve">
-    <value>The package doesn't contain .nuspec file: {0}</value>
+    <value>The package doesn't contain .nuspec file. {0}</value>
     <comment>0 - package folder which doesn't contain .nuspec file</comment>
   </data>
   <data name="PackageEntryAlreadyExist" xml:space="preserve">
@@ -823,5 +823,9 @@ Valid from:</comment>
   </data>
   <data name="MultiplePackageTypes" xml:space="preserve">
     <value>Nuspec file contains multiple package types. Zero or one package type nodes are allowed.</value>
+  </data>
+  <data name="Message_Path" xml:space="preserve">
+    <value>Path: {0}</value>
+    <comment>0 - folder path</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -150,7 +150,7 @@
     <value>MinClientVersion already exists in packages.config</value>
   </data>
   <data name="Error_MissingNuspecFile" xml:space="preserve">
-    <value>The package doesn't contain .nuspec file. {0}</value>
+    <value>The package doesn't contain nuspec file. {0}</value>
     <comment>0 - package folder which doesn't contain .nuspec file</comment>
   </data>
   <data name="PackageEntryAlreadyExist" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -150,7 +150,7 @@
     <value>MinClientVersion already exists in packages.config</value>
   </data>
   <data name="Error_MissingNuspecFile" xml:space="preserve">
-    <value>The package doesn't contain nuspec file. {0}</value>
+    <value>The package is missing the required nuspec file. {0}</value>
     <comment>0 - package folder which doesn't contain .nuspec file</comment>
   </data>
   <data name="PackageEntryAlreadyExist" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -150,8 +150,9 @@
     <value>MinClientVersion already exists in packages.config</value>
   </data>
   <data name="Error_MissingRequiredFiles" xml:space="preserve">
-    <value>The global package folder is missing one or more files. Delete package folder and run the restore again: {0}</value>
-    <comment>{0} is the folder name in which required files such as .nuspec etc., are missing</comment>
+    <value>The package doesn't contain {0} file: {1}</value>
+    <comment>0 - missing file extension
+1 - package folder </comment>
   </data>
   <data name="PackageEntryAlreadyExist" xml:space="preserve">
     <value>Package entry already exists in packages.config. Id: {0}</value>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -149,10 +149,9 @@
   <data name="MinClientVersionAlreadyExist" xml:space="preserve">
     <value>MinClientVersion already exists in packages.config</value>
   </data>
-  <data name="Error_MissingRequiredFiles" xml:space="preserve">
-    <value>The package doesn't contain {0} file: {1}</value>
-    <comment>0 - missing file extension
-1 - package folder </comment>
+  <data name="Error_MissingNuspecFile" xml:space="preserve">
+    <value>The package doesn't contain .nuspec file: {0}</value>
+    <comment>0 - package folder which doesn't contain .nuspec file</comment>
   </data>
   <data name="PackageEntryAlreadyExist" xml:space="preserve">
     <value>Package entry already exists in packages.config. Id: {0}</value>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -149,8 +149,9 @@
   <data name="MinClientVersionAlreadyExist" xml:space="preserve">
     <value>MinClientVersion already exists in packages.config</value>
   </data>
-  <data name="MissingNuspec" xml:space="preserve">
-    <value>Nuspec file does not exist in package.</value>
+  <data name="MissingRequiredFiles" xml:space="preserve">
+    <value>The global package folder copy of package '{0}' is missing one or more files.</value>
+    <comment>{0} is the folder name in which required files such as .nuspec etc., are missing</comment>
   </data>
   <data name="PackageEntryAlreadyExist" xml:space="preserve">
     <value>Package entry already exists in packages.config. Id: {0}</value>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -151,7 +151,7 @@
   </data>
   <data name="Error_MissingNuspecFile" xml:space="preserve">
     <value>The package is missing the required nuspec file. </value>
-    <comment>0 - package folder</comment>
+    <comment>package folder path will be appended to this message, if exists</comment>
   </data>
   <data name="PackageEntryAlreadyExist" xml:space="preserve">
     <value>Package entry already exists in packages.config. Id: {0}</value>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -191,7 +191,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public async void RestoreCommand_MissingNuspecFileInPackage()
+        public async void RestoreCommand_MissingNuspecFileInPackage_FailsWithNU5036()
         {
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
@@ -220,7 +220,7 @@ namespace NuGet.CommandLine.Test
                 var packageFileA = Path.Combine(workingPath, @"outputDir", "a.1.1.0", "a.1.1.0.nupkg");
                 Assert.False(File.Exists(packageFileA));
                 Assert.Equal(_failureCode, r.Item1);
-                Assert.Contains("The package doesn't contain .nuspec file:", r.AllOutput);
+                Assert.Contains("The package doesn't contain nuspec file.", r.AllOutput);
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -191,7 +191,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public async void RestoreCommand_MissingNuspecFileInPackage_FailsWithNU5036()
+        public async void RestoreCommand_MissingNuspecFileInPackage_FailsWithNU5037()
         {
             // Arrange
             var nugetexe = Util.GetNuGetExePath();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -16,11 +16,10 @@ using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using Xunit;
 using System.Text.RegularExpressions;
-using NuGet.Protocol.Core.Types;
-using NuGet.Protocol;
 using NuGet.Common;
-using Test.Utility;
 using NuGet.Frameworks;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
 
 namespace NuGet.CommandLine.Test
 {
@@ -188,6 +187,40 @@ namespace NuGet.CommandLine.Test
                 var packageFileB = Path.Combine(workingPath, @"outputDir", "packageB.2.2.0", "packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
+            }
+        }
+
+        [Fact]
+        public async void RestoreCommand_MissingNuspecFileInPackage()
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var workingPath = TestDirectory.Create())
+            {
+                var repositoryPath = Path.Combine(workingPath, "Repository");
+                var a = new PackageIdentity("a", new NuGetVersion(1, 0, 0));
+                await SimpleTestPackageUtility.CreateFolderFeedV2Async(repositoryPath, a);
+                await SimpleTestPackageUtility.DeleteNuspecFileFromPackageAsync(Path.Combine(repositoryPath, a.ToString() + NuGetConstants.PackageExtension));
+                Util.CreateFile(workingPath, "packages.config",
+@"<packages>
+  <package id=""a"" version=""1.0.0"" targetFramework=""net45"" />
+</packages>");
+
+                string[] args = new string[] { "restore", "-PackagesDirectory", "outputDir", "-Source", repositoryPath };
+
+                // Act
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingPath,
+                    string.Join(" ", args),
+                    waitForExit: true);
+
+                // Assert
+                var packageFileA = Path.Combine(workingPath, @"outputDir", "a.1.1.0", "a.1.1.0.nupkg");
+                Assert.False(File.Exists(packageFileA));
+                Assert.Equal(_failureCode, r.Item1);
+                Assert.Contains("The package doesn't contain .nuspec file:", r.AllOutput);
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -220,7 +220,7 @@ namespace NuGet.CommandLine.Test
                 var packageFileA = Path.Combine(workingPath, @"outputDir", "a.1.1.0", "a.1.1.0.nupkg");
                 Assert.False(File.Exists(packageFileA));
                 Assert.Equal(_failureCode, r.Item1);
-                Assert.Contains("The package doesn't contain nuspec file.", r.AllOutput);
+                Assert.Contains("The package is missing the required nuspec file.", r.AllOutput);
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -172,7 +172,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 r.Success.Should().BeFalse();                
-                r.AllOutput.Should().Contain("The package doesn't contain nuspec file. Path: " + Path.Combine(pathContext.PackageSource, packageX.Id, packageX.Version));
+                r.AllOutput.Should().Contain("The package is missing the required nuspec file. Path: " + Path.Combine(pathContext.PackageSource, packageX.Id, packageX.Version));
             }
         }
 
@@ -209,7 +209,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 r.Success.Should().BeFalse();
-                r.AllOutput.Should().Contain("The package doesn't contain nuspec file. Path: " + Path.Combine(pathContext.UserPackagesFolder, packageX.Id, packageX.Version));
+                r.AllOutput.Should().Contain("The package is missing the required nuspec file. Path: " + Path.Combine(pathContext.UserPackagesFolder, packageX.Id, packageX.Version));
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -171,7 +171,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 r.Success.Should().BeFalse();                
-                r.AllOutput.Should().Contain("The package doesn't contain .nuspec file: " + Path.Combine(pathContext.PackageSource, packageX.Id, packageX.Version));
+                r.AllOutput.Should().Contain("The package doesn't contain .nuspec file. Path: " + Path.Combine(pathContext.PackageSource, packageX.Id, packageX.Version));
             }
         }
 
@@ -208,7 +208,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 r.Success.Should().BeFalse();
-                r.AllOutput.Should().Contain("The package doesn't contain .nuspec file: " + Path.Combine(pathContext.UserPackagesFolder, packageX.Id, packageX.Version));
+                r.AllOutput.Should().Contain("The package doesn't contain .nuspec file. Path: " + Path.Combine(pathContext.UserPackagesFolder, packageX.Id, packageX.Version));
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -140,8 +140,9 @@ namespace NuGet.CommandLine.Test
                 log.Message.Should().Contain("Detected package version outside of dependency constraint: x 1.0.0 requires z (= 1.0.0) but version z 2.0.0 was resolved.");
             }
         }
+
         [Fact]
-        public async Task RestoreLogging_VerifyNU5036WithMissingNuspecInSourceErrorMessageAsync()
+        public async Task RestoreLogging_MissingNuspecInSource_FailsWithNU5036Async()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -171,12 +172,12 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 r.Success.Should().BeFalse();                
-                r.AllOutput.Should().Contain("The package doesn't contain .nuspec file. Path: " + Path.Combine(pathContext.PackageSource, packageX.Id, packageX.Version));
+                r.AllOutput.Should().Contain("The package doesn't contain nuspec file. Path: " + Path.Combine(pathContext.PackageSource, packageX.Id, packageX.Version));
             }
         }
 
         [Fact]
-        public async Task RestoreLogging_VerifyNU5036WithMissingNuspecInGlobalPackageErrorMessageAsync()
+        public async Task RestoreLogging_MissingNuspecInGlobalPackages_FailsWithNU5036Async()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -208,7 +209,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 r.Success.Should().BeFalse();
-                r.AllOutput.Should().Contain("The package doesn't contain .nuspec file. Path: " + Path.Combine(pathContext.UserPackagesFolder, packageX.Id, packageX.Version));
+                r.AllOutput.Should().Contain("The package doesn't contain nuspec file. Path: " + Path.Combine(pathContext.UserPackagesFolder, packageX.Id, packageX.Version));
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -142,7 +142,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public async Task RestoreLogging_MissingNuspecInSource_FailsWithNU5036Async()
+        public async Task RestoreLogging_MissingNuspecInSource_FailsWithNU5037Async()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -177,7 +177,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public async Task RestoreLogging_MissingNuspecInGlobalPackages_FailsWithNU5036Async()
+        public async Task RestoreLogging_MissingNuspecInGlobalPackages_FailsWithNU5037Async()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions;
 using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Test.Utility;
 using Xunit;
@@ -138,62 +137,6 @@ namespace NuGet.CommandLine.Test
                 log.Level.Should().Be(LogLevel.Warning);
                 log.TargetGraphs.Select(e => string.Join(",", e)).Should().Contain(netcoreapp1.DotNetFrameworkName);
                 log.Message.Should().Contain("Detected package version outside of dependency constraint: x 1.0.0 requires z (= 1.0.0) but version z 2.0.0 was resolved.");
-            }
-        }
-
-        [Fact]
-        public async Task RestoreLogging_VerifyNU5128MessageAsync()
-        {
-            // Arrange
-            using (var pathContext = new SimpleTestPathContext())
-            {
-                // Set up solution, project, and packages
-                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-
-                var netcoreapp1 = NuGetFramework.Parse("netcoreapp1.0");
-
-                var projectA = SimpleTestProjectContext.CreateNETCore(
-                    "a",
-                    pathContext.SolutionRoot,
-                    netcoreapp1);
-
-                var packageX = new SimpleTestPackageContext("x", "1.0.0")
-                {
-                    Nuspec = XDocument.Parse($@"<?xml version=""1.0"" encoding=""utf-8""?>
-                        <package>
-                        <metadata>
-                            <id>x</id>
-                            <version>1.0.0</version>
-                            <title />
-                            <dependencies>
-                                <group>
-                                    <dependency id=""z"" version=""[1.0.0]"" />
-                                </group>
-                            </dependencies>
-                        </metadata>
-                        </package>")
-                };
-
-                var packageZ1 = new SimpleTestPackageContext("z", "1.0.0");
-                var packageZ2 = new SimpleTestPackageContext("z", "2.0.0");
-
-                await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageX, packageZ1, packageZ2);
-
-                projectA.AddPackageToAllFrameworks(packageX);
-                projectA.AddPackageToAllFrameworks(packageZ2);
-
-                solution.Projects.Add(projectA);
-                solution.Create(pathContext.SolutionRoot);
-
-                // Act
-                SimpleTestPackageUtility.DeletePackageFolderFile(pathContext.PackageSource, packageX.Id,
-                    packageX.Version,packageX.Id + NuGetConstants.ManifestExtension);
-                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
-
-                // Assert
-                r.Success.Should().BeFalse();
-                r.AllOutput.Should().Contain("The global package folder is missing one or more files. Delete package folder and run the restore again: " +
-                    Path.Combine(pathContext.PackageSource,packageX.Id,packageX.Version));
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Test.Utility;
 using Xunit;
@@ -137,6 +138,60 @@ namespace NuGet.CommandLine.Test
                 log.Level.Should().Be(LogLevel.Warning);
                 log.TargetGraphs.Select(e => string.Join(",", e)).Should().Contain(netcoreapp1.DotNetFrameworkName);
                 log.Message.Should().Contain("Detected package version outside of dependency constraint: x 1.0.0 requires z (= 1.0.0) but version z 2.0.0 was resolved.");
+            }
+        }
+        [Fact]
+        public async Task RestoreLogging_VerifyNU5128ErrorMessageAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp1 = NuGetFramework.Parse("netcoreapp1.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp1);
+
+                var packageX = new SimpleTestPackageContext("x", "1.0.0")
+                {
+                    Nuspec = XDocument.Parse($@"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <package>
+                        <metadata>
+                            <id>x</id>
+                            <version>1.0.0</version>
+                            <title />
+                            <dependencies>
+                                <group>
+                                    <dependency id=""z"" version=""[1.0.0]"" />
+                                </group>
+                            </dependencies>
+                        </metadata>
+                        </package>")
+                };
+
+                var packageZ1 = new SimpleTestPackageContext("z", "1.0.0");
+                var packageZ2 = new SimpleTestPackageContext("z", "2.0.0");
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageX, packageZ1, packageZ2);
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                projectA.AddPackageToAllFrameworks(packageZ2);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                // Act
+                File.Delete(Path.Combine(pathContext.PackageSource, packageX.Id,packageX.Version, packageX.Id + NuGetConstants.ManifestExtension));
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
+
+                // Assert
+                r.Success.Should().BeFalse();
+                r.AllOutput.Should().Contain("The global package folder is missing one or more files. Delete package folder and run the restore again: " +
+                    Path.Combine(pathContext.PackageSource, packageX.Id, packageX.Version));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -734,7 +734,7 @@ namespace NuGet.Packaging.Test
 
                     // Assert
                     var log = exception.AsLogMessage();
-                    Assert.Equal(NuGetLogCode.NU5036, log.Code);
+                    Assert.Equal(NuGetLogCode.NU5037, log.Code);
                     Assert.Contains("The package is missing the required nuspec file.", log.Message);
                 }
             }
@@ -782,7 +782,7 @@ namespace NuGet.Packaging.Test
 
                     // Assert
                     var log = exception.AsLogMessage();
-                    Assert.Equal(NuGetLogCode.NU5036, log.Code);
+                    Assert.Equal(NuGetLogCode.NU5037, log.Code);
                     Assert.Contains("The package is missing the required nuspec file.", log.Message);
                 }
             }
@@ -811,7 +811,7 @@ namespace NuGet.Packaging.Test
 
                     // Assert
                     var log = exception.AsLogMessage();
-                    Assert.Equal(NuGetLogCode.NU5036, log.Code);
+                    Assert.Equal(NuGetLogCode.NU5037, log.Code);
                     Assert.Contains("The package is missing the required nuspec file.", log.Message);
                 }
             }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -735,7 +735,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Matches("^The package doesn't contain .nuspec file: .*$", log.Message);
+                    Assert.Contains("The package doesn't contain .nuspec file.", log.Message);
                 }
             }
         }
@@ -783,7 +783,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Matches("^The package doesn't contain .nuspec file: .*$", log.Message);
+                    Assert.Contains("The package doesn't contain .nuspec file.", log.Message);
                 }
             }
         }
@@ -812,7 +812,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Matches("^The package doesn't contain .nuspec file: .*$", log.Message);
+                    Assert.Contains("The package doesn't contain .nuspec file.", log.Message);
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -735,7 +735,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Contains("The package doesn't contain .nuspec file.", log.Message);
+                    Assert.Contains("The package doesn't contain nuspec file.", log.Message);
                 }
             }
         }
@@ -783,7 +783,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Contains("The package doesn't contain .nuspec file.", log.Message);
+                    Assert.Contains("The package doesn't contain nuspec file.", log.Message);
                 }
             }
         }
@@ -812,7 +812,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Contains("The package doesn't contain .nuspec file.", log.Message);
+                    Assert.Contains("The package doesn't contain nuspec file.", log.Message);
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -735,7 +735,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Contains("The package doesn't contain nuspec file.", log.Message);
+                    Assert.Contains("The package is missing the required nuspec file.", log.Message);
                 }
             }
         }
@@ -783,7 +783,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Contains("The package doesn't contain nuspec file.", log.Message);
+                    Assert.Contains("The package is missing the required nuspec file.", log.Message);
                 }
             }
         }
@@ -812,7 +812,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Contains("The package doesn't contain nuspec file.", log.Message);
+                    Assert.Contains("The package is missing the required nuspec file.", log.Message);
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
@@ -732,7 +733,9 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Matches("^The global package folder is missing one or more files. Delete package folder and run the restore again: .*$", exception.Message);
+                    var log = exception.AsLogMessage();
+                    Assert.Equal(NuGetLogCode.NU5036, log.Code);
+                    Assert.Matches("^The package doesn't contain .nuspec file: .*$", log.Message);
                 }
             }
         }
@@ -778,7 +781,9 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Matches("^The global package folder is missing one or more files. Delete package folder and run the restore again: .*$", exception.Message);
+                    var log = exception.AsLogMessage();
+                    Assert.Equal(NuGetLogCode.NU5036, log.Code);
+                    Assert.Matches("^The package doesn't contain .nuspec file: .*$", log.Message);
                 }
             }
         }
@@ -805,7 +810,9 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Matches("^The global package folder is missing one or more files. Delete package folder and run the restore again: .*$", exception.Message);
+                    var log = exception.AsLogMessage();
+                    Assert.Equal(NuGetLogCode.NU5036, log.Code);
+                    Assert.Matches("^The package doesn't contain .nuspec file: .*$", log.Message);
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -732,7 +732,7 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Equal("Nuspec file does not exist in package.", exception.Message);
+                    Assert.Matches("^The global package folder copy of package .* is missing one or more files.$",exception.Message);
                 }
             }
         }
@@ -778,7 +778,7 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Equal("Nuspec file does not exist in package.", exception.Message);
+                    Assert.Matches("^The global package folder copy of package .* is missing one or more files.$", exception.Message);
                 }
             }
         }
@@ -805,7 +805,7 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Equal("Nuspec file does not exist in package.", exception.Message);
+                    Assert.Matches("^The global package folder copy of package .* is missing one or more files.$", exception.Message);
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -732,7 +732,7 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Matches("^The global package folder copy of package .* is missing one or more files.$",exception.Message);
+                    Assert.Matches("^The global package folder is missing one or more files. Delete package folder and run the restore again: .*$", exception.Message);
                 }
             }
         }
@@ -778,7 +778,7 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Matches("^The global package folder copy of package .* is missing one or more files.$", exception.Message);
+                    Assert.Matches("^The global package folder is missing one or more files. Delete package folder and run the restore again: .*$", exception.Message);
                 }
             }
         }
@@ -805,7 +805,7 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Matches("^The global package folder copy of package .* is missing one or more files.$", exception.Message);
+                    Assert.Matches("^The global package folder is missing one or more files. Delete package folder and run the restore again: .*$", exception.Message);
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
@@ -370,7 +370,7 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Equal("Nuspec file does not exist in package.", exception.Message);
+                    Assert.Matches("^The global package folder copy of package .* is missing one or more files.$", exception.Message);
                 }
             }
         }
@@ -422,7 +422,7 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Equal("Nuspec file does not exist in package.", exception.Message);
+                    Assert.Matches("^The global package folder copy of package .* is missing one or more files.$", exception.Message);
                 }
             }
         }
@@ -452,7 +452,7 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Equal("Nuspec file does not exist in package.", exception.Message);
+                    Assert.Matches("^The global package folder copy of package .* is missing one or more files.$", exception.Message);
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
@@ -373,7 +373,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Contains("The package doesn't contain nuspec file.", log.Message);
+                    Assert.Contains("The package is missing the required nuspec file.", log.Message);
                 }
             }
         }
@@ -427,7 +427,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Contains("The package doesn't contain nuspec file.", log.Message);
+                    Assert.Contains("The package is missing the required nuspec file.", log.Message);
                 }
             }
         }
@@ -459,7 +459,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Contains("The package doesn't contain nuspec file.", log.Message);
+                    Assert.Contains("The package is missing the required nuspec file.", log.Message);
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
@@ -370,7 +370,7 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Matches("^The global package folder copy of package .* is missing one or more files.$", exception.Message);
+                    Assert.Matches("^The global package folder is missing one or more files. Delete package folder and run the restore again: .*$", exception.Message);
                 }
             }
         }
@@ -422,7 +422,7 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Matches("^The global package folder copy of package .* is missing one or more files.$", exception.Message);
+                    Assert.Matches("^The global package folder is missing one or more files. Delete package folder and run the restore again: .*$", exception.Message);
                 }
             }
         }
@@ -452,7 +452,7 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Matches("^The global package folder copy of package .* is missing one or more files.$", exception.Message);
+                    Assert.Matches("^The global package folder is missing one or more files. Delete package folder and run the restore again: .*$", exception.Message);
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
@@ -373,7 +373,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Matches("^The package doesn't contain .nuspec file: .*$", log.Message);
+                    Assert.Contains("The package doesn't contain .nuspec file.", log.Message);
                 }
             }
         }
@@ -427,7 +427,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Matches("^The package doesn't contain .nuspec file: .*$", log.Message);
+                    Assert.Contains("The package doesn't contain .nuspec file.", log.Message);
                 }
             }
         }
@@ -459,7 +459,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Matches("^The package doesn't contain .nuspec file: .*$", log.Message);
+                    Assert.Contains("The package doesn't contain .nuspec file.", log.Message);
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
@@ -372,7 +372,7 @@ namespace NuGet.Packaging.Test
 
                     // Assert
                     var log = exception.AsLogMessage();
-                    Assert.Equal(NuGetLogCode.NU5036, log.Code);
+                    Assert.Equal(NuGetLogCode.NU5037, log.Code);
                     Assert.Contains("The package is missing the required nuspec file.", log.Message);
                 }
             }
@@ -426,7 +426,7 @@ namespace NuGet.Packaging.Test
 
                     // Assert
                     var log = exception.AsLogMessage();
-                    Assert.Equal(NuGetLogCode.NU5036, log.Code);
+                    Assert.Equal(NuGetLogCode.NU5037, log.Code);
                     Assert.Contains("The package is missing the required nuspec file.", log.Message);
                 }
             }
@@ -458,7 +458,7 @@ namespace NuGet.Packaging.Test
 
                     // Assert
                     var log = exception.AsLogMessage();
-                    Assert.Equal(NuGetLogCode.NU5036, log.Code);
+                    Assert.Equal(NuGetLogCode.NU5037, log.Code);
                     Assert.Contains("The package is missing the required nuspec file.", log.Message);
                 }
             }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
@@ -373,7 +373,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Contains("The package doesn't contain .nuspec file.", log.Message);
+                    Assert.Contains("The package doesn't contain nuspec file.", log.Message);
                 }
             }
         }
@@ -427,7 +427,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Contains("The package doesn't contain .nuspec file.", log.Message);
+                    Assert.Contains("The package doesn't contain nuspec file.", log.Message);
                 }
             }
         }
@@ -459,7 +459,7 @@ namespace NuGet.Packaging.Test
                     // Assert
                     var log = exception.AsLogMessage();
                     Assert.Equal(NuGetLogCode.NU5036, log.Code);
-                    Assert.Contains("The package doesn't contain .nuspec file.", log.Message);
+                    Assert.Contains("The package doesn't contain nuspec file.", log.Message);
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Packaging.Core;
+using NuGet.Repositories;
 using NuGet.Test.Utility;
 using Xunit;
 
@@ -370,7 +371,9 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Matches("^The global package folder is missing one or more files. Delete package folder and run the restore again: .*$", exception.Message);
+                    var log = exception.AsLogMessage();
+                    Assert.Equal(NuGetLogCode.NU5036, log.Code);
+                    Assert.Matches("^The package doesn't contain .nuspec file: .*$", log.Message);
                 }
             }
         }
@@ -422,7 +425,9 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Matches("^The global package folder is missing one or more files. Delete package folder and run the restore again: .*$", exception.Message);
+                    var log = exception.AsLogMessage();
+                    Assert.Equal(NuGetLogCode.NU5036, log.Code);
+                    Assert.Matches("^The package doesn't contain .nuspec file: .*$", log.Message);
                 }
             }
         }
@@ -452,7 +457,9 @@ namespace NuGet.Packaging.Test
                     var exception = Assert.Throws<PackagingException>(() => reader.GetNuspec());
 
                     // Assert
-                    Assert.Matches("^The global package folder is missing one or more files. Delete package folder and run the restore again: .*$", exception.Message);
+                    var log = exception.AsLogMessage();
+                    Assert.Equal(NuGetLogCode.NU5036, log.Code);
+                    Assert.Matches("^The package doesn't contain .nuspec file: .*$", log.Message);
                 }
             }
         }

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
@@ -462,6 +462,17 @@ namespace NuGet.Test.Utility
             }
         }
 
+        ///<summary>
+        ///Delete file in global package folder
+        ///</summary>
+        public static void DeletePackageFolderFile(string root,string packageName,string version,string fileName)
+        {
+            string file = Path.Combine(root, packageName, version, fileName);
+
+            if(File.Exists(file))
+                File.Delete(file);
+        }
+
         /// <summary>
         /// Create a v3 folder of nupkgs
         /// </summary>

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
@@ -462,17 +462,6 @@ namespace NuGet.Test.Utility
             }
         }
 
-        ///<summary>
-        ///Delete file in global package folder
-        ///</summary>
-        public static void DeletePackageFolderFile(string root,string packageName,string version,string fileName)
-        {
-            string file = Path.Combine(root, packageName, version, fileName);
-
-            if(File.Exists(file))
-                File.Delete(file);
-        }
-
         /// <summary>
         /// Create a v3 folder of nupkgs
         /// </summary>

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.PackageExtraction;
@@ -592,6 +593,24 @@ namespace NuGet.Test.Utility
             }
         }
 
+        /// <summary>
+        /// Delete nuspec file from the package
+        /// </summary>
+        /// <param name="nupkgPath">Path to package file</param>
+        public static Task DeleteNuspecFileFromPackageAsync(string nupkgPath)
+        {
+            return Task.Run(() => {
+                using (FileStream zipToOpen = new FileStream(nupkgPath, FileMode.Open))
+                {
+                    using (ZipArchive archive = new ZipArchive(zipToOpen, ZipArchiveMode.Update))
+                    {
+                        var nuspec = archive.Entries.Where(entry => entry.Name.EndsWith(NuGetConstants.ManifestExtension)).SingleOrDefault();
+                        nuspec?.Delete();
+                    }
+                }
+            }, CancellationToken.None);
+
+        }
         private static IPackageFile CreatePackageFile(string name)
         {
             var file = new InMemoryFile


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home/issues/8291  
Regression: No  
* Last working version:   
* How are we preventing it in future:  Added tests to make sure code works as expected.

## Fix

Details: Added new error code 5036 to warn the user about the missing required files such as .nuspec in the package folder upon restore.

## Testing/Validation

Tests Added: Yes 
Reason for not adding tests:  
Validation:  
