### PR TITLE
Add smarter config loading logic in restore to avoid parsing the same config file multiple times

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -365,7 +365,7 @@
       <DesktopInputTestAssembliesSpaced>$(DesktopInputTestAssemblies.Replace(';', ' '))</DesktopInputTestAssembliesSpaced>
       
       <!-- Build exe commands -->
-      <DesktopTestCommand>$(XunitConsoleExePath) $(DesktopInputTestAssembliesSpaced)</DesktopTestCommand>
+      <DesktopTestCommand>$(XunitConsoleExePath) $(DesktopInputTestAssembliesSpaced) -verbose</DesktopTestCommand>
       <DesktopTestCommand Condition=" '$(TestResultsXunit)' != '' ">$(DesktopTestCommand) -$(TestResultOutputFormat) $(TestResultsXunit) $(Verbosity)</DesktopTestCommand>
     </PropertyGroup>
 
@@ -378,6 +378,9 @@
     </PropertyGroup>
 
     <!-- Desktop -->
+    <Message Text="Running $(DesktopTestCommand)" 
+          Condition=" '$(SkipDesktopAssemblies)' != 'true' AND '$(DesktopInputTestAssemblies)' != '' "/>
+
     <Exec Command="$(DesktopTestCommand)"
           ContinueOnError="true"
           Condition=" '$(SkipDesktopAssemblies)' != 'true' AND '$(DesktopInputTestAssemblies)' != '' ">
@@ -385,6 +388,9 @@
     </Exec>
 
     <!-- VSTest/NETCore -->
+    <Message Text="Running $(VSTestCommand)" 
+          Condition=" '$(SkipCoreAssemblies)' != 'true' AND '$(CoreInputTestAssemblies)' != '' "/>
+
     <Exec Command="$(VSTestCommand)"
           ContinueOnError="true"
           Condition=" '$(SkipCoreAssemblies)' != 'true' AND '$(CoreInputTestAssemblies)' != '' ">

--- a/build/build.proj
+++ b/build/build.proj
@@ -365,7 +365,7 @@
       <DesktopInputTestAssembliesSpaced>$(DesktopInputTestAssemblies.Replace(';', ' '))</DesktopInputTestAssembliesSpaced>
       
       <!-- Build exe commands -->
-      <DesktopTestCommand>$(XunitConsoleExePath) $(DesktopInputTestAssembliesSpaced) -verbose</DesktopTestCommand>
+      <DesktopTestCommand>$(XunitConsoleExePath) $(DesktopInputTestAssembliesSpaced)</DesktopTestCommand>
       <DesktopTestCommand Condition=" '$(TestResultsXunit)' != '' ">$(DesktopTestCommand) -$(TestResultOutputFormat) $(TestResultsXunit) $(Verbosity)</DesktopTestCommand>
     </PropertyGroup>
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -67,10 +67,10 @@ namespace NuGet.Commands
                 MaxDegreeOfParallelism = Environment.ProcessorCount
             };
 
