### PR TITLE
Build:  onboard to OptProfV2

### DIFF
--- a/build/NuGet.OptProfV2.runsettingsproj
+++ b/build/NuGet.OptProfV2.runsettingsproj
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
+
+  <PropertyGroup>
+    <RunName>NuGet.OptProfV2</RunName>
+    <TestCaseFilter>TestCategory=OptProf</TestCaseFilter>
+    <OutputPath Condition="'$(OutputPath)' == ''">$(ArtifactsDirectory)OptProfV2</OutputPath>
+    <OutDir>$(OutputPath)</OutDir>
+    <MaxCpuCount>1</MaxCpuCount>
+    <TestSessionTimeout>21600000</TestSessionTimeout>
+    <TestAdaptersPaths>C:\Test;C:\NuGet</TestAdaptersPaths>
+    <ResultsDirectory>C:\Test\Results</ResultsDirectory>
+    <LingeringProcessCollector>enabled</LingeringProcessCollector>
+    <OptProfCollector>enabled</OptProfCollector>
+    <ScreenshotCollector>enabled</ScreenshotCollector>
+    <TestRunParametersLogger>enabled</TestRunParametersLogger>
+    <VideoRecorderCollector>enabled</VideoRecorderCollector>
+    <TRXLogger>enabled</TRXLogger>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <DataCollector>
+      <IsEnabled>true</IsEnabled>
+    </DataCollector>
+    <Logger>
+      <IsEnabled>true</IsEnabled>
+    </Logger>
+  </ItemDefinitionGroup>
+
+  <ItemGroup Label="Test Stores">
+    <!-- This represents the build drop that contains NuGet.Tests.dll. -->
+    <TestStore Include="vstsdrop:$(TestDrop)" />
+    <!-- This represents the build drop that contains profiling inputs. -->
+    <TestStore Include="vstsdrop:$(ProfilingInputsDrop)" />
+  </ItemGroup>
+
+  <ItemGroup Label="Test Containers">
+    <TestContainer Include="NuGet.Tests.dll" />
+  </ItemGroup>
+
+  <ItemGroup Label="Data Collectors">
+    <DataCollector Condition="'$(RPSDataCollector)' == 'enabled' And '$(TestIterations)' != ''" Include="datacollector://Microsoft/DevDiv/TestExtensions/PerformanceDataCollector/v1">
+      <FriendlyName>RPS Data Collector</FriendlyName>
+      <Configuration>
+        <Iterations>$(TestIterations)</Iterations>
+        <AttachTracesToTestResult>$(AttachTracesToTestResult)</AttachTracesToTestResult>
+        <TraceOutputFolder>$(TraceOutputFolder)</TraceOutputFolder>
+        <Deployment PackageName="Microsoft.DevDiv.TestExtensions.PerformanceDataCollector" />
+      </Configuration>
+    </DataCollector>
+    <DataCollector Condition="'$(AttachmentCollector)' == 'enabled'" Include="datacollector://Microsoft/DevDiv/TestExtensions/AttachmentCollector/v1">
+      <FriendlyName>Attachment Collector</FriendlyName>
+      <Configuration>
+        <Sources>
+          <DirectorySource Path="%TestContainerDirectory%" Sinks="AggregateSink" Scopes="TestCase" NewFilesOnly="true">
+            <IncludeFiles Pattern="*OmniLog.html" />
+            <IncludeFiles Pattern="*.png" />
+            <IncludeFiles Pattern="*.log" />
+            <IncludeFiles Pattern="AppCertKit.*.zip" />
+          </DirectorySource>
+        </Sources>
+        <Sinks>
+          <VSTSTestResultSink Name="VSTSTestResultAttachment" />
+          <DirectorySink Name="VSTSDropDirectoryAttachment" Path="C:\Test\Attachments" />
+          <AggregateSink Name="AggregateSink" Heuristic="FirstSuccess">
+            <SinkReference Name="VSTSTestResultAttachment" />
+            <SinkReference Name="VSTSDropDirectoryAttachment" />
+          </AggregateSink>
+        </Sinks>
+        <Deployment PackageName="Microsoft.DevDiv.TestExtensions.AttachmentCollector" />
+      </Configuration>
+    </DataCollector>
+    <DataCollector Condition="'$(EnvironmentVariablesCollector)' == 'enabled'" Include="datacollector://Microsoft/DevDiv/TestExtensions/EnvironmentVariablesCollector/v1">
+      <FriendlyName>Environment Variables Collector</FriendlyName>
+      <Configuration>
+        <Triggers>OnTestCaseStart,OnTestCasePass,OnTestCaseFail</Triggers>
+        <Filters>
+          <ProcessName>testhost.x86</ProcessName>
+        </Filters>
+        <Deployment PackageName="Microsoft.DevDiv.TestExtensions.EnvironmentVariablesCollector" />
+      </Configuration>
+    </DataCollector>
+    <DataCollector Condition="'$(FusionLogsCollector)' == 'enabled'" Include="datacollector://Microsoft/DevDiv/TestExtensions/FusionLogsCollector/v1">
+      <FriendlyName>Fusion Logs Collector</FriendlyName>
+      <Configuration>
+        <Destination>C:\Test\Logs\Fusion</Destination>
+        <Scope>All</Scope>
+        <Deployment PackageName="Microsoft.DevDiv.TestExtensions.FusionLogsCollector" />
+      </Configuration>
+    </DataCollector>
+    <DataCollector Condition="'$(LingeringProcessCollector)' == 'enabled'" Include="datacollector://Microsoft/DevDiv/TestExtensions/LingeringProcessCollector/v1">
+      <FriendlyName>Lingering Process Collector</FriendlyName>
+      <Configuration>
+        <KillLingeringProcesses>true</KillLingeringProcesses>
+        <LoggingBehavior>Warning</LoggingBehavior>
+        <CollectDumps>true</CollectDumps>
+        <RootDumpDirectory>%SystemDrive%\Test\Logs\Dumps</RootDumpDirectory>
+        <ShutdownCommands>$(LingeringProcessCollectorShutdownCommands)</ShutdownCommands>
+        <WhiteList>
+          <ProcessName>conhost</ProcessName>
+          <ProcessName>CPC</ProcessName>
+          <ProcessName>MSBuild</ProcessName>
+          <ProcessName>MSpdbsrv</ProcessName>
+          <ProcessName>node</ProcessName>
+          <ProcessName>PerfSvc</ProcessName>
+          <ProcessName>PerfWatson2</ProcessName>
+          <ProcessName>Procmon</ProcessName>
+          <ProcessName>Procmon64</ProcessName>
+          <ProcessName>ServiceHub.DataWarehouseHost</ProcessName>
+          <ProcessName>ServiceHub.Host.CLR.x86</ProcessName>
+          <ProcessName>ServiceHub.Host.Node.x86</ProcessName>
+          <ProcessName>Microsoft.ServiceHub.Controller</ProcessName>
+          <ProcessName>ServiceHub.IdentityHost</ProcessName>
+          <ProcessName>ServiceHub.RoslynCodeAnalysisService32</ProcessName>
+          <ProcessName>ServiceHub.SettingsHost</ProcessName>
+          <ProcessName>ServiceHub.VSDetouredHost</ProcessName>
+          <ProcessName>VBCSCompiler</ProcessName>
+          <ProcessName>VCTip</ProcessName>
+          <ProcessName>VSTestVideoRecorder</ProcessName>
+          <ProcessName>wermgr</ProcessName>
+        </WhiteList>
+        <Deployment PackageName="Microsoft.DevDiv.TestExtensions.LingeringProcessCollector" />
+      </Configuration>
+    </DataCollector>
+    <DataCollector Condition="'$(ProcDumpCollector)' == 'enabled'" Include="datacollector://Microsoft/DevDiv/TestExtensions/ProcDumpCollector/v1">
+      <FriendlyName>ProcDump Collector</FriendlyName>
+      <Configuration>
+        <RootDumpDirectory>C:\Test\Logs\Dumps</RootDumpDirectory>
+        <Deployment PackageName="Microsoft.DevDiv.TestExtensions.ProcDumpCollector" />
+      </Configuration>
+    </DataCollector>
+    <DataCollector Condition="'$(ProcMonDataCollector)' == 'enabled'" Include="datacollector://Microsoft/DevDiv/TestExtensions/ProcMonDataCollector/v1">
+      <FriendlyName>ProcMon Data Collector</FriendlyName>
+      <Configuration>
+        <BackingDirectory>C:\Test\Logs\ProcMon</BackingDirectory>
+        <Scope>TestCase</Scope>
+        <Deployment PackageName="Microsoft.DevDiv.TestExtensions.ProcMonDataCollector" />
+      </Configuration>
+    </DataCollector>
+    <DataCollector Condition="'$(ScreenshotCollector)' == 'enabled'" Include="datacollector://Microsoft/DevDiv/TestExtensions/ScreenshotCollector/v1">
+      <FriendlyName>Screenshot Collector</FriendlyName>
+      <Configuration>
+        <Triggers>OnTestCaseFail</Triggers>
+        <Deployment PackageName="Microsoft.DevDiv.TestExtensions.ScreenshotCollector" />
+      </Configuration>
+    </DataCollector>
+    <DataCollector Condition="'$(TraitsCollector)' == 'enabled'" Include="datacollector://Microsoft/DevDiv/TestExtensions/TraitsCollector/v1">
+      <FriendlyName>Traits Collector</FriendlyName>
+      <Configuration>
+        <Deployment PackageName="Microsoft.DevDiv.TestExtensions.TraitsCollector" />
+      </Configuration>
+    </DataCollector>
+    <DataCollector Condition="'$(VideoRecorderCollector)' == 'enabled'" Include="datacollector://Microsoft/DevDiv/VideoRecorder/2.0">
+      <FriendlyName>Screen and Voice Recorder</FriendlyName>
+      <Configuration>
+        <Deployment PackageName="Microsoft.DevDiv.Validation.MediaRecorder" />
+      </Configuration>
+    </DataCollector>
+  </ItemGroup>
+
+  <ItemGroup Label="In-Proc Data Collectors">
+    <InProcDataCollector Condition="'$(OptProfCollector)' == 'enabled'" Include="datacollector://Microsoft/DevDiv/TestExtensions/OptProfDataCollector/v2">
+      <FriendlyName>OptProf Data Collector</FriendlyName>
+      <CodeBase>C:\Test\Extensions\Microsoft.DevDiv.TestExtensions.OptProfDataCollector\lib\net461\Microsoft.DevDiv.TestExtensions.OptProfDataCollector.dll</CodeBase>
+      <AssemblyQualifiedName>Microsoft.DevDiv.TestExtensions.OptProfDataCollector, Microsoft.DevDiv.TestExtensions.OptProfDataCollector, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null</AssemblyQualifiedName>
+      <Configuration>
+        <WorkingDirectory>C:\OptProf</WorkingDirectory>
+        <ProfilesDirectory>C:\Profiles</ProfilesDirectory>
+        <Deployment PackageName="Microsoft.DevDiv.TestExtensions.OptProfDataCollector" />
+      </Configuration>
+    </InProcDataCollector>
+  </ItemGroup>
+
+  <ItemGroup Label="Loggers">
+    <Logger Condition="'$(FailedRPSTestLogger)' == 'enabled'" Include="logger://Microsoft/DevDiv/TestExtensions/FailedPerformanceTestLogger/v1">
+      <FriendlyName>Failed RPS Test Logger</FriendlyName>
+      <Configuration>
+        <Deployment PackageName="Microsoft.DevDiv.TestExtensions.FailedPerformanceTest.TestLogger" />
+      </Configuration>
+    </Logger>
+    <Logger Condition="'$(TRXLogger)' == 'enabled'" Include="logger://Microsoft/TestPlatform/TrxLogger/v1">
+      <FriendlyName>TRX</FriendlyName>
+    </Logger>
+    <Logger Condition="'$(TestRunParametersLogger)' == 'enabled'" Include="logger://Microsoft/DevDiv/TestExtensions/TestRunParametersLogger/v1">
+      <FriendlyName>TestRunParameters Logger</FriendlyName>
+      <Configuration>
+        <Deployment PackageName="Microsoft.DevDiv.TestExtensions.TestRunParameters.TestLogger" />
+      </Configuration>
+    </Logger>
+    <Logger Condition="'$(TimeTravelLogger)' == 'enabled'" Include="logger://Microsoft/DevDiv/TestExtensions/TimeTravelLogger/v1">
+      <FriendlyName>TimeTravelLogger</FriendlyName>
+      <Configuration>
+        <Deployment PackageName="Microsoft.DevDiv.TestExtensions.TimeTravel.TestLogger" />
+      </Configuration>
+    </Logger>
+  </ItemGroup>
+
+  <ItemGroup Label="Test Adapter Settings">
+    <AdditionalSettings Include="MSTest">
+      <Settings>
+        <MapInconclusiveToFailed>True</MapInconclusiveToFailed>
+      </Settings>
+    </AdditionalSettings>
+  </ItemGroup>
+
+  <Import Project="$(SolutionPackagesFolder)Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks.1.0.308\build\Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks.targets" />
+  <Import Project="$(BuildCommonDirectory)common.targets" />
+</Project>

