### PR TITLE
Decouple Settings and SettingsFile - Settings should own priority

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -83,8 +83,8 @@ namespace NuGet.Configuration
             var sourcesItems = packageSourcesSection?.Items.OfType<SourceItem>();
 
             // Order the list so that the closer to the user appear first
-            var priority = settings.GetConfigFilePaths();
-            var sources = sourcesItems?.OrderBy(i => priority.IndexOf(i.Origin?.ConfigFilePath));
+            IList<string> configFilePaths = settings.GetConfigFilePaths();
+            var sources = sourcesItems?.OrderBy(i => configFilePaths.IndexOf(i.Origin?.ConfigFilePath)); //lower index => higher priority => closer to user.
             // get list of disabled packages
             var disabledSourcesSection = settings.GetSection(ConfigurationConstants.DisabledPackageSources);
             var disabledSourcesSettings = disabledSourcesSection?.Items.OfType<AddItem>();

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -83,8 +83,8 @@ namespace NuGet.Configuration
             var sourcesItems = packageSourcesSection?.Items.OfType<SourceItem>();
 
             // Order the list so that the closer to the user appear first
-            var sources = sourcesItems?.OrderByDescending(item => item.Origin?.Priority ?? 0);
-
+            var priority = settings.GetConfigFilePaths();
+            var sources = sourcesItems?.OrderBy(i => priority.IndexOf(i.Origin?.ConfigFilePath));
             // get list of disabled packages
             var disabledSourcesSection = settings.GetSection(ConfigurationConstants.DisabledPackageSources);
             var disabledSourcesSettings = disabledSourcesSection?.Items.OfType<AddItem>();

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
@@ -51,7 +51,7 @@ namespace NuGet.Configuration
         event EventHandler SettingsChanged;
 
         /// <summary>
-        /// Get a list of all the paths of the settings files used as part of this settings object
+        /// Get a list of all the paths of the settings files used as part of this settings object. The paths are ordered with the closest one to user first.
         /// </summary>
         IList<string> GetConfigFilePaths();
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -41,8 +41,6 @@ namespace NuGet.Configuration
             new[] { "*.config" } :
             new[] { "*.Config", "*.config" };
 
