### PR TITLE
Applied all source-build patches of 7499497 (dev)

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -7,10 +7,6 @@
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <add key="dotnet-roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
-<<<<<<< HEAD
-    <add key="vside" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
-=======
->>>>>>> WiP: removed cps feed in NuGet.Config
     <add key="dotnet-msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
   </packageSources>
   <disabledPackageSources>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -7,7 +7,10 @@
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <add key="dotnet-roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
+<<<<<<< HEAD
     <add key="vside" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
+=======
+>>>>>>> WiP: removed cps feed in NuGet.Config
     <add key="dotnet-msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
   </packageSources>
   <disabledPackageSources>

--- a/build.ps1
+++ b/build.ps1
@@ -106,7 +106,7 @@ Invoke-BuildStep 'Running Restore' {
 
     # Restore
     Trace-Log ". `"$MSBuildExe`" build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /v:m /m:1"
-    & $MSBuildExe build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /v:m /m:1 /p:RestoreAdditionalProjectSources=https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json /bl:restore.binlog
+    & $MSBuildExe build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /v:m /m:1
 
     if (-not $?)
     {
@@ -154,7 +154,7 @@ Invoke-BuildStep 'Running Restore RTM' {
 
     # Restore for VS
     Trace-Log ". `"$MSBuildExe`" build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:BuildRTM=true /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /p:ExcludeTestProjects=true /v:m /m:1 "
-    & $MSBuildExe build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:BuildRTM=true /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /p:ExcludeTestProjects=true /v:m /m:1  /p:RestoreAdditionalProjectSources=https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json /bl:restoreVS.binlog 
+    & $MSBuildExe build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:BuildRTM=true /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /p:ExcludeTestProjects=true /v:m /m:1
 
     if (-not $?)
     {

--- a/build.ps1
+++ b/build.ps1
@@ -106,7 +106,7 @@ Invoke-BuildStep 'Running Restore' {
 
     # Restore
     Trace-Log ". `"$MSBuildExe`" build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /v:m /m:1"
-    & $MSBuildExe build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /v:m /m:1
+    & $MSBuildExe build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /v:m /m:1 /p:RestoreAdditionalProjectSources=https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json /bl:restore.binlog
 
     if (-not $?)
     {
@@ -154,7 +154,7 @@ Invoke-BuildStep 'Running Restore RTM' {
 
     # Restore for VS
     Trace-Log ". `"$MSBuildExe`" build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:BuildRTM=true /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /p:ExcludeTestProjects=true /v:m /m:1 "
-    & $MSBuildExe build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:BuildRTM=true /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /p:ExcludeTestProjects=true /v:m /m:1
+    & $MSBuildExe build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:BuildRTM=true /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /p:ExcludeTestProjects=true /v:m /m:1  /p:RestoreAdditionalProjectSources=https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json /bl:restoreVS.binlog 
 
     if (-not $?)
     {

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -15,7 +15,9 @@
     <NETCoreTargetFramework>netcoreapp2.1</NETCoreTargetFramework>
     <NetStandardVersion>netstandard2.0</NetStandardVersion>
     <TargetFrameworksExe>$(NETFXTargetFramework);$(NETCoreTargetFramework)</TargetFrameworksExe>
+    <TargetFrameworksExe Condition="'$(DotNetBuildFromSource)' == 'true'">$(NETCoreTargetFramework)</TargetFrameworksExe>
     <TargetFrameworksLibrary>$(NETFXTargetFramework);$(NetStandardVersion)</TargetFrameworksLibrary>
+    <TargetFrameworksLibrary Condition="'$(DotNetBuildFromSource)' == 'true'">$(NetStandardVersion)</TargetFrameworksLibrary> 
     <RepositoryRootDirectory>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\</RepositoryRootDirectory>
     <BuildCommonDirectory>$(RepositoryRootDirectory)build\</BuildCommonDirectory>
     <SolutionFile>$(RepositoryRootDirectory)$(RepositoryName).sln</SolutionFile>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -10,14 +10,15 @@
 
   <!-- Common -->
   <PropertyGroup>
+    <IsBuildOnlyXPLATProjects>$(DotNetBuildFromSource)</IsBuildOnlyXPLATProjects>
     <NETFXTargetFrameworkVersion>v4.7.2</NETFXTargetFrameworkVersion>
     <NETFXTargetFramework>net472</NETFXTargetFramework>
     <NETCoreTargetFramework>netcoreapp2.1</NETCoreTargetFramework>
     <NetStandardVersion>netstandard2.0</NetStandardVersion>
     <TargetFrameworksExe>$(NETFXTargetFramework);$(NETCoreTargetFramework)</TargetFrameworksExe>
-    <TargetFrameworksExe Condition="'$(DotNetBuildFromSource)' == 'true'">$(NETCoreTargetFramework)</TargetFrameworksExe>
+    <TargetFrameworksExe Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(NETCoreTargetFramework)</TargetFrameworksExe>
     <TargetFrameworksLibrary>$(NETFXTargetFramework);$(NetStandardVersion)</TargetFrameworksLibrary>
-    <TargetFrameworksLibrary Condition="'$(DotNetBuildFromSource)' == 'true'">$(NetStandardVersion)</TargetFrameworksLibrary> 
+    <TargetFrameworksLibrary Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(NetStandardVersion)</TargetFrameworksLibrary> 
     <RepositoryRootDirectory>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\</RepositoryRootDirectory>
     <BuildCommonDirectory>$(RepositoryRootDirectory)build\</BuildCommonDirectory>
     <SolutionFile>$(RepositoryRootDirectory)$(RepositoryName).sln</SolutionFile>
@@ -44,7 +45,6 @@
     <LocalizationRootDirectory>$(NuGetBuildLocalizationRepository)localize</LocalizationRootDirectory>
     <LocalizationFilesDirectory>$(ArtifactsDirectory)LocalizedFiles</LocalizationFilesDirectory>
     <MicroBuildDirectory>$(SolutionPackagesFolder)MicroBuild.Core.0.2.0\build\</MicroBuildDirectory>
-    <IsBuildOnlyXPLATProjects>$(DotNetBuildFromSource)</IsBuildOnlyXPLATProjects>
     <MicrosoftDotNetBuildTasksFeedFilePath>$(SolutionPackagesFolder)Microsoft.DotNet.Build.Tasks.Feed.2.2.0-beta.19178.1\tools\net472\Microsoft.DotNet.Build.Tasks.Feed.dll</MicrosoftDotNetBuildTasksFeedFilePath>
     <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)Microsoft.DotNet.Maestro.Tasks.1.1.0-beta.19178.1\tools\net472\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
     <NoWarn>$(NoWarn);NU5105</NoWarn>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -10,11 +10,12 @@
 
   <!-- Common -->
   <PropertyGroup>
-    <IsBuildOnlyXPLATProjects>$(DotNetBuildFromSource)</IsBuildOnlyXPLATProjects>
     <NETFXTargetFrameworkVersion>v4.7.2</NETFXTargetFrameworkVersion>
     <NETFXTargetFramework>net472</NETFXTargetFramework>
     <NETCoreTargetFramework>netcoreapp2.1</NETCoreTargetFramework>
     <NetStandardVersion>netstandard2.0</NetStandardVersion>
+    <IsBuildOnlyXPLATProjects>$(DotNetBuildFromSource)</IsBuildOnlyXPLATProjects>
+    <RestoreAdditionalProjectSources Condition="'$(IsBuildOnlyXPLATProjects)' == ''">https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json</RestoreAdditionalProjectSources>
     <TargetFrameworksExe>$(NETFXTargetFramework);$(NETCoreTargetFramework)</TargetFrameworksExe>
     <TargetFrameworksExe Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(NETCoreTargetFramework)</TargetFrameworksExe>
     <TargetFrameworksLibrary>$(NETFXTargetFramework);$(NetStandardVersion)</TargetFrameworksLibrary>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -14,8 +14,6 @@
     <NETFXTargetFramework>net472</NETFXTargetFramework>
     <NETCoreTargetFramework>netcoreapp2.1</NETCoreTargetFramework>
     <NetStandardVersion>netstandard2.0</NetStandardVersion>
-    <IsBuildOnlyXPLATProjects>$(DotNetBuildFromSource)</IsBuildOnlyXPLATProjects>
-    <RestoreAdditionalProjectSources Condition="'$(IsBuildOnlyXPLATProjects)' == ''">https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json</RestoreAdditionalProjectSources>
     <TargetFrameworksExe>$(NETFXTargetFramework);$(NETCoreTargetFramework)</TargetFrameworksExe>
     <TargetFrameworksExe Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">$(NETCoreTargetFramework)</TargetFrameworksExe>
     <TargetFrameworksLibrary>$(NETFXTargetFramework);$(NetStandardVersion)</TargetFrameworksLibrary>

--- a/build/common.props
+++ b/build/common.props
@@ -6,7 +6,7 @@
 
   <!-- When building on non-Windows machines, we need the reference assemblies to build full-framework assemblies. -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND '$(DotNetBuildFromSource)' == 'true'">
-     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-alpha-5" PrivateAssets="All" />
+     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.1" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup Condition="'$(IsNetCoreProject)' == 'true' AND '$(Shipping)' == 'true' AND '$(IsXPlat)' != 'true'">
     <DebugType>full</DebugType>

--- a/build/common.props
+++ b/build/common.props
@@ -4,10 +4,6 @@
     <IsNetCoreProject>true</IsNetCoreProject>
   </PropertyGroup>
 
-  <!-- When building on non-Windows machines, we need the reference assemblies to build full-framework assemblies. -->
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND '$(DotNetBuildFromSource)' == 'true'">
-     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.1" PrivateAssets="All" />
-  </ItemGroup>
   <PropertyGroup Condition="'$(IsNetCoreProject)' == 'true' AND '$(Shipping)' == 'true' AND '$(IsXPlat)' != 'true'">
     <DebugType>full</DebugType>
   </PropertyGroup>

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -380,7 +380,7 @@ Function Restore-SolutionPackages{
     )
     $opts = , 'restore'
     if (-not $SolutionPath) {
-        $opts += "${NuGetClientRoot}\.nuget\packages.config", '-SolutionDirectory', $NuGetClientRoot
+        $opts += "${NuGetClientRoot}\.nuget\packages.config", '-SolutionDirectory', $NuGetClientRoot, '-FallbackSource', 'https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json'
     }
     else {
         $opts += $SolutionPath

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -376,11 +376,13 @@ Function Restore-SolutionPackages{
         [Alias('path')]
         [string]$SolutionPath,
         [ValidateSet(15)]
-        [int]$MSBuildVersion
+        [int]$MSBuildVersion,
+        [Alias('ffeeds')]
+        [string]$FallbackFeeds = ""
     )
     $opts = , 'restore'
     if (-not $SolutionPath) {
-        $opts += "${NuGetClientRoot}\.nuget\packages.config", '-SolutionDirectory', $NuGetClientRoot, '-FallbackSource', 'https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json'
+        $opts += "${NuGetClientRoot}\.nuget\packages.config", '-SolutionDirectory', $NuGetClientRoot
     }
     else {
         $opts += $SolutionPath
@@ -388,6 +390,12 @@ Function Restore-SolutionPackages{
 
     if ($MSBuildVersion) {
         $opts += '-MSBuildVersion', $MSBuildVersion
+    }
+
+    if ($FallbackFeeds) {
+        foreach ($f in $FallbackFeeds.Split(';')) {
+            $opts += '-FallbackSource', $f
+        }
     }
 
     if (-not $VerbosePreference) {

--- a/build/config.props
+++ b/build/config.props
@@ -81,6 +81,11 @@
     <MS_PFX_PATH>$(MSBuildThisFileDirectory)..\keys\35MSSharedLib1024.snk</MS_PFX_PATH>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <IsBuildOnlyXPLATProjects>$(DotNetBuildFromSource)</IsBuildOnlyXPLATProjects>
+    <RestoreAdditionalProjectSources Condition="'$(IsBuildOnlyXPLATProjects)' == ''">https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json</RestoreAdditionalProjectSources>
+  </PropertyGroup>
+
   <Target Name="GetSemanticVersion">
     <Message Text="$(SemanticVersion)" Importance="High"/>
   </Target>
@@ -103,6 +108,9 @@
     <Message Text="$(ToolsetTargetBranches)" Importance="High"/>
   </Target>
   <Target Name="GetCliBranchForTesting">
-      <Message Text="$(CliBranchForTesting)" Importance="High"/>
+    <Message Text="$(CliBranchForTesting)" Importance="High"/>
+  </Target>
+  <Target Name="GetAdditionalFeeds">
+    <Message Text="$(RestoreAdditionalProjectSources)" Importance="High"/>
   </Target>
 </Project>

--- a/build/config.props
+++ b/build/config.props
@@ -48,8 +48,7 @@
 
   <!-- Dependency versions -->
   <PropertyGroup>
-    <NewtonsoftJsonVersionCore Condition="$(NewtonsoftJsonPackageVersion) == ''">9.0.1</NewtonsoftJsonVersionCore>
-    <NewtonsoftJsonVersionCore Condition="$(NewtonsoftJsonPackageVersion) != ''">$(NewtonsoftJsonPackageVersion)</NewtonsoftJsonVersionCore>
+    <NewtonsoftJsonVersionCore>9.0.1</NewtonsoftJsonVersionCore>
     <XunitVersion>2.4.1</XunitVersion>
     <TestSDKVersion>15.5.0</TestSDKVersion>
     <MoqVersion>4.12.0</MoqVersion>

--- a/configure.ps1
+++ b/configure.ps1
@@ -49,8 +49,11 @@ Invoke-BuildStep 'Installing .NET CLI' {
 
 # Restoring tools required for build
 $AdditionalFeeds = .\cli\dotnet.exe msbuild .\build\config.props /v:m /nologo /t:GetAdditionalFeeds
+$AdditionalFeeds = $AdditionalFeeds.Trim()
+Trace-Log "DEEEEEEEEEEEEEEBUUUUUUG: AdditionalFeeds $AdditionalFeeds" 
+$PSVersionTable.PSVersion
 Invoke-BuildStep 'Restoring solution packages' {
-    Restore-SolutionPackages -ffeeds $AdditionalFeeds.Trim()
+    Restore-SolutionPackages -ffeeds:"$AdditionalFeeds"
 } -ev +BuildErrors
 
 Invoke-BuildStep 'Cleaning package cache' {

--- a/configure.ps1
+++ b/configure.ps1
@@ -48,8 +48,9 @@ Invoke-BuildStep 'Installing .NET CLI' {
 } -ev +BuildErrors
 
 # Restoring tools required for build
+$AdditionalFeeds = .\cli\dotnet.exe msbuild .\build\config.props /v:m /nologo /t:GetAdditionalFeeds
 Invoke-BuildStep 'Restoring solution packages' {
-    Restore-SolutionPackages
+    Restore-SolutionPackages -ffeeds $AdditionalFeeds.Trim()
 } -ev +BuildErrors
 
 Invoke-BuildStep 'Cleaning package cache' {

--- a/configure.ps1
+++ b/configure.ps1
@@ -48,10 +48,10 @@ Invoke-BuildStep 'Installing .NET CLI' {
 } -ev +BuildErrors
 
 # Restoring tools required for build
+.\cli\dotnet.exe msbuild .\build\config.props /v:m /nologo /t:GetAdditionalFeeds
+# Workaround: Execute dotnet.exe command twice to avoid first time startup message
 $AdditionalFeeds = .\cli\dotnet.exe msbuild .\build\config.props /v:m /nologo /t:GetAdditionalFeeds
 $AdditionalFeeds = $AdditionalFeeds.Trim()
-Trace-Log "DEEEEEEEEEEEEEEBUUUUUUG: AdditionalFeeds $AdditionalFeeds" 
-$PSVersionTable.PSVersion
 Invoke-BuildStep 'Restoring solution packages' {
     Restore-SolutionPackages -ffeeds:"$AdditionalFeeds"
 } -ev +BuildErrors

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -176,9 +176,6 @@
       <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)**\NuGet*.resources.dll">
         <PackagePath>CoreCLR/</PackagePath>
       </TfmSpecificPackageFile>
-      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)**\*.dll" Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">
-        <PackagePath>CoreCLR/</PackagePath>
-      </TfmSpecificPackageFile>
     </ItemGroup>    
   </Target>
 

--- a/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
@@ -4,7 +4,8 @@
 
   <PropertyGroup>
     <Description>The understanding of target frameworks for NuGet.Packaging.</Description>
-    <TargetFrameworks>$(TargetFrameworksLibrary);net40</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' != 'true'">$(TargetFrameworks);net40</TargetFrameworks>
     <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1574;CS1573</NoWarn>
     <LangVersion>5</LangVersion>

--- a/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Description>The understanding of target frameworks for NuGet.Packaging.</Description>
     <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' != 'true'">$(TargetFrameworks);net40</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsBuildOnlyXPLATProjects)' != 'true'">$(TargetFrameworks);net40</TargetFrameworks>
     <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1574;CS1573</NoWarn>
     <LangVersion>5</LangVersion>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8321
Regression: No
* Last working version:
* How are we preventing it in future: 
  - More collaboration in source-build repo. 
  - Upgrade packages.config NuGet file to PackageDownload

## Fix

- Updates .NET framework reference assemblies to 1.0.0-preview.1
- Disables building binaries targeting .NET Framework when building in source-build
- In NuGet.Build.Tasks.Pack.csproj , removes the mechanism to copy additional NuGet assemblies to the source-built package
- Removes cps, vside NuGet feed and only enabled it on non-source-build environments.

## Testing/Validation

Tests Added: No
Reason for not adding tests: Testing against current test suite
Validation:  NuGet CI

Note: There's a branch with the same changes but targeting release-5.3.x

https://github.com/NuGet/NuGet.Client/tree/dev-dominofire-source-build-patches-release-5.3.x