### PR TITLE
Allow PackageSourceProvider to avoid subscribing to configuration change event

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/PackageSourceBuilder.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/PackageSourceBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using NuGet.Configuration;
 
 namespace NuGet.CommandLine
@@ -7,7 +7,7 @@ namespace NuGet.CommandLine
     {
         internal static Configuration.PackageSourceProvider CreateSourceProvider(Configuration.ISettings settings)
         {
-            return new Configuration.PackageSourceProvider(settings);
+            return new Configuration.PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.CommandLine/PackageSourceBuilder.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/PackageSourceBuilder.cs
@@ -9,7 +9,9 @@ namespace NuGet.CommandLine
     {
         internal static PackageSourceProvider CreateSourceProvider(ISettings settings)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             return new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.CommandLine/PackageSourceBuilder.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/PackageSourceBuilder.cs
@@ -1,13 +1,15 @@
-using System.Collections.Generic;
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using NuGet.Configuration;
 
 namespace NuGet.CommandLine
 {
     internal static class PackageSourceBuilder
     {
-        internal static Configuration.PackageSourceProvider CreateSourceProvider(Configuration.ISettings settings)
+        internal static PackageSourceProvider CreateSourceProvider(ISettings settings)
         {
-            return new Configuration.PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false);
+            return new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/ExtensibleSourceRepositoryProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/ExtensibleSourceRepositoryProvider.cs
@@ -20,7 +20,7 @@ namespace NuGet.PackageManagement.VisualStudio
     {
 
         // TODO: add support for reloading sources when changes occur
-        private Configuration.IPackageSourceProvider _packageSourceProvider;
+        private IPackageSourceProvider _packageSourceProvider;
         private IEnumerable<Lazy<INuGetResourceProvider>> _resourceProviders;
         private Lazy<List<SourceRepository>> _repositories;
 
@@ -59,7 +59,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     _initialized = true;
 
-                    _packageSourceProvider = new Configuration.PackageSourceProvider(_settings.Value, enablePackageSourcesChangedEvent: true);
+                    _packageSourceProvider = new PackageSourceProvider(_settings.Value, enablePackageSourcesChangedEvent: true);
 
                     // Hook up event to refresh package sources when the package sources changed
                     _packageSourceProvider.PackageSourcesChanged += ResetRepositories;
@@ -104,7 +104,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return new SourceRepository(source, _resourceProviders, type);
         }
 
-        public Configuration.IPackageSourceProvider PackageSourceProvider
+        public IPackageSourceProvider PackageSourceProvider
         {
             get
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/ExtensibleSourceRepositoryProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/ExtensibleSourceRepositoryProvider.cs
@@ -59,7 +59,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     _initialized = true;
 
+#pragma warning disable CS0618 // Type or member is obsolete
                     _packageSourceProvider = new PackageSourceProvider(_settings.Value, enablePackageSourcesChangedEvent: true);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     // Hook up event to refresh package sources when the package sources changed
                     _packageSourceProvider.PackageSourcesChanged += ResetRepositories;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/ExtensibleSourceRepositoryProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/ExtensibleSourceRepositoryProvider.cs
@@ -59,7 +59,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     _initialized = true;
 
-                    _packageSourceProvider = new Configuration.PackageSourceProvider(_settings.Value, true);
+                    _packageSourceProvider = new Configuration.PackageSourceProvider(_settings.Value, enablePackageSourcesChangedEvent: true);
 
                     // Hook up event to refresh package sources when the package sources changed
                     _packageSourceProvider.PackageSourcesChanged += ResetRepositories;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
@@ -14,7 +14,7 @@ namespace NuGet.PackageManagement.VisualStudio
 {
     [Export(typeof(ISettings))]
     [PartCreationPolicy(CreationPolicy.Shared)]
-    public class VSSettings : ISettings
+    public class VSSettings : ISettings, IDisposable
     {
         private const string NuGetSolutionSettingsFolder = ".nuget";
 
@@ -108,6 +108,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             if (hasChanged)
             {
+                var invokers = SettingsChanged.GetInvocationList();
                 SettingsChanged?.Invoke(this, EventArgs.Empty);
             }
         }
@@ -144,6 +145,12 @@ namespace NuGet.PackageManagement.VisualStudio
         public IList<string> GetConfigFilePaths() => SolutionSettings.GetConfigFilePaths();
 
         public IList<string> GetConfigRoots() => SolutionSettings.GetConfigRoots();
+
+        public void Dispose()
+        {
+            SolutionManager.SolutionOpening -= OnSolutionOpenedOrClosed;
+            SolutionManager.SolutionClosed -= OnSolutionOpenedOrClosed;
+        }
 
         // The value for SolutionSettings can't possibly be null, but it could be a read-only instance
         private bool CanChangeSettings => !ReferenceEquals(SolutionSettings, NullSettings.Instance);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VSSettings.cs
@@ -14,7 +14,7 @@ namespace NuGet.PackageManagement.VisualStudio
 {
     [Export(typeof(ISettings))]
     [PartCreationPolicy(CreationPolicy.Shared)]
-    public class VSSettings : ISettings, IDisposable
+    public sealed class VSSettings : ISettings, IDisposable
     {
         private const string NuGetSolutionSettingsFolder = ".nuget";
 
@@ -108,7 +108,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
             if (hasChanged)
             {
-                var invokers = SettingsChanged.GetInvocationList();
                 SettingsChanged?.Invoke(this, EventArgs.Empty);
             }
         }

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
@@ -100,7 +100,7 @@ namespace NuGet.Commands
                 {
                     AllowNoOp = true,
                     CacheContext = sourceCacheContext,
-                    CachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(settings)),
+                    CachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false)),
                     Log = logger,
                 };
 

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/RestoreRunnerEx.cs
@@ -100,7 +100,9 @@ namespace NuGet.Commands
                 {
                     AllowNoOp = true,
                     CacheContext = sourceCacheContext,
+#pragma warning disable CS0618 // Type or member is obsolete
                     CachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false)),
+#pragma warning restore CS0618 // Type or member is obsolete
                     Log = logger,
                 };
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
@@ -133,7 +133,7 @@ namespace NuGet.Build.Tasks
                     () => RestoreSourcesOverride?.Select(MSBuildRestoreUtility.FixSourcePath).Select(e => GetGlobalAbsolutePath(e)).ToArray(),
                     () => MSBuildRestoreUtility.ContainsClearKeyword(RestoreSources) ? Array.Empty<string>() : null,
                     () => RestoreSources?.Select(MSBuildRestoreUtility.FixSourcePath).Select(e => UriUtility.GetAbsolutePathFromFile(ProjectUniqueName, e)).ToArray(),
-                    () => (new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false)).LoadPackageSources().Where(e => e.IsEnabled).Select(e => e.Source).ToArray());
+                    () => (PackageSourceProvider.LoadPackageSources(settings)).Where(e => e.IsEnabled).Select(e => e.Source).ToArray());
 
                 // Append additional sources
                 // Escape strings to avoid xplat path issues with msbuild.

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
@@ -133,7 +133,7 @@ namespace NuGet.Build.Tasks
                     () => RestoreSourcesOverride?.Select(MSBuildRestoreUtility.FixSourcePath).Select(e => GetGlobalAbsolutePath(e)).ToArray(),
                     () => MSBuildRestoreUtility.ContainsClearKeyword(RestoreSources) ? Array.Empty<string>() : null,
                     () => RestoreSources?.Select(MSBuildRestoreUtility.FixSourcePath).Select(e => UriUtility.GetAbsolutePathFromFile(ProjectUniqueName, e)).ToArray(),
