### PR TITLE
Use StringBuilder instead of multiple string concatenations

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Versioning;
+using System.Text;
 using System.Threading;
 using System.Xml.Linq;
 using NuGet.Commands;
@@ -439,14 +440,23 @@ namespace NuGet.CommandLine
 
         private void BuildProjectWithMsbuild()
         {
-            string properties = string.Empty;
+            var sb = new StringBuilder();
+            sb.Append('"');
+            sb.Append(_project.FullPath);
+            sb.Append('"');
+
             foreach (var property in ProjectProperties)
             {
-                string escapedValue = MsBuildUtility.Escape(property.Value);
-                properties += $" /p:{property.Key}={escapedValue}";
+                sb.Append(" /p:");
+                sb.Append(property.Key);
+                sb.Append('=');
+                sb.Append(MsBuildUtility.Escape(property.Value));
             }
 
-            int result = MsBuildUtility.Build(_msbuildDirectory, $"\"{_project.FullPath}\" {properties} /toolsversion:{_project.ToolsVersion}");
+            sb.Append(" /toolsversion:");
+            sb.Append(_project.ToolsVersion);
+
+            int result = MsBuildUtility.Build(_msbuildDirectory, sb.ToString());
 
             if (0 != result) // 0 is msbuild.exe success code
             {

--- a/src/NuGet.Clients/NuGet.CommandLine/DiagnosticCommands.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/DiagnosticCommands.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using NuGet.Frameworks;
 using NuGet.ProjectModel;
 
@@ -157,31 +158,49 @@ namespace NuGet.CommandLine
             foreach (var target in targets)
             {
                 _log.LogMinimal($"Target: {target.TargetFramework} {target.RuntimeIdentifier}");
+                var sb = new StringBuilder();
                 foreach (var lib in target.Libraries)
                 {
-                    var provides = string.Empty;
+                    sb.Clear();
+
+                    sb.Append(" * [");
+
                     if (lib.NativeLibraries.Any())
                     {
-                        provides += Native + ",";
+                        sb.Append(Native);
+                        sb.Append(',');
                     }
                     if (lib.RuntimeAssemblies.Any())
                     {
-                        provides += Runtime + ",";
+                        sb.Append(Runtime);
+                        sb.Append(',');
                     }
                     if (lib.CompileTimeAssemblies.Any())
                     {
-                        provides += Compile + ",";
+                        sb.Append(Compile);
+                        sb.Append(',');
                     }
                     if (lib.FrameworkAssemblies.Any())
                     {
-                        provides += Framework + ",";
+                        sb.Append(Framework);
+                        sb.Append(',');
                     }
-                    provides = provides.TrimEnd(',');
-                    if (string.IsNullOrEmpty(provides))
+
+                    if (sb[sb.Length - 1] == ',')
                     {
-                        provides = Nothing;
+                        sb.Length--;
                     }
-                    _log.LogMinimal($" * [{provides}] {lib.Name} {lib.Version}");
+                    else
+                    {
+                        sb.Append(Nothing);
+                    }
+
+                    sb.Append("] ");
+                    sb.Append(lib.Name);
+                    sb.Append(' ');
+                    sb.Append(lib.Version);
+
+                    _log.LogMinimal(sb.ToString());
                 }
             }
             return 0;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ScriptExecutionRequest.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ScriptExecutionRequest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -43,11 +43,12 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public string BuildCommand()
         {
-            var escapedScriptPath = PathUtility.EscapePSPath(ScriptPath);
             var command = new StringBuilder(
                 "$__pc_args=@(); " +
                 "$input|%{$__pc_args+=$_}; " +
-                "& " + escapedScriptPath + " $__pc_args[0] $__pc_args[1] $__pc_args[2]");
+                "& ");
+            command.Append(PathUtility.EscapePSPath(ScriptPath));
+            command.Append(" $__pc_args[0] $__pc_args[1] $__pc_args[2]");
             command.Append(Project != null ? " $__pc_args[3]; " : "; ");
             command.Append("Remove-Variable __pc_args -Scope 0");
 

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Text;
 
 namespace NuGet.Common
 {
@@ -229,30 +230,32 @@ namespace NuGet.Common
                 ++index;
             }
 
-            var path = "";
-
             // check if path2 ends with a non-directory separator and if path1 has the same non-directory at the end
             if (len1 + 1 == len2 && !string.IsNullOrEmpty(path1Segments[index]) &&
                 string.Equals(path1Segments[index], path2Segments[index], compare))
             {
-                return path;
+                return string.Empty;
             }
+
+            var path = new StringBuilder();
 
             for (var i = index; len1 > i; ++i)
             {
-                path += ".." + separator;
+                path.Append("..");
+                path.Append(separator);
             }
             for (var i = index; len2 - 1 > i; ++i)
             {
-                path += path2Segments[i] + separator;
+                path.Append(path2Segments[i]);
+                path.Append(separator);
             }
             // if path2 doesn't end with an empty string it means it ended with a non-directory name, so we add it back
             if (!string.IsNullOrEmpty(path2Segments[len2 - 1]))
             {
-                path += path2Segments[len2 - 1];
+                path.Append(path2Segments[len2 - 1]);
             }
 
-            return path;
+            return path.ToString();
         }
 
         public static string GetAbsolutePath(string basePath, string relativePath)

--- a/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
@@ -171,22 +171,30 @@ namespace NuGet.Credentials
         private PluginCredentialResponse GetPluginResponse(PluginCredentialRequest request,
             CancellationToken cancellationToken)
         {
-            var argumentString =
-                $"-uri {request.Uri}"
-                + (request.IsRetry ? " -isRetry" : string.Empty)
-                + (request.NonInteractive ? " -nonInteractive" : string.Empty);
+            var argumentString = new StringBuilder();
+            argumentString.Append("-uri ");
+            argumentString.Append(request.Uri);
+            if (request.IsRetry)
+            {
+                argumentString.Append(" -isRetry");
+            }
+            if (request.NonInteractive)
+            {
+                argumentString.Append(" -nonInteractive");
+            }
 
             // only apply -verbosity flag if set and != Normal
             // since normal is default
             if (PassVerbosityFlag(request))
             {
-                argumentString += $" -verbosity {request.Verbosity.ToLower()}";
+                argumentString.Append(" -verbosity ");
+                argumentString.Append(request.Verbosity.ToLower());
             }
 
             var startInfo = new ProcessStartInfo
             {
                 FileName = Path,
-                Arguments = argumentString,
+                Arguments = argumentString.ToString(),
 #if IS_DESKTOP                
                 WindowStyle = ProcessWindowStyle.Hidden,
                 ErrorDialog = false,

--- a/src/NuGet.Core/NuGet.PackageManagement/InstallationCompatibility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/InstallationCompatibility.cs
@@ -161,11 +161,10 @@ namespace NuGet.PackageManagement
             else if (packageTypes.Count == 1)
             {
                 var packageType = packageTypes[0];
-                var packageTypeString = packageType.Name;
-                if (packageType.Version != PackageType.EmptyVersion)
-                {
-                    packageTypeString += " " + packageType.Version;
-                }
+                var packageTypeString =
+                    packageType.Version != PackageType.EmptyVersion
+                    ? packageType.Name + " " + packageType.Version
+                    : packageType.Name;
 
                 var projectName = NuGetProject.GetUniqueNameOrName(nuGetProject);
 

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
@@ -29,19 +29,28 @@ namespace NuGet.Packaging.Signing
         public static string X509Certificate2ToString(X509Certificate2 cert, HashAlgorithmName fingerprintAlgorithm)
         {
             var certStringBuilder = new StringBuilder();
-            X509Certificate2ToString(cert, certStringBuilder, fingerprintAlgorithm, indentation: "  ");
+            X509Certificate2ToString(cert, certStringBuilder, fingerprintAlgorithm, indentation: 1);
             return certStringBuilder.ToString();
         }
 
-        private static void X509Certificate2ToString(X509Certificate2 cert, StringBuilder certStringBuilder, HashAlgorithmName fingerprintAlgorithm, string indentation)
+        private static void X509Certificate2ToString(X509Certificate2 cert, StringBuilder certStringBuilder, HashAlgorithmName fingerprintAlgorithm, int indentation)
         {
+            void AppendLine(string str)
+            {
+                for (int level = 1; level <= indentation; level++)
+                {
+                    certStringBuilder.Append("  ");
+                }
+                certStringBuilder.AppendLine(str);
+            }
+
             var certificateFingerprint = GetHashString(cert, fingerprintAlgorithm);
 
-            certStringBuilder.AppendLine($"{indentation}{string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateSubjectName, cert.Subject)}");
-            certStringBuilder.AppendLine($"{indentation}{string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateHashSha1, cert.Thumbprint)}");
-            certStringBuilder.AppendLine($"{indentation}{string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateHash, fingerprintAlgorithm.ToString(),certificateFingerprint)}");
-            certStringBuilder.AppendLine($"{indentation}{string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateIssuer, cert.IssuerName.Name)}");
-            certStringBuilder.AppendLine($"{indentation}{string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateValidity, cert.NotBefore, cert.NotAfter)}");
+            AppendLine(string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateSubjectName, cert.Subject));
+            AppendLine(string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateHashSha1, cert.Thumbprint));
+            AppendLine(string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateHash, fingerprintAlgorithm.ToString(),certificateFingerprint));
+            AppendLine(string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateIssuer, cert.IssuerName.Name));
+            AppendLine(string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateValidity, cert.NotBefore, cert.NotAfter));
         }
 
         /// <summary>
