### PR TITLE
Add an abstraction for ISettingsFile

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/ISettingsFile.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ISettingsFile.cs
@@ -1,0 +1,71 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGet.Configuration
+{
+    internal interface ISettingsFile
+    {
+        /// <summary>
+        /// Full path to the settings file
+        /// </summary>
+        string ConfigFilePath { get; }
+
+        /// <summary>
+        /// Folder under which the settings file is present
+        /// </summary>
+        string DirectoryPath { get; }
+
+        /// <summary>
+        /// Filename of the settings file
+        /// </summary>
+        string FileName { get; }
+
+        /// <summary>
+        /// Defines if the configuration settings have been changed but have not been saved to disk
+        /// </summary>
+        bool IsDirty { get; set; }
+
+        /// <summary>
+        /// Defines if the settings file is considered a machine wide settings file
+        /// </summary>
+        /// <remarks>Machine wide settings files cannot be eddited.</remarks>
+        bool IsMachineWide { get; }
+
+        SettingSection GetSection(string sectionName);
+
+        /// <summary>
+        /// Adds or updates the given <paramref name="item"/> to the settings.
+        /// </summary>
+        /// <param name="sectionName">section where the <paramref name="item"/> has to be added. If this section does not exist, one will be created.</param>
+        /// <param name="item">item to be added to the settings.</param>
+        /// <returns>true if the item was successfully updated or added in the settings</returns>
+        void AddOrUpdate(string sectionName, SettingItem item);
+
+        /// <summary>
+        /// Removes the given <paramref name="item"/> from the settings.
+        /// If the <paramref name="item"/> is the last item in the section, the section will also be removed.
+        /// </summary>
+        /// <param name="sectionName">Section where the <paramref name="item"/> is stored. If this section does not exist, the method will throw</param>
+        /// <param name="item">item to be removed from the settings</param>
+        /// <remarks> If the SettingsFile is a machine wide config this method will throw</remarks>
+        void Remove(string sectionName, SettingItem item);
+
+        /// <summary>
+        /// Flushes any in-memory updates in the SettingsFile to disk.
+        /// </summary>
+        void SaveToDisk();
+
+        bool IsEmpty();
+
+        /// <remarks>
+        /// This method gives you a reference to the actual abstraction instead of a clone of it.
+        /// It should be used only when intended. For most purposes you should be able to use
+        /// GetSection(...) instead.
+        /// </remarks>
+        bool TryGetSection(string sectionName, out SettingSection section);
+
+        void MergeSectionsInto(Dictionary<string, VirtualSettingSection> sectionsContainer);
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/AddItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/AddItem.cs
@@ -40,7 +40,7 @@ namespace NuGet.Configuration
         {
         }
 
-        internal AddItem(XElement element, SettingsFile origin)
+        internal AddItem(XElement element, ISettingsFile origin)
             : base(element, origin)
         {
         }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/AuthorItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/AuthorItem.cs
@@ -19,7 +19,7 @@ namespace NuGet.Configuration
         {
         }
 
-        internal AuthorItem(XElement element, SettingsFile origin)
+        internal AuthorItem(XElement element, ISettingsFile origin)
             : base(element, origin)
         {
         }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/CertificateItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/CertificateItem.cs
@@ -75,7 +75,7 @@ namespace NuGet.Configuration
             AddAttribute(ConfigurationConstants.AllowUntrustedRoot, allowUntrustedRoot.ToString().ToLower());
         }
 
-        internal CertificateItem(XElement element, SettingsFile origin)
+        internal CertificateItem(XElement element, ISettingsFile origin)
             : base(element, origin)
         {
             if (HashAlgorithm == HashAlgorithmName.Unknown)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/ClearItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/ClearItem.cs
@@ -16,7 +16,7 @@ namespace NuGet.Configuration
         {
         }
 
-        internal ClearItem(XElement element, SettingsFile origin)
+        internal ClearItem(XElement element, ISettingsFile origin)
             : base(element, origin)
         {
         }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/CredentialsItem.cs
@@ -144,7 +144,7 @@ namespace NuGet.Configuration
             }
         }
 
