### PR TITLE
Start the plugin processes with Window Style Hidden

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
@@ -159,7 +159,8 @@ namespace NuGet.Protocol.Plugins
                 RedirectStandardError = false,
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
-                StandardOutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)
+                StandardOutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                WindowStyle = ProcessWindowStyle.Hidden,
             };
 #else
             var startInfo = new ProcessStartInfo
@@ -170,7 +171,8 @@ namespace NuGet.Protocol.Plugins
                 RedirectStandardError = false,
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
-                StandardOutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)
+                StandardOutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                WindowStyle = ProcessWindowStyle.Hidden,
             };
 #endif
             var pluginProcess = new PluginProcess(startInfo);


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7511
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 

Start the processes with a window style hidden. 

@satbai I'd imagine you shouldn't have any issues showing the UI despite this change?

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
