### PR TITLE
Implemented fromStorage and fromCert client certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,4 @@ launchSettings.json
 # include the test packages
 !test/EndToEnd/Packages/**/*
 !test/EndToEnd/ProjectTemplates/**/*.pfx
+/NuGet.sln.DotSettings

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ClientCertificatesCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ClientCertificatesCommand.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Configuration;
+using static NuGet.Commands.ClientCertificatesCommandArgs;
+using static NuGet.Configuration.CertificateSearchItem;
+
+namespace NuGet.CommandLine.Commands
+{
+    [Command(typeof(NuGetCommand),
+        "client-certificates",
+        "ClientCertificatesDescription",
+        MinArgs = 0,
+        MaxArgs = 2,
+        UsageSummaryResourceName = "ClientCertificatesCommandUsageSummary", //TODO
+        UsageExampleResourceName = "ClientCertificatesCommandUsageExamples")] //TODO
+    public class ClientCertificatesCommand : Command
+    {
+        internal ClientCertificatesCommand()
+        {
+        }
+
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandCheckCertificateDescription")] //TODO
+        public bool CheckCertificate { get; set; }
+
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandFindTypeDescription")] //TODO
+        public string FindType { get; set; }
+
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandFindValueDescription")] //TODO
+        public string FindValue { get; set; }
+
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandNameDescription")] //TODO
+        public string Name { get; set; }
+
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandPasswordDescription")] //TODO
+        public string Password { get; set; }
+
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandPathDescription")] //TODO
+        public string Path { get; set; }
+
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandPEMDescription")] //TODO
+        public string PEM { get; set; }
+
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandSourceTypeDescription")] //TODO
+        public string SourceType { get; set; }
+
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandStoreLocationDescription")] //TODO
+        public string StoreLocation { get; set; }
+
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandStoreNameDescription")] //TODO
+        public string StoreName { get; set; }
+
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandStorePasswordInClearTextDescription")] //TODO
+        public bool StorePasswordInClearText { get; set; }
+
+        internal IClientCertificatesCommandRunner ClientCertificatesCommandRunner { get; set; }
+
+        public override async Task ExecuteCommandAsync()
+        {
+            var actionString = Arguments.FirstOrDefault();
+
+            ClientCertificatesCommandAction action;
+            if (string.IsNullOrEmpty(actionString))
+            {
+                action = ClientCertificatesCommandAction.List;
+            }
+            else if (!Enum.TryParse(actionString, true, out action))
+            {
+                throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture, NuGetResources.Error_UnknownAction, actionString));
+            }
+
+            ClientCertificatesSourceType? sourceType;
+            if (string.IsNullOrEmpty(SourceType))
+            {
+                sourceType = GuessSourceTypeBasedOnArgument(action);
+            }
+            else if (Enum.TryParse(SourceType, true, out ClientCertificatesSourceType sourceTypeValue))
+            {
+                sourceType = sourceTypeValue;
+            }
+            else
+            {
+                throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture, NuGetResources.Error_UnknownClientCertificatesSourceType, SourceType));
+            }
+
+            StoreName? storeName;
+            if (string.IsNullOrEmpty(StoreName))
+            {
+                storeName = null;
+            }
+            else if (Enum.TryParse(StoreName, true, out StoreName storeNameValue))
+            {
+                storeName = storeNameValue;
+            }
+            else
+            {
+                throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture, NuGetResources.Error_UnknownClientCertificatesStoreName, StoreName));
+            }
+
+            StoreLocation? storeLocation;
+            if (string.IsNullOrEmpty(StoreLocation))
+            {
+                storeLocation = null;
+            }
+            else if (Enum.TryParse(StoreLocation, true, out StoreLocation storeLocationValue))
+            {
+                storeLocation = storeLocationValue;
+            }
+            else
+            {
+                throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture, NuGetResources.Error_UnknownClientCertificatesStoreLocation, StoreLocation));
+            }
+
+            X509FindType? findType;
+            if (string.IsNullOrEmpty(FindType))
+            {
+                findType = null;
+            }
+            else if (Enum.TryParse(FindType, true, out X509FindType findTypeValue))
+            {
+                findType = findTypeValue;
+            }
+            else
+            {
+                throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture, NuGetResources.Error_UnknownClientCertificatesFindType, FindType));
+            }
+
+            var clientCertificateProvider = new ClientCertificateProvider(Settings);
+
+            var args = new ClientCertificatesCommandArgs
+            {
+                Action = action,
+                SourceType = sourceType,
+                CheckCertificate = CheckCertificate,
+                Name = Name,
+                Path = Path,
+                PEM = PEM,
+                Password = Password,
+                StorePasswordInClearText = StorePasswordInClearText,
+                StoreLocation = storeLocation,
+                StoreName = storeName,
+                FindType = findType,
+                FindValue = FindValue,
+                Logger = Console
+            };
+
+            if (ClientCertificatesCommandRunner == null)
+            {
+                ClientCertificatesCommandRunner = new ClientCertificatesCommandRunner(clientCertificateProvider);
+            }
+
+            var result = await ClientCertificatesCommandRunner.ExecuteCommandAsync(args);
+
+            if (result > 0)
+            {
+                throw new ExitCodeException(1);
+            }
+        }
+
+        private ClientCertificatesSourceType? GuessSourceTypeBasedOnArgument(ClientCertificatesCommandAction action)
+        {
+            if (action != ClientCertificatesCommandAction.Add) return null;
+
+            if (!string.IsNullOrWhiteSpace(Path))
+            {
+                return ClientCertificatesSourceType.File;
+            }
+
+            if (!string.IsNullOrWhiteSpace(PEM))
+            {
+                return ClientCertificatesSourceType.PEM;
+            }
+
+            if (!string.IsNullOrWhiteSpace(StoreLocation) || !string.IsNullOrWhiteSpace(StoreName) ||
+                !string.IsNullOrWhiteSpace(FindType) || !string.IsNullOrWhiteSpace(FindValue))
+            {
+                return ClientCertificatesSourceType.Storage;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ClientCertificatesCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ClientCertificatesCommand.cs
@@ -24,37 +24,37 @@ namespace NuGet.CommandLine.Commands
         {
         }
 
-        [Option(typeof(NuGetCommand), "ClientCertificatesCommandCheckCertificateDescription")] //TODO
-        public bool CheckCertificate { get; set; }
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandCheckCertificateDescription")]
+        public bool Check { get; set; }
 
-        [Option(typeof(NuGetCommand), "ClientCertificatesCommandFindTypeDescription")] //TODO
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandFindTypeDescription")]
         public string FindType { get; set; }
 
-        [Option(typeof(NuGetCommand), "ClientCertificatesCommandFindValueDescription")] //TODO
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandFindValueDescription")]
         public string FindValue { get; set; }
 
-        [Option(typeof(NuGetCommand), "ClientCertificatesCommandNameDescription")] //TODO
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandNameDescription")]
         public string Name { get; set; }
 
-        [Option(typeof(NuGetCommand), "ClientCertificatesCommandPasswordDescription")] //TODO
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandPasswordDescription")] 
         public string Password { get; set; }
 
-        [Option(typeof(NuGetCommand), "ClientCertificatesCommandPathDescription")] //TODO
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandPathDescription")] 
         public string Path { get; set; }
 
-        [Option(typeof(NuGetCommand), "ClientCertificatesCommandPEMDescription")] //TODO
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandPEMDescription")]
         public string PEM { get; set; }
 
-        [Option(typeof(NuGetCommand), "ClientCertificatesCommandSourceTypeDescription")] //TODO
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandSourceTypeDescription")]
         public string SourceType { get; set; }
 
-        [Option(typeof(NuGetCommand), "ClientCertificatesCommandStoreLocationDescription")] //TODO
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandStoreLocationDescription")]
         public string StoreLocation { get; set; }
 
-        [Option(typeof(NuGetCommand), "ClientCertificatesCommandStoreNameDescription")] //TODO
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandStoreNameDescription")] 
         public string StoreName { get; set; }
 
-        [Option(typeof(NuGetCommand), "ClientCertificatesCommandStorePasswordInClearTextDescription")] //TODO
+        [Option(typeof(NuGetCommand), "ClientCertificatesCommandStorePasswordInClearTextDescription")]
         public bool StorePasswordInClearText { get; set; }
 
         internal IClientCertificatesCommandRunner ClientCertificatesCommandRunner { get; set; }
@@ -135,7 +135,7 @@ namespace NuGet.CommandLine.Commands
             {
                 Action = action,
                 SourceType = sourceType,
-                CheckCertificate = CheckCertificate,
+                CheckCertificate = Check,
                 Name = Name,
                 Path = Path,
                 PEM = PEM,

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ClientCertificatesCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ClientCertificatesCommand.cs
@@ -16,8 +16,8 @@ namespace NuGet.CommandLine.Commands
         "ClientCertificatesDescription",
         MinArgs = 0,
         MaxArgs = 2,
-        UsageSummaryResourceName = "ClientCertificatesCommandUsageSummary", //TODO
-        UsageExampleResourceName = "ClientCertificatesCommandUsageExamples")] //TODO
+        UsageSummaryResourceName = "ClientCertificatesCommandUsageSummary",
+        UsageExampleResourceName = "ClientCertificatesCommandUsageExamples")]
     public class ClientCertificatesCommand : Command
     {
         internal ClientCertificatesCommand()

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -151,8 +151,20 @@ namespace NuGet.CommandLine
                 SetDefaultCredentialProvider();
                 RepositoryFactory = new CommandLineRepositoryFactory(Console);
 
-                ClientCertificates.Store(ClientCertificateProvider.Provide(Settings));
+                var clientCertificateProvider = new ClientCertificateProvider(Settings);
 
+                IReadOnlyList<CertificateSearchItem> clientCertificates = clientCertificateProvider.GetClientCertificates();
+                foreach (var item in clientCertificates)
+                {
+                    try
+                    {
+                        ClientCertificates.Add(item.Search());
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteWarning(LocalizedResourceManager.GetString("Warning_ClientCertificateSearchFailed"), item.Name, e.Message);
+                    }
+                }
                 UserAgent.SetUserAgentString(new UserAgentStringBuilder(CommandLineConstants.UserAgent));
 
                 OutputNuGetVersion();

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.Credentials;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -149,6 +150,8 @@ namespace NuGet.CommandLine
 
                 SetDefaultCredentialProvider();
                 RepositoryFactory = new CommandLineRepositoryFactory(Console);
+
+                ClientCertificates.Store(ClientCertificateProvider.Provide(Settings));
 
                 UserAgent.SetUserAgentString(new UserAgentStringBuilder(CommandLineConstants.UserAgent));
 

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -108,15 +108,1401 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Indicates that certificate must be checked before Add or check certificate existence on List..
+        /// </summary>
+        internal static string ClientCertificatesCommandCheckCertificateDescription {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandCheckCertificateDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indicates that certificate must be checked before Add or check certificate existence on List..
+        /// </summary>
+        internal static string ClientCertificatesCommandCheckCertificateDescription_chs {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandCheckCertificateDescription_chs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indicates that certificate must be checked before Add or check certificate existence on List..
+        /// </summary>
+        internal static string ClientCertificatesCommandCheckCertificateDescription_cht {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandCheckCertificateDescription_cht", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indicates that certificate must be checked before Add or check certificate existence on List..
+        /// </summary>
+        internal static string ClientCertificatesCommandCheckCertificateDescription_csy {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandCheckCertificateDescription_csy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indicates that certificate must be checked before Add or check certificate existence on List..
+        /// </summary>
+        internal static string ClientCertificatesCommandCheckCertificateDescription_deu {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandCheckCertificateDescription_deu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indicates that certificate must be checked before Add or check certificate existence on List..
+        /// </summary>
+        internal static string ClientCertificatesCommandCheckCertificateDescription_esp {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandCheckCertificateDescription_esp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indicates that certificate must be checked before Add or check certificate existence on List..
+        /// </summary>
+        internal static string ClientCertificatesCommandCheckCertificateDescription_fra {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandCheckCertificateDescription_fra", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indicates that certificate must be checked before Add or check certificate existence on List..
+        /// </summary>
+        internal static string ClientCertificatesCommandCheckCertificateDescription_ita {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandCheckCertificateDescription_ita", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indicates that certificate must be checked before Add or check certificate existence on List..
+        /// </summary>
+        internal static string ClientCertificatesCommandCheckCertificateDescription_jpn {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandCheckCertificateDescription_jpn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indicates that certificate must be checked before Add or check certificate existence on List..
+        /// </summary>
+        internal static string ClientCertificatesCommandCheckCertificateDescription_kor {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandCheckCertificateDescription_kor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indicates that certificate must be checked before Add or check certificate existence on List..
+        /// </summary>
+        internal static string ClientCertificatesCommandCheckCertificateDescription_plk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandCheckCertificateDescription_plk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indicates that certificate must be checked before Add or check certificate existence on List..
+        /// </summary>
+        internal static string ClientCertificatesCommandCheckCertificateDescription_ptb {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandCheckCertificateDescription_ptb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indicates that certificate must be checked before Add or check certificate existence on List..
+        /// </summary>
+        internal static string ClientCertificatesCommandCheckCertificateDescription_rus {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandCheckCertificateDescription_rus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indicates that certificate must be checked before Add or check certificate existence on List..
+        /// </summary>
+        internal static string ClientCertificatesCommandCheckCertificateDescription_trk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandCheckCertificateDescription_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindType added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindTypeDescription {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindTypeDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindType added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindTypeDescription_chs {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindTypeDescription_chs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindType added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindTypeDescription_cht {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindTypeDescription_cht", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindType added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindTypeDescription_csy {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindTypeDescription_csy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindType added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindTypeDescription_deu {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindTypeDescription_deu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindType added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindTypeDescription_esp {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindTypeDescription_esp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindType added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindTypeDescription_fra {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindTypeDescription_fra", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindType added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindTypeDescription_ita {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindTypeDescription_ita", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindType added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindTypeDescription_jpn {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindTypeDescription_jpn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindType added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindTypeDescription_kor {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindTypeDescription_kor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindType added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindTypeDescription_plk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindTypeDescription_plk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindType added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindTypeDescription_ptb {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindTypeDescription_ptb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindType added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindTypeDescription_rus {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindTypeDescription_rus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindType added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindTypeDescription_trk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindTypeDescription_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindValue added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindValueDescription {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindValueDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindValue added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindValueDescription_chs {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindValueDescription_chs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindValue added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindValueDescription_cht {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindValueDescription_cht", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindValue added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindValueDescription_csy {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindValueDescription_csy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindValue added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindValueDescription_deu {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindValueDescription_deu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindValue added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindValueDescription_esp {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindValueDescription_esp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindValue added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindValueDescription_fra {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindValueDescription_fra", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindValue added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindValueDescription_ita {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindValueDescription_ita", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindValue added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindValueDescription_jpn {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindValueDescription_jpn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindValue added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindValueDescription_kor {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindValueDescription_kor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindValue added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindValueDescription_plk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindValueDescription_plk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindValue added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindValueDescription_ptb {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindValueDescription_ptb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindValue added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindValueDescription_rus {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindValueDescription_rus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FindValue added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandFindValueDescription_trk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandFindValueDescription_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name of the client certificate item..
+        /// </summary>
+        internal static string ClientCertificatesCommandNameDescription {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandNameDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name of the client certificate item..
+        /// </summary>
+        internal static string ClientCertificatesCommandNameDescription_chs {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandNameDescription_chs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name of the client certificate item..
+        /// </summary>
+        internal static string ClientCertificatesCommandNameDescription_cht {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandNameDescription_cht", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name of the client certificate item..
+        /// </summary>
+        internal static string ClientCertificatesCommandNameDescription_csy {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandNameDescription_csy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name of the client certificate item..
+        /// </summary>
+        internal static string ClientCertificatesCommandNameDescription_deu {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandNameDescription_deu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name of the client certificate item..
+        /// </summary>
+        internal static string ClientCertificatesCommandNameDescription_esp {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandNameDescription_esp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name of the client certificate item..
+        /// </summary>
+        internal static string ClientCertificatesCommandNameDescription_fra {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandNameDescription_fra", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name of the client certificate item..
+        /// </summary>
+        internal static string ClientCertificatesCommandNameDescription_ita {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandNameDescription_ita", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name of the client certificate item..
+        /// </summary>
+        internal static string ClientCertificatesCommandNameDescription_jpn {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandNameDescription_jpn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name of the client certificate item..
+        /// </summary>
+        internal static string ClientCertificatesCommandNameDescription_kor {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandNameDescription_kor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name of the client certificate item..
+        /// </summary>
+        internal static string ClientCertificatesCommandNameDescription_plk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandNameDescription_plk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name of the client certificate item..
+        /// </summary>
+        internal static string ClientCertificatesCommandNameDescription_ptb {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandNameDescription_ptb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name of the client certificate item..
+        /// </summary>
+        internal static string ClientCertificatesCommandNameDescription_rus {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandNameDescription_rus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name of the client certificate item..
+        /// </summary>
+        internal static string ClientCertificatesCommandNameDescription_trk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandNameDescription_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password for the certificate, if needed. This option can be used to specify the password for the certificate..
+        /// </summary>
+        internal static string ClientCertificatesCommandPasswordDescription {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPasswordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password for the certificate, if needed. This option can be used to specify the password for the certificate..
+        /// </summary>
+        internal static string ClientCertificatesCommandPasswordDescription_chs {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPasswordDescription_chs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password for the certificate, if needed. This option can be used to specify the password for the certificate..
+        /// </summary>
+        internal static string ClientCertificatesCommandPasswordDescription_cht {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPasswordDescription_cht", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password for the certificate, if needed. This option can be used to specify the password for the certificate..
+        /// </summary>
+        internal static string ClientCertificatesCommandPasswordDescription_csy {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPasswordDescription_csy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password for the certificate, if needed. This option can be used to specify the password for the certificate..
+        /// </summary>
+        internal static string ClientCertificatesCommandPasswordDescription_deu {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPasswordDescription_deu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password for the certificate, if needed. This option can be used to specify the password for the certificate..
+        /// </summary>
+        internal static string ClientCertificatesCommandPasswordDescription_esp {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPasswordDescription_esp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password for the certificate, if needed. This option can be used to specify the password for the certificate..
+        /// </summary>
+        internal static string ClientCertificatesCommandPasswordDescription_fra {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPasswordDescription_fra", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password for the certificate, if needed. This option can be used to specify the password for the certificate..
+        /// </summary>
+        internal static string ClientCertificatesCommandPasswordDescription_ita {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPasswordDescription_ita", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password for the certificate, if needed. This option can be used to specify the password for the certificate..
+        /// </summary>
+        internal static string ClientCertificatesCommandPasswordDescription_jpn {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPasswordDescription_jpn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password for the certificate, if needed. This option can be used to specify the password for the certificate..
+        /// </summary>
+        internal static string ClientCertificatesCommandPasswordDescription_kor {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPasswordDescription_kor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password for the certificate, if needed. This option can be used to specify the password for the certificate..
+        /// </summary>
+        internal static string ClientCertificatesCommandPasswordDescription_plk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPasswordDescription_plk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password for the certificate, if needed. This option can be used to specify the password for the certificate..
+        /// </summary>
+        internal static string ClientCertificatesCommandPasswordDescription_ptb {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPasswordDescription_ptb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password for the certificate, if needed. This option can be used to specify the password for the certificate..
+        /// </summary>
+        internal static string ClientCertificatesCommandPasswordDescription_rus {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPasswordDescription_rus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password for the certificate, if needed. This option can be used to specify the password for the certificate..
+        /// </summary>
+        internal static string ClientCertificatesCommandPasswordDescription_trk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPasswordDescription_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path to certificate file added to a file client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPathDescription {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPathDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path to certificate file added to a file client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPathDescription_chs {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPathDescription_chs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path to certificate file added to a file client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPathDescription_cht {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPathDescription_cht", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path to certificate file added to a file client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPathDescription_csy {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPathDescription_csy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path to certificate file added to a file client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPathDescription_deu {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPathDescription_deu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path to certificate file added to a file client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPathDescription_esp {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPathDescription_esp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path to certificate file added to a file client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPathDescription_fra {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPathDescription_fra", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path to certificate file added to a file client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPathDescription_ita {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPathDescription_ita", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path to certificate file added to a file client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPathDescription_jpn {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPathDescription_jpn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path to certificate file added to a file client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPathDescription_kor {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPathDescription_kor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path to certificate file added to a file client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPathDescription_plk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPathDescription_plk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path to certificate file added to a file client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPathDescription_ptb {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPathDescription_ptb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path to certificate file added to a file client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPathDescription_rus {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPathDescription_rus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path to certificate file added to a file client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPathDescription_trk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPathDescription_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Base64 encoded DER certificate in PEM format added to a PEM client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPEMDescription {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPEMDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Base64 encoded DER certificate in PEM format added to a PEM client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPEMDescription_chs {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPEMDescription_chs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Base64 encoded DER certificate in PEM format added to a PEM client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPEMDescription_cht {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPEMDescription_cht", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Base64 encoded DER certificate in PEM format added to a PEM client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPEMDescription_csy {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPEMDescription_csy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Base64 encoded DER certificate in PEM format added to a PEM client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPEMDescription_deu {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPEMDescription_deu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Base64 encoded DER certificate in PEM format added to a PEM client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPEMDescription_esp {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPEMDescription_esp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Base64 encoded DER certificate in PEM format added to a PEM client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPEMDescription_fra {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPEMDescription_fra", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Base64 encoded DER certificate in PEM format added to a PEM client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPEMDescription_ita {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPEMDescription_ita", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Base64 encoded DER certificate in PEM format added to a PEM client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPEMDescription_jpn {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPEMDescription_jpn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Base64 encoded DER certificate in PEM format added to a PEM client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPEMDescription_kor {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPEMDescription_kor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Base64 encoded DER certificate in PEM format added to a PEM client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPEMDescription_plk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPEMDescription_plk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Base64 encoded DER certificate in PEM format added to a PEM client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPEMDescription_ptb {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPEMDescription_ptb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Base64 encoded DER certificate in PEM format added to a PEM client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPEMDescription_rus {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPEMDescription_rus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Base64 encoded DER certificate in PEM format added to a PEM client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandPEMDescription_trk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandPEMDescription_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate source type..
+        /// </summary>
+        internal static string ClientCertificatesCommandSourceTypeDescription {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandSourceTypeDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate source type..
+        /// </summary>
+        internal static string ClientCertificatesCommandSourceTypeDescription_chs {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandSourceTypeDescription_chs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate source type..
+        /// </summary>
+        internal static string ClientCertificatesCommandSourceTypeDescription_cht {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandSourceTypeDescription_cht", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate source type..
+        /// </summary>
+        internal static string ClientCertificatesCommandSourceTypeDescription_csy {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandSourceTypeDescription_csy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate source type..
+        /// </summary>
+        internal static string ClientCertificatesCommandSourceTypeDescription_deu {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandSourceTypeDescription_deu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate source type..
+        /// </summary>
+        internal static string ClientCertificatesCommandSourceTypeDescription_esp {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandSourceTypeDescription_esp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate source type..
+        /// </summary>
+        internal static string ClientCertificatesCommandSourceTypeDescription_fra {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandSourceTypeDescription_fra", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate source type..
+        /// </summary>
+        internal static string ClientCertificatesCommandSourceTypeDescription_ita {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandSourceTypeDescription_ita", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate source type..
+        /// </summary>
+        internal static string ClientCertificatesCommandSourceTypeDescription_jpn {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandSourceTypeDescription_jpn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate source type..
+        /// </summary>
+        internal static string ClientCertificatesCommandSourceTypeDescription_kor {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandSourceTypeDescription_kor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate source type..
+        /// </summary>
+        internal static string ClientCertificatesCommandSourceTypeDescription_plk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandSourceTypeDescription_plk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate source type..
+        /// </summary>
+        internal static string ClientCertificatesCommandSourceTypeDescription_ptb {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandSourceTypeDescription_ptb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate source type..
+        /// </summary>
+        internal static string ClientCertificatesCommandSourceTypeDescription_rus {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandSourceTypeDescription_rus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate source type..
+        /// </summary>
+        internal static string ClientCertificatesCommandSourceTypeDescription_trk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandSourceTypeDescription_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreLocation added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreLocationDescription {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreLocationDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreLocation added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreLocationDescription_chs {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreLocationDescription_chs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreLocation added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreLocationDescription_cht {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreLocationDescription_cht", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreLocation added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreLocationDescription_csy {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreLocationDescription_csy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreLocation added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreLocationDescription_deu {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreLocationDescription_deu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreLocation added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreLocationDescription_esp {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreLocationDescription_esp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreLocation added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreLocationDescription_fra {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreLocationDescription_fra", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreLocation added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreLocationDescription_ita {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreLocationDescription_ita", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreLocation added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreLocationDescription_jpn {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreLocationDescription_jpn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreLocation added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreLocationDescription_kor {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreLocationDescription_kor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreLocation added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreLocationDescription_plk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreLocationDescription_plk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreLocation added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreLocationDescription_ptb {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreLocationDescription_ptb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreLocation added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreLocationDescription_rus {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreLocationDescription_rus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreLocation added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreLocationDescription_trk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreLocationDescription_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreName added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreNameDescription {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreNameDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreName added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreNameDescription_chs {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreNameDescription_chs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreName added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreNameDescription_cht {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreNameDescription_cht", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreName added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreNameDescription_csy {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreNameDescription_csy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreName added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreNameDescription_deu {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreNameDescription_deu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreName added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreNameDescription_esp {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreNameDescription_esp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreName added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreNameDescription_fra {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreNameDescription_fra", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreName added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreNameDescription_ita {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreNameDescription_ita", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreName added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreNameDescription_jpn {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreNameDescription_jpn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreName added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreNameDescription_kor {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreNameDescription_kor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreName added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreNameDescription_plk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreNameDescription_plk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreName added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreNameDescription_ptb {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreNameDescription_ptb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreName added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreNameDescription_rus {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreNameDescription_rus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StoreName added to a storage client certificate source..
+        /// </summary>
+        internal static string ClientCertificatesCommandStoreNameDescription_trk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStoreNameDescription_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables storing password for the certificate by disabling password encryption..
+        /// </summary>
+        internal static string ClientCertificatesCommandStorePasswordInClearTextDescription {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStorePasswordInClearTextDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables storing password for the certificate by disabling password encryption..
+        /// </summary>
+        internal static string ClientCertificatesCommandStorePasswordInClearTextDescription_chs {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStorePasswordInClearTextDescription_chs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables storing password for the certificate by disabling password encryption..
+        /// </summary>
+        internal static string ClientCertificatesCommandStorePasswordInClearTextDescription_cht {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStorePasswordInClearTextDescription_cht", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables storing password for the certificate by disabling password encryption..
+        /// </summary>
+        internal static string ClientCertificatesCommandStorePasswordInClearTextDescription_csy {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStorePasswordInClearTextDescription_csy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables storing password for the certificate by disabling password encryption..
+        /// </summary>
+        internal static string ClientCertificatesCommandStorePasswordInClearTextDescription_deu {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStorePasswordInClearTextDescription_deu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables storing password for the certificate by disabling password encryption..
+        /// </summary>
+        internal static string ClientCertificatesCommandStorePasswordInClearTextDescription_esp {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStorePasswordInClearTextDescription_esp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables storing password for the certificate by disabling password encryption..
+        /// </summary>
+        internal static string ClientCertificatesCommandStorePasswordInClearTextDescription_fra {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStorePasswordInClearTextDescription_fra", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables storing password for the certificate by disabling password encryption..
+        /// </summary>
+        internal static string ClientCertificatesCommandStorePasswordInClearTextDescription_ita {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStorePasswordInClearTextDescription_ita", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables storing password for the certificate by disabling password encryption..
+        /// </summary>
+        internal static string ClientCertificatesCommandStorePasswordInClearTextDescription_jpn {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStorePasswordInClearTextDescription_jpn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables storing password for the certificate by disabling password encryption..
+        /// </summary>
+        internal static string ClientCertificatesCommandStorePasswordInClearTextDescription_kor {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStorePasswordInClearTextDescription_kor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables storing password for the certificate by disabling password encryption..
+        /// </summary>
+        internal static string ClientCertificatesCommandStorePasswordInClearTextDescription_plk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStorePasswordInClearTextDescription_plk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables storing password for the certificate by disabling password encryption..
+        /// </summary>
+        internal static string ClientCertificatesCommandStorePasswordInClearTextDescription_ptb {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStorePasswordInClearTextDescription_ptb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables storing password for the certificate by disabling password encryption..
+        /// </summary>
+        internal static string ClientCertificatesCommandStorePasswordInClearTextDescription_rus {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStorePasswordInClearTextDescription_rus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables storing password for the certificate by disabling password encryption..
+        /// </summary>
+        internal static string ClientCertificatesCommandStorePasswordInClearTextDescription_trk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandStorePasswordInClearTextDescription_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
         ///
-        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
         ///
-        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        ///nuget client-certificates Add -Name certific [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ClientCertificatesCommandUsageExamples {
             get {
@@ -127,13 +1513,13 @@ namespace NuGet.CommandLine {
         /// <summary>
         ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
         ///
-        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
         ///
-        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        ///nuget client-certificates Add -Name certific [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ClientCertificatesCommandUsageExamples_chs {
             get {
@@ -144,13 +1530,13 @@ namespace NuGet.CommandLine {
         /// <summary>
         ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
         ///
-        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
         ///
-        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        ///nuget client-certificates Add -Name certific [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ClientCertificatesCommandUsageExamples_cht {
             get {
@@ -161,13 +1547,13 @@ namespace NuGet.CommandLine {
         /// <summary>
         ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
         ///
-        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
         ///
-        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        ///nuget client-certificates Add -Name certific [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ClientCertificatesCommandUsageExamples_csy {
             get {
@@ -178,13 +1564,13 @@ namespace NuGet.CommandLine {
         /// <summary>
         ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
         ///
-        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
         ///
-        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        ///nuget client-certificates Add -Name certific [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ClientCertificatesCommandUsageExamples_deu {
             get {
@@ -195,13 +1581,13 @@ namespace NuGet.CommandLine {
         /// <summary>
         ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
         ///
-        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
         ///
-        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        ///nuget client-certificates Add -Name certific [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ClientCertificatesCommandUsageExamples_esp {
             get {
@@ -212,13 +1598,13 @@ namespace NuGet.CommandLine {
         /// <summary>
         ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
         ///
-        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
         ///
-        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        ///nuget client-certificates Add -Name certific [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ClientCertificatesCommandUsageExamples_fra {
             get {
@@ -229,13 +1615,13 @@ namespace NuGet.CommandLine {
         /// <summary>
         ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
         ///
-        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
         ///
-        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        ///nuget client-certificates Add -Name certific [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ClientCertificatesCommandUsageExamples_ita {
             get {
@@ -246,13 +1632,13 @@ namespace NuGet.CommandLine {
         /// <summary>
         ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
         ///
-        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
         ///
-        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        ///nuget client-certificates Add -Name certific [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ClientCertificatesCommandUsageExamples_jpn {
             get {
@@ -263,13 +1649,13 @@ namespace NuGet.CommandLine {
         /// <summary>
         ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
         ///
-        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
         ///
-        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        ///nuget client-certificates Add -Name certific [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ClientCertificatesCommandUsageExamples_kor {
             get {
@@ -280,13 +1666,13 @@ namespace NuGet.CommandLine {
         /// <summary>
         ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
         ///
-        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
         ///
-        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        ///nuget client-certificates Add -Name certific [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ClientCertificatesCommandUsageExamples_plk {
             get {
@@ -297,13 +1683,13 @@ namespace NuGet.CommandLine {
         /// <summary>
         ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
         ///
-        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
         ///
-        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        ///nuget client-certificates Add -Name certific [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ClientCertificatesCommandUsageExamples_ptb {
             get {
@@ -314,13 +1700,13 @@ namespace NuGet.CommandLine {
         /// <summary>
         ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
         ///
-        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
         ///
-        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        ///nuget client-certificates Add -Name certific [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ClientCertificatesCommandUsageExamples_rus {
             get {
@@ -331,13 +1717,13 @@ namespace NuGet.CommandLine {
         /// <summary>
         ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
         ///
-        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
         ///
         ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
         ///
-        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        ///nuget client-certificates Add -Name certific [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ClientCertificatesCommandUsageExamples_trk {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -108,6 +108,275 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to nuget client-certificates
+        ///
+        ///nuget client-certificates Add -Name existingClientCertificate -Path .\MyCertificate.pfx
+        ///
+        ///nuget client-certificates Add -Name existingClientCertificate -Path c:\MyCertificate.pfx -Password 42
+        ///
+        ///nuget client-certificates Add -Name existingClientCertificate -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
+        ///
+        ///nuget client-certificates Add -Name existingClientCertificate -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClear [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageExamples {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageExamples", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;List|Add|Remove|&gt; [options].
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageSummary {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;List|Add|Remove|&gt; [选项].
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageSummary_chs {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageSummary_chs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;List|Add|Remove|&gt; [選項].
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageSummary_cht {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageSummary_cht", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;List|Add|Remove|&gt; [možnosti].
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageSummary_csy {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageSummary_csy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;List|Add|Remove|&gt; [Optionen].
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageSummary_deu {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageSummary_deu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;List|Add|Remove|&gt; [opciones].
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageSummary_esp {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageSummary_esp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;List|Add|Remove|&gt; [les options].
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageSummary_fra {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageSummary_fra", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;List|Add|Remove|&gt; [opzioni].
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageSummary_ita {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageSummary_ita", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;List|Add|Remove|&gt; [オプション].
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageSummary_jpn {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageSummary_jpn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;List|Add|Remove|&gt; [옵션].
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageSummary_kor {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageSummary_kor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;List|Add|Remove|&gt; [opcje].
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageSummary_plk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageSummary_plk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;List|Add|Remove|&gt; [opções].
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageSummary_ptb {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageSummary_ptb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;List|Add|Remove|&gt; [параметры].
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageSummary_rus {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageSummary_rus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;List|Add|Remove|&gt; [seçenekler].
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageSummary_trk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageSummary_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Provides the ability to manage list of client certificates located in %AppData%\NuGet\NuGet.config.
+        /// </summary>
+        internal static string ClientCertificatesDescription {
+            get {
+                return ResourceManager.GetString("ClientCertificatesDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 提供管理位于 %AppData%\NuGet\NuGet.config 中的客户端证书列表的功能.
+        /// </summary>
+        internal static string ClientCertificatesDescription_chs {
+            get {
+                return ResourceManager.GetString("ClientCertificatesDescription_chs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 提供管理位於 %AppData%\NuGet\NuGet.config 中的客戶端證書列表的功能.
+        /// </summary>
+        internal static string ClientCertificatesDescription_cht {
+            get {
+                return ResourceManager.GetString("ClientCertificatesDescription_cht", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Poskytuje možnost spravovat seznam klientských certifikátů umístěných v %AppData%\NuGet\NuGet.config.
+        /// </summary>
+        internal static string ClientCertificatesDescription_csy {
+            get {
+                return ResourceManager.GetString("ClientCertificatesDescription_csy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bietet die Möglichkeit, eine Liste der Client-Zertifikate zu verwalten, die sich in %AppData%\NuGet\NuGet.config befinden.
+        /// </summary>
+        internal static string ClientCertificatesDescription_deu {
+            get {
+                return ResourceManager.GetString("ClientCertificatesDescription_deu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Proporciona la capacidad de administrar la lista de certificados de clientes ubicados en %AppData%\NuGet\NuGet.config.
+        /// </summary>
+        internal static string ClientCertificatesDescription_esp {
+            get {
+                return ResourceManager.GetString("ClientCertificatesDescription_esp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Permet de gérer la liste des certificats clients situés dans %AppData%\NuGet\NuGet.config.
+        /// </summary>
+        internal static string ClientCertificatesDescription_fra {
+            get {
+                return ResourceManager.GetString("ClientCertificatesDescription_fra", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fornisce la possibilità di gestire l&apos;elenco dei certificati client situati in %AppData%\NuGet\NuGet.config.
+        /// </summary>
+        internal static string ClientCertificatesDescription_ita {
+            get {
+                return ResourceManager.GetString("ClientCertificatesDescription_ita", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to %AppData%\NuGet\NuGet.config にあるクライアント証明書のリストを管理する機能を提供します.
+        /// </summary>
+        internal static string ClientCertificatesDescription_jpn {
+            get {
+                return ResourceManager.GetString("ClientCertificatesDescription_jpn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to %AppData%\NuGet\NuGet.config 에있는 클라이언트 인증서 목록을 관리하는 기능을 제공합니다..
+        /// </summary>
+        internal static string ClientCertificatesDescription_kor {
+            get {
+                return ResourceManager.GetString("ClientCertificatesDescription_kor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Zapewnia możliwość zarządzania listą certyfikatów klienta znajdujących się w %AppData%\NuGet\NuGet.config.
+        /// </summary>
+        internal static string ClientCertificatesDescription_plk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesDescription_plk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fornece a capacidade de gerenciar a lista de certificados de cliente localizados em %AppData%\NuGet\NuGet.config.
+        /// </summary>
+        internal static string ClientCertificatesDescription_ptb {
+            get {
+                return ResourceManager.GetString("ClientCertificatesDescription_ptb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Предоставляет возможность управлять списком клиентских сертификатов, расположенных в %AppData%\NuGet\NuGet.config.
+        /// </summary>
+        internal static string ClientCertificatesDescription_rus {
+            get {
+                return ResourceManager.GetString("ClientCertificatesDescription_rus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to %AppData%\NuGet\NuGet.config içinde bulunan müşteri sertifikalarının listesini yönetme olanağı sağlar.
+        /// </summary>
+        internal static string ClientCertificatesDescription_trk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesDescription_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The API key for the server..
         /// </summary>
         internal static string CommandApiKey {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -108,19 +108,240 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to nuget client-certificates
+        ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
         ///
-        ///nuget client-certificates Add -Name existingClientCertificate -Path .\MyCertificate.pfx
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
         ///
-        ///nuget client-certificates Add -Name existingClientCertificate -Path c:\MyCertificate.pfx -Password 42
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
         ///
-        ///nuget client-certificates Add -Name existingClientCertificate -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
         ///
-        ///nuget client-certificates Add -Name existingClientCertificate -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClear [rest of string was truncated]&quot;;.
+        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ClientCertificatesCommandUsageExamples {
             get {
                 return ResourceManager.GetString("ClientCertificatesCommandUsageExamples", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+        ///
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
+        ///
+        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageExamples_chs {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageExamples_chs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+        ///
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
+        ///
+        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageExamples_cht {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageExamples_cht", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+        ///
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
+        ///
+        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageExamples_csy {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageExamples_csy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+        ///
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
+        ///
+        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageExamples_deu {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageExamples_deu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+        ///
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
+        ///
+        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageExamples_esp {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageExamples_esp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+        ///
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
+        ///
+        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageExamples_fra {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageExamples_fra", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+        ///
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
+        ///
+        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageExamples_ita {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageExamples_ita", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+        ///
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
+        ///
+        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageExamples_jpn {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageExamples_jpn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+        ///
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
+        ///
+        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageExamples_kor {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageExamples_kor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+        ///
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
+        ///
+        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageExamples_plk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageExamples_plk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+        ///
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
+        ///
+        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageExamples_ptb {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageExamples_ptb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+        ///
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
+        ///
+        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageExamples_rus {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageExamples_rus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+        ///
+        ///nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot;
+        ///
+        ///nuget client-certificates Add -Name certificateName -PEM &quot;-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----&quot; -Password 42 -StorePasswordInClearText true
+        ///
+        ///nuget client-certificates Add -Na [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string ClientCertificatesCommandUsageExamples_trk {
+            get {
+                return ResourceManager.GetString("ClientCertificatesCommandUsageExamples_trk", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5550,4 +5550,103 @@ nuget trusted-signers Remove -Name TrustedRepo</value>
   <data name="PackageCommandDeterministic" xml:space="preserve">
     <value>Specify if the command should create a deterministic package. Multiple invocations of the pack command will create the exact same package.</value>
   </data>
+  <data name="ClientCertificatesCommandUsageSummary" xml:space="preserve">
+<value>&lt;List|Add|Remove|&gt; [options]</value>
+</data>
+  <data name="ClientCertificatesCommandUsageSummary_chs" xml:space="preserve">
+<value>&lt;List|Add|Remove|&gt; [选项]</value>
+</data>
+  <data name="ClientCertificatesCommandUsageSummary_cht" xml:space="preserve">
+<value>&lt;List|Add|Remove|&gt; [選項]</value>
+</data>
+  <data name="ClientCertificatesCommandUsageSummary_csy" xml:space="preserve">
+<value>&lt;List|Add|Remove|&gt; [možnosti]</value>
+</data>
+  <data name="ClientCertificatesCommandUsageSummary_deu" xml:space="preserve">
+<value>&lt;List|Add|Remove|&gt; [Optionen]</value>
+</data>
+  <data name="ClientCertificatesCommandUsageSummary_esp" xml:space="preserve">
+<value>&lt;List|Add|Remove|&gt; [opciones]</value>
+</data>
+  <data name="ClientCertificatesCommandUsageSummary_fra" xml:space="preserve">
+<value>&lt;List|Add|Remove|&gt; [les options]</value>
+</data>
+  <data name="ClientCertificatesCommandUsageSummary_ita" xml:space="preserve">
+<value>&lt;List|Add|Remove|&gt; [opzioni]</value>
+</data>
+  <data name="ClientCertificatesCommandUsageSummary_jpn" xml:space="preserve">
+<value>&lt;List|Add|Remove|&gt; [オプション]</value>
+</data>
+  <data name="ClientCertificatesCommandUsageSummary_kor" xml:space="preserve">
+<value>&lt;List|Add|Remove|&gt; [옵션]</value>
+</data>
+  <data name="ClientCertificatesCommandUsageSummary_plk" xml:space="preserve">
+<value>&lt;List|Add|Remove|&gt; [opcje]</value>
+</data>
+  <data name="ClientCertificatesCommandUsageSummary_ptb" xml:space="preserve">
+<value>&lt;List|Add|Remove|&gt; [opções]</value>
+</data>
+  <data name="ClientCertificatesCommandUsageSummary_rus" xml:space="preserve">
+<value>&lt;List|Add|Remove|&gt; [параметры]</value>
+</data>
+  <data name="ClientCertificatesCommandUsageSummary_trk" xml:space="preserve">
+<value>&lt;List|Add|Remove|&gt; [seçenekler]</value>
+</data>
+  <data name="ClientCertificatesCommandUsageExamples" xml:space="preserve">
+    <value>nuget client-certificates
+
+nuget client-certificates Add -Name existingClientCertificate -Path .\MyCertificate.pfx
+
+nuget client-certificates Add -Name existingClientCertificate -Path c:\MyCertificate.pfx -Password 42
+
+nuget client-certificates Add -Name existingClientCertificate -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
+
+nuget client-certificates Add -Name existingClientCertificate -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----" -Password 42 -StorePasswordInClearText true
+
+nuget client-certificates Add -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Add -StoreLocation My -StoreName Personal -FindType FindByThumbprint -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755</value>
+  </data>
+  <data name="ClientCertificatesDescription" xml:space="preserve">
+    <value>Provides the ability to manage list of client certificates located in %AppData%\NuGet\NuGet.config</value>
+  </data>
+  <data name="ClientCertificatesDescription_chs" xml:space="preserve">
+    <value>提供管理位于 %AppData%\NuGet\NuGet.config 中的客户端证书列表的功能</value>
+  </data>
+  <data name="ClientCertificatesDescription_cht" xml:space="preserve">
+    <value>提供管理位於 %AppData%\NuGet\NuGet.config 中的客戶端證書列表的功能</value>
+  </data>
+  <data name="ClientCertificatesDescription_csy" xml:space="preserve">
+    <value>Poskytuje možnost spravovat seznam klientských certifikátů umístěných v %AppData%\NuGet\NuGet.config</value>
+  </data>
+  <data name="ClientCertificatesDescription_deu" xml:space="preserve">
+    <value>Bietet die Möglichkeit, eine Liste der Client-Zertifikate zu verwalten, die sich in %AppData%\NuGet\NuGet.config befinden</value>
+  </data>
+  <data name="ClientCertificatesDescription_esp" xml:space="preserve">
+    <value>Proporciona la capacidad de administrar la lista de certificados de clientes ubicados en %AppData%\NuGet\NuGet.config</value>
+  </data>
+  <data name="ClientCertificatesDescription_fra" xml:space="preserve">
+    <value>Permet de gérer la liste des certificats clients situés dans %AppData%\NuGet\NuGet.config</value>
+  </data>
+  <data name="ClientCertificatesDescription_ita" xml:space="preserve">
+    <value>Fornisce la possibilità di gestire l'elenco dei certificati client situati in %AppData%\NuGet\NuGet.config</value>
+  </data>
+  <data name="ClientCertificatesDescription_jpn" xml:space="preserve">
+    <value>%AppData%\NuGet\NuGet.config にあるクライアント証明書のリストを管理する機能を提供します</value>
+  </data>
+  <data name="ClientCertificatesDescription_kor" xml:space="preserve">
+    <value>%AppData%\NuGet\NuGet.config 에있는 클라이언트 인증서 목록을 관리하는 기능을 제공합니다.</value>
+  </data>
+  <data name="ClientCertificatesDescription_plk" xml:space="preserve">
+    <value>Zapewnia możliwość zarządzania listą certyfikatów klienta znajdujących się w %AppData%\NuGet\NuGet.config</value>
+  </data>
+  <data name="ClientCertificatesDescription_ptb" xml:space="preserve">
+    <value>Fornece a capacidade de gerenciar a lista de certificados de cliente localizados em %AppData%\NuGet\NuGet.config</value>
+  </data>
+  <data name="ClientCertificatesDescription_rus" xml:space="preserve">
+    <value>Предоставляет возможность управлять списком клиентских сертификатов, расположенных в %AppData%\NuGet\NuGet.config</value>
+  </data>
+  <data name="ClientCertificatesDescription_trk" xml:space="preserve">
+    <value>%AppData%\NuGet\NuGet.config içinde bulunan müşteri sertifikalarının listesini yönetme olanağı sağlar</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5593,19 +5593,357 @@ nuget trusted-signers Remove -Name TrustedRepo</value>
 <value>&lt;List|Add|Remove|&gt; [seçenekler]</value>
 </data>
   <data name="ClientCertificatesCommandUsageExamples" xml:space="preserve">
-    <value>nuget client-certificates
+    <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
 
-nuget client-certificates Add -Name existingClientCertificate -Path .\MyCertificate.pfx
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
 
-nuget client-certificates Add -Name existingClientCertificate -Path c:\MyCertificate.pfx -Password 42
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
 
-nuget client-certificates Add -Name existingClientCertificate -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----" -Password 42 -StorePasswordInClearText true
 
-nuget client-certificates Add -Name existingClientCertificate -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----" -Password 42 -StorePasswordInClearText true
+nuget client-certificates Add -Name certificateName -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
 
-nuget client-certificates Add -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+nuget client-certificates Add -Name certificateName -StoreLocation LocalMachine -StoreName My -FindType FindByThumbprint -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
 
-nuget client-certificates Add -StoreLocation My -StoreName Personal -FindType FindByThumbprint -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755</value>
+nuget client-certificates Remove -Name certificateName
+
+nuget client-certificates
+
+nuget client-certificates List -CheckCertificate true
+
+nuget client-certificates List -Name containsInName
+
+nuget client-certificates List -SourceType storage
+
+nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Path "containsInPath" -StoreName My</value>
+  </data>
+  <data name="ClientCertificatesCommandUsageExamples_chs" xml:space="preserve">
+    <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----" -Password 42 -StorePasswordInClearText true
+
+nuget client-certificates Add -Name certificateName -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Add -Name certificateName -StoreLocation LocalMachine -StoreName My -FindType FindByThumbprint -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Remove -Name certificateName
+
+nuget client-certificates
+
+nuget client-certificates List -CheckCertificate true
+
+nuget client-certificates List -Name containsInName
+
+nuget client-certificates List -SourceType storage
+
+nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Path "containsInPath" -StoreName My</value>
+  </data>
+  <data name="ClientCertificatesCommandUsageExamples_cht" xml:space="preserve">
+    <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----" -Password 42 -StorePasswordInClearText true
+
+nuget client-certificates Add -Name certificateName -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Add -Name certificateName -StoreLocation LocalMachine -StoreName My -FindType FindByThumbprint -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Remove -Name certificateName
+
+nuget client-certificates
+
+nuget client-certificates List -CheckCertificate true
+
+nuget client-certificates List -Name containsInName
+
+nuget client-certificates List -SourceType storage
+
+nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Path "containsInPath" -StoreName My</value>
+  </data>
+  <data name="ClientCertificatesCommandUsageExamples_csy" xml:space="preserve">
+    <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----" -Password 42 -StorePasswordInClearText true
+
+nuget client-certificates Add -Name certificateName -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Add -Name certificateName -StoreLocation LocalMachine -StoreName My -FindType FindByThumbprint -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Remove -Name certificateName
+
+nuget client-certificates
+
+nuget client-certificates List -CheckCertificate true
+
+nuget client-certificates List -Name containsInName
+
+nuget client-certificates List -SourceType storage
+
+nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Path "containsInPath" -StoreName My</value>
+  </data>
+  <data name="ClientCertificatesCommandUsageExamples_deu" xml:space="preserve">
+    <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----" -Password 42 -StorePasswordInClearText true
+
+nuget client-certificates Add -Name certificateName -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Add -Name certificateName -StoreLocation LocalMachine -StoreName My -FindType FindByThumbprint -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Remove -Name certificateName
+
+nuget client-certificates
+
+nuget client-certificates List -CheckCertificate true
+
+nuget client-certificates List -Name containsInName
+
+nuget client-certificates List -SourceType storage
+
+nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Path "containsInPath" -StoreName My</value>
+  </data>
+  <data name="ClientCertificatesCommandUsageExamples_esp" xml:space="preserve">
+    <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----" -Password 42 -StorePasswordInClearText true
+
+nuget client-certificates Add -Name certificateName -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Add -Name certificateName -StoreLocation LocalMachine -StoreName My -FindType FindByThumbprint -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Remove -Name certificateName
+
+nuget client-certificates
+
+nuget client-certificates List -CheckCertificate true
+
+nuget client-certificates List -Name containsInName
+
+nuget client-certificates List -SourceType storage
+
+nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Path "containsInPath" -StoreName My</value>
+  </data>
+  <data name="ClientCertificatesCommandUsageExamples_fra" xml:space="preserve">
+    <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----" -Password 42 -StorePasswordInClearText true
+
+nuget client-certificates Add -Name certificateName -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Add -Name certificateName -StoreLocation LocalMachine -StoreName My -FindType FindByThumbprint -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Remove -Name certificateName
+
+nuget client-certificates
+
+nuget client-certificates List -CheckCertificate true
+
+nuget client-certificates List -Name containsInName
+
+nuget client-certificates List -SourceType storage
+
+nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Path "containsInPath" -StoreName My</value>
+  </data>
+  <data name="ClientCertificatesCommandUsageExamples_ita" xml:space="preserve">
+    <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----" -Password 42 -StorePasswordInClearText true
+
+nuget client-certificates Add -Name certificateName -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Add -Name certificateName -StoreLocation LocalMachine -StoreName My -FindType FindByThumbprint -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Remove -Name certificateName
+
+nuget client-certificates
+
+nuget client-certificates List -CheckCertificate true
+
+nuget client-certificates List -Name containsInName
+
+nuget client-certificates List -SourceType storage
+
+nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Path "containsInPath" -StoreName My</value>
+  </data>
+  <data name="ClientCertificatesCommandUsageExamples_jpn" xml:space="preserve">
+    <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----" -Password 42 -StorePasswordInClearText true
+
+nuget client-certificates Add -Name certificateName -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Add -Name certificateName -StoreLocation LocalMachine -StoreName My -FindType FindByThumbprint -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Remove -Name certificateName
+
+nuget client-certificates
+
+nuget client-certificates List -CheckCertificate true
+
+nuget client-certificates List -Name containsInName
+
+nuget client-certificates List -SourceType storage
+
+nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Path "containsInPath" -StoreName My</value>
+  </data>
+  <data name="ClientCertificatesCommandUsageExamples_kor" xml:space="preserve">
+    <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----" -Password 42 -StorePasswordInClearText true
+
+nuget client-certificates Add -Name certificateName -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Add -Name certificateName -StoreLocation LocalMachine -StoreName My -FindType FindByThumbprint -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Remove -Name certificateName
+
+nuget client-certificates
+
+nuget client-certificates List -CheckCertificate true
+
+nuget client-certificates List -Name containsInName
+
+nuget client-certificates List -SourceType storage
+
+nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Path "containsInPath" -StoreName My</value>
+  </data>
+  <data name="ClientCertificatesCommandUsageExamples_plk" xml:space="preserve">
+    <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----" -Password 42 -StorePasswordInClearText true
+
+nuget client-certificates Add -Name certificateName -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Add -Name certificateName -StoreLocation LocalMachine -StoreName My -FindType FindByThumbprint -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Remove -Name certificateName
+
+nuget client-certificates
+
+nuget client-certificates List -CheckCertificate true
+
+nuget client-certificates List -Name containsInName
+
+nuget client-certificates List -SourceType storage
+
+nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Path "containsInPath" -StoreName My</value>
+  </data>
+  <data name="ClientCertificatesCommandUsageExamples_ptb" xml:space="preserve">
+    <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----" -Password 42 -StorePasswordInClearText true
+
+nuget client-certificates Add -Name certificateName -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Add -Name certificateName -StoreLocation LocalMachine -StoreName My -FindType FindByThumbprint -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Remove -Name certificateName
+
+nuget client-certificates
+
+nuget client-certificates List -CheckCertificate true
+
+nuget client-certificates List -Name containsInName
+
+nuget client-certificates List -SourceType storage
+
+nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Path "containsInPath" -StoreName My</value>
+  </data>
+  <data name="ClientCertificatesCommandUsageExamples_rus" xml:space="preserve">
+    <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----" -Password 42 -StorePasswordInClearText true
+
+nuget client-certificates Add -Name certificateName -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Add -Name certificateName -StoreLocation LocalMachine -StoreName My -FindType FindByThumbprint -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Remove -Name certificateName
+
+nuget client-certificates
+
+nuget client-certificates List -CheckCertificate true
+
+nuget client-certificates List -Name containsInName
+
+nuget client-certificates List -SourceType storage
+
+nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Path "containsInPath" -StoreName My</value>
+  </data>  
+  <data name="ClientCertificatesCommandUsageExamples_trk" xml:space="preserve">
+    <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
+
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
+
+nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----" -Password 42 -StorePasswordInClearText true
+
+nuget client-certificates Add -Name certificateName -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Add -Name certificateName -StoreLocation LocalMachine -StoreName My -FindType FindByThumbprint -FindValue ca4e7b265780fc87f3cb90b6b89c54bf4341e755
+
+nuget client-certificates Remove -Name certificateName
+
+nuget client-certificates
+
+nuget client-certificates List -CheckCertificate true
+
+nuget client-certificates List -Name containsInName
+
+nuget client-certificates List -SourceType storage
+
+nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Path "containsInPath" -StoreName My</value>
+  </data>
+  <data name="ClientCertificatesCommandCheckCertificateDescription" xml:space="preserve">
+    <value>Indicates that certificate must be checked before Add action or check certificate existence on List action</value>
   </data>
   <data name="ClientCertificatesDescription" xml:space="preserve">
     <value>Provides the ability to manage list of client certificates located in %AppData%\NuGet\NuGet.config</value>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx.bak
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx.bak
@@ -5595,7 +5595,7 @@ nuget trusted-signers Remove -Name TrustedRepo</value>
   <data name="ClientCertificatesCommandUsageExamples" xml:space="preserve">
     <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
 
-nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
 
 nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
 
@@ -5609,7 +5609,7 @@ nuget client-certificates Remove -Name certificateName
 
 nuget client-certificates
 
-nuget client-certificates List -Check true
+nuget client-certificates List -CheckCertificate true
 
 nuget client-certificates List -Name containsInName
 
@@ -5620,7 +5620,7 @@ nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Pat
   <data name="ClientCertificatesCommandUsageExamples_chs" xml:space="preserve">
     <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
 
-nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
 
 nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
 
@@ -5634,7 +5634,7 @@ nuget client-certificates Remove -Name certificateName
 
 nuget client-certificates
 
-nuget client-certificates List -Check true
+nuget client-certificates List -CheckCertificate true
 
 nuget client-certificates List -Name containsInName
 
@@ -5645,7 +5645,7 @@ nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Pat
   <data name="ClientCertificatesCommandUsageExamples_cht" xml:space="preserve">
     <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
 
-nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
 
 nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
 
@@ -5659,7 +5659,7 @@ nuget client-certificates Remove -Name certificateName
 
 nuget client-certificates
 
-nuget client-certificates List -Check true
+nuget client-certificates List -CheckCertificate true
 
 nuget client-certificates List -Name containsInName
 
@@ -5670,7 +5670,7 @@ nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Pat
   <data name="ClientCertificatesCommandUsageExamples_csy" xml:space="preserve">
     <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
 
-nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
 
 nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
 
@@ -5684,7 +5684,7 @@ nuget client-certificates Remove -Name certificateName
 
 nuget client-certificates
 
-nuget client-certificates List -Check true
+nuget client-certificates List -CheckCertificate true
 
 nuget client-certificates List -Name containsInName
 
@@ -5695,7 +5695,7 @@ nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Pat
   <data name="ClientCertificatesCommandUsageExamples_deu" xml:space="preserve">
     <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
 
-nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
 
 nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
 
@@ -5709,7 +5709,7 @@ nuget client-certificates Remove -Name certificateName
 
 nuget client-certificates
 
-nuget client-certificates List -Check true
+nuget client-certificates List -CheckCertificate true
 
 nuget client-certificates List -Name containsInName
 
@@ -5720,7 +5720,7 @@ nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Pat
   <data name="ClientCertificatesCommandUsageExamples_esp" xml:space="preserve">
     <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
 
-nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
 
 nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
 
@@ -5734,7 +5734,7 @@ nuget client-certificates Remove -Name certificateName
 
 nuget client-certificates
 
-nuget client-certificates List -Check true
+nuget client-certificates List -CheckCertificate true
 
 nuget client-certificates List -Name containsInName
 
@@ -5745,7 +5745,7 @@ nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Pat
   <data name="ClientCertificatesCommandUsageExamples_fra" xml:space="preserve">
     <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
 
-nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
 
 nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
 
@@ -5759,7 +5759,7 @@ nuget client-certificates Remove -Name certificateName
 
 nuget client-certificates
 
-nuget client-certificates List -Check true
+nuget client-certificates List -CheckCertificate true
 
 nuget client-certificates List -Name containsInName
 
@@ -5770,7 +5770,7 @@ nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Pat
   <data name="ClientCertificatesCommandUsageExamples_ita" xml:space="preserve">
     <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
 
-nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
 
 nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
 
@@ -5784,7 +5784,7 @@ nuget client-certificates Remove -Name certificateName
 
 nuget client-certificates
 
-nuget client-certificates List -Check true
+nuget client-certificates List -CheckCertificate true
 
 nuget client-certificates List -Name containsInName
 
@@ -5795,7 +5795,7 @@ nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Pat
   <data name="ClientCertificatesCommandUsageExamples_jpn" xml:space="preserve">
     <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
 
-nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
 
 nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
 
@@ -5809,7 +5809,7 @@ nuget client-certificates Remove -Name certificateName
 
 nuget client-certificates
 
-nuget client-certificates List -Check true
+nuget client-certificates List -CheckCertificate true
 
 nuget client-certificates List -Name containsInName
 
@@ -5820,7 +5820,7 @@ nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Pat
   <data name="ClientCertificatesCommandUsageExamples_kor" xml:space="preserve">
     <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
 
-nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
 
 nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
 
@@ -5834,7 +5834,7 @@ nuget client-certificates Remove -Name certificateName
 
 nuget client-certificates
 
-nuget client-certificates List -Check true
+nuget client-certificates List -CheckCertificate true
 
 nuget client-certificates List -Name containsInName
 
@@ -5845,7 +5845,7 @@ nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Pat
   <data name="ClientCertificatesCommandUsageExamples_plk" xml:space="preserve">
     <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
 
-nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
 
 nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
 
@@ -5859,7 +5859,7 @@ nuget client-certificates Remove -Name certificateName
 
 nuget client-certificates
 
-nuget client-certificates List -Check true
+nuget client-certificates List -CheckCertificate true
 
 nuget client-certificates List -Name containsInName
 
@@ -5870,7 +5870,7 @@ nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Pat
   <data name="ClientCertificatesCommandUsageExamples_ptb" xml:space="preserve">
     <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
 
-nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
 
 nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
 
@@ -5884,7 +5884,7 @@ nuget client-certificates Remove -Name certificateName
 
 nuget client-certificates
 
-nuget client-certificates List -Check true
+nuget client-certificates List -CheckCertificate true
 
 nuget client-certificates List -Name containsInName
 
@@ -5895,7 +5895,7 @@ nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Pat
   <data name="ClientCertificatesCommandUsageExamples_rus" xml:space="preserve">
     <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
 
-nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
 
 nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
 
@@ -5909,7 +5909,7 @@ nuget client-certificates Remove -Name certificateName
 
 nuget client-certificates
 
-nuget client-certificates List -Check true
+nuget client-certificates List -CheckCertificate true
 
 nuget client-certificates List -Name containsInName
 
@@ -5920,7 +5920,7 @@ nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Pat
   <data name="ClientCertificatesCommandUsageExamples_trk" xml:space="preserve">
     <value>nuget client-certificates Add -Name certificateName -Path .\MyCertificate.pfx
 
-nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -Check true
+nuget client-certificates Add -Name certificateName -Path c:\MyCertificate.pfx -Password 42 -CheckCertificate true
 
 nuget client-certificates Add -Name certificateName -PEM "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
 
@@ -5934,7 +5934,7 @@ nuget client-certificates Remove -Name certificateName
 
 nuget client-certificates
 
-nuget client-certificates List -Check true
+nuget client-certificates List -CheckCertificate true
 
 nuget client-certificates List -Name containsInName
 
@@ -5943,132 +5943,132 @@ nuget client-certificates List -SourceType storage
 nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Path "containsInPath" -StoreName My</value>
   </data>
     <data name="ClientCertificatesCommandCheckCertificateDescription" xml:space="preserve">
-    <value>Indicates that certificate must be checked before Add or check certificate existence on List.</value>
-  </data>                                                                                              
-  <data name="ClientCertificatesCommandCheckCertificateDescription_chs" xml:space="preserve">          
-    <value>Indicates that certificate must be checked before Add or check certificate existence on List.</value>
-  </data>                                                                                              
-  <data name="ClientCertificatesCommandCheckCertificateDescription_cht" xml:space="preserve">          
-    <value>Indicates that certificate must be checked before Add or check certificate existence on List.</value>
-  </data>                                                                                              
-  <data name="ClientCertificatesCommandCheckCertificateDescription_csy" xml:space="preserve">          
-    <value>Indicates that certificate must be checked before Add or check certificate existence on List.</value>
-  </data>                                                                                              
-  <data name="ClientCertificatesCommandCheckCertificateDescription_deu" xml:space="preserve">          
-    <value>Indicates that certificate must be checked before Add or check certificate existence on List.</value>
-  </data>                                                                                              
-  <data name="ClientCertificatesCommandCheckCertificateDescription_esp" xml:space="preserve">          
-    <value>Indicates that certificate must be checked before Add or check certificate existence on List.</value>
-  </data>                                                                                              
-  <data name="ClientCertificatesCommandCheckCertificateDescription_fra" xml:space="preserve">          
-    <value>Indicates that certificate must be checked before Add or check certificate existence on List.</value>
-  </data>                                                                                              
-  <data name="ClientCertificatesCommandCheckCertificateDescription_ita" xml:space="preserve">          
-    <value>Indicates that certificate must be checked before Add or check certificate existence on List.</value>
-  </data>                                                                                              
-  <data name="ClientCertificatesCommandCheckCertificateDescription_jpn" xml:space="preserve">          
-    <value>Indicates that certificate must be checked before Add or check certificate existence on List.</value>
-  </data>                                                                                              
-  <data name="ClientCertificatesCommandCheckCertificateDescription_kor" xml:space="preserve">          
-    <value>Indicates that certificate must be checked before Add or check certificate existence on List.</value>
-  </data>                                                                                              
-  <data name="ClientCertificatesCommandCheckCertificateDescription_plk" xml:space="preserve">          
-    <value>Indicates that certificate must be checked before Add or check certificate existence on List.</value>
-  </data>                                                                                              
-  <data name="ClientCertificatesCommandCheckCertificateDescription_ptb" xml:space="preserve">          
-    <value>Indicates that certificate must be checked before Add or check certificate existence on List.</value>
-  </data>                                                                                              
-  <data name="ClientCertificatesCommandCheckCertificateDescription_rus" xml:space="preserve">          
-    <value>Indicates that certificate must be checked before Add or check certificate existence on List.</value>
-  </data>                                                                                              
-  <data name="ClientCertificatesCommandCheckCertificateDescription_trk" xml:space="preserve">          
-    <value>Indicates that certificate must be checked before Add or check certificate existence on List.</value>
+    <value>Indicates that certificate must be checked before Add or check certificate existence on List</value>
+  </data>
+  <data name="ClientCertificatesCommandCheckCertificateDescription_chs" xml:space="preserve">
+    <value>Indicates that certificate must be checked before Add or check certificate existence on List</value>
+  </data>
+  <data name="ClientCertificatesCommandCheckCertificateDescription_cht" xml:space="preserve">
+    <value>Indicates that certificate must be checked before Add or check certificate existence on List</value>
+  </data>
+  <data name="ClientCertificatesCommandCheckCertificateDescription_csy" xml:space="preserve">
+    <value>Indicates that certificate must be checked before Add or check certificate existence on List</value>
+  </data>
+  <data name="ClientCertificatesCommandCheckCertificateDescription_deu" xml:space="preserve">
+    <value>Indicates that certificate must be checked before Add or check certificate existence on List</value>
+  </data>
+  <data name="ClientCertificatesCommandCheckCertificateDescription_esp" xml:space="preserve">
+    <value>Indicates that certificate must be checked before Add or check certificate existence on List</value>
+  </data>
+  <data name="ClientCertificatesCommandCheckCertificateDescription_fra" xml:space="preserve">
+    <value>Indicates that certificate must be checked before Add or check certificate existence on List</value>
+  </data>
+  <data name="ClientCertificatesCommandCheckCertificateDescription_ita" xml:space="preserve">
+    <value>Indicates that certificate must be checked before Add or check certificate existence on List</value>
+  </data>
+  <data name="ClientCertificatesCommandCheckCertificateDescription_jpn" xml:space="preserve">
+    <value>Indicates that certificate must be checked before Add or check certificate existence on List</value>
+  </data>
+  <data name="ClientCertificatesCommandCheckCertificateDescription_kor" xml:space="preserve">
+    <value>Indicates that certificate must be checked before Add or check certificate existence on List</value>
+  </data>
+  <data name="ClientCertificatesCommandCheckCertificateDescription_plk" xml:space="preserve">
+    <value>Indicates that certificate must be checked before Add or check certificate existence on List</value>
+  </data>
+  <data name="ClientCertificatesCommandCheckCertificateDescription_ptb" xml:space="preserve">
+    <value>Indicates that certificate must be checked before Add or check certificate existence on List</value>
+  </data>
+  <data name="ClientCertificatesCommandCheckCertificateDescription_rus" xml:space="preserve">
+    <value>Indicates that certificate must be checked before Add or check certificate existence on List</value>
+  </data>
+  <data name="ClientCertificatesCommandCheckCertificateDescription_trk" xml:space="preserve">
+    <value>Indicates that certificate must be checked before Add or check certificate existence on List</value>
   </data>
 
     <data name="ClientCertificatesCommandFindTypeDescription" xml:space="preserve">
-    <value>FindType added to a storage client certificate source.</value>
+    <value>FindType added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindTypeDescription_chs" xml:space="preserve">
-    <value>FindType added to a storage client certificate source.</value>
+    <value>FindType added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindTypeDescription_cht" xml:space="preserve">
-    <value>FindType added to a storage client certificate source.</value>
+    <value>FindType added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindTypeDescription_csy" xml:space="preserve">
-    <value>FindType added to a storage client certificate source.</value>
+    <value>FindType added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindTypeDescription_deu" xml:space="preserve">
-    <value>FindType added to a storage client certificate source.</value>
+    <value>FindType added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindTypeDescription_esp" xml:space="preserve">
-    <value>FindType added to a storage client certificate source.</value>
+    <value>FindType added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindTypeDescription_fra" xml:space="preserve">
-    <value>FindType added to a storage client certificate source.</value>
+    <value>FindType added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindTypeDescription_ita" xml:space="preserve">
-    <value>FindType added to a storage client certificate source.</value>
+    <value>FindType added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindTypeDescription_jpn" xml:space="preserve">
-    <value>FindType added to a storage client certificate source.</value>
+    <value>FindType added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindTypeDescription_kor" xml:space="preserve">
-    <value>FindType added to a storage client certificate source.</value>
+    <value>FindType added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindTypeDescription_plk" xml:space="preserve">
-    <value>FindType added to a storage client certificate source.</value>
+    <value>FindType added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindTypeDescription_ptb" xml:space="preserve">
-    <value>FindType added to a storage client certificate source.</value>
+    <value>FindType added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindTypeDescription_rus" xml:space="preserve">
-    <value>FindType added to a storage client certificate source.</value>
+    <value>FindType added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindTypeDescription_trk" xml:space="preserve">
-    <value>FindType added to a storage client certificate source.</value>
+    <value>FindType added to a storage client certificate source</value>
   </data>
 
     <data name="ClientCertificatesCommandFindValueDescription" xml:space="preserve">
-    <value>FindValue added to a storage client certificate source.</value>
+    <value>FindValue added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindValueDescription_chs" xml:space="preserve">
-    <value>FindValue added to a storage client certificate source.</value>
+    <value>FindValue added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindValueDescription_cht" xml:space="preserve">
-    <value>FindValue added to a storage client certificate source.</value>
+    <value>FindValue added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindValueDescription_csy" xml:space="preserve">
-    <value>FindValue added to a storage client certificate source.</value>
+    <value>FindValue added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindValueDescription_deu" xml:space="preserve">
-    <value>FindValue added to a storage client certificate source.</value>
+    <value>FindValue added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindValueDescription_esp" xml:space="preserve">
-    <value>FindValue added to a storage client certificate source.</value>
+    <value>FindValue added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindValueDescription_fra" xml:space="preserve">
-    <value>FindValue added to a storage client certificate source.</value>
+    <value>FindValue added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindValueDescription_ita" xml:space="preserve">
-    <value>FindValue added to a storage client certificate source.</value>
+    <value>FindValue added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindValueDescription_jpn" xml:space="preserve">
-    <value>FindValue added to a storage client certificate source.</value>
+    <value>FindValue added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindValueDescription_kor" xml:space="preserve">
-    <value>FindValue added to a storage client certificate source.</value>
+    <value>FindValue added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindValueDescription_plk" xml:space="preserve">
-    <value>FindValue added to a storage client certificate source.</value>
+    <value>FindValue added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindValueDescription_ptb" xml:space="preserve">
-    <value>FindValue added to a storage client certificate source.</value>
+    <value>FindValue added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindValueDescription_rus" xml:space="preserve">
-    <value>FindValue added to a storage client certificate source.</value>
+    <value>FindValue added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandFindValueDescription_trk" xml:space="preserve">
-    <value>FindValue added to a storage client certificate source.</value>
+    <value>FindValue added to a storage client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandNameDescription" xml:space="preserve">
     <value>Name of the client certificate item.</value>
@@ -6155,88 +6155,88 @@ nuget client-certificates -PEM "containsSequenceInBase64EncodedCertificate" -Pat
     <value>Password for the certificate, if needed. This option can be used to specify the password for the certificate.</value>
   </data>
   <data name="ClientCertificatesCommandPathDescription" xml:space="preserve">
-    <value>Path to certificate file added to a file client certificate source.</value>
+    <value>Path to certificate file added to a file client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPathDescription_chs" xml:space="preserve">
-    <value>Path to certificate file added to a file client certificate source.</value>
+    <value>Path to certificate file added to a file client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPathDescription_cht" xml:space="preserve">
-    <value>Path to certificate file added to a file client certificate source.</value>
+    <value>Path to certificate file added to a file client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPathDescription_csy" xml:space="preserve">
-    <value>Path to certificate file added to a file client certificate source.</value>
+    <value>Path to certificate file added to a file client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPathDescription_deu" xml:space="preserve">
-    <value>Path to certificate file added to a file client certificate source.</value>
+    <value>Path to certificate file added to a file client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPathDescription_esp" xml:space="preserve">
-    <value>Path to certificate file added to a file client certificate source.</value>
+    <value>Path to certificate file added to a file client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPathDescription_fra" xml:space="preserve">
-    <value>Path to certificate file added to a file client certificate source.</value>
+    <value>Path to certificate file added to a file client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPathDescription_ita" xml:space="preserve">
-    <value>Path to certificate file added to a file client certificate source.</value>
+    <value>Path to certificate file added to a file client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPathDescription_jpn" xml:space="preserve">
-    <value>Path to certificate file added to a file client certificate source.</value>
+    <value>Path to certificate file added to a file client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPathDescription_kor" xml:space="preserve">
-    <value>Path to certificate file added to a file client certificate source.</value>
+    <value>Path to certificate file added to a file client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPathDescription_plk" xml:space="preserve">
-    <value>Path to certificate file added to a file client certificate source.</value>
+    <value>Path to certificate file added to a file client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPathDescription_ptb" xml:space="preserve">
-    <value>Path to certificate file added to a file client certificate source.</value>
+    <value>Path to certificate file added to a file client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPathDescription_rus" xml:space="preserve">
-    <value>Path to certificate file added to a file client certificate source.</value>
+    <value>Path to certificate file added to a file client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPathDescription_trk" xml:space="preserve">
-    <value>Path to certificate file added to a file client certificate source.</value>
+    <value>Path to certificate file added to a file client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPEMDescription" xml:space="preserve">
-    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source.</value>
+    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPEMDescription_chs" xml:space="preserve">
-    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source.</value>
+    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPEMDescription_cht" xml:space="preserve">
-    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source.</value>
+    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPEMDescription_csy" xml:space="preserve">
-    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source.</value>
+    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPEMDescription_deu" xml:space="preserve">
-    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source.</value>
+    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPEMDescription_esp" xml:space="preserve">
-    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source.</value>
+    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPEMDescription_fra" xml:space="preserve">
-    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source.</value>
+    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPEMDescription_ita" xml:space="preserve">
-    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source.</value>
+    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPEMDescription_jpn" xml:space="preserve">
-    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source.</value>
+    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPEMDescription_kor" xml:space="preserve">
-    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source.</value>
+    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPEMDescription_plk" xml:space="preserve">
-    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source.</value>
+    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPEMDescription_ptb" xml:space="preserve">
-    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source.</value>
+    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPEMDescription_rus" xml:space="preserve">
-    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source.</value>
+    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandPEMDescription_trk" xml:space="preserve">
-    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source.</value>
+    <value>Base64 encoded DER certificate in PEM format added to a PEM client certificate source</value>
   </data>
   <data name="ClientCertificatesCommandSourceTypeDescription" xml:space="preserve">
     <value>Client certificate source type.</value>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -3445,6 +3445,42 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The find type &apos;{0}&apos; is not recognized..
+        /// </summary>
+        public static string Error_UnknownClientCertificatesFindType {
+            get {
+                return ResourceManager.GetString("Error_UnknownClientCertificatesFindType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The source type &apos;{0}&apos; is not recognized..
+        /// </summary>
+        public static string Error_UnknownClientCertificatesSourceType {
+            get {
+                return ResourceManager.GetString("Error_UnknownClientCertificatesSourceType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The store location &apos;{0}&apos; is not recognized..
+        /// </summary>
+        public static string Error_UnknownClientCertificatesStoreLocation {
+            get {
+                return ResourceManager.GetString("Error_UnknownClientCertificatesStoreLocation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The source name &apos;{0}&apos; is not recognized..
+        /// </summary>
+        public static string Error_UnknownClientCertificatesStoreName {
+            get {
+                return ResourceManager.GetString("Error_UnknownClientCertificatesStoreName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This version of msbuild is not supported: &apos;{0}&apos;.
         /// </summary>
         public static string Error_UnsupportedMsbuild {
@@ -16261,6 +16297,15 @@ namespace NuGet.CommandLine {
         public static string UsingPackagesConfigForDependencies_trk {
             get {
                 return ResourceManager.GetString("UsingPackagesConfigForDependencies_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate &apos;{0}&apos; cannot be included. Certificate search failed with error &apos;{1}&apos;..
+        /// </summary>
+        public static string Warning_ClientCertificateSearchFailed {
+            get {
+                return ResourceManager.GetString("Warning_ClientCertificateSearchFailed", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -435,6 +435,9 @@
   <data name="Warning_NoPromptDeprecated" xml:space="preserve">
     <value>Option 'NoPrompt' has been deprecated. Use 'NonInteractive' instead.</value>
   </data>
+  <data name="Warning_ClientCertificateSearchFailed" xml:space="preserve">
+    <value>Client certificate '{0}' cannot be included. Certificate search failed with error '{1}'.</value>
+  </data>
   <data name="Error_SettingsIsNull" xml:space="preserve">
     <value>Property Settings is null.</value>
   </data>
@@ -6176,6 +6179,22 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="Error_UnknownAction" xml:space="preserve">
     <value>The action '{0}' is not recognized.</value>
     <comment>0 - action</comment>
+  </data>
+  <data name="Error_UnknownClientCertificatesSourceType" xml:space="preserve">
+    <value>The source type '{0}' is not recognized.</value>
+    <comment>0 - source type</comment>
+  </data>
+  <data name="Error_UnknownClientCertificatesStoreName" xml:space="preserve">
+    <value>The source name '{0}' is not recognized.</value>
+    <comment>0 - source name</comment>
+  </data>
+  <data name="Error_UnknownClientCertificatesStoreLocation" xml:space="preserve">
+    <value>The store location '{0}' is not recognized.</value>
+    <comment>0 - store location</comment>
+  </data>
+  <data name="Error_UnknownClientCertificatesFindType" xml:space="preserve">
+    <value>The find type '{0}' is not recognized.</value>
+    <comment>0 - find type</comment>
   </data>
   <data name="ProjectJsonPack_Deprecated" xml:space="preserve">
     <value>`project.json` pack is deprecated. Please consider migrating '{0}' to `PackageReference` and using the pack targets.</value>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -173,6 +173,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
             _vsSolution = await _asyncServiceProvider.GetServiceAsync<SVsSolution, IVsSolution>();
             var dte = await _asyncServiceProvider.GetDTEAsync();
+
+            ClientCertificates.Store(ClientCertificateProvider.Provide(_settings.Value));
+
             UserAgent.SetUserAgentString(
                     new UserAgentStringBuilder(VSNuGetClientName).WithVisualStudioSKU(dte.GetFullVsVersionString()));
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.Designer.cs
@@ -466,6 +466,15 @@ namespace NuGet.PackageManagement.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Client certificate &apos;{0}&apos; cannot be included. Certificate search failed with error &apos;{1}&apos;..
+        /// </summary>
+        public static string Warning_ClientCertificateSearchFailed {
+            get {
+                return ResourceManager.GetString("Warning_ClientCertificateSearchFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Directory &apos;{0}&apos; is not empty. Skipping....
         /// </summary>
         public static string Warning_DirectoryNotEmpty {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.resx
@@ -289,4 +289,7 @@
   <data name="CredentialProviderFailed_PluginCredentialProvider" xml:space="preserve">
     <value>The plugin credential providers could not be loaded.</value>
   </data>
+  <data name="Warning_ClientCertificateSearchFailed" xml:space="preserve">
+    <value>Client certificate '{0}' cannot be included. Certificate search failed with error '{1}'.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/ClientCertificatesCommand/ClientCertificatesCommandArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/ClientCertificatesCommand/ClientCertificatesCommandArgs.cs
@@ -13,7 +13,7 @@ namespace NuGet.Commands
         public ClientCertificatesCommandAction Action { get; set; }
 
         /// <summary>
-        ///     Indicates that certificate must be checked before Add action or check certificate existence on List action
+        ///     Indicates that certificate must be checked before Add or check certificate existence on List
         /// </summary>
         public bool CheckCertificate { get; set; }
 

--- a/src/NuGet.Core/NuGet.Commands/ClientCertificatesCommand/ClientCertificatesCommandArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/ClientCertificatesCommand/ClientCertificatesCommandArgs.cs
@@ -1,0 +1,90 @@
+using System.Security.Cryptography.X509Certificates;
+using NuGet.Common;
+using NuGet.Configuration;
+using static NuGet.Configuration.CertificateSearchItem;
+
+namespace NuGet.Commands
+{
+    public class ClientCertificatesCommandArgs
+    {
+        /// <summary>
+        ///     Action to be performed by the client certificates command.
+        /// </summary>
+        public ClientCertificatesCommandAction Action { get; set; }
+
+        /// <summary>
+        ///     Indicates that certificate must be checked before Add action or check certificate existence on List action
+        /// </summary>
+        public bool CheckCertificate { get; set; }
+
+        /// <summary>
+        ///     FindType added to a storage client certificate source
+        /// </summary>
+        public X509FindType? FindType { get; set; }
+
+        /// <summary>
+        ///     FindValue added to a storage client certificate source
+        /// </summary>
+        public string FindValue { get; set; }
+
+        /// <summary>
+        ///     Logger to be used to display the logs during the execution of sign command.
+        /// </summary>
+        public ILogger Logger { get; set; }
+
+        /// <summary>
+        ///     Name of the client certificate item.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        ///     Password for the certificate, if needed. This option can be used to specify the password for the certificate.
+        /// </summary>
+        public string Password { get; set; }
+
+        /// <summary>
+        ///     Path to certificate file added to a file client certificate source
+        /// </summary>
+        public string Path { get; set; }
+
+        /// <summary>
+        ///     Base64 encoded DER certificate in PEM format added to a PEM client certificate source
+        /// </summary>
+        public string PEM { get; set; }
+
+        /// <summary>
+        ///     Client certificate source type.
+        /// </summary>
+        public ClientCertificatesSourceType? SourceType { get; set; }
+
+        /// <summary>
+        ///     StoreLocation added to a storage client certificate source
+        /// </summary>
+        public StoreLocation? StoreLocation { get; set; }
+
+        /// <summary>
+        ///     StoreName added to a storage client certificate source
+        /// </summary>
+        public StoreName? StoreName { get; set; }
+
+        /// <summary>
+        ///     Enables storing password for the certificate by disabling password encryption.
+        /// </summary>
+        public bool StorePasswordInClearText { get; set; }
+
+        public string GetPassword()
+        {
+            if (string.IsNullOrEmpty(Password)) return null;
+
+            if (StorePasswordInClearText) return Password;
+            return EncryptionUtility.EncryptString(Password);
+        }
+
+        public enum ClientCertificatesCommandAction
+        {
+            Add,
+            List,
+            Remove
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/ClientCertificatesCommand/ClientCertificatesCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/ClientCertificatesCommand/ClientCertificatesCommandRunner.cs
@@ -1,0 +1,316 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Configuration;
+using static NuGet.Commands.ClientCertificatesCommandArgs;
+
+namespace NuGet.Commands
+{
+    /// <summary>
+    ///     Command Runner used to run the business logic for nuget trusted-signers command
+    /// </summary>
+    public class ClientCertificatesCommandRunner : IClientCertificatesCommandRunner
+    {
+        private const int SuccessCode = 0;
+
+        private readonly IClientCertificateProvider _clientCertificateProvider;
+
+        public ClientCertificatesCommandRunner(IClientCertificateProvider clientCertificateProvider)
+        {
+            _clientCertificateProvider = clientCertificateProvider ?? throw new ArgumentNullException(nameof(clientCertificateProvider));
+        }
+
+        public async Task<int> ExecuteCommandAsync(ClientCertificatesCommandArgs args)
+        {
+            ILogger logger = args.Logger ?? NullLogger.Instance;
+
+            switch (args.Action)
+            {
+                case ClientCertificatesCommandAction.List:
+                    ValidateListArguments(args);
+
+                    await ListAllItemsAsync(args, logger);
+
+                    break;
+
+                case ClientCertificatesCommandAction.Add:
+                    ValidateAddArguments(args);
+
+                    await AddItemAsync(args, logger);
+
+                    break;
+
+                case ClientCertificatesCommandAction.Remove:
+                    ValidateRemoveArguments(args);
+
+                    await RemoveItemAsync(args.Name, logger);
+
+                    break;
+            }
+
+            return SuccessCode;
+        }
+
+        private async Task AddItemAsync(ClientCertificatesCommandArgs args, ILogger logger)
+        {
+            CertificateSearchItem item = _clientCertificateProvider.GetClientCertificates()
+                                                                   .FirstOrDefault(i => string.Equals(i.Name, args.Name, StringComparison.OrdinalIgnoreCase));
+            if (item != null)
+            {
+                if (item.SourceType != args.SourceType)
+                {
+                    throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture,
+                                                                                    Strings.Error_ExistingAndRequiredClientCertificateSourceMissmatch,
+                                                                                    item.SourceType,
+                                                                                    args.SourceType));
+                }
+
+                if (item is FromFileItem fromFileItem)
+                {
+                    if (args.Path != null) fromFileItem.Path = args.Path;
+                    var password = args.GetPassword();
+                    if (password != null) fromFileItem.Password = password;
+                }
+
+                if (item is FromPEMItem fromPEMItem)
+                {
+                    if (args.PEM != null) fromPEMItem.Base64Certificate = args.PEM;
+                    var password = args.GetPassword();
+                    if (password != null) fromPEMItem.Password = password;
+                }
+
+                if (item is FromStorageItem fromStorageItem)
+                {
+                    if (args.StoreLocation.HasValue) fromStorageItem.StoreLocation = args.StoreLocation.Value;
+                    if (args.StoreName.HasValue) fromStorageItem.StoreName = args.StoreName.Value;
+                    if (args.FindType.HasValue) fromStorageItem.FindType = args.FindType.Value;
+                    if (args.FindValue != null) fromStorageItem.FindValue = args.FindValue;
+                }
+            }
+            else
+            {
+                switch (args.SourceType)
+                {
+                    case CertificateSearchItem.ClientCertificatesSourceType.File:
+                        item = new FromFileItem(args.Name, args.Path, args.GetPassword());
+                        break;
+                    case CertificateSearchItem.ClientCertificatesSourceType.PEM:
+                        item = new FromPEMItem(args.Name, args.PEM, args.GetPassword());
+                        break;
+                    case CertificateSearchItem.ClientCertificatesSourceType.Storage:
+                        item = new FromStorageItem(args.Name, args.FindValue, args.StoreLocation, args.StoreName, args.FindType);
+                        break;
+                    default:
+                        throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture,
+                                                                                        Strings.Error_UnknownClientCertificateSourceType,
+                                                                                        args.SourceType));
+                }
+            }
+
+            if (args.CheckCertificate)
+            {
+                X509Certificate certificate = item.Search();
+                if (certificate == null)
+                {
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_ClientCertificateNotFound));
+                }
+            }
+
+            _clientCertificateProvider.AddOrUpdate(item);
+
+            await logger.LogAsync(LogLevel.Information, string.Format(CultureInfo.CurrentCulture, Strings.SuccessfullyAddedClientCertificate, args.Name));
+        }
+
+        private IReadOnlyList<CertificateSearchItem> FilterClientCertificates(IReadOnlyList<CertificateSearchItem> items, ClientCertificatesCommandArgs args)
+        {
+            if (args.SourceType.HasValue) items = items.Where(i => i.SourceType == args.SourceType.Value).ToList();
+
+            IEnumerable<FromPEMItem> fromPEMItems = items.OfType<FromPEMItem>();
+            if (!string.IsNullOrEmpty(args.PEM))
+            {
+                fromPEMItems = fromPEMItems.Where(i => (i.Base64Certificate ?? string.Empty).IndexOf(args.PEM, StringComparison.OrdinalIgnoreCase) > -1);
+            }
+
+            IEnumerable<FromFileItem> fromFileItems = items.OfType<FromFileItem>();
+            if (!string.IsNullOrEmpty(args.Path))
+            {
+                fromFileItems = fromFileItems.Where(i => (i.Path ?? string.Empty).IndexOf(args.Path, StringComparison.OrdinalIgnoreCase) > -1);
+            }
+
+            IEnumerable<FromStorageItem> fromStorageItems = items.OfType<FromStorageItem>();
+            if (args.StoreLocation.HasValue) fromStorageItems = fromStorageItems.Where(i => i.StoreLocation == args.StoreLocation.Value);
+            if (args.StoreName.HasValue) fromStorageItems = fromStorageItems.Where(i => i.StoreName == args.StoreName.Value);
+            if (args.FindType.HasValue) fromStorageItems = fromStorageItems.Where(i => i.FindType == args.FindType.Value);
+            if (!string.IsNullOrEmpty(args.FindValue))
+            {
+                fromStorageItems = fromStorageItems.Where(i => (i.FindValue ?? string.Empty).IndexOf(args.FindValue, StringComparison.OrdinalIgnoreCase) > -1);
+            }
+
+            return Enumerable.Empty<CertificateSearchItem>()
+                             .Union(fromPEMItems)
+                             .Union(fromFileItems)
+                             .Union(fromStorageItems)
+                             .ToList();
+        }
+
+        private async Task ListAllItemsAsync(ClientCertificatesCommandArgs args, ILogger logger)
+        {
+            IReadOnlyList<CertificateSearchItem> items = _clientCertificateProvider.GetClientCertificates();
+
+            items = FilterClientCertificates(items, args);
+
+            if (!items.Any())
+            {
+                await logger.LogAsync(LogLevel.Information, Strings.NoClientCertificates);
+                return;
+            }
+
+            var clientCertificatesLogs = new List<LogMessage>();
+
+            await logger.LogAsync(LogLevel.Information, Strings.RegsiteredClientCertificates);
+            await logger.LogAsync(LogLevel.Information, Environment.NewLine);
+
+            for (var i = 0; i < items.Count; i++)
+            {
+                CertificateSearchItem item = items[i];
+
+                var builder = new StringBuilder();
+
+                var index = $" {i + 1}.".PadRight(6);
+                var defaultIndentation = string.Empty.PadRight(6);
+
+                builder.AppendLine($"{index}{string.Format(CultureInfo.CurrentCulture, Strings.ClientCertificatesLogTitle, item.Name, item.ElementName)}");
+
+                if (item is FromPEMItem fromPEMItem)
+                {
+                    builder.AppendLine($"{defaultIndentation}{string.Format(CultureInfo.CurrentCulture, Strings.ClientCertificatesFromPEM, fromPEMItem.Base64Certificate)}");
+                    if (string.IsNullOrEmpty(fromPEMItem.Password))
+                    {
+                        builder.AppendLine($"{defaultIndentation}{string.Format(CultureInfo.CurrentCulture, Strings.ClientCertificatesFromPEMOrFilePasswordNotSet)}");
+                    }
+                    else
+                    {
+                        builder.AppendLine($"{defaultIndentation}{string.Format(CultureInfo.CurrentCulture, Strings.ClientCertificatesFromPEMOrFilePasswordSet)}");
+                    }
+                }
+
+                if (item is FromFileItem fromFileItem)
+                {
+                    builder.AppendLine($"{defaultIndentation}{string.Format(CultureInfo.CurrentCulture, Strings.ClientCertificatesFromFilePath, fromFileItem.Path)}");
+                    if (string.IsNullOrEmpty(fromFileItem.Password))
+                    {
+                        builder.AppendLine($"{defaultIndentation}{string.Format(CultureInfo.CurrentCulture, Strings.ClientCertificatesFromPEMOrFilePasswordNotSet)}");
+                    }
+                    else
+                    {
+                        builder.AppendLine($"{defaultIndentation}{string.Format(CultureInfo.CurrentCulture, Strings.ClientCertificatesFromPEMOrFilePasswordSet)}");
+                    }
+                }
+
+                if (item is FromStorageItem fromStorageItem)
+                {
+                    builder.AppendLine($"{defaultIndentation}{string.Format(CultureInfo.CurrentCulture, Strings.ClientCertificatesFromStorageStoreLocation, fromStorageItem.StoreLocation)}");
+                    builder.AppendLine($"{defaultIndentation}{string.Format(CultureInfo.CurrentCulture, Strings.ClientCertificatesFromStorageStoreName, fromStorageItem.StoreName)}");
+                    builder.AppendLine($"{defaultIndentation}{string.Format(CultureInfo.CurrentCulture, Strings.ClientCertificatesFromStorageFindType, fromStorageItem.FindType)}");
+                    builder.AppendLine($"{defaultIndentation}{string.Format(CultureInfo.CurrentCulture, Strings.ClientCertificatesFromStorageFindValue, fromStorageItem.FindValue)}");
+                }
+
+                if (args.CheckCertificate)
+                {
+                    try
+                    {
+                        X509Certificate certificate = item.Search();
+                        if (certificate == null)
+                        {
+                            throw new Exception(Strings.Error_ClientCertificateNotFound);
+                        }
+
+                        builder.AppendLine($"{defaultIndentation}{string.Format(CultureInfo.CurrentCulture, Strings.ClientCertificatesItemCertificateMessage, Strings.Success_ClientCertificate)}");
+                        builder.AppendLine(certificate.ToString());
+                    }
+                    catch (Exception e)
+                    {
+                        builder.AppendLine($"{defaultIndentation}{string.Format(CultureInfo.CurrentCulture, Strings.ClientCertificatesItemCertificateMessage, e.GetBaseException().Message)}");
+                    }
+                }
+
+                clientCertificatesLogs.Add(new LogMessage(LogLevel.Information, builder.ToString()));
+            }
+
+            await logger.LogMessagesAsync(clientCertificatesLogs);
+        }
+
+        private async Task RemoveItemAsync(string name, ILogger logger)
+        {
+            List<CertificateSearchItem> items = _clientCertificateProvider.GetClientCertificates()
+                                                                          .Where(item => string.Equals(item.Name, name, StringComparison.OrdinalIgnoreCase))
+                                                                          .ToList();
+            if (!items.Any())
+            {
+                await logger.LogAsync(LogLevel.Information, string.Format(CultureInfo.CurrentCulture, Strings.NoClientCertificatesMatching, name));
+                return;
+            }
+
+            _clientCertificateProvider.Remove(items.ToList());
+
+            await logger.LogAsync(LogLevel.Information, string.Format(CultureInfo.CurrentCulture, Strings.SuccessfullyRemovedClientCertificate, name));
+        }
+
+        private void ValidateAddArguments(ClientCertificatesCommandArgs args)
+        {
+            if (!args.SourceType.HasValue)
+            {
+                throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_CouldNotAddClientCertificate, Strings.Error_InvalidCombinationOfArguments));
+            }
+
+            ValidateNameExists(args.Name);
+        }
+
+        private void ValidateListArguments(ClientCertificatesCommandArgs args)
+        {
+            var isPasswordProvided = !string.IsNullOrEmpty(args.Password);
+
+            if (isPasswordProvided)
+            {
+                throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_CouldNotListClientCertificates, Strings.Error_InvalidCombinationOfArguments));
+            }
+        }
+
+        private void ValidateNameExists(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_PropertyCannotBeNullOrEmpty, nameof(name)));
+            }
+        }
+
+        private void ValidateRemoveArguments(ClientCertificatesCommandArgs args)
+        {
+            ValidateNameExists(args.Name);
+
+            var isSourceTypeProvided = args.SourceType.HasValue;
+            var isPasswordProvided = !string.IsNullOrEmpty(args.Password);
+            var isPathProvided = !string.IsNullOrEmpty(args.Path);
+            var isPEMProvided = !string.IsNullOrEmpty(args.PEM);
+
+            var isStoreLocationProvided = args.StoreLocation.HasValue;
+            var isStoreNameProvided = args.StoreName.HasValue;
+            var isFindTypeProvided = args.FindType.HasValue;
+            var isFindValueProvided = !string.IsNullOrEmpty(args.FindValue);
+
+            if (isSourceTypeProvided || isPasswordProvided ||
+                isPathProvided || isPEMProvided || isStoreLocationProvided ||
+                isStoreNameProvided || isFindTypeProvided || isFindValueProvided)
+            {
+                throw new CommandLineArgumentCombinationException(string.Format(CultureInfo.CurrentCulture,
+                                                                                Strings.Error_CouldNotRemoveClientCertificate,
+                                                                                Strings.Error_InvalidCombinationOfArguments));
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/ClientCertificatesCommand/ClientCertificatesCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/ClientCertificatesCommand/ClientCertificatesCommandRunner.cs
@@ -230,8 +230,7 @@ namespace NuGet.Commands
                             throw new Exception(Strings.Error_ClientCertificateNotFound);
                         }
 
-                        builder.AppendLine($"{defaultIndentation}{string.Format(CultureInfo.CurrentCulture, Strings.ClientCertificatesItemCertificateMessage, Strings.Success_ClientCertificate)}");
-                        builder.AppendLine(certificate.ToString());
+                        builder.AppendLine($"{defaultIndentation}{string.Format(CultureInfo.CurrentCulture, Strings.ClientCertificatesItemCertificateMessage, certificate.GetCertHashString())}");
                     }
                     catch (Exception e)
                     {

--- a/src/NuGet.Core/NuGet.Commands/ClientCertificatesCommand/IClientCertificatesCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/ClientCertificatesCommand/IClientCertificatesCommandRunner.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace NuGet.Commands
+{
+    public interface IClientCertificatesCommandRunner
+    {
+        Task<int> ExecuteCommandAsync(ClientCertificatesCommandArgs clientCertificatesArgs);
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
+++ b/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
@@ -69,6 +69,6 @@
     </AssemblyAttribute>
   </ItemGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1970,15 +1970,6 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Client certificate was found..
-        /// </summary>
-        internal static string Success_ClientCertificate {
-            get {
-                return ResourceManager.GetString("Success_ClientCertificate", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Successfully updated the trusted signer &apos;{0}&apos;..
         /// </summary>
         internal static string SuccessfullUpdatedTrustedSigner {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -97,6 +97,96 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Path: {0}.
+        /// </summary>
+        internal static string ClientCertificatesFromFilePath {
+            get {
+                return ResourceManager.GetString("ClientCertificatesFromFilePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PEM definition: {0}.
+        /// </summary>
+        internal static string ClientCertificatesFromPEM {
+            get {
+                return ResourceManager.GetString("ClientCertificatesFromPEM", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password: -.
+        /// </summary>
+        internal static string ClientCertificatesFromPEMOrFilePasswordNotSet {
+            get {
+                return ResourceManager.GetString("ClientCertificatesFromPEMOrFilePasswordNotSet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password: ****.
+        /// </summary>
+        internal static string ClientCertificatesFromPEMOrFilePasswordSet {
+            get {
+                return ResourceManager.GetString("ClientCertificatesFromPEMOrFilePasswordSet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Find type: {0}.
+        /// </summary>
+        internal static string ClientCertificatesFromStorageFindType {
+            get {
+                return ResourceManager.GetString("ClientCertificatesFromStorageFindType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Find value: {0}.
+        /// </summary>
+        internal static string ClientCertificatesFromStorageFindValue {
+            get {
+                return ResourceManager.GetString("ClientCertificatesFromStorageFindValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Store location: {0}.
+        /// </summary>
+        internal static string ClientCertificatesFromStorageStoreLocation {
+            get {
+                return ResourceManager.GetString("ClientCertificatesFromStorageStoreLocation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Store name: {0}.
+        /// </summary>
+        internal static string ClientCertificatesFromStorageStoreName {
+            get {
+                return ResourceManager.GetString("ClientCertificatesFromStorageStoreName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Certificate: {0}.
+        /// </summary>
+        internal static string ClientCertificatesItemCertificateMessage {
+            get {
+                return ResourceManager.GetString("ClientCertificatesItemCertificateMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} [{1}].
+        /// </summary>
+        internal static string ClientCertificatesLogTitle {
+            get {
+                return ResourceManager.GetString("ClientCertificatesLogTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to add trusted author. The package is not author signed..
         /// </summary>
         internal static string Error_AuthorTrustExpectedAuthorSignature {
@@ -133,11 +223,29 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Client certificate was not found..
+        /// </summary>
+        internal static string Error_ClientCertificateNotFound {
+            get {
+                return ResourceManager.GetString("Error_ClientCertificateNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not add the trusted signer: {0}.
         /// </summary>
         internal static string Error_CouldNotAdd {
             get {
                 return ResourceManager.GetString("Error_CouldNotAdd", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not add the client certificate: {0}.
+        /// </summary>
+        internal static string Error_CouldNotAddClientCertificate {
+            get {
+                return ResourceManager.GetString("Error_CouldNotAddClientCertificate", resourceCulture);
             }
         }
         
@@ -151,11 +259,29 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not list the client certificates: {0}.
+        /// </summary>
+        internal static string Error_CouldNotListClientCertificates {
+            get {
+                return ResourceManager.GetString("Error_CouldNotListClientCertificates", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not remove the trusted signer: {0}.
         /// </summary>
         internal static string Error_CouldNotRemove {
             get {
                 return ResourceManager.GetString("Error_CouldNotRemove", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not remove the client certificate: {0}.
+        /// </summary>
+        internal static string Error_CouldNotRemoveClientCertificate {
+            get {
+                return ResourceManager.GetString("Error_CouldNotRemoveClientCertificate", resourceCulture);
             }
         }
         
@@ -192,6 +318,15 @@ namespace NuGet.Commands {
         internal static string Error_EmptySourceFileProjectDirectory {
             get {
                 return ResourceManager.GetString("Error_EmptySourceFileProjectDirectory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not modify client certificate of {0} source type. {1} source type expected..
+        /// </summary>
+        internal static string Error_ExistingAndRequiredClientCertificateSourceMissmatch {
+            get {
+                return ResourceManager.GetString("Error_ExistingAndRequiredClientCertificateSourceMissmatch", resourceCulture);
             }
         }
         
@@ -624,6 +759,15 @@ namespace NuGet.Commands {
         internal static string Error_UnknownBuildAction {
             get {
                 return ResourceManager.GetString("Error_UnknownBuildAction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unknown client certificate source type {0}..
+        /// </summary>
+        internal static string Error_UnknownClientCertificateSourceType {
+            get {
+                return ResourceManager.GetString("Error_UnknownClientCertificateSourceType", resourceCulture);
             }
         }
         
@@ -1511,6 +1655,24 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to There are no client certificates..
+        /// </summary>
+        internal static string NoClientCertificates {
+            get {
+                return ResourceManager.GetString("NoClientCertificates", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No client certificates with the name: &apos;{0}&apos; were found..
+        /// </summary>
+        internal static string NoClientCertificatesMatching {
+            get {
+                return ResourceManager.GetString("NoClientCertificatesMatching", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Properties &apos;{0}&apos;:&apos;{1}&apos; and &apos;{2}&apos;:&apos;{3}&apos; do not match..
         /// </summary>
         internal static string NonMatchingProperties {
@@ -1597,6 +1759,15 @@ namespace NuGet.Commands {
         internal static string PropertyNotAllowedForProjectType {
             get {
                 return ResourceManager.GetString("PropertyNotAllowedForProjectType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Registered client certificates:.
+        /// </summary>
+        internal static string RegsiteredClientCertificates {
+            get {
+                return ResourceManager.GetString("RegsiteredClientCertificates", resourceCulture);
             }
         }
         
@@ -1799,11 +1970,29 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Client certificate was found..
+        /// </summary>
+        internal static string Success_ClientCertificate {
+            get {
+                return ResourceManager.GetString("Success_ClientCertificate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Successfully updated the trusted signer &apos;{0}&apos;..
         /// </summary>
         internal static string SuccessfullUpdatedTrustedSigner {
             get {
                 return ResourceManager.GetString("SuccessfullUpdatedTrustedSigner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Successfully added the client certificate &apos;{0}&apos;..
+        /// </summary>
+        internal static string SuccessfullyAddedClientCertificate {
+            get {
+                return ResourceManager.GetString("SuccessfullyAddedClientCertificate", resourceCulture);
             }
         }
         
@@ -1822,6 +2011,15 @@ namespace NuGet.Commands {
         internal static string SuccessfullyAddedTrustedRepository {
             get {
                 return ResourceManager.GetString("SuccessfullyAddedTrustedRepository", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Successfully removed the client certificate &apos;{0}&apos;..
+        /// </summary>
+        internal static string SuccessfullyRemovedClientCertificate {
+            get {
+                return ResourceManager.GetString("SuccessfullyRemovedClientCertificate", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -751,16 +751,34 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
   <data name="NoTrustedSigners" xml:space="preserve">
     <value>There are no trusted signers.</value>
   </data>
+  <data name="NoClientCertificates" xml:space="preserve">
+    <value>There are no client certificates.</value>
+  </data>
   <data name="NoTrustedSignersMatching" xml:space="preserve">
     <value>No trusted signers with the name: '{0}' were found.</value>
     <comment>0 - trusted signer name</comment>
   </data>
+  <data name="NoClientCertificatesMatching" xml:space="preserve">
+    <value>No client certificates with the name: '{0}' were found.</value>
+    <comment>0 - client certificate name</comment>
+  </data>
   <data name="RegsiteredTrustedSigners" xml:space="preserve">
     <value>Registered trusted signers:</value>
+  </data>
+  <data name="RegsiteredClientCertificates" xml:space="preserve">
+    <value>Registered client certificates:</value>
   </data>
   <data name="SuccessfullyRemovedTrustedSigner" xml:space="preserve">
     <value>Successfully removed the trusted signer '{0}'.</value>
     <comment>0 - trusted signer name</comment>
+  </data>
+  <data name="SuccessfullyRemovedClientCertificate" xml:space="preserve">
+    <value>Successfully removed the client certificate '{0}'.</value>
+    <comment>0 - client certificate name</comment>
+  </data>
+  <data name="SuccessfullyAddedClientCertificate" xml:space="preserve">
+    <value>Successfully added the client certificate '{0}'.</value>
+    <comment>0 - client certificate name</comment>
   </data>
   <data name="TrustedSignerLogCertificates" xml:space="preserve">
     <value>Certificate fingerprint(s):</value>
@@ -792,6 +810,46 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <comment>0 - signer name
 1 - signer type
 </comment>
+  </data>
+  <data name="ClientCertificatesLogTitle" xml:space="preserve">
+    <value>{0} [{1}]</value>
+    <comment>0 - client certificate name
+1 - client certificate source type
+</comment>
+  </data>
+  <data name="ClientCertificatesFromPEM" xml:space="preserve">
+    <value>PEM definition: {0}</value>
+    <comment>0 - Base64 encoded DER certificate in PEM format</comment>
+  </data>
+  <data name="ClientCertificatesFromFilePath" xml:space="preserve">
+    <value>Path: {0}</value>
+    <comment>0 - Path to certificate file</comment>
+  </data>
+  <data name="ClientCertificatesFromStorageStoreLocation" xml:space="preserve">
+    <value>Store location: {0}</value>
+    <comment>0 - Store location</comment>
+  </data>
+  <data name="ClientCertificatesFromStorageStoreName" xml:space="preserve">
+    <value>Store name: {0}</value>
+    <comment>0 - Store name</comment>
+  </data>
+  <data name="ClientCertificatesFromStorageFindType" xml:space="preserve">
+    <value>Find type: {0}</value>
+    <comment>0 - Find type</comment>
+  </data>
+  <data name="ClientCertificatesFromStorageFindValue" xml:space="preserve">
+    <value>Find value: {0}</value>
+    <comment>0 - Find value</comment>
+  </data>
+  <data name="ClientCertificatesItemCertificateMessage" xml:space="preserve">
+    <value>Certificate: {0}</value>
+    <comment>0 - certificate error or success message</comment>
+  </data>
+  <data name="ClientCertificatesFromPEMOrFilePasswordSet" xml:space="preserve">
+    <value>Password: ****</value>
+  </data>
+  <data name="ClientCertificatesFromPEMOrFilePasswordNotSet" xml:space="preserve">
+    <value>Password: -</value>
   </data>
   <data name="ArgumentCannotBeNullOrEmpty" xml:space="preserve">
     <value>The argument cannot be null or empty.</value>
@@ -840,12 +898,38 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <value>Could not add the trusted signer: {0}</value>
     <comment>0 - Reason</comment>
   </data>
+  <data name="Error_CouldNotAddClientCertificate" xml:space="preserve">
+    <value>Could not add the client certificate: {0}</value>
+    <comment>0 - Reason</comment>
+  </data>
   <data name="Error_CouldNotList" xml:space="preserve">
     <value>Could not list the trusted signers: {0}</value>
     <comment>0 - Reason</comment>
   </data>
+  <data name="Error_CouldNotListClientCertificates" xml:space="preserve">
+    <value>Could not list the client certificates: {0}</value>
+    <comment>0 - Reason</comment>
+  </data>
+  <data name="Error_ExistingAndRequiredClientCertificateSourceMissmatch" xml:space="preserve">
+    <value>Could not modify client certificate of {0} source type. {1} source type expected.</value>
+    <comment>0 - existing client certificate source type, 1 - expected client certificate source type</comment>
+  </data>
+  <data name="Error_UnknownClientCertificateSourceType" xml:space="preserve">
+    <value>Unknown client certificate source type {0}.</value>
+    <comment>0 - client certificate source type</comment>
+  </data>
+  <data name="Error_ClientCertificateNotFound" xml:space="preserve">
+    <value>Client certificate was not found.</value>
+  </data>
+  <data name="Success_ClientCertificate" xml:space="preserve">
+    <value>Client certificate was found.</value>
+  </data>
   <data name="Error_CouldNotRemove" xml:space="preserve">
     <value>Could not remove the trusted signer: {0}</value>
+    <comment>0 - Reason</comment>
+  </data>
+  <data name="Error_CouldNotRemoveClientCertificate" xml:space="preserve">
+    <value>Could not remove the client certificate: {0}</value>
     <comment>0 - Reason</comment>
   </data>
   <data name="Error_CouldNotSync" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -921,9 +921,6 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
   <data name="Error_ClientCertificateNotFound" xml:space="preserve">
     <value>Client certificate was not found.</value>
   </data>
-  <data name="Success_ClientCertificate" xml:space="preserve">
-    <value>Client certificate was found.</value>
-  </data>
   <data name="Error_CouldNotRemove" xml:space="preserve">
     <value>Could not remove the trusted signer: {0}</value>
     <comment>0 - Reason</comment>

--- a/src/NuGet.Core/NuGet.Configuration/ClientCertificate/ClientCertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/ClientCertificate/ClientCertificateProvider.cs
@@ -6,8 +6,6 @@ namespace NuGet.Configuration
 {
     public static class ClientCertificateProvider
     {
-        #region Static members
-
         public static IEnumerable<X509Certificate> Provide(ISettings settings)
         {
             SettingSection clientCertificatesSection = settings.GetSection(ConfigurationConstants.ClientCertificates);
@@ -15,7 +13,5 @@ namespace NuGet.Configuration
                                             .OfType<CertificateSearchItem>()
                                             .Select(i => i.Search());
         }
-
-        #endregion
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/ClientCertificate/ClientCertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/ClientCertificate/ClientCertificateProvider.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+
+namespace NuGet.Configuration
+{
+    public static class ClientCertificateProvider
+    {
+        #region Static members
+
+        public static IEnumerable<X509Certificate> Provide(ISettings settings)
+        {
+            SettingSection clientCertificatesSection = settings.GetSection(ConfigurationConstants.ClientCertificates);
+            return clientCertificatesSection?.Items
+                                            .OfType<CertificateSearchItem>()
+                                            .Select(i => i.Search());
+        }
+
+        #endregion
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/ClientCertificate/IClientCertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/ClientCertificate/IClientCertificateProvider.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace NuGet.Configuration
+{
+    public interface IClientCertificateProvider
+    {
+        /// <summary>
+        ///     Adds a new client certificate or updates an existing one in the settings.
+        /// </summary>
+        /// <param name="item">Client certificate to be added or updated</param>
+        void AddOrUpdate(CertificateSearchItem item);
+
+        /// <summary>
+        ///     Get a list of all the trusted signer entries under the computer trusted signers section.
+        /// </summary>
+        IReadOnlyList<CertificateSearchItem> GetClientCertificates();
+
+        /// <summary>
+        ///     Removes client certificates from the settings.
+        /// </summary>
+        /// <param name="items">Client certificates to be removed</param>
+        void Remove(IReadOnlyList<CertificateSearchItem> items);
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -277,38 +277,38 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A fromCert item must have Path entry..
+        ///   Looks up a localized string similar to A fromFile item must have Path entry..
         /// </summary>
-        internal static string FromCertItemMustHavePath {
+        internal static string FromFileItemMustHavePath {
             get {
-                return ResourceManager.GetString("FromCertItemMustHavePath", resourceCulture);
+                return ResourceManager.GetString("FromFileItemMustHavePath", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A fromCert item Path value and Base-64 encoded points X.509 certificate not set..
+        ///   Looks up a localized string similar to A fromFile item Path value points on non existing file..
         /// </summary>
-        internal static string FromCertItemPathFileAndBase64NotSet {
+        internal static string FromFileItemPathFileNotExist {
             get {
-                return ResourceManager.GetString("FromCertItemPathFileAndBase64NotSet", resourceCulture);
+                return ResourceManager.GetString("FromFileItemPathFileNotExist", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A fromCert item must have only one Path value or Base-64 encoded X.509 certificate..
+        ///   Looks up a localized string similar to A fromFile item Path not set..
         /// </summary>
-        internal static string FromCertItemPathFileAndBase64Set {
+        internal static string FromFileItemPathFileNotSet {
             get {
-                return ResourceManager.GetString("FromCertItemPathFileAndBase64Set", resourceCulture);
+                return ResourceManager.GetString("FromFileItemPathFileNotSet", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A fromCert item Path value points on non existing file..
+        ///   Looks up a localized string similar to A fromPEM item must have only one Base-64 encoded X.509 certificate (PEM)..
         /// </summary>
-        internal static string FromCertItemPathFileNotExist {
+        internal static string FromPEMItemBase64Set {
             get {
-                return ResourceManager.GetString("FromCertItemPathFileNotExist", resourceCulture);
+                return ResourceManager.GetString("FromPEMItemBase64Set", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -142,7 +142,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Certificate was not found in {0}.{1} storage by {2} criteria with {3} value.
+        ///   Looks up a localized string similar to Certificate was not found in {0}.{1} storage by {2} criteria with {3} value..
         /// </summary>
         internal static string Error_FromStorageCertificateNotFound {
             get {
@@ -151,7 +151,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} certificates were found in {1}.{2} storage by {3} criteria with {4} value.
+        ///   Looks up a localized string similar to {0} certificates were found in {1}.{2} storage by {3} criteria with {4} value..
         /// </summary>
         internal static string Error_FromStorageSeveralCertificatesFound {
             get {

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -142,6 +142,24 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Certificate was not found in {0}.{1} storage by {2} criteria with {3} value.
+        /// </summary>
+        internal static string Error_FromStorageCertificateNotFound {
+            get {
+                return ResourceManager.GetString("Error_FromStorageCertificateNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} certificates were found in {1}.{2} storage by {3} criteria with {4} value.
+        /// </summary>
+        internal static string Error_FromStorageSeveralCertificatesFound {
+            get {
+                return ResourceManager.GetString("Error_FromStorageSeveralCertificatesFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The attribute {0}-{1} is not valid..
         /// </summary>
         internal static string Error_InvalidAttribute {
@@ -160,11 +178,65 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A fromCert item must have only one Password entry..
+        /// </summary>
+        internal static string Error_MoreThanOneCertificatePassword {
+            get {
+                return ResourceManager.GetString("Error_MoreThanOneCertificatePassword", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A fromStorage item must have only one FindType entry..
+        /// </summary>
+        internal static string Error_MoreThanOneFindType {
+            get {
+                return ResourceManager.GetString("Error_MoreThanOneFindType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A fromStorage item must have only one FindValue entry..
+        /// </summary>
+        internal static string Error_MoreThanOneFindValue {
+            get {
+                return ResourceManager.GetString("Error_MoreThanOneFindValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A credentials item must have only one Password or ClearTextPassword entry..
         /// </summary>
         internal static string Error_MoreThanOnePassword {
             get {
                 return ResourceManager.GetString("Error_MoreThanOnePassword", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A fromCert item must have only one Path entry..
+        /// </summary>
+        internal static string Error_MoreThanOnePath {
+            get {
+                return ResourceManager.GetString("Error_MoreThanOnePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A fromStorage item must have only one StoreLocation entry..
+        /// </summary>
+        internal static string Error_MoreThanOneStoreLocation {
+            get {
+                return ResourceManager.GetString("Error_MoreThanOneStoreLocation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A fromStorage item must have only one StoreName entry..
+        /// </summary>
+        internal static string Error_MoreThanOneStoreName {
+            get {
+                return ResourceManager.GetString("Error_MoreThanOneStoreName", resourceCulture);
             }
         }
         
@@ -201,6 +273,78 @@ namespace NuGet.Configuration {
         internal static string FileDoesNotExist {
             get {
                 return ResourceManager.GetString("FileDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A fromCert item must have Path entry..
+        /// </summary>
+        internal static string FromCertItemMustHavePath {
+            get {
+                return ResourceManager.GetString("FromCertItemMustHavePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A fromCert item Path value and Base-64 encoded points X.509 certificate not set..
+        /// </summary>
+        internal static string FromCertItemPathFileAndBase64NotSet {
+            get {
+                return ResourceManager.GetString("FromCertItemPathFileAndBase64NotSet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A fromCert item must have only one Path value or Base-64 encoded X.509 certificate..
+        /// </summary>
+        internal static string FromCertItemPathFileAndBase64Set {
+            get {
+                return ResourceManager.GetString("FromCertItemPathFileAndBase64Set", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A fromCert item Path value points on non existing file..
+        /// </summary>
+        internal static string FromCertItemPathFileNotExist {
+            get {
+                return ResourceManager.GetString("FromCertItemPathFileNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A fromStorage item FindType entry is not supported..
+        /// </summary>
+        internal static string FromStorageItemFindTypeNotSupported {
+            get {
+                return ResourceManager.GetString("FromStorageItemFindTypeNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A fromStorage item must have FindValue entry..
+        /// </summary>
+        internal static string FromStorageItemMustHaveFindValue {
+            get {
+                return ResourceManager.GetString("FromStorageItemMustHaveFindValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A fromStorage item StoreLocation entry is not supported..
+        /// </summary>
+        internal static string FromStorageItemStoreLocationNotSupported {
+            get {
+                return ResourceManager.GetString("FromStorageItemStoreLocationNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A fromStorage item StoreName entry is not supported..
+        /// </summary>
+        internal static string FromStorageItemStoreNameNotSupported {
+            get {
+                return ResourceManager.GetString("FromStorageItemStoreNameNotSupported", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -142,7 +142,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Certificate was not found in {0}. {1} storage by {2} criteria with {3} value..
+        ///   Looks up a localized string similar to Certificate was not found in {0}.{1} storage by {2} criteria with {3} value..
         /// </summary>
         internal static string Error_FromStorageCertificateNotFound {
             get {
@@ -151,7 +151,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} certificates were found in {1}. {2} storage by {3} criteria with {4} value..
+        ///   Looks up a localized string similar to {0} certificates were found in {1}.{2} storage by {3} criteria with {4} value..
         /// </summary>
         internal static string Error_FromStorageSeveralCertificatesFound {
             get {

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -142,7 +142,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Certificate was not found in {0}.{1} storage by {2} criteria with {3} value..
+        ///   Looks up a localized string similar to Certificate was not found in {0}. {1} storage by {2} criteria with {3} value..
         /// </summary>
         internal static string Error_FromStorageCertificateNotFound {
             get {
@@ -151,7 +151,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} certificates were found in {1}.{2} storage by {3} criteria with {4} value..
+        ///   Looks up a localized string similar to {0} certificates were found in {1}. {2} storage by {3} criteria with {4} value..
         /// </summary>
         internal static string Error_FromStorageSeveralCertificatesFound {
             get {

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -150,10 +150,10 @@
     <value>Encryption is not supported on non-Windows platforms.</value>
   </data>
   <data name="Error_FromStorageCertificateNotFound" xml:space="preserve">
-    <value>Certificate was not found in {0}. {1} storage by {2} criteria with {3} value.</value>
+    <value>Certificate was not found in {0}.{1} storage by {2} criteria with {3} value.</value>
   </data>
   <data name="Error_FromStorageSeveralCertificatesFound" xml:space="preserve">
-    <value>{0} certificates were found in {1}. {2} storage by {3} criteria with {4} value.</value>
+    <value>{0} certificates were found in {1}.{2} storage by {3} criteria with {4} value.</value>
   </data>
   <data name="Error_InvalidAttribute" xml:space="preserve">
     <value>The attribute {0}-{1} is not valid.</value>

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -150,10 +150,10 @@
     <value>Encryption is not supported on non-Windows platforms.</value>
   </data>
   <data name="Error_FromStorageCertificateNotFound" xml:space="preserve">
-    <value>Certificate was not found in {0}.{1} storage by {2} criteria with {3} value</value>
+    <value>Certificate was not found in {0}.{1} storage by {2} criteria with {3} value.</value>
   </data>
   <data name="Error_FromStorageSeveralCertificatesFound" xml:space="preserve">
-    <value>{0} certificates were found in {1}.{2} storage by {3} criteria with {4} value</value>
+    <value>{0} certificates were found in {1}.{2} storage by {3} criteria with {4} value.</value>
   </data>
   <data name="Error_InvalidAttribute" xml:space="preserve">
     <value>The attribute {0}-{1} is not valid.</value>

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -150,10 +150,10 @@
     <value>Encryption is not supported on non-Windows platforms.</value>
   </data>
   <data name="Error_FromStorageCertificateNotFound" xml:space="preserve">
-    <value>Certificate was not found in {0}.{1} storage by {2} criteria with {3} value.</value>
+    <value>Certificate was not found in {0}. {1} storage by {2} criteria with {3} value.</value>
   </data>
   <data name="Error_FromStorageSeveralCertificatesFound" xml:space="preserve">
-    <value>{0} certificates were found in {1}.{2} storage by {3} criteria with {4} value.</value>
+    <value>{0} certificates were found in {1}. {2} storage by {3} criteria with {4} value.</value>
   </data>
   <data name="Error_InvalidAttribute" xml:space="preserve">
     <value>The attribute {0}-{1} is not valid.</value>

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -196,17 +196,17 @@
   <data name="FileDoesNotExist" xml:space="preserve">
     <value>File '{0}' does not exist.</value>
   </data>
-  <data name="FromCertItemMustHavePath" xml:space="preserve">
-    <value>A fromCert item must have Path entry.</value>
+  <data name="FromFileItemMustHavePath" xml:space="preserve">
+    <value>A fromFile item must have Path entry.</value>
   </data>
-  <data name="FromCertItemPathFileNotExist" xml:space="preserve">
-    <value>A fromCert item Path value points on non existing file.</value>
+  <data name="FromFileItemPathFileNotExist" xml:space="preserve">
+    <value>A fromFile item Path value points on non existing file.</value>
   </data>
-  <data name="FromCertItemPathFileAndBase64NotSet" xml:space="preserve">
-    <value>A fromCert item Path value and Base-64 encoded points X.509 certificate not set.</value>
+  <data name="FromFileItemPathFileNotSet" xml:space="preserve">
+    <value>A fromFile item Path not set.</value>
   </data>
-  <data name="FromCertItemPathFileAndBase64Set" xml:space="preserve">
-    <value>A fromCert item must have only one Path value or Base-64 encoded X.509 certificate.</value>
+  <data name="FromPEMItemBase64Set" xml:space="preserve">
+    <value>A fromPEM item must have only one Base-64 encoded X.509 certificate (PEM).</value>
   </data>
   <data name="FromStorageItemFindTypeNotSupported" xml:space="preserve">
     <value>A fromStorage item FindType entry is not supported.</value>

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -149,6 +149,12 @@
   <data name="Error_EncryptionUnsupported" xml:space="preserve">
     <value>Encryption is not supported on non-Windows platforms.</value>
   </data>
+  <data name="Error_FromStorageCertificateNotFound" xml:space="preserve">
+    <value>Certificate was not found in {0}.{1} storage by {2} criteria with {3} value</value>
+  </data>
+  <data name="Error_FromStorageSeveralCertificatesFound" xml:space="preserve">
+    <value>{0} certificates were found in {1}.{2} storage by {3} criteria with {4} value</value>
+  </data>
   <data name="Error_InvalidAttribute" xml:space="preserve">
     <value>The attribute {0}-{1} is not valid.</value>
     <comment>0 - attribute name
@@ -157,8 +163,26 @@
   <data name="Error_MergeTwoDifferentSections" xml:space="preserve">
     <value>Cannot merge two different sections.</value>
   </data>
+  <data name="Error_MoreThanOneCertificatePassword" xml:space="preserve">
+    <value>A fromCert item must have only one Password entry.</value>
+  </data>
+  <data name="Error_MoreThanOneFindType" xml:space="preserve">
+    <value>A fromStorage item must have only one FindType entry.</value>
+  </data>
+  <data name="Error_MoreThanOneFindValue" xml:space="preserve">
+    <value>A fromStorage item must have only one FindValue entry.</value>
+  </data>
   <data name="Error_MoreThanOnePassword" xml:space="preserve">
     <value>A credentials item must have only one Password or ClearTextPassword entry.</value>
+  </data>
+  <data name="Error_MoreThanOnePath" xml:space="preserve">
+    <value>A fromCert item must have only one Path entry.</value>
+  </data>
+  <data name="Error_MoreThanOneStoreLocation" xml:space="preserve">
+    <value>A fromStorage item must have only one StoreLocation entry.</value>
+  </data>
+  <data name="Error_MoreThanOneStoreName" xml:space="preserve">
+    <value>A fromStorage item must have only one StoreName entry.</value>
   </data>
   <data name="Error_MoreThanOneUsername" xml:space="preserve">
     <value>A credentials item must have only one Username entry.</value>
@@ -171,6 +195,30 @@
   </data>
   <data name="FileDoesNotExist" xml:space="preserve">
     <value>File '{0}' does not exist.</value>
+  </data>
+  <data name="FromCertItemMustHavePath" xml:space="preserve">
+    <value>A fromCert item must have Path entry.</value>
+  </data>
+  <data name="FromCertItemPathFileNotExist" xml:space="preserve">
+    <value>A fromCert item Path value points on non existing file.</value>
+  </data>
+  <data name="FromCertItemPathFileAndBase64NotSet" xml:space="preserve">
+    <value>A fromCert item Path value and Base-64 encoded points X.509 certificate not set.</value>
+  </data>
+  <data name="FromCertItemPathFileAndBase64Set" xml:space="preserve">
+    <value>A fromCert item must have only one Path value or Base-64 encoded X.509 certificate.</value>
+  </data>
+  <data name="FromStorageItemFindTypeNotSupported" xml:space="preserve">
+    <value>A fromStorage item FindType entry is not supported.</value>
+  </data>
+  <data name="FromStorageItemMustHaveFindValue" xml:space="preserve">
+    <value>A fromStorage item must have FindValue entry.</value>
+  </data>
+  <data name="FromStorageItemStoreLocationNotSupported" xml:space="preserve">
+    <value>A fromStorage item StoreLocation entry is not supported.</value>
+  </data>
+  <data name="FromStorageItemStoreNameNotSupported" xml:space="preserve">
+    <value>A fromStorage item StoreName entry is not supported.</value>
   </data>
   <data name="InvalidNullSettingsOperation" xml:space="preserve">
     <value>"{0}" cannot be called on a NullSettings. This may be caused on account of insufficient permissions to read or write to "%AppData%\NuGet\NuGet.config".</value>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/CertificateSearchItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/CertificateSearchItem.cs
@@ -5,8 +5,6 @@ namespace NuGet.Configuration
 {
     public abstract class CertificateSearchItem : SettingItem
     {
-        #region Constructors
-
         protected CertificateSearchItem()
         {
         }
@@ -16,18 +14,8 @@ namespace NuGet.Configuration
         {
         }
 
-        #endregion
-
-        #region Properties
-
         protected override bool CanHaveChildren => true;
 
-        #endregion
-
-        #region Members
-
         public abstract X509Certificate Search();
-
-        #endregion
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/CertificateSearchItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/CertificateSearchItem.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Security.Cryptography.X509Certificates;
 using System.Xml.Linq;
 
@@ -5,8 +8,25 @@ namespace NuGet.Configuration
 {
     public abstract class CertificateSearchItem : SettingItem
     {
-        protected CertificateSearchItem()
+        public static int MergeHash(params int[] hashes)
         {
+            var result = 0;
+            foreach (var hash in hashes)
+            {
+                result = (result * 397) ^ hash;
+            }
+
+            return result;
+        }
+
+        protected CertificateSearchItem(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(name));
+            }
+
+            AddAttribute(ConfigurationConstants.NameAttribute, name);
         }
 
         internal CertificateSearchItem(XElement element, SettingsFile origin)
@@ -14,8 +34,55 @@ namespace NuGet.Configuration
         {
         }
 
+        public string Name => Attributes[ConfigurationConstants.NameAttribute];
+        public abstract ClientCertificatesSourceType SourceType { get; }
+
         protected override bool CanHaveChildren => true;
 
+        protected override IReadOnlyCollection<string> RequiredAttributes { get; } = new HashSet<string> { ConfigurationConstants.NameAttribute };
+
+        public override bool Equals(object other)
+        {
+            var item = other as CertificateSearchItem;
+
+            if (item == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, item))
+            {
+                return true;
+            }
+
+            if (!string.Equals(ElementName, item.ElementName, StringComparison.Ordinal)) return false;
+            if (!string.Equals(Name, item.Name, StringComparison.Ordinal)) return false;
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return MergeHash(ElementName.GetHashCode(), Name.GetHashCode());
+        }
+
         public abstract X509Certificate Search();
+
+        protected void SetName(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.PropertyCannotBeNullOrEmpty, nameof(Name)));
+            }
+
+            UpdateAttribute(ConfigurationConstants.NameAttribute, value);
+        }
+
+        public enum ClientCertificatesSourceType
+        {
+            File,
+            PEM,
+            Storage
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/CertificateSearchItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/CertificateSearchItem.cs
@@ -1,0 +1,33 @@
+using System.Security.Cryptography.X509Certificates;
+using System.Xml.Linq;
+
+namespace NuGet.Configuration
+{
+    public abstract class CertificateSearchItem : SettingItem
+    {
+        #region Constructors
+
+        protected CertificateSearchItem()
+        {
+        }
+
+        internal CertificateSearchItem(XElement element, SettingsFile origin)
+            : base(element, origin)
+        {
+        }
+
+        #endregion
+
+        #region Properties
+
+        protected override bool CanHaveChildren => true;
+
+        #endregion
+
+        #region Members
+
+        public abstract X509Certificate Search();
+
+        #endregion
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/FromCertItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/FromCertItem.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Xml.Linq;
+using NuGet.Common;
+
+namespace NuGet.Configuration
+{
+    /// <summary>
+    ///     A FromCertItem have 2 children and body text:
+    ///     - [Required] Hex certificate body or Path (AddItem)
+    ///     - [Optional] Password (AddItem)
+    /// </summary>
+    public sealed class FromCertItem : CertificateSearchItem
+    {
+        #region Static members
+
+        private static byte[] ReadStream(Stream input)
+        {
+            var buffer = new byte[16 * 1024];
+            using (var ms = new MemoryStream())
+            {
+                int read;
+                while ((read = input.Read(buffer, 0, buffer.Length)) > 0)
+                {
+                    ms.Write(buffer, 0, read);
+                }
+
+                return ms.ToArray();
+            }
+        }
+
+        #endregion
+
+        private readonly AddItem _password;
+        private readonly AddItem _path;
+
+        #region Constructors
+
+        internal FromCertItem(string filePath = null, string base64Certificate = null, string password = null, SettingsFile origin = null)
+        {
+            ElementName = ConfigurationConstants.FromCert;
+            SetOrigin(origin);
+
+            _path = new AddItem(ConfigurationConstants.PathToken, filePath);
+            _password = new AddItem(ConfigurationConstants.PasswordToken, password);
+            Base64Certificate = base64Certificate;
+
+            ValidateItem();
+        }
+
+        internal FromCertItem(XElement element, SettingsFile origin)
+            : base(element, origin)
+        {
+            ElementName = ConfigurationConstants.FromCert;
+
+            IEnumerable<AddItem> parsedItems = element.Elements()
+                                                      .Select(e => SettingFactory.Parse(e, origin) as AddItem)
+                                                      .Where(i => i != null);
+
+            foreach (AddItem item in parsedItems)
+            {
+                if (string.Equals(item.Key, ConfigurationConstants.PathToken, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (_path != null)
+                    {
+                        throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                            Resources.UserSettings_UnableToParseConfigFile,
+                                                                            Resources.Error_MoreThanOnePath,
+                                                                            origin.ConfigFilePath));
+                    }
+
+                    _path = item;
+                }
+                else if (string.Equals(item.Key, ConfigurationConstants.PasswordToken, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (_password != null)
+                    {
+                        throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                            Resources.UserSettings_UnableToParseConfigFile,
+                                                                            Resources.Error_MoreThanOneCertificatePassword,
+                                                                            origin.ConfigFilePath));
+                    }
+
+                    _password = item;
+                }
+            }
+
+            if (_path == null) _path = new AddItem(ConfigurationConstants.PathToken, null);
+            if (_password == null) _password = new AddItem(ConfigurationConstants.PasswordToken, null);
+
+            Base64Certificate = element.Value.Trim(' ', '\n', '\r');
+
+            ValidateItem();
+        }
+
+        #endregion
+
+        #region Properties
+
+        public string Base64Certificate { get; set; }
+
+        public string Password
+        {
+            get => _password.Value;
+            set => _password.Value = value;
+        }
+
+        public string Path
+        {
+            get => _path.Value;
+            set => _path.Value = value;
+        }
+
+        #endregion
+
+        #region Override members
+
+        public override SettingBase Clone()
+        {
+            return new FromCertItem(Path, Base64Certificate, Password, Origin);
+        }
+
+        public override X509Certificate Search()
+        {
+            byte[] certificateData;
+            if (string.IsNullOrWhiteSpace(Base64Certificate))
+            {
+                //Read certificate from file
+                using (FileStream stream = File.OpenRead(FindAbsoluteFilePath()))
+                {
+                    certificateData = ReadStream(stream);
+                }
+            }
+            else
+            {
+                //Transform base64 certificate to bytes
+                certificateData = Encoding.UTF8.GetBytes(Base64Certificate);
+            }
+
+            //If password not set try to create certificate from file stream
+            if (string.IsNullOrWhiteSpace(Password)) return new X509Certificate2(certificateData);
+
+            //If password is set decrypt it first and try to create certificate from file stream and decrypted password
+            var decryptedPassword = EncryptionUtility.DecryptString(Password);
+            return new X509Certificate2(certificateData, decryptedPassword);
+
+        }
+
+        #endregion
+
+        #region Members
+
+        private string FindAbsoluteFilePath()
+        {
+            var originalValue = _path.Value;
+            var expectedFiles = new List<string>
+            {
+                originalValue //Means absolute path
+            };
+
+            if (PathValidator.IsValidRelativePath(originalValue))
+            {
+                if (Origin != null)
+                {
+                    //Relative to config file path
+                    expectedFiles.Add(PathUtility.GetAbsolutePath(PathUtility.EnsureTrailingSlash(Origin.DirectoryPath), originalValue));
+                }
+
+                //Relative to current directory file path
+                expectedFiles.Add(PathUtility.GetAbsolutePath(PathUtility.EnsureTrailingSlash(Directory.GetCurrentDirectory()), originalValue));
+            }
+
+            return expectedFiles.FirstOrDefault(File.Exists);
+        }
+
+        private void ValidateItem()
+        {
+            if (string.IsNullOrWhiteSpace(Base64Certificate) && string.IsNullOrWhiteSpace(Path))
+            {
+                throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                    Resources.UserSettings_UnableToParseConfigFile,
+                                                                    Resources.FromCertItemPathFileAndBase64NotSet,
+                                                                    Origin.ConfigFilePath));
+            }
+
+            if (!string.IsNullOrWhiteSpace(Base64Certificate) && !string.IsNullOrWhiteSpace(Path))
+            {
+                throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                    Resources.UserSettings_UnableToParseConfigFile,
+                                                                    Resources.FromCertItemPathFileAndBase64Set,
+                                                                    Origin.ConfigFilePath));
+            }
+
+            if (string.IsNullOrWhiteSpace(Base64Certificate))
+            {
+                var filePath = FindAbsoluteFilePath();
+                if (string.IsNullOrWhiteSpace(filePath))
+                {
+                    throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                        Resources.UserSettings_UnableToParseConfigFile,
+                                                                        Resources.FromCertItemPathFileNotExist,
+                                                                        Origin.ConfigFilePath));
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/FromCertItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/FromCertItem.cs
@@ -17,8 +17,6 @@ namespace NuGet.Configuration
     /// </summary>
     public sealed class FromCertItem : CertificateSearchItem
     {
-        #region Static members
-
         private static byte[] ReadStream(Stream input)
         {
             var buffer = new byte[16 * 1024];
@@ -34,12 +32,8 @@ namespace NuGet.Configuration
             }
         }
 
-        #endregion
-
         private readonly AddItem _password;
         private readonly AddItem _path;
-
-        #region Constructors
 
         internal FromCertItem(string filePath = null, string base64Certificate = null, string password = null, SettingsFile origin = null)
         {
@@ -98,10 +92,6 @@ namespace NuGet.Configuration
             ValidateItem();
         }
 
-        #endregion
-
-        #region Properties
-
         public string Base64Certificate { get; set; }
 
         public string Password
@@ -115,10 +105,6 @@ namespace NuGet.Configuration
             get => _path.Value;
             set => _path.Value = value;
         }
-
-        #endregion
-
-        #region Override members
 
         public override SettingBase Clone()
         {
@@ -150,10 +136,6 @@ namespace NuGet.Configuration
             return new X509Certificate2(certificateData, decryptedPassword);
 
         }
-
-        #endregion
-
-        #region Members
 
         private string FindAbsoluteFilePath()
         {
@@ -208,7 +190,5 @@ namespace NuGet.Configuration
                 }
             }
         }
-
-        #endregion
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/FromPEMItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/FromPEMItem.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Xml.Linq;
+
+namespace NuGet.Configuration
+{
+    /// <summary>
+    ///     A FromPEMItem have one children and body text:
+    ///     - [Required] Hex certificate body in PEM format
+    ///     - [Optional] Password (AddItem)
+    /// </summary>
+    public sealed class FromPEMItem : CertificateSearchItem
+    {
+        private readonly AddItem _password;
+
+        internal FromPEMItem(string base64Certificate = null, string password = null, SettingsFile origin = null)
+        {
+            ElementName = ConfigurationConstants.FromPEM;
+            SetOrigin(origin);
+
+            _password = new AddItem(ConfigurationConstants.PasswordToken, password);
+            Base64Certificate = base64Certificate;
+
+            ValidateItem();
+        }
+
+        internal FromPEMItem(XElement element, SettingsFile origin)
+            : base(element, origin)
+        {
+            ElementName = ConfigurationConstants.FromPEM;
+
+            IEnumerable<AddItem> parsedItems = element.Elements()
+                                                      .Select(e => SettingFactory.Parse(e, origin) as AddItem)
+                                                      .Where(i => i != null);
+
+            foreach (AddItem item in parsedItems)
+            {
+                if (string.Equals(item.Key, ConfigurationConstants.PasswordToken, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (_password != null)
+                    {
+                        throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                            Resources.UserSettings_UnableToParseConfigFile,
+                                                                            Resources.Error_MoreThanOneCertificatePassword,
+                                                                            origin.ConfigFilePath));
+                    }
+
+                    _password = item;
+                }
+            }
+
+            if (_password == null) _password = new AddItem(ConfigurationConstants.PasswordToken, null);
+
+            Base64Certificate = element.Value.Trim(' ', '\n', '\r');
+
+            ValidateItem();
+        }
+
+        public string Base64Certificate { get; set; }
+
+        public string Password
+        {
+            get => _password.Value;
+            set => _password.Value = value;
+        }
+
+        public override SettingBase Clone()
+        {
+            return new FromPEMItem(Base64Certificate, Password, Origin);
+        }
+
+        public override X509Certificate Search()
+        {
+            //Transform base64 certificate to bytes
+            byte[] certificateData = Encoding.UTF8.GetBytes(Base64Certificate);
+
+            //If password not set try to create certificate from file stream
+            if (string.IsNullOrWhiteSpace(Password)) return new X509Certificate2(certificateData);
+
+            //If password is set decrypt it first and try to create certificate from file stream and decrypted password
+            var decryptedPassword = EncryptionUtility.DecryptString(Password);
+            return new X509Certificate2(certificateData, decryptedPassword);
+        }
+
+        private void ValidateItem()
+        {
+            if (string.IsNullOrWhiteSpace(Base64Certificate))
+            {
+                throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                    Resources.UserSettings_UnableToParseConfigFile,
+                                                                    Resources.FromPEMItemBase64Set,
+                                                                    Origin.ConfigFilePath));
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/FromStorageItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/FromStorageItem.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Xml.Linq;
+
+namespace NuGet.Configuration
+{
+    /// <summary>
+    ///     A FromStorageItem have 4 children:
+    ///     - [Optional] StoreLocation (AddItem). StoreLocation.CurrentUser by default.
+    ///     - [Optional] StoreName (AddItem). StoreName.My by default.
+    ///     - [Optional] FindType (AddItem). X509FindType.FindByThumbprint by default.
+    ///     - [Required] FindValue (AddItem)
+    /// </summary>
+    public sealed class FromStorageItem : CertificateSearchItem
+    {
+        #region Constants
+
+        private const X509FindType DefaultFindType = X509FindType.FindByThumbprint;
+        private const StoreLocation DefaultStoreLocation = StoreLocation.CurrentUser;
+        private const StoreName DefaultStoreName = StoreName.My;
+
+        #endregion
+
+        private readonly AddItem _findType;
+        private readonly AddItem _findValue;
+        private readonly AddItem _storeLocation;
+        private readonly AddItem _storeName;
+
+        #region Constructors
+
+        public FromStorageItem(string findValue,
+                               StoreLocation storeLocation = DefaultStoreLocation,
+                               StoreName storeName = DefaultStoreName,
+                               X509FindType findType = DefaultFindType)
+        {
+            ElementName = ConfigurationConstants.FromStorage;
+
+            if (string.IsNullOrEmpty(findValue))
+            {
+                throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(findValue));
+            }
+
+            _storeLocation = new AddItem(ConfigurationConstants.StoreLocationToken, storeLocation.ToString());
+            _storeName = new AddItem(ConfigurationConstants.StoreNameToken, storeName.ToString());
+            _findType = new AddItem(ConfigurationConstants.FindTypeToken, findType.ToString());
+            _findValue = new AddItem(ConfigurationConstants.FindValueToken, findValue);
+        }
+
+        internal FromStorageItem(XElement element, SettingsFile origin)
+            : base(element, origin)
+        {
+            ElementName = ConfigurationConstants.FromStorage;
+
+            IEnumerable<AddItem> parsedItems = element.Elements()
+                                                      .Select(e => SettingFactory.Parse(e, origin) as AddItem)
+                                                      .Where(i => i != null);
+
+            foreach (AddItem item in parsedItems)
+            {
+                if (string.Equals(item.Key, ConfigurationConstants.StoreLocationToken, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (_storeLocation != null)
+                    {
+                        throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                            Resources.UserSettings_UnableToParseConfigFile,
+                                                                            Resources.Error_MoreThanOneStoreLocation,
+                                                                            origin.ConfigFilePath));
+                    }
+
+                    _storeLocation = item;
+                }
+                else if (string.Equals(item.Key, ConfigurationConstants.StoreNameToken, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (_storeName != null)
+                    {
+                        throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                            Resources.UserSettings_UnableToParseConfigFile,
+                                                                            Resources.Error_MoreThanOneStoreName,
+                                                                            origin.ConfigFilePath));
+                    }
+
+                    _storeName = item;
+                }
+                else if (string.Equals(item.Key, ConfigurationConstants.FindTypeToken, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (_findType != null)
+                    {
+                        throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                            Resources.UserSettings_UnableToParseConfigFile,
+                                                                            Resources.Error_MoreThanOneFindType,
+                                                                            origin.ConfigFilePath));
+                    }
+
+                    _findType = item;
+                }
+                else if (string.Equals(item.Key, ConfigurationConstants.FindValueToken, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (_findValue != null)
+                    {
+                        throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                            Resources.UserSettings_UnableToParseConfigFile,
+                                                                            Resources.Error_MoreThanOneFindValue,
+                                                                            origin.ConfigFilePath));
+                    }
+
+                    _findValue = item;
+                }
+            }
+
+            if (_storeLocation == null)
+            {
+                _storeLocation = new AddItem(ConfigurationConstants.StoreLocationToken, DefaultStoreLocation.ToString());
+            }
+
+            if (_storeName == null)
+            {
+                _storeName = new AddItem(ConfigurationConstants.StoreNameToken, DefaultStoreName.ToString());
+            }
+
+            if (_findType == null)
+            {
+                _findType = new AddItem(ConfigurationConstants.FindTypeToken, DefaultFindType.ToString());
+            }
+
+            if (_findValue == null)
+            {
+                throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                    Resources.UserSettings_UnableToParseConfigFile,
+                                                                    Resources.FromStorageItemMustHaveFindValue,
+                                                                    origin.ConfigFilePath));
+            }
+
+            ValidateItem();
+        }
+
+        #endregion
+
+        #region Properties
+
+        public X509FindType FindType
+        {
+            get
+            {
+                if (Enum.TryParse(_findType.Value, true, out X509FindType result)) return result;
+                return DefaultFindType;
+            }
+            set
+            {
+                var stringValue = value.ToString();
+                _findType.Value = stringValue;
+            }
+        }
+
+        public string FindValue
+        {
+            get => _findValue.Value;
+            set => _findType.Value = value;
+        }
+
+        public StoreLocation StoreLocation
+        {
+            get
+            {
+                if (Enum.TryParse(_storeLocation.Value, true, out StoreLocation result)) return result;
+                return DefaultStoreLocation;
+            }
+            set
+            {
+                var stringValue = value.ToString();
+                _storeLocation.Value = stringValue;
+            }
+        }
+
+        public StoreName StoreName
+        {
+            get
+            {
+                if (Enum.TryParse(_storeName.Value, true, out StoreName result)) return result;
+                return DefaultStoreName;
+            }
+            set
+            {
+                var stringValue = value.ToString();
+                _storeName.Value = stringValue;
+            }
+        }
+
+        #endregion
+
+        #region Override members
+
+        public override SettingBase Clone()
+        {
+            return new FromStorageItem(FindValue, StoreLocation, StoreName, FindType);
+        }
+
+        public override X509Certificate Search()
+        {
+            var store = new X509Store(StoreName, StoreLocation);
+            try
+            {
+                store.Open(OpenFlags.ReadOnly);
+                X509Certificate2Collection foundCertificates = store.Certificates.Find(FindType, FindValue, true);
+                if (foundCertificates.Count == 0)
+                {
+                    throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                        Resources.Error_FromStorageCertificateNotFound,
+                                                                        StoreLocation,
+                                                                        StoreName,
+                                                                        FindType,
+                                                                        FindValue
+                                                          ));
+                }
+
+                if (foundCertificates.Count > 1)
+                {
+                    throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                        Resources.Error_FromStorageCertificateNotFound,
+                                                                        foundCertificates.Count,
+                                                                        StoreLocation,
+                                                                        StoreName,
+                                                                        FindType,
+                                                                        FindValue
+                                                          ));
+                }
+
+                return foundCertificates[0];
+            }
+            finally
+            {
+                store.Close();
+            }
+        }
+
+        #endregion
+
+        #region Members
+
+        private void ValidateItem()
+        {
+            if (!Enum.TryParse(_storeLocation?.Value, true, out StoreLocation _))
+            {
+                throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                    Resources.UserSettings_UnableToParseConfigFile,
+                                                                    Resources.FromStorageItemStoreLocationNotSupported,
+                                                                    Origin.ConfigFilePath));
+            }
+
+            if (!Enum.TryParse(_storeName.Value, true, out StoreName _))
+            {
+                throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                    Resources.UserSettings_UnableToParseConfigFile,
+                                                                    Resources.FromStorageItemStoreNameNotSupported,
+                                                                    Origin.ConfigFilePath));
+            }
+
+            if (!Enum.TryParse(_findType.Value, true, out X509FindType _))
+            {
+                throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                    Resources.UserSettings_UnableToParseConfigFile,
+                                                                    Resources.FromStorageItemFindTypeNotSupported,
+                                                                    Origin.ConfigFilePath));
+            }
+
+            if (string.IsNullOrWhiteSpace(_findValue?.Value))
+            {
+                throw new NuGetConfigurationException(string.Format(CultureInfo.CurrentCulture,
+                                                                    Resources.UserSettings_UnableToParseConfigFile,
+                                                                    Resources.FromStorageItemMustHaveFindValue,
+                                                                    Origin.ConfigFilePath));
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/FromStorageItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/FromStorageItem.cs
@@ -16,20 +16,14 @@ namespace NuGet.Configuration
     /// </summary>
     public sealed class FromStorageItem : CertificateSearchItem
     {
-        #region Constants
-
         private const X509FindType DefaultFindType = X509FindType.FindByThumbprint;
         private const StoreLocation DefaultStoreLocation = StoreLocation.CurrentUser;
         private const StoreName DefaultStoreName = StoreName.My;
-
-        #endregion
 
         private readonly AddItem _findType;
         private readonly AddItem _findValue;
         private readonly AddItem _storeLocation;
         private readonly AddItem _storeName;
-
-        #region Constructors
 
         public FromStorageItem(string findValue,
                                StoreLocation storeLocation = DefaultStoreLocation,
@@ -136,10 +130,6 @@ namespace NuGet.Configuration
             ValidateItem();
         }
 
-        #endregion
-
-        #region Properties
-
         public X509FindType FindType
         {
             get
@@ -188,10 +178,6 @@ namespace NuGet.Configuration
             }
         }
 
-        #endregion
-
-        #region Override members
-
         public override SettingBase Clone()
         {
             return new FromStorageItem(FindValue, StoreLocation, StoreName, FindType);
@@ -235,10 +221,6 @@ namespace NuGet.Configuration
             }
         }
 
-        #endregion
-
-        #region Members
-
         private void ValidateItem()
         {
             if (!Enum.TryParse(_storeLocation?.Value, true, out StoreLocation _))
@@ -273,7 +255,5 @@ namespace NuGet.Configuration
                                                                     Origin.ConfigFilePath));
             }
         }
-
-        #endregion
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingElementType.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingElementType.cs
@@ -37,6 +37,10 @@ namespace NuGet.Configuration
 
         Owners,
 
-        Repository
+        Repository,
+
+        FromStorage,
+
+        FromCert
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingElementType.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingElementType.cs
@@ -41,6 +41,8 @@ namespace NuGet.Configuration
 
         FromStorage,
 
-        FromCert
+        FromFile,
+
+        FromPEM
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -69,6 +69,12 @@ namespace NuGet.Configuration
 
                     case SettingElementType.Repository:
                         return new RepositoryItem(element, origin);
+
+                    case SettingElementType.FromStorage:
+                        return new FromStorageItem(element, origin);
+
+                    case SettingElementType.FromCert:
+                        return new FromCertItem(element, origin);
                 }
 
                 return new UnknownItem(element, origin);

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -73,8 +73,11 @@ namespace NuGet.Configuration
                     case SettingElementType.FromStorage:
                         return new FromStorageItem(element, origin);
 
-                    case SettingElementType.FromCert:
-                        return new FromCertItem(element, origin);
+                    case SettingElementType.FromFile:
+                        return new FromFileItem(element, origin);
+
+                    case SettingElementType.FromPEM:
+                        return new FromPEMItem(element, origin);
                 }
 
                 return new UnknownItem(element, origin);

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -27,6 +27,8 @@ namespace NuGet.Configuration
 
         public static readonly string ClearTextPasswordToken = "ClearTextPassword";
 
+        public static readonly string ClientCertificates = "clientCertificates";
+
         public static readonly string Config = "config";
 
         public static readonly string Configuration = "configuration";
@@ -53,9 +55,17 @@ namespace NuGet.Configuration
 
         public static readonly string FallbackPackageFolders = "fallbackPackageFolders";
 
+        public static readonly string FindTypeToken = "FindType";
+
+        public static readonly string FindValueToken = "FindValue";
+
         public static readonly string Fingerprint = "fingerprint";
 
         public static readonly string FingerprintAlgorithm = "fingerprintAlgorithm";
+
+        public static readonly string FromCert = "fromCert";
+
+        public static readonly string FromStorage = "fromStorage";
 
         public static readonly string GlobalPackagesFolder = "globalPackagesFolder";
 
@@ -79,6 +89,8 @@ namespace NuGet.Configuration
 
         public static readonly string PackageRestore = "packageRestore";
 
+        public static readonly string PathToken = "Path";
+
         public static readonly string PasswordKey = "http_proxy.password";
 
         public static readonly string PasswordToken = "Password";
@@ -94,6 +106,10 @@ namespace NuGet.Configuration
         public static readonly string SignatureValidationMode = "signatureValidationMode";
 
         public static readonly string SkipBindingRedirectsKey = "skip";
+
+        public static readonly string StoreLocationToken = "StoreLocation";
+
+        public static readonly string StoreNameToken = "StoreName";
 
         public static readonly string TrustedSigners = "trustedSigners";
 

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -63,7 +63,9 @@ namespace NuGet.Configuration
 
         public static readonly string FingerprintAlgorithm = "fingerprintAlgorithm";
 
-        public static readonly string FromCert = "fromCert";
+        public static readonly string FromFile = "fromFile";
+
+        public static readonly string FromPEM = "fromPEM";
 
         public static readonly string FromStorage = "fromStorage";
 

--- a/src/NuGet.Core/NuGet.Protocol/ClientCertificates.cs
+++ b/src/NuGet.Core/NuGet.Protocol/ClientCertificates.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
+
+namespace NuGet.Protocol.Core.Types
+{
+    public static class ClientCertificates
+    {
+        #region Static members
+
+        /// <summary>
+        ///     Setup http client handler with stored client certificates
+        /// </summary>
+        /// <param name="httpClientHandler">Http client handler</param>
+        public static void SetupClientHandler(HttpClientHandler httpClientHandler)
+        {
+            if (httpClientHandler == null) throw new ArgumentNullException(nameof(httpClientHandler));
+            httpClientHandler.ClientCertificates.AddRange(Certificates);
+        }
+
+        /// <summary>
+        ///     Store client certificates which will be set to http clients
+        /// </summary>
+        /// <param name="certificates"></param>
+        public static void Store(IEnumerable<X509Certificate> certificates)
+        {
+            if (certificates == null)
+            {
+                Certificates = Enumerable.Empty<X509Certificate>().ToArray();
+            }
+            else
+            {
+                Certificates = certificates.Where(c => c != null).ToArray();
+            }
+        }
+
+        private static X509Certificate[] Certificates { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        static ClientCertificates()
+        {
+            //Default client certificates
+            Certificates = Enumerable.Empty<X509Certificate>().ToArray();
+        }
+
+        #endregion
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/ClientCertificates.cs
+++ b/src/NuGet.Core/NuGet.Protocol/ClientCertificates.cs
@@ -16,7 +16,11 @@ namespace NuGet.Protocol.Core.Types
         /// <param name="httpClientHandler">Http client handler</param>
         public static void SetupClientHandler(HttpClientHandler httpClientHandler)
         {
-            if (httpClientHandler == null) throw new ArgumentNullException(nameof(httpClientHandler));
+            if (httpClientHandler == null)
+            {
+                throw new ArgumentNullException(nameof(httpClientHandler));
+            }
+
             httpClientHandler.ClientCertificates.AddRange(Certificates);
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/ClientCertificates.cs
+++ b/src/NuGet.Core/NuGet.Protocol/ClientCertificates.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 
@@ -8,6 +7,16 @@ namespace NuGet.Protocol.Core.Types
 {
     public static class ClientCertificates
     {
+        #region Constructors
+
+        static ClientCertificates()
+        {
+            //Default client certificates
+            Certificates = new List<X509Certificate>();
+        }
+
+        #endregion
+
         #region Static members
 
         /// <summary>
@@ -21,36 +30,21 @@ namespace NuGet.Protocol.Core.Types
                 throw new ArgumentNullException(nameof(httpClientHandler));
             }
 
-            httpClientHandler.ClientCertificates.AddRange(Certificates);
+            httpClientHandler.ClientCertificates.AddRange(Certificates.ToArray());
         }
 
         /// <summary>
-        ///     Store client certificates which will be set to http clients
+        ///     Add client certificates which will be set to http clients
         /// </summary>
-        /// <param name="certificates"></param>
-        public static void Store(IEnumerable<X509Certificate> certificates)
+        /// <param name="certificate">Client certificate</param>
+        public static void Add(X509Certificate certificate)
         {
-            if (certificates == null)
-            {
-                Certificates = Enumerable.Empty<X509Certificate>().ToArray();
-            }
-            else
-            {
-                Certificates = certificates.Where(c => c != null).ToArray();
-            }
+            if (certificate == null) return;
+
+            Certificates.Add(certificate);
         }
 
-        private static X509Certificate[] Certificates { get; set; }
-
-        #endregion
-
-        #region Constructors
-
-        static ClientCertificates()
-        {
-            //Default client certificates
-            Certificates = Enumerable.Empty<X509Certificate>().ToArray();
-        }
+        private static readonly List<X509Certificate> Certificates;
 
         #endregion
     }

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
@@ -47,6 +47,9 @@ namespace NuGet.Protocol
                 AutomaticDecompression = (DecompressionMethods.GZip | DecompressionMethods.Deflate)
             };
 
+            // Setup http client handler client certificates
+            ClientCertificates.SetupClientHandler(clientHandler);
+
             // HTTP handler pipeline can be injected here, around the client handler
             HttpMessageHandler messageHandler = new ServerWarningLogHandler(clientHandler);
 


### PR DESCRIPTION
## Feature implementation

Implements: https://github.com/NuGet/Home/issues/5773

## Implementation

Details: Implemented ability to add client x509 certificates via NuGet Cli processing.

1) Internally certificates extracted from configuration items on base Command.Execute and stored as singleton inside static ClientCertificates class with ClientCertificates.Store method.
2) On any HttpHandlerResourceV3 creation internal HttpClientHandler filled with configured certificates with ClientCertificates.SetupClientHandler method.
3)Added new nuget.config configuration section **clientCertificates** which may have children of 2 types:

**fromStorage** - item for certificate import from [certificate store](https://docs.microsoft.com/en-us/dotnet/framework/wcf/feature-details/working-with-certificates#certificate-stores). Internally uses [X509Certificate2Collection.Find](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2collection.find?view=netframework-4.8#System_Security_Cryptography_X509Certificates_X509Certificate2Collection_Find_System_Security_Cryptography_X509Certificates_X509FindType_System_Object_System_Boolean_) method.
Can be configured with 4 Add item's

- Optional Key="**StoreLocation**" Value="[possible values](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.storelocation?view=netframework-4.8#fields)".  
Equals '**CurrentUser**' by default
- Optional Key="**StoreName**" Value="[possible values](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.storename?view=netframework-4.8#fields)". 
Equals '**My**' by default
- Optional Key="**FindType**" Value="[possible values](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509findtype?view=netframework-4.8#fields)". 
Equals '**FindByThumbprint**' by default
- Optional Key="**FindValue**" Value="The search criteria as an object"

- **fromFile** - item for certificate import directly from file (DER encoded x.509, Base-64 encoded x.509, PKCS)
Can be configured with 2 Add item's

- Key="**Path**" Value="Absolute or relative path to certificate file". Relative path resolve have 2 stages: first relative to configuration file origin, second relative to current application directory.
- Optional Key="**Password**" Value="Encrypted password". Password for certificate file. Encrypted in same manner as PackageSourceCredential password.

- **fromPEM** - item for certificate import directly from configuration body (Base-64 encoded x.509 in PEM format)
Can be configured with 1 optional Add item

- Items body must  be filled with [PEM](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail) (Base-64 encoded x.509 certificate). Start and end of text are trimmed from spaces and new line chars.

- Optional Key="**Password**" Value="Encrypted password". Password for certificate file. Encrypted in same manner as PackageSourceCredential password.

## Configuration example

```xml
<configuration>
...
    <clientCertificates>	
        <fromStorage name="Some key from storage">
            <!-- Optional. CurrentUser by default -->
            <add key="StoreLocation" value="CurrentUser" />
            <!-- Optional. My by default -->
            <add key="StoreName" value="My" />
            <!-- Optional. FindByThumbprint by default -->
            <add key="FindType" value="FindByThumbprint" />
            <!-- Required. -->
            <add key="FindValue" value="4894671ae5aa84840cc1079e89e82d426bc24ec6" />
        </fromStorage>
        <fromFile  name="Some key from file">
            <!-- Absolute or relative path to certificate file. -->
            <add key="Path" value=".\certificate.pfx" />
            <!-- Encrypted password -->
            <add key="Password" value="..." />
        </fromFile>
        <fromPEM  name="Some key from PEM">
-----BEGIN CERTIFICATE-----
MIIEjjCCA3agAwIBAgIJIBkBGf8AAAAPMA0GCSqGSIb3DQEBCwUAMIGzMQswCQYD
...
tJl1UvF7GWJd0yNyPVqCCnBY
-----END CERTIFICATE-----
        </fromPEM>
    </clientCertificates>
...
</configuration>
```

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Implementation must be reviewed prior test adding 
