### PR TITLE
Enables PoliCheck in CI

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -298,6 +298,7 @@ phases:
     displayName: 'Wording Review'
     inputs:
       targetType: F
+      targetArgument: '$(Build.SourcesDirectory)/src'
       optionsFC: '1'
       optionsXS: '1'
       optionsSEV: '1|2'

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -955,3 +955,20 @@ phases:
         . $(Build.Repository.LocalPath)\\scripts\\e2etests\\VSUtils.ps1
         KillRunningInstancesOfVS
     condition: "always()"
+<<<<<<< HEAD
+=======
+
+- phase: Automatic_Reviews
+  queue:
+    name: VSEng-MicroBuildVS2017
+    timeoutInMinutes: 60
+
+  steps:
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+    displayName: 'Wording Automatic Review'
+    inputs:
+      targetType: F
+      SOMEnabled: true
+      uploadToSOM: true
+      workspaceId: 'ce576670-f1b4-4c3d-b150-4bbfa665e203'
+>>>>>>> Wording review from CI

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -294,6 +294,18 @@ phases:
     displayName: 'Component Detection'
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'true'))"
 
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+    displayName: 'Wording Review'
+    inputs:
+      targetType: F
+      optionsFC: '1'
+      optionsXS: '1'
+      optionsSEV: '1|2'
+      optionsHMENABLE: '0'
+      SOMEnabled: true
+      uploadToSOM: true
+      workspaceId: ce576670-f1b4-4c3d-b150-4bbfa665e203
+
   - task: CopyFiles@2
     displayName: "Copy Nupkgs"
     inputs:
@@ -955,20 +967,3 @@ phases:
         . $(Build.Repository.LocalPath)\\scripts\\e2etests\\VSUtils.ps1
         KillRunningInstancesOfVS
     condition: "always()"
-<<<<<<< HEAD
-=======
-
-- phase: Automatic_Reviews
-  queue:
-    name: VSEng-MicroBuildVS2017
-    timeoutInMinutes: 60
-
-  steps:
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
-    displayName: 'Wording Automatic Review'
-    inputs:
-      targetType: F
-      SOMEnabled: true
-      uploadToSOM: true
-      workspaceId: 'ce576670-f1b4-4c3d-b150-4bbfa665e203'
->>>>>>> Wording review from CI


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/7929
Regression: No
* Last working version: N/A
* How are we preventing it in future: By adding more automatic analysis tools.

## Fix

Adds a build task just after Component Governance task.

## Testing/Validation

Tests Added: No
Reason for not adding tests: Build step that only lives in the CI
Validation:  CI build
