### PR TITLE
Stop displaying version duplicates in allowed and blocked versions list in PMUI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -162,7 +162,7 @@ namespace NuGet.PackageManagement.UI
             // null, if all versions are allowed to install or update
             var blockedVersions = allVersions
                 .Select(v => v.version)
-                .Where(v => !allVersionsAllowed.Any(allowed => allowed.version.Version.Equals(v)))
+                .Where(v => !allVersionsAllowed.Any(allowed => allowed.version.Equals(v)))
                 .ToArray();
 
             // get latest prerelease or stable based on allowed versions


### PR DESCRIPTION
## Bug

Fixes: /NuGet/Home/issues/8679
Regression: Yes  
* Last working version: VS 2017 (15.9) and VS 2019 (16.3 Preview 3)
* How are we preventing it in future:  

## Fix

Details: Same package versions are displayed in both allowed and blocked versions in PM UI. This fix will make it easier for users to determine which version they should choose and prevent them from updating to blocked versions.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  This fix is related to UI
Validation:  Validated fix by debugging VS client