-                    () => (new PackageSourceProvider(settings)).LoadPackageSources().Where(e => e.IsEnabled).Select(e => e.Source).ToArray());
+                    () => (new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false)).LoadPackageSources().Where(e => e.IsEnabled).Select(e => e.Source).ToArray());
 
                 // Append additional sources
                 // Escape strings to avoid xplat path issues with msbuild.

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/DeleteCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/DeleteCommand.cs
@@ -72,7 +72,9 @@ namespace NuGet.CommandLine.XPlat
 
                     DefaultCredentialServiceUtility.SetupDefaultCredentialService(getLogger(), !interactive.HasValue());
 
+#pragma warning disable CS0618 // Type or member is obsolete
                     PackageSourceProvider sourceProvider = new PackageSourceProvider(XPlatUtility.CreateDefaultSettings(), enablePackageSourcesChangedEvent: false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     await DeleteRunner.Run(
                         sourceProvider.Settings,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/DeleteCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/DeleteCommand.cs
@@ -72,7 +72,7 @@ namespace NuGet.CommandLine.XPlat
 
                     DefaultCredentialServiceUtility.SetupDefaultCredentialService(getLogger(), !interactive.HasValue());
 
-                    PackageSourceProvider sourceProvider = new PackageSourceProvider(XPlatUtility.CreateDefaultSettings());
+                    PackageSourceProvider sourceProvider = new PackageSourceProvider(XPlatUtility.CreateDefaultSettings(), enablePackageSourcesChangedEvent: false);
 
                     await DeleteRunner.Run(
                         sourceProvider.Settings,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
@@ -152,8 +152,7 @@ namespace NuGet.CommandLine.XPlat
 
         private static IEnumerable<PackageSource> GetPackageSources(ISettings settings, IEnumerable<string> sources, CommandOption config)
         {
-            var sourceProvider = new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false);
-            var availableSources = sourceProvider.LoadPackageSources().Where(source => source.IsEnabled);
+            var availableSources = PackageSourceProvider.LoadPackageSources(settings).Where(source => source.IsEnabled);
             var uniqueSources = new HashSet<string>();
 
             var packageSources = new List<PackageSource>();

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
@@ -152,7 +152,7 @@ namespace NuGet.CommandLine.XPlat
 
         private static IEnumerable<PackageSource> GetPackageSources(ISettings settings, IEnumerable<string> sources, CommandOption config)
         {
-            var sourceProvider = new PackageSourceProvider(settings);
+            var sourceProvider = new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false);
             var availableSources = sourceProvider.LoadPackageSources().Where(source => source.IsEnabled);
             var uniqueSources = new HashSet<string>();
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
@@ -98,7 +98,7 @@ namespace NuGet.CommandLine.XPlat
                         throw new ArgumentException(Strings.Push_InvalidTimeout);
                     }
 
-                    var sourceProvider = new PackageSourceProvider(XPlatUtility.CreateDefaultSettings());
+                    var sourceProvider = new PackageSourceProvider(XPlatUtility.CreateDefaultSettings(), enablePackageSourcesChangedEvent: true);
 
                     try
                     {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
@@ -98,7 +98,9 @@ namespace NuGet.CommandLine.XPlat
                         throw new ArgumentException(Strings.Push_InvalidTimeout);
                     }
 
+#pragma warning disable CS0618 // Type or member is obsolete
                     var sourceProvider = new PackageSourceProvider(XPlatUtility.CreateDefaultSettings(), enablePackageSourcesChangedEvent: false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     try
                     {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
@@ -98,7 +98,7 @@ namespace NuGet.CommandLine.XPlat
                         throw new ArgumentException(Strings.Push_InvalidTimeout);
                     }
 
-                    var sourceProvider = new PackageSourceProvider(XPlatUtility.CreateDefaultSettings(), enablePackageSourcesChangedEvent: true);
+                    var sourceProvider = new PackageSourceProvider(XPlatUtility.CreateDefaultSettings(), enablePackageSourcesChangedEvent: false);
 
                     try
                     {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -140,7 +140,9 @@ namespace NuGet.Commands
 
         private List<SourceRepository> GetEffectiveSourcesCore(ISettings settings, IList<PackageSource> dgSpecSources)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var packageSourceProvider = new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false);
+#pragma warning restore CS0618 // Type or member is obsolete
             var packageSourcesFromProvider = packageSourceProvider.LoadPackageSources();
             var sourceObjects = new Dictionary<string, PackageSource>();
             for(var i = 0; i < dgSpecSources.Count; i++)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -140,7 +140,7 @@ namespace NuGet.Commands
 
         private List<SourceRepository> GetEffectiveSourcesCore(ISettings settings, IList<PackageSource> dgSpecSources)
         {
-            var packageSourceProvider = new PackageSourceProvider(settings);
+            var packageSourceProvider = new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false);
             var packageSourcesFromProvider = packageSourceProvider.LoadPackageSources();
             var sourceObjects = new Dictionary<string, PackageSource>();
             for(var i = 0; i < dgSpecSources.Count; i++)

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -49,7 +49,7 @@ namespace NuGet.Configuration
             _configurationDefaultSources = LoadConfigurationDefaultSources(configurationDefaultSources);
         }
 
-        private IEnumerable<PackageSource> LoadConfigurationDefaultSources(IEnumerable<PackageSource> configurationDefaultSources)
+        private static IEnumerable<PackageSource> LoadConfigurationDefaultSources(IEnumerable<PackageSource> configurationDefaultSources)
         {
 #if !IS_CORECLR
             // Global default NuGet source doesn't make sense on Mono
@@ -71,16 +71,16 @@ namespace NuGet.Configuration
                 .Select(source => source.PackageSource);
         }
 
-        private Dictionary<string, IndexedPackageSource> LoadPackageSourceLookup(bool byName)
+        private static Dictionary<string, IndexedPackageSource> LoadPackageSourceLookup(bool byName, ISettings settings)
         {
-            var packageSourcesSection = Settings.GetSection(ConfigurationConstants.PackageSources);
+            var packageSourcesSection = settings.GetSection(ConfigurationConstants.PackageSources);
             var sourcesItems = packageSourcesSection?.Items.OfType<SourceItem>();
 
             // Order the list so that the closer to the user appear first
             var sources = sourcesItems?.OrderByDescending(item => item.Origin?.Priority ?? 0);
 
             // get list of disabled packages
-            var disabledSourcesSection = Settings.GetSection(ConfigurationConstants.DisabledPackageSources);
+            var disabledSourcesSection = settings.GetSection(ConfigurationConstants.DisabledPackageSources);
             var disabledSourcesSettings = disabledSourcesSection?.Items.OfType<AddItem>();
 
             var disabledSources = new HashSet<string>(disabledSourcesSettings?.GroupBy(setting => setting.Key).Select(group => group.First().Key) ?? Enumerable.Empty<string>());
@@ -94,7 +94,7 @@ namespace NuGet.Configuration
                 {
                     var name = setting.Key;
                     var isEnabled = !disabledSources.Contains(name);
-                    var packageSource = ReadPackageSource(setting, isEnabled);
+                    var packageSource = ReadPackageSource(setting, isEnabled, settings);
 
                     packageIndex = AddOrUpdateIndexedSource(packageSourceLookup, packageIndex, packageSource, byName ? packageSource.Name : packageSource.Source);
                 }
@@ -102,41 +102,53 @@ namespace NuGet.Configuration
             return packageSourceLookup;
         }
 
-        private Dictionary<string, IndexedPackageSource> LoadPackageSourceLookupByName()
+        private static Dictionary<string, IndexedPackageSource> LoadPackageSourceLookupByName(ISettings settings)
         {
-            return LoadPackageSourceLookup(byName: true);
+            return LoadPackageSourceLookup(byName: true, settings);
         }
 
         private Dictionary<string, IndexedPackageSource> LoadPackageSourceLookupBySource()
         {
-            return LoadPackageSourceLookup(byName: false);
+            return LoadPackageSourceLookup(byName: false, Settings);
         }
 
         /// <summary>
-        /// Returns PackageSources if specified in the config file. Else returns the default sources specified in the
+        /// Returns PackageSources specified in the config file merged with any default sources specified in the
         /// constructor.
-        /// If no default values were specified, returns an empty sequence.
         /// </summary>
         public IEnumerable<PackageSource> LoadPackageSources()
         {
-            var loadedPackageSources = LoadPackageSourceLookupByName().Values
+            return LoadPackageSources(Settings, _configurationDefaultSources);
+        }
+
+        /// <summary>
+        /// Returns PackageSources if specified in the settings object, combined with the default sources from the default configuration.
+        /// </summary>
+        public static IEnumerable<PackageSource> LoadPackageSources(ISettings settings)
+        {
+            return LoadPackageSources(settings, ConfigurationDefaults.Instance.DefaultPackageSources);
+        }
+
+        private static List<PackageSource> LoadPackageSources(ISettings settings, IEnumerable<PackageSource> defaultPackageSources)
+        {
+            var loadedPackageSources = LoadPackageSourceLookupByName(settings).Values
                 .OrderBy(source => source.Index)
                 .Select(source => source.PackageSource)
                 .ToList();
 
-            if (_configurationDefaultSources != null && _configurationDefaultSources.Any())
+            if (defaultPackageSources != null && defaultPackageSources.Any())
             {
-                SetDefaultPackageSources(loadedPackageSources);
+                AddDefaultPackageSources(loadedPackageSources, defaultPackageSources);
             }
 
             return loadedPackageSources;
         }
 
-        private void SetDefaultPackageSources(List<PackageSource> loadedPackageSources)
+        private static void AddDefaultPackageSources(List<PackageSource> loadedPackageSources, IEnumerable<PackageSource> defaultPackageSources)
         {
             var defaultPackageSourcesToBeAdded = new List<PackageSource>();
 
-            foreach (var packageSource in _configurationDefaultSources)
+            foreach (var packageSource in defaultPackageSources)
             {
                 var sourceMatching = loadedPackageSources.Any(p => p.Source.Equals(packageSource.Source, StringComparison.CurrentCultureIgnoreCase));
                 var feedNameMatching = loadedPackageSources.Any(p => p.Name.Equals(packageSource.Name, StringComparison.CurrentCultureIgnoreCase));
@@ -157,16 +169,16 @@ namespace NuGet.Configuration
             loadedPackageSources.InsertRange(defaultSourcesInsertIndex, defaultPackageSourcesToBeAdded);
         }
 
-        private PackageSource ReadPackageSource(SourceItem setting, bool isEnabled)
+        private static PackageSource ReadPackageSource(SourceItem setting, bool isEnabled, ISettings settings)
         {
             var name = setting.Key;
             var packageSource = new PackageSource(setting.GetValueAsPath(), name, isEnabled)
             {
                 IsMachineWide = setting.Origin?.IsMachineWide ?? false,
-                MaxHttpRequestsPerSource = SettingsUtility.GetMaxHttpRequest(Settings)
+                MaxHttpRequestsPerSource = SettingsUtility.GetMaxHttpRequest(settings)
             };
 
-            var credentials = ReadCredential(name);
+            var credentials = ReadCredential(name, settings);
             if (credentials != null)
             {
                 packageSource.Credentials = credentials;
@@ -212,7 +224,7 @@ namespace NuGet.Configuration
             return packageIndex;
         }
 
-        private PackageSourceCredential ReadCredential(string sourceName)
+        private static PackageSourceCredential ReadCredential(string sourceName, ISettings settings)
         {
             var environmentCredentials = ReadCredentialFromEnvironment(sourceName);
 
@@ -221,7 +233,7 @@ namespace NuGet.Configuration
                 return environmentCredentials;
             }
 
-            var credentialsSection = Settings.GetSection(ConfigurationConstants.CredentialsSectionName);
+            var credentialsSection = settings.GetSection(ConfigurationConstants.CredentialsSectionName);
             var credentialsItem = credentialsSection?.Items.OfType<CredentialsItem>().FirstOrDefault(s => string.Equals(s.ElementName, sourceName, StringComparison.Ordinal));
 
             if (credentialsItem != null && !credentialsItem.IsEmpty())
@@ -237,7 +249,7 @@ namespace NuGet.Configuration
             return null;
         }
 
-        private PackageSourceCredential ReadCredentialFromEnvironment(string sourceName)
+        private static PackageSourceCredential ReadCredentialFromEnvironment(string sourceName)
         {
             var rawCredentials = Environment.GetEnvironmentVariable("NuGetPackageSourceCredentials_" + sourceName);
             if (string.IsNullOrEmpty(rawCredentials))
@@ -295,7 +307,7 @@ namespace NuGet.Configuration
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(name));
             }
 
-            return GetPackageSource(name, LoadPackageSourceLookupByName());
+            return GetPackageSource(name, LoadPackageSourceLookupByName(Settings));
         }
 
         public PackageSource GetPackageSourceBySource(string source)
@@ -490,7 +502,7 @@ namespace NuGet.Configuration
                     credentialsSettingsItem = credentialsSection?.Items.OfType<CredentialsItem>().Where(s => string.Equals(s.ElementName, sourceToUpdate.Key, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
                 }
 
-                var oldPackageSource = ReadPackageSource(sourceToUpdate, disabledSourceItem == null);
+                var oldPackageSource = ReadPackageSource(sourceToUpdate, disabledSourceItem == null, Settings);
                 var isDirty = false;
 
                 UpdatePackageSource(
@@ -641,7 +653,7 @@ namespace NuGet.Configuration
                     existingSettingsLookup.TryGetValue(source.Name, out existingSourceItem) &&
                     ReadProtocolVersion(existingSourceItem) == source.ProtocolVersion)
                 {
-                    var oldPackageSource = ReadPackageSource(existingSourceItem, existingSourceIsEnabled);
+                    var oldPackageSource = ReadPackageSource(existingSourceItem, existingSourceIsEnabled, Settings);
 
                     existingCredentialsLookup?.TryGetValue(source.Name, out existingCredentialsItem);
 

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -18,10 +18,13 @@ namespace NuGet.Configuration
 
         public PackageSourceProvider(
           ISettings settings)
+#pragma warning disable CS0618 // Type or member is obsolete
             : this(settings, ConfigurationDefaults.Instance.DefaultPackageSources, enablePackageSourcesChangedEvent: true)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
         }
 
+        [Obsolete("Constructor with enablePackageSourcesChangedEvent will go away: https://github.com/NuGet/Home/issues/8479")]
         public PackageSourceProvider(
           ISettings settings,
           bool enablePackageSourcesChangedEvent)
@@ -32,10 +35,13 @@ namespace NuGet.Configuration
         public PackageSourceProvider(
             ISettings settings,
             IEnumerable<PackageSource> configurationDefaultSources)
+#pragma warning disable CS0618 // Type or member is obsolete
             : this (settings, configurationDefaultSources, enablePackageSourcesChangedEvent: true)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
         }
 
+        [Obsolete("Constructor with enablePackageSourcesChangedEvent will go away: https://github.com/NuGet/Home/issues/8479")]
         public PackageSourceProvider(
             ISettings settings,
             IEnumerable<PackageSource> configurationDefaultSources,

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -24,7 +24,7 @@ namespace NuGet.Configuration
         {
         }
 
-        [Obsolete("Constructor with enablePackageSourcesChangedEvent will go away: https://github.com/NuGet/Home/issues/8479")]
+        [Obsolete("https://github.com/NuGet/Home/issues/8479")]
         public PackageSourceProvider(
           ISettings settings,
           bool enablePackageSourcesChangedEvent)
@@ -41,7 +41,7 @@ namespace NuGet.Configuration
         {
         }
 
-        [Obsolete("Constructor with enablePackageSourcesChangedEvent will go away: https://github.com/NuGet/Home/issues/8479")]
+        [Obsolete("https://github.com/NuGet/Home/issues/8479")]
         public PackageSourceProvider(
             ISettings settings,
             IEnumerable<PackageSource> configurationDefaultSources,

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -18,17 +18,34 @@ namespace NuGet.Configuration
 
         public PackageSourceProvider(
           ISettings settings)
-            : this(settings, ConfigurationDefaults.Instance.DefaultPackageSources)
+            : this(settings, ConfigurationDefaults.Instance.DefaultPackageSources, enablePackageSourcesChangedEvent: true)
+        {
+        }
+
+        public PackageSourceProvider(
+          ISettings settings,
+          bool enablePackageSourcesChangedEvent)
+            : this(settings, ConfigurationDefaults.Instance.DefaultPackageSources, enablePackageSourcesChangedEvent)
         {
         }
 
         public PackageSourceProvider(
             ISettings settings,
-            IEnumerable<PackageSource> configurationDefaultSources
-            )
+            IEnumerable<PackageSource> configurationDefaultSources)
+            : this (settings, configurationDefaultSources, enablePackageSourcesChangedEvent: true)
+        {
+        }
+
+        public PackageSourceProvider(
+            ISettings settings,
+            IEnumerable<PackageSource> configurationDefaultSources,
+            bool enablePackageSourcesChangedEvent)
         {
             Settings = settings ?? throw new ArgumentNullException(nameof(settings));
-            Settings.SettingsChanged += (_, __) => { OnPackageSourcesChanged(); };
+            if (enablePackageSourcesChangedEvent)
+            {
+                Settings.SettingsChanged += (_, __) => { OnPackageSourcesChanged(); };
+            }
             _configurationDefaultSources = LoadConfigurationDefaultSources(configurationDefaultSources);
         }
 

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -355,8 +355,7 @@ namespace NuGet.Configuration
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            var provider = new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false);
-            return provider.LoadPackageSources().Where(e => e.IsEnabled == true).ToList();
+            return PackageSourceProvider.LoadPackageSources(settings).Where(e => e.IsEnabled == true).ToList();
         }
 
         /// <summary>
