### PR TITLE
Build:  enable OptProfV2 release to not have drop share dependency

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -116,6 +116,14 @@ phases:
       arguments: "-BuildCounterFile $(BuildCounterFile) -BuildInfoJsonFile $(BuildInfoJsonFile) -BuildRTM $(BuildRTM) -SkipUpdateBuildNumber"
     displayName: "Configure VSTS CI Environment"
 
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish buildinfo.json as an artifact'
+    inputs:
+      ArtifactName: 'BuildInfo'
+      ArtifactType: 'Container'
+      PathToPublish: '$(Build.Repository.LocalPath)\artifacts\buildinfo.json'
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
   - task: PowerShell@1
     displayName: "Print Environment Variables"
     inputs:


### PR DESCRIPTION
Progress on https://github.com/NuGet/Home/issues/6007.