### PR TITLE
Fixes possible `Index was outside the bounds of the array` /VS + MSBuild

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
@@ -32,7 +32,12 @@ namespace NuGet.Packaging.Rules
             {
                 var files = builder.GetFiles()
                                     .Select(t => PathUtility.GetPathWithDirectorySeparator(t))
-                                    .Where(t => t.StartsWith(folder + Path.DirectorySeparatorChar));
+                                    .Where(t =>
+                                        t.StartsWith(
+                                            folder + Path.DirectorySeparatorChar,
+                                            StringComparison.OrdinalIgnoreCase
+                                        )
+                                    );
 
                 var packageId = builder.NuspecReader.GetId();
                 var conventionViolators = IdentifyViolators(files, packageId);
@@ -53,7 +58,10 @@ namespace NuGet.Packaging.Rules
                                                         PathUtility.GetPathWithDirectorySeparator(
                                                             t.ExpectedPath
                                                         )
-                                                        .StartsWith(folder + Path.DirectorySeparatorChar)
+                                                        .StartsWith(
+                                                            folder + Path.DirectorySeparatorChar,
+                                                            StringComparison.OrdinalIgnoreCase
+                                                        )
                                                     );
 
                 foreach (var conViolator in currentConventionViolators)

--- a/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/UpholdBuildConventionRule.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using NuGet.Client;
@@ -29,7 +30,10 @@ namespace NuGet.Packaging.Rules
             var warnings = new List<PackagingLogMessage>();
             foreach (var folder in _folders)
             {
-                var files = builder.GetFiles().Where(t => t.StartsWith(folder));
+                var files = builder.GetFiles()
+                                    .Select(t => PathUtility.GetPathWithDirectorySeparator(t))
+                                    .Where(t => t.StartsWith(folder + Path.DirectorySeparatorChar));
+
                 var packageId = builder.NuspecReader.GetId();
                 var conventionViolators = IdentifyViolators(files, packageId);
                 warnings.AddRange(GenerateWarnings(conventionViolators));
@@ -44,7 +48,14 @@ namespace NuGet.Packaging.Rules
             foreach (var folder in _folders)
             {
                 var warningMessage = new StringBuilder();
-                var currentConventionViolators = conventionViolators.Where(t => t.ExpectedPath.StartsWith(folder + '/'));
+                var currentConventionViolators = conventionViolators
+                                                    .Where(t =>
+                                                        PathUtility.GetPathWithDirectorySeparator(
+                                                            t.ExpectedPath
+                                                        )
+                                                        .StartsWith(folder + Path.DirectorySeparatorChar)
+                                                    );
+
                 foreach (var conViolator in currentConventionViolators)
                 {
                     warningMessage.AppendLine(string.Format(MessageFormat, conViolator.Extension, conViolator.Path, conViolator.ExpectedPath));

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -1305,6 +1305,10 @@ namespace Dotnet.Integration.Test
         [InlineData("build", "", "build")]
         [InlineData("../build", "", "build")]
         [InlineData("../build", "folderA/", "folderA/build")]
+        [InlineData("../Build-Info.txt", "/", "Build-Info.txt")]
+        [InlineData("BuildFoo.bar", "", "BuildFoo.bar")]
+        [InlineData("dataBuild.txt", "", "dataBuild.txt")]
+        [InlineData("BUILD.LOG", "", "BUILD.LOG")]
         public void PackCommand_PackProject_PackagePathPacksContentCorrectly(string sourcePath, string packagePath,
             string expectedTargetPaths)
         {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -1294,6 +1294,17 @@ namespace Dotnet.Integration.Test
         [InlineData("##/folderA/abc.txt", "folderX;folderY", "folderX/abc.txt;folderY/abc.txt")]
         [InlineData("##/../abc.txt", "folderX;folderY", "folderX/abc.txt;folderY/abc.txt")]
 
+        // 'build' naming: https://github.com/NuGet/Home/issues/8810
+        [InlineData("build-info.txt", "", "build-info.txt")]
+        [InlineData("../build-info.txt", "/", "build-info.txt")]
+        [InlineData("../build-info.txt", "folderA/", "folderA/build-info.txt")]
+        [InlineData("buildInfo.txt", "/", "buildInfo.txt")]
+        [InlineData("buildfoo.bar", "", "buildfoo.bar")]
+        [InlineData("databuild.txt", "", "databuild.txt")]
+        [InlineData("build.log", "", "build.log")]
+        [InlineData("build", "", "build")]
+        [InlineData("../build", "", "build")]
+        [InlineData("../build", "folderA/", "folderA/build")]
         public void PackCommand_PackProject_PackagePathPacksContentCorrectly(string sourcePath, string packagePath,
             string expectedTargetPaths)
         {


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8810

## Testing/Validation

Tests Added: Yes 
Validation: steps to reproduce from https://github.com/NuGet/Home/issues/8810 and this:

```xml
<NuGetPackTaskAssemblyFile>D:\tmp\_Issues\VS2019\NugetErrIndex\PR\NuGet.Client\artifacts\NuGet.Build.Tasks.Pack\16.0\bin\debug\netstandard2.0\ilmerge\NuGet.Build.Tasks.Pack.dll</NuGetPackTaskAssemblyFile>
```
