### PR TITLE
Remove 2nd N.B.T.P package

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -227,16 +227,6 @@
              Targets="PackProjects"
              Properties="$(CommonMSBuildProperties);
                          VisualStudioVersion=$(VisualStudioVersion)" />
-
-    <Message Text="Packing for 2nd NuGet.Build.Tasks.pack" Importance="high" />
-    <!-- Pack the 2nd NuGet.Build.Tasks.pack only when IsXPlat != true  -->
-    <MSBuild Condition=" '$(IsXPlat)' != 'true' "
-             BuildInParallel="false"
-             Projects="$(NuGetBuildTasksPackProject)"
-             Targets="PackProjects"
-             Properties="$(CommonMSBuildProperties);
-                         VisualStudioVersion=$(VisualStudioVersion);
-                         Create2ndNupkg=true" />
   </Target>
 
   <!--
@@ -252,14 +242,6 @@
              Targets="PackProjects"
              Properties="$(CommonMSBuildProperties);
                          VisualStudioVersion=$(VisualStudioVersion)" />
-
-    <Message Text="Packing for 2nd NuGet.Build.Tasks.pack   $(NuGetBuildTasksPackProject)" Importance="high" />
-    <MSBuild BuildInParallel="false"
-             Projects="$(NuGetBuildTasksPackProject)"
-             Targets="PackProjects"
-             Properties="$(CommonMSBuildProperties);
-                         VisualStudioVersion=$(VisualStudioVersion);
-                         Create2ndNupkg=true" />
   </Target>
 
   <!--

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -12,8 +12,8 @@
     <NETFXTargetFramework>net472</NETFXTargetFramework>
     <NETCoreTargetFramework>netcoreapp2.1</NETCoreTargetFramework>
     <NETCoreTargetFrameworks Condition=" '$(RequiresSigningXplatAPIs)' != 'true' ">netcoreapp2.1</NETCoreTargetFrameworks>
-    <NETCoreTargetFrameworks Condition=" '$(RequiresSigningXplatAPIs)' == 'true' and '$(TestForOneSDK)' != 'true' ">netcoreapp2.1;netcoreapp3.0</NETCoreTargetFrameworks>
-    <NETCoreTargetFrameworks Condition=" '$(RequiresSigningXplatAPIs)' == 'true' and '$(TestForOneSDK)' == 'true' ">netcoreapp3.0</NETCoreTargetFrameworks>
+    <NETCoreTargetFrameworks Condition=" '$(RequiresSigningXplatAPIs)' == 'true' and '$(TestForLatestNetCoreOnly)' != 'true' ">netcoreapp2.1;netcoreapp3.0</NETCoreTargetFrameworks>
+    <NETCoreTargetFrameworks Condition=" '$(RequiresSigningXplatAPIs)' == 'true' and '$(TestForLatestNetCoreOnly)' == 'true' ">netcoreapp3.0</NETCoreTargetFrameworks>
     <NetStandardVersion>netstandard2.0</NetStandardVersion>
     <TargetFrameworksExe>$(NETFXTargetFramework);$(NETCoreTargetFrameworks)</TargetFrameworksExe>
     <TargetFrameworksLibrary  Condition=" '$(RequiresSigningXplatAPIs)' != 'true' ">$(NETFXTargetFramework);$(NetStandardVersion)</TargetFrameworksLibrary>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -11,9 +11,9 @@
     <NETFXTargetFrameworkVersion>v4.7.2</NETFXTargetFrameworkVersion>
     <NETFXTargetFramework>net472</NETFXTargetFramework>
     <NETCoreTargetFramework>netcoreapp2.1</NETCoreTargetFramework>
-    <NETCore3TargetFramework>netcoreapp3.0</NETCore3TargetFramework>
     <NETCoreTargetFrameworks Condition=" '$(RequiresSigningXplatAPIs)' != 'true' ">netcoreapp2.1</NETCoreTargetFrameworks>
