### PR TITLE
Use string comparison type based on OS before throwing ErrorUnsafePackageEntry exception

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -550,7 +550,8 @@ namespace NuGet.Packaging
                 throw new UnsafePackageEntryException(string.Format(
                     CultureInfo.CurrentCulture,
                     Strings.ErrorUnsafePackageEntry,
-                    packageIdentity));
+                    packageIdentity,
+                    normalizedFilePath));
             }
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -545,7 +545,7 @@ namespace NuGet.Packaging
             // Destination and filePath must be normalized.
             var fullPath = Path.GetFullPath(Path.Combine(normalizedDestination, normalizedFilePath));
 
-            if(!fullPath.StartsWith(normalizedDestination, StringComparison.Ordinal) || fullPath.Length == normalizedDestination.Length)
+            if(!fullPath.StartsWith(normalizedDestination,PathUtility.GetStringComparisonBasedOnOS()) || fullPath.Length == normalizedDestination.Length)
             {
                 throw new UnsafePackageEntryException(string.Format(
                     CultureInfo.CurrentCulture,

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -475,7 +475,7 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package &apos;{0}&apos; contains an entry which is unsafe for extraction..
+        ///   Looks up a localized string similar to The package &apos;{0}&apos; contains an entry &apos;{1}&apos; which is unsafe for extraction..
         /// </summary>
         internal static string ErrorUnsafePackageEntry {
             get {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -700,8 +700,9 @@ Valid from:</comment>
     <value>An unexpected error occurred while checking package entries.</value>
   </data>
   <data name="ErrorUnsafePackageEntry" xml:space="preserve">
-    <value>The package '{0}' contains an entry which is unsafe for extraction.</value>
-    <comment>{0} is the package identity.</comment>
+    <value>The package '{0}' contains an entry '{1}' which is unsafe for extraction.</value>
+    <comment>{0} is the package identity.
+    {1} is the package entry</comment>
   </data>
   <data name="NoRepositoryCountersignature" xml:space="preserve">
     <value>Verification settings require a repository countersignature, but the package does not have a repository countersignature.</value>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -1059,6 +1059,7 @@ namespace NuGet.Packaging.Test
                     using (var packageReader = new PackageArchiveReader(packageStream))
                     {
                         // Act & Assert
+                        //The return value of Path.GetFullPath() varies based on OS. Hence DirectoryNotFoundException is thrown instead of UnsafePackageEntryException
                         await Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await packageReader.CopyFilesAsync(
                              destination.Path.ToUpper(),
                              new[] { "readme~.txt" },

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -1059,7 +1059,7 @@ namespace NuGet.Packaging.Test
                     using (var packageReader = new PackageArchiveReader(packageStream))
                     {
                         // Act & Assert
-                        await Assert.ThrowsAsync<UnsafePackageEntryException>(async () => await packageReader.CopyFilesAsync(
+                        await Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await packageReader.CopyFilesAsync(
                              destination.Path.ToUpper(),
                              new[] { "readme~.txt" },
                              ExtractFile,

--- a/test/TestUtilities/Test.Utility/TestPackagesCore.cs
+++ b/test/TestUtilities/Test.Utility/TestPackagesCore.cs
@@ -240,6 +240,33 @@ namespace NuGet.Test.Utility
             return file;
         }
 
+        public static TempFile GetPackageCoreReaderTestPackageWithTildaInFileName()
+        {
+            var file = new TempFile();
+
+            using (var zip = new ZipArchive(File.Create(file), ZipArchiveMode.Create))
+            {
+                zip.AddEntry("lib/net45/a~c.dll", ZeroContent);
+                zip.AddEntry("lib/net45/b.dll", ZeroContent);
+
+                zip.AddEntry("Aa.nuspec", @"<?xml version=""1.0"" encoding=""utf-8""?>
+                            <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+                              <metadata minClientVersion=""1.2.3"">
+                                <id>Aa</id>
+                                <version>4.5.6</version>
+                                <authors>author</authors>
+                                <description>description</description>
+                                <packageTypes>
+                                  <packageType name=""Bb"" />
+                                  <packageType name=""Cc"" version=""7.8.9"" />
+                                </packageTypes>
+                              </metadata>
+                            </package>", Encoding.UTF8);
+            }
+
+            return file;
+        }
+
         public static TempFile GetPackageCoreReaderLongPathTestPackage()
         {
             var file = new TempFile();

--- a/test/TestUtilities/Test.Utility/TestPackagesCore.cs
+++ b/test/TestUtilities/Test.Utility/TestPackagesCore.cs
@@ -240,33 +240,6 @@ namespace NuGet.Test.Utility
             return file;
         }
 
-        public static TempFile GetPackageCoreReaderTestPackageWithTildaInFileName()
-        {
-            var file = new TempFile();
-
-            using (var zip = new ZipArchive(File.Create(file), ZipArchiveMode.Create))
-            {
-                zip.AddEntry("lib/net45/a~c.dll", ZeroContent);
-                zip.AddEntry("lib/net45/b.dll", ZeroContent);
-
-                zip.AddEntry("Aa.nuspec", @"<?xml version=""1.0"" encoding=""utf-8""?>
-                            <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
-                              <metadata minClientVersion=""1.2.3"">
-                                <id>Aa</id>
-                                <version>4.5.6</version>
-                                <authors>author</authors>
-                                <description>description</description>
-                                <packageTypes>
-                                  <packageType name=""Bb"" />
-                                  <packageType name=""Cc"" version=""7.8.9"" />
-                                </packageTypes>
-                              </metadata>
-                            </package>", Encoding.UTF8);
-            }
-
-            return file;
-        }
-
         public static TempFile GetPackageCoreReaderLongPathTestPackage()
         {
             var file = new TempFile();


### PR DESCRIPTION
## Bug

Fixes:  /NuGet/Home#7505
Regression: No

## Fix

Details: As per this [doc](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#short-vs-long-names) it is valid to have `~` char in file names. If a file name contains `~` char and it's length is <=8 chars then windows performs a disk access to get the 8.3 form of a long file name. If the casing is different between input path parameter and output then the current implementation treats package file as unsafe for extraction. Windows and Mac OS performs case insensitive comparison where as Linux perform case sensitive comparison while accessing paths. Hence modified NuGet code to decide the string comparison approach at run time based on the OS. Appended file name to the error message for better user experience.

## Testing/Validation

Tests Added: Yes