### PR TITLE
Use Microsoft.SourceLink.GitHub for SourceLink

### DIFF
--- a/build/common.legacy.props
+++ b/build/common.legacy.props
@@ -4,7 +4,7 @@
     <IsNetCoreProject>false</IsNetCoreProject>
   </PropertyGroup>
   <ItemGroup Condition="'$(Shipping)' == 'true' AND '$(IsXPlat)' != 'true'">
-    <PackageReference Include="PdbGit" Version="3.0.41" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>
   </ItemGroup>
   
   <!-- Load config -->

--- a/build/common.legacy.props
+++ b/build/common.legacy.props
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <IsNetCoreProject>false</IsNetCoreProject>
   </PropertyGroup>
-  <ItemGroup Condition="'$(Shipping)' == 'true' AND '$(IsXPlat)' != 'true'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>
-  </ItemGroup>
   
   <!-- Load config -->
   <Import Project="config.props" />

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -276,5 +276,10 @@
    <ApexProjects Include="$(RepositoryRootDirectory)test\NuGet.Tests.Apex\*\*.csproj" />
   </ItemGroup>
 
+  <!-- source link -->
+  <ItemGroup Condition="'$(Shipping)' == 'true' AND '$(IsXPlat)' != 'true'">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>
+  </ItemGroup>
+
   <Import Project="OptProfV2.props"/>
 </Project>

--- a/build/common.props
+++ b/build/common.props
@@ -4,9 +4,6 @@
     <IsNetCoreProject>true</IsNetCoreProject>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(Shipping)' == 'true' AND '$(IsXPlat)' != 'true'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>
-  </ItemGroup>
   <!-- When building on non-Windows machines, we need the reference assemblies to build full-framework assemblies. -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND '$(DotNetBuildFromSource)' == 'true'">
      <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-alpha-5" PrivateAssets="All" />

--- a/build/common.props
+++ b/build/common.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(Shipping)' == 'true' AND '$(IsXPlat)' != 'true'">
-    <PackageReference Include="PdbGit" Version="3.0.41" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>
   </ItemGroup>
   <!-- When building on non-Windows machines, we need the reference assemblies to build full-framework assemblies. -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND '$(DotNetBuildFromSource)' == 'true'">


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8449
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Use Microsoft's SourceLink package instead of PDBGit.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  no code changes.
Validation:  

Opening a nupkg in NuGet Package Explorer after running `build.ps1` I see this:

![image](https://user-images.githubusercontent.com/5030577/62912237-22244300-bd3c-11e9-869c-627fc55c8b4b.png)

For comparison, using PDBGit, we don't get the commit hash.

@cristinamanum how can I verify that the pdb itself has the "right stuff"?