### PR TITLE
VS:  mark select NuGet assemblies for ngen

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -112,40 +112,76 @@
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Common\NuGet.Common.csproj">
       <Project>{98bee375-a5a0-4fc2-9b7a-25db41c8045d}</Project>
       <Name>NuGet.Common</Name>
+      <Ngen>True</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Configuration\NuGet.Configuration.csproj">
       <Project>{e3ef26e1-80a7-4573-b3a4-1d4b0042616e}</Project>
       <Name>NuGet.Configuration</Name>
+      <Ngen>True</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.DependencyResolver.Core\NuGet.DependencyResolver.Core.csproj">
       <Project>{cf8e1753-ee98-410f-bb4b-6624b19c6b64}</Project>
       <Name>NuGet.DependencyResolver.Core</Name>
+      <Ngen>True</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Frameworks\NuGet.Frameworks.csproj">
       <Project>{9a9a9f26-597a-4fa6-a4f1-415063484d9c}</Project>
       <Name>NuGet.Frameworks</Name>
+      <Ngen>True</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.LibraryModel\NuGet.LibraryModel.csproj">
       <Project>{13883e8e-7de1-4edd-8e4a-c5357ba8cd81}</Project>
       <Name>NuGet.LibraryModel</Name>
+      <Ngen>True</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.PackageManagement\NuGet.PackageManagement.csproj">
       <Project>{394aeb96-493c-4839-a5ac-8d93cd2fad40}</Project>
       <Name>NuGet.PackageManagement</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>True</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Packaging\NuGet.Packaging.csproj">
       <Project>{bd6bbc90-60be-4e7d-8458-91e9cda66abe}</Project>
       <Name>NuGet.Packaging</Name>
+      <Ngen>True</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.ProjectModel\NuGet.ProjectModel.csproj">
       <Project>{f013e43f-b6d5-4f59-acf0-eecec2c794f5}</Project>
       <Name>NuGet.ProjectModel</Name>
+      <Ngen>True</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Protocol\NuGet.Protocol.csproj">
       <Project>{020f4c88-3a5c-4b89-9868-089e867cc223}</Project>
       <Name>NuGet.Protocol</Name>
+      <Ngen>True</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Resolver\NuGet.Resolver.csproj">
       <Project>{51aa27a9-b8b4-458f-9211-e6889b441573}</Project>
@@ -154,6 +190,10 @@
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Versioning\NuGet.Versioning.csproj">
       <Project>{24e62ab7-64e4-4975-9417-883559d1bc19}</Project>
       <Name>NuGet.Versioning</Name>
+      <Ngen>True</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\NuGet.Tools\NuGet.Tools.csproj">
       <Project>{D0F9864B-D782-4471-81A2-29555E5DC0D7}</Project>
@@ -172,6 +212,10 @@
       <Name>NuGet.Commands</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>True</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Credentials\NuGet.Credentials.csproj">
       <Project>{32a23995-14c7-483b-98c3-0ae4185373ea}</Project>
@@ -184,12 +228,20 @@
       <Name>NuGet.SolutionRestoreManager</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bPkgdefProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>True</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\NuGet.VisualStudio.Implementation\NuGet.VisualStudio.Implementation.csproj">
       <Project>{9623cf30-192c-4864-b419-29649169ae30}</Project>
       <Name>NuGet.VisualStudio.Implementation</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>True</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\NuGet.PackageManagement.PowerShellCmdlets\NuGet.PackageManagement.PowerShellCmdlets.csproj">
       <Project>{26dc17ac-a390-4515-a2c0-07a0950036c5}</Project>
@@ -208,6 +260,10 @@
       <Name>NuGet.PackageManagement.VisualStudio</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>True</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\NuGet.VisualStudio.Interop\NuGet.VisualStudio.Interop.csproj">
       <Project>{7DB43FE1-75E1-49F9-B2C8-06A552BA2144}</Project>
@@ -220,18 +276,30 @@
       <Name>NuGet.VisualStudio.Common</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>True</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\NuGet.VisualStudio\NuGet.VisualStudio.csproj">
       <Project>{e5556bc6-a7fd-4d8e-8a7d-7648df1d7471}</Project>
       <Name>NuGet.VisualStudio</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>True</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\NuGet.Console\NuGet.Console.csproj">
       <Project>{50e33da2-af14-486d-81b8-bd8409744a38}</Project>
       <Name>NuGet.Console</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>True</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\NuGetConsole.Host.PowerShell\NuGetConsole.Host.PowerShell.csproj">
       <Project>{5a79eef3-51c0-4a14-8d37-50ef38ad835d}</Project>


### PR DESCRIPTION
I think this will fix https://github.com/NuGet/Home/issues/8477.

The set of assemblies comes from [build/OptProfV2.props](https://github.com/NuGet/NuGet.Client/blob/ef18f978b0a9fd6de7aa65cec8c6a6fda08f3f69/build/OptProfV2.props).

See https://docs.microsoft.com/en-us/visualstudio/extensibility/ngen-support?view=vs-2019 for details.