--- a/build/OptProfV2.props
+++ b/build/OptProfV2.props
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <ItemGroup Label="OptProfV2 Configuration"
+    Condition="'$(IsXPlat)' == 'false' and
+      (
+        '$(AssemblyName)' == 'NuGet.Commands' or
+        '$(AssemblyName)' == 'NuGet.Common' or
+        '$(AssemblyName)' == 'NuGet.Configuration' or
+        '$(AssemblyName)' == 'NuGet.Console' or
+        '$(AssemblyName)' == 'NuGet.DependencyResolver.Core' or
+        '$(AssemblyName)' == 'NuGet.Frameworks' or
+        '$(AssemblyName)' == 'NuGet.LibraryModel' or
+        '$(AssemblyName)' == 'NuGet.PackageManagement' or
+        '$(AssemblyName)' == 'NuGet.PackageManagement.VisualStudio' or
+        '$(AssemblyName)' == 'NuGet.Packaging' or
+        '$(AssemblyName)' == 'NuGet.ProjectModel' or
+        '$(AssemblyName)' == 'NuGet.Protocol' or
+        '$(AssemblyName)' == 'NuGet.SolutionRestoreManager' or
+        '$(AssemblyName)' == 'NuGet.Versioning' or
+        '$(AssemblyName)' == 'NuGet.VisualStudio.Common' or
+        '$(AssemblyName)' == 'NuGet.VisualStudio'
+      )">
+    <OptProf Include="$(OutputPath)$(AssemblyName).dll">
+      <Technology>IBC</Technology>
+      <InstallationPath>Common7\IDE\CommonExtensions\Microsoft\NuGet\$(AssemblyName).dll</InstallationPath>
+      <InstrumentationArguments>/ExeConfig:"%VisualStudio.InstallationUnderTest.Path%\Common7\IDE\vsn.exe"</InstrumentationArguments>
+      <Scenarios>
+        <TestContainer Name="NuGet.Tests">
+          <TestCase Weight="100" FullyQualifiedName="NuGet.OptProfV2Tests.OpenSolutionAndBuild_PackageReferenceSdk" />
+        </TestContainer>
+      </Scenarios>
+    </OptProf>
+  </ItemGroup>
+</Project>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), &quot;README.md&quot;))\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.props')" />
+
   <!-- Helper properties -->
   <PropertyGroup>
     <IsXPlat>false</IsXPlat>
