### PR TITLE
Fix exception preventing versions list

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageMetadataProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageMetadataProvider.cs
@@ -188,7 +188,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private static async Task<PackageDeprecationMetadata> MergeDeprecationMetadataAsync(PackageIdentity identity, IEnumerable<IPackageSearchMetadata> packages)
         {
             var deprecationMetadatas = await Task.WhenAll(packages.Select(m => m.GetDeprecationMetadataAsync()));
-            return deprecationMetadatas.First(d => d != null);
+            return deprecationMetadatas.FirstOrDefault(d => d != null);
         }
 
         private async Task<(IEnumerable<VersionInfo> versions, PackageDeprecationMetadata deprecationMetadata)> FetchAndMergeVersionsAndDeprecationMetadataAsync(


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8483
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Make code capable of handing when no deprecated packages exist.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  difficult to write tests for UI stuff
Validation:  