@@ -382,8 +381,7 @@ namespace NuGet.Configuration
             if (sourceUri != null && !sourceUri.IsAbsoluteUri)
             {
                 // For non-absolute sources, it could be the name of a config source, or a relative file path.
-                IPackageSourceProvider sourceProvider = new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false);
-                var allSources = sourceProvider.LoadPackageSources();
+                var allSources = PackageSourceProvider.LoadPackageSources(settings);
 
                 if (!allSources.Any(s => s.IsEnabled && s.Name.Equals(source, StringComparison.OrdinalIgnoreCase)))
                 {

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -355,7 +355,7 @@ namespace NuGet.Configuration
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            var provider = new PackageSourceProvider(settings);
+            var provider = new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false);
             return provider.LoadPackageSources().Where(e => e.IsEnabled == true).ToList();
         }
 
@@ -382,7 +382,7 @@ namespace NuGet.Configuration
             if (sourceUri != null && !sourceUri.IsAbsoluteUri)
             {
                 // For non-absolute sources, it could be the name of a config source, or a relative file path.
-                IPackageSourceProvider sourceProvider = new PackageSourceProvider(settings);
+                IPackageSourceProvider sourceProvider = new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false);
                 var allSources = sourceProvider.LoadPackageSources();
 
                 if (!allSources.Any(s => s.IsEnabled && s.Name.Equals(source, StringComparison.OrdinalIgnoreCase)))

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -284,8 +284,10 @@ namespace NuGet.PackageManagement
             bool isRestoreOriginalAction,
             bool restoreForceEvaluate)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var caching = new CachingSourceProvider(new PackageSourceProvider(context.Settings, enablePackageSourcesChangedEvent: false));