-        //private readonly SettingsFile _settingsHead;
-
         private readonly Dictionary<string, VirtualSettingSection> _computedSections;
 
         public SettingSection GetSection(string sectionName)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -186,7 +186,7 @@ namespace NuGet.Configuration
         /// <param name="settingsFiles"></param>
         internal Settings(IList<SettingsFile> settingsFiles)
         {
-            SettingsFiles = settingsFiles;
+            SettingsFiles = settingsFiles ?? throw new ArgumentNullException(nameof(settingsFiles));
 
             var computedSections = new Dictionary<string, VirtualSettingSection>();
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
@@ -17,7 +17,7 @@ namespace NuGet.Configuration
         /// <summary>
         /// Full path to the settings file
         /// </summary>
-        public string ConfigFilePath => Path.GetFullPath(Path.Combine(DirectoryPath, FileName));
+        internal string ConfigFilePath { get; }
 
         /// <summary>
         /// Folder under which the settings file is present
@@ -28,11 +28,6 @@ namespace NuGet.Configuration
         /// Filename of the settings file
         /// </summary>
         internal string FileName { get; }
-
-        /// <summary>
-        /// Next config file to read in the hierarchy
-        /// </summary>
-        internal SettingsFile Next { get; private set; }
 
         /// <summary>
         /// Defines if the configuration settings have been changed but have not been saved to disk
@@ -46,12 +41,6 @@ namespace NuGet.Configuration
         internal bool IsMachineWide { get; }
 
         /// <summary>
-        /// Order in which the files will be read.
-        /// A larger number means closer to the user.
-        /// </summary>
-        internal int Priority { get; private set; }
-
-        /// <summary>
         /// XML element for settings file
         /// </summary>
         private readonly XDocument _xDocument;
@@ -61,6 +50,17 @@ namespace NuGet.Configuration
         /// By definition of a nuget.config, the root element has to be a 'configuration' element
         /// </summary>
         private readonly NuGetConfiguration _rootElement;
+
+        /// <summary>
+        /// Next config file to read in the hierarchy
+        /// </summary>
+        internal SettingsFile Next { get; private set; }
+
+        /// <summary>
+        /// Order in which the files will be read.
+        /// A larger number means closer to the user.
+        /// </summary>
+        internal int Priority { get; private set; }
 
         /// <summary>
         /// Creates an instance of a non machine wide SettingsFile with the default filename.
@@ -108,8 +108,9 @@ namespace NuGet.Configuration
 
             DirectoryPath = directoryPath;
             FileName = fileName;
+            ConfigFilePath = Path.GetFullPath(Path.Combine(DirectoryPath, FileName));
             IsMachineWide = isMachineWide;
-            Priority = 0;
+            //Priority = 0;
 
             XDocument config = null;
             ExecuteSynchronized(() =>
@@ -183,30 +184,30 @@ namespace NuGet.Configuration
            return _rootElement.Sections.TryGetValue(sectionName, out section);
         }
 
-        internal static void ConnectSettingsFilesLinkedList(IList<SettingsFile> settingFiles)
-        {
-            if (settingFiles == null && !settingFiles.Any())
-            {
-                throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(settingFiles));
-            }
+        //internal static void ConnectSettingsFilesLinkedList(IList<SettingsFile> settingFiles)
+        //{
+        //    if (settingFiles == null && !settingFiles.Any())
+        //    {
+        //        throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(settingFiles));
+        //    }
 
-            settingFiles.First().Priority = settingFiles.Count;
+        //    settingFiles.First().Priority = settingFiles.Count;
 
-            if (settingFiles.Count > 1)
-            {
-                // if multiple setting files were loaded, chain them in a linked list
-                for (var i = 1; i < settingFiles.Count; ++i)
-                {
-                    settingFiles[i].SetNextFile(settingFiles[i - 1]);
-                }
-            }
-        }
+        //    if (settingFiles.Count > 1)
+        //    {
+        //        // if multiple setting files were loaded, chain them in a linked list
+        //        for (var i = 1; i < settingFiles.Count; ++i)
+        //        {
+        //            settingFiles[i].SetNextFile(settingFiles[i - 1]);
+        //        }
+        //    }
+        //}
 
