### PR TITLE
Add more discoverable names for file and forget nuget events

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
@@ -19,7 +19,7 @@ namespace NuGet.VisualStudio.Telemetry
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(memberName));
             }
 
-            return $"{VSTelemetrySession.VSEventNamePrefix}/fileandforget/{typeName}/{memberName}";
+            return $"{VSTelemetrySession.VSEventNamePrefix}fileandforget/{typeName}/{memberName}";
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/TelemetryUtility.cs
@@ -19,7 +19,7 @@ namespace NuGet.VisualStudio.Telemetry
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(memberName));
             }
 
-            return $"{VSTelemetrySession.VSEventNamePrefix}{typeName}/{memberName}";
+            return $"{VSTelemetrySession.VSEventNamePrefix}/fileandforget/{typeName}/{memberName}";
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/TelemetryUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/TelemetryUtilityTests.cs
@@ -34,7 +34,7 @@ namespace NuGet.VisualStudio.Common.Test
         {
             string actualResult = TelemetryUtility.CreateFileAndForgetEventName("a", "b");
 
-            Assert.Equal("VS/NuGet/a/b", actualResult);
+            Assert.Equal("VS/NuGet/fileandforget/a/b", actualResult);
         }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8519
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Add a prefix to make file and forget telemetry events distinguishable from the normal telemetry events.

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
