### PR TITLE
Screen reader should read number of deprecated packages when Installed tab with warning icon is focused

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FilterLabel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FilterLabel.xaml
@@ -27,9 +27,10 @@
       AutomationProperties.AutomationId="{Binding ElementName=_labelText, Path=Text}"
       FocusVisualStyle="{DynamicResource ControlsFocusVisualStyle}">
       <AutomationProperties.Name>
-        <MultiBinding StringFormat=" {0} {1}">
+        <MultiBinding StringFormat=" {0} {1} {2}">
           <Binding ElementName="_labelText" Path="Text" />
           <Binding ElementName="_textBlockCount" Path="Text" />
+          <Binding ElementName="_warningIcon" Path="ToolTip" />
         </MultiBinding>
       </AutomationProperties.Name>
       <nuget:TabItemButton.Template>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8518
Regression: No
* Last working version:   n/a
* How are we preventing it in future:   n/a

## Fix

Browse tab still reads: "Browse tab item"

Installed tab now reads:
with N deprecated packages - "Installed You have N deprecated package(s) installed tab item"
without deprecated packages - "Installed tab item"

Updates tab still reads:
with N packages that are not latest - "Updates N tab item"
with all latest packages - "Updates tab item"

## Testing/Validation

Tests Added: No
Reason for not adding tests:  Can't write tests for XAML AFAIK
Validation:  Works on my machine in projects with and without deprecated packages.