-        internal void SetNextFile(SettingsFile settingsFile)
-        {
-            Next = settingsFile;
-            Priority = settingsFile.Priority - 1;
-        }
+        //internal void SetNextFile(SettingsFile settingsFile)
+        //{
+        //    Next = settingsFile;
+        //    Priority = settingsFile.Priority - 1;
+        //}
 
         internal void MergeSectionsInto(Dictionary<string, VirtualSettingSection> sectionsContainer)
         {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
 using NuGet.Common;
@@ -50,17 +49,6 @@ namespace NuGet.Configuration
         /// By definition of a nuget.config, the root element has to be a 'configuration' element
         /// </summary>
         private readonly NuGetConfiguration _rootElement;
-
-        /// <summary>
-        /// Next config file to read in the hierarchy
-        /// </summary>
-        internal SettingsFile Next { get; private set; }
-
-        /// <summary>
-        /// Order in which the files will be read.
-        /// A larger number means closer to the user.
-        /// </summary>
-        internal int Priority { get; private set; }
 
         /// <summary>
         /// Creates an instance of a non machine wide SettingsFile with the default filename.
@@ -110,7 +98,6 @@ namespace NuGet.Configuration
             FileName = fileName;
             ConfigFilePath = Path.GetFullPath(Path.Combine(DirectoryPath, FileName));
             IsMachineWide = isMachineWide;
-            //Priority = 0;
 
             XDocument config = null;
             ExecuteSynchronized(() =>
@@ -183,31 +170,6 @@ namespace NuGet.Configuration
         {
            return _rootElement.Sections.TryGetValue(sectionName, out section);
         }
-
-        //internal static void ConnectSettingsFilesLinkedList(IList<SettingsFile> settingFiles)
-        //{
-        //    if (settingFiles == null && !settingFiles.Any())
-        //    {
-        //        throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(settingFiles));
-        //    }
-
-        //    settingFiles.First().Priority = settingFiles.Count;
-
-        //    if (settingFiles.Count > 1)
-        //    {
-        //        // if multiple setting files were loaded, chain them in a linked list
-        //        for (var i = 1; i < settingFiles.Count; ++i)
-        //        {
-        //            settingFiles[i].SetNextFile(settingFiles[i - 1]);
-        //        }
-        //    }
-        //}
-
-        //internal void SetNextFile(SettingsFile settingsFile)
-        //{
-        //    Next = settingsFile;
-        //    Priority = settingsFile.Priority - 1;
-        //}
 
         internal void MergeSectionsInto(Dictionary<string, VirtualSettingSection> sectionsContainer)
         {

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -301,10 +301,9 @@ namespace NuGet.Configuration
 
             // Settings are usually read from top to bottom, but in the case of fallback folders
             // we care more about the bottom ones, so those ones should go first.
-            var priority = settings.GetConfigFilePaths();
-
+            IList<string> configFilePaths = settings.GetConfigFilePaths();
             return fallbackValues
-                .OrderBy(i => priority.IndexOf(i.Origin?.ConfigFilePath)) //lower index => higher priority => closer to user.
+                .OrderBy(i => configFilePaths.IndexOf(i.Origin?.ConfigFilePath)) //lower index => higher priority => closer to user.
                 .OfType<AddItem>()
                 .Select(folder => folder.GetValueAsPath())
                 .ToList();

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -304,7 +304,7 @@ namespace NuGet.Configuration
             var priority = settings.GetConfigFilePaths();
 
             return fallbackValues
-                .OrderBy(i => priority.IndexOf(i.Origin.ConfigFilePath)) //lower index => higher priority => closer to user.
+                .OrderBy(i => priority.IndexOf(i.Origin?.ConfigFilePath)) //lower index => higher priority => closer to user.
                 .OfType<AddItem>()
                 .Select(folder => folder.GetValueAsPath())
                 .ToList();

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -304,7 +304,7 @@ namespace NuGet.Configuration
             var priority = settings.GetConfigFilePaths();
 
             return fallbackValues
-                .OrderBy(i => priority.IndexOf(i.Origin.ConfigFilePath)) //lower index means higher priority
+                .OrderBy(i => priority.IndexOf(i.Origin.ConfigFilePath)) //lower index => higher priority => closer to user.
                 .OfType<AddItem>()
                 .Select(folder => folder.GetValueAsPath())
                 .ToList();

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -301,8 +301,10 @@ namespace NuGet.Configuration
 
             // Settings are usually read from top to bottom, but in the case of fallback folders
             // we care more about the bottom ones, so those ones should go first.
+            var priority = settings.GetConfigFilePaths();
+
             return fallbackValues
-                .OrderByDescending(i => i.Origin?.Priority ?? 0)
+                .OrderBy(i => priority.IndexOf(i.Origin.ConfigFilePath)) //lower index means higher priority
                 .OfType<AddItem>()
                 .Select(folder => folder.GetValueAsPath())
                 .ToList();

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
@@ -51,6 +51,9 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 .Setup(x => x.GetSection("config"))
                 .Returns(() => new VirtualSettingSection("config",
                     new AddItem("globalPackagesFolder", "solution/packages")));
+            Mock.Get(settings)
+                .Setup(s => s.GetConfigFilePaths())
+                .Returns(new List<string>());
 
             var target = new VsPathContextProvider(
                 settings,
@@ -79,6 +82,9 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                     new AddItem("a", "solution/packagesA"),
                     new AddItem("b", "solution/packagesB")
                 ));
+            settings
+                .Setup(x => x.GetConfigFilePaths())
+                .Returns(new List<string>());
 
             var target = new VsPathContextProvider(
                 settings.Object,
@@ -333,6 +339,8 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                     new AddItem("a", "solution/packagesA"),
                     new AddItem("b", "solution/packagesB")
                 ));
+                settings.Setup(s => s.GetConfigFilePaths())
+                .Returns(new List<string>());
 
                 var solutionManager = new Mock<IVsSolutionManager>();
                 solutionManager

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -698,7 +698,8 @@ namespace NuGet.Configuration.Test
                 .Returns(new VirtualSettingSection("packageSourceCredentials"));
             settings.Setup(s => s.GetSection("config"))
                 .Returns(new VirtualSettingSection("config"));
-
+            settings.Setup(s => s.GetConfigFilePaths())
+                .Returns(new List<string>());
             // Act
             List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 
@@ -733,6 +734,8 @@ namespace NuGet.Configuration.Test
 
             settings.Setup(s => s.GetSection("config"))
                 .Returns(new VirtualSettingSection("config"));
+            settings.Setup(s => s.GetConfigFilePaths())
+                .Returns(new List<string>());
 
             // Act
             List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
@@ -772,7 +775,8 @@ namespace NuGet.Configuration.Test
                 .Returns(new VirtualSettingSection("disabledPackageSources",
                         new AddItem("Source4", "true")
                     ));
-
+            settings.Setup(s => s.GetConfigFilePaths())
+                .Returns(new List<string>());
             // Act
             List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 
@@ -864,7 +868,8 @@ namespace NuGet.Configuration.Test
                     new SourceItem("two", "twosource"),
                     new SourceItem("three", "threesource")
                 ));
