### PR TITLE
Validation Rule for the <package_Id>.props convention in build files

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -781,6 +781,11 @@ namespace NuGet.Common
         NU5128 = 5128,
 
         /// <summary>
+        /// No build files that follow the build convention ("package_id".props)
+        /// </summary>
+        NU5129 = 5129,
+
+        /// <summary>
         /// TFM dependencies in the lib or ref folder has a compatible match, but not an exact match
         /// </summary>
         NU5130 = 5130,

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
@@ -79,7 +79,7 @@ namespace NuGet.Packaging.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A {0} file was found in &apos;{1}&apos;. However, this file is not &apos;{2}&apos;. Change the file to fit this format..
+        ///   Looks up a localized string similar to - A {0} file was found in the folder &apos;{1}&apos;. However, this file is not &apos;{2}&apos;. Change the file to fit this format..
         /// </summary>
         public static string BuildConventionIsViolatedWarning {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
@@ -79,6 +79,15 @@ namespace NuGet.Packaging.Rules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A {0} file was found in &apos;{1}&apos;. However, this file is not &apos;{2}&apos;. Change the file to fit this format..
+        /// </summary>
+        public static string BuildConventionIsViolatedWarning {
+            get {
+                return ResourceManager.GetString("BuildConventionIsViolatedWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The value &quot;{0}&quot; for {1} is a sample value and should be removed. Replace it with an appropriate value or remove it and rebuild your package..
         /// </summary>
         public static string DefaultSpecValueWarning {

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
@@ -79,7 +79,7 @@ namespace NuGet.Packaging.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to - A {0} file was found in the folder &apos;{1}&apos;. However, this file is not &apos;{2}&apos;. Change the file to fit this format..
+        ///   Looks up a localized string similar to - At least one {0} file was found in &apos;{1}&apos;, but &apos;{2}&apos; was not..
         /// </summary>
         public static string BuildConventionIsViolatedWarning {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
@@ -123,6 +123,9 @@
   <data name="AssemblyOutsideLibWarning" xml:space="preserve">
     <value>The assembly '{0}' is not inside the 'lib' folder and hence it won't be added as a reference when the package is installed into a project. Move it into the 'lib' folder if it needs to be referenced.</value>
   </data>
+  <data name="BuildConventionIsViolatedWarning" xml:space="preserve">
+    <value>A {0} file was found in '{1}'. However, this file is not '{2}'. Change the file to fit this format.</value>
+  </data>
   <data name="DefaultSpecValueWarning" xml:space="preserve">
     <value>The value "{0}" for {1} is a sample value and should be removed. Replace it with an appropriate value or remove it and rebuild your package.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
@@ -124,7 +124,10 @@
     <value>The assembly '{0}' is not inside the 'lib' folder and hence it won't be added as a reference when the package is installed into a project. Move it into the 'lib' folder if it needs to be referenced.</value>
   </data>
   <data name="BuildConventionIsViolatedWarning" xml:space="preserve">
-    <value>- A {0} file was found in the folder '{1}'. However, this file is not '{2}'. Change the file to fit this format.</value>
+    <value>- At least one {0} file was found in '{1}', but '{2}' was not.</value>
+    <comment>0 - file extension (either .props or .targets)
+1 - directory that the file falls under
+2 - correct file path </comment>
   </data>
   <data name="DefaultSpecValueWarning" xml:space="preserve">
     <value>The value "{0}" for {1} is a sample value and should be removed. Replace it with an appropriate value or remove it and rebuild your package.</value>

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
@@ -124,7 +124,7 @@
     <value>The assembly '{0}' is not inside the 'lib' folder and hence it won't be added as a reference when the package is installed into a project. Move it into the 'lib' folder if it needs to be referenced.</value>
   </data>
   <data name="BuildConventionIsViolatedWarning" xml:space="preserve">
-    <value>A {0} file was found in '{1}'. However, this file is not '{2}'. Change the file to fit this format.</value>
+    <value>- A {0} file was found in the folder '{1}'. However, this file is not '{2}'. Change the file to fit this format.</value>
   </data>
   <data name="DefaultSpecValueWarning" xml:space="preserve">
     <value>The value "{0}" for {1} is a sample value and should be removed. Replace it with an appropriate value or remove it and rebuild your package.</value>

--- a/src/NuGet.Core/NuGet.Packaging/Rules/RuleSet.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/RuleSet.cs
@@ -29,6 +29,7 @@ namespace NuGet.Packaging.Rules
                 new LicenseUrlDeprecationWarning(AnalysisResources.LicenseUrlDeprecationWarning),
                 new NoRefOrLibFolderInPackageRule(AnalysisResources.NoRefOrLibFolderInPackage),
                 new DependenciesGroupsForEachTFMRule(),
+                new UpholdBuildConventionRule(),
             }
         );
 

--- a/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
@@ -66,19 +66,12 @@ namespace NuGet.Packaging.Rules
 
         internal (IDictionary<string, string>, IDictionary<string, string>) IdentifyViolators(IEnumerable<string> files, string packageId)
         {
-            var collection = new ContentItemCollection();
-            collection.Load(files.Where(t => PathUtility.GetPathWithDirectorySeparator(t).Count(m => m == Path.DirectorySeparatorChar) > 1));
-
-            var buildItems = ContentExtractor.GetContentForPattern(collection, ManagedCodeConventions.Patterns.MSBuildFiles);
-            var tfms = ContentExtractor.GetGroupFrameworks(buildItems).Select(m => m.GetShortFolderName()).ToArray();
-
             var groupedFiles = files.GroupBy(t => GetFolderName(t), m => GetFile(m));
             var conventionViolatorsProps = new Dictionary<string, string>();
             var conventionViolatorsTargets = new Dictionary<string, string>();
 
             var correctPropsPattern = packageId + _propsExtension;
             var correctTargetsPattern = packageId + _targetsExtension;
-
 
             if (files.Count() != 0)
             {

--- a/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
@@ -48,16 +48,21 @@ namespace NuGet.Packaging.Rules
 
         internal IEnumerable<PackagingLogMessage> GenerateWarnings(IEnumerable<ConventionViolator> conventionViolators)
         {
-            var issues = new List<PackagingLogMessage>();
-            var warningMessage = new StringBuilder();
-            foreach (var vio in conventionViolators)
-            {
-                warningMessage.AppendLine(string.Format(MessageFormat, vio.Extension, vio.Path, vio.ExpectedPath));
-            }
 
-            if (warningMessage.ToString() != string.Empty)
+            var issues = new List<PackagingLogMessage>();
+            foreach (var folder in _folders)
             {
-                issues.Add(PackagingLogMessage.CreateWarning(warningMessage.ToString(), NuGetLogCode.NU5129));
+                var warningMessage = new StringBuilder();
+                var currentConventionViolators = conventionViolators.Where(t => t.ExpectedPath.StartsWith(folder + '/'));
+                foreach (var conViolator in currentConventionViolators)
+                {
+                    warningMessage.AppendLine(string.Format(MessageFormat, conViolator.Extension, conViolator.Path, conViolator.ExpectedPath));
+                }
+
+                if (warningMessage.ToString() != string.Empty)
+                {
+                    issues.Add(PackagingLogMessage.CreateWarning(warningMessage.ToString(), NuGetLogCode.NU5129));
+                }
             }
             return issues;
         }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
@@ -88,11 +88,6 @@ namespace NuGet.Packaging.Rules
             return filePath.Split('/')[0] + '/' + hi + '/';
         }
 
-        private string GetFile(string filePath)
-        {
-            return filePath.Split('/')[filePath.Count(p => p == '/')];
-        }
-
         internal class ConventionViolator
         {
             public string Path { get; }

--- a/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
@@ -1,0 +1,114 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NuGet.Client;
+using NuGet.Common;
+using NuGet.ContentModel;
+using NuGet.Packaging.Core;
+using NuGet.RuntimeModel;
+
+namespace NuGet.Packaging.Rules
+{
+    internal class UpholdBuildConventionRule : IPackageRule
+    {
+        private static ManagedCodeConventions ManagedCodeConventions = new ManagedCodeConventions(new RuntimeGraph());
+        private string _propsExtension = ManagedCodeConventions.Properties["msbuild"].FileExtensions[1];
+        private string _targetsExtension = ManagedCodeConventions.Properties["msbuild"].FileExtensions[0];
+
+        public string MessageFormat => AnalysisResources.BuildConventionIsViolatedWarning;
+
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
+        {
+            var files = builder.GetFiles().Where(t => t.StartsWith(PackagingConstants.Folders.Build));
+            var packageId = builder.NuspecReader.GetId();
+            var (conventionViolatorsProps, conventionViolatorsTargets) = IdentifyViolators(files, packageId);
+            return GenerateWarnings(conventionViolatorsProps, conventionViolatorsTargets);
+        }
+
+        internal IEnumerable<PackagingLogMessage> GenerateWarnings(IDictionary<string, string> conventionViolatorsProps, IDictionary<string, string> conventionViolatorsTargets)
+        {
+            var issues = new List<PackagingLogMessage>();
+            foreach (var props in conventionViolatorsProps)
+            {
+                var warning = string.Format(MessageFormat, _propsExtension, props.Key, props.Value);
+                issues.Add(PackagingLogMessage.CreateWarning(warning, NuGetLogCode.NU5129));
+            }
+
+            foreach (var targets in conventionViolatorsTargets)
+            {
+                var warning = string.Format(MessageFormat, _targetsExtension, targets.Key, targets.Value);
+                issues.Add(PackagingLogMessage.CreateWarning(warning, NuGetLogCode.NU5129));
+            }
+            return issues;
+        }
+
+        internal (IDictionary<string, string>, IDictionary<string, string>) IdentifyViolators(IEnumerable<string> files, string packageId)
+        {
+            var collection = new ContentItemCollection();
+            collection.Load(files.Where(t => PathUtility.GetPathWithDirectorySeparator(t).Count(m => m == Path.DirectorySeparatorChar) > 1));
+
+            var buildItems = ContentExtractor.GetContentForPattern(collection, ManagedCodeConventions.Patterns.MSBuildFiles);
+            var tfms = ContentExtractor.GetGroupFrameworks(buildItems).Select(m => m.GetShortFolderName());
+
+            var conventionViolatorsProps = new Dictionary<string, string>();
+            var conventionViolatorsTargets = new Dictionary<string, string>();
+
+            var correctProps = packageId + _propsExtension;
+            var correctTargets = packageId + _targetsExtension;
+
+            var filesUnderTFM = files.Where(t => t.Count(m => m == '/') > 1);
+            var filesUnderBuild = files.Where(t => t.Count(m => m == '/') == 1);
+
+            if (files.Count() != 0)
+            {
+                if (filesUnderBuild.Count() != 0)
+                {
+                    var hasPropsUnderBuild = filesUnderBuild.Any(t => t.EndsWith(_propsExtension));
+                    var hasTargetsUnderBuild = filesUnderBuild.Any(t => t.EndsWith(_targetsExtension));
+
+                    var correctPropsFilesUnderBuild = filesUnderBuild.Where(t => t.EndsWith(_propsExtension) && t.EndsWith(correctProps));
+                    var correctTargetsFilesUnderBuild = filesUnderBuild.Where(t => t.EndsWith(_targetsExtension) && t.EndsWith(correctTargets));
+
+                    if (correctPropsFilesUnderBuild.Count() == 0 && hasPropsUnderBuild)
+                    {
+                        conventionViolatorsProps.Add(PackagingConstants.Folders.Build, correctProps);
+                    }
+
+                    if (correctTargetsFilesUnderBuild.Count() == 0 && hasTargetsUnderBuild)
+                    {
+                        conventionViolatorsTargets.Add(PackagingConstants.Folders.Build, correctTargets);
+                    }
+                }
+
+                foreach (var tfm in tfms)
+                {
+                    var hasPropsUnderTFMs = filesUnderTFM.Any(t => t.StartsWith(PackagingConstants.Folders.Build + "/" + tfm) && t.EndsWith(_propsExtension));
+                    var hasTargetsUnderTFMs = filesUnderTFM.Any(t => t.StartsWith(PackagingConstants.Folders.Build + "/" + tfm) && t.EndsWith(_targetsExtension));
+
+                    var correctTargetsFiles = filesUnderTFM.Where(t => t.StartsWith(PackagingConstants.Folders.Build + "/" + tfm) && t.EndsWith(correctTargets));
+                    var correctPropsFiles = filesUnderTFM.Where(t => t.StartsWith(PackagingConstants.Folders.Build + "/" + tfm) && t.EndsWith(correctProps));
+
+                    if (correctPropsFiles.Count() == 0 && hasPropsUnderTFMs)
+                    {
+                        conventionViolatorsProps.Add(PackagingConstants.Folders.Build + "/" + tfm, correctProps);
+                    }
+
+                    if (correctTargetsFiles.Count() == 0 && hasTargetsUnderTFMs)
+                    {
+                        conventionViolatorsTargets.Add(PackagingConstants.Folders.Build + "/" + tfm, correctTargets);
+                    }
+                }
+            }
+
+            return (conventionViolatorsProps,conventionViolatorsTargets);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
@@ -7,8 +7,11 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using NuGet.Client;
 using NuGet.Common;
 using NuGet.ContentModel;
@@ -21,12 +24,14 @@ namespace NuGet.Packaging.Rules
     internal class UpholdBuildConventionRule : IPackageRule
     {
         private static ManagedCodeConventions ManagedCodeConventions = new ManagedCodeConventions(new RuntimeGraph());
-
+        
         public string MessageFormat => AnalysisResources.BuildConventionIsViolatedWarning;
 
         public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
         {
-            var files = builder.GetFiles().Where(t => t.StartsWith(PackagingConstants.Folders.Build));
+            var files = builder.GetFiles().Where(t => t.StartsWith(PackagingConstants.Folders.Build) ||
+                                                    t.StartsWith(PackagingConstants.Folders.BuildTransitive) ||
+                                                    t.StartsWith(PackagingConstants.Folders.BuildCrossTargeting));
             var packageId = builder.NuspecReader.GetId();
             var conventionViolators = IdentifyViolators(files, packageId);
             return GenerateWarnings(conventionViolators);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/UpholdBuildConventionRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/UpholdBuildConventionRuleTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -22,8 +25,8 @@ namespace NuGet.Packaging.Test
 
             //Act
             var rule = new UpholdBuildConventionRule();
-            var (propsViolators, targetsViolators) = rule.IdentifyViolators(files, packageId);
-            var issues = rule.GenerateWarnings(propsViolators, targetsViolators);
+            var conventionViolators = rule.IdentifyViolators(files, packageId);
+            var issues = rule.GenerateWarnings(conventionViolators);
 
             //Assert
             Assert.Empty(issues);
@@ -38,12 +41,41 @@ namespace NuGet.Packaging.Test
 
             //Act
             var rule = new UpholdBuildConventionRule();
-            var (propsViolators, targetsViolators) = rule.IdentifyViolators(files, packageId);
-            var issues = rule.GenerateWarnings(propsViolators, targetsViolators);
+            var conventionViolators = rule.IdentifyViolators(files, packageId);
+            var issues = rule.GenerateWarnings(conventionViolators);
 
             //Assert
             Assert.Equal(issues.Count(), 1);
             var singleIssue = issues.Single(p => p.Code == NuGetLogCode.NU5129);
+        }
+
+        public static class FileSource
+        {
+            public static readonly List<object[]> WarningNotRaisedData
+                = new List<object[]>
+                {
+                    new object[] { new string[] { "build/packageId.props" } },
+                    new object[] { new string[] { "build/net45/packageId.props" } },
+                    new object[] { new string[] { "build/net45/packageId.targets" } },
+                    new object[] { new string[] { "build/packageId.targets" } },
+                    new object[] { new string[] { "build/net45/packageId.props", "build/net45/packageId.targets" } },
+                    new object[] { new string[] { "build/packageId.props", "build/packageId.targets" } },
+                    new object[] { new string[] { "build/PackageID.props", "build/PackageID.targets" } },
+                    new object[] { new string[] { "build/extra/packageId.props", "build/packageId.props" } },
+                    new object[] { new string[] { "build/net45/extra/packageId.props", "build/net45/packageId.props" } },
+                    new object[] { new string[] { "build/random.dll" } }
+                };
+
+            public static readonly List<object[]> WarningRaisedData
+                = new List<object[]>
+                {
+                    new object[] { new string[] { "build/package_Id.props" } },
+                    new object[] { new string[] { "build/net45/package_Id.props" } },
+                    new object[] { new string[] { "build/net45/package_Id.targets" } },
+                    new object[] { new string[] { "build/package_Id.targets" } },
+                    new object[] { new string[] { "build/extra/packageId.props" } },
+                    new object[] { new string[] { "build/net45/extra/packageId.props" } },
+                };
         }
 
         [Fact]
@@ -58,14 +90,14 @@ namespace NuGet.Packaging.Test
             };
             //Act
             var rule = new UpholdBuildConventionRule();
-            var (propsViolators, targetsViolators) = rule.IdentifyViolators(files, packageId);
-            var issues = rule.GenerateWarnings(propsViolators, targetsViolators);
+            var conventionViolators = rule.IdentifyViolators(files, packageId);
+            var issues = rule.GenerateWarnings(conventionViolators);
 
             //Assert
             Assert.Equal(issues.Count(), 1);
             var singleIssue = issues.Single(p => p.Code == NuGetLogCode.NU5129);
-            var expectedMessage = "- A .props file was found in the folder 'net45'. However, this file is not 'packageId.props'. Change the file to fit this format.\r\n" +
-                "- A .targets file was found in the folder 'net45'. However, this file is not 'packageId.targets'. Change the file to fit this format.\r\n";
+            var expectedMessage = "- At least one .targets file was found in 'build/net45/', but 'build/net45/packageId.targets' was not." + Environment.NewLine +
+                "- At least one .props file was found in 'build/net45/', but 'build/net45/packageId.props' was not." + Environment.NewLine;
             Assert.True(singleIssue.Message.Equals(expectedMessage));
         }
 
@@ -86,17 +118,17 @@ namespace NuGet.Packaging.Test
 
             //Act
             var rule = new UpholdBuildConventionRule();
-            var (propsViolators, targetsViolators) = rule.IdentifyViolators(files, packageId);
-            var issues = rule.GenerateWarnings(propsViolators, targetsViolators);
+            var conventionViolators = rule.IdentifyViolators(files, packageId);
+            var issues = rule.GenerateWarnings(conventionViolators);
 
             //Assert
             Assert.Equal(issues.Count(), 1);
             var singleIssue = issues.Single(p => p.Code == NuGetLogCode.NU5129);
-            var expectedMessage = "- A .props file was found in the folder 'net45'. However, this file is not 'packageId.props'. Change the file to fit this format.\r\n" +
-                "- A .props file was found in the folder 'net462'. However, this file is not 'packageId.props'. Change the file to fit this format.\r\n" +
-                "- A .props file was found in the folder 'net471'. However, this file is not 'packageId.props'. Change the file to fit this format.\r\n" +
-                "- A .props file was found in the folder 'netstandard1.3'. However, this file is not 'packageId.props'. Change the file to fit this format.\r\n" +
-                "- A .props file was found in the folder 'netcoreapp1.1'. However, this file is not 'packageId.props'. Change the file to fit this format.\r\n";
+            var expectedMessage = "- At least one .props file was found in 'build/net45/', but 'build/net45/packageId.props' was not." + Environment.NewLine +
+                "- At least one .props file was found in 'build/net462/', but 'build/net462/packageId.props' was not." + Environment.NewLine +
+                "- At least one .props file was found in 'build/net471/', but 'build/net471/packageId.props' was not." + Environment.NewLine +
+                "- At least one .props file was found in 'build/netstandard1.3/', but 'build/netstandard1.3/packageId.props' was not." + Environment.NewLine +
+                "- At least one .props file was found in 'build/netcoreapp1.1/', but 'build/netcoreapp1.1/packageId.props' was not." + Environment.NewLine;
             Assert.True(singleIssue.Message.Equals(expectedMessage));
         }
 
@@ -109,19 +141,18 @@ namespace NuGet.Packaging.Test
             {
                 "build/package_Id.props",
                 "build/package_Id.targets"
-
             };
 
             //Act
             var rule = new UpholdBuildConventionRule();
-            var (propsViolators, targetsViolators) = rule.IdentifyViolators(files, packageId);
-            var issues = rule.GenerateWarnings(propsViolators, targetsViolators);
+            var conventionViolators = rule.IdentifyViolators(files, packageId);
+            var issues = rule.GenerateWarnings(conventionViolators);
 
             //Assert
             Assert.Equal(issues.Count(), 1);
             var singleIssue = issues.Single(p => p.Code == NuGetLogCode.NU5129);
-            var expectedMessage = "- A .props file was found in the folder 'build or other'. However, this file is not 'packageId.props'. Change the file to fit this format.\r\n" +
-                "- A .targets file was found in the folder 'build or other'. However, this file is not 'packageId.targets'. Change the file to fit this format.\r\n";
+            var expectedMessage = "- At least one .targets file was found in 'build/', but 'build/packageId.targets' was not." + Environment.NewLine +
+                "- At least one .props file was found in 'build/', but 'build/packageId.props' was not." + Environment.NewLine;
             Assert.True(singleIssue.Message.Equals(expectedMessage));
         }
 
@@ -135,7 +166,6 @@ namespace NuGet.Packaging.Test
                 "build/net45/packageId.props",
                 "build/net45/package_ID.props",
                 "build/net462/package_Id.props",
-                "build/net471/package_Id.props",
                 "build/netstandard1.3/packageId.targets",
                 "build/netstandard1.3/package_Id.targets",
                 "build/netcoreapp1.1/package_Id.props",
@@ -145,13 +175,15 @@ namespace NuGet.Packaging.Test
 
             //Act
             var rule = new UpholdBuildConventionRule();
-            var (propsViolators, targetsViolators) = rule.IdentifyViolators(files, packageId);
+            var conventionViolators = rule.IdentifyViolators(files, packageId);
 
             //Assert
-            Assert.Equal(propsViolators.Count(), 3);
-            Assert.Empty(targetsViolators);
-            Assert.False(propsViolators.Keys.Contains("net45"));
-            Assert.False(targetsViolators.Keys.Contains("netstandard1.3"));
+            Assert.Equal(2, conventionViolators.Count());
+            Assert.False(conventionViolators.Any(t => t.Path.Equals("build/net45/")));
+            Assert.False(conventionViolators.Any(t => t.Path.Equals("build/netstandard1.3/")));
+            Assert.False(conventionViolators.Any(t => t.Path.Equals("build/")));
+            var secondIssue = conventionViolators.Single(t => t.Path.Equals("build/netcoreapp1.1/"));
+            var thirdIssue = conventionViolators.Single(t => t.Path.Equals("build/net462/"));
         }
 
         [Fact]
@@ -168,55 +200,11 @@ namespace NuGet.Packaging.Test
 
             //Act
             var rule = new UpholdBuildConventionRule();
-            var (propsViolators, targetsViolators) = rule.IdentifyViolators(files, packageId);
+            var conventionViolators = rule.IdentifyViolators(files, packageId);
 
             //Assert
-            Assert.Empty(propsViolators);
-            Assert.Equal(targetsViolators.Count(), 1);
-            Assert.True(targetsViolators.Keys.Contains("unsupported"));
-        }
-
-        [Fact]
-        public void IdentifyViolators_PackageWithPropsAndTargetsIsCasedDifferentlyThanPackageId_ShouldNotWarn()
-        {
-            //Arrange
-            string packageId = "packageId";
-            var files = new string[]
-            {
-                "build/PackageID.props",
-                "build/PackageID.targets"
-            };
-
-            //Act
-            var rule = new UpholdBuildConventionRule();
-            var (propsViolators, targetsViolators) = rule.IdentifyViolators(files, packageId);
-
-            //Assert
-            Assert.Empty(propsViolators);
-            Assert.Empty(targetsViolators);
-        }
-
-        public static class FileSource
-        {
-            public static readonly List<object[]> WarningNotRaisedData
-                = new List<object[]>
-                {
-                    new object[] { new string[] { "build/packageId.props" } },
-                    new object[] { new string[] { "build/net45/packageId.props" } },
-                    new object[] { new string[] { "build/net45/packageId.targets" } },
-                    new object[] { new string[] { "build/packageId.targets" } },
-                    new object[] { new string[] { "build/net45/packageId.props", "build/net45/packageId.targets" } },
-                    new object[] { new string[] { "build/packageId.props", "build/packageId.targets" } }
-                };
-
-            public static readonly List<object[]> WarningRaisedData
-                = new List<object[]>
-                {
-                    new object[] { new string[] { "build/package_Id.props" } },
-                    new object[] { new string[] { "build/net45/package_Id.props" } },
-                    new object[] { new string[] { "build/net45/package_Id.targets" } },
-                    new object[] { new string[] { "build/package_Id.targets" } },
-                };
+            Assert.Equal(conventionViolators.Count(), 1);
+            Assert.True(conventionViolators.All(t => t.Path.Equals("build/")));
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/UpholdBuildConventionRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/UpholdBuildConventionRuleTests.cs
@@ -83,7 +83,7 @@ namespace NuGet.Packaging.Test
                 "build/netcoreapp1.1/package_Id.props"
 
             };
-            var tfms = files.Select(t => t.Split('/')[1]);
+
             //Act
             var rule = new UpholdBuildConventionRule();
             var (propsViolators, targetsViolators) = rule.IdentifyViolators(files, packageId);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/UpholdBuildConventionRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/UpholdBuildConventionRuleTests.cs
@@ -63,7 +63,11 @@ namespace NuGet.Packaging.Test
                     new object[] { new string[] { "build/PackageID.props", "build/PackageID.targets" } },
                     new object[] { new string[] { "build/extra/packageId.props", "build/packageId.props" } },
                     new object[] { new string[] { "build/net45/extra/packageId.props", "build/net45/packageId.props" } },
-                    new object[] { new string[] { "build/random.dll" } }
+                    new object[] { new string[] { "build/random.dll" } },
+                    new object[] { new string[] { "buildCrossTargeting/packageId.props", "buildCrossTargeting/packageId.targets" } },
+                    new object[] { new string[] { "buildCrossTargeting/net45/packageId.props", "buildCrossTargeting/net45/packageId.targets" } },
+                    new object[] { new string[] { "buildTransitive/packageId.props", "buildTransitive/packageId.targets" } },
+                    new object[] { new string[] { "buildTransitive/net45/packageId.props", "buildTransitive/net45/packageId.targets" } }
                 };
 
             public static readonly List<object[]> WarningRaisedData
@@ -75,6 +79,14 @@ namespace NuGet.Packaging.Test
                     new object[] { new string[] { "build/package_Id.targets" } },
                     new object[] { new string[] { "build/extra/packageId.props" } },
                     new object[] { new string[] { "build/net45/extra/packageId.props" } },
+                    new object[] { new string[] { "buildCrossTargeting/net45/package_Id.props"} },
+                    new object[] { new string[] { "buildCrossTargeting/net45/extra/packageId.props"} },
+                    new object[] { new string[] { "buildCrossTargeting/package_Id.props"} },
+                    new object[] { new string[] { "buildCrossTargeting/extra/package_Id.props"} },
+                    new object[] { new string[] { "buildTransitive/net45/package_Id.props"} },
+                    new object[] { new string[] { "buildTransitive/net45/extra/packageId.props"} },
+                    new object[] { new string[] { "buildTransitive/package_Id.props"} },
+                    new object[] { new string[] { "buildTransitive/extra/package_Id.props"} }
                 };
         }
 
@@ -102,7 +114,7 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
-        public void GenerateWarnings_PackageWithPropsAndTargetsInMultipleSubFolders_ShouldWarn()
+        public void GenerateWarnings_PackageWithPropsAndTargetsInCrosspleSubFolders_ShouldWarn()
         {
             //Arrange
             string packageId = "packageId";

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/UpholdBuildConventionRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/UpholdBuildConventionRuleTests.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Castle.DynamicProxy.Generators.Emitters;
+using NuGet.Common;
+using NuGet.Packaging.Rules;
+using Org.BouncyCastle.Asn1.X509;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class UpholdBuildConventionRuleTests
+    {
+        [Theory]
+        [MemberData("WarningNotRaisedData", MemberType = typeof(FileSource))]
+        public void WarningNotRaisedWhenGenerateWarningsCalledAndConventionIsFollowed(string[] files)
+        {
+            //Arrange
+            string packageId = "packageId";
+
+            //Act
+            var rule = new UpholdBuildConventionRule();
+            var (propsViolators, targetsViolators) = rule.IdentifyViolators(files, packageId);
+            var issues = rule.GenerateWarnings(propsViolators, targetsViolators);
+
+            //Assert
+            Assert.Empty(issues);
+        }
+
+        [Theory]
+        [MemberData("WarningRaisedData", MemberType = typeof(FileSource))]
+        public void WarningRaisedWhenGenerateWarningsCalledAndConventionIsNotFollowed(string[] files)
+        {
+            //Arrange
+            string packageId = "packageId";
+
+            //Act
+            var rule = new UpholdBuildConventionRule();
+            var (propsViolators, targetsViolators) = rule.IdentifyViolators(files, packageId);
+            var issues = rule.GenerateWarnings(propsViolators, targetsViolators);
+
+            //Assert
+            Assert.True(issues.All(p => p.Code == NuGetLogCode.NU5129));
+        }
+
+        [Fact]
+        public void GenerateWarnings_PackageWithPropsAndTargetsInSameSubFolderDoesNotFollowConvention_ShouldThrowTwoWarnings()
+        {
+            //Arrange
+            string packageId = "packageId";
+            var files = new string[]
+            {
+                "build/net45/packageID.props",
+                "build/net45/packageID.targets"
+            };
+            //Act
+            var rule = new UpholdBuildConventionRule();
+            var (propsViolators, targetsViolators) = rule.IdentifyViolators(files, packageId);
+            var issues = rule.GenerateWarnings(propsViolators, targetsViolators);
+
+            //Assert
+            Assert.Equal(issues.Count(), 2);
+            Assert.True(issues.All(p => p.Code == NuGetLogCode.NU5129));
+        }
+
+        [Fact]
+        public void GenerateWarnings_PackageWithPropsAndTargetsInMultipleSubFolders_ShouldThrowWarningForEachFolder()
+        {
+            //Arrange
+            string packageId = "packageId";
+            var files = new string[]
+            {
+                "build/net45/packageID.props",
+                "build/net462/packageID.props",
+                "build/net471/packageID.props",
+                "build/netstandard1.3/packageID.props",
+                "build/netcoreapp1.1/packageID.props"
+
+            };
+            var tfms = files.Select(t => t.Split('/')[1]);
+            //Act
+            var rule = new UpholdBuildConventionRule();
+            var (propsViolators, targetsViolators) = rule.IdentifyViolators(files, packageId);
+            var issues = rule.GenerateWarnings(propsViolators, targetsViolators);
+
+            //Assert
+            Assert.Equal(issues.Count(), 5);
+            Assert.True(issues.All(p => p.Code == NuGetLogCode.NU5129));
+            foreach(var tfm in tfms)
+            {
+                var message = string.Format("A .props file was found in 'build/{0}'. However, this file is not 'packageId.props'. Change the file to fit this format.", tfm);
+                Assert.True(issues.Any(p => p.Message.Equals(message)));
+            }
+        }
+
+        [Fact]
+        public void GenerateWarnings_PackageWithPropsAndTargetsUnderBuild_ShouldThrowWarningTwice()
+        {
+            //Arrange
+            string packageId = "packageId";
+            var files = new string[]
+            {
+                "build/packageID.props",
+                "build/packageID.targets"
+
+            };
+
+            //Act
+            var rule = new UpholdBuildConventionRule();
+            var (propsViolators, targetsViolators) = rule.IdentifyViolators(files, packageId);
+            var issues = rule.GenerateWarnings(propsViolators, targetsViolators);
+
+            //Assert
+            Assert.Equal(issues.Count(), 2);
+            Assert.True(issues.All(p => p.Code == NuGetLogCode.NU5129));
+            var propsIssue = issues.Single(p => p.Message.Equals("A .props file was found in 'build'. However, this file is not 'packageId.props'. Change the file to fit this format."));
+            var targetsIssue = issues.Single(p => p.Message.Equals("A .targets file was found in 'build'. However, this file is not 'packageId.targets'. Change the file to fit this format."));
+        }
+
+        [Fact]
+        public void IdentifyViolators_PackageWithPropsAndTargetsFilesInSubfolders_ShouldHaveTheCorrectLocations()
+        {
+            //Arrange
+            string packageId = "packageId";
+            var files = new string[]
+            {
+                "build/net45/packageId.props",
+                "build/net45/package_ID.props",
+                "build/net462/packageID.props",
+                "build/net471/packageID.props",
+                "build/netstandard1.3/packageId.targets",
+                "build/netstandard1.3/packageID.targets",
+                "build/netcoreapp1.1/packageID.props",
+                "build/packageId.props",
+                "build/package_ID.props"
+            };
+
+            //Act
+            var rule = new UpholdBuildConventionRule();
+            var (propsViolators, targetsViolators) = rule.IdentifyViolators(files, packageId);
+
+            //Assert
+            Assert.Equal(propsViolators.Count(), 3);
+            Assert.Empty(targetsViolators);
+            Assert.False(propsViolators.Keys.Contains("build/net45"));
+            Assert.False(targetsViolators.Keys.Contains("build/netstandard1.3"));
+        }
+
+        [Fact]
+        public void IdentifyViolators_PackageWithPropsAndTargetsFilesUnderBuild_ShouldHaveTheCorrectLocations()
+        {
+            //Arrange
+            string packageId = "packageId";
+            var files = new string[]
+            {
+                "build/packageId.props",
+                "build/package_ID.props",
+                "build/packageID.targets"
+            };
+
+            //Act
+            var rule = new UpholdBuildConventionRule();
+            var (propsViolators, targetsViolators) = rule.IdentifyViolators(files, packageId);
+
+            //Assert
+            Assert.Empty(propsViolators);
+            Assert.Equal(targetsViolators.Count(), 1);
+            Assert.True(targetsViolators.Keys.Contains("build"));
+        }
+
+        public static class FileSource
+        {
+            public static readonly List<object[]> WarningNotRaisedData
+                = new List<object[]>
+                {
+                    new object[] { new string[] { "build/packageId.props" } },
+                    new object[] { new string[] { "build/net45/packageId.props" } },
+                    new object[] { new string[] { "build/net45/packageId.targets" } },
+                    new object[] { new string[] { "build/packageId.targets" } },
+                    new object[] { new string[] { "build/net45/packageId.props", "build/net45/packageId.targets" } },
+                    new object[] { new string[] { "build/packageId.props", "build/packageId.targets" } }
+                };
+
+            public static readonly List<object[]> WarningRaisedData
+                = new List<object[]>
+                {
+                    new object[] { new string[] { "build/packageID.props" } },
+                    new object[] { new string[] { "build/net45/packageID.props" } },
+                    new object[] { new string[] { "build/net45/packageID.targets" } },
+                    new object[] { new string[] { "build/packageID.targets" } },
+                };
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/UpholdBuildConventionRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/UpholdBuildConventionRuleTests.cs
@@ -114,7 +114,7 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
-        public void GenerateWarnings_PackageWithPropsAndTargetsInCrosspleSubFolders_ShouldWarn()
+        public void GenerateWarnings_PackageWithPropsAndTargetsInMultipleSubFolders_ShouldWarn()
         {
             //Arrange
             string packageId = "packageId";

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/UpholdBuildConventionRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/UpholdBuildConventionRuleTests.cs
@@ -42,18 +42,19 @@ namespace NuGet.Packaging.Test
             var issues = rule.GenerateWarnings(propsViolators, targetsViolators);
 
             //Assert
-            Assert.True(issues.All(p => p.Code == NuGetLogCode.NU5129));
+            Assert.Equal(issues.Count(), 1);
+            var singleIssue = issues.Single(p => p.Code == NuGetLogCode.NU5129);
         }
 
         [Fact]
-        public void GenerateWarnings_PackageWithPropsAndTargetsInSameSubFolderDoesNotFollowConvention_ShouldThrowTwoWarnings()
+        public void GenerateWarnings_PackageWithPropsAndTargetsInSameSubFolderDoesNotFollowConvention_ShouldWarn()
         {
             //Arrange
             string packageId = "packageId";
             var files = new string[]
             {
-                "build/net45/packageID.props",
-                "build/net45/packageID.targets"
+                "build/net45/package_Id.props",
+                "build/net45/package_Id.targets"
             };
             //Act
             var rule = new UpholdBuildConventionRule();
@@ -61,22 +62,25 @@ namespace NuGet.Packaging.Test
             var issues = rule.GenerateWarnings(propsViolators, targetsViolators);
 
             //Assert
-            Assert.Equal(issues.Count(), 2);
-            Assert.True(issues.All(p => p.Code == NuGetLogCode.NU5129));
+            Assert.Equal(issues.Count(), 1);
+            var singleIssue = issues.Single(p => p.Code == NuGetLogCode.NU5129);
+            var expectedMessage = "- A .props file was found in the folder 'net45'. However, this file is not 'packageId.props'. Change the file to fit this format.\r\n" +
+                "- A .targets file was found in the folder 'net45'. However, this file is not 'packageId.targets'. Change the file to fit this format.\r\n";
+            Assert.True(singleIssue.Message.Equals(expectedMessage));
         }
 
         [Fact]
-        public void GenerateWarnings_PackageWithPropsAndTargetsInMultipleSubFolders_ShouldThrowWarningForEachFolder()
+        public void GenerateWarnings_PackageWithPropsAndTargetsInMultipleSubFolders_ShouldWarn()
         {
             //Arrange
             string packageId = "packageId";
             var files = new string[]
             {
-                "build/net45/packageID.props",
-                "build/net462/packageID.props",
-                "build/net471/packageID.props",
-                "build/netstandard1.3/packageID.props",
-                "build/netcoreapp1.1/packageID.props"
+                "build/net45/package_Id.props",
+                "build/net462/package_Id.props",
+                "build/net471/package_Id.props",
+                "build/netstandard1.3/package_Id.props",
+                "build/netcoreapp1.1/package_Id.props"
 
             };
             var tfms = files.Select(t => t.Split('/')[1]);
@@ -86,24 +90,25 @@ namespace NuGet.Packaging.Test
             var issues = rule.GenerateWarnings(propsViolators, targetsViolators);
 
             //Assert
-            Assert.Equal(issues.Count(), 5);
-            Assert.True(issues.All(p => p.Code == NuGetLogCode.NU5129));
-            foreach(var tfm in tfms)
-            {
-                var message = string.Format("A .props file was found in 'build/{0}'. However, this file is not 'packageId.props'. Change the file to fit this format.", tfm);
-                Assert.True(issues.Any(p => p.Message.Equals(message)));
-            }
+            Assert.Equal(issues.Count(), 1);
+            var singleIssue = issues.Single(p => p.Code == NuGetLogCode.NU5129);
+            var expectedMessage = "- A .props file was found in the folder 'net45'. However, this file is not 'packageId.props'. Change the file to fit this format.\r\n" +
+                "- A .props file was found in the folder 'net462'. However, this file is not 'packageId.props'. Change the file to fit this format.\r\n" +
+                "- A .props file was found in the folder 'net471'. However, this file is not 'packageId.props'. Change the file to fit this format.\r\n" +
+                "- A .props file was found in the folder 'netstandard1.3'. However, this file is not 'packageId.props'. Change the file to fit this format.\r\n" +
+                "- A .props file was found in the folder 'netcoreapp1.1'. However, this file is not 'packageId.props'. Change the file to fit this format.\r\n";
+            Assert.True(singleIssue.Message.Equals(expectedMessage));
         }
 
         [Fact]
-        public void GenerateWarnings_PackageWithPropsAndTargetsUnderBuild_ShouldThrowWarningTwice()
+        public void GenerateWarnings_PackageWithPropsAndTargetsUnderBuild_ShouldWarn()
         {
             //Arrange
             string packageId = "packageId";
             var files = new string[]
             {
-                "build/packageID.props",
-                "build/packageID.targets"
+                "build/package_Id.props",
+                "build/package_Id.targets"
 
             };
 
@@ -113,10 +118,11 @@ namespace NuGet.Packaging.Test
             var issues = rule.GenerateWarnings(propsViolators, targetsViolators);
 
             //Assert
-            Assert.Equal(issues.Count(), 2);
-            Assert.True(issues.All(p => p.Code == NuGetLogCode.NU5129));
-            var propsIssue = issues.Single(p => p.Message.Equals("A .props file was found in 'build'. However, this file is not 'packageId.props'. Change the file to fit this format."));
-            var targetsIssue = issues.Single(p => p.Message.Equals("A .targets file was found in 'build'. However, this file is not 'packageId.targets'. Change the file to fit this format."));
+            Assert.Equal(issues.Count(), 1);
+            var singleIssue = issues.Single(p => p.Code == NuGetLogCode.NU5129);
+            var expectedMessage = "- A .props file was found in the folder 'build or other'. However, this file is not 'packageId.props'. Change the file to fit this format.\r\n" +
+                "- A .targets file was found in the folder 'build or other'. However, this file is not 'packageId.targets'. Change the file to fit this format.\r\n";
+            Assert.True(singleIssue.Message.Equals(expectedMessage));
         }
 
         [Fact]
@@ -128,11 +134,11 @@ namespace NuGet.Packaging.Test
             {
                 "build/net45/packageId.props",
                 "build/net45/package_ID.props",
-                "build/net462/packageID.props",
-                "build/net471/packageID.props",
+                "build/net462/package_Id.props",
+                "build/net471/package_Id.props",
                 "build/netstandard1.3/packageId.targets",
-                "build/netstandard1.3/packageID.targets",
-                "build/netcoreapp1.1/packageID.props",
+                "build/netstandard1.3/package_Id.targets",
+                "build/netcoreapp1.1/package_Id.props",
                 "build/packageId.props",
                 "build/package_ID.props"
             };
@@ -144,8 +150,8 @@ namespace NuGet.Packaging.Test
             //Assert
             Assert.Equal(propsViolators.Count(), 3);
             Assert.Empty(targetsViolators);
-            Assert.False(propsViolators.Keys.Contains("build/net45"));
-            Assert.False(targetsViolators.Keys.Contains("build/netstandard1.3"));
+            Assert.False(propsViolators.Keys.Contains("net45"));
+            Assert.False(targetsViolators.Keys.Contains("netstandard1.3"));
         }
 
         [Fact]
@@ -157,7 +163,7 @@ namespace NuGet.Packaging.Test
             {
                 "build/packageId.props",
                 "build/package_ID.props",
-                "build/packageID.targets"
+                "build/package_Id.targets"
             };
 
             //Act
@@ -167,7 +173,27 @@ namespace NuGet.Packaging.Test
             //Assert
             Assert.Empty(propsViolators);
             Assert.Equal(targetsViolators.Count(), 1);
-            Assert.True(targetsViolators.Keys.Contains("build"));
+            Assert.True(targetsViolators.Keys.Contains("unsupported"));
+        }
+
+        [Fact]
+        public void IdentifyViolators_PackageWithPropsAndTargetsIsCasedDifferentlyThanPackageId_ShouldNotWarn()
+        {
+            //Arrange
+            string packageId = "packageId";
+            var files = new string[]
+            {
+                "build/PackageID.props",
+                "build/PackageID.targets"
+            };
+
+            //Act
+            var rule = new UpholdBuildConventionRule();
+            var (propsViolators, targetsViolators) = rule.IdentifyViolators(files, packageId);
+
+            //Assert
+            Assert.Empty(propsViolators);
+            Assert.Empty(targetsViolators);
         }
 
         public static class FileSource
@@ -186,10 +212,10 @@ namespace NuGet.Packaging.Test
             public static readonly List<object[]> WarningRaisedData
                 = new List<object[]>
                 {
-                    new object[] { new string[] { "build/packageID.props" } },
-                    new object[] { new string[] { "build/net45/packageID.props" } },
-                    new object[] { new string[] { "build/net45/packageID.targets" } },
-                    new object[] { new string[] { "build/packageID.targets" } },
+                    new object[] { new string[] { "build/package_Id.props" } },
+                    new object[] { new string[] { "build/net45/package_Id.props" } },
+                    new object[] { new string[] { "build/net45/package_Id.targets" } },
+                    new object[] { new string[] { "build/package_Id.targets" } },
                 };
         }
     }


### PR DESCRIPTION
## Bug

Fixes: [8295](https://github.com/NuGet/Home/issues/8295)  
Regression: No  

## Fix

Details: added rule to validate that build files follow the `package_id.props` convention

## Testing

Tests Added: Yes 
