### PR TITLE
Disables OptProfv2 CI tasks if ShouldSkipOptimize = true

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -345,14 +345,14 @@ phases:
     inputs:
       command: 'custom'
       arguments: 'sources add -Name VS -Source $(VsPackageFeedUrl) -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
 
   - task: NuGetCommand@2
     displayName: 'OptProfV2:  install the NuGet package for building .runsettingsproj file'
     inputs:
       command: 'custom'
       arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.308 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
 
   - task: ms-vseng.MicroBuildTasks.0e9d0d4d-71ec-4e4e-ae40-db9896f1ae74.MicroBuildBuildVSBootstrapper@2
     displayName: 'OptProfV2:  build a Visual Studio bootstrapper'
@@ -362,7 +362,7 @@ phases:
       manifests: '$(Build.Repository.LocalPath)\artifacts\$(VsixPublishDir)\Microsoft.VisualStudio.NuGet.Core.vsman'
       outputFolder: '$(Build.Repository.LocalPath)\artifacts\$(VsixPublishDir)'
     continueOnError: true
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
 
   - task: PublishBuildArtifacts@1
     displayName: 'OptProfV2:  publish BootstrapperInfo.json as a build artifact'
@@ -370,7 +370,7 @@ phases:
       PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
       ArtifactName: MicroBuildOutputs
       ArtifactType: Container
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
 
   - task: PowerShell@1
     displayName: 'OptProfV2:  set the TestDrop environment variable'
@@ -378,13 +378,15 @@ phases:
       scriptType: 'inlineScript'
       inlineScript: |
         [string] $bootstrapperInfoFilePath = "$Env:BUILD_STAGINGDIRECTORY\MicroBuild\Output\BootstrapperInfo.json"
+        Write-Host "Path: $bootstrapperInfoFilePath"
+        Get-Content $bootstrapperInfoFilePath
         $json = Get-Content $bootstrapperInfoFilePath | ConvertFrom-Json
         [string] $buildDropPath = $json.BuildDrop
         Write-Host "Build drop:  $buildDropPath"
         [string] $testDropPath = $buildDropPath.Replace('/Products/', '/Tests/').Substring('https://vsdrop.corp.microsoft.com/file/v1/'.Length)
         Write-Host "Test drop:  $testDropPath"
         Write-Host "##vso[task.setvariable variable=TestDrop]$testDropPath"
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
 
   - task: MSBuild@1
     displayName: 'OptProfV2:  generate a .runsettings file'
@@ -392,7 +394,7 @@ phases:
       solution: 'build\NuGet.OptProfV2.runsettingsproj'
       msbuildVersion: '16.0'
       msbuildArguments: '/p:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /p:TestDrop="$(TestDrop)" /p:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)"'
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
 
   - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
     displayName: 'OptProfV2:  publish the .runsettings file to artifact services'
@@ -403,7 +405,7 @@ phases:
       toLowerCase: false
       usePat: false
       dropMetadataContainerName: RunSettings
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
 
   - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
     displayName: 'OptProfV2:  publish profiling inputs to artifact services'
@@ -413,7 +415,7 @@ phases:
       sourcePath: '$(Build.ArtifactStagingDirectory)\OptProf\ProfilingInputs'
       toLowerCase: false
       usePat: false
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
 
   - task: PublishBuildArtifacts@1
     displayName: "Publish NuGet.exe VSIX and EndToEnd.zip as artifact"

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -378,8 +378,6 @@ phases:
       scriptType: 'inlineScript'
       inlineScript: |
         [string] $bootstrapperInfoFilePath = "$Env:BUILD_STAGINGDIRECTORY\MicroBuild\Output\BootstrapperInfo.json"
-        Write-Host "Path: $bootstrapperInfoFilePath"
-        Get-Content $bootstrapperInfoFilePath
         $json = Get-Content $bootstrapperInfoFilePath | ConvertFrom-Json
         [string] $buildDropPath = $json.BuildDrop
         Write-Host "Build drop:  $buildDropPath"


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8578
Regression: Not a product regression
* Last working version: 5.3.0.6234
* How are we preventing it in future: More code review

## Fix

Add a condition to all but the first OptProfV2 tasks. The first task already reads the variable and skips execution if `ShouldSkipOptimize = 'true'`

## Testing/Validation

Tests Added: No
Reason for not adding tests: CI infrastructure. Hard to test in 
Validation:  CI Build on Official Build. See https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3043046&view=logs&j=8460ae35-dae7-5d3d-b89d-5bc71d24ad43

**NOTE**: if approved/merged, this commit should also be cherry-picked to `dev`.
