### PR TITLE
Escrow Mode. Incremented NetCoreAssemblyBuildNumber

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -24,9 +24,9 @@
     <!-- ** Increment each insertion, set to zero after incrementing Major/Minor or Patch version -->
     <!-- We need to update this netcoreassembly build number with EVERY insertion into VS to workaround any breaking api
     changes we might have made.-->
-    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">3</NetCoreAssemblyBuildNumber>
+    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">4</NetCoreAssemblyBuildNumber>
 
-    <IsEscrowMode>false</IsEscrowMode>
+    <IsEscrowMode>true</IsEscrowMode>
 
     <!-- Visual Studio Insertion Logic -->    
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>


### PR DESCRIPTION
## Bug
Fixes: NuGet/Home#8575
Regression: No

## Fix
Set $IsEscrow = True and increments $NetCoreAssemblyBuildNumber to 4 . Note that I did a direct commit before to this branch but, it didn't work because of OptProf drop artifact failure in the CI.

## Testing/Validation
Tests Added: No
Reason for not adding tests: Only a change in properties.
Validation: CI run