-
+            settings.Setup(s => s.GetConfigFilePaths())
+                .Returns(new List<string>());
             settings
                 .Setup(s => s.GetSection("packageSourceCredentials"))
                 .Returns(new VirtualSettingSection("two",
@@ -902,7 +907,8 @@ namespace NuGet.Configuration.Test
                 .Returns(new VirtualSettingSection("packageSourceCredentials",
                     new CredentialsItem("two source", "user1", encryptedPassword, isPasswordClearText: false, validAuthenticationTypes: null)
                     ));
-
+            settings.Setup(s => s.GetConfigFilePaths())
+                .Returns(new List<string>());
             // Act
             List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 
@@ -934,7 +940,8 @@ namespace NuGet.Configuration.Test
              .Returns(new VirtualSettingSection("two",
                  new CredentialsItem("two", "user1", clearTextPassword, isPasswordClearText: true, validAuthenticationTypes: null)
                  ));
-
+            settings.Setup(s => s.GetConfigFilePaths())
+                .Returns(new List<string>());
             // Act
             List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 
@@ -964,7 +971,8 @@ namespace NuGet.Configuration.Test
                 .Returns(new VirtualSettingSection("two",
                     new CredentialsItem("two", "settinguser", "settingpassword", isPasswordClearText: true, validAuthenticationTypes: null)
                     ));
-
+            settings.Setup(s => s.GetConfigFilePaths())
+                .Returns(new List<string>());
             // Act
             List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 
@@ -1230,7 +1238,8 @@ namespace NuGet.Configuration.Test
                 .Returns(new VirtualSettingSection("packageSourceCredentials"));
             settings.Setup(s => s.GetSection("config"))
                 .Returns(new VirtualSettingSection("config"));
-
+            settings.Setup(s => s.GetConfigFilePaths())
+                .Returns(new List<string>());
             // Act
             List<PackageSource> values = LoadPackageSources(useStaticMethod, settings.Object);
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingsFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingsFileTests.cs
@@ -794,35 +794,40 @@ namespace NuGet.Configuration.Test
             }
         }
 
