### PR TITLE
Improve performance in GetMatches by processing in parallel

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace NuGet.Common
 {
@@ -21,7 +22,7 @@ namespace NuGet.Common
         public static IEnumerable<T> GetMatches<T>(IEnumerable<T> source, Func<T, string> getPath, IEnumerable<string> wildcards)
         {
             var filters = wildcards.Select(WildcardToRegex);
-            return source.Where(item =>
+            return source.AsParallel().Where(item =>
             {
                 string path = getPath(item);
                 return filters.Any(f => f.IsMatch(path));


### PR DESCRIPTION
## Bug

Fixes: Path matching could be parallelized for improved performance.
Regression: No 

## Fix

Details: Utilize .NET Standard 2.0's ParallelEnumerable functionality to parallelize the regular expression processing of the GetMatches function, which improves performance of excludes processing and other similar matching operations.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  The change alters how the method runs internally and should improve performance, but does not change any contract or functionality of the method.
Validation:  I ran a few pack operations on large file sets where the regular expression that would filter out embedded nuspec files ("**\*.nuspec") would be processed. I saw the performance improve roughly equal to the number of cores I had on the machine (262 seconds down to 65 seconds for 4 cores) as expected.
