### PR TITLE
Dotnet.exe push now has --skip-duplicate

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
@@ -76,6 +76,11 @@ namespace NuGet.CommandLine.XPlat
                     Strings.NuGetXplatCommand_Interactive,
                     CommandOptionType.NoValue);
 
+                var skipDuplicate = push.Option(
+                    "--skip-duplicate",
+                    Strings.PushCommandSkipDuplicateDescription,
+                    CommandOptionType.NoValue);
+
                 push.OnExecute(async () =>
                 {
                     if (arguments.Values.Count < 1)
@@ -91,6 +96,7 @@ namespace NuGet.CommandLine.XPlat
                     bool disableBufferingValue = disableBuffering.HasValue();
                     bool noSymbolsValue = noSymbols.HasValue();
                     bool noServiceEndpoint = noServiceEndpointDescription.HasValue();
+                    bool skipDuplicateValue = skipDuplicate.HasValue();
                     int timeoutSeconds = 0;
 
                     if (timeout.HasValue() && !int.TryParse(timeout.Value(), out timeoutSeconds))
@@ -105,7 +111,6 @@ namespace NuGet.CommandLine.XPlat
                     try
                     {
                         DefaultCredentialServiceUtility.SetupDefaultCredentialService(getLogger(), !interactive.HasValue());
-                        var skipDuplicate = false;
                         await PushRunner.Run(
                             sourceProvider.Settings,
                             sourceProvider,
@@ -118,7 +123,7 @@ namespace NuGet.CommandLine.XPlat
                             disableBufferingValue,
                             noSymbolsValue,
                             noServiceEndpoint,
-                            skipDuplicate,
+                            skipDuplicateValue,
                             getLogger());
                     }
                     catch (TaskCanceledException ex)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
 using NuGet.Commands;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -1140,6 +1140,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to If a package and version already exists, skip it and continue with the next package in the push, if any..
+        /// </summary>
+        internal static string PushCommandSkipDuplicateDescription {
+            get {
+                return ResourceManager.GetString("PushCommandSkipDuplicateDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Removes a package reference from a project..
         /// </summary>
         internal static string RemovePkg_Description {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -591,4 +591,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
   <data name="ListPkg_DeprecationReasons" xml:space="preserve">
     <value>Reason(s)</value>
   </data>
+  <data name="PushCommandSkipDuplicateDescription" xml:space="preserve">
+    <value>If a package and version already exists, skip it and continue with the next package in the push, if any.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -405,9 +405,6 @@ namespace NuGet.Protocol.Core.Types
                  AdvertiseAvailableOptionToIgnore(response.StatusCode, logger);
 #endif
             }
-
-            //No exception to the rule specified.
-            response.EnsureSuccessStatusCode();
             return null;
         }
 
@@ -460,7 +457,6 @@ namespace NuGet.Protocol.Core.Types
         /// <param name="logger"></param>
         private static void AdvertiseAvailableOptionToIgnore(HttpStatusCode errorCodeThatOccurred, ILogger logger)
         {
-            
             string advertiseDescription = null;
 
             switch (errorCodeThatOccurred)

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -405,6 +405,9 @@ namespace NuGet.Protocol.Core.Types
                  AdvertiseAvailableOptionToIgnore(response.StatusCode, logger);
 #endif
             }
+
+            //No exception to the rule specified.
+            response.EnsureSuccessStatusCode();
             return null;
         }
 
@@ -466,7 +469,7 @@ namespace NuGet.Protocol.Core.Types
                     break;
 
                 default: break; //Not a supported response code.
-            }
+            } 
 
             if (advertiseDescription != null)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -463,11 +463,11 @@ namespace NuGet.Protocol.Core.Types
             {
                 case HttpStatusCode.Conflict:
 
-                #if IS_DESKTOP
+#if IS_DESKTOP
                     advertiseDescription = Strings.PushCommandSkipDuplicateAdvertiseNuGetExe;
-                #else
+#else
                     advertiseDescription = Strings.PushCommandSkipDuplicateAdvertiseDotnetExe;
-                #endif
+#endif
                     break;
 
                 default: break; //Not a supported response code.

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -401,9 +401,7 @@ namespace NuGet.Protocol.Core.Types
             }
             else
             {
-#if IS_DESKTOP
                  AdvertiseAvailableOptionToIgnore(response.StatusCode, logger);
-#endif
             }
 
             //No exception to the rule specified.
@@ -452,7 +450,6 @@ namespace NuGet.Protocol.Core.Types
             return skippedErrorOccurred;
         }
 
