### PR TITLE
swallow an exception of a disposing plugin

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Sender.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Sender.cs
@@ -51,8 +51,15 @@ namespace NuGet.Protocol.Plugins
             }
 
             Close();
-
-            _textWriter.Dispose();
+            try
+            {
+                _textWriter.Dispose();
+            }
+            catch (IOException)
+            {
+                // can throw a named pipe exception
+                // we don't care since we are disposing. 
+            }
 
             GC.SuppressFinalize(this);
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8732
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: The close method on a plugin can sometimes throw a broken pipe exception crashing the whole process, raising a false negative.

## Testing/Validation

Tests Added: No  
Reason for not adding tests: There's no way to easy way to hijack what streamwriter dispose does.
Validation: Manual by running restores in the corefx and asp net core repos. 
