### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# review when someone opens a pull request.
+# For more on how to customize the CODEOWNERS file - https://help.github.com/en/articles/about-code-owners
+*       @donnie-msft @dominoFire @dtivel @heng-liu @kartheekp-ms @nkolev92 @zivkan @zkat


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8480  
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Add a code owners file to automaticallly request code reviews from everyone on the team. 

Note that this can be configure dto request reviews from a team, but we have no such team yet. (nuget/nuget-client has extra people so maybe not appropriate, plus it's secret) :) 

I'll chat with @rrelyea about creating one.  If we agree that's the right approach, I'll create an issue and do the change. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  None needed
Validation:  