-    <NETCoreTargetFrameworks Condition=" '$(RequiresSigningXplatAPIs)' == 'true' ">netcoreapp2.1;netcoreapp3.0</NETCoreTargetFrameworks>
+    <NETCoreTargetFrameworks Condition=" '$(RequiresSigningXplatAPIs)' == 'true' and '$(TestForOneSDK)' != 'true' ">netcoreapp2.1;netcoreapp3.0</NETCoreTargetFrameworks>
+    <NETCoreTargetFrameworks Condition=" '$(RequiresSigningXplatAPIs)' == 'true' and '$(TestForOneSDK)' == 'true' ">netcoreapp3.0</NETCoreTargetFrameworks>
     <NetStandardVersion>netstandard2.0</NetStandardVersion>
     <TargetFrameworksExe>$(NETFXTargetFramework);$(NETCoreTargetFrameworks)</TargetFrameworksExe>
     <TargetFrameworksLibrary  Condition=" '$(RequiresSigningXplatAPIs)' != 'true' ">$(NETFXTargetFramework);$(NetStandardVersion)</TargetFrameworksLibrary>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -11,6 +11,7 @@
     <NETFXTargetFrameworkVersion>v4.7.2</NETFXTargetFrameworkVersion>
     <NETFXTargetFramework>net472</NETFXTargetFramework>
     <NETCoreTargetFramework>netcoreapp2.1</NETCoreTargetFramework>
+    <NETCore3TargetFramework>netcoreapp3.0</NETCore3TargetFramework>
     <NETCoreTargetFrameworks Condition=" '$(RequiresSigningXplatAPIs)' != 'true' ">netcoreapp2.1</NETCoreTargetFrameworks>
     <NETCoreTargetFrameworks Condition=" '$(RequiresSigningXplatAPIs)' == 'true' ">netcoreapp2.1;netcoreapp3.0</NETCoreTargetFrameworks>
     <NetStandardVersion>netstandard2.0</NetStandardVersion>
@@ -34,7 +35,6 @@
     <ILMergeExePath>$(SolutionPackagesFolder)ILMerge.3.0.21\tools\net452\ILMerge.exe</ILMergeExePath>
     <XunitXmlLoggerDirectory>$(SolutionPackagesFolder)XunitXml.TestLogger.2.0.0\build\_common</XunitXmlLoggerDirectory>
     <NuGetBuildTasksPackTargets Condition="Exists('$(SolutionPackagesFolder)NuGet.Build.Tasks.Pack.4.9.2\build\NuGet.Build.Tasks.Pack.targets')">$(SolutionPackagesFolder)NuGet.Build.Tasks.Pack.4.9.2\build\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
-    <NuGetBuildTasksPackProject Condition="Exists('$(NuGetCoreSrcDirectory)NuGet.Build.Tasks.Pack\NuGet.Build.Tasks.Pack.csproj')">$(NuGetCoreSrcDirectory)NuGet.Build.Tasks.Pack\NuGet.Build.Tasks.Pack.csproj</NuGetBuildTasksPackProject>
     <EnlistmentRoot>$(RepositoryRootDirectory)</EnlistmentRoot>
     <EnlistmentRootSrc>$(RepositoryRootDirectory)src</EnlistmentRootSrc>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(RepositoryRootDirectory)</SolutionDir>

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -272,7 +272,7 @@ Function Install-DotnetCLI {
     }
 
     # install SDK2 runtime as we encounter problems on running dotnet vstest command when only download SDK3.
-    & $DotNetInstall -Runtime dotnet -Version 2.2.3 -i $CLIRoot 
+    & $DotNetInstall -Runtime dotnet -Version 2.2.3 -i $CLIRoot -NoPath
     
 }
 

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -271,6 +271,8 @@ Function Install-DotnetCLI {
         & $DotNetExe --info
     }
 
+    # install SDK2 runtime as we encounter problems on running dotnet vstest command when only download SDK3.
+    & $DotNetInstall -Runtime dotnet -Version 2.2.3 -i $CLIRoot 
     
 }
 

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -272,7 +272,7 @@ Function Install-DotnetCLI {
     }
 
     # install SDK2 runtime as we encounter problems on running dotnet vstest command when only download SDK3.
