### PR TITLE
Add Copy button and shortcut to PreviewWindow

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PreviewWindowModel.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+using System.Windows.Input;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -11,6 +14,49 @@ namespace NuGet.PackageManagement.UI
 
         public string Title { get; private set; }
 
+        public InputGestureCollection CopyGestures;
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            foreach (var r in PreviewResults)
+            {
+                sb.AppendLine(r.Name);
+                sb.AppendLine("");
+                if (r.Deleted.Any())
+                {
+                    sb.AppendLine(Resources.Label_UninstalledPackages);
+                    sb.AppendLine("");
+                    foreach (var p in r.Deleted)
+                    {
+                        sb.AppendLine(p.ToString());
+                    }
+                    sb.AppendLine("");
+                }
+                if (r.Updated.Any())
+                {
+                    sb.AppendLine(Resources.Label_UpdatedPackages);
+                    sb.AppendLine("");
+                    foreach (var p in r.Updated)
+                    {
+                        sb.AppendLine(p.ToString());
+                    }
+                    sb.AppendLine("");
+                }
+                if (r.Added.Any())
+                {
+                    sb.AppendLine(Resources.Label_InstalledPackages);
+                    sb.AppendLine("");
+                    foreach (var p in r.Added)
+                    {
+                        sb.AppendLine(p.ToString());
+                    }
+                    sb.AppendLine("");
+                }
+            }
+            return sb.ToString();
+        }
+
         public int ButtonMinWidth => 86;
         public int DoNotShowAgainMinWidth => 180;
         public int WindowMinwidth => 2 * ButtonMinWidth + DoNotShowAgainMinWidth;