@@ -274,4 +276,5 @@
    <ApexProjects Include="$(RepositoryRootDirectory)test\NuGet.Tests.Apex\*\*.csproj" />
   </ItemGroup>
 
+  <Import Project="OptProfV2.props"/>
 </Project>

--- a/build/common.targets
+++ b/build/common.targets
@@ -320,4 +320,6 @@
       Condition=" %(Reference.NuGetPackageId) == 'Newtonsoft.Json' AND %(Reference.NuGetPackageVersion) != '$(NewtonsoftJsonVersionCore)' " />
   </Target>
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), &quot;README.md&quot;))\packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" />
+
 </Project>

--- a/build/config.props
+++ b/build/config.props
@@ -16,7 +16,7 @@
     <MinorNuGetVersion Condition="'$(MinorNuGetVersion)' == ''">3</MinorNuGetVersion>
     <PatchNuGetVersion Condition="'$(PatchNuGetVersion)' == ''">0</PatchNuGetVersion>
     <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">$(MajorNuGetVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</SemanticVersion>
-    <VsTargetMajorVersion>16</VsTargetMajorVersion>
+    <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <VsTargetBranch>master</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>

--- a/build/config.props
+++ b/build/config.props
@@ -16,11 +16,14 @@
     <MinorNuGetVersion Condition="'$(MinorNuGetVersion)' == ''">3</MinorNuGetVersion>
     <PatchNuGetVersion Condition="'$(PatchNuGetVersion)' == ''">0</PatchNuGetVersion>
     <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">$(MajorNuGetVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</SemanticVersion>
