### PR TITLE
Refactor logic in _GetRestoreProjectStyle target to a task

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectStyleTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectStyleTask.cs
@@ -18,6 +18,9 @@ namespace NuGet.Build.Tasks
         /// </summary>
         public bool HasPackageReferenceItems { get; set; }
 
+        [Output]
+        public bool IsPackageReferenceCompatibleProjectStyle { get; set; }
+
         /// <summary>
         /// Gets or sets the full path to the project directory.
         /// </summary>
@@ -29,9 +32,6 @@ namespace NuGet.Build.Tasks
         /// </summary>
         [Required]
         public string MSBuildProjectName { get; set; }
-
-        [Output]
-        public bool PackageReferenceCompatibleProjectStyle { get; set; }
 
         /// <summary>
         /// The path to a project.json file.
@@ -62,11 +62,11 @@ namespace NuGet.Build.Tasks
 
             var result = MSBuildRestoreUtility.GetProjectRestoreStyle(RestoreProjectStyle, HasPackageReferenceItems, ProjectJsonPath, MSBuildProjectDirectory, MSBuildProjectName, log);
 
-            PackageReferenceCompatibleProjectStyle = result.PackageReferenceCompatibleProjectStyle;
+            IsPackageReferenceCompatibleProjectStyle = result.IsPackageReferenceCompatibleProjectStyle;
             ProjectStyle = result.ProjectStyle;
 
             // Log Outputs
-            BuildTasksUtility.LogOutputParam(log, nameof(PackageReferenceCompatibleProjectStyle), PackageReferenceCompatibleProjectStyle.ToString());
+            BuildTasksUtility.LogOutputParam(log, nameof(IsPackageReferenceCompatibleProjectStyle), IsPackageReferenceCompatibleProjectStyle.ToString());
             BuildTasksUtility.LogOutputParam(log, nameof(ProjectStyle), ProjectStyle.ToString());
 
             return !Log.HasLoggedErrors;

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectStyleTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectStyleTask.cs
@@ -62,8 +62,11 @@ namespace NuGet.Build.Tasks
 
             var result = MSBuildRestoreUtility.GetProjectRestoreStyle(RestoreProjectStyle, HasPackageReferenceItems, ProjectJsonPath, MSBuildProjectDirectory, MSBuildProjectName, log);
 
