### PR TITLE
Change default symbol package to snupkg

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -38,7 +38,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ContentTargetFolders Condition="'$(ContentTargetFolders)' == ''">content;contentFiles</ContentTargetFolders>
     <PackDependsOn>$(BeforePack); _IntermediatePack; GenerateNuspec; $(PackDependsOn)</PackDependsOn>
     <IsInnerBuild Condition="'$(TargetFramework)' != '' AND '$(TargetFrameworks)' != ''">true</IsInnerBuild>
-    <SymbolPackageFormat Condition="'$(SymbolPackageFormat)' == ''">symbols.nupkg</SymbolPackageFormat>
+    <SymbolPackageFormat Condition="'$(SymbolPackageFormat)' == ''">snupkg</SymbolPackageFormat>
     <AddPriFileDependsOn Condition="'$(MicrosoftPortableCurrentVersionPropsHasBeenImported)' == 'true'">DeterminePortableBuildCapabilities</AddPriFileDependsOn>
     <NuspecOutputPath Condition="'$(NuspecOutputPath)' == ''">$(BaseIntermediateOutputPath)$(Configuration)\</NuspecOutputPath>
     <WarnOnPackingNonPackableProject Condition="'$(WarnOnPackingNonPackableProject)' == ''">false</WarnOnPackingNonPackableProject>

--- a/src/NuGet.Core/NuGet.Commands/CommandArgs/PackArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandArgs/PackArgs.cs
@@ -27,7 +27,7 @@ namespace NuGet.Commands
         public bool InstallPackageToOutputPath { get; set; }
         public IMachineWideSettings MachineWideSettings { get; set; }
         public Version MinClientVersion { get; set; }
-        public SymbolPackageFormat SymbolPackageFormat { get; set; } = SymbolPackageFormat.SymbolsNupkg;
+        public SymbolPackageFormat SymbolPackageFormat { get; set; } = SymbolPackageFormat.Snupkg;
         public Lazy<string> MsBuildDirectory { get; set; }
         public bool NoDefaultExcludes { get; set; }
         public bool NoPackageAnalysis { get; set; }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -404,6 +404,53 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        public void PackCommand_SymbolPackageDefaultFormat()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var workingDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "lib", "uap10.0"),
+                    "packageA.dll",
+                    string.Empty);
+
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "lib", "uap10.0"),
+                    "packageA.pdb",
+                    string.Empty);
+
+                Util.CreateFile(
+                    workingDirectory,
+                    "packageA.nuspec",
+@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
+  <metadata>
+    <id>packageA</id>
+    <version>1.0.0</version>
+    <title>packageA</title>
+    <authors>test</authors>
+    <owners>test</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Description</description>
+    <copyright>Copyright ©  2013</copyright>
+  </metadata>
+</package>");
+
+                // Act
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingDirectory,
+                    "pack packageA.nuspec -symbols",
+                    waitForExit: true);
+                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+
+                // Assert
+                var symbolPath = Path.Combine(workingDirectory, "packageA.1.0.0.snupkg");
+                Assert.True(File.Exists(symbolPath), symbolPath + " does not exist");
+        }
+
+        [Fact]
         public void PackCommand_SymbolPackageWithNuspecFile()
         {
             var nugetexe = Util.GetNuGetExePath();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -448,6 +448,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 var symbolPath = Path.Combine(workingDirectory, "packageA.1.0.0.snupkg");
                 Assert.True(File.Exists(symbolPath), symbolPath + " does not exist");
+            }
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -75,6 +75,23 @@ namespace Dotnet.Integration.Test
         }
 
         [PlatformFact(Platform.Windows)]
+        public void PackCommand_PackNewDefaultProject_DefaultSymbolsPackageFormat()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                // Act
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                msbuildFixture.PackProject(workingDirectory, projectName, $"--include-symbols -o {workingDirectory}");
+
+                var symbolPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.snupkg");
+                Assert.True(File.Exists(symbolPath), "The output .snupkg is not in the expected place");
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
         public void PackCommand_PackNewDefaultProject_IncludeSymbolsWithSnupkg()
         {
             using (var testDirectory = TestDirectory.Create())

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -186,7 +186,7 @@ namespace Dotnet.Integration.Test
                 }
 
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
-                var args = includeSymbols ? $"-o {workingDirectory} --include-symbols" : $"-o {workingDirectory}";
+                var args = includeSymbols ? $"-o {workingDirectory} --include-symbols -p:SymbolPackageFormat=symbols.nupkg" : $"-o {workingDirectory}";
                 msbuildFixture.PackProject(workingDirectory, projectName, args);
 
                 var nupkgPath = includeSymbols
@@ -2016,7 +2016,7 @@ namespace ClassLibrary
 
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
                 msbuildFixture.PackProject(workingDirectory, projectName,
-                    $"--include-source /p:PackageOutputPath={workingDirectory}");
+                    $"--include-source -p:PackageOutputPath={workingDirectory} -p:SymbolPackageFormat=symbols.nupkg");
 
                 var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
                 var symbolsNupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.symbols.nupkg");

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -87,7 +87,6 @@ namespace NuGet.Build.Tasks.Pack.Test
                         OutputDirectory = directory,
                         Path = nuspecPath,
                         Exclude = Array.Empty<string>(),
-                        Symbols = true,
                         Logger = NullLogger.Instance
                     },
                     MSBuildProjectFactory.ProjectCreator,

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/DefaultManifestValuesRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/DefaultManifestValuesRuleTests.cs
@@ -50,7 +50,6 @@ urlMetadata +
                         OutputDirectory = testDirectory,
                         Path = nuspecPath,
                         Exclude = Array.Empty<string>(),
-                        Symbols = true,
                         Logger = NullLogger.Instance
                     },
                     MSBuildProjectFactory.ProjectCreator,
@@ -108,7 +107,6 @@ urlMetadata +
                         OutputDirectory = testDirectory,
                         Path = nuspecPath,
                         Exclude = Array.Empty<string>(),
-                        Symbols = true,
                         Logger = NullLogger.Instance
                     },
                     MSBuildProjectFactory.ProjectCreator,

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/InvalidFrameworkFolderRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/InvalidFrameworkFolderRuleTests.cs
@@ -53,7 +53,6 @@ namespace NuGet.Packaging.Test
                         OutputDirectory = testDirectory,
                         Path = nuspecPath,
                         Exclude = Array.Empty<string>(),
-                        Symbols = true,
                         Logger = NullLogger.Instance
                     },
                     MSBuildProjectFactory.ProjectCreator,
@@ -115,7 +114,6 @@ namespace NuGet.Packaging.Test
                         OutputDirectory = testDirectory,
                         Path = nuspecPath,
                         Exclude = Array.Empty<string>(),
-                        Symbols = true,
                         Logger = NullLogger.Instance
                     },
                     MSBuildProjectFactory.ProjectCreator,


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#7815
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Change default symbols package format to snupkg

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