+    <VsTargetMajorVersion>16</VsTargetMajorVersion>
     <VsTargetBranch>master</VsTargetBranch>
+    <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">release/2.2.3xx</CliBranchForTesting>
     <!-- This branches are used for creating insertion PRs -->
-    <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d16.$(MinorNuGetVersion)</VsTargetBranch>
+    <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetBranch>
+    <VsTargetChannel Condition="'$(IsEscrowMode)' == 'true'">Release</VsTargetChannel>
     <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</CliTargetBranches>
     <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">master</CliTargetBranches>
     <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</SdkTargetBranches>
@@ -73,8 +76,14 @@
   <Target Name="GetSemanticVersion">
     <Message Text="$(SemanticVersion)" Importance="High"/>
   </Target>
+  <Target Name="GetVsTargetMajorVersion">
+    <Message Text="$(VsTargetMajorVersion)" Importance="High"/>
+  </Target>
   <Target Name="GetVsTargetBranch">
     <Message Text="$(VsTargetBranch)" Importance="High"/>
+  </Target>
+  <Target Name="GetVsTargetChannel">
+    <Message Text="$(VsTargetChannel)" Importance="High"/>
   </Target>
   <Target Name="GetCliTargetBranches">
     <Message Text="$(CliTargetBranches)" Importance="High"/>

