### PR TITLE
vs/nuget/nugetaction event should properly log when the action is cancelled

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -444,6 +444,8 @@ namespace NuGet.PackageManagement.UI
                         packageCount,
                         duration.TotalSeconds);
 
+                    actionTelemetryEvent.AddPiiData("internal.test.key.mattev", "internal.test.value.mattev");
+
                     TelemetryActivity.EmitTelemetryEvent(actionTelemetryEvent);
                 }
             }, token);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -314,8 +314,6 @@ namespace NuGet.PackageManagement.UI
             var startTime = DateTimeOffset.Now;
             var packageCount = 0;
 
-            IDictionary<string, object> additionalTelemetryProperties = new Dictionary<string, object>();
-
             bool continueAfterPreview = true;
             bool acceptedLicense = true;
 
@@ -350,9 +348,6 @@ namespace NuGet.PackageManagement.UI
                         {
                             var addCount = results.SelectMany(result => result.Added).
                                 Select(package => package.Id).Distinct().Count();
-
-                            var packageIds = results.SelectMany(result => result.Added).Select(package => package.Id).Distinct().OrderBy(x => x);
-                            additionalTelemetryProperties.Add("AddedPackages", string.Join(", ", packageIds));
 
                             var updateCount = results.SelectMany(result => result.Updated).
                                 Select(result => result.New.Id).Distinct().Count();
@@ -477,16 +472,6 @@ namespace NuGet.PackageManagement.UI
                     {
                         actionTelemetryEvent["AcceptedLicense"] = "False";
                     }
-
-                    // we exposed some helpful telemetry properties during processing
-                    if (additionalTelemetryProperties != null && additionalTelemetryProperties.Count > 0)
-                    {
-                        foreach (var property in additionalTelemetryProperties)
-                        {
-                            actionTelemetryEvent[property.Key] = property.Value;
-                        }
-                    }
-
 
                     TelemetryActivity.EmitTelemetryEvent(actionTelemetryEvent);
                 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8782 
Regression: Yes/No  No
* Last working version:   Unknown
* How are we preventing it in future:   Unknown

## Fix

Details: Set condition variables when different user cancel gestures are taken.  In the finally block, before generating the telemetry event, check and set cancel status appropriately

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Didn't see other VS UI telemetry tests
Validation:  manual testing under debugger and with telemetry monitor running
