### PR TITLE
Don't use a silent context silent to ensure PIN prompts appear if CNG/CAPI requires it

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/X509SignatureProvider.cs
@@ -136,7 +136,7 @@ namespace NuGet.Packaging.Signing
 
             try
             {
-                cms.ComputeSignature(cmsSigner);
+                cms.ComputeSignature(cmsSigner, false); // silent is false to ensure PIN prompts appear if CNG/CAPI requires it
             }
             catch (CryptographicException ex) when (ex.HResult == INVALID_PROVIDER_TYPE_HRESULT)
             {


### PR DESCRIPTION
The current overload of `ComputeSignature` changed meaning between .NET Framework and .NET Core. In .NET Core, the context is silent by default, which won't enable PIN prompts for smart cards/usb tokens that require it. `false` must be passed in to enable that if applicable.

Will block code signing from working from most USB thumb drives if not set.

@heng-liu @dtivel 