### PR TITLE
Get more specific HttpContent MethodInfos

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -83,7 +83,10 @@ namespace NuGet.Protocol
                 // store the auth state before sending the request
                 var beforeLockVersion = _credentials.Version;
 
-                response = await base.SendAsync(request, cancellationToken);
+                using (var req = request.Clone())
+                {
+                    response = await base.SendAsync(req, cancellationToken);
+                }
 
                 if (_credentialService == null)
                 {

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/ProxyAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/ProxyAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -57,15 +57,26 @@ namespace NuGet.Protocol
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
+            HttpResponseMessage response = null;
             var logger = request.GetOrCreateConfiguration().Logger;
+
             while (true)
             {
+                // Clean up any previous responses
+                if (response != null)
+                {
+                    response.Dispose();
+                }
+
                 // Store the auth start before sending the request
                 var cacheVersion = _credentialCache.Version;
 
                 try
                 {
-                    var response = await base.SendAsync(request, cancellationToken);
+                    using (var req = request.Clone())
+                    {
+                        response = await base.SendAsync(req, cancellationToken);
+                    }
 
                     if (response.StatusCode != HttpStatusCode.ProxyAuthenticationRequired)
                     {
@@ -209,7 +220,7 @@ namespace NuGet.Protocol
                 promptCredentials = null;
             }
 
-            return promptCredentials?.GetCredential(proxyAddress, BasicAuthenticationType);;
+            return promptCredentials?.GetCredential(proxyAddress, BasicAuthenticationType);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/StsAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/StsAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #if !IS_CORECLR
@@ -88,9 +88,12 @@ namespace NuGet.Protocol
                 // keep the token store version
                 var cacheVersion = _tokenStore.Version;
 
-                PrepareSTSRequest(request);
+                using (var req = request.Clone())
+                {
+                    PrepareSTSRequest(req);
 
-                response = await base.SendAsync(request, cancellationToken);
+                    response = await base.SendAsync(req, cancellationToken);
+                }
 
                 if (!shouldRetry && response.StatusCode == HttpStatusCode.Unauthorized)
                 {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/LambdaMessageHandler.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/LambdaMessageHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -10,9 +10,19 @@ namespace NuGet.Protocol.Tests
 {
     internal class LambdaMessageHandler : HttpMessageHandler
     {
-        private readonly Func<HttpRequestMessage, HttpResponseMessage> _delegate;
+        private readonly Func<HttpRequestMessage, Task<HttpResponseMessage>> _delegate;
 
         public LambdaMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> @delegate)
+        {
+            if (@delegate == null)
+            {
+                throw new ArgumentNullException(nameof(@delegate));
+            }
+
+            _delegate = request => Task.FromResult(@delegate(request));
+        }
+
+        public LambdaMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> @delegate)
         {
             if (@delegate == null)
             {
@@ -24,7 +34,7 @@ namespace NuGet.Protocol.Tests
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            return Task.FromResult(_delegate(request));
+            return _delegate(request);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/ProxyAuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/ProxyAuthenticationHandlerTests.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
@@ -220,6 +221,42 @@ namespace NuGet.Protocol.Tests
                         It.IsAny<string>(),
                         It.IsAny<CancellationToken>()),
                     Times.Once());
+        }
+
+        [Fact]
+        public async Task SendAsync_RetryWithClonedRequest()
+        {
+            var defaultClientHandler = GetDefaultClientHandler();
+
+            var service = Mock.Of<ICredentialService>();
+            Mock.Get(service)
+                .Setup(
+                    x => x.GetCredentialsAsync(
+                        ProxyAddress,
+                        It.IsAny<IWebProxy>(),
+                        CredentialRequestType.Proxy,
+                        It.IsAny<string>(),
+                        It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult<ICredentials>(new NetworkCredential()));
+
+            var requests = 0;
+            var handler = new ProxyAuthenticationHandler(defaultClientHandler, service, ProxyCache.Instance)
+            {
+                InnerHandler = new LambdaMessageHandler(
+                    request =>
+                    {
+                        Assert.Null(request.Headers.Authorization);
+                        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", "TEST");
+                        requests++;
+                        return new HttpResponseMessage(HttpStatusCode.ProxyAuthenticationRequired);
+                    })
+            };
+
+            var response = await SendAsync(handler);
+
+            Assert.True(requests > 1, "No retries");
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.ProxyAuthenticationRequired, response.StatusCode);
         }
 
         private static HttpClientHandler GetDefaultClientHandler()


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8661

dotnet core includes a [new](https://github.com/dotnet/corefx/pull/27029) [`SerializeToStreamAsync`](https://github.com/dotnet/corefx/blob/a528006b4536e5b73227285b57d2a56116532506/src/System.Net.Http/src/System/Net/Http/HttpContent.cs#L317-L318) overload which is currently internal, but can be received via reflection. Which is done in the `HttpContentWrapper` introduced in https://github.com/NuGet/NuGet.Client/pull/3078 . Since the `GetMethod` wasn't very specifc about the method parameters this throws a `TypeInitializerException` with an inner `AmbiguousMatchException` on dotnet core 3.0.

Fixes: https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/866
Regression: Yes
* Last working version: before https://github.com/NuGet/NuGet.Client/pull/3078
* How are we preventing it in future: running tests on dotnet core 3.x

## Fix

Get more specific MethodInfo.

## Testing/Validation

Tests Added: No
Reason for not adding tests: covered by existing tests
Validation:  