@@ -70,7 +79,7 @@ namespace NuGet.Packaging.Signing
             for (var i = 0; i < Math.Min(_limit, certCollection.Count); i++)
             {
                 var cert = certCollection[i];
-                X509Certificate2ToString(cert, collectionStringBuilder, fingerprintAlgorithm, indentation: "  ");
+                X509Certificate2ToString(cert, collectionStringBuilder, fingerprintAlgorithm, indentation: 1);
                 collectionStringBuilder.AppendLine();
             }
 
@@ -85,16 +94,13 @@ namespace NuGet.Packaging.Signing
         public static string X509ChainToString(X509Chain chain, HashAlgorithmName fingerprintAlgorithm)
         {
             var collectionStringBuilder = new StringBuilder();
-            var indentationLevel = "      ";
-            var indentation = indentationLevel;
 
             var chainElementsCount = chain.ChainElements.Count;
             // Start in 1 to omit main certificate (only build the chain)
             for (var i = 1; i < Math.Min(_limit, chainElementsCount); i++)
             {
-                X509Certificate2ToString(chain.ChainElements[i].Certificate, collectionStringBuilder, fingerprintAlgorithm, indentation);
+                X509Certificate2ToString(chain.ChainElements[i].Certificate, collectionStringBuilder, fingerprintAlgorithm, indentation: i*3);
                 collectionStringBuilder.AppendLine();
-                indentation += indentationLevel;
             }
 
             if (chainElementsCount > _limit)


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8540
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Mostly by using StringBuilder, but in a few places other techniques were used to avoid string concatenation.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  No features added or changed. Relying on existing tests instead.
Validation:  
