### PR TITLE
Remove the deterministic pack switch in nuget.exe as the feature is disabled. 

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
@@ -98,9 +98,6 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "PackageCommandConfigFile")]
         public new string ConfigFile { get; set; }
 
-        [Option(typeof(NuGetCommand), "PackageCommandDeterministic")]
-        public bool Deterministic { get; set; }
-
         public override void ExecuteCommand()
         {
             var packArgs = new PackArgs();
@@ -140,7 +137,6 @@ namespace NuGet.CommandLine
             {
                 packArgs.SymbolPackageFormat = PackArgs.GetSymbolPackageFormat(SymbolPackageFormat);
             }
-            packArgs.Deterministic = Deterministic;
             packArgs.Build = Build;
             packArgs.Exclude = Exclude;
             packArgs.ExcludeEmptyDirectories = ExcludeEmptyDirectories;


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8602
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
The feature was reverted

## Testing/Validation

Tests Added: No, already disabled in previous PR
Reason for not adding tests:  
Validation:  
