### PR TITLE
Reinstating PR #2987: Validation Rule: Reference groups in the nuspec match the files in the ref folder

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -779,7 +779,7 @@ namespace NuGet.Common
         /// TFM dependencies in the lib or ref folder don't have exact matches in the nuspec
         /// </summary>
         NU5128 = 5128,
-
+        
         /// <summary>
         /// No build files that follow the build convention ("package_id".props)
         /// </summary>
@@ -789,6 +789,11 @@ namespace NuGet.Common
         /// TFM dependencies in the lib or ref folder has a compatible match, but not an exact match
         /// </summary>
         NU5130 = 5130,
+
+        /// <summary>
+        /// References in the nuspec don't match up with the ref folder in the package
+        /// </summary>
+        NU5131 = 5131,
 
         /// <summary>
         /// Undefined package warning

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -779,7 +779,7 @@ namespace NuGet.Common
         /// TFM dependencies in the lib or ref folder don't have exact matches in the nuspec
         /// </summary>
         NU5128 = 5128,
-        
+
         /// <summary>
         /// No build files that follow the build convention ("package_id".props)
         /// </summary>

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
@@ -278,7 +278,7 @@ namespace NuGet.Packaging.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to References were found in the nuspec, but some were not found within the ref folder. Add the following reference assemblies:.
+        ///   Looks up a localized string similar to References were found in the nuspec, but some reference assemblies were not found in both the nuspec and ref folder. Add the following reference assemblies:.
         /// </summary>
         public static string ReferencesInNuspecAndRefFilesDontMatchWarning {
             get {
@@ -292,6 +292,15 @@ namespace NuGet.Packaging.Rules {
         public static string ReferencesInNuspecAndRefFilesDontMatchWarningAddToNuspecListItemFormat {
             get {
                 return ResourceManager.GetString("ReferencesInNuspecAndRefFilesDontMatchWarningAddToNuspecListItemFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to - Add {0} to the references element in the nuspec.
+        /// </summary>
+        public static string ReferencesInNuspecAndRefFilesDontMatchWarningAddToNuspecNoTfmListItemFormat {
+            get {
+                return ResourceManager.GetString("ReferencesInNuspecAndRefFilesDontMatchWarningAddToNuspecNoTfmListItemFormat", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.Designer.cs
@@ -278,6 +278,33 @@ namespace NuGet.Packaging.Rules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to References were found in the nuspec, but some were not found within the ref folder. Add the following reference assemblies:.
+        /// </summary>
+        public static string ReferencesInNuspecAndRefFilesDontMatchWarning {
+            get {
+                return ResourceManager.GetString("ReferencesInNuspecAndRefFilesDontMatchWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to - Add {0} to the {1} reference group in the nuspec.
+        /// </summary>
+        public static string ReferencesInNuspecAndRefFilesDontMatchWarningAddToNuspecListItemFormat {
+            get {
+                return ResourceManager.GetString("ReferencesInNuspecAndRefFilesDontMatchWarningAddToNuspecListItemFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to - Add {0} to the ref/{1}/ directory.
+        /// </summary>
+        public static string ReferencesInNuspecAndRefFilesDontMatchWarningAddToRefListItemFormat {
+            get {
+                return ResourceManager.GetString("ReferencesInNuspecAndRefFilesDontMatchWarningAddToRefListItemFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The script file &apos;{0}&apos; is outside the &apos;tools&apos; folder and hence will not be executed during installation of this package. Move it into the &apos;tools&apos; folder..
         /// </summary>
         public static string ScriptOutsideToolsWarning {

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
@@ -198,6 +198,15 @@
   <data name="PlaceholderFileInPackageWarning" xml:space="preserve">
     <value>An empty folder placeholder file '{0}' is in a non-empty folder and should be removed.</value>
   </data>
+  <data name="ReferencesInNuspecAndRefFilesDontMatchWarning" xml:space="preserve">
+    <value>References were found in the nuspec, but some were not found within the ref folder. Add the following reference assemblies:</value>
+  </data>
+  <data name="ReferencesInNuspecAndRefFilesDontMatchWarningAddToNuspecListItemFormat" xml:space="preserve">
+    <value>- Add {0} to the {1} reference group in the nuspec</value>
+  </data>
+  <data name="ReferencesInNuspecAndRefFilesDontMatchWarningAddToRefListItemFormat" xml:space="preserve">
+    <value>- Add {0} to the ref/{1}/ directory</value>
+  </data>
   <data name="ScriptOutsideToolsWarning" xml:space="preserve">
     <value>The script file '{0}' is outside the 'tools' folder and hence will not be executed during installation of this package. Move it into the 'tools' folder.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/AnalysisResources.resx
@@ -199,10 +199,13 @@
     <value>An empty folder placeholder file '{0}' is in a non-empty folder and should be removed.</value>
   </data>
   <data name="ReferencesInNuspecAndRefFilesDontMatchWarning" xml:space="preserve">
-    <value>References were found in the nuspec, but some were not found within the ref folder. Add the following reference assemblies:</value>
+    <value>References were found in the nuspec, but some reference assemblies were not found in both the nuspec and ref folder. Add the following reference assemblies:</value>
   </data>
   <data name="ReferencesInNuspecAndRefFilesDontMatchWarningAddToNuspecListItemFormat" xml:space="preserve">
     <value>- Add {0} to the {1} reference group in the nuspec</value>
+  </data>
+  <data name="ReferencesInNuspecAndRefFilesDontMatchWarningAddToNuspecNoTfmListItemFormat" xml:space="preserve">
+    <value>- Add {0} to the references element in the nuspec</value>
   </data>
   <data name="ReferencesInNuspecAndRefFilesDontMatchWarningAddToRefListItemFormat" xml:space="preserve">
     <value>- Add {0} to the ref/{1}/ directory</value>

--- a/src/NuGet.Core/NuGet.Packaging/Rules/ReferencesInNuspecMatchRefAssetsRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/ReferencesInNuspecMatchRefAssetsRule.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using NuGet.Client;
+using NuGet.Common;
+using NuGet.ContentModel;
+using NuGet.Frameworks;
+using NuGet.Packaging.Core;
+using NuGet.RuntimeModel;
+
+namespace NuGet.Packaging.Rules
+{
+    class ReferencesInNuspecMatchRefAssetsRule : IPackageRule
+    {
+        private string _addToRefFormat = AnalysisResources.ReferencesInNuspecAndRefFilesDontMatchWarningAddToRefListItemFormat;
+        private string _addToNuspecFormat = AnalysisResources.ReferencesInNuspecAndRefFilesDontMatchWarningAddToNuspecListItemFormat;
+        public string MessageFormat => AnalysisResources.ReferencesInNuspecAndRefFilesDontMatchWarning;
+
+        public IEnumerable<PackagingLogMessage> Validate(PackageArchiveReader builder)
+        {
+            var refFiles = builder.GetFiles().Where(t => t.StartsWith(PackagingConstants.Folders.Ref));
+            var nuspecReferences = GetReferencesFromNuspec(builder.GetNuspec());
+            var missingItems = Compare(nuspecReferences, refFiles);
+            return GenerateWarnings(missingItems);
+        }
+
+        internal IDictionary<string, string[]> GetReferencesFromNuspec(Stream nuspecStream)
+        {
+            var nuspecReferences = new Dictionary<string, string[]>();
+            var packageNuspec = new NuspecReader(nuspecStream);
+            var nuspec = packageNuspec.Xml;
+            if (nuspec != null)
+            {
+                XNamespace name = nuspec.Root.Name.Namespace;
+                var keys = nuspec.Descendants(XName.Get("{" + name.NamespaceName + "}references")).Elements().Attributes("targetFramework");
+                var shortName = keys.Select(t => NuGetFramework.Parse(t.Value).GetShortFolderName());
+                nuspecReferences = shortName.Zip(keys.Select(t => t.Parent.Elements().Attributes("file").Select(m => m.Value)), (tfm, refFiles) => new { tfm, refFiles = refFiles.ToArray() })
+                    .ToDictionary(val => val.tfm, val => val.refFiles);
+            }
+            return nuspecReferences;
+        }
+
+        internal IEnumerable<MissingReference> Compare(IDictionary<string, string[]> nuspecReferences, IEnumerable<string> refFiles)
+        {
+            var filesByTFM = refFiles.Where(t => t.Count(m => m == '/') > 1).GroupBy(t => NuGetFramework.ParseFolder(t.Split('/')[1]).GetShortFolderName(), t => GetFile(t));
+            var missingItems = new List<MissingReference>();
+
+            foreach (var files in filesByTFM)
+            {
+                if(files.Key == "unsupported")
+                {
+                    continue;
+                }
+
+                var missingFiles = Array.Empty<string>();
+                var missingReferences = Array.Empty<string>();    
+                if (nuspecReferences.TryGetValue(files.Key, out var currentReferences))
+                {
+                    missingReferences = files.Where(m => !currentReferences.Contains(m)).ToArray();
+                    missingFiles = currentReferences.Where(t => !files.Contains(t)).ToArray();
+                }
+                else
+                {
+                    missingReferences = files.ToArray();
+                }
+
+                if (missingFiles.Length != 0)
+                {
+                    missingItems.Add(new MissingReference("ref", files.Key, missingFiles));
+                }
+
+                if (missingReferences.Length != 0)
+                {
+                    missingItems.Add(new MissingReference("nuspec", files.Key, missingReferences));
+                }
+            }
+            return missingItems;
+        }
+
+        internal IEnumerable<PackagingLogMessage> GenerateWarnings(IEnumerable<MissingReference> missingItems)
+        {
+            var issues = new List<PackagingLogMessage>();
+            if (missingItems.Count() != 0)
+            {
+                var message = new StringBuilder();
+                message.AppendLine(MessageFormat);
+                var referencesMissing = missingItems.Where(t => t.MissingFrom == "nuspec");
+                var refFilesMissing = missingItems.Where(t => t.MissingFrom == "ref");
+                foreach (var file in refFilesMissing)
+                {
+                    foreach(var item in file.MissingItems)
+                    {
+                        message.AppendLine(string.Format(_addToRefFormat, item, file.TFM));
+                    }
+                }
+
+                foreach (var reference in referencesMissing)
+                {
+                    foreach (var item in reference.MissingItems)
+                    {
+                        message.AppendLine(string.Format(_addToNuspecFormat, item, reference.TFM));
+                    }
+                }
+                issues.Add(PackagingLogMessage.CreateWarning(message.ToString(), NuGetLogCode.NU5131));
+            }
+            return issues;
+        }
+
+        private string GetFile(string filePath)
+        {
+            return filePath.Split('/')[filePath.Count(p => p == '/')];
+        }
+
+
+        internal class MissingReference
+        {
+            public string MissingFrom { get; }
+
+            public string TFM { get; }
+
+            public string[] MissingItems { get; }
+
+            public MissingReference(string missingFrom, string tfm, string[] missingItems)
+            {
+                MissingFrom = missingFrom;
+                TFM = tfm;
+                MissingItems = missingItems;
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Rules/ReferencesInNuspecMatchRefAssetsRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/ReferencesInNuspecMatchRefAssetsRule.cs
@@ -43,8 +43,10 @@ namespace NuGet.Packaging.Rules
             {
                 XNamespace name = nuspec.Root.Name.Namespace;
                 var targetFrameworks = nuspec.Descendants(XName.Get("{" + name.NamespaceName + "}references")).Elements().Attributes("targetFramework");
-                nuspecReferences = targetFrameworks.ToDictionary(k => NuGetFramework.Parse(k.Value).GetShortFolderName(), k => k.Parent.Elements().Attributes("file").Select(f => f.Value));
-                var filesWithoutTFM = nuspec.Descendants(XName.Get("{" + name.NamespaceName + "}references")).Elements().Attributes("file").Select(f => f.Value);
+                nuspecReferences = targetFrameworks.ToDictionary(k => NuGetFramework.Parse(k.Value).GetShortFolderName(),
+                                                                k => k.Parent.Elements().Attributes("file").Select(f => f.Value));
+                var filesWithoutTFM = nuspec.Descendants(XName.Get("{" + name.NamespaceName + "}references"))
+                    .Elements().Attributes("file").Select(f => f.Value);
                 nuspecReferences.Add("any", filesWithoutTFM);
             }
             return nuspecReferences;
@@ -57,8 +59,12 @@ namespace NuGet.Packaging.Rules
             {
                 if (refFiles.Count() != 0)
                 {
-                    var filesByTFM = refFiles.Where(t => t.Count(m => m == '/') > 1).GroupBy(t => NuGetFramework.ParseFolder(t.Split('/')[1]).GetShortFolderName(), t => Path.GetFileName(t));
-                    var missingSubfolderInFiles = nuspecReferences.Keys.Where(t => !GetAllKeys(filesByTFM).Contains(t) && !NuGetFramework.ParseFolder(t).GetShortFolderName().Equals("unsupported") && !NuGetFramework.ParseFolder(t).GetShortFolderName().Equals("any"));
+                    var filesByTFM = refFiles.Where(t => t.Count(m => m == '/') > 1)
+                        .GroupBy(t => NuGetFramework.ParseFolder(t.Split('/')[1]).GetShortFolderName(), t => Path.GetFileName(t));
+                    var keys = GetAllKeys(filesByTFM);
+                    var missingSubfolderInFiles = nuspecReferences.Keys.Where(t => !keys.Contains(t) &&
+                    !NuGetFramework.ParseFolder(t).GetShortFolderName().Equals("unsupported") &&
+                    !NuGetFramework.ParseFolder(t).GetShortFolderName().Equals("any"));
                     if (missingSubfolderInFiles.Count() != 0)
                     {
                         var subfolder = nuspecReferences.Where(t => missingSubfolderInFiles.Contains(t.Key));
@@ -78,7 +84,8 @@ namespace NuGet.Packaging.Rules
                         string[] missingNuspecReferences;
                         string[] missingFiles;
                         IEnumerable<string> anyReferences = null;
-                        if (nuspecReferences.TryGetValue(files.Key, out var currentReferences) || nuspecReferences.TryGetValue("any", out anyReferences))
+                        if (nuspecReferences.TryGetValue(files.Key, out var currentReferences) ||
+                            nuspecReferences.TryGetValue("any", out anyReferences))
                         {
                             if (anyReferences != null && currentReferences == null)
                             {

--- a/src/NuGet.Core/NuGet.Packaging/Rules/RuleSet.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/RuleSet.cs
@@ -30,6 +30,7 @@ namespace NuGet.Packaging.Rules
                 new NoRefOrLibFolderInPackageRule(AnalysisResources.NoRefOrLibFolderInPackage),
                 new DependenciesGroupsForEachTFMRule(),
                 new UpholdBuildConventionRule(),
+                new ReferencesInNuspecMatchRefAssetsRule(),
             }
         );
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ReferencesInNuspecMatchRefAssetsRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ReferencesInNuspecMatchRefAssetsRuleTests.cs
@@ -3,12 +3,14 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 using NuGet.Common;
 using NuGet.Packaging.Rules;
 using Xunit;
+using static NuGet.Packaging.Rules.ReferencesInNuspecMatchRefAssetsRule;
 
 namespace NuGet.Packaging.Test
 {
@@ -18,10 +20,29 @@ namespace NuGet.Packaging.Test
         public void Compare_PackageWithReferencesAndRefFolderMatching_ShouldBeEmpty()
         {
             //Arrange
-            var references = new Dictionary<string, string[]>
+            var references = new Dictionary<string, IEnumerable<string>>
             {
-                {"net462", new string[] {"MyLib.dll", "MyHelpers.dll"} }
+                {"net462", new List<string>() {"MyLib.dll", "MyHelpers.dll"} }
             };
+            var files = new string[]
+            {
+                "ref/net462/MyLib.dll",
+                "ref/net462/MyHelpers.dll"
+            };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingItems = rule.Compare(references, files);
+
+            //Assert
+            Assert.Empty(missingItems);
+        }
+
+        [Fact]
+        public void Compare_PackageWithNoReferences_ShouldBeEmpty()
+        {
+            //Arrange
+            var references = new Dictionary<string, IEnumerable<string>>();
             var files = new string[]
             {
                 "ref/net462/MyLib.dll",
@@ -40,9 +61,9 @@ namespace NuGet.Packaging.Test
         public void Compare_PackageWithReferencesThatTheRefFolderDoesNotHave_RefFilesMissingShouldNotBeEmpty()
         {
             //Arrange
-            var references = new Dictionary<string, string[]>
+            var references = new Dictionary<string, IEnumerable<string>>
             {
-                {"net462", new string[] {"MyLib.dll", "MyHelpers.dll"} }
+                {"net462", new List<string>() {"MyLib.dll", "MyHelpers.dll"} }
             };
             var files = new string[]
             {
@@ -55,16 +76,19 @@ namespace NuGet.Packaging.Test
 
             //Assert
             Assert.Equal(missingItems.Count(), 1);
-            var singleIssue = missingItems.Single(t => t.TFM.Equals("net462") && t.MissingItems.Contains("MyHelpers.dll"));
+            var singleIssue = missingItems.Single(t => t.Tfm.Equals("net462") && t.MissingItems.Contains("MyHelpers.dll"));
+            Assert.Equal("net462", missingItems.First().Tfm);
+            Assert.Equal(1, missingItems.First().MissingItems.Count());
+            Assert.Equal("MyHelpers.dll", missingItems.First().MissingItems[0]);
         }
 
         [Fact]
         public void Compare_PackageWithRefAssetsThatTheNuspecDoesNotHave_ShouldHaveOneMissingItem()
         {
             //Arrange
-            var references = new Dictionary<string, string[]>
+            var references = new Dictionary<string, IEnumerable<string>>
             {
-                {"net462", new string[] {"MyLib.dll"} }
+                {"net462", new List<string>() {"MyLib.dll"} }
             };
             var files = new string[]
             {
@@ -78,14 +102,17 @@ namespace NuGet.Packaging.Test
 
             //Assert
             Assert.Equal(missingItems.Count(), 1);
-            var singleIssue = missingItems.Single(t => t.TFM.Equals("net462") && t.MissingItems.Contains("MyHelpers.dll"));
+            var singleIssue = missingItems.Single(t => t.Tfm.Equals("net462") && t.MissingItems.Contains("MyHelpers.dll"));
         }
 
         [Fact]
         public void Compare_PackageWithRefAssetsUnderRefFolder_ShouldBeEmpty()
         {
             //Arrange
-            var references = new Dictionary<string, string[]>();
+            var references = new Dictionary<string, IEnumerable<string>>()
+            {
+                {"net462", new List<string>() {"MyLib.dll", "MyHelpers.dll"} }
+            };
             var files = new string[]
             {
                 "ref/MyLib.dll",
@@ -104,7 +131,10 @@ namespace NuGet.Packaging.Test
         public void Compare_PackageWithAssetsUnderMiscellaneousFolders_ShouldBeEmpty()
         {
             //Arrange
-            var references = new Dictionary<string, string[]>();
+            var references = new Dictionary<string, IEnumerable<string>>()
+            {
+                { "MyCompany", new List<string>() {"MyLib.dll"} }
+            };
             var files = new string[]
             {
                 "ref/MyCompany/MyLib.dll",
@@ -123,10 +153,10 @@ namespace NuGet.Packaging.Test
         public void Compare_PackageWithMismatchedReferencesInMultipleSubFolders_ShouldHaveCorrectItems()
         {
             //Arrange
-            var references = new Dictionary<string, string[]>
+            var references = new Dictionary<string, IEnumerable<string>>
             {
-                {"net462", new string[] {"MyLib.dll", "MyHelpers.dll"} },
-                {"net472", new string[] { "MyLib.dll"} }
+                {"net462", new List<string>() {"MyLib.dll", "MyHelpers.dll"} },
+                {"net472", new List<string>() { "MyLib.dll"} }
             };
             var files = new string[]
             {
@@ -141,17 +171,46 @@ namespace NuGet.Packaging.Test
 
             //Assert
             Assert.Equal(missingItems.Count(), 2);
-            var singleRefFilesMissing = missingItems.Single(t => t.TFM == "net462" && t.MissingItems.Count() == 1 && t.MissingItems.Contains("MyHelpers.dll"));
-            var singleReferencesMissing = missingItems.Single(t => t.TFM == "net472" && t.MissingItems.Count() == 1 && t.MissingItems.Contains("MyHelpers.dll"));
+            var singleRefFilesMissing = missingItems.Single(t => t.MissingFrom.Equals("ref"));
+            var singleReferencesMissing = missingItems.Single(t => t.MissingFrom.Equals("nuspec"));
+            Assert.Equal("net462", singleRefFilesMissing.Tfm);
+            Assert.Equal(1, singleRefFilesMissing.MissingItems.Count());
+            Assert.Equal("MyHelpers.dll", singleRefFilesMissing.MissingItems[0]);
+            Assert.Equal("net472", singleReferencesMissing.Tfm);
+            Assert.Equal(1, singleReferencesMissing.MissingItems.Count());
+            Assert.Equal("MyHelpers.dll", singleReferencesMissing.MissingItems[0]);
         }
 
         [Fact]
-        public void GenerateWarnings_PackageWithMatchingAssetsAndReferences_ShouldNotWarn()
+        public void Compare_PackageHasReferencesWithNoRefFiles_ShouldContainCorrectFile()
         {
             //Arrange
-            var references = new Dictionary<string, string[]>
+            var references = new Dictionary<string, IEnumerable<string>>
             {
-                {"net462", new string[] {"MyLib.dll", "MyHelpers.dll"} }
+                {"net462", new List<string>() {"MyLib.dll"} }
+            };
+            var files = Array.Empty<string>();
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingItems = rule.Compare(references, files);
+
+            //Assert
+            Assert.Equal(missingItems.Count(), 1);
+            var singleIssue = missingItems.Single(t => t.Tfm.Equals("net462"));
+            Assert.Equal("net462", missingItems.First().Tfm);
+            Assert.Equal(1, missingItems.First().MissingItems.Count());
+            Assert.Equal("MyLib.dll", missingItems.First().MissingItems[0]);
+            Assert.Equal("ref", missingItems.First().MissingFrom);
+        }
+
+        [Fact]
+        public void Compare_PackageWithMatchingAssetsAndReferences_ShouldBeEmpty()
+        {
+            //Arrange
+            var references = new Dictionary<string, IEnumerable<string>>
+            {
+                {"net462", new List<string>() {"MyLib.dll", "MyHelpers.dll"} }
             };
             var files = new string[]
             {
@@ -162,35 +221,26 @@ namespace NuGet.Packaging.Test
             //Act
             var rule = new ReferencesInNuspecMatchRefAssetsRule();
             var missingItems = rule.Compare(references, files);
-            var issues = rule.GenerateWarnings(missingItems);
 
             //Assert
-            Assert.Empty(issues);
+            Assert.Empty(missingItems);
         }
 
         [Fact]
         public void GenerateWarnings_PackageWithReferencesMissingFromTheNuspec_ShouldWarn()
         {
-            //Arrange
-            var references = new Dictionary<string, string[]>
-            {
-                {"net462", new string[] {"MyLib.dll"} }
-            };
-            var files = new string[]
-            {
-                "ref/net462/MyLib.dll",
-                "ref/net462/MyHelpers.dll"
-            };
-
             //Act
             var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = rule.Compare(references, files);
+            var missingItems = new List<MissingReference>
+            {
+                new MissingReference("nuspec", "net462", new string[] { "MyHelpers.dll"})
+            };
             var issues = rule.GenerateWarnings(missingItems);
 
             //Assert
             Assert.Equal(issues.Count(), 1);
             var singleIssue = issues.Single(t => t.Code == NuGetLogCode.NU5131);
-            var expectedMessage = "References were found in the nuspec, but some were not found within the ref folder. Add the following reference assemblies:" + Environment.NewLine +
+            var expectedMessage = "References were found in the nuspec, but some reference assemblies were not found in both the nuspec and ref folder. Add the following reference assemblies:" + Environment.NewLine +
                 "- Add MyHelpers.dll to the net462 reference group in the nuspec" + Environment.NewLine;
             Assert.Equal(singleIssue.Message, expectedMessage);
         }
@@ -198,10 +248,86 @@ namespace NuGet.Packaging.Test
         [Fact]
         public void GenerateWarnings_PackageWithAssetsMissingFromTheRefFolder_ShouldWarn()
         {
-            //Arrange
-            var references = new Dictionary<string, string[]>
+            //Arrange & Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingItems = new List<MissingReference>
             {
-                {"net462", new string[] { "MyLib.dll", "MyHelpers.dll"} }
+                new MissingReference("ref", "net462", new string[] { "MyHelpers.dll"})
+            };
+            var issues = rule.GenerateWarnings(missingItems);
+
+            //Assert
+            Assert.Equal(issues.Count(), 1);
+            var singleIssue = issues.Single(t => t.Code == NuGetLogCode.NU5131);
+            var expectedMessage = "References were found in the nuspec, but some reference assemblies were not found in both the nuspec and ref folder. Add the following reference assemblies:" + Environment.NewLine +
+                "- Add MyHelpers.dll to the ref/net462/ directory" + Environment.NewLine;
+            Assert.Equal(singleIssue.Message, expectedMessage);
+        }
+
+        [Fact]
+        public void GenerateWarnings_PackageWithSubfoldersThatAreMismatched_ShouldWarn()
+        {
+            //Arrange & Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingItems = new List<MissingReference>
+            {
+                new MissingReference("ref", "net472", new string[] { "MyLib.dll"}),
+                new MissingReference("nuspec", "net462", new string[] { "MyHelpers.dll"})
+            };
+            var issues = rule.GenerateWarnings(missingItems);
+
+            //Assert
+            Assert.Equal(1 ,issues.Count());
+            var singleIssue = issues.Single(t => t.Code == NuGetLogCode.NU5131);
+            var expectedMessage = "References were found in the nuspec, but some reference assemblies were not found in both the nuspec and ref folder. Add the following reference assemblies:" + Environment.NewLine +
+                "- Add MyLib.dll to the ref/net472/ directory" + Environment.NewLine +
+                "- Add MyHelpers.dll to the net462 reference group in the nuspec" + Environment.NewLine;
+            Assert.Equal(singleIssue.Message, expectedMessage);
+        }
+
+        [Fact]
+        public void GenerateWarnings_PackageWithSubFoldersThatAreCorrect_ShouldNotWarn()
+        {
+            //Arrange & Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingItems = Array.Empty<MissingReference>();
+            var issues = rule.GenerateWarnings(missingItems);
+
+            //Assert
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Compare_NuspecHasFilesWithNoSpecificTfmWithMatchingRefFiles_ShouldBeEmpty()
+        {
+            //Arrange
+            var references = new Dictionary<string, IEnumerable<string>>
+            {
+                {"any", new List<string>() { "MyLib.dll", "MyHelpers.dll"} }
+            };
+            var files = new string[]
+            {
+                "ref/net462/MyLib.dll",
+                "ref/net462/MyHelpers.dll",
+                "ref/net472/MyLib.dll",
+                "ref/net472/MyHelpers.dll"
+            };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingItems = rule.Compare(references, files);
+
+            //Assert
+            Assert.Empty(missingItems);
+        }
+
+        [Fact]
+        public void GenerateWarnings_NuspecHasFilesWithNoSpecificTfmWithMissingRefFiles_ShouldWarnOnce()
+        {
+            //Arrange
+            var references = new Dictionary<string, IEnumerable<string>>
+            {
+                {"any", new List<string>() { "MyLib.dll", "MyHelpers.dll"} }
             };
             var files = new string[]
             {
@@ -216,25 +342,23 @@ namespace NuGet.Packaging.Test
             //Assert
             Assert.Equal(issues.Count(), 1);
             var singleIssue = issues.Single(t => t.Code == NuGetLogCode.NU5131);
-            var expectedMessage = "References were found in the nuspec, but some were not found within the ref folder. Add the following reference assemblies:" + Environment.NewLine +
+            var expectedMessage = "References were found in the nuspec, but some reference assemblies were not found in both the nuspec and ref folder. Add the following reference assemblies:" + Environment.NewLine +
                 "- Add MyHelpers.dll to the ref/net462/ directory" + Environment.NewLine;
             Assert.Equal(singleIssue.Message, expectedMessage);
         }
 
         [Fact]
-        public void GenerateWarnings_PackageWithSubfoldersThatAreMismatched_ShouldWarn()
+        public void GenerateWarnings_NuspecHasFilesWithNoSpecificTfmWithMissingReferences_ShouldWarn()
         {
             //Arrange
-            var references = new Dictionary<string, string[]>
+            var references = new Dictionary<string, IEnumerable<string>>
             {
-                {"net462", new string[] { "MyLib.dll", } },
-                {"net472", new string[] { "MyLib.dll", "MyHelpers.dll"} }
+                {"any", new List<string>() { "MyLib.dll",} }
             };
             var files = new string[]
             {
                 "ref/net462/MyLib.dll",
                 "ref/net462/MyHelpers.dll",
-                "ref/net472/MyHelpers.dll"
             };
 
             //Act
@@ -243,38 +367,11 @@ namespace NuGet.Packaging.Test
             var issues = rule.GenerateWarnings(missingItems);
 
             //Assert
-            Assert.Equal(1 ,issues.Count());
+            Assert.Equal(issues.Count(), 1);
             var singleIssue = issues.Single(t => t.Code == NuGetLogCode.NU5131);
-            var expectedMessage = "References were found in the nuspec, but some were not found within the ref folder. Add the following reference assemblies:" + Environment.NewLine +
-                "- Add MyLib.dll to the ref/net472/ directory" + Environment.NewLine +
+            var expectedMessage = "References were found in the nuspec, but some reference assemblies were not found in both the nuspec and ref folder. Add the following reference assemblies:" + Environment.NewLine +
                 "- Add MyHelpers.dll to the net462 reference group in the nuspec" + Environment.NewLine;
             Assert.Equal(singleIssue.Message, expectedMessage);
-        }
-
-        [Fact]
-        public void GenerateWarnings_PackageWithSubFoldersThatAreCorrect_ShouldNotWarn()
-        {
-            //Arrange
-            var references = new Dictionary<string, string[]>
-            {
-                {"net462", new string[] { "MyLib.dll", "MyHelpers.dll"} },
-                {"net472", new string[] { "MyLib.dll", "MyHelpers.dll"} }
-            };
-            var files = new string[]
-            {
-                "ref/net462/MyLib.dll",
-                "ref/net462/MyHelpers.dll",
-                "ref/net472/MyLib.dll",
-                "ref/net472/MyHelpers.dll"
-            };
-
-            //Act
-            var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = rule.Compare(references, files);
-            var issues = rule.GenerateWarnings(missingItems);
-
-            //Assert
-            Assert.Empty(issues);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ReferencesInNuspecMatchRefAssetsRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ReferencesInNuspecMatchRefAssetsRuleTests.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
+using NuGet.Common;
+using NuGet.Packaging.Rules;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class ReferencesInNuspecMatchRefAssetsRuleTests
+    {
+        [Fact]
+        public void Compare_PackageWithReferencesAndRefFolderMatching_ShouldBeEmpty()
+        {
+            //Arrange
+            var references = new Dictionary<string, string[]>
+            {
+                {"net462", new string[] {"MyLib.dll", "MyHelpers.dll"} }
+            };
+            var files = new string[]
+            {
+                "ref/net462/MyLib.dll",
+                "ref/net462/MyHelpers.dll"
+            };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingItems = rule.Compare(references, files);
+
+            //Assert
+            Assert.Empty(missingItems);
+        }
+
+        [Fact]
+        public void Compare_PackageWithReferencesThatTheRefFolderDoesNotHave_RefFilesMissingShouldNotBeEmpty()
+        {
+            //Arrange
+            var references = new Dictionary<string, string[]>
+            {
+                {"net462", new string[] {"MyLib.dll", "MyHelpers.dll"} }
+            };
+            var files = new string[]
+            {
+                "ref/net462/MyLib.dll",
+            };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingItems = rule.Compare(references, files);
+
+            //Assert
+            Assert.Equal(missingItems.Count(), 1);
+            var singleIssue = missingItems.Single(t => t.TFM.Equals("net462") && t.MissingItems.Contains("MyHelpers.dll"));
+        }
+
+        [Fact]
+        public void Compare_PackageWithRefAssetsThatTheNuspecDoesNotHave_ShouldHaveOneMissingItem()
+        {
+            //Arrange
+            var references = new Dictionary<string, string[]>
+            {
+                {"net462", new string[] {"MyLib.dll"} }
+            };
+            var files = new string[]
+            {
+                "ref/net462/MyLib.dll",
+                "ref/net462/MyHelpers.dll"
+            };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingItems = rule.Compare(references, files);
+
+            //Assert
+            Assert.Equal(missingItems.Count(), 1);
+            var singleIssue = missingItems.Single(t => t.TFM.Equals("net462") && t.MissingItems.Contains("MyHelpers.dll"));
+        }
+
+        [Fact]
+        public void Compare_PackageWithRefAssetsUnderRefFolder_ShouldBeEmpty()
+        {
+            //Arrange
+            var references = new Dictionary<string, string[]>();
+            var files = new string[]
+            {
+                "ref/MyLib.dll",
+                "ref/MyHelpers.dll"
+            };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingItems = rule.Compare(references, files);
+
+            //Assert
+            Assert.Empty(missingItems);
+        }
+
+        [Fact]
+        public void Compare_PackageWithAssetsUnderMiscellaneousFolders_ShouldBeEmpty()
+        {
+            //Arrange
+            var references = new Dictionary<string, string[]>();
+            var files = new string[]
+            {
+                "ref/MyCompany/MyLib.dll",
+                "ref/MyCompany/MyHelpers.dll"
+            };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingItems = rule.Compare(references, files);
+
+            //Assert
+            Assert.Empty(missingItems);
+        }
+
+        [Fact]
+        public void Compare_PackageWithMismatchedReferencesInMultipleSubFolders_ShouldHaveCorrectItems()
+        {
+            //Arrange
+            var references = new Dictionary<string, string[]>
+            {
+                {"net462", new string[] {"MyLib.dll", "MyHelpers.dll"} },
+                {"net472", new string[] { "MyLib.dll"} }
+            };
+            var files = new string[]
+            {
+                "ref/net462/MyLib.dll",
+                "ref/net472/MyLib.dll",
+                "ref/net472/MyHelpers.dll"
+            };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingItems = rule.Compare(references, files);
+
+            //Assert
+            Assert.Equal(missingItems.Count(), 2);
+            var singleRefFilesMissing = missingItems.Single(t => t.TFM == "net462" && t.MissingItems.Count() == 1 && t.MissingItems.Contains("MyHelpers.dll"));
+            var singleReferencesMissing = missingItems.Single(t => t.TFM == "net472" && t.MissingItems.Count() == 1 && t.MissingItems.Contains("MyHelpers.dll"));
+        }
+
+        [Fact]
+        public void GenerateWarnings_PackageWithMatchingAssetsAndReferences_ShouldNotWarn()
+        {
+            //Arrange
+            var references = new Dictionary<string, string[]>
+            {
+                {"net462", new string[] {"MyLib.dll", "MyHelpers.dll"} }
+            };
+            var files = new string[]
+            {
+                "ref/net462/MyLib.dll",
+                "ref/net462/MyHelpers.dll"
+            };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingItems = rule.Compare(references, files);
+            var issues = rule.GenerateWarnings(missingItems);
+
+            //Assert
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void GenerateWarnings_PackageWithReferencesMissingFromTheNuspec_ShouldWarn()
+        {
+            //Arrange
+            var references = new Dictionary<string, string[]>
+            {
+                {"net462", new string[] {"MyLib.dll"} }
+            };
+            var files = new string[]
+            {
+                "ref/net462/MyLib.dll",
+                "ref/net462/MyHelpers.dll"
+            };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingItems = rule.Compare(references, files);
+            var issues = rule.GenerateWarnings(missingItems);
+
+            //Assert
+            Assert.Equal(issues.Count(), 1);
+            var singleIssue = issues.Single(t => t.Code == NuGetLogCode.NU5131);
+            var expectedMessage = "References were found in the nuspec, but some were not found within the ref folder. Add the following reference assemblies:" + Environment.NewLine +
+                "- Add MyHelpers.dll to the net462 reference group in the nuspec" + Environment.NewLine;
+            Assert.Equal(singleIssue.Message, expectedMessage);
+        }
+
+        [Fact]
+        public void GenerateWarnings_PackageWithAssetsMissingFromTheRefFolder_ShouldWarn()
+        {
+            //Arrange
+            var references = new Dictionary<string, string[]>
+            {
+                {"net462", new string[] { "MyLib.dll", "MyHelpers.dll"} }
+            };
+            var files = new string[]
+            {
+                "ref/net462/MyLib.dll"
+            };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingItems = rule.Compare(references, files);
+            var issues = rule.GenerateWarnings(missingItems);
+
+            //Assert
+            Assert.Equal(issues.Count(), 1);
+            var singleIssue = issues.Single(t => t.Code == NuGetLogCode.NU5131);
+            var expectedMessage = "References were found in the nuspec, but some were not found within the ref folder. Add the following reference assemblies:" + Environment.NewLine +
+                "- Add MyHelpers.dll to the ref/net462/ directory" + Environment.NewLine;
+            Assert.Equal(singleIssue.Message, expectedMessage);
+        }
+
+        [Fact]
+        public void GenerateWarnings_PackageWithSubfoldersThatAreMismatched_ShouldWarn()
+        {
+            //Arrange
+            var references = new Dictionary<string, string[]>
+            {
+                {"net462", new string[] { "MyLib.dll", } },
+                {"net472", new string[] { "MyLib.dll", "MyHelpers.dll"} }
+            };
+            var files = new string[]
+            {
+                "ref/net462/MyLib.dll",
+                "ref/net462/MyHelpers.dll",
+                "ref/net472/MyHelpers.dll"
+            };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingItems = rule.Compare(references, files);
+            var issues = rule.GenerateWarnings(missingItems);
+
+            //Assert
+            Assert.Equal(1 ,issues.Count());
+            var singleIssue = issues.Single(t => t.Code == NuGetLogCode.NU5131);
+            var expectedMessage = "References were found in the nuspec, but some were not found within the ref folder. Add the following reference assemblies:" + Environment.NewLine +
+                "- Add MyLib.dll to the ref/net472/ directory" + Environment.NewLine +
+                "- Add MyHelpers.dll to the net462 reference group in the nuspec" + Environment.NewLine;
+            Assert.Equal(singleIssue.Message, expectedMessage);
+        }
+
+        [Fact]
+        public void GenerateWarnings_PackageWithSubFoldersThatAreCorrect_ShouldNotWarn()
+        {
+            //Arrange
+            var references = new Dictionary<string, string[]>
+            {
+                {"net462", new string[] { "MyLib.dll", "MyHelpers.dll"} },
+                {"net472", new string[] { "MyLib.dll", "MyHelpers.dll"} }
+            };
+            var files = new string[]
+            {
+                "ref/net462/MyLib.dll",
+                "ref/net462/MyHelpers.dll",
+                "ref/net472/MyLib.dll",
+                "ref/net472/MyHelpers.dll"
+            };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingItems = rule.Compare(references, files);
+            var issues = rule.GenerateWarnings(missingItems);
+
+            //Assert
+            Assert.Empty(issues);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ReferencesInNuspecMatchRefAssetsRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ReferencesInNuspecMatchRefAssetsRuleTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -22,7 +25,7 @@ namespace NuGet.Packaging.Test
             //Arrange
             var references = new Dictionary<string, IEnumerable<string>>
             {
-                {"net462", new List<string>() {"MyLib.dll", "MyHelpers.dll"} }
+                { "net462", new List<string>() { "MyLib.dll", "MyHelpers.dll" } }
             };
             var files = new string[]
             {
@@ -32,10 +35,10 @@ namespace NuGet.Packaging.Test
 
             //Act
             var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = rule.Compare(references, files);
+            var missingReferences = rule.Compare(references, files);
 
             //Assert
-            Assert.Empty(missingItems);
+            Assert.Empty(missingReferences);
         }
 
         [Fact]
@@ -51,10 +54,10 @@ namespace NuGet.Packaging.Test
 
             //Act
             var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = rule.Compare(references, files);
+            var missingReferences = rule.Compare(references, files);
 
             //Assert
-            Assert.Empty(missingItems);
+            Assert.Empty(missingReferences);
         }
 
         [Fact]
@@ -63,7 +66,7 @@ namespace NuGet.Packaging.Test
             //Arrange
             var references = new Dictionary<string, IEnumerable<string>>
             {
-                {"net462", new List<string>() {"MyLib.dll", "MyHelpers.dll"} }
+                { "net462", new List<string>() { "MyLib.dll", "MyHelpers.dll" } }
             };
             var files = new string[]
             {
@@ -72,14 +75,14 @@ namespace NuGet.Packaging.Test
 
             //Act
             var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = rule.Compare(references, files);
+            var missingReferences = rule.Compare(references, files);
 
             //Assert
-            Assert.Equal(missingItems.Count(), 1);
-            var singleIssue = missingItems.Single(t => t.Tfm.Equals("net462") && t.MissingItems.Contains("MyHelpers.dll"));
-            Assert.Equal("net462", missingItems.First().Tfm);
-            Assert.Equal(1, missingItems.First().MissingItems.Count());
-            Assert.Equal("MyHelpers.dll", missingItems.First().MissingItems[0]);
+            Assert.Equal(missingReferences.Count(), 1);
+            var singleIssue = missingReferences.Single(t => t.Tfm.Equals("net462") && t.MissingItems.Contains("MyHelpers.dll"));
+            Assert.Equal("net462", missingReferences.First().Tfm);
+            Assert.Equal(1, missingReferences.First().MissingItems.Count());
+            Assert.Equal("MyHelpers.dll", missingReferences.First().MissingItems[0]);
         }
 
         [Fact]
@@ -88,7 +91,7 @@ namespace NuGet.Packaging.Test
             //Arrange
             var references = new Dictionary<string, IEnumerable<string>>
             {
-                {"net462", new List<string>() {"MyLib.dll"} }
+                { "net462", new List<string>() { "MyLib.dll" } }
             };
             var files = new string[]
             {
@@ -98,11 +101,11 @@ namespace NuGet.Packaging.Test
 
             //Act
             var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = rule.Compare(references, files);
+            var missingReferences = rule.Compare(references, files);
 
             //Assert
-            Assert.Equal(missingItems.Count(), 1);
-            var singleIssue = missingItems.Single(t => t.Tfm.Equals("net462") && t.MissingItems.Contains("MyHelpers.dll"));
+            Assert.Equal(missingReferences.Count(), 1);
+            var singleIssue = missingReferences.Single(t => t.Tfm.Equals("net462") && t.MissingItems.Contains("MyHelpers.dll"));
         }
 
         [Fact]
@@ -111,7 +114,7 @@ namespace NuGet.Packaging.Test
             //Arrange
             var references = new Dictionary<string, IEnumerable<string>>()
             {
-                {"net462", new List<string>() {"MyLib.dll", "MyHelpers.dll"} }
+                { "net462", new List<string>() { "MyLib.dll", "MyHelpers.dll" } }
             };
             var files = new string[]
             {
@@ -121,10 +124,15 @@ namespace NuGet.Packaging.Test
 
             //Act
             var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = rule.Compare(references, files);
+            var missingReferences = rule.Compare(references, files);
 
             //Assert
-            Assert.Empty(missingItems);
+            Assert.Equal(missingReferences.Count(), 1);
+            var singleIssue = missingReferences.Single(t => t.MissingFrom.Equals("ref"));
+            Assert.Equal("net462", missingReferences.First().Tfm);
+            Assert.Equal(2, missingReferences.First().MissingItems.Count());
+            Assert.True(missingReferences.First().MissingItems.Contains("MyLib.dll"));
+            Assert.True(missingReferences.First().MissingItems.Contains("MyHelpers.dll"));
         }
 
         [Fact]
@@ -133,7 +141,7 @@ namespace NuGet.Packaging.Test
             //Arrange
             var references = new Dictionary<string, IEnumerable<string>>()
             {
-                { "MyCompany", new List<string>() {"MyLib.dll"} }
+                { "MyCompany", new List<string>() { "MyLib.dll" } }
             };
             var files = new string[]
             {
@@ -143,10 +151,10 @@ namespace NuGet.Packaging.Test
 
             //Act
             var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = rule.Compare(references, files);
+            var missingReferences = rule.Compare(references, files);
 
             //Assert
-            Assert.Empty(missingItems);
+            Assert.Empty(missingReferences);
         }
 
         [Fact]
@@ -155,8 +163,8 @@ namespace NuGet.Packaging.Test
             //Arrange
             var references = new Dictionary<string, IEnumerable<string>>
             {
-                {"net462", new List<string>() {"MyLib.dll", "MyHelpers.dll"} },
-                {"net472", new List<string>() { "MyLib.dll"} }
+                { "net462", new List<string>() { "MyLib.dll", "MyHelpers.dll" } },
+                { "net472", new List<string>() { "MyLib.dll" } }
             };
             var files = new string[]
             {
@@ -167,15 +175,14 @@ namespace NuGet.Packaging.Test
 
             //Act
             var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = rule.Compare(references, files);
+            var missingReferences = rule.Compare(references, files);
 
             //Assert
-            Assert.Equal(missingItems.Count(), 2);
-            var singleRefFilesMissing = missingItems.Single(t => t.MissingFrom.Equals("ref"));
-            var singleReferencesMissing = missingItems.Single(t => t.MissingFrom.Equals("nuspec"));
+            Assert.Equal(missingReferences.Count(), 2);
+            var singleRefFilesMissing = missingReferences.Single(t => t.MissingFrom.Equals("ref"));
+            var singleReferencesMissing = missingReferences.Single(t => t.MissingFrom.Equals("nuspec"));
             Assert.Equal("net462", singleRefFilesMissing.Tfm);
             Assert.Equal(1, singleRefFilesMissing.MissingItems.Count());
-            Assert.Equal("MyHelpers.dll", singleRefFilesMissing.MissingItems[0]);
             Assert.Equal("net472", singleReferencesMissing.Tfm);
             Assert.Equal(1, singleReferencesMissing.MissingItems.Count());
             Assert.Equal("MyHelpers.dll", singleReferencesMissing.MissingItems[0]);
@@ -187,21 +194,21 @@ namespace NuGet.Packaging.Test
             //Arrange
             var references = new Dictionary<string, IEnumerable<string>>
             {
-                {"net462", new List<string>() {"MyLib.dll"} }
+                { "net462", new List<string>() { "MyLib.dll" } }
             };
             var files = Array.Empty<string>();
 
             //Act
             var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = rule.Compare(references, files);
+            var missingReferences = rule.Compare(references, files);
 
             //Assert
-            Assert.Equal(missingItems.Count(), 1);
-            var singleIssue = missingItems.Single(t => t.Tfm.Equals("net462"));
-            Assert.Equal("net462", missingItems.First().Tfm);
-            Assert.Equal(1, missingItems.First().MissingItems.Count());
-            Assert.Equal("MyLib.dll", missingItems.First().MissingItems[0]);
-            Assert.Equal("ref", missingItems.First().MissingFrom);
+            Assert.Equal(missingReferences.Count(), 1);
+            var singleIssue = missingReferences.Single(t => t.Tfm.Equals("net462"));
+            Assert.Equal("net462", missingReferences.First().Tfm);
+            Assert.Equal(1, missingReferences.First().MissingItems.Count());
+            Assert.Equal("MyLib.dll", missingReferences.First().MissingItems[0]);
+            Assert.Equal("ref", missingReferences.First().MissingFrom);
         }
 
         [Fact]
@@ -210,7 +217,7 @@ namespace NuGet.Packaging.Test
             //Arrange
             var references = new Dictionary<string, IEnumerable<string>>
             {
-                {"net462", new List<string>() {"MyLib.dll", "MyHelpers.dll"} }
+                { "net462", new List<string>() { "MyLib.dll", "MyHelpers.dll" } }
             };
             var files = new string[]
             {
@@ -220,22 +227,123 @@ namespace NuGet.Packaging.Test
 
             //Act
             var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = rule.Compare(references, files);
+            var missingReferences = rule.Compare(references, files);
 
             //Assert
-            Assert.Empty(missingItems);
+            Assert.Empty(missingReferences);
         }
 
+        [Fact]
+        public void Compare_NuspecHasFilesWithNoSpecificTfmWithMatchingRefFiles_ShouldBeEmpty()
+        {
+            //Arrange
+            var references = new Dictionary<string, IEnumerable<string>>
+            {
+                { "any", new List<string>() { "MyLib.dll", "MyHelpers.dll" } }
+            };
+            var files = new string[]
+            {
+                "ref/net462/MyLib.dll",
+                "ref/net462/MyHelpers.dll",
+                "ref/net472/MyLib.dll",
+                "ref/net472/MyHelpers.dll"
+            };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingReferences = rule.Compare(references, files);
+
+            //Assert
+            Assert.Empty(missingReferences);
+        }
+        
+        [Fact]
+        public void Compare_MissingSubFolderInNuspec_ShouldHaveSubFolder()
+        {
+            //Arrange
+            var references = new Dictionary<string, IEnumerable<string>>
+            {
+                { "net462", new List<string>() { "MyLib.dll", "MyHelpers.dll" } },
+                { "net472", new List<string>() { "MyLib.dll", "MyHelpers.dll" } }
+            };
+            var files = new string[]
+            {
+                "ref/net462/MyLib.dll",
+                "ref/net462/MyHelpers.dll",
+            };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingReferences = rule.Compare(references, files);
+
+            //Assert
+            Assert.Equal(missingReferences.Count(), 1);
+            var singleMissingReference = missingReferences.Single(t => t.MissingFrom.Equals("ref"));
+            Assert.Equal("net472", singleMissingReference.Tfm);
+            Assert.Equal(2, singleMissingReference.MissingItems.Count());
+            Assert.True(singleMissingReference.MissingItems.Contains("MyLib.dll"));
+            Assert.True(singleMissingReference.MissingItems.Contains("MyHelpers.dll"));
+        }
+        [Fact]
+        public void Compare_NuspecHasFilesWithNoSpecificTfmWithMissingRefFiles_ShouldWarnOnce()
+        {
+            //Arrange
+            var references = new Dictionary<string, IEnumerable<string>>
+            {
+                { "any", new List<string>() { "MyLib.dll", "MyHelpers.dll" } }
+            };
+            var files = new string[]
+            {
+                "ref/net462/MyLib.dll"
+            };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingReferences = rule.Compare(references, files);
+
+            //Assert
+            Assert.Equal(missingReferences.Count(), 1);
+            var singleMissingReference = missingReferences.Single(t => t.MissingFrom.Equals("ref"));
+            Assert.Equal("net462", singleMissingReference.Tfm);
+            Assert.Equal(1, singleMissingReference.MissingItems.Count());
+            Assert.True(singleMissingReference.MissingItems.Contains("MyHelpers.dll"));
+        }
+
+        [Fact]
+        public void Compare_NuspecHasFilesWithNoSpecificTfmWithMissingReferences_ShouldWarn()
+        {
+            //Arrange
+            var references = new Dictionary<string, IEnumerable<string>>
+            {
+                { "any", new List<string>() { "MyLib.dll",} }
+            };
+            var files = new string[]
+            {
+                "ref/net462/MyLib.dll",
+                "ref/net462/MyHelpers.dll",
+            };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingReferences = rule.Compare(references, files);
+
+            //Assert
+            Assert.Equal(missingReferences.Count(), 1);
+            var singleMissingReference = missingReferences.Single(t => t.MissingFrom.Equals("nuspec"));
+            Assert.Equal("net462", singleMissingReference.Tfm);
+            Assert.Equal(1, singleMissingReference.MissingItems.Count());
+            Assert.True(singleMissingReference.MissingItems.Contains("MyHelpers.dll"));
+        }
         [Fact]
         public void GenerateWarnings_PackageWithReferencesMissingFromTheNuspec_ShouldWarn()
         {
             //Act
             var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = new List<MissingReference>
+            var missingReferences = new List<MissingReference>
             {
-                new MissingReference("nuspec", "net462", new string[] { "MyHelpers.dll"})
+                new MissingReference("nuspec", "net462", new string[] { "MyHelpers.dll" })
             };
-            var issues = rule.GenerateWarnings(missingItems);
+            var issues = rule.GenerateWarnings(missingReferences);
 
             //Assert
             Assert.Equal(issues.Count(), 1);
@@ -250,11 +358,11 @@ namespace NuGet.Packaging.Test
         {
             //Arrange & Act
             var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = new List<MissingReference>
+            var missingReferences = new List<MissingReference>
             {
-                new MissingReference("ref", "net462", new string[] { "MyHelpers.dll"})
+                new MissingReference("ref", "net462", new string[] { "MyHelpers.dll" })
             };
-            var issues = rule.GenerateWarnings(missingItems);
+            var issues = rule.GenerateWarnings(missingReferences);
 
             //Assert
             Assert.Equal(issues.Count(), 1);
@@ -269,15 +377,15 @@ namespace NuGet.Packaging.Test
         {
             //Arrange & Act
             var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = new List<MissingReference>
+            var missingReferences = new List<MissingReference>
             {
-                new MissingReference("ref", "net472", new string[] { "MyLib.dll"}),
-                new MissingReference("nuspec", "net462", new string[] { "MyHelpers.dll"})
+                new MissingReference("ref", "net472", new string[] { "MyLib.dll" }),
+                new MissingReference("nuspec", "net462", new string[] { "MyHelpers.dll" })
             };
-            var issues = rule.GenerateWarnings(missingItems);
+            var issues = rule.GenerateWarnings(missingReferences);
 
             //Assert
-            Assert.Equal(1 ,issues.Count());
+            Assert.Equal(1, issues.Count());
             var singleIssue = issues.Single(t => t.Code == NuGetLogCode.NU5131);
             var expectedMessage = "References were found in the nuspec, but some reference assemblies were not found in both the nuspec and ref folder. Add the following reference assemblies:" + Environment.NewLine +
                 "- Add MyLib.dll to the ref/net472/ directory" + Environment.NewLine +
@@ -290,88 +398,11 @@ namespace NuGet.Packaging.Test
         {
             //Arrange & Act
             var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = Array.Empty<MissingReference>();
-            var issues = rule.GenerateWarnings(missingItems);
+            var missingReferences = Array.Empty<MissingReference>();
+            var issues = rule.GenerateWarnings(missingReferences);
 
             //Assert
             Assert.Empty(issues);
-        }
-
-        [Fact]
-        public void Compare_NuspecHasFilesWithNoSpecificTfmWithMatchingRefFiles_ShouldBeEmpty()
-        {
-            //Arrange
-            var references = new Dictionary<string, IEnumerable<string>>
-            {
-                {"any", new List<string>() { "MyLib.dll", "MyHelpers.dll"} }
-            };
-            var files = new string[]
-            {
-                "ref/net462/MyLib.dll",
-                "ref/net462/MyHelpers.dll",
-                "ref/net472/MyLib.dll",
-                "ref/net472/MyHelpers.dll"
-            };
-
-            //Act
-            var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = rule.Compare(references, files);
-
-            //Assert
-            Assert.Empty(missingItems);
-        }
-
-        [Fact]
-        public void GenerateWarnings_NuspecHasFilesWithNoSpecificTfmWithMissingRefFiles_ShouldWarnOnce()
-        {
-            //Arrange
-            var references = new Dictionary<string, IEnumerable<string>>
-            {
-                {"any", new List<string>() { "MyLib.dll", "MyHelpers.dll"} }
-            };
-            var files = new string[]
-            {
-                "ref/net462/MyLib.dll"
-            };
-
-            //Act
-            var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = rule.Compare(references, files);
-            var issues = rule.GenerateWarnings(missingItems);
-
-            //Assert
-            Assert.Equal(issues.Count(), 1);
-            var singleIssue = issues.Single(t => t.Code == NuGetLogCode.NU5131);
-            var expectedMessage = "References were found in the nuspec, but some reference assemblies were not found in both the nuspec and ref folder. Add the following reference assemblies:" + Environment.NewLine +
-                "- Add MyHelpers.dll to the ref/net462/ directory" + Environment.NewLine;
-            Assert.Equal(singleIssue.Message, expectedMessage);
-        }
-
-        [Fact]
-        public void GenerateWarnings_NuspecHasFilesWithNoSpecificTfmWithMissingReferences_ShouldWarn()
-        {
-            //Arrange
-            var references = new Dictionary<string, IEnumerable<string>>
-            {
-                {"any", new List<string>() { "MyLib.dll",} }
-            };
-            var files = new string[]
-            {
-                "ref/net462/MyLib.dll",
-                "ref/net462/MyHelpers.dll",
-            };
-
-            //Act
-            var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingItems = rule.Compare(references, files);
-            var issues = rule.GenerateWarnings(missingItems);
-
-            //Assert
-            Assert.Equal(issues.Count(), 1);
-            var singleIssue = issues.Single(t => t.Code == NuGetLogCode.NU5131);
-            var expectedMessage = "References were found in the nuspec, but some reference assemblies were not found in both the nuspec and ref folder. Add the following reference assemblies:" + Environment.NewLine +
-                "- Add MyHelpers.dll to the net462 reference group in the nuspec" + Environment.NewLine;
-            Assert.Equal(singleIssue.Message, expectedMessage);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ReferencesInNuspecMatchRefAssetsRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ReferencesInNuspecMatchRefAssetsRuleTests.cs
@@ -81,7 +81,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal(missingReferences.Count(), 1);
             var singleIssue = missingReferences.Single(t => t.Tfm.Equals("net462") && t.MissingItems.Contains("MyHelpers.dll"));
             Assert.Equal("net462", missingReferences.First().Tfm);
-            Assert.Equal(1, missingReferences.First().MissingItems.Count());
+            Assert.Equal(1, missingReferences.First().MissingItems.Length);
             Assert.Equal("MyHelpers.dll", missingReferences.First().MissingItems[0]);
         }
 
@@ -130,7 +130,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal(missingReferences.Count(), 1);
             var singleIssue = missingReferences.Single(t => t.MissingFrom.Equals("ref"));
             Assert.Equal("net462", missingReferences.First().Tfm);
-            Assert.Equal(2, missingReferences.First().MissingItems.Count());
+            Assert.Equal(2, missingReferences.First().MissingItems.Length);
             Assert.True(missingReferences.First().MissingItems.Contains("MyLib.dll"));
             Assert.True(missingReferences.First().MissingItems.Contains("MyHelpers.dll"));
         }
@@ -182,9 +182,9 @@ namespace NuGet.Packaging.Test
             var singleRefFilesMissing = missingReferences.Single(t => t.MissingFrom.Equals("ref"));
             var singleReferencesMissing = missingReferences.Single(t => t.MissingFrom.Equals("nuspec"));
             Assert.Equal("net462", singleRefFilesMissing.Tfm);
-            Assert.Equal(1, singleRefFilesMissing.MissingItems.Count());
+            Assert.Equal(1, singleRefFilesMissing.MissingItems.Length);
             Assert.Equal("net472", singleReferencesMissing.Tfm);
-            Assert.Equal(1, singleReferencesMissing.MissingItems.Count());
+            Assert.Equal(1, singleReferencesMissing.MissingItems.Length);
             Assert.Equal("MyHelpers.dll", singleReferencesMissing.MissingItems[0]);
         }
 
@@ -206,33 +206,11 @@ namespace NuGet.Packaging.Test
             Assert.Equal(missingReferences.Count(), 1);
             var singleIssue = missingReferences.Single(t => t.Tfm.Equals("net462"));
             Assert.Equal("net462", missingReferences.First().Tfm);
-            Assert.Equal(1, missingReferences.First().MissingItems.Count());
+            Assert.Equal(1, missingReferences.First().MissingItems.Length);
             Assert.Equal("MyLib.dll", missingReferences.First().MissingItems[0]);
             Assert.Equal("ref", missingReferences.First().MissingFrom);
         }
-
-        [Fact]
-        public void Compare_PackageWithMatchingAssetsAndReferences_ShouldBeEmpty()
-        {
-            //Arrange
-            var references = new Dictionary<string, IEnumerable<string>>
-            {
-                { "net462", new List<string>() { "MyLib.dll", "MyHelpers.dll" } }
-            };
-            var files = new string[]
-            {
-                "ref/net462/MyLib.dll",
-                "ref/net462/MyHelpers.dll"
-            };
-
-            //Act
-            var rule = new ReferencesInNuspecMatchRefAssetsRule();
-            var missingReferences = rule.Compare(references, files);
-
-            //Assert
-            Assert.Empty(missingReferences);
-        }
-
+    
         [Fact]
         public void Compare_NuspecHasFilesWithNoSpecificTfmWithMatchingRefFiles_ShouldBeEmpty()
         {
@@ -280,7 +258,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal(missingReferences.Count(), 1);
             var singleMissingReference = missingReferences.Single(t => t.MissingFrom.Equals("ref"));
             Assert.Equal("net472", singleMissingReference.Tfm);
-            Assert.Equal(2, singleMissingReference.MissingItems.Count());
+            Assert.Equal(2, singleMissingReference.MissingItems.Length);
             Assert.True(singleMissingReference.MissingItems.Contains("MyLib.dll"));
             Assert.True(singleMissingReference.MissingItems.Contains("MyHelpers.dll"));
         }
@@ -305,7 +283,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal(missingReferences.Count(), 1);
             var singleMissingReference = missingReferences.Single(t => t.MissingFrom.Equals("ref"));
             Assert.Equal("net462", singleMissingReference.Tfm);
-            Assert.Equal(1, singleMissingReference.MissingItems.Count());
+            Assert.Equal(1, singleMissingReference.MissingItems.Length);
             Assert.True(singleMissingReference.MissingItems.Contains("MyHelpers.dll"));
         }
 
@@ -331,7 +309,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal(missingReferences.Count(), 1);
             var singleMissingReference = missingReferences.Single(t => t.MissingFrom.Equals("nuspec"));
             Assert.Equal("net462", singleMissingReference.Tfm);
-            Assert.Equal(1, singleMissingReference.MissingItems.Count());
+            Assert.Equal(1, singleMissingReference.MissingItems.Length);
             Assert.True(singleMissingReference.MissingItems.Contains("MyHelpers.dll"));
         }
         [Fact]


### PR DESCRIPTION
## Bug

Fixes: [8296](https://github.com/NuGet/Home/issues/8296)
Regression: No   

## Fix

Details: Added validation rule to ensure reference groups in the nuspec match the files in the `ref/` folder

## Testing/Validation

Tests Added: Yes