### PR TITLE
fix dotnet transitive outdated listing

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/InstalledPackageReference.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/InstalledPackageReference.cs
@@ -22,6 +22,10 @@ namespace NuGet.CommandLine.XPlat
         internal IPackageSearchMetadata LatestPackageMetadata { get; set; }
         internal bool AutoReference { get; set; }
         internal UpdateLevel UpdateLevel { get; set; }
+        /// <summary>
+        ///  The particular type of dependency, as a string. For example, "package", "project", or others.
+        /// </summary>
+        internal string Type { get; set; }
 
         /// <summary>
         /// A constructor that takes a name of a package

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -458,6 +458,7 @@ namespace NuGet.CommandLine.XPlat
                                 .FromIdentity(new PackageIdentity(library.Name, library.Version))
                                 .Build()
                         };
+                        installedPackage.Type = library.Type;
                         transitivePackages.Add(installedPackage);
                     }
                 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/ProjectPackagesPrintUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/ProjectPackagesPrintUtility.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Configuration;
+using NuGet.LibraryModel;
 using NuGet.Protocol;
 using NuGet.Versioning;
 
@@ -119,6 +120,9 @@ namespace NuGet.CommandLine.XPlat.Utility
             var autoReferenceFound = false;
             var deprecatedFound = false;
 
+            // Exclude known project references from the listing.
+            packages = packages.Where(p => p.Type != LibraryType.Project);
+
             if (!packages.Any())
             {
                 return new PrintPackagesResult(autoReferenceFound, deprecatedFound);
@@ -174,6 +178,7 @@ namespace NuGet.CommandLine.XPlat.Utility
                        async p => p.LatestPackageMetadata?.Identity?.Version == null
                             ? Strings.ListPkg_NotFoundAtSources
                             : PrintVersion(
+
                                 p.LatestPackageMetadata.Identity.Version,
                                 await p.LatestPackageMetadata.GetDeprecationMetadataAsync() != null,
                                 outdated));


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/7890

## Bug

Fixes: https://github.com/NuGet/Home/issues/7890 
Regression: No   

## Fix

Details: This attempts to fix the issue by filtering out project ref packages from the table listing.

## Testing/Validation

Tests Added: Yes