-        internal CredentialsItem(XElement element, SettingsFile origin)
+        internal CredentialsItem(XElement element, ISettingsFile origin)
             : base(element, origin)
         {
             ElementName = element.Name.LocalName;
@@ -320,7 +320,7 @@ namespace NuGet.Configuration
             }
         }
 
-        internal override void SetOrigin(SettingsFile origin)
+        internal override void SetOrigin(ISettingsFile origin)
         {
             base.SetOrigin(origin);
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/OwnersItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/OwnersItem.cs
@@ -35,7 +35,7 @@ namespace NuGet.Configuration
             Content = owners.Split(OwnersListSeparator).Select(o => o.Trim()).ToList();
         }
 
-        internal OwnersItem(XElement element, SettingsFile origin)
+        internal OwnersItem(XElement element, ISettingsFile origin)
             : base(element, origin)
         {
             var descendants = element.Nodes().Where(n => n is XText text && !string.IsNullOrWhiteSpace(text.Value) || n is XElement)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/RepositoryItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/RepositoryItem.cs
@@ -54,7 +54,7 @@ namespace NuGet.Configuration
             }
         }
 
-        internal RepositoryItem(XElement element, SettingsFile origin)
+        internal RepositoryItem(XElement element, ISettingsFile origin)
             : base(element, origin)
         {
             var parsedOwners = _parsedDescendants.OfType<OwnersItem>();
@@ -147,7 +147,7 @@ namespace NuGet.Configuration
             return combiner.CombinedHash;
         }
 
-        internal override void SetOrigin(SettingsFile origin)
+        internal override void SetOrigin(ISettingsFile origin)
         {
             base.SetOrigin(origin);
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
@@ -46,7 +46,7 @@ namespace NuGet.Configuration
             return combiner.CombinedHash;
         }
 
-        internal SourceItem(XElement element, SettingsFile origin)
+        internal SourceItem(XElement element, ISettingsFile origin)
             : base(element, origin)
         {
         }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/TrustedSignerItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/TrustedSignerItem.cs
@@ -52,7 +52,7 @@ namespace NuGet.Configuration
             }
         }
 
-        internal TrustedSignerItem(XElement element, SettingsFile origin)
+        internal TrustedSignerItem(XElement element, ISettingsFile origin)
             : base(element, origin)
         {
             _parsedDescendants = element.Nodes().Where(n => n is XElement || n is XText text && !string.IsNullOrWhiteSpace(text.Value))
@@ -69,7 +69,7 @@ namespace NuGet.Configuration
             Certificates = parsedCertificates;
         }
 
-        internal override void SetOrigin(SettingsFile origin)
+        internal override void SetOrigin(ISettingsFile origin)
         {
             base.SetOrigin(origin);
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/UnknownItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/UnknownItem.cs
@@ -23,7 +23,7 @@ namespace NuGet.Configuration
 
         private Dictionary<SettingBase, SettingBase> _mutableChildren;
 
-        internal UnknownItem(XElement element, SettingsFile origin)
+        internal UnknownItem(XElement element, ISettingsFile origin)
             : base(element, origin)
         {
             ElementName = element.Name.LocalName;
@@ -231,7 +231,7 @@ namespace NuGet.Configuration
             }
         }
 
-        internal override void SetOrigin(SettingsFile origin)
+        internal override void SetOrigin(ISettingsFile origin)
         {
             base.SetOrigin(origin);
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/NuGetConfiguration.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NuGetConfiguration.cs
@@ -40,7 +40,7 @@ namespace NuGet.Configuration
             }
         }
 