--- a/build/config.props
+++ b/build/config.props
@@ -23,7 +23,7 @@
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">release/2.2.3xx</CliBranchForTesting>
     <!-- This branches are used for creating insertion PRs -->
     <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetBranch>
-    <VsTargetChannel Condition="'$(IsEscrowMode)' == 'true'">Release</VsTargetChannel>
+    <VsTargetChannel Condition="'$(IsEscrowMode)' == 'true'">Preview</VsTargetChannel>
     <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</CliTargetBranches>
     <CliTargetBranches Condition="'$(OverrideCliTargetBranches)' == ''">master</CliTargetBranches>
     <SdkTargetBranches Condition="'$(OverrideCliTargetBranches)' != ''">$(OverrideCliTargetBranches)</SdkTargetBranches>

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -5,7 +5,7 @@ phases:
   queue:
     name: VSEng-MicroBuildVS2019
     timeoutInMinutes: 60
-    demands: 
+    demands:
       - DotNetFramework
       - msbuild
 
@@ -44,6 +44,12 @@ phases:
         $productVersion = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSemanticVersion
         $productVersion = $productVersion.Trim()
         $FullBuildNumber = "$productVersion.$newBuildCounter"
+        $targetChannel = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetChannel
+        $targetChannel = $targetChannel.Trim()
+        $targetMajorVersion = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetVsTargetMajorVersion
+        $targetMajorVersion = $targetMajorVersion.Trim()
+        Write-Host "##vso[task.setvariable variable=VsTargetChannel;isOutput=true]$targetChannel"
+        Write-Host "##vso[task.setvariable variable=VsTargetMajorVersion;isOutput=true]$targetMajorVersion"
         Write-Host "##vso[build.updatebuildnumber]$FullBuildNumber"
         Write-Host "##vso[task.setvariable variable=BuildNumber;isOutput=true]$newBuildCounter"
         Write-Host "##vso[task.setvariable variable=FullVstsBuildNumber;isOutput=true]$FullBuildNumber"
@@ -61,6 +67,9 @@ phases:
   variables:
     BuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
+    VsTargetChannel: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
+    VsTargetMajorVersion: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
+    ShouldSkipOptimize: true
   queue:
     name: VSEng-MicroBuildVS2019
     timeoutInMinutes: 90