-            // Parallel.Foreach has an optimization for Arrays, so calling .ToArray() is better and adds almost no overhead
-            Parallel.ForEach(dgFile.Restore.ToArray(), parallelOptions, projectNameToRestore =>
+            using (var settingsLoadingContext = new SettingsLoadingContext())
             {
-                foreach (var projectNameToRestore in dgFile.Restore)
+                // Parallel.Foreach has an optimization for Arrays, so calling .ToArray() is better and adds almost no overhead
+                Parallel.ForEach(dgFile.Restore.ToArray(), parallelOptions, projectNameToRestore =>
                 {
                     var closure = dgFile.GetClosure(projectNameToRestore);
 
@@ -92,9 +92,8 @@ namespace NuGet.Commands
                     {
                         requests.Add(request);
                     }
-                }
-            });
-
+                });
+            }
             // Filter out duplicate tool restore requests
             foreach (var subSetRequest in ToolRestoreUtility.GetSubSetRequests(toolRequests))
             {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -70,25 +70,28 @@ namespace NuGet.Commands
             // Parallel.Foreach has an optimization for Arrays, so calling .ToArray() is better and adds almost no overhead
             Parallel.ForEach(dgFile.Restore.ToArray(), parallelOptions, projectNameToRestore =>
             {
-                var closure = dgFile.GetClosure(projectNameToRestore);
-
-                var projectDependencyGraphSpec = dgFile.WithProjectClosure(projectNameToRestore);
-
-                var externalClosure = new HashSet<ExternalProjectReference>(closure.Select(GetExternalProject));
-
-                var rootProject = externalClosure.Single(p =>
-                    StringComparer.Ordinal.Equals(projectNameToRestore, p.UniqueName));
-
-                var request = Create(projectNameToRestore, rootProject, externalClosure, restoreContext, projectDgSpec: projectDependencyGraphSpec);
-
-                if (request.Request.ProjectStyle == ProjectStyle.DotnetCliTool)
+                foreach (var projectNameToRestore in dgFile.Restore)
                 {
-                    // Store tool requests to be filtered later
-                    toolRequests.Add(request);
-                }
-                else
-                {
-                    requests.Add(request);
+                    var closure = dgFile.GetClosure(projectNameToRestore);
+
+                    var projectDependencyGraphSpec = dgFile.WithProjectClosure(projectNameToRestore);
+
+                    var externalClosure = new HashSet<ExternalProjectReference>(closure.Select(GetExternalProject));
+
+                    var rootProject = externalClosure.Single(p =>
+                        StringComparer.Ordinal.Equals(projectNameToRestore, p.UniqueName));
+
+                    var request = Create(projectNameToRestore, rootProject, externalClosure, restoreContext, projectDgSpec: projectDependencyGraphSpec, settingsLoadingContext: settingsLoadingContext);
+
+                    if (request.Request.ProjectStyle == ProjectStyle.DotnetCliTool)
+                    {
+                        // Store tool requests to be filtered later
+                        toolRequests.Add(request);
+                    }
+                    else
+                    {
+                        requests.Add(request);
+                    }
                 }
             });
 
@@ -133,13 +136,14 @@ namespace NuGet.Commands
             ExternalProjectReference project,
             HashSet<ExternalProjectReference> projectReferenceClosure,
             RestoreArgs restoreArgs,
-            DependencyGraphSpec projectDgSpec)
+            DependencyGraphSpec projectDgSpec,
+            SettingsLoadingContext settingsLoadingContext)
         {
             var projectPackageSpec = projectDgSpec.GetProjectSpec(projectNameToRestore);
             //fallback paths, global packages path and sources need to all be passed in the dg spec
             var fallbackPaths = projectPackageSpec.RestoreMetadata.FallbackFolders;
             var globalPath = GetPackagesPath(restoreArgs, projectPackageSpec);
-            var settings = Settings.LoadSettingsGivenConfigPaths(projectPackageSpec.RestoreMetadata.ConfigFilePaths);
+            var settings = Settings.LoadImmutableSettingsGivenConfigPaths(projectPackageSpec.RestoreMetadata.ConfigFilePaths, settingsLoadingContext);
             var sources = restoreArgs.GetEffectiveSources(settings, projectPackageSpec.RestoreMetadata.Sources);
             var clientPolicyContext = ClientPolicyContext.GetClientPolicy(settings, restoreArgs.Log);
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ImmutableSettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ImmutableSettings.cs
@@ -15,7 +15,7 @@ namespace NuGet.Configuration
 
         internal ImmutableSettings(ISettings settings)
         {
-            _settings = settings ?? throw new ArgumentNullException(nameof(settings)));
+            _settings = settings ?? throw new ArgumentNullException(nameof(settings));
         }
 
         public event EventHandler SettingsChanged

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ImmutableSettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ImmutableSettings.cs
@@ -1,0 +1,62 @@
+// All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace NuGet.Configuration
+{
+    // Represents a wrapper for an immutable settings instance.
+    // This means that any methods invoked on this instance that try to alter it will throw.
+    internal class ImmutableSettings : ISettings
+    {
+        private readonly ISettings _settings;
+
+        internal ImmutableSettings(ISettings settings)
+        {
+            _settings = settings ?? throw new ArgumentNullException(string.Format(CultureInfo.CurrentCulture, Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(settings)));
+        }
+
+        public event EventHandler SettingsChanged
+        {
+            add
+            {
+                _settings.SettingsChanged += value;
+            }
+            remove
+            {
+                _settings.SettingsChanged -= value;
+            }
+        }
+        public void AddOrUpdate(string sectionName, SettingItem item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IList<string> GetConfigFilePaths()
+        {
+            return _settings.GetConfigFilePaths();
+        }
+
+        public IList<string> GetConfigRoots()
+        {
+            return _settings.GetConfigRoots();
+        }
+
+        public SettingSection GetSection(string sectionName)
+        {
+            return _settings.GetSection(sectionName);
+        }
+
+        public void Remove(string sectionName, SettingItem item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SaveToDisk()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ImmutableSettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ImmutableSettings.cs
@@ -15,7 +15,7 @@ namespace NuGet.Configuration
 
         internal ImmutableSettings(ISettings settings)
         {
-            _settings = settings ?? throw new ArgumentNullException(string.Format(CultureInfo.CurrentCulture, Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(settings)));
+            _settings = settings ?? throw new ArgumentNullException(nameof(settings)));
         }
 
         public event EventHandler SettingsChanged
@@ -31,7 +31,7 @@ namespace NuGet.Configuration
         }
         public void AddOrUpdate(string sectionName, SettingItem item)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public IList<string> GetConfigFilePaths()
@@ -51,12 +51,12 @@ namespace NuGet.Configuration
 
         public void Remove(string sectionName, SettingItem item)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public void SaveToDisk()
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ImmutableSettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ImmutableSettings.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 
 namespace NuGet.Configuration
 {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -317,15 +317,15 @@ namespace NuGet.Configuration
 
         public static ISettings LoadImmutableSettingsGivenConfigPaths(IList<string> configFilePaths, SettingsLoadingContext settingsLoadingContext)
         {
-            var settings = new List<SettingsFile>();
             if (configFilePaths == null || configFilePaths.Count == 0)
             {
                 return NullSettings.Instance;
             }
+            var settings = new List<SettingsFile>();
 
-            foreach (var configFile in configFilePaths)
+            foreach (var configFilePath in configFilePaths)
             {
-                settings.Add(settingsLoadingContext.GetOrCreateSettingsFile(filePath: configFile));
+                settings.Add(settingsLoadingContext.GetOrCreateSettingsFile(configFilePath));
             }
 
             return new ImmutableSettings(LoadSettingsGivenSettingsFiles(settings));

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -315,6 +315,22 @@ namespace NuGet.Configuration
                 useTestingGlobalPath: false);
         }
 
+        public static ISettings LoadImmutableSettingsGivenConfigPaths(IList<string> configFilePaths, SettingsLoadingContext settingsLoadingContext)
+        {
+            var settings = new List<SettingsFile>();
+            if (configFilePaths == null || configFilePaths.Count == 0)
+            {
+                return NullSettings.Instance;
+            }
+
+            foreach (var configFile in configFilePaths)
+            {
+                settings.Add(settingsLoadingContext.GetOrCreateSettingsFile(filePath: configFile));
+            }
+
+            return new ImmutableSettings(LoadSettingsGivenSettingsFiles(settings));
+        }
+
         public static ISettings LoadSettingsGivenConfigPaths(IList<string> configFilePaths)
         {
             var settings = new List<SettingsFile>();
@@ -329,14 +345,21 @@ namespace NuGet.Configuration
                 settings.Add(new SettingsFile(file.DirectoryName, file.Name));
             }
 
-            return LoadSettingsForSpecificConfigs(
-                settings.First().DirectoryPath,
-                settings.First().FileName,
-                validSettingFiles: settings,
-                machineWideSettings: null,
-                loadUserWideSettings: false,
-                useTestingGlobalPath: false);
+            return LoadSettingsGivenSettingsFiles(settings);
         }
+
+
+        private static ISettings LoadSettingsGivenSettingsFiles(List<SettingsFile> settings)
+        {
+            return LoadSettingsForSpecificConfigs(
+                            settings.First().DirectoryPath,
+                            settings.First().FileName,
+                            validSettingFiles: settings,
+                            machineWideSettings: null,
+                            loadUserWideSettings: false,
+                            useTestingGlobalPath: false);
+        }
+
 
         /// <summary>
         /// For internal use only

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsLoadingContext.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsLoadingContext.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+
+namespace NuGet.Configuration
+{
+    public class SettingsLoadingContext : IDisposable
+    {
+        private IList<SettingsFile> _settingsFiles = new List<SettingsFile>();
+        private readonly SemaphoreSlim _semaphore;
+        private bool _isDisposed;
+
+        public SettingsLoadingContext()
+        {
+            _semaphore = new SemaphoreSlim(1, 1);
+        }
+
+        internal SettingsFile GetOrCreateSettingsFile(string filePath)
+        {
+            if (filePath == null)
+            {
+                throw new ArgumentNullException(string.Format(CultureInfo.CurrentCulture, Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(filePath)));
+            }
+            _semaphore.Wait();
+            try
+            {
+                for (int i = 0; i < _settingsFiles.Count; i++)
+                {
+                    if (_settingsFiles[i].ConfigFilePath.Equals(filePath))
+                    {
+                        return _settingsFiles[i];
+                    }
+                }
+                var file = new FileInfo(filePath);
+                var settingsFile = new SettingsFile(file.DirectoryName, file.Name);
+                _settingsFiles.Add(settingsFile);
+                return settingsFile;
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+            _semaphore.Dispose();
+
+            GC.SuppressFinalize(this);
+
+            _isDisposed = true;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsLoadingContext.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsLoadingContext.cs
@@ -23,6 +23,11 @@ namespace NuGet.Configuration
 
         internal SettingsFile GetOrCreateSettingsFile(string filePath)
         {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(SettingsLoadingContext));
+            }
+
             if (filePath == null)
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(filePath)));
@@ -60,6 +65,7 @@ namespace NuGet.Configuration
                 return;
             }
             _semaphore.Dispose();
+            _settingsFiles.Clear();
 
             GC.SuppressFinalize(this);
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2367,6 +2367,51 @@ namespace NuGet.Configuration.Test
             Assert.Equal(Path.Combine(originDirectoryPath, path), resolvedPath);
         }
 
