### PR TITLE
OptProfV2:  use ProvideCodeBase on NuGet.VisualStudio.Implementation.dll

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
+++ b/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
@@ -111,6 +111,11 @@
       <Project>{eea49a74-6efc-410e-9745-bad367ac151d}</Project>
       <Name>NuGet.VisualStudio.Common</Name>
     </ProjectReference>
+    <!-- NuGet.VisualStudio.Implementation is referenced only to enable generation of .pkgdef entries via ProvideCodeBaseAttribute. -->
+    <ProjectReference Include="..\NuGet.VisualStudio.Implementation\NuGet.VisualStudio.Implementation.csproj">
+      <Project>{9623cf30-192c-4864-b419-29649169ae30}</Project>
+      <Name>NuGet.VisualStudio.Implementation</Name>
+    </ProjectReference>
     <!-- NuGet.VisualStudio.Interop is referenced only to enable generation of .pkgdef entries via ProvideCodeBaseAttribute. -->
     <ProjectReference Include="..\NuGet.VisualStudio.Interop\NuGet.VisualStudio.Interop.csproj">
       <Project>{7db43fe1-75e1-49f9-b2c8-06a552ba2144}</Project>

--- a/src/NuGet.Clients/NuGet.Tools/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Properties/AssemblyInfo.cs
@@ -34,6 +34,7 @@ using Microsoft.VisualStudio.Shell;
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.Versioning.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.Common.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.Implementation.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\NuGet.VisualStudio.Interop.dll")]
 
 #if SIGNED_BUILD


### PR DESCRIPTION
Progress on https://github.com/NuGet/Home/issues/8426.

NuGet.VisualStudio.Implementation.dll needs to be loaded via `ProvideCodeBase` attribute not `Assembly.Load*(…)` to support OptProfV2.

This is a follow-up to https://github.com/NuGet/NuGet.Client/pull/2863.