### PR TITLE
Disable pack determinism because of unforeseen impact on deployment tools

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -91,7 +91,7 @@ namespace NuGet.Packaging
         private PackageBuilder(bool includeEmptyDirectories, bool deterministic)
         {
             _includeEmptyDirectories = includeEmptyDirectories;
-            _deterministic = false;
+            _deterministic = false; // fix in https://github.com/NuGet/Home/issues/8601
             Files = new Collection<IPackageFile>();
             DependencyGroups = new Collection<PackageDependencyGroup>();
             FrameworkReferences = new Collection<FrameworkAssemblyReference>();

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -91,7 +91,7 @@ namespace NuGet.Packaging
         private PackageBuilder(bool includeEmptyDirectories, bool deterministic)
         {
             _includeEmptyDirectories = includeEmptyDirectories;
-            _deterministic = deterministic;
+            _deterministic = false;
             Files = new Collection<IPackageFile>();
             DependencyGroups = new Collection<PackageDependencyGroup>();
             FrameworkReferences = new Collection<FrameworkAssemblyReference>();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -5970,7 +5970,7 @@ $@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/8601")]
         public void PackCommand_Deterministic_MultiplePackInvocations_CreateIdenticalPackages()
         {
             var nugetexe = Util.GetNuGetExePath();

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -3967,7 +3967,7 @@ namespace ClassLibrary
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+        [PlatformFact(Platform.Windows, Skip = "https://github.com/NuGet/Home/issues/8601")]
         public void PackCommand_Deterministic_MultiplePackInvocations_CreateIdenticalPackages()
         {
             using (var testDirectory = TestDirectory.Create())


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8599
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Porting https://github.com/NuGet/NuGet.Client/pull/3058

Follow up to 5.3 https://github.com/NuGet/Home/issues/8602
Follow up in 5.4 https://github.com/NuGet/Home/issues/8602

## Testing/Validation

Tests Added: No, disabled the ones testing the feature.   
Reason for not adding tests:  
Validation:  
