### PR TITLE
Pack:  fix default exclusion and improve performance

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/PackCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/PackCommandRunnerTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using NuGet.Common;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class PackCommandRunnerTests
+    {
+        [Fact]
+        public void BuildPackage_WithDefaultExcludes_ExcludesDefaultExcludes()
+        {
+            using (var test = DefaultExclusionsTest.Create())
+            {
+                var args = new PackArgs()
+                {
+                    CurrentDirectory = test.CurrentDirectory.FullName,
+                    Exclude = Enumerable.Empty<string>(),
+                    Logger = NullLogger.Instance,
+                    Path = test.NuspecFile.FullName
+                };
+                var runner = new PackCommandRunner(args, createProjectFactory: null);
+
+                runner.BuildPackage();
+
+                using (FileStream stream = test.NupkgFile.OpenRead())
+                using (var package = new ZipArchive(stream, ZipArchiveMode.Read))
+                {
+                    foreach (string unexpectedEntryName in test.UnexpectedEntryNames)
+                    {
+                        Assert.Equal(0, package.Entries.Count(entry => entry.Name == unexpectedEntryName));
+                    }
+
+                    foreach (string expectedEntryName in test.ExpectedEntryNames)
+                    {
+                        Assert.Equal(1, package.Entries.Count(entry => entry.Name == expectedEntryName));
+                    }
+                }
+            }
+        }
+
+        private sealed class DefaultExclusionsTest : IDisposable
+        {
+            private readonly TestDirectory _testDirectory;
+
+            internal DirectoryInfo CurrentDirectory { get; }
+            internal FileInfo NupkgFile { get; }
+            internal FileInfo NuspecFile { get; }
+            internal IEnumerable<string> ExpectedEntryNames { get; }
+            internal IEnumerable<string> UnexpectedEntryNames { get; }
+
+            private DefaultExclusionsTest(
+                TestDirectory testDirectory,
+                DirectoryInfo currentDirectory,
+                FileInfo nuspecFile,
+                FileInfo nupkgFile,
+                IEnumerable<string> expectedEntryNames,
+                IEnumerable<string> unexpectedEntryNames)
+            {
+                _testDirectory = testDirectory;
+                CurrentDirectory = currentDirectory;
+                NuspecFile = nuspecFile;
+                NupkgFile = nupkgFile;
+                ExpectedEntryNames = expectedEntryNames;
+                UnexpectedEntryNames = unexpectedEntryNames;
+            }
+
+            internal static DefaultExclusionsTest Create()
+            {
+                TestDirectory testDirectory = TestDirectory.Create();
+
+                var rootDirectory = new DirectoryInfo(testDirectory.Path);
+
+                DirectoryInfo packRootDirectory = rootDirectory.CreateSubdirectory("a");
+
+                string[] expectedEntryNames = new[] { ".d.e", "f.g" };
+                string[] unexpectedEntryNames = new[] { "b.nupkg", ".c" };
+
+                foreach (string entryName in expectedEntryNames.Concat(unexpectedEntryNames))
+                {
+                    File.WriteAllText(Path.Combine(packRootDirectory.FullName, entryName), string.Empty);
+                }
+
+                DirectoryInfo currentDirectory = rootDirectory.CreateSubdirectory("h");
+
+                var nuspecFile = new FileInfo(Path.Combine(currentDirectory.FullName, "i.nuspec"));
+
+                string pattern = $"..{Path.DirectorySeparatorChar}{packRootDirectory.Name}{Path.DirectorySeparatorChar}**{Path.DirectorySeparatorChar}*.*";
+
+                const string packageId = "DefaultExclusions";
+                const string packageVersion = "1.0.0";
+
+                File.WriteAllText(nuspecFile.FullName, $@"<?xml version=""1.0""?>
+<package>
+    <metadata>
+        <id>{packageId}</id>
+        <version>{packageVersion}</version>
+        <title>title</title>
+        <description>description</description>
+        <authors>author</authors>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <dependencies />
+    </metadata>
+    <files>
+        <file src=""{pattern}"" target="""" />
+    </files>   
+</package>");
+
+                var nupkgFile = new FileInfo(Path.Combine(currentDirectory.FullName, $"{packageId}.{packageVersion}.nupkg"));
+
+                return new DefaultExclusionsTest(
+                    testDirectory,
+                    currentDirectory,
+                    nuspecFile,
+                    nupkgFile,
+                    expectedEntryNames.Prepend($"{packageId}.nuspec"),
+                    unexpectedEntryNames);
+            }
+
+            public void Dispose()
+            {
+                _testDirectory.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Note:**  To focus review on functional/performance changes look at [this commit](https://github.com/NuGet/NuGet.Client/pull/3114/commits/8be9e1e0d4b73f3ae437c0405f3c17ecda37f887) in isolation.

## Bug

Fixes: https://github.com/NuGet/Home/issues/8798
Also makes progress on https://github.com/NuGet/Home/issues/5016
Regression: Yes
* Last working version:   3.5.0
* How are we preventing it in future:   adding a test

## Fix

Details: This PR improves pack performance with default exclusions (https://github.com/NuGet/Home/issues/5016).  The problem is that [recursive backtracking makes packing slow](https://github.com/NuGet/NuGet.Client/pull/1644#issuecomment-322304735).  The fix is to simplify the regular expression patterns for default exclusions to avoid complex pattern matching.

One of the default exclusion patterns was already [not working as it should](https://github.com/NuGet/Home/issues/8798), so rather than migrate a broken pattern this PR fixes it.

To demonstrate the performance improvement, I used a PowerShell script that timed execution of packing the repro in https://github.com/NuGet/Home/issues/5016 using a specific version of NuGet.exe and recorded the duration.  I tested multiple NuGet versions 101 times each and discarded each version's first attempt, since it tended to be an outlier anyway.
```PowerShell
For ($i = 0; $i -lt 101; ++$i)
{
    $elapsed = Measure-Command { .\nuget.3.5.0.exe pack -Version 3.5.0 nuget-performance-test.nuspec }

    If ($i -gt 0)
    {
        Add-Content .\log.txt "$($elapsed.TotalSeconds.ToString()),3.5.0"
    }
}
```
Results:

Version | Average | 95th Percentile
-- | -- | --
3.5.0 | 2.38677 | 3.0592
4.1.0 | 4.06877 | 4.49155
5.3.0 | 4.50423 | 4.7177
5.5.x | 3.12323 | 3.4116

## Testing/Validation

Tests Added: Yes