-    & $DotNetInstall -Runtime dotnet -Version 2.2.3 -i $CLIRoot -NoPath
+    & $DotNetInstall -Runtime dotnet -Channel 2.2 -i $CLIRoot -NoPath
     
 }
 

--- a/build/config.props
+++ b/build/config.props
@@ -21,9 +21,9 @@
     <!-- when LockSDKVersion is not true, it will ignore the properties and just use the latest version for the channel specified in CliVersionForBuilding for building, CliBranchForTesting for testing -->
     <LockSDKVersion>true</LockSDKVersion>
     <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == ''"></OverrideCliBranchForTesting>
-    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">release/3.0.1xx 3.0.100-preview7-012802;release/2.2.3xx</OverrideCliBranchForTesting>
+    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">release/3.0.1xx 3.0.100-preview7-012802</OverrideCliBranchForTesting>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>
-    <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">release/3.0.1xx;release/2.2.3xx</CliBranchForTesting>
+    <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">release/3.0.1xx</CliBranchForTesting>
     <CliVersionForBuilding Condition="'$(LockSDKVersion)' == ''">3.0.x</CliVersionForBuilding>
     <CliVersionForBuilding Condition="'$(LockSDKVersion)' == 'true'">3.0.100-preview6-012264</CliVersionForBuilding>
     <!-- This branches are used for creating insertion PRs -->

--- a/build/config.props
+++ b/build/config.props
@@ -21,9 +21,9 @@
     <!-- when LockSDKVersion is not true, it will ignore the properties and just use the latest version for the channel specified in CliVersionForBuilding for building, CliBranchForTesting for testing -->
     <LockSDKVersion>true</LockSDKVersion>
     <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == ''"></OverrideCliBranchForTesting>
-    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">release/3.0.1xx 3.0.100-preview7-012802</OverrideCliBranchForTesting>
+    <OverrideCliBranchForTesting Condition="'$(LockSDKVersion)' == 'true'">release/3.0.1xx 3.0.100-preview7-012802;release/2.2.3xx</OverrideCliBranchForTesting>
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>
-    <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">release/3.0.1xx</CliBranchForTesting>
+    <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' == ''">release/3.0.1xx;release/2.2.3xx</CliBranchForTesting>
     <CliVersionForBuilding Condition="'$(LockSDKVersion)' == ''">3.0.x</CliVersionForBuilding>
     <CliVersionForBuilding Condition="'$(LockSDKVersion)' == 'true'">3.0.100-preview6-012264</CliVersionForBuilding>
     <!-- This branches are used for creating insertion PRs -->

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -69,7 +69,7 @@ done
 echo "================="
 
 # install SDK2 runtime as we encounter problems on running dotnet vstest command when only download SDK3.
-cli/dotnet-install.sh -runtime dotnet --version 2.2.3 -i cli -NoPath
+cli/dotnet-install.sh -runtime dotnet -Channel 2.2 -i cli -NoPath
 
 echo "Deleting .NET Core temporary files"
 rm -rf "/tmp/"dotnet.*

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -68,6 +68,8 @@ do
 done
 echo "================="
 
+# install SDK2 runtime as we encounter problems on running dotnet vstest command when only download SDK3.
+cli/dotnet-install.sh -runtime dotnet --version 2.2.3 -i cli -NoPath
 
 echo "Deleting .NET Core temporary files"
 rm -rf "/tmp/"dotnet.*

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -18,9 +18,7 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <XPLATProject>true</XPLATProject>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <TargetsForTfmSpecificContentInPackage Condition=" '$(Create2ndNupkg)' != 'true'">$(TargetsForTfmSpecificContentInPackage);CreatePackNupkg</TargetsForTfmSpecificContentInPackage>
-    <TargetsForTfmSpecificContentInPackage Condition=" '$(Create2ndNupkg)' == 'true'">$(TargetsForTfmSpecificContentInPackage);CreatePackNupkg2X</TargetsForTfmSpecificContentInPackage>
-    <PackageId Condition=" '$(Create2ndNupkg)' == 'true'">$(AssemblyName).Sdk2x</PackageId>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);CreatePackNupkg</TargetsForTfmSpecificContentInPackage>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <DevelopmentDependency>true</DevelopmentDependency>
     <PackageDescription>NuGet pack for dotnet CLI.</PackageDescription>
