### PR TITLE
Convert async void test methods to async Task

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -17,6 +17,6 @@
   <package id="NuGetValidator" version="2.0.1" targetFramework="net461" />
   <package id="VSLangProj140" version="14.0.25029" targetFramework="net46" />
   <package id="VSLangProj150" version="1.0.0" targetFramework="net46" />
-  <package id="xunit.runner.console" version="2.3.1" targetFramework="net45" />
+  <package id="xunit.runner.console" version="2.4.1" targetFramework="net45" />
   <package id="XunitXml.TestLogger" version="2.0.0" />
 </packages>

--- a/build/TestShared/GlobalSuppressions.cs
+++ b/build/TestShared/GlobalSuppressions.cs
@@ -1,0 +1,10 @@
+
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Test case methods follow different naming conventions.", Scope = "namespaceanddescendants", Target = "Dotnet.Integration.Test")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Test case methods follow different naming conventions.", Scope = "namespaceanddescendants", Target = "NuGet.PackageManagement.VisualStudio.Test")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Test case methods follow different naming conventions.", Scope = "namespaceanddescendants", Target = "NuGet.Test")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Test case methods follow different naming conventions.", Scope = "namespaceanddescendants", Target = "NuGet.XPlat.FuncTest")]

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -27,7 +27,7 @@
     <NupkgOutputDirectory Condition=" '$(BuildRTM)' != 'true' ">$(ArtifactsDirectory)nupkgs\</NupkgOutputDirectory>
     <NupkgOutputDirectory Condition=" '$(BuildRTM)' == 'true' ">$(ArtifactsDirectory)ReleaseNupkgs\</NupkgOutputDirectory>
     <SolutionPackagesFolder>$(RepositoryRootDirectory)packages\</SolutionPackagesFolder>
-    <XunitConsoleExePath>$(SolutionPackagesFolder)xunit.runner.console.2.3.1\tools\net452\xunit.console.x86.exe</XunitConsoleExePath>
+    <XunitConsoleExePath>$(SolutionPackagesFolder)xunit.runner.console.2.4.1\tools\net452\xunit.console.x86.exe</XunitConsoleExePath>
     <ILMergeExePath>$(SolutionPackagesFolder)ILMerge.3.0.21\tools\net452\ILMerge.exe</ILMergeExePath>
     <XunitXmlLoggerDirectory>$(SolutionPackagesFolder)XunitXml.TestLogger.2.0.0\build\_common</XunitXmlLoggerDirectory>
     <NuGetBuildTasksPackTargets Condition="Exists('$(SolutionPackagesFolder)NuGet.Build.Tasks.Pack.4.9.2\build\NuGet.Build.Tasks.Pack.targets')">$(SolutionPackagesFolder)NuGet.Build.Tasks.Pack.4.9.2\build\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>

--- a/build/config.props
+++ b/build/config.props
@@ -38,9 +38,9 @@
   <PropertyGroup>
     <NewtonsoftJsonVersionCore Condition="$(NewtonsoftJsonPackageVersion) == ''">9.0.1</NewtonsoftJsonVersionCore>
     <NewtonsoftJsonVersionCore Condition="$(NewtonsoftJsonPackageVersion) != ''">$(NewtonsoftJsonPackageVersion)</NewtonsoftJsonVersionCore>
-    <XunitVersion>2.3.1</XunitVersion>
+    <XunitVersion>2.4.1</XunitVersion>
     <TestSDKVersion>15.5.0</TestSDKVersion>
-    <MoqVersion>4.10.1</MoqVersion>
+    <MoqVersion>4.12.0</MoqVersion>
     <FluentAssertionsVersion>4.19.4</FluentAssertionsVersion>
     <MicrosoftBuildPackageVersion Condition="$(MicrosoftBuildPackageVersion) == ''">16.0.461</MicrosoftBuildPackageVersion>
   </PropertyGroup>

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -127,7 +127,7 @@ fi
 
 #run mono test
 TestDir="$DIR/artifacts/NuGet.CommandLine.Test/"
