### PR TITLE
Allow order of lockfile frameworks to not impact the restore with locked mode

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -105,8 +105,6 @@ namespace NuGet.ProjectModel
             var projectRuntimesKeys = project.RuntimeGraph.Runtimes.Select(r => r.Key).Where(k => k != null);
             var lockFileRuntimes = nuGetLockFile.Targets.Select(t => t.RuntimeIdentifier).Where(r => r != null).Distinct();
 
-
-            //BUG: 8661 - Making it order both lists so we dont have this bug again with SequenceEquals
             if (!projectRuntimesKeys.OrderedEquals(
                             lockFileRuntimes,
                             x => x,

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -111,10 +111,11 @@ namespace NuGet.ProjectModel
             //Based on the above code, we want to order the reading side.
             //Making it order both lists so we dont have this bug again with SequenceEquals
             if (!projectRuntimesKeys.OrderedEquals(
-                                                    lockFileRuntimes,
-                                                    x => x,
-                                                    Comparer<string>.Default,
-                                                    EqualityComparer<string>.Default))
+                            lockFileRuntimes,
+                            x => x,
+                            StringComparer.InvariantCultureIgnoreCase,
+                            StringComparer.InvariantCultureIgnoreCase))
+
             {
                 return false;
             }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -105,17 +105,13 @@ namespace NuGet.ProjectModel
             var projectRuntimesKeys = project.RuntimeGraph.Runtimes.Select(r => r.Key).Where(k => k != null);
             var lockFileRuntimes = nuGetLockFile.Targets.Select(t => t.RuntimeIdentifier).Where(r => r != null).Distinct();
 
-            ;
 
-            //JsonRuntimeFormat.WriteRuntimeGraph is doing a sort based on runtimeIdentifier
-            //Based on the above code, we want to order the reading side.
-            //Making it order both lists so we dont have this bug again with SequenceEquals
+            //BUG: 8661 - Making it order both lists so we dont have this bug again with SequenceEquals
             if (!projectRuntimesKeys.OrderedEquals(
                             lockFileRuntimes,
                             x => x,
                             StringComparer.InvariantCultureIgnoreCase,
                             StringComparer.InvariantCultureIgnoreCase))
-
             {
                 return false;
             }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -105,7 +105,16 @@ namespace NuGet.ProjectModel
             var projectRuntimesKeys = project.RuntimeGraph.Runtimes.Select(r => r.Key).Where(k => k != null);
             var lockFileRuntimes = nuGetLockFile.Targets.Select(t => t.RuntimeIdentifier).Where(r => r != null).Distinct();
 
-            if (!projectRuntimesKeys.SequenceEqual(lockFileRuntimes))
+            ;
+
+            //JsonRuntimeFormat.WriteRuntimeGraph is doing a sort based on runtimeIdentifier
+            //Based on the above code, we want to order the reading side.
+            //Making it order both lists so we dont have this bug again with SequenceEquals
+            if (!projectRuntimesKeys.OrderedEquals(
+                                                    lockFileRuntimes,
+                                                    x => x,
+                                                    Comparer<string>.Default,
+                                                    EqualityComparer<string>.Default))
             {
                 return false;
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -9021,6 +9021,7 @@ namespace NuGet.CommandLine.Test
                 var originalTargets = packagesLockFile.Targets.Where(t => t.RuntimeIdentifier != null).Select(t => t.RuntimeIdentifier).ToList();
                 runtimeidentifiers.ShouldBeEquivalentTo(originalTargets);
 
+                //Nuget.exe test so reordering to make it not match.  It should still restore correctly
                 packagesLockFile.Targets = packagesLockFile.Targets.
                     OrderByDescending(t => t.RuntimeIdentifier==null).
                     ThenByDescending( i => i.RuntimeIdentifier).ToList();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -9008,6 +9008,7 @@ namespace NuGet.CommandLine.Test
                 var packagesLockFile = PackagesLockFileFormat.Read(projectA.NuGetLockFileOutputPath);
 
                 //Modify the list of target/runtimes so they are reordered in the lock file.
+                Assert.True(packagesLockFile.Targets.Count >=3); //Since we are removing the second one and adding to the end.
                 var oneOfTargets = packagesLockFile.Targets[1];
                 packagesLockFile.Targets.RemoveAt(1);
                 packagesLockFile.Targets.Insert(packagesLockFile.Targets.Count - 1, oneOfTargets);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\NuGet.Core\NuGet.Frameworks\NuGet.Frameworks.csproj" />
     <ProjectReference Include="..\NuGet.XPlat.FuncTest\NuGet.XPlat.FuncTest.csproj" />
     <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
   </ItemGroup>
@@ -21,6 +22,6 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
@@ -13,7 +13,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\NuGet.Core\NuGet.Frameworks\NuGet.Frameworks.csproj" />
     <ProjectReference Include="..\NuGet.XPlat.FuncTest\NuGet.XPlat.FuncTest.csproj" />
     <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8645  and potentially https://github.com/NuGet/Home/issues/8639
Regression: Yes  
* Last working version:   Not sure - Sometime before https://github.com/NuGet/NuGet.Client/commit/ee368364795a580a09e3fc8542fff7930485e606, the cause.
* How are we preventing it in future:   Unit Test added.

## Fix

Details: Ordered compare instead of assuming order is correct.

## Testing/Validation

Tests Added: Yes