-       
         /// <summary>
         /// If we provide such option, output a help message that explains that the error that occurred can be ignored by using it.
         /// </summary>
@@ -465,11 +462,16 @@ namespace NuGet.Protocol.Core.Types
             switch (errorCodeThatOccurred)
             {
                 case HttpStatusCode.Conflict:
-                    advertiseDescription = Strings.PushCommandSkipDuplicateAdvertise;
+
+                #if IS_DESKTOP
+                    advertiseDescription = Strings.PushCommandSkipDuplicateAdvertiseNuGetExe;
+                #else
+                    advertiseDescription = Strings.PushCommandSkipDuplicateAdvertiseDotnetExe;
+                #endif
                     break;
 
                 default: break; //Not a supported response code.
-            } 
+            }
 
             if (advertiseDescription != null)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -1024,7 +1024,7 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To skip already published packages, use &lt;command&gt; --skip-duplicate.
+        ///   Looks up a localized string similar to To skip already published packages, use the option --skip-duplicate.
         /// </summary>
         internal static string PushCommandSkipDuplicateAdvertiseDotnetExe {
             get {
@@ -1033,7 +1033,7 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To skip already published packages, use &lt;command&gt; -SkipDuplicate.
+        ///   Looks up a localized string similar to To skip already published packages, use the option -SkipDuplicate.
         /// </summary>
         internal static string PushCommandSkipDuplicateAdvertiseNuGetExe {
             get {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -1033,7 +1033,7 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To skip already published packages, use &lt;command&gt; -skipduplicate.
+        ///   Looks up a localized string similar to To skip already published packages, use &lt;command&gt; -SkipDuplicate.
         /// </summary>
         internal static string PushCommandSkipDuplicateAdvertiseNuGetExe {
             get {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -1024,11 +1024,20 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to See help for push option to automatically skip duplicates..
+        ///   Looks up a localized string similar to To skip already published packages, use &lt;command&gt; --skip-duplicate.
         /// </summary>
-        internal static string PushCommandSkipDuplicateAdvertise {
+        internal static string PushCommandSkipDuplicateAdvertiseDotnetExe {
             get {
-                return ResourceManager.GetString("PushCommandSkipDuplicateAdvertise", resourceCulture);
+                return ResourceManager.GetString("PushCommandSkipDuplicateAdvertiseDotnetExe", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To skip already published packages, use &lt;command&gt; -skipduplicate.
+        /// </summary>
+        internal static string PushCommandSkipDuplicateAdvertiseNuGetExe {
+            get {
+                return ResourceManager.GetString("PushCommandSkipDuplicateAdvertiseNuGetExe", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -520,7 +520,7 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
     <comment>0 - plugin path, 1 - error message </comment>
   </data>
   <data name="PushCommandSkipDuplicateAdvertiseNuGetExe" xml:space="preserve">
-    <value>To skip already published packages, use &lt;command&gt; -SkipDuplicate</value>
+    <value>To skip already published packages, use the option -SkipDuplicate</value>
   </data>
   <data name="PushCommandSkipDuplicateNotImplemented" xml:space="preserve">
     <value>The option to skip duplicates is not currently supported for this type of push.</value>
@@ -532,6 +532,6 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
 {2} is the plugin process exit code</comment>
   </data>
   <data name="PushCommandSkipDuplicateAdvertiseDotnetExe" xml:space="preserve">
-    <value>To skip already published packages, use &lt;command&gt; --skip-duplicate</value>
+    <value>To skip already published packages, use the option --skip-duplicate</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -520,7 +520,7 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
     <comment>0 - plugin path, 1 - error message </comment>
   </data>
   <data name="PushCommandSkipDuplicateAdvertiseNuGetExe" xml:space="preserve">
-    <value>To skip already published packages, use &lt;command&gt; -skipduplicate</value>
+    <value>To skip already published packages, use &lt;command&gt; -SkipDuplicate</value>
   </data>
   <data name="PushCommandSkipDuplicateNotImplemented" xml:space="preserve">
     <value>The option to skip duplicates is not currently supported for this type of push.</value>

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -519,8 +519,8 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
     <value>Problem starting the plugin '{0}'. {1}</value>
     <comment>0 - plugin path, 1 - error message </comment>
   </data>
-  <data name="PushCommandSkipDuplicateAdvertise" xml:space="preserve">
-    <value>See help for push option to automatically skip duplicates.</value>
+  <data name="PushCommandSkipDuplicateAdvertiseNuGetExe" xml:space="preserve">
+    <value>To skip already published packages, use &lt;command&gt; -skipduplicate</value>
   </data>
   <data name="PushCommandSkipDuplicateNotImplemented" xml:space="preserve">
     <value>The option to skip duplicates is not currently supported for this type of push.</value>
@@ -530,5 +530,8 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
     <comment>{0} is the plugin name
 {1} is the number of seconds
 {2} is the plugin process exit code</comment>
+  </data>
+  <data name="PushCommandSkipDuplicateAdvertiseDotnetExe" xml:space="preserve">
+    <value>To skip already published packages, use &lt;command&gt; --skip-duplicate</value>
   </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
@@ -18,7 +18,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         private const string MESSAGE_PACKAGE_PUSHED = "Your package was pushed.";
         private const string TEST_PACKAGE_SHOULD_NOT_PUSH = "The package should not have been pushed";
         private const string TEST_PACKAGE_SHOULD_PUSH = "The package should have been pushed";
-        private const string ADVERTISE_CONTINUE_OPTION = "See help for push option to automatically skip duplicates.";
+        private const string ADVERTISE_SKIPDUPLICATE_OPTION = "See help for push option to automatically skip duplicates.";
 
         /// <summary>
         /// 100 seconds is significant because that is the default timeout on <see cref="HttpClient"/>.
@@ -114,7 +114,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         }
 
         [Fact]
-        public void PushCommand_Server_ContinueOn_NotSpecified_PushHalts()
+        public void PushCommand_Server_SkipDuplicate_NotSpecified_PushHalts()
         {
             // Arrange
             using (var packageDirectory = TestDirectory.Create())
@@ -128,7 +128,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 using (var server = new MockServer())
                 {
-                    SetupMockServerForContinueOnError(server,
+                    SetupMockServerForSkipDuplicate(server,
                                                       FuncOutputPath_SwitchesOnThirdPush(outputPath, outputPath2),
                                                       FuncStatusDuplicate_OccursOnSecondPush());
 
@@ -170,14 +170,14 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     Assert.False(0 == result2.Item1, result2.AllOutput);
                     Assert.Contains(MESSAGE_RESPONSE_NO_SUCCESS, result2.AllOutput);
                     Assert.DoesNotContain(MESSAGE_EXISTING_PACKAGE, result2.AllOutput);
-                    Assert.Contains(ADVERTISE_CONTINUE_OPTION, result2.AllOutput);
+                    Assert.Contains(ADVERTISE_SKIPDUPLICATE_OPTION, result2.AllOutput);
                     Assert.Equal(File.ReadAllBytes(sourcePath), File.ReadAllBytes(outputPath));
                 }
             }
         }
 
         [Fact]
-        public void PushCommand_Server_ContinueOn_Duplicate_PushProceeds()
+        public void PushCommand_Server_SkipDuplicate_IsSpecified_PushProceeds()
         {
             // Arrange
             using (var packageDirectory = TestDirectory.Create())
@@ -191,7 +191,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
 
                 using (var server = new MockServer())
                 {
-                    SetupMockServerForContinueOnError(server,
+                    SetupMockServerForSkipDuplicate(server,
                                                       FuncOutputPath_SwitchesOnThirdPush(outputPath, outputPath2),
                                                       FuncStatusDuplicate_OccursOnSecondPush());
 
@@ -205,7 +205,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                         waitForExit: true,
                         timeOutInMilliseconds: 120 * 1000); // 120 seconds
 
-                    //Run again so that it will be a duplicate push but use the option to continue on errors.
+                    //Run again so that it will be a duplicate push but use the option to skip duplicate packages.
                     var result2 = CommandRunner.Run(
                         nuget,
                         packageDirectory,
@@ -235,7 +235,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
                     Assert.Contains(MESSAGE_EXISTING_PACKAGE, result2.AllOutput);
                     Assert.DoesNotContain(MESSAGE_RESPONSE_NO_SUCCESS, result2.AllOutput);
 
-                    // Third run after a duplicate should be successful with the ContinueOnError flag.
+                    // Third run after a duplicate should be successful with the SkipDuplicate flag.
                     Assert.True(0 == result3.Item1, $"{result3.Item2} {result3.Item3}");
                     Assert.Contains(MESSAGE_PACKAGE_PUSHED, result3.AllOutput);
                     Assert.True(File.Exists(outputPath2), TEST_PACKAGE_SHOULD_PUSH);
@@ -253,7 +253,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         /// <param name="server">Server object to modify.</param>
         /// <param name="outputPathFunc">Function to determine path to output package.</param>
         /// <param name="responseCodeFunc">Function to determine which HttpStatusCode to return.</param>
-        private static void SetupMockServerForContinueOnError(MockServer server,
+        private static void SetupMockServerForSkipDuplicate(MockServer server,
                                                               Func<int, string> outputPathFunc,
                                                               Func<int, HttpStatusCode> responseCodeFunc)
         {

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
@@ -18,7 +18,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         private const string MESSAGE_PACKAGE_PUSHED = "Your package was pushed.";
         private const string TEST_PACKAGE_SHOULD_NOT_PUSH = "The package should not have been pushed";
         private const string TEST_PACKAGE_SHOULD_PUSH = "The package should have been pushed";
-        private const string ADVERTISE_SKIPDUPLICATE_OPTION = "To skip already published packages, use <command> -skipduplicate"; //PushCommandSkipDuplicateAdvertiseNuGetExe
+        private const string ADVERTISE_SKIPDUPLICATE_OPTION = "To skip already published packages, use <command> -SkipDuplicate"; //PushCommandSkipDuplicateAdvertiseNuGetExe
 
         /// <summary>
         /// 100 seconds is significant because that is the default timeout on <see cref="HttpClient"/>.

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
@@ -18,7 +18,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         private const string MESSAGE_PACKAGE_PUSHED = "Your package was pushed.";
         private const string TEST_PACKAGE_SHOULD_NOT_PUSH = "The package should not have been pushed";
         private const string TEST_PACKAGE_SHOULD_PUSH = "The package should have been pushed";
-        private const string ADVERTISE_SKIPDUPLICATE_OPTION = "To skip already published packages, use <command> -SkipDuplicate"; //PushCommandSkipDuplicateAdvertiseNuGetExe
+        private const string ADVERTISE_SKIPDUPLICATE_OPTION = "To skip already published packages, use the option -SkipDuplicate"; //PushCommandSkipDuplicateAdvertiseNuGetExe
 
         /// <summary>
         /// 100 seconds is significant because that is the default timeout on <see cref="HttpClient"/>.

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
@@ -18,7 +18,7 @@ namespace NuGet.CommandLine.FuncTest.Commands
         private const string MESSAGE_PACKAGE_PUSHED = "Your package was pushed.";
         private const string TEST_PACKAGE_SHOULD_NOT_PUSH = "The package should not have been pushed";
         private const string TEST_PACKAGE_SHOULD_PUSH = "The package should have been pushed";
-        private const string ADVERTISE_SKIPDUPLICATE_OPTION = "See help for push option to automatically skip duplicates.";
+        private const string ADVERTISE_SKIPDUPLICATE_OPTION = "To skip already published packages, use <command> -skipduplicate"; //PushCommandSkipDuplicateAdvertiseNuGetExe
 
         /// <summary>
         /// 100 seconds is significant because that is the default timeout on <see cref="HttpClient"/>.

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatPushTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatPushTests.cs
@@ -91,13 +91,6 @@ namespace NuGet.XPlat.FuncTest
                 var exitCodeSecondPush = NuGet.CommandLine.XPlat.Program.MainInternal(pushArgs.ToArray(), logSecondPush);
 
                 // Assert First Push - it should happen without error.
-                Console.WriteLine("Waiting for debugger to attach.");
-                Console.WriteLine($"Process ID: {Process.GetCurrentProcess().Id}");
-                while (!Debugger.IsAttached)
-                {
-                    System.Threading.Thread.Sleep(100);
-                }
-                Debugger.Break();
                 var outputMessagesFirstPush = logFirstPush.ShowMessages();
                 Assert.Equal(string.Empty, logFirstPush.ShowErrors());
                 Assert.Equal(0, exitCodeFirstPush);

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PackageSourceTheoryAttribute.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PackageSourceTheoryAttribute.cs
@@ -28,7 +28,7 @@ namespace NuGet.Test.Utility
         public override string Skip
         {
             get
-            {
+            {   
                 var skip = _skip;
 
                 if (string.IsNullOrEmpty(skip))

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PackageSourceTheoryAttribute.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PackageSourceTheoryAttribute.cs
@@ -28,7 +28,7 @@ namespace NuGet.Test.Utility
         public override string Skip
         {
             get
-            {   
+            {
                 var skip = _skip;
 
                 if (string.IsNullOrEmpty(skip))


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8100

## Fix

Details: 

- Adds the `--skip-duplicate` option to dotnet.exe.

- Advertising the option when a 409-Conflict HTTP response has been enabled for dotnet.exe (already in nuget.exe).

- Advertising message was modified to show the name of the option:
nuget.exe: `To skip already published packages, use the option -SkipDuplicate`
dotnet.exe: `To skip already published packages, use the option --skip-duplicate`

- Added some XPlat FuncTests for testing server's with real response codes, but these are disabled for now (see below).

- Minor: refactored NuGet.exe FuncTests to use the "skip duplicate" terminology.

## Testing/Validation

Tests Added: Yes (but disabled) 
Reason for not adding tests:  
The core logic is shared with nuget.exe and is already being tested by the mock server testing in the client [PushCommandTest](https://github.com/NuGet/NuGet.Client/blob/3e3a03c9a7f65a51ca30a3a46e7571f5ef919279/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs#L233).
We do not currently have any test servers setup to do automated testing for HTTP responses. These tests have been skipped for a long while. I improved the Skip messages for the PackageSources that were there, and also improved the test in general so it's in a better place when we do reintroduce this test. Issue to correct this has been created: https://github.com/NuGet/Home/issues/8695

We will also add this to our Manual Testing process.

Validation:  
**dotnet nuget push** with and without the --skip-duplicate option. Verified push continued with the option specified. Verified advertisement message showed and with correct option for dotnet. Verified Help showed correct message.

**nuget.exe push** made comparable verifications (for -skipduplicate) to make sure there were no regressions.