### PR TITLE
Remove hardcoded copyright from generated nuspec

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
@@ -99,7 +99,7 @@ namespace NuGet.CommandLine
             manifest.Metadata.LicenseMetadata = new LicenseMetadata(LicenseType.Expression, "MIT", NuGetLicenseExpression.Parse("MIT"), new string[] {}, LicenseMetadata.CurrentVersion);
             manifest.Metadata.SetIconUrl(sampleIconUrl);
             manifest.Metadata.Tags = sampleTags;
-            manifest.Metadata.Copyright = "Copyright " + DateTime.Now.Year;
+            manifest.Metadata.Copyright = "$copyright$";
             manifest.Metadata.ReleaseNotes = sampleReleaseNotes;
             string nuspecFile = fileName + PackagingConstants.ManifestExtension;
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
@@ -49,7 +49,7 @@ namespace NuGet.CommandLine.Test
     <iconUrl>http://icon_url_here_or_delete_this_line/</iconUrl>
     <description>Package description</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
-    <copyright>Copyright {DateTime.Now.Year}</copyright>
+    <copyright>$copyright$</copyright>
     <tags>Tag1 Tag2</tags>
     <dependencies>
       <group targetFramework="".NETStandard2.1"">
@@ -92,7 +92,7 @@ namespace NuGet.CommandLine.Test
     <iconUrl>http://icon_url_here_or_delete_this_line/</iconUrl>
     <description>Package description</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
-    <copyright>Copyright {DateTime.Now.Year}</copyright>
+    <copyright>$copyright$</copyright>
     <tags>Tag1 Tag2</tags>
     <dependencies>
       <group targetFramework="".NETStandard2.1"">
@@ -148,7 +148,7 @@ namespace NuGet.CommandLine.Test
     <iconUrl>http://icon_url_here_or_delete_this_line/</iconUrl>
     <description>$description$</description>
     <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
-    <copyright>Copyright {DateTime.Now.Year}</copyright>
+    <copyright>$copyright$</copyright>
     <tags>Tag1 Tag2</tags>
   </metadata>
 </package>".Replace("\r\n", "\n"), nuspec.Replace("\r\n", "\n"));


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8696
Regression: No  
* Last working version:   -
* How are we preventing it in future:   -

## Fix

Details: Changed `nuget spec` command to generate the copyright tag with a placeholder value instead of the previous hardcoded value

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Tests for checking nuspec output already exist
Validation:  
