### PR TITLE
The CredentialService in the msbuild/dotnet scenario uses a delegating logger to avoid logging infrastructure lifetime issues.

### DIFF
--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using NuGet.Commands;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Credentials;
 using NuGet.LibraryModel;
@@ -173,6 +174,11 @@ namespace Microsoft.Build.NuGetSdkResolver
                     catch (Exception e)
                     {
                         errors.Add(e.Message);
+                    }
+                    finally
+                    {
+                        // The CredentialService lifetime is for the duration of the process. We should not leave a potentially unavailable logger. 
+                        DefaultCredentialServiceUtility.UpdateCredentialServiceDelegatingLogger(NullLogger.Instance);
                     }
                 }
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/Common/DelegatingLogger.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Common/DelegatingLogger.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+
+namespace NuGet.Build
+{
+    /// <summary>
+    ///  A delegating logger.
+    /// </summary>
+    internal class DelegatingLogger : LoggerBase, ILogger
+    {
+        private int _lock;
+
+        private ILogger _delegateLogger;
+
+        internal DelegatingLogger(ILogger delegateLogger)
+        {
+            _delegateLogger = delegateLogger ?? throw new ArgumentNullException(nameof(delegateLogger));
+        }
+
+        internal void UpdateDelegate(ILogger logger)
+        {
+            if (Interlocked.CompareExchange(ref _lock, 1, 0) == 0)
+            {
+                _delegateLogger = logger ?? throw new ArgumentNullException(nameof(logger));
+            }
+        }
+
+        public override void Log(ILogMessage message)
+        {
+            if (Interlocked.CompareExchange(ref _lock, 1, 0) == 0)
+            {
+
+                _delegateLogger?.Log(message);
+            }
+        }
+
+        public override async Task LogAsync(ILogMessage message)
+        {
+            if (Interlocked.CompareExchange(ref _lock, 1, 0) == 0)
+            {
+                await _delegateLogger?.LogAsync(message);
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -114,6 +114,7 @@ namespace NuGet.Build.Tasks
 
             try
             {
+                DefaultCredentialServiceUtility.SetupDefaultCredentialService(log, !Interactive);
                 return ExecuteAsync(log).Result;
             }
             catch (AggregateException ex) when (_cts.Token.IsCancellationRequested && ex.InnerException is TaskCanceledException)
@@ -204,9 +205,6 @@ namespace NuGet.Build.Tasks
                 {
                     HttpSourceResourceProvider.Throttle = SemaphoreSlimThrottle.CreateBinarySemaphore();
                 }
-
-                DefaultCredentialServiceUtility.SetupDefaultCredentialService(log, !Interactive);
-                DefaultCredentialServiceUtility.OldLogger.LogMinimal("yay, nice, crash the logger");
 
                 _cts.Token.ThrowIfCancellationRequested();
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -83,8 +83,8 @@ namespace NuGet.Build.Tasks
         public override bool Execute()
         {
 #if DEBUG
-            var debugPackTask = Environment.GetEnvironmentVariable("DEBUG_RESTORE_TASK");
-            if (!string.IsNullOrEmpty(debugPackTask) && debugPackTask.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase))
+            var debugRestoreTask = Environment.GetEnvironmentVariable("DEBUG_RESTORE_TASK");
+            if (!string.IsNullOrEmpty(debugRestoreTask) && debugRestoreTask.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase))
             {
 #if IS_CORECLR
                 Console.WriteLine("Waiting for debugger to attach.");

--- a/src/NuGet.Core/NuGet.Credentials/DefaultCredentialServiceUtility.cs
+++ b/src/NuGet.Core/NuGet.Credentials/DefaultCredentialServiceUtility.cs
@@ -14,11 +14,21 @@ namespace NuGet.Credentials
 {
     public class DefaultCredentialServiceUtility
     {
+        /// <summary>
+        /// Set-ups the CredentialService and all of it's providers.
+        /// It always updates the logger the CredentialService and its children own,
+        /// because the lifetime of the logging infrastructure is not guaranteed. 
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <param name="nonInteractive"></param>
         public static void SetupDefaultCredentialService(ILogger logger, bool nonInteractive)
         {
+            // Always update the delegating logger.
+            UpdateCredentialServiceDelegatingLogger(logger);
+
             if (HttpHandlerResourceV3.CredentialService == null)
             {
-                var providers = new AsyncLazy<IEnumerable<ICredentialProvider>>(async () => await GetCredentialProvidersAsync(logger));
+                var providers = new AsyncLazy<IEnumerable<ICredentialProvider>>(async () => await GetCredentialProvidersAsync(DelegatingLogger));
                 HttpHandlerResourceV3.CredentialService = new Lazy<ICredentialService>(
                     () => new CredentialService(
                         providers: providers,
@@ -26,6 +36,24 @@ namespace NuGet.Credentials
                         handlesDefaultCredentials: PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders));
             }
         }
+
+        /// <summary>
+        /// Update the delegating logger for the credential service.
+        /// </summary>
+        /// <param name="log"></param>
+        public static void UpdateCredentialServiceDelegatingLogger(ILogger log)
+        {
+            if (DelegatingLogger == null)
+            {
+                DelegatingLogger = new DelegatingLogger(log);
+            }
+            else
+            {
+                DelegatingLogger.UpdateDelegate(log);
+            }
+        }
+
+        private static DelegatingLogger DelegatingLogger { get; set; }
 
         // Add only the secure plugin. This will be done when there's nothing set
         // By default the plugins cannot prompt. Currently this is only used to setup from MSBuild/dotnet.exe code paths

--- a/src/NuGet.Core/NuGet.Credentials/DefaultCredentialServiceUtility.cs
+++ b/src/NuGet.Core/NuGet.Credentials/DefaultCredentialServiceUtility.cs
@@ -15,7 +15,7 @@ namespace NuGet.Credentials
     public class DefaultCredentialServiceUtility
     {
         /// <summary>
-        /// Set-ups the CredentialService and all of it's providers.
+        /// Sets-up the CredentialService and all of its providers.
         /// It always updates the logger the CredentialService and its children own,
         /// because the lifetime of the logging infrastructure is not guaranteed. 
         /// </summary>
@@ -53,7 +53,7 @@ namespace NuGet.Credentials
             }
         }
 
-        private static DelegatingLogger DelegatingLogger { get; set; }
+        private static DelegatingLogger DelegatingLogger;
 
         // Add only the secure plugin. This will be done when there's nothing set
         // By default the plugins cannot prompt. Currently this is only used to setup from MSBuild/dotnet.exe code paths

--- a/src/NuGet.Core/NuGet.Credentials/DelegatingLogger.cs
+++ b/src/NuGet.Core/NuGet.Credentials/DelegatingLogger.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 
-namespace NuGet.Build
+namespace NuGet.Credentials
 {
     /// <summary>
     ///  A delegating logger.
@@ -34,7 +34,6 @@ namespace NuGet.Build
         {
             if (Interlocked.CompareExchange(ref _lock, 1, 0) == 0)
             {
-
                 _delegateLogger?.Log(message);
             }
         }

--- a/src/NuGet.Core/NuGet.Credentials/DelegatingLogger.cs
+++ b/src/NuGet.Core/NuGet.Credentials/DelegatingLogger.cs
@@ -13,7 +13,7 @@ namespace NuGet.Credentials
     /// </summary>
     internal class DelegatingLogger : LoggerBase, ILogger
     {
-        private SemaphoreSlim _semaphore;
+        private readonly SemaphoreSlim _semaphore;
         private ILogger _delegateLogger;
 
         internal DelegatingLogger(ILogger delegateLogger) : base()

--- a/src/NuGet.Core/NuGet.Credentials/DelegatingLogger.cs
+++ b/src/NuGet.Core/NuGet.Credentials/DelegatingLogger.cs
@@ -9,7 +9,7 @@ using NuGet.Common;
 namespace NuGet.Credentials
 {
     /// <summary>
-    ///  A delegating logger. This 
+    ///  A delegating logger.
     /// </summary>
     internal class DelegatingLogger : LoggerBase, ILogger
     {

--- a/src/NuGet.Core/NuGet.Credentials/DelegatingLogger.cs
+++ b/src/NuGet.Core/NuGet.Credentials/DelegatingLogger.cs
@@ -24,9 +24,9 @@ namespace NuGet.Credentials
 
         internal void UpdateDelegate(ILogger logger)
         {
+            _semaphore.Wait();
             try
             {
-                _semaphore.Wait();
                 _delegateLogger = logger ?? throw new ArgumentNullException(nameof(logger));
             }
             finally
@@ -37,9 +37,9 @@ namespace NuGet.Credentials
 
         public override void Log(ILogMessage message)
         {
+            _semaphore.Wait();
             try
             {
-                _semaphore.Wait();
                 _delegateLogger?.Log(message);
             }
             finally
@@ -50,9 +50,9 @@ namespace NuGet.Credentials
 
         public override async Task LogAsync(ILogMessage message)
         {
+            await _semaphore.WaitAsync();
             try
             {
-                await _semaphore.WaitAsync();
                 await _delegateLogger?.LogAsync(message);
             }
             finally

--- a/src/NuGet.Core/NuGet.Credentials/NuGet.Credentials.csproj
+++ b/src/NuGet.Core/NuGet.Credentials/NuGet.Credentials.csproj
@@ -46,6 +46,18 @@
     </Compile>
   </ItemGroup>
 
+  <ItemGroup Condition="$(DefineConstants.Contains(SIGNED_BUILD))">
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>NuGet.Credentials.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup Condition="!$(DefineConstants.Contains(SIGNED_BUILD))">
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>NuGet.Credentials.Test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/NuGet.Core.Tests/NuGet.Credentials.Test/DelegatingLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Credentials.Test/DelegatingLoggerTests.cs
@@ -1,0 +1,125 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NuGet.Common;
+using Xunit;
+
+namespace NuGet.Credentials.Test
+{
+    public class DelegatingLoggerTests
+    {
+        [Fact]
+        public void DelegateLogger_LogsAllMessages()
+        {
+            var catchAllLogger = new CatchAllLogger();
+
+            var delegateLogger = new DelegatingLogger(catchAllLogger);
+
+            var messageCount = 5;
+            for (var i = 1; i <= messageCount; i++)
+            {
+                delegateLogger.LogInformation(i.ToString());
+
+            }
+
+            Assert.Equal(5, catchAllLogger.messages.Count);
+
+            int count = 1;
+            foreach (var message in catchAllLogger.messages)
+            {
+                Assert.Equal(count.ToString(), message);
+                count++;
+            }
+        }
+
+        [Fact]
+        public async Task DelegateLogger_LogsAllMessagesAsync()
+        {
+            var catchAllLogger = new CatchAllLogger();
+
+            var delegateLogger = new DelegatingLogger(catchAllLogger);
+
+            var messageCount = 5;
+            for (var i = 1; i <= messageCount; i++)
+            {
+                await delegateLogger.LogAsync(new RestoreLogMessage(LogLevel.Information, i.ToString()));
+            }
+
+            Assert.Equal(5, catchAllLogger.messages.Count);
+
+            int count = 1;
+            foreach (var message in catchAllLogger.messages)
+            {
+                Assert.Equal(count.ToString(), message);
+                count++;
+            }
+        }
+
+        [Fact]
+        public async Task DelegateLogger_ReplacesAndLogsAllMessagesAsync()
+        {
+            // Set up
+            var catchAllLogger1 = new CatchAllLogger();
+            var catchAllLogger2 = new CatchAllLogger();
+
+            var delegateLogger = new DelegatingLogger(catchAllLogger1);
+
+            // Act
+            var messageCount = 5;
+            for (var i = 1; i <= messageCount; i++)
+            {
+                await delegateLogger.LogAsync(new RestoreLogMessage(LogLevel.Information, i.ToString()));
+            }
+
+            // Assert
+            Assert.Equal(5, catchAllLogger1.messages.Count);
+
+            int count = 1;
+            foreach (var message in catchAllLogger1.messages)
+            {
+                Assert.Equal(count.ToString(), message);
+                count++;
+            }
+
+            // Now replace and log 5 more messages.
+            delegateLogger.UpdateDelegate(catchAllLogger2);
+
+            // Set up 
+            for (var i = 1; i <= messageCount; i++)
+            {
+                await delegateLogger.LogAsync(new RestoreLogMessage(LogLevel.Information, i.ToString()));
+            }
+
+            // Act
+            Assert.Equal(5, catchAllLogger2.messages.Count);
+
+            // Assert
+            count = 1;
+            foreach (var message in catchAllLogger2.messages)
+            {
+                Assert.Equal(count.ToString(), message);
+                count++;
+            }
+
+        }
+    }
+
+    internal class CatchAllLogger : LoggerBase, ILogger
+    {
+
+        public IList<string> messages = new List<string>();
+
+        public override void Log(ILogMessage message)
+        {
+            messages.Add(message.Message);
+        }
+
+        public override Task LogAsync(ILogMessage message)
+        {
+            Log(message);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8688
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: The problem is described in detail in the linked issue. 
Basically we are holding onto a logger from a previous task that has had its infrastructure torn down. 

The CredentialService is a static and it propagates a logger to its credential providers (in our case, a plugin). In MSBuild the logger is tied to the task.

While retail restore does not call the restore task more than 1 during an msbuild process, some custom implementations like arcade might, wittingly or unwittingly.
Additionally, the NuGet SDK resolver also sets up the credential service. 
Another notable thing is that there's a guarantee no more than 1 RestoreTask will be running in the same process.

Now because of the all the above it's possible that by the time the logging infrastructure is used by the plugin, MSBuild has cleaned it up. 

Tearing down the credential service and it's plugins could be expensive and arguably unnecessary. 
Given that it's a static singleton, we can provide it a static singleton delegating logger. 

Now this means that every task that sets up the credential service will not reset the logger. 
It's a bit ugly, but will work :) 

fyi @jeffkl @rainersigwald 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation: Manual, on the .NET Core repros 