@@ -107,12 +116,34 @@ phases:
       arguments: "-BuildCounterFile $(BuildCounterFile) -BuildInfoJsonFile $(BuildInfoJsonFile) -BuildRTM $(BuildRTM) -SkipUpdateBuildNumber"
     displayName: "Configure VSTS CI Environment"
 
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish buildinfo.json as an artifact'
+    inputs:
+      ArtifactName: 'BuildInfo'
+      ArtifactType: 'Container'
+      PathToPublish: '$(Build.Repository.LocalPath)\artifacts\buildinfo.json'
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
   - task: PowerShell@1
     displayName: "Print Environment Variables"
     inputs:
       scriptType: "inlineScript"
       inlineScript: |
         gci env:* | sort-object name
+
+  - task: NuGetCommand@2
+    displayName: 'MicroBuild:  add package source'
+    inputs:
+      command: 'custom'
+      arguments: 'sources add -Name MicroBuild -Source $(MicroBuildToolsetPackageFeedUrl) -UserName $(MicroBuildToolsetPackageFeedUsername) -Password $(MicroBuildToolsetPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+  - task: NuGetCommand@2
+    displayName: 'MicroBuild:  install core package'
+    inputs:
+      command: 'custom'
+      arguments: 'install Microsoft.VisualStudioEng.MicroBuild.Core -Version 0.4.1 -Source $(MicroBuildToolsetPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: MicroBuildLocalizationPlugin@1
     displayName: "Install Localization Plugin"
@@ -125,6 +156,13 @@ phases:
 
   - task: MicroBuildSwixPlugin@1
     displayName: "Install Swix Plugin"
+
+  - task: ms-vseng.MicroBuildTasks.965C8DC6-1483-45C9-B384-5AC75DA1F1A4.MicroBuildOptProfPlugin@4
+    displayName: 'OptProfV2:  install the plugin'
+    inputs:
+      getDropNameByDrop: true
+      optimizationInputsDropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: MSBuild@1
     displayName: "Restore for VS2019"
@@ -290,7 +328,7 @@ phases:
     displayName: "Create EndToEnd Test Package"
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\CreateEndToEndTestPackage.ps1"
-      arguments: "-c $(BuildConfiguration) -tv 16 -out $(Build.Repository.LocalPath)\\artifacts\\VS15"
+      arguments: "-c $(BuildConfiguration) -tv 16 -out $(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)"
       failOnStandardError: "true"
     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
@@ -310,11 +348,86 @@ phases:
         $(VsixPublishDir)\\EndToEnd.zip
       TargetFolder: "$(BuildOutputTargetPath)\\artifacts"
 
