### PR TITLE
Fix the localization validator

### DIFF
--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -479,14 +479,14 @@ phases:
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
       arguments: "-BuildRTM $(BuildRTM) -BuildOutputTargetPath $(BuildOutputTargetPath) -ValidateVsix"
-    condition: " and(succeeded()) "
+    condition: "succeeded()"
 
   - task: PowerShell@1
     displayName: "Validate Repository Artifacts Localization"
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
       arguments: "-BuildRTM $(BuildRTM) -BuildOutputTargetPath $(BuildOutputTargetPath)"
-    condition: " and(succeeded()) "
+    condition: "succeeded()"
 
     # Use dotnet msbuild instead of MSBuild CLI.
     # Using MSBuild CLI results in an assembly binding failure for NuGet.Common.dll 4.4.0.3 because Microsoft.DotNet.Build.Tasks.Feed.dll references SleetLib.dll which references NuGet.Common 4.4.0.3.

--- a/build/vsts_build.yaml
+++ b/build/vsts_build.yaml
@@ -479,14 +479,14 @@ phases:
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
       arguments: "-BuildRTM $(BuildRTM) -BuildOutputTargetPath $(BuildOutputTargetPath) -ValidateVsix"
-    condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
+    condition: " and(succeeded()) "
 
   - task: PowerShell@1
     displayName: "Validate Repository Artifacts Localization"
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\BuildValidator.ps1"
       arguments: "-BuildRTM $(BuildRTM) -BuildOutputTargetPath $(BuildOutputTargetPath)"
-    condition: " and(succeeded(), eq(variables['IsOfficialBuild'], 'true')) "
+    condition: " and(succeeded()) "
 
     # Use dotnet msbuild instead of MSBuild CLI.
     # Using MSBuild CLI results in an assembly binding failure for NuGet.Common.dll 4.4.0.3 because Microsoft.DotNet.Build.Tasks.Feed.dll references SleetLib.dll which references NuGet.Common 4.4.0.3.

--- a/scripts/cibuild/BuildValidator.ps1
+++ b/scripts/cibuild/BuildValidator.ps1
@@ -27,7 +27,7 @@ if ($BuildRTM -eq 'false')
 {   
 
     $NuGetClientRoot = $env:BUILD_REPOSITORY_LOCALPATH
-    $NuGetValidator = [System.IO.Path]::Combine($NuGetClientRoot, 'packages', 'NuGetValidator.2.0.1', 'tools', 'NuGetValidator.exe')
+    $NuGetValidator = [System.IO.Path]::Combine($NuGetClientRoot, 'packages', 'nugetvalidator', '2.0.1', 'tools', 'NuGetValidator.exe')
     $VsixLogOutputDir = [System.IO.Path]::Combine($BuildOutputTargetPath, 'LocalizationValidation', 'vsix' )
     $LocalizationRepository = [System.IO.Path]::Combine($NuGetClientRoot, 'submodules', 'NuGet.Build.Localization', 'localize', 'comments', '15')
     


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8816
Regression: Yes 
* Last working version:  Regressed in NuGet/NuGet.Client@52ee9a5
* How are we preventing it in future:   Eliminate the discrepancy between private and official builds

## Fix

Details: Regressed in NuGet/NuGet.Client@52ee9a5

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3216283

Likely because the validator doesn't run on local builds.

Fix and enable validator on local builds. I don't see why this validator shouldn't run on local builds. It's super fast (runs within a few seconds)

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
