### PR TITLE
Fix browse tab details pane not loading

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -507,7 +507,7 @@ namespace NuGet.PackageManagement.UI
                                 return new DetailedPackageMetadata(
                                     m.searchMetadata ?? versionInfo.PackageSearchMetadata,
                                     m.deprecationMetadata,
-                                    m.searchMetadata?.DownloadCount ?? versionInfo.DownloadCount);
+                                    m.searchMetadata?.DownloadCount ?? versionInfo?.DownloadCount);
                             })
                          .ToDictionary(m => m.Version);
                 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8504
Regression: Yes
* Last working version:   16.2 (I think?)
* How are we preventing it in future:   Unfortunately none--I would add unit tests, but it seems unfeasible to do so without refactoring. See Testing/Validation section below.

## Fix

[The null-conditional operator](https://github.com/NuGet/NuGet.Client/commit/9173d9bc53b5123d5cadec6cae513149d40505b0#diff-35d6d0f152827c971017324386a2b3cbL504) was [accidentally removed](https://github.com/NuGet/NuGet.Client/commit/9173d9bc53b5123d5cadec6cae513149d40505b0#diff-35d6d0f152827c971017324386a2b3cbR510). This meant that, for the browse tab, which never has download counts, the code would crash and the details pane would never load.

## Testing/Validation

Tests Added: No

Reason for not adding tests:  Ideally, we would add tests to this, but unfortunately this code is deep in our UI layer (`DetailControlModel` is a XAML class) and it would be nontrivial to move it. I think in the future, some refactoring should be done to clean up this code, but fixing this bug is a higher priority.

Validation:  Verified that issue is fixed on @nkolev92's and my machines.
