### PR TITLE
Build:  retry nuget.exe download on failure

### DIFF
--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -13,17 +13,17 @@ RESULTCODE=0
 
 # move up to the repo root
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-DIR=$SCRIPTDIR/../../
-pushd $DIR
+DIR=$SCRIPTDIR/../..
+pushd $DIR/
 
 NuGetExe="$DIR/.nuget/nuget.exe"
 #Get NuGet.exe
-curl -o $NuGetExe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+curl -o $NuGetExe --retry 5 --retry-delay 10 https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
 
 mono --version
 
 #restore solution packages
-mono $NuGetExe restore  "$DIR/.nuget/packages.config" -SolutionDirectory "$DIR"
+mono $NuGetExe restore  "$DIR/.nuget/packages.config" -SolutionDirectory "$DIR/"
 if [ $? -ne 0 ]; then
 	echo "Restore failed!!"
 	exit 1
@@ -93,13 +93,13 @@ fi
 
 RESULTFILE="build/TestResults/TestResults.xml"
 
-echo "Checking if result file exists at $DIR$RESULTFILE"
-if [ -f  "$DIR$RESULTFILE" ]
+echo "Checking if result file exists at $DIR/$RESULTFILE"
+if [ -f  "$DIR/$RESULTFILE" ]
 then
-	echo "Renaming $DIR$RESULTFILE"
+	echo "Renaming $DIR/$RESULTFILE"
 	mv "$RESULTFILE" "$DIR/build/TestResults/TestResults.$(date +%H%M%S).xml"
 else
-	echo "$DIR$RESULTFILE not found."
+	echo "$DIR/$RESULTFILE not found."
 fi
 
 # Func tests
@@ -111,13 +111,13 @@ if [ $? -ne 0 ]; then
 	echo "CoreFuncTests failed!!"
 fi
 
-echo "Checking if result file exists at $DIR$RESULTFILE"
-if [ -f  "$DIR$RESULTFILE" ]
+echo "Checking if result file exists at $DIR/$RESULTFILE"
+if [ -f  "$DIR/$RESULTFILE" ]
 then
-	echo "Renaming $DIR$RESULTFILE"
+	echo "Renaming $DIR/$RESULTFILE"
 	mv "$RESULTFILE" "$DIR/build/TestResults/TestResults.$(date +%H%M%S).xml"
 else
-	echo "$DIR$RESULTFILE not found."
+	echo "$DIR/$RESULTFILE not found."
 fi
 
 if [ -z "$CI" ]; then
@@ -141,7 +141,7 @@ case "$(uname -s)" in
 			#mono $XunitConsole "$TestDir/NuGet.CommandLine.Test.dll" -notrait Platform=Windows -notrait Platform=Darwin -xml "build/TestResults/monoonlinux.xml"
 			if [ $RESULTCODE -ne '0' ]; then
 				RESULTCODE=$?
-				echo "Unit Tests or Core Func Tests failed on Linux"				
+				echo "Unit Tests or Core Func Tests failed on Linux"
 				exit 1
 			fi
 			;;


### PR DESCRIPTION
Resolve https://github.com/NuGet/Home/issues/8499.

Also, I noticed from a subsequent failure to execute the partially downloaded `nuget.exe` in Mono that there's an extra slash (`/`) in `$DIR` concatenations:

    Cannot open assembly '/home/user/agent/_work/2/s/scripts/funcTests/../..//.nuget/nuget.exe': File does not contain a valid CIL image.

This PR also removes the extra slash.