### PR TITLE
Support custom HttpHandlerResource provider

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/FactoryExtensionsV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/FactoryExtensionsV3.cs
@@ -11,6 +11,12 @@ namespace NuGet.Protocol
 {
     public static class FactoryExtensionsV3
     {
+        public static Func<INuGetResourceProvider> CreateHttpHandlerResourceV3Provider
+        {
+            get;
+            set;
+        } = () => new HttpHandlerResourceV3Provider();
+
         public static SourceRepository GetCoreV3(this Repository.RepositoryFactory factory, string source, FeedType type)
         {
             return Repository.CreateSource(Repository.Provider.GetCoreV3(), source, type);
@@ -40,7 +46,7 @@ namespace NuGet.Protocol
             yield return new Lazy<INuGetResourceProvider>(() => new PackageDetailsUriResourceV3Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new ServiceIndexResourceV3Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new ODataServiceDocumentResourceV2Provider());
-            yield return new Lazy<INuGetResourceProvider>(() => new HttpHandlerResourceV3Provider());
+            yield return new Lazy<INuGetResourceProvider>(() => CreateHttpHandlerResourceV3Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new HttpSourceResourceProvider());
             yield return new Lazy<INuGetResourceProvider>(() => new PluginFindPackageByIdResourceProvider());
             yield return new Lazy<INuGetResourceProvider>(() => new HttpFileSystemBasedFindPackageByIdResourceProvider());

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/FactoryExtensionsV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/FactoryExtensionsV3Tests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using NuGet.Protocol.Core.Types;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class FactoryExtensionsV3Tests
+    {
+        static INuGetResourceProvider GetProvider(IEnumerable<Lazy<INuGetResourceProvider>> providers, Type type)
+        {
+            foreach (var provider in providers)
+            {
+                if (provider.Value.ResourceType == type)
+                {
+                    return provider.Value;
+                }
+             }
+            return null;
+        }
+
+        [Fact]
+        public void DefaultHttpHandlerProvider()
+        {
+            var providers = Repository.Provider.GetCoreV3().ToList();
+            INuGetResourceProvider provider = GetProvider (providers, typeof(HttpHandlerResource));
+
+            Assert.IsType<HttpHandlerResourceV3Provider>(provider);
+        }
+
+        [Fact]
+        public void CustomHttpHandlerProvider()
+        {
+            var originalProvider = FactoryExtensionsV3.CreateHttpHandlerResourceV3Provider;
+
+            try
+            {
+                Func<HttpClientHandler> messageHandlerFactory = () => new HttpClientHandler();
+                var testProvider = new TestHttpHandlerProvider(messageHandlerFactory);
+                FactoryExtensionsV3.CreateHttpHandlerResourceV3Provider = () => testProvider;
+                var providers = Repository.Provider.GetCoreV3().ToList();
+                INuGetResourceProvider provider = GetProvider(providers, typeof(HttpHandlerResource));
+
+                Assert.IsType<TestHttpHandlerProvider>(provider);
+            }
+            finally
+            {
+                FactoryExtensionsV3.CreateHttpHandlerResourceV3Provider = originalProvider;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8330
Regression: No  
* Last working version:   N/A
* How are we preventing it in future:  N/A

## Fix

Details: Running a NuGet restore or install with a project that uses
PackageReferences would bypass the custom HttpHandlerResources
associated with the SourceRepository instances. Whilst most operations
use the HttpHandlerResource provider some operations that use the
CachingSourceProvider result in new providers being created.

Now there is a way to specify a custom provider for the
HttpHandlerResource.

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests: 
Validation:  