@@ -32,9 +30,6 @@
     <Compile Include="..\NuGet.Build.Tasks\Common\MSBuildLogger.cs" />
     <Compile Include="..\NuGet.Build.Tasks\GetProjectTargetFrameworksTask.cs" />
     <Content Include="NuGet.Build.Tasks.Pack.targets" Pack="true" PackagePath="build;buildCrossTargeting">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="NuGet.Build.Tasks.Pack.Sdk2x.targets" Pack="true" PackagePath="build;buildCrossTargeting" Condition=" '$(Create2ndNupkg)' == 'true'">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
@@ -174,33 +169,6 @@
       </TfmSpecificPackageFile>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)NuGet.Build.Tasks.Pack.dll">
-        <PackagePath>CoreCLR/</PackagePath>
-      </TfmSpecificPackageFile>
-      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)**\NuGet*.resources.dll">
-        <PackagePath>CoreCLR/</PackagePath>
-      </TfmSpecificPackageFile>
-      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)**\*.dll" Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">
-        <PackagePath>CoreCLR/</PackagePath>
-      </TfmSpecificPackageFile>
-    </ItemGroup>    
-  </Target>
-
-   <!--These targets help get files for packing the second NuGet.Build.Tasks.Pack.Sdk2x package, for netstandard2.0.-->
-   <Target Name="CreatePackNupkg2X">
-    <PropertyGroup>
-      <!-- Build from source can't use ILMerge. -->
-      <ILMergeSubpath Condition="'$(IsBuildOnlyXPLATProjects)' != 'true'">ilmerge\</ILMergeSubpath>
-    </PropertyGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)' AND '$(IsBuildOnlyXPLATProjects)' != 'true'">
-      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)NuGet.Build.Tasks.Pack.dll">
-        <PackagePath>Desktop/</PackagePath>
-      </TfmSpecificPackageFile>
-      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)**\NuGet*.resources.dll">
-        <PackagePath>Desktop/</PackagePath>
-      </TfmSpecificPackageFile>
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == '$(NetStandardVersion)'">
       <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)NuGet.Build.Tasks.Pack.dll">
         <PackagePath>CoreCLR/</PackagePath>
       </TfmSpecificPackageFile>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <RequiresSigningXplatAPIs>true</RequiresSigningXplatAPIs>
-    <TestForOneSDK>true</TestForOneSDK>
+    <TestForLatestNetCoreOnly>true</TestForLatestNetCoreOnly>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
@@ -7,7 +7,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   
   <PropertyGroup>
