### PR TITLE
Signing:  support both ASN.1 structures when reading timestamps

### DIFF
--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandSignPackagesTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -28,12 +27,12 @@ namespace NuGet.CommandLine.FuncTest.Commands
     [Collection(SignCommandTestCollection.Name)]
     public class RestoreCommandSignPackagesTests
     {
-        private static readonly string _NU3008Message = "The package integrity check failed.";
-        private static readonly string _NU3008 = "NU3008: {0}";
-        private static readonly string _NU3027Message = "The signature should be timestamped to enable long-term signature validity after the certificate has expired.";
-        private static readonly string _NU3027 = "NU3027: {0}";
-        private static readonly string _NU3005CompressedMessage = "The package signature file entry is invalid. The central directory header field 'compression method' has an invalid value (8).";
-        private static readonly string _NU3005 = "NU3005: {0}";
+        private static readonly string NU3008Message = "The package integrity check failed.";
+        private static readonly string NU3008 = "NU3008: {0}";
+        private static readonly string NU3027Message = "The signature should be timestamped to enable long-term signature validity after the certificate has expired.";
+        private static readonly string NU3027 = "NU3027: {0}";
+        private static readonly string NU3005CompressedMessage = "The package signature file entry is invalid. The central directory header field 'compression method' has an invalid value (8).";
+        private static readonly string NU3005 = "NU3005: {0}";
 
         private SignCommandTestFixture _testFixture;
         private TrustedTestCert<TestCertificate> _trustedTestCert;
@@ -92,8 +91,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(1);
-                result.Errors.Should().Contain(string.Format(_NU3008, SigningTestUtility.AddSignatureLogPrefix(_NU3008Message, packageX.Identity, pathContext.PackageSource)));
-                result.AllOutput.Should().Contain(string.Format(_NU3027, SigningTestUtility.AddSignatureLogPrefix(_NU3027Message, packageX.Identity, pathContext.PackageSource)));
+                result.Errors.Should().Contain(string.Format(NU3008, SigningTestUtility.AddSignatureLogPrefix(NU3008Message, packageX.Identity, pathContext.PackageSource)));
+                result.AllOutput.Should().Contain(string.Format(NU3027, SigningTestUtility.AddSignatureLogPrefix(NU3027Message, packageX.Identity, pathContext.PackageSource)));
             }
         }
 
@@ -136,17 +135,17 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(1);
-                result.Errors.Should().Contain(string.Format(_NU3008, SigningTestUtility.AddSignatureLogPrefix(_NU3008Message, packageX.Identity, pathContext.PackageSource)));
-                result.AllOutput.Should().Contain($"WARNING: {string.Format(_NU3027, SigningTestUtility.AddSignatureLogPrefix(_NU3027Message, packageX.Identity, pathContext.PackageSource))}");
+                result.Errors.Should().Contain(string.Format(NU3008, SigningTestUtility.AddSignatureLogPrefix(NU3008Message, packageX.Identity, pathContext.PackageSource)));
+                result.AllOutput.Should().Contain($"WARNING: {string.Format(NU3027, SigningTestUtility.AddSignatureLogPrefix(NU3027Message, packageX.Identity, pathContext.PackageSource))}");
 
                 errors.Count().Should().Be(1);
                 errors.First().Code.Should().Be(NuGetLogCode.NU3008);
-                errors.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(_NU3008Message, packageX.Identity, pathContext.PackageSource));
+                errors.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(NU3008Message, packageX.Identity, pathContext.PackageSource));
                 errors.First().LibraryId.Should().Be(packageX.Id);
 
                 warnings.Count().Should().Be(1);
                 warnings.First().Code.Should().Be(NuGetLogCode.NU3027);
-                warnings.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(_NU3027Message, packageX.Identity, pathContext.PackageSource));
+                warnings.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(NU3027Message, packageX.Identity, pathContext.PackageSource));
                 warnings.First().LibraryId.Should().Be(packageX.Id);
             }
         }
@@ -161,7 +160,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (var packageStream = await packageX.CreateAsStreamAsync())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+                AuthorPrimarySignature signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+
                 using (var package = new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: true))
                 {
                     var signatureEntry = package.CreateEntry(SigningSpecifications.V1.SignaturePath);
@@ -206,13 +206,13 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(0);
-                result.AllOutput.Should().Contain($"WARNING: {string.Format(_NU3005, SigningTestUtility.AddSignatureLogPrefix(_NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource))}");
+                result.AllOutput.Should().Contain($"WARNING: {string.Format(NU3005, SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource))}");
 
                 errors.Count().Should().Be(0);
 
                 warnings.Count().Should().Be(1);
                 warnings.First().Code.Should().Be(NuGetLogCode.NU3005);
-                warnings.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(_NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource));
+                warnings.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource));
                 warnings.First().LibraryId.Should().Be(packageX.Id);
             }
         }