-        //TODO [Fact]
-        //public void SettingsFile_ConnectSettingsFilesLinkedList_ConnectsConfigsCorrectly()
-        //{
-        //    // Arrange
-        //    var configFile = "NuGet.Config";
-        //    using (var mockBaseDirectory = TestDirectory.Create())
-        //    using (var mockSubDirectory = TestDirectory.Create(mockBaseDirectory))
-        //    using (var mockSubSubDirectory = TestDirectory.Create(mockSubDirectory))
-        //    {
-        //        SettingsTestUtils.CreateConfigurationFile(configFile, mockBaseDirectory, @"<configuration></configuration>");
-        //        SettingsTestUtils.CreateConfigurationFile(configFile, mockSubDirectory, @"<configuration></configuration>");
-        //        SettingsTestUtils.CreateConfigurationFile(configFile, mockSubSubDirectory, @"<configuration></configuration>");
+        [Fact]
+        public void SettingsFile_PriorityIsPreservedInSettings()
+        {
+            // Arrange
+            var configFile = "NuGet.Config";
+            using (var mockBaseDirectory = TestDirectory.Create())
+            using (var mockSubDirectory = TestDirectory.Create(mockBaseDirectory))
+            using (var mockSubSubDirectory = TestDirectory.Create(mockSubDirectory))
+            {
+                SettingsTestUtils.CreateConfigurationFile(configFile, mockBaseDirectory, @"<configuration></configuration>");
+                SettingsTestUtils.CreateConfigurationFile(configFile, mockSubDirectory, @"<configuration></configuration>");
+                SettingsTestUtils.CreateConfigurationFile(configFile, mockSubSubDirectory, @"<configuration></configuration>");
 
-        //        var baseSettingsFile = new SettingsFile(mockBaseDirectory);
-        //        var subSettingsFile = new SettingsFile(mockSubDirectory);
-        //        var subSubSettingsFile = new SettingsFile(mockSubSubDirectory);
+                var baseSettingsFile = new SettingsFile(mockBaseDirectory);
+                var subSettingsFile = new SettingsFile(mockSubDirectory);
+                var subSubSettingsFile = new SettingsFile(mockSubSubDirectory);
 
-        //        // Act & Assert
-        //        baseSettingsFile.Should().NotBeNull();
-        //        subSettingsFile.Should().NotBeNull();
-        //        subSubSettingsFile.Should().NotBeNull();
+                // Act & Assert
+                baseSettingsFile.Should().NotBeNull();
+                subSettingsFile.Should().NotBeNull();
+                subSubSettingsFile.Should().NotBeNull();
+                var settings = new Settings(new List<SettingsFile>() { subSubSettingsFile, subSettingsFile, baseSettingsFile });
 
-        //        SettingsFile.ConnectSettingsFilesLinkedList(new List<SettingsFile>() { baseSettingsFile, subSettingsFile, subSubSettingsFile });
+                var priority = settings.Priority.GetEnumerator();
 
-        //        subSubSettingsFile.Next.Should().BeSameAs(subSettingsFile);
-        //        subSettingsFile.Next.Should().BeSameAs(baseSettingsFile);
-        //        baseSettingsFile.Next.Should().BeNull();
-        //    }
-        //}
+                Assert.True(priority.MoveNext());
+                priority.Current.Should().BeSameAs(subSubSettingsFile);
+                Assert.True(priority.MoveNext());
+                priority.Current.Should().BeSameAs(subSettingsFile);
+                Assert.True(priority.MoveNext());
+                priority.Current.Should().BeSameAs(baseSettingsFile);
+                Assert.False(priority.MoveNext());
+            }
+        }
 
         [Fact]
         public void SettingsFile_MergeSectionsInto_WhenSectionDoNotMatch_AllSectionsAreReturned()

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingsFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsFileParsingTests/SettingsFileTests.cs
@@ -794,35 +794,35 @@ namespace NuGet.Configuration.Test
             }
         }
 
