### PR TITLE
Right-side pane of PM UI should default to the installed version and then the latest version

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -455,9 +455,11 @@ namespace NuGet.PackageManagement.UI
                 (_versions.Any(v => v != null && !v.IsValidVersion) &&
                     _versions.IndexOf(SelectedVersion) > _versions.IndexOf(_versions.FirstOrDefault(v => v != null && !v.IsValidVersion))))
             {
-                // it should always select the top version from versions list to install or update
-                // which has a valid version. If find none, then just set to null.
-                SelectedVersion = _versions.FirstOrDefault(v => v != null && v.IsValidVersion);
+                // Select the installed version by default.
+                // Otherwise, select the first version in the version list.
+                SelectedVersion =
+                    _versions.FirstOrDefault(v => v != null && v.Version.Equals(_searchResultPackage.InstalledVersion))
+                    ?? _versions.FirstOrDefault(v => v != null && v.IsValidVersion);
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -457,9 +457,10 @@ namespace NuGet.PackageManagement.UI
             {
                 // Select the installed version by default.
                 // Otherwise, select the first version in the version list.
+                var possibleVersions = _versions.Where(v => v != null);
                 SelectedVersion =
-                    _versions.FirstOrDefault(v => v != null && v.Version.Equals(_searchResultPackage.InstalledVersion))
-                    ?? _versions.FirstOrDefault(v => v != null && v.IsValidVersion);
+                    possibleVersions.FirstOrDefault(v => v.Version.Equals(_searchResultPackage.InstalledVersion))
+                    ?? possibleVersions.FirstOrDefault(v => v.IsValidVersion);
             }
         }
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8541
Regression: No
* Last working version:   n/a
* How are we preventing it in future:   n/a

## Fix

Feedback from @anangaur was that upon navigating to a deprecated package on the installed tab, the UI shows the latest version on the right pane first, so users have to navigate the dropdown in order to find the reason for why their package is deprecated.

This change makes it so that it defaults to the installed package. I think this change fits better with the purpose of the installed tab--to show the metadata of the packages you have installed.

Note that for the solution view, it defaults to the minimum version installed. This is how the code currently resolved the `InstalledVersion` property with multiple versions. I could change this, but I felt it was out of scope.

## Testing/Validation

Tests Added: No
Reason for not adding tests:  Untestable XAML class
Validation:  works locally in project/solution view as expected