@@ -227,7 +227,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (var packageStream = await packageX.CreateAsStreamAsync())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+                AuthorPrimarySignature signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+
                 using (var package = new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: true))
                 {
                     var signatureEntry = package.CreateEntry(SigningSpecifications.V1.SignaturePath);
@@ -280,11 +281,11 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(1);
-                result.Errors.Should().Contain(string.Format(_NU3005, SigningTestUtility.AddSignatureLogPrefix(_NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource)));
+                result.Errors.Should().Contain(string.Format(NU3005, SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource)));
 
                 errors.Count().Should().Be(1);
                 errors.First().Code.Should().Be(NuGetLogCode.NU3005);
-                errors.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(_NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource));
+                errors.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource));
                 errors.First().LibraryId.Should().Be(packageX.Id);
 
                 warnings.Count().Should().Be(0);
@@ -305,7 +306,8 @@ namespace NuGet.CommandLine.FuncTest.Commands
             using (var packageStream = await packageX.CreateAsStreamAsync())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+                AuthorPrimarySignature signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+
                 using (var package = new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: true))
                 {
                     var signatureEntry = package.CreateEntry(SigningSpecifications.V1.SignaturePath);
@@ -358,11 +360,11 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 // Assert
                 result.ExitCode.Should().Be(1);
-                result.Errors.Should().Contain(string.Format(_NU3005, SigningTestUtility.AddSignatureLogPrefix(_NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource)));
+                result.Errors.Should().Contain(string.Format(NU3005, SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource)));
 
                 errors.Count().Should().Be(1);
                 errors.First().Code.Should().Be(NuGetLogCode.NU3005);
-                errors.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(_NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource));
+                errors.First().Message.Should().Be(SigningTestUtility.AddSignatureLogPrefix(NU3005CompressedMessage, packageX.Identity, pathContext.PackageSource));
                 errors.First().LibraryId.Should().Be(packageX.Identity.Id.ToString());
 
                 warnings.Count().Should().Be(0);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
@@ -27,7 +27,7 @@ namespace NuGet.Packaging.FuncTest
         private readonly UTF8Encoding _readerEncoding = new UTF8Encoding();
         private readonly UTF8Encoding _writerEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
-        private SigningSpecifications _specification => SigningSpecifications.V1;
+        private readonly SigningSpecifications _specification = SigningSpecifications.V1;
 
         private SigningTestFixture _testFixture;
         private TrustedTestCert<TestCertificate> _trustedTestCert;
@@ -233,7 +233,8 @@ namespace NuGet.Packaging.FuncTest
             using (var packageStream = await nupkg.CreateAsStreamAsync())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+                AuthorPrimarySignature signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+
                 using (var package = new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: true))
                 {
                     var signatureEntry = package.CreateEntry(_specification.SignaturePath);
@@ -271,7 +272,8 @@ namespace NuGet.Packaging.FuncTest
             using (var packageStream = await nupkg.CreateAsStreamAsync())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+                AuthorPrimarySignature signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+
                 using (var package = new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: true))
                 {
                     var signatureEntry = package.CreateEntry(_specification.SignaturePath);
@@ -297,7 +299,8 @@ namespace NuGet.Packaging.FuncTest
             using (var packageStream = await nupkg.CreateAsStreamAsync())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+                AuthorPrimarySignature signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+
                 using (var package = new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: true))
                 {
                     var signatureEntry = package.CreateEntry(_specification.SignaturePath, CompressionLevel.Optimal);
@@ -335,7 +338,8 @@ namespace NuGet.Packaging.FuncTest
             using (var packageStream = await nupkg.CreateAsStreamAsync())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+                AuthorPrimarySignature signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+
                 using (var package = new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: true))
                 {
                     var signatureEntry = package.CreateEntry(_specification.SignaturePath, CompressionLevel.Optimal);
@@ -989,7 +993,8 @@ namespace NuGet.Packaging.FuncTest
             using (var packageStream = await nupkg.CreateAsStreamAsync())
             using (var testCertificate = new X509Certificate2(_trustedTestCert.Source.Cert))
             {
-                var signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+                AuthorPrimarySignature signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream);
+
                 using (var package = new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: true))
                 {
                     var signatureEntry = package.CreateEntry(_specification.SignaturePath, CompressionLevel.Optimal);

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -24,8 +24,8 @@ namespace NuGet.Packaging.FuncTest
     [Collection(SigningTestCollection.Name)]
     public class TimestampProviderTests
     {
-        private const string _argumentNullExceptionMessage = "Value cannot be null.\r\nParameter name: {0}";
-        private const string _operationCancelledExceptionMessage = "The operation was canceled.";
+        private const string ArgumentNullExceptionMessage = "Value cannot be null.\r\nParameter name: {0}";
+        private const string OperationCancelledExceptionMessage = "The operation was canceled.";
 
         private SigningTestFixture _testFixture;
         private TrustedTestCert<TestCertificate> _trustedTestCert;
@@ -80,7 +80,7 @@ namespace NuGet.Packaging.FuncTest
             using (var packageStream = await nupkg.CreateAsStreamAsync())
             {
                 // Act
-                var signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(authorCert, packageStream, timestampProvider);
+                AuthorPrimarySignature signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(authorCert, packageStream, timestampProvider);
                 var authorSignedCms = signature.SignedCms;
                 var timestamp = signature.Timestamps.First();
                 var timestampCms = timestamp.SignedCms;
@@ -162,7 +162,7 @@ namespace NuGet.Packaging.FuncTest
 
                 // Assert
                 timestampAction.ShouldThrow<ArgumentNullException>()
-                    .WithMessage(string.Format(_argumentNullExceptionMessage, nameof(request)));
+                    .WithMessage(string.Format(ArgumentNullExceptionMessage, nameof(request)));
             }
         }
 
@@ -193,7 +193,7 @@ namespace NuGet.Packaging.FuncTest
 
                 // Assert
                 timestampAction.ShouldThrow<ArgumentNullException>()
-                    .WithMessage(string.Format(_argumentNullExceptionMessage, "logger"));
+                    .WithMessage(string.Format(ArgumentNullExceptionMessage, "logger"));
             }
         }
 