-        [Fact]
-        public void SettingsFile_ConnectSettingsFilesLinkedList_ConnectsConfigsCorrectly()
-        {
-            // Arrange
-            var configFile = "NuGet.Config";
-            using (var mockBaseDirectory = TestDirectory.Create())
-            using (var mockSubDirectory = TestDirectory.Create(mockBaseDirectory))
-            using (var mockSubSubDirectory = TestDirectory.Create(mockSubDirectory))
-            {
-                SettingsTestUtils.CreateConfigurationFile(configFile, mockBaseDirectory, @"<configuration></configuration>");
-                SettingsTestUtils.CreateConfigurationFile(configFile, mockSubDirectory, @"<configuration></configuration>");
-                SettingsTestUtils.CreateConfigurationFile(configFile, mockSubSubDirectory, @"<configuration></configuration>");
+        //TODO [Fact]
+        //public void SettingsFile_ConnectSettingsFilesLinkedList_ConnectsConfigsCorrectly()
+        //{
+        //    // Arrange
+        //    var configFile = "NuGet.Config";
+        //    using (var mockBaseDirectory = TestDirectory.Create())
+        //    using (var mockSubDirectory = TestDirectory.Create(mockBaseDirectory))
+        //    using (var mockSubSubDirectory = TestDirectory.Create(mockSubDirectory))
+        //    {
+        //        SettingsTestUtils.CreateConfigurationFile(configFile, mockBaseDirectory, @"<configuration></configuration>");
+        //        SettingsTestUtils.CreateConfigurationFile(configFile, mockSubDirectory, @"<configuration></configuration>");
+        //        SettingsTestUtils.CreateConfigurationFile(configFile, mockSubSubDirectory, @"<configuration></configuration>");
 
-                var baseSettingsFile = new SettingsFile(mockBaseDirectory);
-                var subSettingsFile = new SettingsFile(mockSubDirectory);
-                var subSubSettingsFile = new SettingsFile(mockSubSubDirectory);
+        //        var baseSettingsFile = new SettingsFile(mockBaseDirectory);
+        //        var subSettingsFile = new SettingsFile(mockSubDirectory);
+        //        var subSubSettingsFile = new SettingsFile(mockSubSubDirectory);
 
-                // Act & Assert
-                baseSettingsFile.Should().NotBeNull();
-                subSettingsFile.Should().NotBeNull();
-                subSubSettingsFile.Should().NotBeNull();
+        //        // Act & Assert
+        //        baseSettingsFile.Should().NotBeNull();
+        //        subSettingsFile.Should().NotBeNull();
+        //        subSubSettingsFile.Should().NotBeNull();
 
-                SettingsFile.ConnectSettingsFilesLinkedList(new List<SettingsFile>() { baseSettingsFile, subSettingsFile, subSubSettingsFile });
+        //        SettingsFile.ConnectSettingsFilesLinkedList(new List<SettingsFile>() { baseSettingsFile, subSettingsFile, subSubSettingsFile });
 
-                subSubSettingsFile.Next.Should().BeSameAs(subSettingsFile);
-                subSettingsFile.Next.Should().BeSameAs(baseSettingsFile);
-                baseSettingsFile.Next.Should().BeNull();
-            }
-        }
+        //        subSubSettingsFile.Next.Should().BeSameAs(subSettingsFile);
+        //        subSettingsFile.Next.Should().BeSameAs(baseSettingsFile);
+        //        baseSettingsFile.Next.Should().BeNull();
+        //    }
+        //}
 
         [Fact]
         public void SettingsFile_MergeSectionsInto_WhenSectionDoNotMatch_AllSectionsAreReturned()

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2243,7 +2243,7 @@ namespace NuGet.Configuration.Test
         public void GetConfigFilePaths_SettingsWithoutFiles_ReturnEmptyList()
         {
             var settings = new Settings(new List<SettingsFile>());
-            // Why does this not throw?
+
             var configFilePaths = settings.GetConfigFilePaths();
 
             configFilePaths.Should().NotBeNull();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -1076,7 +1076,7 @@ namespace NuGet.Configuration.Test
             {
                 SettingsTestUtils.CreateConfigurationFile(configFile, mockBaseDirectory, @"<configuration></configuration>");
                 var settingsFile = new SettingsFile(mockBaseDirectory);
-                var settings = new Settings(settingsFile);
+                var settings = new Settings(new SettingsFile[] { settingsFile });
 
                 // Act & Assert
                 var ex = Record.Exception(() => settings.AddOrUpdate(settingsFile, "", new AddItem("SomeKey", "SomeValue")));
@@ -1095,7 +1095,7 @@ namespace NuGet.Configuration.Test
             {
                 SettingsTestUtils.CreateConfigurationFile(configFile, mockBaseDirectory, @"<configuration></configuration>");
                 var settingsFile = new SettingsFile(mockBaseDirectory);
-                var settings = new Settings(settingsFile);
+                var settings = new Settings(new SettingsFile[] { settingsFile });
 
                 // Act & Assert
                 var ex = Record.Exception(() => settings.AddOrUpdate(settingsFile, "SomeKey", item: null));
@@ -1112,7 +1112,7 @@ namespace NuGet.Configuration.Test
             {
                 SettingsTestUtils.CreateConfigurationFile("a1.config", Path.Combine(mockBaseDirectory, "nuget", "Config"), @"<configuration></configuration>");
                 var settingsFile = new SettingsFile(Path.Combine(mockBaseDirectory, "nuget", "Config"), "a1.config", isMachineWide: true);
-                var settings = new Settings(settingsFile);
+                var settings = new Settings(new SettingsFile[] { settingsFile });
 
                 // Act
                 var ex = Record.Exception(() => settings.AddOrUpdate(settingsFile, "section", new AddItem("SomeKey", "SomeValue")));
@@ -1139,7 +1139,7 @@ namespace NuGet.Configuration.Test
 
                 SettingsTestUtils.CreateConfigurationFile(configFile, mockBaseDirectory, config);
                 var settingsFile = new SettingsFile(mockBaseDirectory);
-                var settings = new Settings(settingsFile);
+                var settings = new Settings(new SettingsFile[] { settingsFile });
 
                 // Act
                 settings.AddOrUpdate(settingsFile, "NewSectionName", new AddItem("key", "value"));
@@ -1179,7 +1179,7 @@ namespace NuGet.Configuration.Test
 
                 SettingsTestUtils.CreateConfigurationFile(configFile, mockBaseDirectory, config);
                 var settingsFile = new SettingsFile(mockBaseDirectory);
-                var settings = new Settings(settingsFile);
+                var settings = new Settings(new SettingsFile[] { settingsFile });
 
                 // Act
                 settings.AddOrUpdate(settingsFile, "SectionName", new AddItem("keyTwo", "valueTwo"));
@@ -1215,7 +1215,7 @@ namespace NuGet.Configuration.Test
 
                 SettingsTestUtils.CreateConfigurationFile(configFile, mockBaseDirectory, config);
                 var settingsFile = new SettingsFile(mockBaseDirectory);
-                var settings = new Settings(settingsFile);
+                var settings = new Settings(new SettingsFile[] { settingsFile });
 
                 // Act
                 settings.AddOrUpdate(settingsFile, "SectionName", new AddItem("key", "NewValue"));
@@ -1261,7 +1261,7 @@ namespace NuGet.Configuration.Test
             {
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
                 var settingsFile = new SettingsFile(mockBaseDirectory);
-                var settings = new Settings(settingsFile);
+                var settings = new Settings(new SettingsFile[] { settingsFile });
 
                 // Act & Assert
                 settings.AddOrUpdate(settingsFile, "SectionName", new AddItem("newKey", "value"));
@@ -1316,7 +1316,7 @@ namespace NuGet.Configuration.Test
             {
                 SettingsTestUtils.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
                 var settingsFile = new SettingsFile(mockBaseDirectory);
-                var settings = new Settings(settingsFile);
+                var settings = new Settings(new SettingsFile[] { settingsFile });
 
                 // Act & Assert
                 settings.AddOrUpdate(settingsFile, "SectionName", new AddItem("newKey", "value"));
@@ -2242,8 +2242,8 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void GetConfigFilePaths_SettingsWithoutFiles_ReturnEmptyList()
         {
-            var settings = new Settings(settingsHead: null);
-
+            var settings = new Settings(new List<SettingsFile>());
+            // Why does this not throw?
             var configFilePaths = settings.GetConfigFilePaths();
 
             configFilePaths.Should().NotBeNull();
@@ -2315,7 +2315,7 @@ namespace NuGet.Configuration.Test
         [Fact]
         public void GetConfigRoots_SettingsWithoutFiles_ReturnEmptyList()
         {
-            var settings = new Settings(settingsHead: null);
+            var settings = new Settings(new List<SettingsFile>());
 
             var configRoots = settings.GetConfigRoots();
 


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8811
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: The motivation for this comes from: https://github.com/NuGet/NuGet.Client/pull/3086
Settings objects own a bunch of SettingsFiles. 
The SettingsFiles themselves have priority in that Settings object.
The fact that a Settings object changes the SettingsFile object it uses, the caching cannot be done on that level. 

Because SettingsFile is the origin for every settings item, the priority needs to be understood at the settings object level in order to perform the updates correctly.

See: https://github.com/NuGet/NuGet.Client/blob/48f67796ff38e98e3dfe4ab55fce000577b74fea/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs#L86

https://github.com/NuGet/NuGet.Client/blob/48f67796ff38e98e3dfe4ab55fce000577b74fea/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs#L233

The above 2 now make use of the ConfigFilePaths returning the config paths in the correct priority.

## Testing/Validation

Tests Added: Yes, only 1  
Reason for not adding tests: This is supposed to be an idempotent change.  
Validation:  Automation, manual