-XunitConsole="$DIR/packages/xunit.runner.console.2.3.1/tools/net452/xunit.console.exe"
+XunitConsole="$DIR/packages/xunit.runner.console.2.4.1/tools/net452/xunit.console.exe"
 
 #Clean System dll
 rm -r -f "$TestDir/System.*" "$TestDir/WindowsBase.dll" "$TestDir/Microsoft.CSharp.dll" "$TestDir/Microsoft.Build.Engine.dll"

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetLocalsCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetLocalsCommandTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using System.Threading.Tasks;
 using Moq;
 using NuGet.CommandLine.Commands;
 using NuGet.Commands;
@@ -110,7 +111,7 @@ namespace NuGet.CommandLine.Test
         [InlineData("temp")]
         [InlineData("http-cache")]
         [InlineData("global-packages")]
-        public async void LocalsCommand_ParsingValidation_WithNoConfigParam(string arg)
+        public async Task LocalsCommand_ParsingValidation_WithNoConfigParam(string arg)
         {
             // Use a test directory to validate test key-value pairs within ISettings object passed to Runner
             using (var mockCurrentDirectory = TestDirectory.Create())
@@ -153,7 +154,7 @@ namespace NuGet.CommandLine.Test
         [InlineData("temp")]
         [InlineData("http-cache")]
         [InlineData("global-packages")]
-        public async void LocalsCommand_ParsingValidation_WithConfigParam(string arg)
+        public async Task LocalsCommand_ParsingValidation_WithConfigParam(string arg)
         {
             // Use a test directory to validate test key-value pairs within ISettings object passed to Runner
             using (var mockCurrentDirectory = TestDirectory.Create())

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/WpfTestCase.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/WpfTestCase.cs
@@ -28,9 +28,13 @@ namespace NuGet.PackageManagement.UI.Test
 
         public ISourceInformation SourceInformation
         {
-            get { return _testCase.SourceInformation; }
-            set { _testCase.SourceInformation = value; }
+            get => _testCase.SourceInformation;
+            set => _testCase.SourceInformation = value;
         }
+
+        public Exception InitializationException => _testCase.InitializationException;
+
+        public int Timeout => _testCase.Timeout;
 
         public WpfTestCase(IXunitTestCase testCase)
         {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceRestoreUtilityTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft;
 using NuGet.Commands;
 using NuGet.Common;
@@ -38,7 +39,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_Success()
+        public async Task DependencyGraphRestoreUtility_LegacyPackageRef_Restore_Success()
         {
             using (var packageSource = TestDirectory.Create())
             {
@@ -126,7 +127,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_GenerateLockFile()
+        public async Task DependencyGraphRestoreUtility_LegacyPackageRef_Restore_GenerateLockFile()
         {
             using (var packageSource = TestDirectory.Create())
             {
@@ -267,7 +268,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_ReadLockFile()
+        public async Task DependencyGraphRestoreUtility_LegacyPackageRef_Restore_ReadLockFile()
         {
             using (var packageSource = TestDirectory.Create())
             {
@@ -393,7 +394,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_UpdateLockFile()
+        public async Task DependencyGraphRestoreUtility_LegacyPackageRef_Restore_UpdateLockFile()
         {
             using (var packageSource = TestDirectory.Create())
             {
@@ -545,7 +546,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_RestorePackagesWithLockFile_False()
+        public async Task DependencyGraphRestoreUtility_LegacyPackageRef_Restore_RestorePackagesWithLockFile_False()
         {
             using (var packageSource = TestDirectory.Create())
             {
@@ -635,7 +636,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_LockedMode()
+        public async Task DependencyGraphRestoreUtility_LegacyPackageRef_Restore_LockedMode()
         {
             using (var packageSource = TestDirectory.Create())
             {
@@ -769,7 +770,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_PackageShaValidationFailed()
+        public async Task DependencyGraphRestoreUtility_LegacyPackageRef_Restore_PackageShaValidationFailed()
         {
             using (var packageSource = TestDirectory.Create())
             {
@@ -893,7 +894,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void TestPacMan_InstallPackageAsync_LegacyPackageRefProjects_Duality()
+        public async Task TestPacMan_InstallPackageAsync_LegacyPackageRefProjects_Duality()
         {
             using (var packageSource = TestDirectory.Create())
             {
@@ -949,7 +950,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                         projectTargetFrameworkStr);
 
                     var projectServicesA = new TestProjectSystemServices();
-                    
+
                     projectServicesA.SetupProjectDependencies(
                         new ProjectRestoreReference
                         {
@@ -991,7 +992,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void TestPacMan_InstallPackageAsync_LegacyPackageRefProjects_developmentDependency()
+        public async Task TestPacMan_InstallPackageAsync_LegacyPackageRefProjects_developmentDependency()
         {
             using (var packageSource = TestDirectory.Create())
             {
@@ -1085,7 +1086,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void TestPacMan_LegacyPackageRefProjects_UpdatePackage_KeepExistingMetadata()
+        public async Task TestPacMan_LegacyPackageRefProjects_UpdatePackage_KeepExistingMetadata()
         {
             using (var packageSource = TestDirectory.Create())
             {
@@ -1191,7 +1192,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_MissingProjectsInSolution()
+        public async Task DependencyGraphRestoreUtility_LegacyPackageRef_Restore_MissingProjectsInSolution()
         {
             using (var packageSource = TestDirectory.Create())
             {
@@ -1336,7 +1337,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_PackagesLockFile_ResolveExactVersion()
+        public async Task DependencyGraphRestoreUtility_LegacyPackageRef_Restore_PackagesLockFile_ResolveExactVersion()
         {
             using (var packageSource = TestDirectory.Create())
             {
@@ -1500,7 +1501,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_PackagesLockFile_P2PReference()
+        public async Task DependencyGraphRestoreUtility_LegacyPackageRef_Restore_PackagesLockFile_P2PReference()
         {
             using (var packageSource = TestDirectory.Create())
             {
@@ -1666,7 +1667,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public async void DependencyGraphRestoreUtility_LegacyPackageRef_Restore_BuildTransitive()
+        public async Task DependencyGraphRestoreUtility_LegacyPackageRef_Restore_BuildTransitive()
         {
             using (var packageSource = TestDirectory.Create())
             {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using NuGet.Packaging;
 using NuGet.Test.Utility;
@@ -25,7 +26,7 @@ namespace Dotnet.Integration.Test
 
 
         [PlatformFact(Platform.Windows)]
-        public async void DotnetListPackage_Succeed()
+        public async Task DotnetListPackage_Succeed()
         {
             using (var pathContext = new SimpleTestPathContext())
             {
@@ -55,7 +56,7 @@ namespace Dotnet.Integration.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public async void DotnetListPackage_NoRestore_Fail()
+        public async Task DotnetListPackage_NoRestore_Fail()
         {
             using (var pathContext = new SimpleTestPathContext())
             {
@@ -82,7 +83,7 @@ namespace Dotnet.Integration.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public async void DotnetListPackage_Transitive()
+        public async Task DotnetListPackage_Transitive()
         {
             using (var pathContext = new SimpleTestPathContext())
             {
@@ -128,7 +129,7 @@ namespace Dotnet.Integration.Test
         [InlineData("--framework net451 --framework net46", "net451", null)]
         [InlineData("--framework net451", "net451", "net46")]
         [InlineData("--framework net46", "net46", "net451")]
-        public async void DotnetListPackage_FrameworkSpecific_Success(string args, string shouldInclude, string shouldntInclude)
+        public async Task DotnetListPackage_FrameworkSpecific_Success(string args, string shouldInclude, string shouldntInclude)
         {
             using (var pathContext = new SimpleTestPathContext())
             {
@@ -165,7 +166,7 @@ namespace Dotnet.Integration.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public async void DotnetListPackage_InvalidFramework_Fail()
+        public async Task DotnetListPackage_InvalidFramework_Fail()
         {
             using (var pathContext = new SimpleTestPathContext())
             {
@@ -201,7 +202,7 @@ namespace Dotnet.Integration.Test
         // In 2.2.100 of CLI. DotNet list package would show a section for each TFM and for each TFM/RID.
         // This is testing to ensure that it only shows one section for each TFM.
         [PlatformFact(Platform.Windows)]
-        public async void DotnetListPackage_ShowFrameworksOnly_SDK()
+        public async Task DotnetListPackage_ShowFrameworksOnly_SDK()
         {
             using (var pathContext = new SimpleTestPathContext())
             {
@@ -253,7 +254,7 @@ namespace Dotnet.Integration.Test
         [InlineData("1.0.0", "--highest-minor", "1.9.0")]
         [InlineData("1.0.0", "--highest-patch --include-prerelease", "1.0.10-beta")]
         [InlineData("1.0.0", "--highest-minor --include-prerelease", "1.10.0-beta")]
-        public async void DotnetListPackage_Outdated_Succeed(string currentVersion, string args, string expectedVersion)
+        public async Task DotnetListPackage_Outdated_Succeed(string currentVersion, string args, string expectedVersion)
         {
             using (var pathContext = new SimpleTestPathContext())
             {
@@ -290,7 +291,7 @@ namespace Dotnet.Integration.Test
         // We read the original PackageReference items by calling the CollectPackageReference target.
         // If a project has InitialTargets we need to deal with the response properly in the C# based invocation.
         [PlatformFact(Platform.Windows)]
-        public async void DotnetListPackage_ProjectWithInitialTargets_Succeeds()
+        public async Task DotnetListPackage_ProjectWithInitialTargets_Succeeds()
         {
             using (var pathContext = new SimpleTestPathContext())
             {

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
 using Moq;
 using NuGet.CommandLine.XPlat;
@@ -129,7 +130,7 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("*")]
         [InlineData("1.*")]
         [InlineData("1.0.*")]
-        public async void AddPkg_UnconditionalAdd_Success(string userInputVersion)
+        public async Task AddPkg_UnconditionalAdd_Success(string userInputVersion)
         {
             // Arrange
 
@@ -165,7 +166,7 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("*")]
         [InlineData("1.*")]
         [InlineData("1.0.*")]
-        public async void AddPkg_UnconditionalAddIntoExeProject_Success(string userInputVersion)
+        public async Task AddPkg_UnconditionalAddIntoExeProject_Success(string userInputVersion)
         {
             // Arrange
 
@@ -204,7 +205,7 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("*")]
         [InlineData("1.*")]
         [InlineData("1.0.*")]
-        public async void AddPkg_UnconditionalAddWithDotnetCliTool_Success(string userInputVersion)
+        public async Task AddPkg_UnconditionalAddWithDotnetCliTool_Success(string userInputVersion)
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -254,7 +255,6 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
-
         [Theory]
         [InlineData("net46", "net46; netcoreapp1.0", "1.*")]
         [InlineData("net46; netcoreapp1.0", "net46; netcoreapp1.0", "1.*")]
@@ -265,7 +265,7 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("net46", "net46; netstandard2.0", "1.*")]
         [InlineData("net46; netstandard2.0", "net46; netstandard2.0", "1.*")]
         [InlineData("netstandard2.0", "net46; netstandard2.0", "1.*")]
-        public async void AddPkg_UnconditionalAddWithNoRestore_Success(string packageFrameworks,
+        public async Task AddPkg_UnconditionalAddWithNoRestore_Success(string packageFrameworks,
             string projectFrameworks,
             string userInputVersion)
         {
@@ -305,7 +305,7 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("net46; netcoreapp1.0", "1.*")]
         [InlineData("net46; netcoreapp2.0", "1.*")]
         [InlineData("net46; netstandard2.0", "1.*")]
-        public async void AddPkg_UnconditionalAddWithDotnetCliToolAndNoRestore_Success(string projectFrameworks,
+        public async Task AddPkg_UnconditionalAddWithDotnetCliToolAndNoRestore_Success(string projectFrameworks,
             string userInputVersion)
         {
             // Arrange
@@ -357,7 +357,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public async void AddPkg_UnconditionalAddWithoutVersion_Success()
+        public async Task AddPkg_UnconditionalAddWithoutVersion_Success()
         {
             // Arrange
 
@@ -396,7 +396,7 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("net46", "net46; netcoreapp2.0", "*")]
         [InlineData("net46", "net46; netstandard2.0", "1.0.0")]
         [InlineData("net46", "net46; netstandard2.0", "*")]
-        public async void AddPkg_ConditionalAddWithoutUserInputFramework_Success(string packageFrameworks,
+        public async Task AddPkg_ConditionalAddWithoutUserInputFramework_Success(string packageFrameworks,
             string projectFrameworks, string userInputVersion)
         {
             // Arrange
@@ -444,7 +444,7 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("net46; netstandard2.0", "net46; netstandard2.0", "net46")]
         [InlineData("net46; netstandard2.0", "net46; netstandard2.0", "netstandard2.0")]
         [InlineData("net46", "net46; netstandard2.0", "net46; netstandard2.0")]
-        public async void AddPkg_ConditionalAddWithUserInputFramework_Success(string packageFrameworks, string projectFrameworks, string userInputFrameworks)
+        public async Task AddPkg_ConditionalAddWithUserInputFramework_Success(string packageFrameworks, string projectFrameworks, string userInputFrameworks)
         {
             // Arrange
 
@@ -492,7 +492,7 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("net46; netstandard2.0", "net46; netstandard2.0", "net46")]
         [InlineData("net46; netstandard2.0", "net46; netstandard2.0", "netstandard2.0")]
         [InlineData("net46", "net46; netstandard2.0", "net46; netstandard2.0")]
-        public async void AddPkg_ConditionalAddWithoutVersion_Success(string packageFrameworks,
+        public async Task AddPkg_ConditionalAddWithoutVersion_Success(string packageFrameworks,
             string projectFrameworks,
             string userInputFrameworks)
         {
@@ -539,7 +539,7 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("net46", "unknown_framework")]
         [InlineData("netcoreapp1.0", "unknown_framework")]
         [InlineData("net46; netcoreapp1.0", "unknown_framework")]
-        public async void AddPkg_FailureIncompatibleFrameworks(string packageFrameworks, string userInputFrameworks)
+        public async Task AddPkg_FailureIncompatibleFrameworks(string packageFrameworks, string userInputFrameworks)
         {
             // Arrange
 
@@ -570,7 +570,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public async void AddPkg_FailureUnknownPackage()
+        public async Task AddPkg_FailureUnknownPackage()
         {
             // Arrange
 
@@ -601,7 +601,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public async void AddPkg_UnconditionalAddTwoPackages_Success()
+        public async Task AddPkg_UnconditionalAddTwoPackages_Success()
         {
             // Arrange
 
@@ -658,7 +658,7 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("net46; netstandard2.0", "net46; netstandard2.0", "netstandard2.0")]
         [InlineData("net46", "net46; netstandard2.0", "net46; netstandard2.0")]
         [InlineData("netstandard2.0", "net46; netstandard2.0", "net46; netstandard2.0")]
-        public async void AddPkg_ConditionalAddTwoPackages_Success(string packageFrameworks, string projectFrameworks, string userInputFrameworks)
+        public async Task AddPkg_ConditionalAddTwoPackages_Success(string packageFrameworks, string projectFrameworks, string userInputFrameworks)
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -707,7 +707,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public async void AddPkg_UnconditionalAddWithPackageDirectory_Success()
+        public async Task AddPkg_UnconditionalAddWithPackageDirectory_Success()
         {
             // Arrange
 
@@ -754,7 +754,7 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("*", "1.0.0", false)]
         [InlineData("*", "0.9", false)]
         [InlineData("*", "1.*", false)]
-        public async void AddPkg_UnconditionalAddAsUpdate_Succcess(string userInputVersionOld, string userInputVersionNew, bool noVersion)
+        public async Task AddPkg_UnconditionalAddAsUpdate_Succcess(string userInputVersionOld, string userInputVersionNew, bool noVersion)
         {
             // Arrange
 
@@ -823,7 +823,7 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("net46; netstandard2.0", "*", "0.9", false)]
         [InlineData("net46; netstandard2.0", "*", "1.*", false)]
         [InlineData("net46; netstandard2.0", "0.0.5", "*", true)]
-        public async void AddPkg_ConditionalAddAsUpdate_Success(string projectFrameworks, string userInputVersionOld, string userInputVersionNew, bool noVersion)
+        public async Task AddPkg_ConditionalAddAsUpdate_Success(string projectFrameworks, string userInputVersionOld, string userInputVersionNew, bool noVersion)
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -870,7 +870,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public async void AddPkg_DevelopmentDependency()
+        public async Task AddPkg_DevelopmentDependency()
         {
             // Arrange
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
 using Moq;
 using NuGet.CommandLine.XPlat;
@@ -69,7 +70,7 @@ namespace NuGet.XPlat.FuncTest
         // Remove Related Tests
 
         [Fact]
-        public async void RemovePkg_UnconditionalRemove_Success()
+        public async Task RemovePkg_UnconditionalRemove_Success()
         {
             // Arrange
 
@@ -134,7 +135,7 @@ namespace NuGet.XPlat.FuncTest
         [Theory]
         [InlineData("net46")]
         [InlineData("netcoreapp1.0")]
-        public async void RemovePkg_ConditionalRemove_Success(string packageframework)
+        public async Task RemovePkg_ConditionalRemove_Success(string packageframework)
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -1711,7 +1711,7 @@ namespace NuGet.Test
         }
 
         [Fact]
-        public async void TestPacMan_BuildIntegrated_PreviewUpdatesAsync_NoUpdatesAvailable()
+        public async Task TestPacMan_BuildIntegrated_PreviewUpdatesAsync_NoUpdatesAvailable()
         {
             using (var packageSource = TestDirectory.Create())
             {
@@ -1775,7 +1775,7 @@ namespace NuGet.Test
         }
 
         [Fact]
-        public async void TestPacMan_BuildIntegrated_PreviewUpdatesAsync_WithStrictVersionRange()
+        public async Task TestPacMan_BuildIntegrated_PreviewUpdatesAsync_WithStrictVersionRange()
         {
             // Set up Package Source
             var packages = new List<SourcePackageDependencyInfo>

--- a/test/TestExtensions/NuGet.StaFact/NuGetWpfTestCase.cs
+++ b/test/TestExtensions/NuGet.StaFact/NuGetWpfTestCase.cs
@@ -28,9 +28,12 @@ namespace NuGet.StaFact
 
         public ISourceInformation SourceInformation
         {
-            get { return _testCase.SourceInformation; }
-            set { _testCase.SourceInformation = value; }
+            get => _testCase.SourceInformation;
+            set => _testCase.SourceInformation = value;
         }
+
+        public Exception InitializationException => _testCase.InitializationException;
+        public int Timeout => _testCase.Timeout;
 
         public NuGetWpfTestCase(IXunitTestCase testCase)
         {


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8406
Regression: No  

## Fix

Details: 
Converted `async void` test methods to `async Task`.
Whilst at it, also upgraded `xUnit` and `Moq` dependencies to latest stable releases.