-            foreach( var source in sources)
+#pragma warning restore CS0618 // Type or member is obsolete
+            foreach ( var source in sources)
             {
                 caching.AddSourceRepository(source);
             }

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -284,7 +284,7 @@ namespace NuGet.PackageManagement
             bool isRestoreOriginalAction,
             bool restoreForceEvaluate)
         {
-            var caching = new CachingSourceProvider(new PackageSourceProvider(context.Settings));
+            var caching = new CachingSourceProvider(new PackageSourceProvider(context.Settings, enablePackageSourcesChangedEvent: false));
             foreach( var source in sources)
             {
                 caching.AddSourceRepository(source);

--- a/src/NuGet.Core/NuGet.Protocol/Repository.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Repository.cs
@@ -33,6 +33,7 @@ namespace NuGet.Protocol.Core.Types
         /// <summary>
         /// Create the default source repository provider
         /// </summary>
+        [Obsolete("https://github.com/NuGet/Home/issues/8479")]
         public static ISourceRepositoryProvider CreateProvider(IEnumerable<INuGetResourceProvider> resourceProviders)
         {
             return new SourceRepositoryProvider(Settings.LoadDefaultSettings(null, null, null), CreateLazy(resourceProviders));
@@ -42,6 +43,7 @@ namespace NuGet.Protocol.Core.Types
         /// Find sources from nuget.config based on the root path
         /// </summary>
         /// <param name="rootPath">lowest folder path</param>
+        [Obsolete("https://github.com/NuGet/Home/issues/8479")]
         public static ISourceRepositoryProvider CreateProvider(IEnumerable<INuGetResourceProvider> resourceProviders, string rootPath)
         {
             return new SourceRepositoryProvider(Settings.LoadDefaultSettings(rootPath, null, null), CreateLazy(resourceProviders));

--- a/src/NuGet.Core/NuGet.Protocol/SourceRepositoryProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SourceRepositoryProvider.cs
@@ -18,7 +18,9 @@ namespace NuGet.Protocol.Core.Types
         private List<SourceRepository> _repositories;
 
         public SourceRepositoryProvider(ISettings settings, IEnumerable<Lazy<INuGetResourceProvider>> resourceProviders)
+#pragma warning disable CS0618 // Type or member is obsolete
             : this(new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false), resourceProviders)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/SourceRepositoryProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SourceRepositoryProvider.cs
@@ -17,10 +17,9 @@ namespace NuGet.Protocol.Core.Types
         private IEnumerable<Lazy<INuGetResourceProvider>> _resourceProviders;
         private List<SourceRepository> _repositories;
 
+        [Obsolete("https://github.com/NuGet/Home/issues/8479")]
         public SourceRepositoryProvider(ISettings settings, IEnumerable<Lazy<INuGetResourceProvider>> resourceProviders)
-#pragma warning disable CS0618 // Type or member is obsolete
-            : this(new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false), resourceProviders)
-#pragma warning restore CS0618 // Type or member is obsolete
+            : this(new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: true), resourceProviders)
         {
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/SourceRepositoryProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SourceRepositoryProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -18,7 +18,7 @@ namespace NuGet.Protocol.Core.Types
         private List<SourceRepository> _repositories;
 
         public SourceRepositoryProvider(ISettings settings, IEnumerable<Lazy<INuGetResourceProvider>> resourceProviders)
-            : this(new PackageSourceProvider(settings), resourceProviders)
+            : this(new PackageSourceProvider(settings, enablePackageSourcesChangedEvent: false), resourceProviders)
         {
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -2109,6 +2109,24 @@ namespace NuGet.Configuration.Test
             }
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void PackageSourcesChanged_EventRunsSubscriptions(bool subscribeToEvent)
+        {
+            // Arrange
+            var setting = new Mock<ISettings>();
+            var target = new PackageSourceProvider(setting.Object, subscribeToEvent);
+            bool eventRun = false;
+            target.PackageSourcesChanged += (s, e) => { eventRun = true; };
+
+            // Act
+            setting.Raise(s => s.SettingsChanged += null, (EventArgs)null);
+
+            // Assert
+            Assert.Equal(subscribeToEvent, eventRun);
+        }
+
         private string CreateNuGetConfigContent(string enabledReplacement = "", string disabledReplacement = "", string activeSourceReplacement = "")
         {
             var nugetConfigBaseString = new StringBuilder();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -85,8 +85,10 @@ namespace NuGet.Configuration.Test
             }
         }
 
-        [Fact]
-        public void LoadPackageSources_LoadsCredentials()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoadPackageSources_LoadsCredentials(bool useStaticMethod)
         {
             // Arrange
             var nugetConfigFilePath = "NuGet.Config";
@@ -148,10 +150,9 @@ namespace NuGet.Configuration.Test
             {
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigFilePath, directory, configContent);
                 var settings = new Settings(directory);
-                var packageSourceProvider = new PackageSourceProvider(settings);
 
                 // Act
-                var sources = packageSourceProvider.LoadPackageSources().ToList();
+                List<PackageSource> sources = LoadPackageSources(useStaticMethod, settings);
 
                 // Assert
                 sources.Count.Should().Be(6);
@@ -160,31 +161,19 @@ namespace NuGet.Configuration.Test
             }
         }
 
