### PR TITLE
stop spurious warning when packing with no refs

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Rules/ReferencesInNuspecMatchRefAssetsRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/ReferencesInNuspecMatchRefAssetsRule.cs
@@ -119,7 +119,11 @@ namespace NuGet.Packaging.Rules
                 {
                     foreach (var item in nuspecReferences)
                     {
-                        missingReferences.Add(new MissingReference("ref", item.Key, item.Value.ToArray()));
+                        var refs = item.Value.ToArray();
+                        if (refs.Length != 0)
+                        {
+                            missingReferences.Add(new MissingReference("ref", item.Key, refs));
+                        }
                     }
                 }
             }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ReferencesInNuspecMatchRefAssetsRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ReferencesInNuspecMatchRefAssetsRuleTests.cs
@@ -42,6 +42,24 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
+        public void Compare_EmptyNuspecReferences_ShouldBeEmpty()
+        {
+            //Arrange
+            var references = new Dictionary<string, IEnumerable<string>>
+            {
+                { "any", new List<string>() }
+            };
+            var files = new string[] { };
+
+            //Act
+            var rule = new ReferencesInNuspecMatchRefAssetsRule();
+            var missingReferences = rule.Compare(references, files);
+
+            //Assert
+            Assert.Empty(missingReferences);
+        }
+
+        [Fact]
         public void Compare_PackageWithNoReferences_ShouldBeEmpty()
         {
             //Arrange


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/8467

## Bug

Fixes: https://github.com/NuGet/Home/issues/8467
Regression: Yes  
* Last working version: pre-5.3  
* How are we preventing it in future:   Unit test added

## Fix

Details: This `else` case was adding missing refs even when there were no refs involved. The hole should be plugged now, if I understood what was happening.

## Testing/Validation

Tests Added: Yes

