### PR TITLE
"(Deprecated)" should show in version select list in installed tab right pane

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/DisplayVersion.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/DisplayVersion.cs
@@ -51,6 +51,7 @@ namespace NuGet.PackageManagement.UI
             Version = range.MinVersion;
             IsCurrentInstalled = isCurrentInstalled;
             AutoReferenced = autoReferenced;
+            IsDeprecated = isDeprecated;
 
             // Display a single version if the range is locked
             // If range is unlocked, display it and use the original value for floating ranges
@@ -66,7 +67,7 @@ namespace NuGet.PackageManagement.UI
 
             _toString += versionString;
 
-            if (isDeprecated)
+            if (IsDeprecated)
             {
                 _toString += string.Format(
                     CultureInfo.CurrentCulture,
@@ -85,6 +86,8 @@ namespace NuGet.PackageManagement.UI
 
         public bool AutoReferenced { get; set; }
 
+        public bool IsDeprecated { get; set; }
+
         public override string ToString()
         {
             return _toString;
@@ -93,7 +96,10 @@ namespace NuGet.PackageManagement.UI
         public override bool Equals(object obj)
         {
             var other = obj as DisplayVersion;
-            return other != null && other.Version == Version && string.Equals(other.AdditionalInfo, AdditionalInfo, StringComparison.Ordinal);
+            return other != null
+                && other.Version == Version
+                && string.Equals(other.AdditionalInfo, AdditionalInfo, StringComparison.Ordinal)
+                && IsDeprecated == other.IsDeprecated;
         }
 
         public override int GetHashCode()

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/DisplayVersion.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/DisplayVersion.cs
@@ -54,18 +54,21 @@ namespace NuGet.PackageManagement.UI
             IsDeprecated = isDeprecated;
 
             // Display a single version if the range is locked
-            // If range is unlocked, display it and use the original value for floating ranges
-            var versionString = range.HasLowerAndUpperBounds && range.MinVersion == range.MaxVersion ?
-                Version.ToString(versionFormat, VersionFormatter.Instance)
-                : Range.OriginalString;
-
-            _toString = "";
-            if (!string.IsNullOrEmpty(AdditionalInfo))
+            if (range.HasLowerAndUpperBounds && range.MinVersion == range.MaxVersion)
             {
-                _toString += AdditionalInfo + " ";
-            }
+                var formattedVersionString = Version.ToString(versionFormat, VersionFormatter.Instance);
 
-            _toString += versionString;
+                _toString = string.IsNullOrEmpty(AdditionalInfo) ?
+                    formattedVersionString :
+                    AdditionalInfo + " " + formattedVersionString;
+            }
+            else
+            {
+                // Display the range, use the original value for floating ranges
+                _toString = string.IsNullOrEmpty(AdditionalInfo) ?
+                    Range.OriginalString :
+                    AdditionalInfo + " " + Range.OriginalString;
+            }
 
             if (IsDeprecated)
             {


### PR DESCRIPTION
## Bug

Fixes: part of https://github.com/NuGet/Home/issues/8516 and https://github.com/NuGet/Home/issues/8541
Regression: No
* Last working version:   n/a
* How are we preventing it in future:   n/a

## Fix

Changed the version list show "(Deprecated)" alongside deprecated versions.

![image](https://user-images.githubusercontent.com/18014088/64299300-90b88300-cf2d-11e9-9ea1-8832189ebf76.png)

Unfortunately, this only applies to the Installed tab for now as the Browse tab doesn't have the deprecation metadata available when it renders the list.

This will make it easier for users to determine which version they should choose and prevent them from updating to deprecated versions.

## Testing/Validation

Tests Added: No
Reason for not adding tests:  UI stuff
Validation:  worked on my machine for packages with/without deprecated versions in both project and solution view
