### PR TITLE
Move NuGet.Configuration.ISettings type initialization to a thread pool thread

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/ExtensibleSourceRepositoryProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/ExtensibleSourceRepositoryProvider.cs
@@ -10,6 +10,9 @@ using NuGet.Configuration;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.VisualStudio;
+using Microsoft.VisualStudio.Threading;
+using NuGet.VisualStudio;
+using System.Threading.Tasks;
 
 namespace NuGet.PackageManagement.VisualStudio
 {


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8675  
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: The realization of MEF components during initialization of `NuGet.Configuration.Settings` is offloaded from UI thread to improve UI responsiveness.@AArnott mentioned following important points in an offline conversation.
-`MEF parts are not supposed to have any thread affinity, so moving the realization of exports to a background thread can move all the disk I/O from assembly loads, JIT time, and other non-UI code to a background thread and could dramatically reduce the UI delay.`
-`Moving the heavyweight code that’s in the MEF activation path out of that path and into other methods that can be made asynchronous.`

Working with Roslyn team to further improve UI responsiveness based on above guidance.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  UI delay fix.
Validation:  Compared `PerfView` traces before and after the fix. Observed improvement in the performance as few dll(s) were loaded by MEF components in a background thread improving UI responsiveness.
