### PR TITLE
switch to new feed for CPS packages, per breaking change notice

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -7,7 +7,7 @@
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <add key="dotnet-roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
-    <add key="cps" value="https://vside.myget.org/F/devcore/api/v3/index.json" />
+    <add key="cps" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
     <add key="dotnet-msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
   </packageSources>
   <disabledPackageSources>


### PR DESCRIPTION
## Bug

Fixes: Adapt to moving package feed for CPS ( https://github.com/NuGet/Home/issues/8474)
Regression: No  
* Last working version:   n/a
* How are we preventing it in future:   n/a

## Fix

Details: Change feed per the CPS team breaking change email.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  No tests needed for package feed changes.
Validation:  dev build (dev-rrelyea-fixCpsFeed)

@zivkan @nkolev92 @zkat @donnie-msft @heng-liu @dominoFire @dtivel 