-        [Fact]
-        public void TestNoPackageSourcesAreReturnedIfUserSettingsIsEmpty()
-        {
-            // Arrange
-            var provider = CreatePackageSourceProvider();
-
-            // Act
-            var values = provider.LoadPackageSources().ToList();
-
-            // Assert
-            Assert.Equal(0, values.Count);
-        }
-
-        [Fact]
-        public void LoadPackageSourcesReturnsEmptySequence()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TestNoPackageSourcesAreReturnedIfUserSettingsIsEmpty(bool useStaticMethod)
         {
             // Arrange
             var settings = new Mock<ISettings>();
-            var provider = CreatePackageSourceProvider(settings.Object);
 
             // Act
-            var values = provider.LoadPackageSources();
+            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 
             // Assert
-            Assert.False(values.Any());
+            Assert.Equal(0, values.Count);
         }
 
         [Fact]
@@ -200,7 +189,7 @@ namespace NuGet.Configuration.Test
             {
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigFilePath, directory, configContent);
                 var settings = new Settings(directory);
-                var provider = CreatePackageSourceProvider(settings);
+                var provider = new PackageSourceProvider(settings);
 
                 // Act
                 provider.SavePackageSources(
@@ -677,8 +666,7 @@ namespace NuGet.Configuration.Test
                 Assert.Equal(1, disabledSources.Count);
                 Assert.Equal("Microsoft and .NET", disabledSources[0].Key);
 
-                packageSourceProvider = new PackageSourceProvider(newSettings);
-                packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
+                packageSourceList = PackageSourceProvider.LoadPackageSources(newSettings).ToList();
 
                 Assert.Equal(2, packageSourceList.Count);
                 Assert.Equal("a", packageSourceList[0].Name);
@@ -688,8 +676,10 @@ namespace NuGet.Configuration.Test
             }
         }
 
