### PR TITLE
Fixes VS Build Drop reference in OptProfV2

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -26,7 +26,7 @@
     changes we might have made. -->
     <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">0</NetCoreAssemblyBuildNumber>
 
-    <IsEscrowMode>false</IsEscrowMode>
+    <IsEscrowMode>true</IsEscrowMode>
 
     <!-- Visual Studio Insertion Logic -->    
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>

--- a/build/config.props
+++ b/build/config.props
@@ -33,7 +33,7 @@
     <VsTargetBranch>master</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
     <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetBranch>
-    <VsTargetChannel Condition="'$(IsEscrowMode)' == 'true'">Preview</VsTargetChannel>
+    <VsTargetChannel Condition="'$(IsEscrowMode)' == 'true'">int.$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetChannel>
 
     <!-- .NET Core SDK Insertion Logic -->    
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>

--- a/build/config.props
+++ b/build/config.props
@@ -26,14 +26,15 @@
     changes we might have made. -->
     <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">0</NetCoreAssemblyBuildNumber>
 
-    <IsEscrowMode>true</IsEscrowMode>
+    <IsEscrowMode>false</IsEscrowMode>
 
     <!-- Visual Studio Insertion Logic -->    
     <VsTargetMajorVersion>$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <VsTargetBranch>master</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
     <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetBranch>
-    <VsTargetChannel Condition="'$(IsEscrowMode)' == 'true'">int.$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetChannel>
+    <!-- VS short branch name. See https://github.com/dotnet/arcade/blob/master/Documentation/ArcadeSdk.md#visual-studio-training-inputs-generation -->
+    <VsTargetChannel Condition="'$(IsEscrowMode)' == 'true'">int.d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetChannel>
 
     <!-- .NET Core SDK Insertion Logic -->    
     <CliBranchForTesting Condition="'$(OverrideCliBranchForTesting)' != ''">$(OverrideCliBranchForTesting)</CliBranchForTesting>

--- a/build/config.props
+++ b/build/config.props
@@ -33,7 +33,6 @@
     <VsTargetBranch>master</VsTargetBranch>
     <VsTargetChannel>int.$(VsTargetBranch)</VsTargetChannel>
     <VsTargetBranch Condition="'$(IsEscrowMode)' == 'true'">rel/d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetBranch>
-    <!-- VS short branch name. See https://github.com/dotnet/arcade/blob/master/Documentation/ArcadeSdk.md#visual-studio-training-inputs-generation -->
     <VsTargetChannel Condition="'$(IsEscrowMode)' == 'true'">int.d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetChannel>
 
     <!-- .NET Core SDK Insertion Logic -->    

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -345,14 +345,14 @@ phases:
     inputs:
       command: 'custom'
       arguments: 'sources add -Name VS -Source $(VsPackageFeedUrl) -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: NuGetCommand@2
     displayName: 'OptProfV2:  install the NuGet package for building .runsettingsproj file'
     inputs:
       command: 'custom'
       arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.308 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: ms-vseng.MicroBuildTasks.0e9d0d4d-71ec-4e4e-ae40-db9896f1ae74.MicroBuildBuildVSBootstrapper@2
     displayName: 'OptProfV2:  build a Visual Studio bootstrapper'
@@ -362,7 +362,7 @@ phases:
       manifests: '$(Build.Repository.LocalPath)\artifacts\$(VsixPublishDir)\Microsoft.VisualStudio.NuGet.Core.vsman'
       outputFolder: '$(Build.Repository.LocalPath)\artifacts\$(VsixPublishDir)'
     continueOnError: true
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: PublishBuildArtifacts@1
     displayName: 'OptProfV2:  publish BootstrapperInfo.json as a build artifact'
@@ -370,7 +370,7 @@ phases:
       PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
       ArtifactName: MicroBuildOutputs
       ArtifactType: Container
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: PowerShell@1
     displayName: 'OptProfV2:  set the TestDrop environment variable'
@@ -384,7 +384,7 @@ phases:
         [string] $testDropPath = $buildDropPath.Replace('/Products/', '/Tests/').Substring('https://vsdrop.corp.microsoft.com/file/v1/'.Length)
         Write-Host "Test drop:  $testDropPath"
         Write-Host "##vso[task.setvariable variable=TestDrop]$testDropPath"
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: MSBuild@1
     displayName: 'OptProfV2:  generate a .runsettings file'
@@ -392,7 +392,7 @@ phases:
       solution: 'build\NuGet.OptProfV2.runsettingsproj'
       msbuildVersion: '16.0'
       msbuildArguments: '/p:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /p:TestDrop="$(TestDrop)" /p:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)"'
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
     displayName: 'OptProfV2:  publish the .runsettings file to artifact services'
@@ -403,7 +403,7 @@ phases:
       toLowerCase: false
       usePat: false
       dropMetadataContainerName: RunSettings
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
     displayName: 'OptProfV2:  publish profiling inputs to artifact services'
@@ -413,7 +413,7 @@ phases:
       sourcePath: '$(Build.ArtifactStagingDirectory)\OptProf\ProfilingInputs'
       toLowerCase: false
       usePat: false
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'), eq(variables['ShouldSkipOptimize'], 'false'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: PublishBuildArtifacts@1
     displayName: "Publish NuGet.exe VSIX and EndToEnd.zip as artifact"


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8671
Regression: Yes
* Last working version: Last good build is 5.3.0.6234
* How are we preventing it in future: Thoughtful review of arcade documentation.

## Fix

-  Removes dependency on $ShouldSkipOptimize variable: all related OptProfV2 tasks will run even if the plugin installation is disabled
- Corrected VS Drop reference

## Testing/Validation

Tests Added: No
Reason for not adding tests: CI infrastructure, needs an official build.
Validation: Local dotnet/arcade execution (in progress)
