### PR TITLE
Warn that symbol package format will change in future release

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
@@ -140,6 +140,11 @@ namespace NuGet.CommandLine
             {
                 packArgs.SymbolPackageFormat = PackArgs.GetSymbolPackageFormat(SymbolPackageFormat);
             }
+            else if (Symbols)
+            {
+                packArgs.Logger.Log(LogMessage.CreateWarning(NuGetLogCode.NU5132, LocalizedResourceManager.GetString("PackageCommandDefaultSymbolPackageFormatChanging")));
+            }
+
             packArgs.Deterministic = Deterministic;
             packArgs.Build = Build;
             packArgs.Exclude = Exclude;

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -7342,6 +7342,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The default symbols package format will change to snupkg in an upcoming version. Use SymbolPackageFormat to keep using symbols.nupkg..
+        /// </summary>
+        public static string PackageCommandDefaultSymbolPackageFormatChanging {
+            get {
+                return ResourceManager.GetString("PackageCommandDefaultSymbolPackageFormatChanging", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to File from dependency is changed. Adding file &apos;{0}&apos;..
         /// </summary>
         public static string PackageCommandFileFromDependencyIsChanged {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6182,4 +6182,8 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
     <comment>Do not localize project.json and `PackageReference` 
 0 - project path (project.json file path)</comment>
   </data>
+  <data name="PackageCommandDefaultSymbolPackageFormatChanging" xml:space="preserve">
+    <value>The default symbols package format will change to snupkg in an upcoming version. Use SymbolPackageFormat to keep using symbols.nupkg.</value>
+    <comment>Please don't localize snupkg, SymbolPackageFormat, or symbols.nupkg.</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/DefaultSymbolsPackageFormatChangingWarningTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/DefaultSymbolsPackageFormatChangingWarningTask.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Globalization;
+using Microsoft.Build.Utilities;
+using NuGet.Common;
+
+namespace NuGet.Build.Tasks.Pack
+{
+    public class DefaultSymbolsPackageFormatChangingWarningTask : Task
+    {
+        public ILogger Logger => new MSBuildLogger(Log);
+
+        public override bool Execute()
+        {
+            Logger.Log(LogMessage.CreateWarning(NuGetLogCode.NU5132,
+                string.Format(CultureInfo.CurrentCulture, Strings.DefaultSymbolsPackageFormatChanging)));
+            return true;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -22,6 +22,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="NuGet.Build.Tasks.GetProjectTargetFrameworksTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.Pack.GetProjectReferencesFromAssetsFileTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.Pack.IsPackableFalseWarningTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
+  <UsingTask TaskName="NuGet.Build.Tasks.Pack.DefaultSymbolsPackageFormatChangingWarningTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
 
   <PropertyGroup>
     <PackageId Condition=" '$(PackageId)' == '' ">$(AssemblyName)</PackageId>
@@ -38,6 +39,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ContentTargetFolders Condition="'$(ContentTargetFolders)' == ''">content;contentFiles</ContentTargetFolders>
     <PackDependsOn>$(BeforePack); _IntermediatePack; GenerateNuspec; $(PackDependsOn)</PackDependsOn>
     <IsInnerBuild Condition="'$(TargetFramework)' != '' AND '$(TargetFrameworks)' != ''">true</IsInnerBuild>
+    <_UsingDefaultSymbolPackageFormat Condition="'$(SymbolPackageFormat)' == ''">true</_UsingDefaultSymbolPackageFormat>
     <SymbolPackageFormat Condition="'$(SymbolPackageFormat)' == ''">symbols.nupkg</SymbolPackageFormat>
     <AddPriFileDependsOn Condition="'$(MicrosoftPortableCurrentVersionPropsHasBeenImported)' == 'true'">DeterminePortableBuildCapabilities</AddPriFileDependsOn>
     <NuspecOutputPath Condition="'$(NuspecOutputPath)' == ''">$(BaseIntermediateOutputPath)$(Configuration)\</NuspecOutputPath>
@@ -184,7 +186,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="Pack" DependsOnTargets="$(PackDependsOn)">
-     <IsPackableFalseWarningTask Condition="'$(IsPackable)' == 'false' AND '$(WarnOnPackingNonPackableProject)' == 'true'"/>
+    <IsPackableFalseWarningTask Condition="'$(IsPackable)' == 'false' AND '$(WarnOnPackingNonPackableProject)' == 'true'"/>
+    <DefaultSymbolsPackageFormatChangingWarningTask Condition=" '$(_UsingDefaultSymbolPackageFormat)' == 'true' AND '$(IncludeSymbols)' == 'true' " />
   </Target>
   <Target Name="_IntermediatePack">
     <PropertyGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/Strings.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace NuGet.Build.Tasks.Pack {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace NuGet.Build.Tasks.Pack {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -40,7 +39,7 @@ namespace NuGet.Build.Tasks.Pack {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.Build.Tasks.Pack.Strings", typeof(Strings).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.Build.Tasks.Pack.Strings", typeof(Strings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -76,6 +75,15 @@ namespace NuGet.Build.Tasks.Pack {
         internal static string AssetsFileNotFound {
             get {
                 return ResourceManager.GetString("AssetsFileNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The default symbols package format will change to snupkg in an upcoming version. Use SymbolPackageFormat to keep using symbols.nupkg..
+        /// </summary>
+        internal static string DefaultSymbolsPackageFormatChanging {
+            get {
+                return ResourceManager.GetString("DefaultSymbolsPackageFormatChanging", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/Strings.resx
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/Strings.resx
@@ -125,6 +125,10 @@
     <value>The assets file produced by restore does not exist. Try restoring the project again. The expected location of the assets file is {0}.</value>
     <comment>{0} is the path to the assets file.</comment>
   </data>
+  <data name="DefaultSymbolsPackageFormatChanging" xml:space="preserve">
+    <value>The default symbols package format will change to snupkg in an upcoming version. Use SymbolPackageFormat to keep using symbols.nupkg.</value>
+    <comment>Please don't localize snupkg, SymbolPackageFormat, or symbols.nupkg.</comment>
+  </data>
   <data name="Error_FileNotFound" xml:space="preserve">
     <value>The file '{0}' to be packed was not found on disk.</value>
     <comment>{0} is the file being packed.</comment>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -806,6 +806,11 @@ namespace NuGet.Common
         NU5131 = 5131,
 
         /// <summary>
+        /// Default symbols package format changing
+        /// </summary>
+        NU5132 = 5132,
+
+        /// <summary>
         /// Undefined package warning
         /// </summary>
         NU5500 = 5500,


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8473
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Warn when packing and symbols are requested, but a symbol package format was not specified. 

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
