### PR TITLE
Add supportedOS to manifest to fix OS version

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/app.manifest
+++ b/src/NuGet.Clients/NuGet.CommandLine/app.manifest
@@ -5,4 +5,18 @@
       <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>
+
+  <!-- Supported operating systems -->
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
 </assembly>


### PR DESCRIPTION
## Bug

* Fixes: https://github.com/NuGet/Home/issues/8739
* Regression: No  
* Last working version: Unknown
* How are we preventing it in future:   

## Fix

Details: Part of the `User-Agent` string is built by calling `Environment.OSVersion`. On Windows 8.1 and later, this API does not return the actual Windows version unless the application is manifested correctly. From [`GetVersionEx`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexa):

> With the release of Windows 8.1, the behavior of the GetVersionEx API has changed in the value it will return for the operating system version. The value returned by the GetVersionEx function now depends on how the application is manifested.

## Testing/Validation

Tests Added: No  
Reason for not adding tests: Highly dependent on the computer the test is run on.
Validation: I used Fiddler to verify that the `User-Agent` header was fixed with this patch. On my machine, it is now `user-agent: NuGet Command Line/5.4.0 (Microsoft Windows NT 10.0.18362.0)`