+  - task: NuGetCommand@2
+    displayName: 'OptProfV2:  add the NuGet package source'
+    inputs:
+      command: 'custom'
+      arguments: 'sources add -Name VS -Source $(VsPackageFeedUrl) -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+  - task: NuGetCommand@2
+    displayName: 'OptProfV2:  install the NuGet package for building .runsettingsproj file'
+    inputs:
+      command: 'custom'
+      arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.308 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+  - task: ms-vseng.MicroBuildTasks.0e9d0d4d-71ec-4e4e-ae40-db9896f1ae74.MicroBuildBuildVSBootstrapper@2
+    displayName: 'OptProfV2:  build a Visual Studio bootstrapper'
+    inputs:
+      channelName: "$(VsTargetChannel)"
+      vsMajorVersion: "$(VsTargetMajorVersion)"
+      manifests: '$(Build.Repository.LocalPath)\artifacts\$(VsixPublishDir)\Microsoft.VisualStudio.NuGet.Core.vsman'
+      outputFolder: '$(Build.Repository.LocalPath)\artifacts\$(VsixPublishDir)'
+    continueOnError: true
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'OptProfV2:  publish BootstrapperInfo.json as a build artifact'
+    inputs:
+      PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
+      ArtifactName: MicroBuildOutputs
+      ArtifactType: Container
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+  - task: PowerShell@1
+    displayName: 'OptProfV2:  set the TestDrop environment variable'
+    inputs:
+      scriptType: 'inlineScript'
+      inlineScript: |
+        [string] $bootstrapperInfoFilePath = "$Env:BUILD_STAGINGDIRECTORY\MicroBuild\Output\BootstrapperInfo.json"
+        $json = Get-Content $bootstrapperInfoFilePath | ConvertFrom-Json
+        [string] $buildDropPath = $json.BuildDrop
+        Write-Host "Build drop:  $buildDropPath"
+        [string] $testDropPath = $buildDropPath.Replace('/Products/', '/Tests/').Substring('https://vsdrop.corp.microsoft.com/file/v1/'.Length)
+        Write-Host "Test drop:  $testDropPath"
+        Write-Host "##vso[task.setvariable variable=TestDrop]$testDropPath"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+  - task: MSBuild@1
+    displayName: 'OptProfV2:  generate a .runsettings file'
+    inputs:
+      solution: 'build\NuGet.OptProfV2.runsettingsproj'
+      msbuildVersion: '16.0'
+      msbuildArguments: '/p:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /p:TestDrop="$(TestDrop)" /p:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)"'
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+  - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
+    displayName: 'OptProfV2:  publish the .runsettings file to artifact services'
+    inputs:
+      dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+      buildNumber: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)'
+      sourcePath: 'artifacts\RunSettings'
+      toLowerCase: false
+      usePat: false
+      dropMetadataContainerName: RunSettings
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
+  - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
+    displayName: 'OptProfV2:  publish profiling inputs to artifact services'
+    inputs:
+      dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+      buildNumber: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)'
+      sourcePath: '$(Build.ArtifactStagingDirectory)\OptProf\ProfilingInputs'
+      toLowerCase: false
+      usePat: false
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+
   - task: PublishBuildArtifacts@1
     displayName: "Publish NuGet.exe VSIX and EndToEnd.zip as artifact"
     inputs:
       PathtoPublish: "$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)"
-      ArtifactName: "VS15"
+      ArtifactName: "$(VsixPublishDir)"
       ArtifactType: "Container"
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
@@ -366,7 +479,7 @@ phases:
   - task: MicroBuildUploadVstsDropFolder@1
     displayName: "Upload VSTS Drop"
     inputs:
-      DropFolder: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
+      DropFolder: "$(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir)"
     condition: " and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
   - task: PowerShell@1
@@ -583,7 +696,7 @@ phases:
     condition: "always()"
 
   - task: DownloadBuildArtifacts@0
-    displayName: "Download NuGet.ComamandLine.Test artifacts"
+    displayName: "Download NuGet.CommandLine.Test artifacts"
     inputs:
       artifactName: "NuGet.CommandLine.Test"
       downloadPath: "$(Build.Repository.LocalPath)/artifacts"
@@ -641,14 +754,14 @@ phases:
   - task: DownloadBuildArtifacts@0
     displayName: "Download Build artifacts"
     inputs:
-      artifactName: "VS15"
+      artifactName: "$(VsixPublishDir)"
       downloadPath: "$(Build.Repository.LocalPath)/artifacts"
 
   - task: PowerShell@1
     displayName: "Bootstrap.ps1"
     inputs:
       scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
-      arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
+      arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
 
   - task: PowerShell@1
     displayName: "SetupFunctionalTests.ps1"
@@ -664,7 +777,7 @@ phases:
     displayName: "InstallNuGetVSIX.ps1"
     inputs:
       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
-      arguments: "-NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 16.0"
+      arguments: "-NuGetDropPath $(System.DefaultWorkingDirectory)\\artifacts\\$(VsixPublishDir) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 16.0"
       failOnStandardError: "false"
 
   - task: PowerShell@1
@@ -677,7 +790,7 @@ phases:
     condition: "failed()"
 
   - task: PowerShell@1
-    displayName: "RunFunctionalTests.ps1"    
+    displayName: "RunFunctionalTests.ps1"
     timeoutInMinutes: 75
     continueOnError: "true"
     inputs:
@@ -729,7 +842,7 @@ phases:
   - checkout: self
     clean: true
     submodules: true
-    
+
   - task: PowerShell@1
     displayName: "Print Environment Variables"
     inputs:
@@ -741,9 +854,9 @@ phases:
   - task: DownloadBuildArtifacts@0
     displayName: "Download Build artifacts"
     inputs:
