### PR TITLE
Stop writing out licenseUrl when using nuget spec

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,6 +10,8 @@ using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.Packaging.Licenses;
+using NuGet.Versioning;
 
 namespace NuGet.CommandLine
 {
@@ -15,15 +20,6 @@ namespace NuGet.CommandLine
             UsageSummaryResourceName = "SpecCommandUsageSummary", UsageExampleResourceName = "SpecCommandUsageExamples")]
     public class SpecCommand : Command
     {
-        internal static readonly string SampleProjectUrl = "http://project_url_here_or_delete_this_line/";
-        internal static readonly string SampleLicenseUrl = "http://license_url_here_or_delete_this_line/";
-        internal static readonly string SampleIconUrl = "http://icon_url_here_or_delete_this_line/";
-        internal static readonly string SampleTags = "Tag1 Tag2";
-        internal static readonly string SampleReleaseNotes = "Summary of changes made in this release of the package.";
-        internal static readonly string SampleDescription = "Package description";
-        internal static readonly NuGetFramework SampleTfm = new NuGetFramework("472");
-        internal static readonly PackageDependency SampleManifestDependency = new PackageDependency("SampleDependency", new Versioning.VersionRange(new Versioning.NuGetVersion("1.0.0")));
-
         [Option(typeof(NuGetCommand), "SpecCommandAssemblyPathDescription")]
         public string AssemblyPath
         {
@@ -40,6 +36,14 @@ namespace NuGet.CommandLine
 
         public override void ExecuteCommand()
         {
+            string sampleProjectUrl = "http://project_url_here_or_delete_this_line/";
+            string sampleIconUrl = "http://icon_url_here_or_delete_this_line/";
+            string sampleTags = "Tag1 Tag2";
+            string sampleReleaseNotes = "Summary of changes made in this release of the package.";
+            string sampleDescription = "Package description";
+            NuGetFramework sampleTfm = NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetStandard21;
+            PackageDependency sampleManifestDependency = new PackageDependency("SampleDependency", new VersionRange(new NuGetVersion("1.0.0")));
+
             var manifest = new Manifest(new ManifestMetadata());
             string projectFile = null;
             string fileName = null;
@@ -81,22 +85,22 @@ namespace NuGet.CommandLine
             // If we're using a project file then we want the a minimal nuspec
             if (String.IsNullOrEmpty(projectFile))
             {
-                manifest.Metadata.Description = manifest.Metadata.Description ?? SampleDescription;
+                manifest.Metadata.Description = manifest.Metadata.Description ?? sampleDescription;
                 if (!manifest.Metadata.Authors.Any() || String.IsNullOrEmpty(manifest.Metadata.Authors.First()))
                 {
                     manifest.Metadata.Authors = new List<string>() { Environment.UserName };
                 }
                 manifest.Metadata.DependencyGroups = new List<PackageDependencyGroup>() {
-                    new PackageDependencyGroup(SampleTfm, new List<PackageDependency>() { SampleManifestDependency })
+                    new PackageDependencyGroup(sampleTfm, new List<PackageDependency>() { sampleManifestDependency })
                 };
             }
 
-            manifest.Metadata.SetProjectUrl(SampleProjectUrl);
-            manifest.Metadata.SetLicenseUrl(SampleLicenseUrl);
-            manifest.Metadata.SetIconUrl(SampleIconUrl);
-            manifest.Metadata.Tags = SampleTags;
+            manifest.Metadata.SetProjectUrl(sampleProjectUrl);
+            manifest.Metadata.LicenseMetadata = new LicenseMetadata(LicenseType.Expression, "MIT", NuGetLicenseExpression.Parse("MIT"), new string[] {}, LicenseMetadata.CurrentVersion);
+            manifest.Metadata.SetIconUrl(sampleIconUrl);
+            manifest.Metadata.Tags = sampleTags;
             manifest.Metadata.Copyright = "Copyright " + DateTime.Now.Year;
-            manifest.Metadata.ReleaseNotes = SampleReleaseNotes;
+            manifest.Metadata.ReleaseNotes = sampleReleaseNotes;
             string nuspecFile = fileName + PackagingConstants.ManifestExtension;
 
             // Skip the creation if the file exists and force wasn't specified
@@ -110,7 +114,7 @@ namespace NuGet.CommandLine
                 {
                     using (var stream = new MemoryStream())
                     {
-                        manifest.Save(stream);
+                        manifest.Save(stream, generateBackwardsCompatible: false);
                         stream.Seek(0, SeekOrigin.Begin);
                         string content = stream.ReadToEnd();
                         // We have to replace it here because we can't have

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
@@ -63,8 +63,29 @@ namespace NuGet.Packaging
         /// Saves the current manifest to the specified stream.
         /// </summary>
         /// <param name="stream">The target stream.</param>
+        /// <param name="generateBackwardsCompatible">Write out a manifest that's consumable by legacy clients, by adding any necessary translations into legacy fields.</param>
+        public void Save(Stream stream, bool generateBackwardsCompatible)
+        {
+            Save(stream, minimumManifestVersion: 1, generateBackwardsCompatible);
+        }
+
+        /// <summary>
+        /// Saves the current manifest to the specified stream.
+        /// </summary>
+        /// <param name="stream">The target stream.</param>
         /// <param name="minimumManifestVersion">The minimum manifest version that this class must use when saving.</param>
         public void Save(Stream stream, int minimumManifestVersion)
+        {
+            Save(stream, minimumManifestVersion, generateBackwardsCompatible: true);
+        }
+
+        /// <summary>
+        /// Saves the current manifest to the specified stream.
+        /// </summary>
+        /// <param name="stream">The target stream.</param>
+        /// <param name="minimumManifestVersion">The minimum manifest version that this class must use when saving.</param>
+        /// <param name="generateBackwardsCompatible">Write out a manifest that's consumable by legacy clients, by adding any necessary translations into legacy fields.</param>
+        public void Save(Stream stream, int minimumManifestVersion, bool generateBackwardsCompatible)
         {
 
             Validate(this);
@@ -74,7 +95,7 @@ namespace NuGet.Packaging
 
             new XDocument(
                 new XElement(schemaNamespace + "package",
-                    Metadata.ToXElement(schemaNamespace),
+                    Metadata.ToXElement(schemaNamespace, generateBackwardsCompatible: generateBackwardsCompatible),
                     Files.Any() ?
                         new XElement(schemaNamespace + "files",
                             Files.Select(file => new XElement(schemaNamespace + "file",
@@ -231,7 +252,7 @@ namespace NuGet.Packaging
 
             // Run all validations
             results.AddRange(manifest.Metadata.Validate());
-            foreach(var manifestFile in manifest.Files)
+            foreach (var manifestFile in manifest.Files)
             {
                 results.AddRange(manifestFile.Validate());
             }

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
@@ -26,6 +26,11 @@ namespace NuGet.Packaging.Xml
 
         public static XElement ToXElement(this ManifestMetadata metadata, XNamespace ns)
         {
+            return ToXElement(metadata, ns, generateBackwardsCompatible: true);
+        }
+
+        public static XElement ToXElement(this ManifestMetadata metadata, XNamespace ns, bool generateBackwardsCompatible = true)
+        {
             var elem = new XElement(ns + "metadata");
             if (metadata.MinClientVersionString != null)
             {
@@ -55,7 +60,10 @@ namespace NuGet.Packaging.Xml
                     {
                         elem.Add(licenseElement);
                     }
-                    licenseUrlToWrite = metadata.LicenseMetadata.LicenseUrl.OriginalString;
+                    if (generateBackwardsCompatible)
+                    {
+                        licenseUrlToWrite = metadata.LicenseMetadata.LicenseUrl.OriginalString;
+                    }
                 }
                 AddElementIfNotNull(elem, ns, "licenseUrl", licenseUrlToWrite);
 
@@ -91,7 +99,7 @@ namespace NuGet.Packaging.Xml
             elem.Add(GetXElementFromGroupableItemSets(
                 ns,
                 metadata.DependencyGroups,
-                set => set.TargetFramework.IsSpecificFramework || 
+                set => set.TargetFramework.IsSpecificFramework ||
                        set.Packages.Any(dependency => dependency.Exclude.Count > 0 || dependency.Include.Count > 0),
                 set => set.TargetFramework.IsSpecificFramework ? set.TargetFramework.GetFrameworkString() : null,
                 set => set.Packages,
@@ -115,9 +123,9 @@ namespace NuGet.Packaging.Xml
                 isGroupable: set => true, // the TFM is required for framework references
                 getGroupIdentifer: set => set.TargetFramework.GetFrameworkString(),
                 getItems: set => set.FrameworkReferences,
-                getXElementFromItem : GetXElementFromFrameworkReference,
+                getXElementFromItem: GetXElementFromFrameworkReference,
                 parentName: NuspecUtility.FrameworkReferences,
-                identifierAttributeName : TargetFramework));
+                identifierAttributeName: TargetFramework));
 
             elem.Add(GetXElementFromFrameworkAssemblies(ns, metadata.FrameworkReferences));
             elem.Add(GetXElementFromManifestContentFiles(ns, metadata.ContentFiles));

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
@@ -36,23 +36,25 @@ namespace NuGet.CommandLine.Test
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
 
                 var nuspec = File.ReadAllText(Path.Combine(workingDirectory, "Package.nuspec"));
-                Assert.Equal($@"<?xml version=""1.0""?>
+                Assert.Equal($@"<?xml version=""1.0"" encoding=""utf-8""?>
 <package >
   <metadata>
     <id>Package</id>
     <version>1.0.0</version>
     <authors>{Environment.UserName}</authors>
     <owners>{Environment.UserName}</owners>
-    <licenseUrl>http://LICENSE_URL_HERE_OR_DELETE_THIS_LINE</licenseUrl>
-    <projectUrl>http://PROJECT_URL_HERE_OR_DELETE_THIS_LINE</projectUrl>
-    <iconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>http://license_url_here_or_delete_this_line/</licenseUrl>
+    <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
+    <iconUrl>http://icon_url_here_or_delete_this_line/</iconUrl>
     <description>Package description</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
     <copyright>Copyright 2019</copyright>
     <tags>Tag1 Tag2</tags>
     <dependencies>
-      <dependency id=""SampleDependency"" version=""1.0"" />
+      <group targetFramework=""4720.0"">
+        <dependency id=""SampleDependency"" version=""1.0.0"" />
+      </group>
     </dependencies>
   </metadata>
 </package>", nuspec);
@@ -77,23 +79,25 @@ namespace NuGet.CommandLine.Test
                 var fileName = Path.Combine(workingDirectory, "Whatnot.nuspec");
                 Assert.True(File.Exists(fileName));
                 var nuspec = File.ReadAllText(fileName);
-                Assert.Equal($@"<?xml version=""1.0""?>
+                Assert.Equal($@"<?xml version=""1.0"" encoding=""utf-8""?>
 <package >
   <metadata>
     <id>Whatnot</id>
     <version>1.0.0</version>
     <authors>{Environment.UserName}</authors>
     <owners>{Environment.UserName}</owners>
-    <licenseUrl>http://LICENSE_URL_HERE_OR_DELETE_THIS_LINE</licenseUrl>
-    <projectUrl>http://PROJECT_URL_HERE_OR_DELETE_THIS_LINE</projectUrl>
-    <iconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>http://license_url_here_or_delete_this_line/</licenseUrl>
+    <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
+    <iconUrl>http://icon_url_here_or_delete_this_line/</iconUrl>
     <description>Package description</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
     <copyright>Copyright 2019</copyright>
     <tags>Tag1 Tag2</tags>
     <dependencies>
-      <dependency id=""SampleDependency"" version=""1.0"" />
+      <group targetFramework=""4720.0"">
+        <dependency id=""SampleDependency"" version=""1.0.0"" />
+      </group>
     </dependencies>
   </metadata>
 </package>", nuspec);
@@ -130,7 +134,7 @@ namespace NuGet.CommandLine.Test
                 var fileName = Path.Combine(workingDirectory, "Project.nuspec");
                 Assert.True(File.Exists(fileName));
                 var nuspec = File.ReadAllText(fileName);
-                Assert.Equal($@"<?xml version=""1.0""?>
+                Assert.Equal($@"<?xml version=""1.0"" encoding=""utf-8""?>
 <package >
   <metadata>
     <id>$id$</id>
@@ -138,10 +142,10 @@ namespace NuGet.CommandLine.Test
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>
-    <licenseUrl>http://LICENSE_URL_HERE_OR_DELETE_THIS_LINE</licenseUrl>
-    <projectUrl>http://PROJECT_URL_HERE_OR_DELETE_THIS_LINE</projectUrl>
-    <iconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>http://license_url_here_or_delete_this_line/</licenseUrl>
+    <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
+    <iconUrl>http://icon_url_here_or_delete_this_line/</iconUrl>
     <description>$description$</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
     <copyright>Copyright 2019</copyright>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.CommandLine.Test
@@ -16,6 +18,137 @@ namespace NuGet.CommandLine.Test
         public void SpecCommand_Failure_InvalidArguments(string cmd)
         {
             Util.TestCommandInvalidArguments(cmd);
+        }
+
+        [Fact]
+        public void SpecCommand_NoProjectFile()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var workingDirectory = TestDirectory.Create())
+            {
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingDirectory,
+                    "spec",
+                    waitForExit: true);
+
+                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+
+                var nuspec = File.ReadAllText(Path.Combine(workingDirectory, "Package.nuspec"));
+                Assert.Equal($@"<?xml version=""1.0""?>
+<package >
+  <metadata>
+    <id>Package</id>
+    <version>1.0.0</version>
+    <authors>{Environment.UserName}</authors>
+    <owners>{Environment.UserName}</owners>
+    <licenseUrl>http://LICENSE_URL_HERE_OR_DELETE_THIS_LINE</licenseUrl>
+    <projectUrl>http://PROJECT_URL_HERE_OR_DELETE_THIS_LINE</projectUrl>
+    <iconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Package description</description>
+    <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
+    <copyright>Copyright 2019</copyright>
+    <tags>Tag1 Tag2</tags>
+    <dependencies>
+      <dependency id=""SampleDependency"" version=""1.0"" />
+    </dependencies>
+  </metadata>
+</package>", nuspec);
+            }
+        }
+
+        [Fact]
+        public void SpecCommand_NoProjectFile_WithArg()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var workingDirectory = TestDirectory.Create())
+            {
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingDirectory,
+                    "spec Whatnot",
+                    waitForExit: true);
+
+                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+
+                var fileName = Path.Combine(workingDirectory, "Whatnot.nuspec");
+                Assert.True(File.Exists(fileName));
+                var nuspec = File.ReadAllText(fileName);
+                Assert.Equal($@"<?xml version=""1.0""?>
+<package >
+  <metadata>
+    <id>Whatnot</id>
+    <version>1.0.0</version>
+    <authors>{Environment.UserName}</authors>
+    <owners>{Environment.UserName}</owners>
+    <licenseUrl>http://LICENSE_URL_HERE_OR_DELETE_THIS_LINE</licenseUrl>
+    <projectUrl>http://PROJECT_URL_HERE_OR_DELETE_THIS_LINE</projectUrl>
+    <iconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Package description</description>
+    <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
+    <copyright>Copyright 2019</copyright>
+    <tags>Tag1 Tag2</tags>
+    <dependencies>
+      <dependency id=""SampleDependency"" version=""1.0"" />
+    </dependencies>
+  </metadata>
+</package>", nuspec);
+            }
+        }
+
+        [Fact]
+        public void SpecCommand_WithProjectFile()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var workingDirectory = TestDirectory.Create())
+            {
+                Util.CreateFile(
+                    workingDirectory,
+                    "Project.csproj",
+                    @"<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>");
+
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingDirectory,
+                    "spec",
+                    waitForExit: true);
+
+                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+
+                var fileName = Path.Combine(workingDirectory, "Project.nuspec");
+                Assert.True(File.Exists(fileName));
+                var nuspec = File.ReadAllText(fileName);
+                Assert.Equal($@"<?xml version=""1.0""?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
+    <licenseUrl>http://LICENSE_URL_HERE_OR_DELETE_THIS_LINE</licenseUrl>
+    <projectUrl>http://PROJECT_URL_HERE_OR_DELETE_THIS_LINE</projectUrl>
+    <iconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>$description$</description>
+    <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
+    <copyright>Copyright 2019</copyright>
+    <tags>Tag1 Tag2</tags>
+  </metadata>
+</package>", nuspec);
+            }
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
@@ -1,9 +1,8 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NuGet.Test.Utility;
 using Xunit;
 
@@ -44,7 +43,7 @@ namespace NuGet.CommandLine.Test
     <authors>{Environment.UserName}</authors>
     <owners>{Environment.UserName}</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <licenseUrl>http://license_url_here_or_delete_this_line/</licenseUrl>
+    <license type=""expression"">MIT</license>
     <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
     <iconUrl>http://icon_url_here_or_delete_this_line/</iconUrl>
     <description>Package description</description>
@@ -52,12 +51,12 @@ namespace NuGet.CommandLine.Test
     <copyright>Copyright 2019</copyright>
     <tags>Tag1 Tag2</tags>
     <dependencies>
-      <group targetFramework=""4720.0"">
+      <group targetFramework="".NETStandard2.1"">
         <dependency id=""SampleDependency"" version=""1.0.0"" />
       </group>
     </dependencies>
   </metadata>
-</package>", nuspec);
+</package>".Replace("\r\n", "\n"), nuspec.Replace("\r\n", "\n"));
             }
         }
 
@@ -87,7 +86,7 @@ namespace NuGet.CommandLine.Test
     <authors>{Environment.UserName}</authors>
     <owners>{Environment.UserName}</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <licenseUrl>http://license_url_here_or_delete_this_line/</licenseUrl>
+    <license type=""expression"">MIT</license>
     <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
     <iconUrl>http://icon_url_here_or_delete_this_line/</iconUrl>
     <description>Package description</description>
@@ -95,12 +94,12 @@ namespace NuGet.CommandLine.Test
     <copyright>Copyright 2019</copyright>
     <tags>Tag1 Tag2</tags>
     <dependencies>
-      <group targetFramework=""4720.0"">
+      <group targetFramework="".NETStandard2.1"">
         <dependency id=""SampleDependency"" version=""1.0.0"" />
       </group>
     </dependencies>
   </metadata>
-</package>", nuspec);
+</package>".Replace("\r\n", "\n"), nuspec.Replace("\r\n", "\n"));
             }
         }
 
@@ -143,7 +142,7 @@ namespace NuGet.CommandLine.Test
     <authors>$author$</authors>
     <owners>$author$</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <licenseUrl>http://license_url_here_or_delete_this_line/</licenseUrl>
+    <license type=""expression"">MIT</license>
     <projectUrl>http://project_url_here_or_delete_this_line/</projectUrl>
     <iconUrl>http://icon_url_here_or_delete_this_line/</iconUrl>
     <description>$description$</description>
@@ -151,7 +150,7 @@ namespace NuGet.CommandLine.Test
     <copyright>Copyright 2019</copyright>
     <tags>Tag1 Tag2</tags>
   </metadata>
-</package>", nuspec);
+</package>".Replace("\r\n", "\n"), nuspec.Replace("\r\n", "\n"));
             }
         }
     }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/nuget/home/issues/7531  
Regression: No  

## Fix

Details:

* Refactors `nuget spec` to stop using the `ClientV2` assembly and uses `NuGet.Packaging.Manifest` instead. This involves some minor changes to the output of the command due to serialization differences that I don't believe should be backported.
* Makes `nuget spec` stop writing `<licenseUrl>` elements into the generated `.nuspec`s, and replaces that with proper `<license>` elements, due to the former being deprecated now.
* (in order to achieve the above) Changes `NuGet.Packaging.Manifest`'s XML serialization such that a `<licenseUrl>` element is ONLY generated if one was provided explicitly.

## Testing/Validation

Tests Added: Yes
