### PR TITLE
Align solution view list with project view list

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -403,26 +403,17 @@
                   <Setter TargetName="_installButton" Property="Visibility" Value="Collapsed" />
                 </DataTrigger>
 
-                <!-- installed version is visible when
-                     * IsSolution is false;
-                     * InstalledVersion is not null;
-                -->
+                <!-- installed version is visible when  InstalledVersion is not null -->
                 <MultiDataTrigger>
                   <MultiDataTrigger.Conditions>
                     <Condition
                       Binding="{Binding InstalledVersion,Converter={StaticResource NullToBooleanConverter}}"
                       Value="False" />
-                    <Condition
-                      Binding="{Binding IsSolution, RelativeSource={RelativeSource AncestorType={x:Type nuget:InfiniteScrollList}}}"
-                      Value="False" />
                   </MultiDataTrigger.Conditions>
                   <Setter TargetName="_installedVersion" Property="Visibility" Value="Visible" />
                 </MultiDataTrigger>
 
-                <!-- version to install is visible when
-                     * Status is NotInstalled
-                     * Or IsSolution is true
-                -->
+                <!-- version to install is visible when Status is NotInstalled -->
                 <MultiDataTrigger>
                   <MultiDataTrigger.Conditions>
                     <Condition
@@ -437,33 +428,12 @@
                     Property="Visibility" Value="Visible" />
                 </MultiDataTrigger>
 
-                <MultiDataTrigger>
-                  <MultiDataTrigger.Conditions>
-                    <Condition
-                      Binding="{Binding IsSolution, RelativeSource={RelativeSource AncestorType={x:Type nuget:InfiniteScrollList}}}"
-                      Value="True">
-                    </Condition>
-                    <Condition
-                      Binding="{Binding LatestVersion,Converter={StaticResource NullToBooleanConverter}}"
-                      Value="False" />
-                  </MultiDataTrigger.Conditions>
-                  <Setter
-                    TargetName="_versionToInstall"
-                    Property="Visibility" Value="Visible" />
-                </MultiDataTrigger>
-
-                <!-- version to update to is visible when
-                     * Status is UpdateAvailable;
-                     * IsSolution is false
-                -->
+                <!-- version to update to is visible when Status is UpdateAvailable -->
                 <MultiDataTrigger>
                   <MultiDataTrigger.Conditions>
                     <Condition
                       Binding="{Binding Status}"
                       Value="UpdateAvailable" />
-                    <Condition
-                      Binding="{Binding IsSolution, RelativeSource={RelativeSource AncestorType={x:Type nuget:InfiniteScrollList}}}"
-                      Value="False" />
                   </MultiDataTrigger.Conditions>
                   <Setter
                     TargetName="_versionToUpdateTo"
@@ -539,14 +509,7 @@
                   <Setter TargetName="_updateButton" Property="Visibility" Value="Collapsed" />
                 </DataTrigger>
 
-                <!-- The deprecation indicator becomes invisible when
-                   * IsSolution is true; or
-                   * IsPackageDeprecated is true
-                -->
-                <DataTrigger
-                  Binding="{Binding IsSolution, RelativeSource={RelativeSource AncestorType={x:Type nuget:InfiniteScrollList}}}" Value="true">
-                  <Setter TargetName="_deprecationIndicator" Property="Visibility" Value="Collapsed" />
-                </DataTrigger>
+                <!-- The deprecation indicator becomes visible when IsPackageDeprecated is true -->
                 <DataTrigger
                   Binding="{Binding IsPackageDeprecated}" Value="false">
                   <Setter TargetName="_deprecationIndicator" Property="Visibility" Value="Collapsed" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -403,7 +403,7 @@
                   <Setter TargetName="_installButton" Property="Visibility" Value="Collapsed" />
                 </DataTrigger>
 
-                <!-- installed version is visible when  InstalledVersion is not null -->
+                <!-- installed version is visible when InstalledVersion is not null -->
                 <MultiDataTrigger>
                   <MultiDataTrigger.Conditions>
                     <Condition


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8545, part of https://github.com/NuGet/Home/issues/8516
Regression: No  
* Last working version:   n/a
* How are we preventing it in future:   n/a

## Fix

Previously, in the solution view, we would ALWAYS show the latest version of the package in the infinite scroll list. For deprecation, we felt that showing the icon there next to the latest version was misleading, so we initially did not show the deprecation icon on the list. Unfortunately, this makes it nearly impossible for users to find deprecated packages in the solution view because there's no indicator for what installed packages are deprecated.

As a mitigation for this, I have changed the behavior so that the installed/latest versions will now appear in the solution view in the same way that they appear in the project view. I believe this is a general improvement.

![image](https://user-images.githubusercontent.com/18014088/64465443-8fb85a80-d0c1-11e9-8c69-a00ca4cb7db2.png)

The only major thing to note is that when multiple versions of the package are installed across the solution, the version displayed in the list is the oldest. I tried to change it so that it displays multiple versions in a list but doing so was too complex in order to push out with 16.3. In the future I think we should make this change, but for now, I think showing the oldest version is okay.

## Testing/Validation

Tests Added: No
Reason for not adding tests:  UI stuff
Validation:  works on my machine