-    <TargetFrameworks>$(NETCoreTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(NETCore3TargetFramework)</TargetFrameworks>
     <TestProject>true</TestProject>
   </PropertyGroup>
   

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
@@ -1,13 +1,14 @@
 ﻿<Project>
   <PropertyGroup>
     <RequiresSigningXplatAPIs>true</RequiresSigningXplatAPIs>
+    <TestForOneSDK>true</TestForOneSDK>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   
   <PropertyGroup>
-    <TargetFrameworks>$(NETCore3TargetFramework)</TargetFrameworks>
+    <TargetFrameworks>$(NETCoreTargetFrameworks)</TargetFrameworks>
     <TestProject>true</TestProject>
   </PropertyGroup>
   

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -225,12 +225,12 @@ EndGlobal";
                     var xml = XDocument.Load(stream);
 
                     var attributes = new Dictionary<string, string>() { { "Version", "1.0.0" } };
-#if NETCORE3_0
+
                     ProjectFileUtils.ChangeProperty(
                         xml,
                         "TargetFramework",
                         "netstandard2.1");
-#endif
+
                     ProjectFileUtils.AddItem(
                         xml,
                         "PackageReference",

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -530,13 +530,9 @@ namespace Dotnet.Integration.Test
                     Assert.Equal(1,
                         dependencyGroups.Count);
 
-#if NETCORE3_0
                     Assert.Equal(FrameworkConstants.CommonFrameworks.NetCoreApp30,
                         dependencyGroups[0].TargetFramework);
-#else
-                    Assert.Equal(FrameworkConstants.CommonFrameworks.NetCoreApp22,
-                        dependencyGroups[0].TargetFramework);
-#endif
+
                     var packagesA = dependencyGroups[0].Packages.ToList();
                     Assert.Equal(1,
                         packagesA.Count);
@@ -549,19 +545,11 @@ namespace Dotnet.Integration.Test
                     // Validate the assets.
                     var libItems = nupkgReader.GetLibItems().ToList();
                     Assert.Equal(1, libItems.Count);
-#if NETCORE3_0
                     Assert.Equal(FrameworkConstants.CommonFrameworks.NetCoreApp30, libItems[0].TargetFramework);
                     Assert.Equal(
                         new[]
                         {"lib/netcoreapp3.0/ClassLibrary1.dll", "lib/netcoreapp3.0/ClassLibrary1.runtimeconfig.json"},
                         libItems[0].Items);
-#else
-                    Assert.Equal(FrameworkConstants.CommonFrameworks.NetCoreApp22, libItems[0].TargetFramework);
-                    Assert.Equal(
-                        new[]
-                        {"lib/netcoreapp2.2/ClassLibrary1.dll", "lib/netcoreapp2.2/ClassLibrary1.runtimeconfig.json"},
-                        libItems[0].Items);
-#endif
                 }
             }
         }
@@ -3987,96 +3975,6 @@ namespace ClassLibrary
             }
         }
 #endif
