### PR TITLE
Fix plugin logging time accuracy

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogger.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogger.cs
@@ -20,7 +20,7 @@ namespace NuGet.Protocol.Plugins
         internal static PluginLogger DefaultInstance { get; } = new PluginLogger(EnvironmentVariableWrapper.Instance);
 
         public bool IsEnabled { get; }
-        // The DateTimeOffset and Stopwatch ticks are not equivalent. Convert them. 1/10000000 is 1 DateTime tick.
+        // The DateTimeOffset and Stopwatch ticks are not equivalent. 1/10000000 is 1 DateTime tick.
         public DateTimeOffset Now => _startTime.AddTicks(_stopwatch.ElapsedTicks * 10000000 / Stopwatch.Frequency);
 
         internal PluginLogger(IEnvironmentVariableReader environmentVariableReader)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogger.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogger.cs
@@ -20,8 +20,8 @@ namespace NuGet.Protocol.Plugins
         internal static PluginLogger DefaultInstance { get; } = new PluginLogger(EnvironmentVariableWrapper.Instance);
 
         public bool IsEnabled { get; }
-
-        public DateTimeOffset Now => _startTime.AddTicks(_stopwatch.ElapsedTicks);
+        // The DateTimeOffset and Stopwatch ticks are not equivalent. Convert them. 1/10000000 is 1 DateTime tick.
+        public DateTimeOffset Now => _startTime.AddTicks(_stopwatch.ElapsedTicks * 10000000 / Stopwatch.Frequency);
 
         internal PluginLogger(IEnvironmentVariableReader environmentVariableReader)
         {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8747
Regression: Yes  
* Last working version:  5.2
* How are we preventing it in future:  More restrictive test

## Fix

Details: The ticks in DateTime and Stopwatch are different. 
The DateTime ticks at 100ns each. The stopwatch ticks are machine dependent. (Pretty much all Windows machines I've tested have the same accuracy as DateTime, so not unexpected that we don't see it often on Windows).

## Testing/Validation

Tests Added: Yes, making an existing test more restrictive.
Reason for not adding tests:  
Validation:  