-            IsPackageReferenceCompatibleProjectStyle = result.IsPackageReferenceCompatibleProjectStyle;
-            ProjectStyle = result.ProjectStyle;
+            if (result != null)
+            {
+                IsPackageReferenceCompatibleProjectStyle = result.Value.IsPackageReferenceCompatibleProjectStyle;
+                ProjectStyle = result.Value.ProjectStyle;
+            }
 
             // Log Outputs
             BuildTasksUtility.LogOutputParam(log, nameof(IsPackageReferenceCompatibleProjectStyle), IsPackageReferenceCompatibleProjectStyle.ToString());

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectStyleTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectStyleTask.cs
@@ -1,0 +1,82 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.IO;
+using Microsoft.Build.Framework;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.ProjectModel;
+using ILogger = NuGet.Common.ILogger;
+using Task = Microsoft.Build.Utilities.Task;
+
+namespace NuGet.Build.Tasks
+{
+    /// <summary>
+    /// Gets the project style.
+    /// </summary>
+    public sealed class GetRestoreProjectStyleTask : Task
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether or not the project has any PackageReference items.
+        /// </summary>
+        [Required]
+        public bool HasPackageReferenceItems { get; set; }
+
+        /// <summary>
+        /// Gets or sets the full path to the project directory.
+        /// </summary>
+        [Required]
+        public string MSBuildProjectDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the project file.
+        /// </summary>
+        [Required]
+        public string MSBuildProjectName { get; set; }
+
+        [Output]
+        public bool PackageReferenceCompatibleProjectStyle { get; set; }
+
+        /// <summary>
+        /// The path to a project.json file.
+        /// </summary>
+        public string ProjectJsonPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="NuGet.ProjectModel.ProjectStyle"/> of the project.
+        /// </summary>
+        [Output]
+        public ProjectStyle ProjectStyle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user specified project style of the project.
+        /// </summary>
+        public string RestoreProjectStyle { get; set; }
+
+        public override bool Execute()
+        {
+            var log = new MSBuildLogger(Log);
+
+            // Log Inputs
+            BuildTasksUtility.LogInputParam(log, nameof(HasPackageReferenceItems), HasPackageReferenceItems.ToString());
+            BuildTasksUtility.LogInputParam(log, nameof(MSBuildProjectDirectory), MSBuildProjectDirectory);
+            BuildTasksUtility.LogInputParam(log, nameof(MSBuildProjectName), MSBuildProjectName);
+            BuildTasksUtility.LogInputParam(log, nameof(ProjectJsonPath), ProjectJsonPath);
+            BuildTasksUtility.LogInputParam(log, nameof(RestoreProjectStyle), RestoreProjectStyle);
+
+            var result = MSBuildRestoreUtility.GetProjectRestoreStyle(RestoreProjectStyle, HasPackageReferenceItems, ProjectJsonPath, MSBuildProjectDirectory, MSBuildProjectName, log);
+
+            PackageReferenceCompatibleProjectStyle = result.PackageReferenceCompatibleProjectStyle;
+            ProjectStyle = result.ProjectStyle;
+
+            // Log Outputs
+            BuildTasksUtility.LogOutputParam(log, nameof(PackageReferenceCompatibleProjectStyle), PackageReferenceCompatibleProjectStyle.ToString());
+            BuildTasksUtility.LogOutputParam(log, nameof(ProjectStyle), ProjectStyle.ToString());
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectStyleTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectStyleTask.cs
@@ -1,15 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Globalization;
-using System.IO;
 using Microsoft.Build.Framework;
 using NuGet.Commands;
-using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.ProjectModel;
-using ILogger = NuGet.Common.ILogger;
 using Task = Microsoft.Build.Utilities.Task;
 
 namespace NuGet.Build.Tasks
@@ -22,7 +16,6 @@ namespace NuGet.Build.Tasks
         /// <summary>
         /// Gets or sets a value indicating whether or not the project has any PackageReference items.
         /// </summary>
-        [Required]
         public bool HasPackageReferenceItems { get; set; }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectStyleTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectStyleTask.cs
@@ -72,7 +72,7 @@ namespace NuGet.Build.Tasks
             BuildTasksUtility.LogOutputParam(log, nameof(IsPackageReferenceCompatibleProjectStyle), IsPackageReferenceCompatibleProjectStyle.ToString());
             BuildTasksUtility.LogOutputParam(log, nameof(ProjectStyle), ProjectStyle.ToString());
 
-            return !Log.HasLoggedErrors;
+            return result != null;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -102,6 +102,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreSettingsTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.WarnForInvalidProjectsTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetReferenceNearestTargetFrameworkTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
+  <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreProjectStyleTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
 
   <!--
     ============================================================
@@ -429,20 +430,15 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_GetRestoreProjectStyle"
     DependsOnTargets="_GetProjectJsonPath;CollectPackageReferences"
     Returns="$(RestoreProjectStyle);$(PackageReferenceCompatibleProjectStyle)">
-    <!-- This may be overridden by setting RestoreProjectStyle in the project. -->
-    <PropertyGroup>
-      <!-- If any PackageReferences exist treat it as PackageReference. This has priority over project.json. -->
-      <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND @(PackageReference) != '' ">PackageReference</RestoreProjectStyle>
-      <!-- If this is not a PackageReference project check if project.json or projectName.project.json exists. -->
-      <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND '$(_CurrentProjectJsonPath)' != '' ">ProjectJson</RestoreProjectStyle>
-      <!-- If this is not a PackageReference or ProjectJson project check if packages.config or packages.ProjectName.config exists -->
-      <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND (Exists('$(MSBuildProjectDirectory)\packages.config') Or Exists('$(MSBuildProjectDirectory)\packages.$(MSBuildProjectName).config'))">PackagesConfig</RestoreProjectStyle>
-      <!-- This project is either a packages.config project or one that does not use NuGet at all. -->
-      <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' ">Unknown</RestoreProjectStyle>
-    </PropertyGroup>
-    <PropertyGroup>
-      <PackageReferenceCompatibleProjectStyle Condition="  '$(RestoreProjectStyle)' == 'PackageReference' OR '$(RestoreProjectStyle)' == 'DotnetToolReference' ">true</PackageReferenceCompatibleProjectStyle>
-    </PropertyGroup>
+    <GetRestoreProjectStyleTask
+      HasPackageReferenceItems="@(PackageReference->Count()) > 0"
+      MSBuildProjectDirectory="$(MSBuildProjectDirectory)"
+      MSBuildProjectName="$(MSBuildProjectName)"
+      ProjectJsonPath="$(_CurrentProjectJsonPath)"
+      RestoreProjectStyle="$(RestoreProjectStyle)">
+        <Output TaskParameter="ProjectStyle" PropertyName="RestoreProjectStyle" />
+        <Output TaskParameter="PackageReferenceCompatibleProjectStyle" PropertyName="PackageReferenceCompatibleProjectStyle" />
+    </GetRestoreProjectStyleTask>
   </Target>
 
   <!--

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -430,8 +430,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_GetRestoreProjectStyle"
     DependsOnTargets="_GetProjectJsonPath;CollectPackageReferences"
     Returns="$(RestoreProjectStyle);$(PackageReferenceCompatibleProjectStyle)">
+    <PropertyGroup>
+      <_HasPackageReferenceItems Condition="@(PackageReference->Count()) > 0">true</_HasPackageReferenceItems>
+    </PropertyGroup>
+
     <GetRestoreProjectStyleTask
-      HasPackageReferenceItems="@(PackageReference->Count()) > 0"
+      HasPackageReferenceItems="$(_HasPackageReferenceItems)"
       MSBuildProjectDirectory="$(MSBuildProjectDirectory)"
       MSBuildProjectName="$(MSBuildProjectName)"
       ProjectJsonPath="$(_CurrentProjectJsonPath)"
@@ -439,6 +443,10 @@ Copyright (c) .NET Foundation. All rights reserved.
         <Output TaskParameter="ProjectStyle" PropertyName="RestoreProjectStyle" />
         <Output TaskParameter="PackageReferenceCompatibleProjectStyle" PropertyName="PackageReferenceCompatibleProjectStyle" />
     </GetRestoreProjectStyleTask>
+
+    <PropertyGroup>
+      <_HasPackageReferenceItems />
+    </PropertyGroup>
   </Target>
 
   <!--

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -441,7 +441,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ProjectJsonPath="$(_CurrentProjectJsonPath)"
       RestoreProjectStyle="$(RestoreProjectStyle)">
         <Output TaskParameter="ProjectStyle" PropertyName="RestoreProjectStyle" />
-        <Output TaskParameter="PackageReferenceCompatibleProjectStyle" PropertyName="PackageReferenceCompatibleProjectStyle" />
+        <Output TaskParameter="IsPackageReferenceCompatibleProjectStyle" PropertyName="PackageReferenceCompatibleProjectStyle" />
     </GetRestoreProjectStyleTask>
 
     <PropertyGroup>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -930,7 +930,7 @@ namespace NuGet.Commands
         /// <param name="projectName">The name of the project file.</param>
         /// <param name="log">An <see cref="ILogger"/> object used to log messages.</param>
         /// <returns>A <see cref="Tuple{ProjectStyle, bool}"/> containing the project style and a value indicating if the project is using a style that is compatible with PackageReference.</returns>
-        public static (ProjectStyle ProjectStyle, bool PackageReferenceCompatibleProjectStyle) GetProjectRestoreStyle(string restoreProjectStyle, bool hasPackageReferenceItems, string projectJsonPath, string projectDirectory, string projectName, ILogger log)
+        public static (ProjectStyle ProjectStyle, bool IsPackageReferenceCompatibleProjectStyle) GetProjectRestoreStyle(string restoreProjectStyle, bool hasPackageReferenceItems, string projectJsonPath, string projectDirectory, string projectName, ILogger log)
         {
             ProjectStyle projectStyle = ProjectStyle.Unknown;
 
@@ -965,9 +965,9 @@ namespace NuGet.Commands
                 projectStyle = ProjectStyle.Unknown;
             }
 
-            bool packageReferenceCompatibleProjectStyle = projectStyle == ProjectStyle.PackageReference || projectStyle == ProjectStyle.DotnetToolReference;
+            bool isPackageReferenceCompatibleProjectStyle = projectStyle == ProjectStyle.PackageReference || projectStyle == ProjectStyle.DotnetToolReference;
 
-            return (projectStyle, packageReferenceCompatibleProjectStyle);
+            return (projectStyle, isPackageReferenceCompatibleProjectStyle);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -929,8 +929,9 @@ namespace NuGet.Commands
         /// <param name="projectDirectory">The full path to the project directory.</param>
         /// <param name="projectName">The name of the project file.</param>
         /// <param name="log">An <see cref="ILogger"/> object used to log messages.</param>
-        /// <returns>A <see cref="Tuple{ProjectStyle, bool}"/> containing the project style and a value indicating if the project is using a style that is compatible with PackageReference.</returns>
-        public static (ProjectStyle ProjectStyle, bool IsPackageReferenceCompatibleProjectStyle) GetProjectRestoreStyle(string restoreProjectStyle, bool hasPackageReferenceItems, string projectJsonPath, string projectDirectory, string projectName, ILogger log)
+        /// <returns>A <see cref="Tuple{ProjectStyle, bool}"/> containing the project style and a value indicating if the project is using a style that is compatible with PackageReference.
+        /// If the value of <paramref name="restoreProjectStyle"/> is not empty and could not be parsed, <code>null</code> is returned.</returns>
+        public static (ProjectStyle ProjectStyle, bool IsPackageReferenceCompatibleProjectStyle)? GetProjectRestoreStyle(string restoreProjectStyle, bool hasPackageReferenceItems, string projectJsonPath, string projectDirectory, string projectName, ILogger log)
         {
             ProjectStyle projectStyle = ProjectStyle.Unknown;
 
@@ -940,6 +941,8 @@ namespace NuGet.Commands
                 if (!Enum.TryParse(restoreProjectStyle, ignoreCase: true, out ProjectStyle userSuppliedProjectStyle))
                 {
                     log.Log(LogMessage.CreateError(NuGetLogCode.NU1008, string.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidProjectRestoreStyle, restoreProjectStyle)));
+
+                    return null;
                 }
 
                 projectStyle = userSuppliedProjectStyle;
@@ -954,7 +957,7 @@ namespace NuGet.Commands
                 // If this is not a PackageReference project check if project.json or projectName.project.json exists.
                 projectStyle = ProjectStyle.ProjectJson;
             }
-            else if (MSBuildRestoreUtility.ProjectHasPackagesConfigFile(projectDirectory, projectName))
+            else if (ProjectHasPackagesConfigFile(projectDirectory, projectName))
             {
                 // If this is not a PackageReference or ProjectJson project check if packages.config or packages.ProjectName.config exists
                 projectStyle = ProjectStyle.PackagesConfig;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -937,7 +937,7 @@ namespace NuGet.Commands
             // Allow a user to override by setting RestoreProjectStyle in the project.
             if (!string.IsNullOrWhiteSpace(restoreProjectStyle))
             {
-                if (!Enum.TryParse(restoreProjectStyle, out ProjectStyle userSuppliedProjectStyle))
+                if (!Enum.TryParse(restoreProjectStyle, ignoreCase: true, out ProjectStyle userSuppliedProjectStyle))
                 {
                     log.Log(LogMessage.CreateError(NuGetLogCode.NU1008, string.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidProjectRestoreStyle, restoreProjectStyle)));
                 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -919,5 +919,80 @@ namespace NuGet.Commands
 
             return logger.LogMessagesAsync(logMessages);
         }
+
+        /// <summary>
+        /// Determines the restore style of a project.
+        /// </summary>
+        /// <param name="restoreProjectStyle">An optional user supplied restore style.</param>
+        /// <param name="hasPackageReferenceItems">A <see cref="bool"/> indicating whether or not the project has any PackageReference items.</param>
+        /// <param name="projectJsonPath">An optional path to the project's project.json file.</param>
+        /// <param name="projectDirectory">The full path to the project directory.</param>
+        /// <param name="projectName">The name of the project file.</param>
+        /// <param name="log">An <see cref="ILogger"/> object used to log messages.</param>
+        /// <returns>A <see cref="Tuple{ProjectStyle, bool}"/> containing the project style and a value indicating if the project is using a style that is compatible with PackageReference.</returns>
+        public static (ProjectStyle ProjectStyle, bool PackageReferenceCompatibleProjectStyle) GetProjectRestoreStyle(string restoreProjectStyle, bool hasPackageReferenceItems, string projectJsonPath, string projectDirectory, string projectName, ILogger log)
+        {
+            ProjectStyle projectStyle = ProjectStyle.Unknown;
+
+            // Allow a user to override by setting RestoreProjectStyle in the project.
+            if (!string.IsNullOrWhiteSpace(restoreProjectStyle))
+            {
+                if (!Enum.TryParse(restoreProjectStyle, out ProjectStyle userSuppliedProjectStyle))
+                {
+                    log.Log(LogMessage.CreateError(NuGetLogCode.NU1008, string.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidProjectRestoreStyle, restoreProjectStyle)));
+                }
+
+                projectStyle = userSuppliedProjectStyle;
+            }
+            else if (hasPackageReferenceItems)
+            {
+                // If any PackageReferences exist treat it as PackageReference. This has priority over project.json.
+                projectStyle = ProjectStyle.PackageReference;
+            }
+            else if (!string.IsNullOrWhiteSpace(projectJsonPath))
+            {
+                // If this is not a PackageReference project check if project.json or projectName.project.json exists.
+                projectStyle = ProjectStyle.ProjectJson;
+            }
+            else if (MSBuildRestoreUtility.ProjectHasPackagesConfigFile(projectDirectory, projectName))
+            {
+                // If this is not a PackageReference or ProjectJson project check if packages.config or packages.ProjectName.config exists
+                projectStyle = ProjectStyle.PackagesConfig;
+            }
+            else
+            {
+                // This project is either a packages.config project or one that does not use NuGet at all.
+                projectStyle = ProjectStyle.Unknown;
+            }
+
+            bool packageReferenceCompatibleProjectStyle = projectStyle == ProjectStyle.PackageReference || projectStyle == ProjectStyle.DotnetToolReference;
+
+            return (projectStyle, packageReferenceCompatibleProjectStyle);
+        }
+
+        /// <summary>
+        /// Determines if the project has a packages.config file.
+        /// </summary>
+        /// <param name="projectDirectory">The full path of the project directory.</param>
+        /// <param name="projectName">The name of the project file.</param>
+        /// <returns><code>true</code> if a packages.config exists next to the project, otherwise <code>false</code>.</returns>
+        private static bool ProjectHasPackagesConfigFile(string projectDirectory, string projectName)
+        {
+            string packagesConfigPath = Path.Combine(projectDirectory, NuGetConstants.PackageReferenceFile);
+
+            if (File.Exists(packagesConfigPath))
+            {
+                return true;
+            }
+
+            packagesConfigPath = Path.Combine(projectDirectory, $"packages.{projectName}.config");
+
+            if (File.Exists(packagesConfigPath))
+            {
+                return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -295,6 +295,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid project restore style &apos;{0}&apos;..
+        /// </summary>
+        internal static string Error_InvalidProjectRestoreStyle {
+            get {
+                return ResourceManager.GetString("Error_InvalidProjectRestoreStyle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The provided SymbolPackageFormat value {0} is invalid. Allowed values : &apos;snupkg&apos;, &apos;symbols.nupkg&apos;..
         /// </summary>
         internal static string Error_InvalidSymbolPackageFormat {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -896,4 +896,8 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <value>Package content hash validation failed for {0}. Expected: {1} Actual: {2}</value>
     <comment>0 - package ID, 1 - expected Sha, 2 - actual sha</comment>
   </data>
+  <data name="Error_InvalidProjectRestoreStyle" xml:space="preserve">
+    <value>Invalid project restore style '{0}'.</value>
+    <comment>0 - User specified restore project style</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -80,6 +80,11 @@ namespace NuGet.Common
         NU1007 = 1007,
 
         /// <summary>
+        /// Project style specified is not a valid value.
+        /// </summary>
+        NU1008 = 1008,
+
+        /// <summary>
         /// Unable to resolve package, generic message for unknown type constraints.
         /// </summary>
         NU1100 = 1100,

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreProjectStyleTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreProjectStyleTaskTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
@@ -15,7 +16,7 @@ namespace NuGet.Build.Tasks.Test
     public class GetRestoreProjectStyleTaskTests
     {
         [Fact]
-        public void GetRestoreProjectStyleTask_WhenInvalidProjectStyleSupplied_LogsError()
+        public void Execute_WhenInvalidProjectStyleSupplied_LogsError()
         {
             var buildEngine = new TestBuildEngine();
             var testLogger = buildEngine.TestLogger;
@@ -28,11 +29,11 @@ namespace NuGet.Build.Tasks.Test
 
             task.Execute().Should().BeFalse();
 
-            testLogger.ErrorMessages.Should().ContainSingle().Which.Should().Be("Invalid project restore style 'Invalid'.");
+            testLogger.LogMessages.Should().Contain(i => i.Code == NuGetLogCode.NU1008 && i.Message == "Invalid project restore style 'Invalid'.");
         }
 
         [Fact]
-        public void GetRestoreProjectStyleTask_WhenNothingMatches_ReturnsUnknown()
+        public void Execute_WhenNothingMatches_ReturnsUnknown()
         {
             var buildEngine = new TestBuildEngine();
 
@@ -53,7 +54,7 @@ namespace NuGet.Build.Tasks.Test
         }
 
         [Fact]
-        public void GetRestoreProjectStyleTask_WhenProjectHasPackageReferenceItems_ReturnsPackageReference()
+        public void Execute_WhenProjectHasPackageReferenceItems_ReturnsPackageReference()
         {
             var buildEngine = new TestBuildEngine();
 
@@ -72,7 +73,7 @@ namespace NuGet.Build.Tasks.Test
         [Theory]
         [InlineData("packages.config")]
         [InlineData("packages.ProjectA.config")]
-        public void GetRestoreProjectStyleTask_WhenProjectHasPackagesConfigFile_ReturnsPackagesConfig(string packagesConfigFileName)
+        public void Execute_WhenProjectHasPackagesConfigFile_ReturnsPackagesConfig(string packagesConfigFileName)
         {
             using (var testDirectory = TestDirectory.Create())
             {
@@ -95,7 +96,7 @@ namespace NuGet.Build.Tasks.Test
         }
 
         [Fact]
-        public void GetRestoreProjectStyleTask_WhenProjectJsonPathSpecified_ReturnsProjectJson()
+        public void Execute_WhenProjectJsonPathSpecified_ReturnsProjectJson()
         {
             var buildEngine = new TestBuildEngine();
 
@@ -112,7 +113,7 @@ namespace NuGet.Build.Tasks.Test
         }
 
         [Fact]
-        public void GetRestoreProjectStyleTask_WhenProjectStyleSupplied_ReturnsSuppliedProjectStyle()
+        public void Execute_WhenProjectStyleSupplied_ReturnsSuppliedProjectStyle()
         {
             foreach (var lowerCase in new[] { true, false })
             {
@@ -142,7 +143,7 @@ namespace NuGet.Build.Tasks.Test
         }
 
         [Fact]
-        public void GetRestoreProjectStyleTask_WhenUserSuppliedValueOverridesDefault_ReturnsUserSuppliedProjectStyle()
+        public void Execute_WhenUserSuppliedValueOverridesDefault_ReturnsUserSuppliedProjectStyle()
         {
             var expected = ProjectStyle.Standalone;
 

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreProjectStyleTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreProjectStyleTaskTests.cs
@@ -1,0 +1,169 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using NuGet.Configuration;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Build.Tasks.Test
+{
+    public class GetRestoreProjectStyleTaskTests
+    {
+        [Fact]
+        public void GetRestoreProjectStyleTask_CanDetectPackageReference()
+        {
+            var buildEngine = new TestBuildEngine();
+
+            var task = new GetRestoreProjectStyleTask
+            {
+                BuildEngine = buildEngine,
+                HasPackageReferenceItems = true
+            };
+
+            task.Execute().Should().BeTrue();
+
+            task.ProjectStyle.Should().Be(ProjectStyle.PackageReference);
+            task.PackageReferenceCompatibleProjectStyle.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("packages.config")]
+        [InlineData("packages.ProjectA.config")]
+        public void GetRestoreProjectStyleTask_CanDetectPackagesConfig(string packagesConfigFileName)
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                File.WriteAllText(Path.Combine(testDirectory, packagesConfigFileName), string.Empty);
+
+                var buildEngine = new TestBuildEngine();
+
+                var task = new GetRestoreProjectStyleTask
+                {
+                    BuildEngine = buildEngine,
+                    MSBuildProjectDirectory = testDirectory,
+                    MSBuildProjectName = "ProjectA"
+                };
+
+                task.Execute().Should().BeTrue();
+
+                task.ProjectStyle.Should().Be(ProjectStyle.PackagesConfig);
+                task.PackageReferenceCompatibleProjectStyle.Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public void GetRestoreProjectStyleTask_CanDetectProjectJson()
+        {
+            var buildEngine = new TestBuildEngine();
+
+            var task = new GetRestoreProjectStyleTask
+            {
+                BuildEngine = buildEngine,
+                ProjectJsonPath = "SomePath"
+            };
+
+            task.Execute().Should().BeTrue();
+
+            task.ProjectStyle.Should().Be(ProjectStyle.ProjectJson);
+            task.PackageReferenceCompatibleProjectStyle.Should().BeFalse();
+        }
+
+        [Fact]
+        public void GetRestoreProjectStyleTask_CanParseExistingProjectStyle()
+        {
+            foreach (var projectStyle in Enum.GetValues(typeof(ProjectStyle)).Cast<ProjectStyle>())
+            {
+                var buildEngine = new TestBuildEngine();
+
+                var task = new GetRestoreProjectStyleTask
+                {
+                    BuildEngine = buildEngine,
+                    RestoreProjectStyle = projectStyle.ToString()
+                };
+
+                task.Execute().Should().BeTrue();
+
+                task.ProjectStyle.Should().Be(projectStyle);
+                if (projectStyle == ProjectStyle.PackageReference || projectStyle == ProjectStyle.DotnetToolReference)
+                {
+                    task.PackageReferenceCompatibleProjectStyle.Should().BeTrue();
+                }
+                else
+                {
+                    task.PackageReferenceCompatibleProjectStyle.Should().BeFalse();
+                }
+            }
+        }
+
+        [Fact]
+        public void GetRestoreProjectStyleTask_DefaultsToUnknown()
+        {
+            var buildEngine = new TestBuildEngine();
+
+            var task = new GetRestoreProjectStyleTask
+            {
+                BuildEngine = buildEngine,
+                RestoreProjectStyle = string.Empty,
+                ProjectJsonPath = string.Empty,
+                HasPackageReferenceItems = false,
+                MSBuildProjectName = "ProjectA",
+                MSBuildProjectDirectory = "SomeDirectory"
+            };
+
+            task.Execute().Should().BeTrue();
+
+            task.ProjectStyle.Should().Be(ProjectStyle.Unknown);
+            task.PackageReferenceCompatibleProjectStyle.Should().BeFalse();
+        }
+
+        [Fact]
+        public void GetRestoreProjectStyleTask_LogsErrorWhenInvalidRestoreStyleSpecified()
+        {
+            var buildEngine = new TestBuildEngine();
+            var testLogger = buildEngine.TestLogger;
+
+            var task = new GetRestoreProjectStyleTask
+            {
+                BuildEngine = buildEngine,
+                RestoreProjectStyle = "Invalid"
+            };
+
+            task.Execute().Should().BeFalse();
+
+            testLogger.ErrorMessages.Should().ContainSingle().Which.Should().Be("Invalid project restore style 'Invalid'.");
+        }
+
+        [Fact]
+        public void GetRestoreProjectStyleTask_UserSpecifiedValueOverridesDetectedValue()
+        {
+            var expected = ProjectStyle.Standalone;
+
+            using (var testDirectory = TestDirectory.Create())
+            {
+                File.WriteAllText(Path.Combine(testDirectory, NuGetConstants.PackageReferenceFile), string.Empty);
+
+                var buildEngine = new TestBuildEngine();
+
+                var task = new GetRestoreProjectStyleTask
+                {
+                    BuildEngine = buildEngine,
+                    RestoreProjectStyle = expected.ToString(),
+                    ProjectJsonPath = "Some value",
+                    HasPackageReferenceItems = true,
+                    MSBuildProjectName = "ProjectA",
+                    MSBuildProjectDirectory = "SomeDirectory"
+                };
+
+                task.Execute().Should().BeTrue();
+
+                task.ProjectStyle.Should().Be(expected);
+                task.PackageReferenceCompatibleProjectStyle.Should().BeFalse();
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreProjectStyleTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreProjectStyleTaskTests.cs
@@ -76,28 +76,32 @@ namespace NuGet.Build.Tasks.Test
         [Fact]
         public void GetRestoreProjectStyleTask_CanParseExistingProjectStyle()
         {
-            foreach (var projectStyle in Enum.GetValues(typeof(ProjectStyle)).Cast<ProjectStyle>())
+            foreach (var lowerCase in new [] { true, false })
             {
-                var buildEngine = new TestBuildEngine();
-
-                var task = new GetRestoreProjectStyleTask
+                foreach (var projectStyle in Enum.GetValues(typeof(ProjectStyle)).Cast<ProjectStyle>())
                 {
-                    BuildEngine = buildEngine,
-                    RestoreProjectStyle = projectStyle.ToString()
-                };
+                    var buildEngine = new TestBuildEngine();
 
-                task.Execute().Should().BeTrue();
+                    var task = new GetRestoreProjectStyleTask
+                    {
+                        BuildEngine = buildEngine,
+                        RestoreProjectStyle = lowerCase ? projectStyle.ToString().ToLower() : projectStyle.ToString()
+                    };
 
-                task.ProjectStyle.Should().Be(projectStyle);
-                if (projectStyle == ProjectStyle.PackageReference || projectStyle == ProjectStyle.DotnetToolReference)
-                {
-                    task.PackageReferenceCompatibleProjectStyle.Should().BeTrue();
-                }
-                else
-                {
-                    task.PackageReferenceCompatibleProjectStyle.Should().BeFalse();
+                    task.Execute().Should().BeTrue();
+
+                    task.ProjectStyle.Should().Be(projectStyle);
+                    if (projectStyle == ProjectStyle.PackageReference || projectStyle == ProjectStyle.DotnetToolReference)
+                    {
+                        task.PackageReferenceCompatibleProjectStyle.Should().BeTrue();
+                    }
+                    else
+                    {
+                        task.PackageReferenceCompatibleProjectStyle.Should().BeFalse();
+                    }
                 }
             }
+            
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/TestBuildEngine.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/TestBuildEngine.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections;
 using Microsoft.Build.Framework;
 using NuGet.Common;
@@ -40,9 +41,15 @@ namespace NuGet.Build.Tasks.Test
         {
             var message = new RestoreLogMessage(LogLevel.Error, e.Message)
             {
+            
                 FilePath = e.File,
                 ProjectPath = e.ProjectFile
             };
+
+            if (!string.IsNullOrWhiteSpace(e.Code) && Enum.TryParse(e.Code, ignoreCase: true, out NuGetLogCode code))
+            {
+                message.Code = code;
+            }
 
             TestLogger.Log(message);
         }
@@ -77,6 +84,11 @@ namespace NuGet.Build.Tasks.Test
                 FilePath = e.File,
                 ProjectPath = e.ProjectFile
             };
+
+            if (!string.IsNullOrWhiteSpace(e.Code) && Enum.TryParse(e.Code, ignoreCase: true, out NuGetLogCode code))
+            {
+                message.Code = code;
+            }
 
             TestLogger.Log(message);
         }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8804
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Refactor logic in _GetRestoreProjectStyle target to a task.  This will allow the logic to be reused when I use MSBuild Static Graph instead of running the targets.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