@@ -225,7 +225,7 @@ namespace NuGet.Packaging.FuncTest
 
                 // Assert
                 timestampAction.ShouldThrow<OperationCanceledException>()
-                    .WithMessage(_operationCancelledExceptionMessage);
+                    .WithMessage(OperationCancelledExceptionMessage);
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampTests.cs
@@ -55,7 +55,7 @@ namespace NuGet.Packaging.FuncTest
 
                     var timestampProvider = new Rfc3161TimestampProvider(timestampService.Url);
 
-                    var signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream, timestampProvider);
+                    AuthorPrimarySignature signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(testCertificate, packageStream, timestampProvider);
                     var timestamp = signature.Timestamps.First();
 
                     var settings = new SignedPackageVerifierSettings(

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignatureUtilityTests.cs
@@ -212,7 +212,7 @@ namespace NuGet.Packaging.Test
                 var packageContext = new SimpleTestPackageContext();
                 var unsignedPackageStream = await packageContext.CreateAsStreamAsync();
 
-                var signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(
+                AuthorPrimarySignature signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(
                     certificate,
                     unsignedPackageStream);
 
@@ -231,7 +231,7 @@ namespace NuGet.Packaging.Test
                 var packageContext = new SimpleTestPackageContext();
                 var unsignedPackageStream = await packageContext.CreateAsStreamAsync();
 
-                var signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(
+                AuthorPrimarySignature signature = await SignedArchiveTestUtility.CreateAuthorSignatureForPackageAsync(
                     certificate,
                     unsignedPackageStream);
 

--- a/test/TestUtilities/Test.Utility/Signing/SignedArchiveTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SignedArchiveTestUtility.cs
@@ -235,7 +235,7 @@ namespace Test.Utility.Signing
         /// <param name="packageStream">Package stream for which the signature has to be generated.</param>
         /// <param name="timestampProvider">An optional timestamp provider.</param>
         /// <returns>Signature for the package.</returns>
-        public static async Task<PrimarySignature> CreateAuthorSignatureForPackageAsync(
+        public static async Task<AuthorPrimarySignature> CreateAuthorSignatureForPackageAsync(
             X509Certificate2 testCert,
             Stream packageStream,
             ITimestampProvider timestampProvider = null)
@@ -244,7 +244,7 @@ namespace Test.Utility.Signing
             using (var request = new AuthorSignPackageRequest(testCert, hashAlgorithm))
             using (var package = new PackageArchiveReader(packageStream, leaveStreamOpen: true))
             {
-                return await CreatePrimarySignatureForPackageAsync(package, request, timestampProvider);
+                return (AuthorPrimarySignature)await CreatePrimarySignatureForPackageAsync(package, request, timestampProvider);
             }
         }
 


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/8629.