-        [Fact]
-        public void LoadPackageSourcesReturnCorrectDataFromSettings()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoadPackageSourcesReturnCorrectDataFromSettings(bool useStaticMethod)
         {
             // Arrange
             var settings = new Mock<ISettings>(MockBehavior.Strict);
@@ -709,10 +699,8 @@ namespace NuGet.Configuration.Test
             settings.Setup(s => s.GetSection("config"))
                 .Returns(new VirtualSettingSection("config"));
 
-            var provider = CreatePackageSourceProvider(settings.Object);
-
             // Act
-            var values = provider.LoadPackageSources().ToList();
+            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 
             // Assert
             Assert.Equal(3, values.Count);
@@ -721,8 +709,10 @@ namespace NuGet.Configuration.Test
             AssertPackageSource(values[2], "three", "threesource", isEnabled: true);
         }
 
-        [Fact]
-        public void LoadPackageSourcesReturnCorrectDataFromSettingsWhenSomePackageSourceIsDisabled()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoadPackageSourcesReturnCorrectDataFromSettingsWhenSomePackageSourceIsDisabled(bool useStaticMethod)
         {
             // Arrange
             var settings = new Mock<ISettings>(MockBehavior.Strict);
@@ -744,10 +734,8 @@ namespace NuGet.Configuration.Test
             settings.Setup(s => s.GetSection("config"))
                 .Returns(new VirtualSettingSection("config"));
 
-            var provider = CreatePackageSourceProvider(settings.Object);
-
             // Act
-            var values = provider.LoadPackageSources().ToList();
+            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 
             // Assert
             Assert.Equal(3, values.Count);
@@ -756,8 +744,10 @@ namespace NuGet.Configuration.Test
             AssertPackageSource(values[2], "three", "threesource", isEnabled: true);
         }
 
-        [Fact]
-        public void LoadPackageSources_ReadsSourcesWithProtocolVersionFromPackageSourceSections()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoadPackageSources_ReadsSourcesWithProtocolVersionFromPackageSourceSections(bool useStaticMethod)
         {
             // Arrange
             var settings = new Mock<ISettings>();
@@ -783,11 +773,8 @@ namespace NuGet.Configuration.Test
                         new AddItem("Source4", "true")
                     ));
 
-            var provider = CreatePackageSourceProvider(
-                settings.Object);
-
             // Act
-            var values = provider.LoadPackageSources().ToList();
+            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 
             // Assert
             Assert.Collection(values,
@@ -835,7 +822,7 @@ namespace NuGet.Configuration.Test
             settings.Setup(s => s.AddOrUpdate("disabledPackageSources", It.IsAny<AddItem>())).Verifiable();
             settings.Setup(s => s.SaveToDisk()).Verifiable();
 
-            var provider = CreatePackageSourceProvider(settings.Object);
+            var provider = new PackageSourceProvider(settings.Object);
 
             // Act
             provider.DisablePackageSource("A");
@@ -852,7 +839,7 @@ namespace NuGet.Configuration.Test
             settings.Setup(s => s.GetSection("disabledPackageSources"))
                 .Returns(new VirtualSettingSection("disabledPackageSources",
                     new AddItem("A", "sdfds")));
-            var provider = CreatePackageSourceProvider(settings.Object);
+            var provider = new PackageSourceProvider(settings.Object);
 
             // Act
             var isEnabled = provider.IsPackageSourceEnabled("A");
@@ -861,8 +848,10 @@ namespace NuGet.Configuration.Test
             Assert.False(isEnabled);
         }
 
