### PR TITLE
Build:  enable setting ShouldSkipOptimize at build queue time

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -69,7 +69,6 @@ phases:
     FullVstsBuildNumber: $[dependencies.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
     VsTargetChannel: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetChannel']]
     VsTargetMajorVersion: $[dependencies.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
-    ShouldSkipOptimize: false
   queue:
     name: VSEng-MicroBuildVS2019
     timeoutInMinutes: 90


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/8553.

This change makes `ShouldSkipOptimize` settable at build queue time and eliminates the need for the 2 extra commits to get an unbuildable branch back in a buildable state..