-      artifactName: "VS15"
+      artifactName: "$(VsixPublishDir)"
       downloadPath: "$(Build.Repository.LocalPath)/artifacts"
-        
+
   - task: NuGetToolInstaller@0
     displayName: "Use NuGet 4.5.0"
     inputs:
@@ -761,7 +874,7 @@ phases:
     displayName: "Bootstrap.ps1"
     inputs:
       scriptName: "$(System.DefaultWorkingDirectory)/scripts/e2etests/Bootstrap.ps1"
-      arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
+      arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -verbose"
 
   - task: PowerShell@1
     displayName: "SetupFunctionalTests.ps1"
@@ -773,7 +886,7 @@ phases:
     displayName: "InstallNuGetVSIX.ps1"
     inputs:
       scriptName: "$(System.DefaultWorkingDirectory)\\artifacts\\EndToEnd\\scripts\\InstallNuGetVSIX.ps1"
-      arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\VS15 -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 16.0"
+      arguments: "-NuGetDropPath $(Build.Repository.LocalPath)\\artifacts\\$(VsixPublishDir) -FuncTestRoot $(System.DefaultWorkingDirectory)\\artifacts -NuGetVSIXID $(NuGetVsixId) -ProcessExitTimeoutInSeconds 180 -VSVersion 16.0"
       failOnStandardError: "false"
 
   # - task: PowerShell@1

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -116,14 +116,6 @@ phases:
       arguments: "-BuildCounterFile $(BuildCounterFile) -BuildInfoJsonFile $(BuildInfoJsonFile) -BuildRTM $(BuildRTM) -SkipUpdateBuildNumber"
     displayName: "Configure VSTS CI Environment"
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish buildinfo.json as an artifact'
-    inputs:
-      ArtifactName: 'BuildInfo'
-      ArtifactType: 'Container'
-      PathToPublish: '$(Build.Repository.LocalPath)\artifacts\buildinfo.json'
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
   - task: PowerShell@1
     displayName: "Print Environment Variables"
     inputs:

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -132,13 +132,6 @@ phases:
         gci env:* | sort-object name
 
   - task: NuGetCommand@2
-    displayName: 'MicroBuild:  add package source'
-    inputs:
-      command: 'custom'
-      arguments: 'sources add -Name MicroBuild -Source $(MicroBuildToolsetPackageFeedUrl) -UserName $(MicroBuildToolsetPackageFeedUsername) -Password $(MicroBuildToolsetPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
-
-  - task: NuGetCommand@2
     displayName: 'MicroBuild:  install core package'
     inputs:
       command: 'custom'

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -193,16 +193,8 @@ else
         ToolsetTargetBranches = $ToolsetTargetBranches.Trim()
     }
 
-    # First create the file locally so that we can laster publish it as a build artifact from a local source file instead of a remote source file.
-    $localBuildInfoJsonFilePath = [System.IO.Path]::Combine("$Env:BUILD_REPOSITORY_LOCALPATH\artifacts", 'buildinfo.json')
-
-    New-Item $localBuildInfoJsonFilePath -Force
-    $jsonRepresentation | ConvertTo-Json | Set-Content $localBuildInfoJsonFilePath
-
-    # Now copy the file to the remote folder.
-    [System.IO.Directory]::CreateDirectory([System.IO.Path]::GetDirectoryName($BuildInfoJsonFile))
-    [System.IO.File]::Copy($localBuildInfoJsonFilePath, $BuildInfoJsonFile)
-
+    New-Item $BuildInfoJsonFile -Force
+    $jsonRepresentation | ConvertTo-Json | Set-Content $BuildInfoJsonFile
     $productVersion = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSemanticVersion
     if (-not $?)
     {


### PR DESCRIPTION
Progress on https://github.com/NuGet/Home/issues/6007.

This PR onboards NuGet.Client to OptProfV2 for partial NGEN-ing of NuGet assemblies in Visual Studio.

This PR will trigger generation of optimization but will not update assemblies with optimization data.

A subsequent PR will switch `ShouldSkipOptimize` to `false` (in vsts_build.yaml), which will cause builds to update assemblies with optimization data from a previous build.