+        [Fact]
+        public void GetImmutableSettings()
+        {
+            // Arrange
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                var nugetConfigPath = "NuGet.Config";
+                var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <SectionName>
+        <add key=""key1"" value=""a"" />
+    </SectionName>
+</configuration>";
+                var subDir = Path.Combine(mockBaseDirectory, "a");
+                var configAPath = Path.Combine(subDir, nugetConfigPath);
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, subDir, config);
+
+                config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <SectionName>
+        <add key=""key1"" value=""b"" />
+    </SectionName>
+</configuration>";
+                subDir = Path.Combine(mockBaseDirectory, "b");
+                var configBPath = Path.Combine(subDir, nugetConfigPath);
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, subDir, config);
+
+                config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <SectionName>
+        <add key=""key1"" value=""c"" />
+    </SectionName>
+</configuration>";
+                subDir = Path.Combine(mockBaseDirectory, "c");
+                var configCPath = Path.Combine(subDir, nugetConfigPath);
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, subDir, config);
+
+                // Act
+                var settings = Settings.LoadImmutableSettingsGivenConfigPaths(new string[] { configAPath, configBPath}, new SettingsLoadingContext() );
+                var section = settings.GetSection("SectionName");
+                Assert.Equal(1, section.Items.Count);
+                Assert.Equal("a", section.Items.First().ElementName);
+            }
+        }
+
         private static string GetOriginDirectoryPath()
         {
             if (RuntimeEnvironmentHelper.IsWindows)

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2368,7 +2368,7 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void GetImmutableSettings()
+        public void LoadImmutableSettingsGivenConfigPaths_MergesConfigsInCorrectOrder()
         {
             // Arrange
             using (var mockBaseDirectory = TestDirectory.Create())
@@ -2404,11 +2404,119 @@ namespace NuGet.Configuration.Test
                 var configCPath = Path.Combine(subDir, nugetConfigPath);
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, subDir, config);
 
+                var settingsLoadContext = new SettingsLoadingContext();
+
                 // Act
-                var settings = Settings.LoadImmutableSettingsGivenConfigPaths(new string[] { configAPath, configBPath}, new SettingsLoadingContext() );
+                var settings = Settings.LoadImmutableSettingsGivenConfigPaths(new string[] { configAPath, configBPath}, settingsLoadContext);
+                // Assert
                 var section = settings.GetSection("SectionName");
                 Assert.Equal(1, section.Items.Count);
-                Assert.Equal("a", section.Items.First().ElementName);
+                Assert.Equal("a", ((AddItem)section.Items.First()).Value);
+
+                // Act
+                settings = Settings.LoadImmutableSettingsGivenConfigPaths(new string[] { configCPath, configBPath }, settingsLoadContext);
+                // Assert
+                section = settings.GetSection("SectionName");
+                Assert.Equal(1, section.Items.Count);
+                Assert.Equal("c", ((AddItem)section.Items.First()).Value);
+
+                // Act
+                settings = Settings.LoadImmutableSettingsGivenConfigPaths(new string[] { configBPath, configCPath }, settingsLoadContext);
+                // Assert
+                section = settings.GetSection("SectionName");
+                Assert.Equal(1, section.Items.Count);
+                Assert.Equal("b", ((AddItem)section.Items.First()).Value);
+            }
+        }
+
+        [Fact]
+        public void LoadImmutableSettingsGivenConfigPaths_CachesConfigs()
+        {
+            // Arrange
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                var nugetConfigPath = "NuGet.Config";
+                var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <SectionName>
+        <add key=""key1"" value=""a"" />
+    </SectionName>
+</configuration>";
+                var subDir = Path.Combine(mockBaseDirectory, "a");
+                var configAPath = Path.Combine(subDir, nugetConfigPath);
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, subDir, config);
+
+
+                config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <SectionName>
+        <add key=""key1"" value=""b"" />
+    </SectionName>
+</configuration>";
+                subDir = Path.Combine(mockBaseDirectory, "b");
+                var configBPath = Path.Combine(subDir, nugetConfigPath);
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, subDir, config);
+
+                // Act
+                var settings = Settings.LoadImmutableSettingsGivenConfigPaths(new string[] { configAPath, configBPath }, new SettingsLoadingContext());
+                // Assert
+                var section = settings.GetSection("SectionName");
+                Assert.Equal(1, section.Items.Count);
+                Assert.Equal("a", ((AddItem)section.Items.First()).Value);
+
+                // Change the value of config A...basically this ensures we get the cached version, since there's no way to ensure that the same SettingsFile was returned.
+
+                config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <SectionName>
+        <add key=""key1"" value=""new"" />
+    </SectionName>
+</configuration>";
+                subDir = Path.Combine(mockBaseDirectory, "a");
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, subDir, config);
+
+                settings = Settings.LoadImmutableSettingsGivenConfigPaths(new string[] { configAPath, configBPath }, new SettingsLoadingContext());
+                section = settings.GetSection("SectionName");
+                Assert.Equal(1, section.Items.Count);
+                Assert.Equal("new", ((AddItem)section.Items.First()).Value);
+            }
+        }
+
+        [Fact]
+        public void LoadImmutableSettingsGivenConfigPaths_ImmutableSettigns_ThrowForNotSupportedOperations()
+        {
+            // Arrange
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+                var nugetConfigPath = "NuGet.Config";
+                var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <SectionName>
+        <add key=""key1"" value=""a"" />
+    </SectionName>
+</configuration>";
+                var subDir = Path.Combine(mockBaseDirectory, "a");
+                var configAPath = Path.Combine(subDir, nugetConfigPath);
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, subDir, config);
+
+
+                config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <SectionName>
+        <add key=""key1"" value=""b"" />
+    </SectionName>
+</configuration>";
+                subDir = Path.Combine(mockBaseDirectory, "b");
+                var configBPath = Path.Combine(subDir, nugetConfigPath);
+                SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, subDir, config);
+
+                // Act
+                var settings = Settings.LoadImmutableSettingsGivenConfigPaths(new string[] { configAPath, configBPath }, new SettingsLoadingContext());
+
+                // Assert
+                Assert.Throws<NotSupportedException>(() => settings.AddOrUpdate("name", new AddItem("key", "value")));
+                Assert.Throws<NotSupportedException>(() => settings.Remove("name", new AddItem("key", "value")));
+                Assert.Throws<NotSupportedException>(() => settings.SaveToDisk());
             }
         }
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8728
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
In large solutions, during one restore operation the same config file is parsed multiple times. 
This changes saves us some extra time, especially noticeable in large solution no-op restores.

@jeffkl This is the settings change we discussed on Monday. 

On NuGet.Client this is the change: 

NuGet.Configuration.Settings.LoadSettingsGivenConfigPaths(IList) 1.84% - 248ms
NuGet.Configuration.Settings.LoadImmutableSettingsGivenConfigPaths(IList, SettingsLoadingContext) 0.10% - 12ms

In @jeffkl's case, I imagine this can be closer to a 1s. 

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation: Some manual. 