@@ -19,6 +65,7 @@ namespace NuGet.PackageManagement.UI
         {
             PreviewResults = results;
             Title = Resources.WindowTitle_PreviewChanges;
+            CopyGestures = ApplicationCommands.Copy.InputGestures;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -286,6 +286,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Copy.
+        /// </summary>
+        public static string Button_Copy {
+            get {
+                return ResourceManager.GetString("Button_Copy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Dismiss.
         /// </summary>
         public static string Button_Dismiss {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -279,6 +279,9 @@
   <data name="Button_Cancel" xml:space="preserve">
     <value>Cancel</value>
   </data>
+  <data name="Button_Copy" xml:space="preserve">
+    <value>Copy</value>
+  </data>
   <data name="Text_Loading" xml:space="preserve">
     <value>Loading...</value>
   </data>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml
@@ -22,7 +22,11 @@
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
   </Window.Resources>
-
+  <nuget:VsDialogWindow.CommandBindings>
+    <CommandBinding
+      Command="{x:Static ApplicationCommands.Copy}"
+      Executed="ExecuteCopyToClipboard" />
+  </nuget:VsDialogWindow.CommandBindings>
   <Grid>
     <Grid.RowDefinitions>
       <RowDefinition
@@ -31,14 +35,30 @@
       <RowDefinition
         Height="auto" />
     </Grid.RowDefinitions>
-    <TextBlock
+    <Grid
+      Grid.Row="0">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="auto" />
+        <ColumnDefinition Width="auto" />
+      </Grid.ColumnDefinitions>
+      <TextBlock
       Grid.Row="0"
+      Grid.Column="0"
       Margin="12,12,12,0"
       TextWrapping="Wrap"
       x:Name="_changesText"
       AutomationProperties.Name="{Binding Text}"
       Text="{x:Static nuget:Resources.Text_Changes}" />
-
+      <Button
+        Grid.Column="1"
+        MinWidth="{Binding ButtonMinWidth}"
+        MinHeight="24"
+        Margin="12"
+        AutomationProperties.AutomationId="Copy"
+        Content="{x:Static nuget:Resources.Button_Copy}"
+        Click="CopyButtonClicked" />
+    </Grid>
     <Border
       Grid.Row="1"
       Margin="12,12"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PreviewWindow.xaml.cs
@@ -1,13 +1,16 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Text;
 using System.Windows;
+using System.Linq;
 using NuGet.PackageManagement.VisualStudio;
+using System.Windows.Input;
 
 namespace NuGet.PackageManagement.UI
 {
     /// <summary>
-    /// Interaction logic for InstallPreviewWindow.xaml
+    /// Interaction logic for PreviewWindow.xaml
     /// </summary>
     public partial class PreviewWindow : VsDialogWindow
     {
@@ -20,7 +23,16 @@ namespace NuGet.PackageManagement.UI
             _uiContext = uiContext;
             InitializeComponent();
             _doNotShowCheckBox.IsChecked = IsDoNotShowPreviewWindowEnabled();
-
+            var copyBindings = ApplicationCommands.Copy.InputGestures;
+            foreach (KeyGesture gesture in copyBindings)
+            {
+                InputBindings.Add(
+                    new KeyBinding(
+                        ApplicationCommands.Copy,
+                        gesture
+                    )
+                );
+            }
             _initialized = true;
         }
 
@@ -34,8 +46,25 @@ namespace NuGet.PackageManagement.UI
             DialogResult = true;
         }
 
+        private void CopyToClipboard()
+        {
+            var windowModel = _changesItems.DataContext as PreviewWindowModel;
+            Clipboard.SetText(windowModel.ToString());
+        }
+
+        private void CopyButtonClicked(object sender, RoutedEventArgs e)
+        {
+            CopyToClipboard();
+        }
+
+        private void ExecuteCopyToClipboard(object sender, ExecutedRoutedEventArgs e)
+        {
+            CopyToClipboard();
+        }
+
         private void DoNotShowCheckBox_Checked(object sender, RoutedEventArgs e)
         {
+
             if (!_initialized)
             {
                 return;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/PreviewWindowModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/PreviewWindowModelTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.Protocol.Core.Types;
+using Xunit;
+
+namespace NuGet.PackageManagement.UI
+{
+    public class PreviewWindowModelTests
+    {
+        class MockProject : ProjectManagement.NuGetProject
+        {
+            public override Task<IEnumerable<PackageReference>> GetInstalledPackagesAsync(CancellationToken token)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task<bool> InstallPackageAsync(PackageIdentity packageIdentity, DownloadResourceResult downloadResourceResult, INuGetProjectContext nuGetProjectContext, CancellationToken token)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task<bool> UninstallPackageAsync(PackageIdentity packageIdentity, INuGetProjectContext nuGetProjectContext, CancellationToken token)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Fact]
+        public void PreviewWindowModelToString_Test()
+        {
+            var added = new List<PackageIdentity>();
+            var deleted = new List<PackageIdentity>();
+            var updated = new List<UpdatePreviewResult>();
+
+            added.Add(new PackageIdentity("PkgA", new Versioning.NuGetVersion("1.2.3")));
+            deleted.Add(new PackageIdentity("PkgB", new Versioning.NuGetVersion("3.2.1")));
+            updated.Add(new UpdatePreviewResult(
+                new PackageIdentity("PkgC", new Versioning.NuGetVersion("1.0.0")),
+                new PackageIdentity("PkgC", new Versioning.NuGetVersion("2.0.0"))
+            ));
+
+            var ProjA = new MockProject();
+            var previewResult = new PreviewResult(ProjA, added, deleted, updated);
+            var allResults = new List<PreviewResult>();
+            allResults.Add(previewResult);
+            var model = new PreviewWindowModel(allResults);
+
+            var sb = new StringBuilder();
+            sb.AppendLine("Unknown Project");
+            sb.AppendLine();
+            sb.AppendLine(Resources.Label_UninstalledPackages);
+            sb.AppendLine();
+            foreach (var p in deleted)
+            {
+                sb.AppendLine(p.ToString());
+            }
+            sb.AppendLine();
+            sb.AppendLine(Resources.Label_UpdatedPackages);
+            sb.AppendLine();
+            foreach (var p in updated)
+            {
+                sb.AppendLine(p.ToString());
+            }
+            sb.AppendLine();
+            sb.AppendLine(Resources.Label_InstalledPackages);
+            sb.AppendLine();
+            foreach (var p in added)
+            {
+                sb.AppendLine(p.ToString());
+            }
+            sb.AppendLine();
+
+            Assert.Equal(sb.ToString(), model.ToString());
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
@@ -29,6 +29,7 @@
     <Compile Include="Converters\VersionToStringConverterTests.cs" />
     <Compile Include="ConverterTests.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Models\PreviewWindowModelTests.cs" />
     <Compile Include="Models\DetailedPackageMetadataTests.cs" />
     <Compile Include="PackageItemLoaderTests.cs" />
     <Compile Include="PackageLicenseUtilitiesTests.cs" />


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8324 
Regression: No

## Fix

Details: This PR adds a copy button to the updater UI as a shortcut to copy details about the update.


Sample text after clicking "Copy":
<details>
<pre>
QuickTest

Uninstalling:

Microsoft.Win32.Registry.4.0.0
System.Collections.Immutable.1.2.0
System.Collections.NonGeneric.4.0.1
System.Collections.Specialized.4.0.1
System.ComponentModel.4.0.1
System.ComponentModel.EventBasedAsync.4.0.11
System.ComponentModel.Primitives.4.1.0
System.ComponentModel.TypeConverter.4.1.0
System.Diagnostics.Process.4.1.0
System.Private.DataContractSerialization.4.1.1
System.Reflection.Metadata.1.3.0
System.Runtime.Loader.4.0.0
System.Runtime.Serialization.Json.4.0.2
System.Threading.Thread.4.0.0
System.Threading.ThreadPool.4.0.10
System.Xml.XmlDocument.4.0.1
System.Xml.XmlSerializer.4.0.11
System.Xml.XPath.4.0.1
System.Xml.XPath.XmlDocument.4.0.1

Updates:

Microsoft.CodeCoverage.16.2.0 -> Microsoft.CodeCoverage.16.3.0-preview-20190808-03
Microsoft.NET.Test.Sdk.16.2.0 -> Microsoft.NET.Test.Sdk.16.3.0-preview-20190808-03
Microsoft.TestPlatform.ObjectModel.16.2.0 -> Microsoft.TestPlatform.ObjectModel.16.3.0-preview-20190808-03
Microsoft.TestPlatform.TestHost.16.2.0 -> Microsoft.TestPlatform.TestHost.16.3.0-preview-20190808-03
MSTest.TestAdapter.1.4.0 -> MSTest.TestAdapter.2.0.0-beta4
MSTest.TestFramework.1.4.0 -> MSTest.TestFramework.2.0.0-beta4

</pre>
</details>

Screenshot:
![SharedScreenshot](https://user-images.githubusercontent.com/17535/62965684-69e9af80-bdba-11e9-960f-a8fc9c6c586b.jpg)

## Testing/Validation

Tests Added: Yes  
Validation:  
