### PR TITLE
Fix Update button disable when current version installed

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -131,14 +131,14 @@ namespace NuGet.PackageManagement.UI
             // Add latest prerelease if neeeded
             if (latestPrerelease.version != null
                 && (latestStableVersion.version == null || latestPrerelease.version > latestStableVersion.version) &&
-                !latestPrerelease.Equals(installedVersion))
+                !latestPrerelease.version.Equals(installedVersion))
             {
                 _versions.Add(new DisplayVersion(latestPrerelease.version, Resources.Version_LatestPrerelease, isDeprecated: latestPrerelease.isDeprecated));
             }
 
             // Add latest stable if needed
             if (latestStableVersion.version != null &&
-                !latestStableVersion.Equals(installedVersion))
+                !latestStableVersion.version.Equals(installedVersion))
             {
                 _versions.Add(new DisplayVersion(latestStableVersion.version, Resources.Version_LatestStable, isDeprecated: latestStableVersion.isDeprecated));
             }
@@ -152,12 +152,12 @@ namespace NuGet.PackageManagement.UI
             // first add all the available versions to be updated
             foreach (var version in allVersionsAllowed)
             {
-                var installed = version.Equals(installedVersion);
+                var installed = version.version.Equals(installedVersion);
                 var autoReferenced = false;
 
                 if (installed && _projectVersionConstraints.Any(e => e.IsAutoReferenced && e.VersionRange?.Satisfies(version.version) == true))
                 {
-                    // do not allow auto referenced packatges
+                    // do not allow auto referenced packages
                     autoReferenced = true;
                 }
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8562
Regression: Yes
* Last working version:   idk...it was introduced with https://github.com/NuGet/NuGet.Client/commit/aef196b3789efc873dae26c1d3079d479c269a9e
* How are we preventing it in future:   Nothing: we would need to rewrite our UI layer to make this code testable...it's in XAML right now.

## Fix

I had changed a list from containing `NuGetVersion`s to containing tuples of `NuGetVersion`s and `bool`s. I updated most of the usages of these tuples, but I missed these `.Equals` calls because `object.Equals(object other)` and `NuGetVersion.Equals(NuGetVersion other)` have the same call structure.

## Testing/Validation

Tests Added: No
Reason for not adding tests:  This code is in the XAML layer. Also, this is intended to go out with 16.3 so the changeset needs to be minimal.
Validation:  bug no longer reproduces with fix locally
