### PR TITLE
Test:  skip flaky test NetCoreTransitivePackageReferenceLimitAsync

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -197,7 +197,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [NuGetWpfTheory]
+        [NuGetWpfTheory(Skip = "https://github.com/NuGet/Home/issues/8469")]
         [MemberData(nameof(GetNetCoreTemplates))]
         public async Task NetCoreTransitivePackageReferenceLimitAsync(ProjectTemplate projectTemplate)
         {


### PR DESCRIPTION
Progress on https://github.com/NuGet/Home/issues/8469.