-        [Fact]
-        public void LoadPackageSources_ReadsCredentialPairsFromSettings()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoadPackageSources_ReadsCredentialPairsFromSettings(bool useStaticMethod)
         {
             // Arrange
             var encryptedPassword = Guid.NewGuid().ToString();
@@ -882,10 +871,8 @@ namespace NuGet.Configuration.Test
                     new CredentialsItem("two", "user1", encryptedPassword, isPasswordClearText: false, validAuthenticationTypes: null)
                     ));
 
-            var provider = CreatePackageSourceProvider(settings.Object);
-
             // Act
-            var values = provider.LoadPackageSources().ToList();
+            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 
             // Assert
             Assert.Equal(3, values.Count);
@@ -893,8 +880,10 @@ namespace NuGet.Configuration.Test
             AssertCredentials(values[1].Credentials, "two", "user1", encryptedPassword, isPasswordClearText: false);
         }
 
-        [Fact]
-        public void LoadPackageSources_WithSpaceInName_ReadsCredentialPairsFromSettings()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoadPackageSources_WithSpaceInName_ReadsCredentialPairsFromSettings(bool useStaticMethod)
         {
             // Arrange
             var encryptedPassword = Guid.NewGuid().ToString();
@@ -914,10 +903,8 @@ namespace NuGet.Configuration.Test
                     new CredentialsItem("two source", "user1", encryptedPassword, isPasswordClearText: false, validAuthenticationTypes: null)
                     ));
 
-            var provider = CreatePackageSourceProvider(settings.Object);
-
             // Act
-            var values = provider.LoadPackageSources().ToList();
+            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 
             // Assert
             Assert.Equal(3, values.Count);
@@ -925,8 +912,10 @@ namespace NuGet.Configuration.Test
             AssertCredentials(values[1].Credentials, "two source", "user1", encryptedPassword, isPasswordClearText: false);
         }
 
-        [Fact]
-        public void LoadPackageSources_ReadsClearTextCredentialPairsFromSettings()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoadPackageSources_ReadsClearTextCredentialPairsFromSettings(bool useStaticMethod)
         {
             // Arrange
             const string clearTextPassword = "topsecret";
@@ -946,10 +935,8 @@ namespace NuGet.Configuration.Test
                  new CredentialsItem("two", "user1", clearTextPassword, isPasswordClearText: true, validAuthenticationTypes: null)
                  ));
 
-            var provider = CreatePackageSourceProvider(settings.Object);
-
             // Act
-            var values = provider.LoadPackageSources().ToList();
+            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 
             // Assert
             Assert.Equal(3, values.Count);
@@ -957,8 +944,10 @@ namespace NuGet.Configuration.Test
             AssertCredentials(values[1].Credentials, "two", "user1", clearTextPassword);
         }
 
-        [Fact]
-        public void LoadPackageSources_WhenEnvironmentCredentialsAreMalformed_FallsbackToSettingsCredentials()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoadPackageSources_WhenEnvironmentCredentialsAreMalformed_FallsbackToSettingsCredentials(bool useStaticMethod)
         {
             // Arrange
             var settings = new Mock<ISettings>();
@@ -976,10 +965,8 @@ namespace NuGet.Configuration.Test
                     new CredentialsItem("two", "settinguser", "settingpassword", isPasswordClearText: true, validAuthenticationTypes: null)
                     ));
 
-            var provider = CreatePackageSourceProvider(settings.Object);
-
             // Act
-            var values = provider.LoadPackageSources().ToList();
+            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 
             // Assert
             Assert.Equal(3, values.Count);
@@ -1222,8 +1209,10 @@ namespace NuGet.Configuration.Test
             }
         }
 
-        [Fact]
-        public void LoadPackageSourcesWithDisabledPackageSourceIsUpperCase()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoadPackageSourcesWithDisabledPackageSourceIsUpperCase(bool useStaticMethod)
         {
             // Arrange
             var settings = new Mock<ISettings>(MockBehavior.Strict);
@@ -1242,10 +1231,8 @@ namespace NuGet.Configuration.Test
             settings.Setup(s => s.GetSection("config"))
                 .Returns(new VirtualSettingSection("config"));
 
-            var provider = CreatePackageSourceProvider(settings.Object);
-
             // Act
-            var values = provider.LoadPackageSources().ToList();
+            List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 
             // Assert
             Assert.Equal(3, values.Count);
@@ -1256,8 +1243,10 @@ namespace NuGet.Configuration.Test
 
         // Test that a source added in a high priority config file is not
         // disabled by <disabledPackageSources> in a low priority file.
-        [Fact]
-        public void HighPrioritySourceDisabled()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void HighPrioritySourceDisabled(bool useStaticMethod)
         {
             // Arrange
             using (var directory = TestDirectory.Create())
@@ -1281,9 +1270,8 @@ namespace NuGet.Configuration.Test
                     loadUserWideSettings: false,
                     useTestingGlobalPath: false);
 
-                var provider = CreatePackageSourceProvider(settings);
                 // Act
-                var values = provider.LoadPackageSources().ToList();
+                List<PackageSource> values = LoadPackageSources(useStaticMethod, settings);
 
                 // Assert
                 Assert.Equal(1, values.Count);
@@ -1295,8 +1283,10 @@ namespace NuGet.Configuration.Test
 
         // Test that a source added in a low priority config file is disabled
         // if it's listed in <disabledPackageSources> in a high priority file.
-        [Fact]
-        public void LowPrioritySourceDisabled()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LowPrioritySourceDisabled(bool useStaticMethod)
         {
             // Arrange
             using (var directory = TestDirectory.Create())
@@ -1320,10 +1310,8 @@ namespace NuGet.Configuration.Test
                     loadUserWideSettings: false,
                     useTestingGlobalPath: false);
 
-                var provider = CreatePackageSourceProvider(settings);
-
                 // Act
-                var values = provider.LoadPackageSources().ToList();
+                List<PackageSource> values = LoadPackageSources(useStaticMethod, settings);
 
                 // Assert
                 Assert.Equal(1, values.Count);
@@ -1333,8 +1321,10 @@ namespace NuGet.Configuration.Test
             }
         }
 
