### PR TITLE
Match dotnet CLI message when combining outdated and deprecated args

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -610,7 +610,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid command. Combining the &apos;--outdated&apos; and &apos;--deprecated&apos; options is not supported..
+        ///   Looks up a localized string similar to Option &apos;--outdated&apos; and &apos;--deprecated&apos; cannot be combined..
         /// </summary>
         internal static string ListPkg_InvalidOptionsOutdatedAndDeprecated {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -574,7 +574,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <value>The following sources were used:</value>
   </data>
   <data name="ListPkg_InvalidOptionsOutdatedAndDeprecated" xml:space="preserve">
-    <value>Invalid command. Combining the '--outdated' and '--deprecated' options is not supported.</value>
+    <value>Option '--outdated' and '--deprecated' cannot be combined.</value>
   </data>
   <data name="ListPkg_NoDeprecatedPackagesForProject" xml:space="preserve">
     <value>The given project `{0}` has no deprecated packages given the current sources.</value>


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8454
Regression: No 

## Fix

Details: Changed message wording to match dotnet CLI message. 