### PR TITLE
Fix empty sequence bug in dotnet list package

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -436,7 +436,7 @@ namespace NuGet.CommandLine.XPlat
                 {
                     var matchingPackage = packagesVersionsDict.Where(p => p.Key.Equals(topLevelPackage.Name, StringComparison.OrdinalIgnoreCase)).First();
 
-                    if (!listPackageArgs.IncludeDeprecated)
+                    if (!listPackageArgs.IncludeDeprecated && matchingPackage.Value.Count > 0)
                     {
                         var latestVersion = matchingPackage.Value.Where(newVersion => MeetsConstraints(newVersion.Identity.Version, topLevelPackage, listPackageArgs)).Max(i => i.Identity.Version);
 
@@ -459,7 +459,7 @@ namespace NuGet.CommandLine.XPlat
                 {
                     var matchingPackage = packagesVersionsDict.Where(p => p.Key.Equals(transitivePackage.Name, StringComparison.OrdinalIgnoreCase)).First();
 
-                    if (!listPackageArgs.IncludeDeprecated)
+                    if (!listPackageArgs.IncludeDeprecated && matchingPackage.Value.Count > 0)
                     {
                         var latestVersion = matchingPackage.Value.Where(newVersion => MeetsConstraints(newVersion.Identity.Version, transitivePackage, listPackageArgs)).Max(i => i.Identity.Version);
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -34,7 +34,18 @@ namespace NuGet.CommandLine.XPlat
         public static int MainInternal(string[] args, CommandOutputLogger log)
         {
 #if DEBUG
-            MSBuildLocator.RegisterDefaults();
+            try
+            {
+                // .NET JIT compiles one method at a time. If this method calls `MSBuildLocator` directly, the
+                // try block is never entered if Microsoft.Build.Locator.dll can't be found. So, run it in a
+                // lambda function to ensure we're in the try block. C# IIFE!
+                ((Action)(() => MSBuildLocator.RegisterDefaults()))();
+            }
+            catch
+            {
+                // MSBuildLocator is used only to enable Visual Studio debugging.
+                // It's not needed when using a patched dotnet sdk, so it doesn't matter if it fails.
+            }
 
             var debugNuGetXPlat = Environment.GetEnvironmentVariable("DEBUG_NUGET_XPLAT");
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -379,7 +380,7 @@ namespace Dotnet.Integration.Test
 
                 foreach (var nupkg in Directory.EnumerateDirectories(pathContext.PackageSource))
                 {
-                    Directory.Delete(nupkg, true);
+                    Directory.Delete(nupkg, recursive: true);
                 }
 
                 // Act
@@ -387,15 +388,7 @@ namespace Dotnet.Integration.Test
                     $"list {projectA.ProjectPath} package --outdated");
 
                 // Assert
-                var lines = new List<string>();
-                using (var stringReader = new StringReader(listResult.AllOutput))
-                {
-                    string line;
-                    while ((line = stringReader.ReadLine())!= null)
-                    {
-                        lines.Add(line);
-                    }
-                }
+                var lines = listResult.AllOutput.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
                 Assert.True(lines.Any(l => l.Contains("packageX") && l.Contains("Not found at the sources")), "Line containing 'packageX' and 'Not found at the sources' not found: " + listResult.AllOutput);
             }
         }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using NuGet.Packaging;
@@ -299,6 +301,102 @@ namespace Dotnet.Integration.Test
 
                 Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, $"packageX{currentVersion}{currentVersion}{expectedVersion}"));
 
+            }
+        }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(true, true)]
+        public void DotnetListPackage_ProjectReference_Succeeds(bool includeTransitive, bool outdated)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, "net46");
+                var projectB = XPlatTestUtils.CreateProject("ProjectB", pathContext, "net46");
+
+                var addResult = _fixture.RunDotnet(Directory.GetParent(projectA.ProjectPath).FullName,
+                    $"add {projectA.ProjectPath} reference {projectB.ProjectPath}");
+                Assert.True(addResult.Success);
+
+                var restoreResult = _fixture.RunDotnet(Directory.GetParent(projectA.ProjectPath).FullName,
+                    $"restore {projectA.ProjectName}.csproj");
+                Assert.True(restoreResult.Success);
+
+                var argsBuilder = new StringBuilder();
+                if (includeTransitive)
+                {
+                    argsBuilder.Append(" --include-transitive");
+                }
+                if (outdated)
+                {
+                    argsBuilder.Append(" --outdated");
+                }
+
+                // Act
+                var listResult = _fixture.RunDotnet(Directory.GetParent(projectA.ProjectPath).FullName,
+                    $"list {projectA.ProjectPath} package {argsBuilder}");
+
+                // Assert
+                if (outdated)
+                {
+                    Assert.Contains("The given project `ProjectA` has no updates given the current sources.", listResult.AllOutput);
+                }
+                else if (includeTransitive)
+                {
+                    Assert.Contains("ProjectB", listResult.AllOutput);
+                }
+                else
+                {
+                    Assert.Contains("No packages were found for this framework.", listResult.AllOutput);
+                }
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task DotnetListPackage_OutdatedWithNoVersionsFound_Succeeds()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, "net46");
+                var packageX = XPlatTestUtils.CreatePackage(packageId: "packageX", packageVersion: "1.0.0");
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                        pathContext.PackageSource,
+                        PackageSaveMode.Defaultv3,
+                        packageX);
+
+                var addResult = _fixture.RunDotnet(Directory.GetParent(projectA.ProjectPath).FullName,
+                    $"add {projectA.ProjectPath} package packageX --version 1.0.0 --no-restore");
+                Assert.True(addResult.Success);
+
+                var restoreResult = _fixture.RunDotnet(Directory.GetParent(projectA.ProjectPath).FullName,
+                    $"restore {projectA.ProjectName}.csproj");
+                Assert.True(restoreResult.Success);
+
+                foreach (var nupkg in Directory.EnumerateDirectories(pathContext.PackageSource))
+                {
+                    Directory.Delete(nupkg, true);
+                }
+
+                // Act
+                var listResult = _fixture.RunDotnet(Directory.GetParent(projectA.ProjectPath).FullName,
+                    $"list {projectA.ProjectPath} package --outdated");
+
+                // Assert
+                var lines = new List<string>();
+                using (var stringReader = new StringReader(listResult.AllOutput))
+                {
+                    string line;
+                    while ((line = stringReader.ReadLine())!= null)
+                    {
+                        lines.Add(line);
+                    }
+                }
+                Assert.True(lines.Any(l => l.Contains("packageX") && l.Contains("Not found at the sources")), "Line containing 'packageX' and 'Not found at the sources' not found: " + listResult.AllOutput);
             }
         }
 


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8434
Regression: No
* Last working version:   
* How are we preventing it in future:  Added tests for the two cases it caused problems; project references and when no source contains any versions of a package.

## Fix

Details: Skip trying to find the highest version when there are no versions.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
