### PR TITLE
Reset PackageDeprecationAlternatePackageText when no deprecation metadata or no alternate package

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Controls;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
@@ -365,16 +366,21 @@ namespace NuGet.PackageManagement.UI
                 {
                     _packageMetadata = value;
 
+                    string newDeprecationReasons = null;
+                    string newAlternatePackageText = null;
                     if (_packageMetadata?.DeprecationMetadata != null)
                     {
-                        PackageDeprecationReasons = ExplainPackageDeprecationReasons(_packageMetadata.DeprecationMetadata.Reasons?.ToList());
+                        newDeprecationReasons = ExplainPackageDeprecationReasons(_packageMetadata.DeprecationMetadata.Reasons?.ToList());
 
                         var alternatePackage = _packageMetadata.DeprecationMetadata.AlternatePackage;
                         if (alternatePackage != null)
                         {
-                            PackageDeprecationAlternatePackageText = GetPackageDeprecationAlternatePackageText(alternatePackage);
+                            newAlternatePackageText = GetPackageDeprecationAlternatePackageText(alternatePackage);
                         }
                     }
+
+                    PackageDeprecationReasons = newDeprecationReasons;
+                    PackageDeprecationAlternatePackageText = newAlternatePackageText;
 
                     OnPropertyChanged(nameof(PackageMetadata));
                     OnPropertyChanged(nameof(IsPackageDeprecated));

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -7,7 +7,6 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Controls;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8509
Regression: No
* Last working version:   N/A
* How are we preventing it in future:   N/A

## Fix

When the package does not deprecation metadata or does have an alternate package, we did not update either `PackageDeprecationReasons` or `PackageDeprecationAlternatePackageText`.

## Testing/Validation

Tests Added: No
Reason for not adding tests:  UI stuff that is difficult to write tests for
Validation:  It works locally