### PR TITLE
Add deprecation icon to the solution view's Installed tab

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -421,7 +421,7 @@
 
                 <!-- version to install is visible when
                      * Status is NotInstalled
-                     * Or IsSolution is true
+                     * Or IsSolution is true and IsPackageDeprecated is false
                 -->
                 <MultiDataTrigger>
                   <MultiDataTrigger.Conditions>
@@ -445,6 +445,9 @@
                     </Condition>
                     <Condition
                       Binding="{Binding LatestVersion,Converter={StaticResource NullToBooleanConverter}}"
+                      Value="False" />
+                    <Condition
+                      Binding="{Binding IsPackageDeprecated}"
                       Value="False" />
                   </MultiDataTrigger.Conditions>
                   <Setter
@@ -539,14 +542,7 @@
                   <Setter TargetName="_updateButton" Property="Visibility" Value="Collapsed" />
                 </DataTrigger>
 
-                <!-- The deprecation indicator becomes invisible when
-                   * IsSolution is true; or
-                   * IsPackageDeprecated is true
-                -->
-                <DataTrigger
-                  Binding="{Binding IsSolution, RelativeSource={RelativeSource AncestorType={x:Type nuget:InfiniteScrollList}}}" Value="true">
-                  <Setter TargetName="_deprecationIndicator" Property="Visibility" Value="Collapsed" />
-                </DataTrigger>
+                <!-- The deprecation indicator becomes visible when IsPackageDeprecated is true -->
                 <DataTrigger
                   Binding="{Binding IsPackageDeprecated}" Value="false">
                   <Setter TargetName="_deprecationIndicator" Property="Visibility" Value="Collapsed" />


### PR DESCRIPTION
## Bug

Fixes: Part of https://github.com/NuGet/Home/issues/8516
Regression: No  
* Last working version:   n/a
* How are we preventing it in future:   n/a

## Fix

Right now, in the solution view's installed tab, it's impossible to determine which installed package is deprecated, because there is no icon associated with the rows for the packages that are deprecated.

However, if we just add the icon alongside the latest version that displays, it would be confusing that the version that is deprecated is the latest version. To mitigate this, I have it made it so that the latest version only displays on the solution view if the package is not deprecated.

![image](https://user-images.githubusercontent.com/18014088/64376400-029bd580-cfdd-11e9-813c-0438849e628b.png)

Note that the same rule is also applied to the Browse tab, as it is impossible to distinguish between the two tabs from within the XAML, but because the data in the browse tab is based off search, which doesn't have deprecation information, the package in the feed will never be deprecated, so the deprecation icon will still never show there. 

## Testing/Validation

Tests Added: No
Reason for not adding tests:  Cannot write unit tests for XAML AFAIK
Validation:  tested locally