-        [Fact]
-        public void V2NotDisabled()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void V2NotDisabled(bool useStaticMethod)
         {
             // Arrange
             using (var directory = TestDirectory.Create())
@@ -1353,13 +1343,11 @@ namespace NuGet.Configuration.Test
                     loadUserWideSettings: false,
                     useTestingGlobalPath: false);
 
-                var provider = CreatePackageSourceProvider(settings);
-
                 // Act
-                var values = provider.LoadPackageSources().Where(p => p.Name.Equals("nuget.org", StringComparison.OrdinalIgnoreCase)).ToList();
+                List<PackageSource> values = LoadPackageSources(useStaticMethod, settings);
 
                 // Assert
-                Assert.True(values[0].IsEnabled);
+                Assert.True(values.Single(p => p.Name.Equals("nuget.org", StringComparison.OrdinalIgnoreCase)).IsEnabled);
             }
         }
 
@@ -1733,8 +1721,10 @@ namespace NuGet.Configuration.Test
             }
         }
 
-        [Fact]
-        public void DisabledMachineWideSourceByDefaultWithNull()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DisabledMachineWideSourceByDefaultWithNull(bool useStaticMethod)
         {
             using (var directory = TestDirectory.Create())
             {
@@ -1746,18 +1736,19 @@ namespace NuGet.Configuration.Test
                     machineWideSettings: null,
                     loadUserWideSettings: true,
                     useTestingGlobalPath: true);
-                var packageSourceProvider = new PackageSourceProvider(settings);
 
                 // Act
-                var sources = packageSourceProvider.LoadPackageSources().ToList();
+                List<PackageSource> sources = LoadPackageSources(useStaticMethod, settings);
 
                 // Assert
                 Assert.Equal(1, sources.Count);
             }
         }
 
-        [Fact]
-        public void LoadPackageSourceEmptyConfigFileOnUserMachine()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoadPackageSourceEmptyConfigFileOnUserMachine(bool useStaticMethod)
         {
             using (var directory = TestDirectory.Create())
             {
@@ -1776,18 +1767,19 @@ namespace NuGet.Configuration.Test
                                   machineWideSettings: null,
                                   loadUserWideSettings: true,
                                   useTestingGlobalPath: true);
-                var packageSourceProvider = new PackageSourceProvider(settings);
 
                 // Act
-                var sources = packageSourceProvider.LoadPackageSources().ToList();
+                List<PackageSource> sources = LoadPackageSources(useStaticMethod, settings);
 
                 // Assert
                 Assert.Equal(0, sources.Count);
             }
         }
 
-        [Fact]
-        public void LoadPackageSourceLocalConfigFileOnUserMachine()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoadPackageSourceLocalConfigFileOnUserMachine(bool useStaticMethod)
         {
             using (var directory = TestDirectory.Create())
             {
@@ -1807,10 +1799,9 @@ namespace NuGet.Configuration.Test
                                   machineWideSettings: null,
                                   loadUserWideSettings: true,
                                   useTestingGlobalPath: true);
-                var packageSourceProvider = new PackageSourceProvider(settings);
 
                 // Act
-                var sources = packageSourceProvider.LoadPackageSources().ToList();
+                List<PackageSource> sources = LoadPackageSources(useStaticMethod, settings);
 
                 // Assert
                 Assert.Equal(1, sources.Count);
@@ -2154,28 +2145,17 @@ namespace NuGet.Configuration.Test
             return nugetConfig;
         }
 
-        private void VerifyPackageSource(PackageSourceProvider psp, int count, string[] names, string[] feeds, bool[] isEnabled, bool[] isOfficial)
+        private List<PackageSource> LoadPackageSources(bool useStaticMethod, ISettings settings)
         {
-            var toVerifyList = new List<PackageSource>();
-            toVerifyList = psp.LoadPackageSources().ToList();
-
-            Assert.Equal(toVerifyList.Count, count);
-            var index = 0;
-            foreach (var ps in toVerifyList)
+            if (useStaticMethod)
             {
-                Assert.Equal(ps.Name, names[index]);
-                Assert.Equal(ps.Source, feeds[index]);
-                Assert.Equal(ps.IsEnabled, isEnabled[index]);
-                Assert.Equal(ps.IsOfficial, isOfficial[index]);
-                index++;
+                return PackageSourceProvider.LoadPackageSources(settings).ToList();
             }
-        }
-
-        private PackageSourceProvider CreatePackageSourceProvider(
-            ISettings settings = null)
-        {
-            settings = settings ?? new Mock<ISettings>().Object;
-            return new PackageSourceProvider(settings);
+            else
+            {
+                var provider = new PackageSourceProvider(settings);
+                return provider.LoadPackageSources().ToList();
+            }
         }
 
         private void AssertPackageSource(PackageSource ps, string name, string source, bool isEnabled, bool isMachineWide = false, bool isOfficial = false)
@@ -2185,13 +2165,6 @@ namespace NuGet.Configuration.Test
             Assert.True(ps.IsEnabled == isEnabled);
             Assert.True(ps.IsMachineWide == isMachineWide);
             Assert.True(ps.IsOfficial == isOfficial);
-        }
-
-        private static void AssertKeyValuePair(string expectedKey, string expectedValue, KeyValuePair<string, string> actual)
-        {
-            Assert.NotNull(actual);
-            Assert.Equal(expectedKey, actual.Key);
-            Assert.Equal(expectedValue, actual.Value);
         }
 
         private void AssertCredentials(PackageSourceCredential actual, string source, string userName, string passwordText, bool isPasswordClearText = true)

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -2107,7 +2107,9 @@ namespace NuGet.Configuration.Test
         {
             // Arrange
             var setting = new Mock<ISettings>();
+#pragma warning disable CS0618 // Type or member is obsolete
             var target = new PackageSourceProvider(setting.Object, subscribeToEvent);
+#pragma warning restore CS0618 // Type or member is obsolete
             bool eventRun = false;
             target.PackageSourcesChanged += (s, e) => { eventRun = true; };
 


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8471
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Overload constructor to allow opting out of subscribing to the events. Note: this is a short/medium term fix, NuGet/Home#8479 is needed to fix it properly.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