-        internal NuGetConfiguration(SettingsFile origin)
+        internal NuGetConfiguration(ISettingsFile origin)
             : base()
         {
             var defaultSource = new SourceItem(NuGetConstants.FeedName, NuGetConstants.V3FeedUrl, protocolVersion: PackageSourceProvider.MaxSupportedProtocolVersion.ToString());
@@ -60,7 +60,7 @@ namespace NuGet.Configuration
             SetOrigin(origin);
         }
 
-        internal NuGetConfiguration(XElement element, SettingsFile origin)
+        internal NuGetConfiguration(XElement element, ISettingsFile origin)
             : base(element, origin)
         {
             if (!string.Equals(element.Name.LocalName, ElementName, StringComparison.OrdinalIgnoreCase))

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ParsedSettingSection.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ParsedSettingSection.cs
@@ -9,7 +9,7 @@ namespace NuGet.Configuration
 {
     internal sealed class ParsedSettingSection : SettingSection
     {
-        internal ParsedSettingSection(XElement element, SettingsFile origin)
+        internal ParsedSettingSection(XElement element, ISettingsFile origin)
             : base(element, origin)
         {
         }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/PhysicalSettingsFile.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/PhysicalSettingsFile.cs
@@ -1,0 +1,158 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Xml;
+using System.Xml.Linq;
+using NuGet.Common;
+
+namespace NuGet.Configuration
+{
+    internal sealed class PhysicalSettingsFile : ISettingsFile
+    {
+        public string ConfigFilePath { get; }
+
+        public string DirectoryPath { get; }
+
+        public string FileName { get; }
+
+        public bool IsDirty { get; set; }
+
+        public bool IsMachineWide { get; }
+
+        /// <summary>
+        /// XML element for settings file
+        /// </summary>
+        private readonly XDocument _xDocument;
+
+        /// <summary>
+        /// Root element of configuration file.
+        /// By definition of a nuget.config, the root element has to be a 'configuration' element
+        /// </summary>
+        private readonly NuGetConfiguration _rootElement;
+
+        /// <summary>
+        /// Creates an instance of a PhysicalSettingsFile
+        /// </summary>
+        /// <remarks>It will parse the specified document,
+        /// if it doesn't exist it will create one with the default configuration.</remarks>
+        /// <param name="directoryPath">path to the directory where the file is</param>
+        /// <param name="fileName">name of config file</param>
+        /// <param name="isMachineWide">specifies if the SettingsFile is machine wide</param>
+        public PhysicalSettingsFile(string directoryPath, string fileName, bool isMachineWide)
+        {
+            if (string.IsNullOrEmpty(directoryPath))
+            {
+                throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(directoryPath));
+            }
+
+            if (string.IsNullOrEmpty(fileName))
+            {
+                throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(fileName));
+            }
+
+            if (!FileSystemUtility.IsPathAFile(fileName))
+            {
+                throw new ArgumentException(Resources.Settings_FileName_Cannot_Be_A_Path, nameof(fileName));
+            }
+
+            DirectoryPath = directoryPath;
+            FileName = fileName;
+            IsMachineWide = isMachineWide;
+            ConfigFilePath = Path.GetFullPath(Path.Combine(DirectoryPath, FileName));
+
+            XDocument config = null;
+            ExecuteSynchronized(() =>
+            {
+                config = XmlUtility.GetOrCreateDocument(CreateDefaultConfig(), ConfigFilePath);
+            });
+
+            _xDocument = config;
+
+            _rootElement = new NuGetConfiguration(_xDocument.Root, origin: this);
+        }
+
+        public SettingSection GetSection(string sectionName)
+        {
+            return _rootElement.GetSection(sectionName);
+        }
+
+        public void AddOrUpdate(string sectionName, SettingItem item)
+        {
+            _rootElement.AddOrUpdate(sectionName, item);
+        }
+
+        public void Remove(string sectionName, SettingItem item)
+        {
+            _rootElement.Remove(sectionName, item);
+        }
+
+        public void SaveToDisk()
+        {
+            if (IsDirty)
+            {
+                ExecuteSynchronized(() =>
+                {
+                    FileSystemUtility.AddFile(ConfigFilePath, _xDocument.Save);
+                });
+
+                IsDirty = false;
+            }
+        }
+
+        public bool IsEmpty() => _rootElement == null || _rootElement.IsEmpty();
+
+        public bool TryGetSection(string sectionName, out SettingSection section)
+        {
+            return _rootElement.Sections.TryGetValue(sectionName, out section);
+        }
+
+        public void MergeSectionsInto(Dictionary<string, VirtualSettingSection> sectionsContainer)
+        {
+            _rootElement.MergeSectionsInto(sectionsContainer);
+        }
+
+        private XDocument CreateDefaultConfig()
+        {
+            var configurationElement = new NuGetConfiguration(this);
+            return new XDocument(configurationElement.AsXNode());
+        }
+
+        private void ExecuteSynchronized(Action ioOperation)
+        {
+            ConcurrencyUtilities.ExecuteWithFileLocked(filePath: ConfigFilePath, action: () =>
+            {
+                try
+                {
+                    ioOperation();
+                }
+                catch (InvalidOperationException e)
+                {
+                    throw new NuGetConfigurationException(
+                        string.Format(CultureInfo.CurrentCulture, Resources.ShowError_ConfigInvalidOperation, ConfigFilePath, e.Message), e);
+                }
+
+                catch (UnauthorizedAccessException e)
+                {
+                    throw new NuGetConfigurationException(
+                        string.Format(CultureInfo.CurrentCulture, Resources.ShowError_ConfigUnauthorizedAccess, ConfigFilePath, e.Message), e);
+                }
+
+                catch (XmlException e)
+                {
+                    throw new NuGetConfigurationException(
+                        string.Format(CultureInfo.CurrentCulture, Resources.ShowError_ConfigInvalidXml, ConfigFilePath, e.Message), e);
+                }
+
+                catch (Exception e)
+                {
+                    throw new NuGetConfigurationException(
+                        string.Format(CultureInfo.CurrentCulture, Resources.Unknown_Config_Exception, ConfigFilePath, e.Message), e);
+                }
+            });
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingBase.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingBase.cs
@@ -12,9 +12,9 @@ namespace NuGet.Configuration
 
         internal ISettingsGroup Parent { get; set; }
 
-        internal SettingsFile Origin { get; private set; }
+        internal ISettingsFile Origin { get; private set; }
 
-        internal SettingBase(XNode node, SettingsFile origin)
+        internal SettingBase(XNode node, ISettingsFile origin)
         {
             Node = node ?? throw new ArgumentNullException(nameof(node));
             Origin = origin ?? throw new ArgumentNullException(nameof(origin));
@@ -67,7 +67,7 @@ namespace NuGet.Configuration
         /// Since an origin should not be updated, any update will be ignored.
         /// </summary>
         /// <remarks>Each setting can override this method to include any descendants to the origin</remarks>
-        internal virtual void SetOrigin(SettingsFile origin)
+        internal virtual void SetOrigin(ISettingsFile origin)
         {
             if (Origin == null || (Origin != null && Origin == origin))
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingElement.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingElement.cs
@@ -93,7 +93,7 @@ namespace NuGet.Configuration
         /// </summary>
         /// <param name="element">Xelement read from XML file document tree</param>
         /// <param name="origin">Settings file that this element was read from</param>
-        internal SettingElement(XElement element, SettingsFile origin)
+        internal SettingElement(XElement element, ISettingsFile origin)
             : base(element, origin)
         {
             ValidateAttributes(element, origin);
@@ -227,7 +227,7 @@ namespace NuGet.Configuration
             return true;
         }
 
-        private void ValidateAttributes(XElement element, SettingsFile origin)
+        private void ValidateAttributes(XElement element, ISettingsFile origin)
         {
             if (AllowedAttributes != null)
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -10,7 +10,7 @@ namespace NuGet.Configuration
 {
     internal static class SettingFactory
     {
-        internal static SettingBase Parse(XNode node, SettingsFile origin)
+        internal static SettingBase Parse(XNode node, ISettingsFile origin)
         {
             if (node == null)
             {
@@ -77,7 +77,7 @@ namespace NuGet.Configuration
             return null;
         }
 
-        internal static IEnumerable<T> ParseChildren<T>(XElement xElement, SettingsFile origin, bool canBeCleared) where T : SettingElement
+        internal static IEnumerable<T> ParseChildren<T>(XElement xElement, ISettingsFile origin, bool canBeCleared) where T : SettingElement
         {
             var children = new List<T>();
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingItem.cs
@@ -25,7 +25,7 @@ namespace NuGet.Configuration
         {
         }
 
-        internal SettingItem(XElement element, SettingsFile origin)
+        internal SettingItem(XElement element, ISettingsFile origin)
             : base(element, origin)
         {
             if (!CanHaveChildren && element.HasElements)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingSection.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingSection.cs
@@ -47,7 +47,7 @@ namespace NuGet.Configuration
             ElementName = name;
         }
 
-        internal SettingSection(XElement element, SettingsFile origin)
+        internal SettingSection(XElement element, ISettingsFile origin)
             : base(element, origin)
         {
         }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingText.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingText.cs
@@ -68,7 +68,7 @@ namespace NuGet.Configuration
             return newSetting;
         }
 
-        internal SettingText(XText text, SettingsFile origin)
+        internal SettingText(XText text, ISettingsFile origin)
             : base(text, origin)
         {
             var value = text.Value.Trim();

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
@@ -74,7 +74,6 @@ namespace NuGet.Configuration
         {
             _physicalSettingsFile = new PhysicalSettingsFile(directoryPath, fileName, isMachineWide);
              Priority = 0;
-            
         }
 
         public SettingSection GetSection(string sectionName) => _physicalSettingsFile.GetSection(sectionName);

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsGroup.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsGroup.cs
@@ -35,7 +35,7 @@ namespace NuGet.Configuration
 
         public override bool IsEmpty() => !Children.Any() || Children.All(c => c.IsEmpty());
 
-        internal SettingsGroup(XElement element, SettingsFile origin)
+        internal SettingsGroup(XElement element, ISettingsFile origin)
             : base(element, origin)
         {
             ElementName = element.Name.LocalName;
@@ -65,7 +65,7 @@ namespace NuGet.Configuration
             return element;
         }
 
-        internal override void SetOrigin(SettingsFile origin)
+        internal override void SetOrigin(ISettingsFile origin)
         {
             base.SetOrigin(origin);
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8811
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: The motivation for this comes from: NuGet/NuGet.Client#3086. This change is a prerequisite for that.

Settings objects own a bunch of SettingsFiles.
The SettingsFiles themselves have priority in that Settings object.
The fact that a Settings object changes the SettingsFile object it uses, the caching cannot be done on that level.

Because SettingsFile is the origin for every settings item, the priority needs to be understood at the settings object level in order to perform the updates correctly.

See: https://github.com/NuGet/NuGet.Client/blob/48f67796ff38e98e3dfe4ab55fce000577b74fea/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs#L86

https://github.com/NuGet/NuGet.Client/blob/48f67796ff38e98e3dfe4ab55fce000577b74fea/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs#L233

Originally I wanted to make the Settings object itself understand the priority but that proved challenging because of the PackageSourceProvider.

Now the approach is to have an interface for ISettingsFile and have a SettingsFile wrapper that delegates to a physical settings file which will be the one that's cached.

**Note: All these types are internal :) So we're free to refactor as we see fit with no fear of breaking changes!**
If anyone is curious, here's my hacky attempt at getting priorities to be handled differently. https://github.com/NuGet/NuGet.Client/compare/dev-nkolev92-settingsFile?expand=1

## Testing/Validation

Tests Added: No  
Reason for not adding tests: This is an idempotent change.   
Validation: Manual, automation.