-
-
-        [PlatformFact(Platform.Windows)]
-        public void PackCommand_PackAsMsbuildTargets()
-        {
-            
-            using (var pathContext = new SimpleTestPathContext())
-            {
-                // Arrange
-                // Set up solution, project, program.cs and package
-                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-
-                var net461 = NuGetFramework.Parse("net461");
-
-                // Set up project.csproj
-                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference("nonSDKprojectA",
-                                                                                      pathContext.SolutionRoot,
-                                                                                      net461);
-                projectA.Properties.Add("PackageOutputPath", ".\\");
-                projectA.Properties.Add("Authors", "someone");
-                projectA.Save();
-
-                var projectPath = projectA.ProjectPath;
-                var projectFolder = projectPath.Substring(0, projectPath.Length - projectPath.Split('\\').Last().Length - 1);
-
-                using (var stream = new FileStream(projectPath, FileMode.Open, FileAccess.ReadWrite))
-                {
-                    var xml = XDocument.Load(stream);
-
-                    var properties = new Dictionary<string, string>();
-                    properties["Version"] = "4.0.0-aaa";
-                    properties["IncludeAssets"] = "runtime; build; native; contentfiles; analyzers; buildtransitive";
-                    properties["PrivateAssets"] = "all";
-                    ProjectFileUtils.AddItem(xml,
-                                            "PackageReference",
-                                            "NuGet.Build.Tasks.Pack.Sdk2x",
-                                            string.Empty,
-                                            properties,
-                                            new Dictionary<string, string>());
-
-                    ProjectFileUtils.WriteXmlToFile(xml, stream);
-                }
-
-                // Set up program.cs
-                var programContents = @"
-using System;
-
-namespace nonSDKprojectA
-{
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            Console.WriteLine(""Hello World!"");
-        }
-    }
-}";
-                var programPath = Path.Combine(projectFolder, "Program.cs");
-                File.WriteAllText(programPath, programContents);
-
-                // Copy the NuGet.Build.Tasks.Pack.Sdk2x package to nupkgSourcePath
-                var nupkgsDirectory = DotnetCliUtil.GetNupkgDirectoryInRepo();
-                var nupkgSourcePath = Directory.GetFiles(nupkgsDirectory, "NuGet.Build.Tasks.Pack.Sdk2x.*").First();
-                var nupkgFileName = nupkgSourcePath.Split("\\").Last();
-                var nupkgDestPath = pathContext.PackageSource + "\\" + nupkgFileName;
-                File.Copy(nupkgSourcePath, nupkgDestPath);
-
-          
-                var msBuildDirectory = "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\MSBuild\\Current\\Bin";
-                var msBuildExe = Path.Combine(msBuildDirectory, "MSBuild.exe");
-
-                var restoreResult = CommandRunner.Run(msBuildExe,
-                                               projectFolder,
-                                               $"/t:restore",
-                                               waitForExit: true);
-                Assert.True(restoreResult.Item1 == 0, $"Restore project failed with following log information :\n {restoreResult.AllOutput}");
-                Assert.True(string.IsNullOrWhiteSpace(restoreResult.Item3), $"restore project failed with following message in error stream :\n {restoreResult.AllOutput}");
-
-                // Act
-                var packResult = CommandRunner.Run(msBuildExe,
-                                               projectFolder,
-                                               $"/t:pack",
-                                               waitForExit: true);
-
-                // Assert
-                Assert.True(packResult.Item1 == 0, $"Pack project failed with following log information :\n {packResult.AllOutput}");
-                Assert.True(string.IsNullOrWhiteSpace(packResult.Item3), $"Pack project failed with following message in error stream :\n {packResult.AllOutput}");
-
-            }
-        }
     }
 
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
@@ -131,12 +131,7 @@ namespace NuGet.XPlat.FuncTest
 
                 var relativePaths = new string[]
                 {
-#if NETCORE3_0
-                    Path.Combine("artifacts", "NuGet.CommandLine.XPlat", "16.0", "bin", configuration, "netcoreapp3.0", XPlatDll),
-#else
-                    Path.Combine("artifacts", "NuGet.CommandLine.XPlat", "16.0", "bin", configuration, "netcoreapp2.1", XPlatDll),
-#endif
-                    Path.Combine("artifacts", "NuGet.CommandLine.XPlat", "15.0", "bin", configuration, "netcoreapp2.1", XPlatDll)
+                    Path.Combine("artifacts", "NuGet.CommandLine.XPlat", "16.0", "bin", configuration, "netcoreapp3.0", XPlatDll)
                 };
 
                 foreach (var relativePath in relativePaths)

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <RequiresSigningXplatAPIs>true</RequiresSigningXplatAPIs>
-    <TestForOneSDK>true</TestForOneSDK>
+    <TestForLatestNetCoreOnly>true</TestForLatestNetCoreOnly>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
@@ -1,6 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <RequiresSigningXplatAPIs>true</RequiresSigningXplatAPIs>
+    <TestForOneSDK>true</TestForOneSDK>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />


### PR DESCRIPTION
As there is no more NuGet insertion into SDK 2.x, there is no need to generate the NuGet.Build.Tasks.Pack.Sdk2x package in our code.

## Bug

Fixes: [NuGet/Home/8403](https://github.com/NuGet/Home/issues/8403)
  
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

- Remove generating process for 2nd N.B.T.P package.
- Download only one version of SDK(3.0) into cli folder. 
- Download SDK(2.2.3) runtime into cli folder for running netcoreapp2.1 apps.
- Change NuGet.XPlat.FuncTest.csproj to test for SDK3 only.
- Change Dotnet.Integration.Test to test for SDK3 only.
   1. Change csproj file to target only netcoreapp3.0
   2. Patch only for SDK3
   3. Remove "#if NETCORE3_0" and "#else" from Dotnet.Integration.Test.
   4. Remove generating temp global.json from MsbuildIntegrationTestFixture.cs for testing
- Remove PackCommand_PackAsMsbuildTargets test.


## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
