### PR TITLE
Use recommended version of dotnet cli for bootstrapping xplat

### DIFF
--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -37,8 +37,8 @@ curl -o cli/dotnet-install.sh https://dot.net/v1/dotnet-install.sh
 # Run install.sh
 chmod +x cli/dotnet-install.sh
 
-# v1 needed for some test and bootstrapping testing version
-cli/dotnet-install.sh -i cli -c 1.0
+# Get recommended version for bootstrapping testing version
+cli/dotnet-install.sh -i cli
 
 DOTNET="$(pwd)/cli/dotnet"
 


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8365
Regression: No  
* Last working version:   
* How are we preventing it in future:  don't pin installs used for bootstrapping to specific versions

## Fix

Details: Let the dotnet-install script choose what version to install

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  build infrastructure, not product code.
Validation:  
