### PR TITLE
Add option to make DependencyGraphSpec read-only

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -66,6 +66,11 @@ namespace NuGet.ProjectModel
         }
 
         /// <summary>
+        /// Gets or sets a value indicating if this instance can be treated as read-only and no other threads will update it.
+        /// </summary>
+        public bool IsReadOnly { get; set; }
+
+        /// <summary>
         /// File json.
         /// </summary>
         public JObject Json { get; }
@@ -116,12 +121,11 @@ namespace NuGet.ProjectModel
         /// <returns></returns>
         public DependencyGraphSpec WithProjectClosure(string projectUniqueName)
         {
-
             var projectDependencyGraphSpec = new DependencyGraphSpec();
             projectDependencyGraphSpec.AddRestore(projectUniqueName);
             foreach (var spec in GetClosure(projectUniqueName))
             {
-                projectDependencyGraphSpec.AddProject(spec.Clone());
+                projectDependencyGraphSpec.AddProject(!IsReadOnly ? spec.Clone() : spec);
             }
 
             return projectDependencyGraphSpec;

--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -21,6 +21,8 @@ namespace NuGet.ProjectModel
 
         private const int _version = 1;
 
+        private readonly bool _isReadOnly;
+
         public static string GetDGSpecFileName(string projectName)
         {
             return string.Format(DGSpecFileNameExtension, projectName);
@@ -39,8 +41,14 @@ namespace NuGet.ProjectModel
         }
 
         public DependencyGraphSpec()
+            : this(isReadOnly: false)
+        {
+        }
+
+        public DependencyGraphSpec(bool isReadOnly)
         {
             Json = new JObject();
+            _isReadOnly = isReadOnly;
         }
 
         /// <summary>
@@ -64,11 +72,6 @@ namespace NuGet.ProjectModel
                 return _projects.Values.ToList();
             }
         }
-
-        /// <summary>
-        /// Gets or sets a value indicating if this instance can be treated as read-only and no other threads will update it.
-        /// </summary>
-        public bool IsReadOnly { get; set; }
 
         /// <summary>
         /// File json.
@@ -125,7 +128,7 @@ namespace NuGet.ProjectModel
             projectDependencyGraphSpec.AddRestore(projectUniqueName);
             foreach (var spec in GetClosure(projectUniqueName))
             {
-                projectDependencyGraphSpec.AddProject(!IsReadOnly ? spec.Clone() : spec);
+                projectDependencyGraphSpec.AddProject(!_isReadOnly ? spec.Clone() : spec);
             }
 
             return projectDependencyGraphSpec;

--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -128,7 +128,8 @@ namespace NuGet.ProjectModel
             projectDependencyGraphSpec.AddRestore(projectUniqueName);
             foreach (var spec in GetClosure(projectUniqueName))
             {
-                projectDependencyGraphSpec.AddProject(!_isReadOnly ? spec.Clone() : spec);
+                // Clone the PackageSpec unless the caller has indicated that the objects won't be modified
+                projectDependencyGraphSpec.AddProject(_isReadOnly ? spec : spec.Clone());
             }
 
             return projectDependencyGraphSpec;


### PR DESCRIPTION
Cloning the PackageSpec object for each project's closure causes significant overhead when the original DependencyGraphSpec contains hundreds of projects.

## Bug

Fixes: https://github.com/NuGet/Home/issues/8744
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Adding an `isReadOnly` parameter to the constructor of `DependencyGraphSpec` to convey that the objects won't be modified so it can skip cloning them.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Existing tests should cover this scenario
Validation:  Profiling shows a reduction in no-op restore time and memory allocations.
