### PR TITLE
Revert "Don't reuse HttpRequestMessage objects"

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -82,10 +82,7 @@ namespace NuGet.Protocol
                 // store the auth state before sending the request
                 var beforeLockVersion = _credentials.Version;
 
-                using (var req = request.Clone())
-                {
-                    response = await base.SendAsync(req, cancellationToken);
-                }
+                response = await base.SendAsync(request, cancellationToken);
 
                 if (_credentialService == null)
                 {

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/ProxyAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/ProxyAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -57,26 +57,15 @@ namespace NuGet.Protocol
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            HttpResponseMessage response = null;
             var logger = request.GetOrCreateConfiguration().Logger;
-
             while (true)
             {
-                // Clean up any previous responses
-                if (response != null)
-                {
-                    response.Dispose();
-                }
-
                 // Store the auth start before sending the request
                 var cacheVersion = _credentialCache.Version;
 
                 try
                 {
-                    using (var req = request.Clone())
-                    {
-                        response = await base.SendAsync(req, cancellationToken);
-                    }
+                    var response = await base.SendAsync(request, cancellationToken);
 
                     if (response.StatusCode != HttpStatusCode.ProxyAuthenticationRequired)
                     {
@@ -220,7 +209,7 @@ namespace NuGet.Protocol
                 promptCredentials = null;
             }
 
-            return promptCredentials?.GetCredential(proxyAddress, BasicAuthenticationType);
+            return promptCredentials?.GetCredential(proxyAddress, BasicAuthenticationType);;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/StsAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/StsAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #if !IS_CORECLR
@@ -88,12 +88,9 @@ namespace NuGet.Protocol
                 // keep the token store version
                 var cacheVersion = _tokenStore.Version;
 
-                using (var req = request.Clone())
-                {
-                    PrepareSTSRequest(req);
+                PrepareSTSRequest(request);
 
-                    response = await base.SendAsync(req, cancellationToken);
-                }
+                response = await base.SendAsync(request, cancellationToken);
 
                 if (!shouldRetry && response.StatusCode == HttpStatusCode.Unauthorized)
                 {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/ProxyAuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/ProxyAuthenticationHandlerTests.cs
@@ -1,11 +1,10 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
@@ -221,42 +220,6 @@ namespace NuGet.Protocol.Tests
                         It.IsAny<string>(),
                         It.IsAny<CancellationToken>()),
                     Times.Once());
-        }
-
-        [Fact]
-        public async Task SendAsync_RetryWithClonedRequest()
-        {
-            var defaultClientHandler = GetDefaultClientHandler();
-
-            var service = Mock.Of<ICredentialService>();
-            Mock.Get(service)
-                .Setup(
-                    x => x.GetCredentialsAsync(
-                        ProxyAddress,
-                        It.IsAny<IWebProxy>(),
-                        CredentialRequestType.Proxy,
-                        It.IsAny<string>(),
-                        It.IsAny<CancellationToken>()))
-                .Returns(() => Task.FromResult<ICredentials>(new NetworkCredential()));
-
-            var requests = 0;
-            var handler = new ProxyAuthenticationHandler(defaultClientHandler, service, ProxyCache.Instance)
-            {
-                InnerHandler = new LambdaMessageHandler(
-                    request =>
-                    {
-                        Assert.Null(request.Headers.Authorization);
-                        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", "TEST");
-                        requests++;
-                        return new HttpResponseMessage(HttpStatusCode.ProxyAuthenticationRequired);
-                    })
-            };
-
-            var response = await SendAsync(handler);
-
-            Assert.True(requests > 1, "No retries");
-            Assert.NotNull(response);
-            Assert.Equal(HttpStatusCode.ProxyAuthenticationRequired, response.StatusCode);
         }
 
         private static HttpClientHandler GetDefaultClientHandler()

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/StsAuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/StsAuthenticationHandlerTests.cs
@@ -7,8 +7,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using Moq;
 using NuGet.Configuration;
 using Xunit;
 
@@ -22,6 +22,7 @@ namespace NuGet.Protocol.Tests
             var packageSource = new PackageSource("http://package.source.net");
             var tokenStore = new TokenStore();
 
+            var credentialService = new Mock<ICredentialService>(MockBehavior.Strict);
             var handler = new StsAuthenticationHandler(packageSource, tokenStore)
             {
                 InnerHandler = GetLambdaMessageHandler(HttpStatusCode.OK)
@@ -146,40 +147,6 @@ namespace NuGet.Protocol.Tests
 
             var response = await SendAsync(handler);
 
-            Assert.NotNull(response);
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        }
-
-        [Fact]
-        public async Task SendAsync_RetryWithClonedRequest()
-        {
-            var packageSource = new PackageSource("http://package.source.net");
-            var tokenStore = new TokenStore();
-            tokenStore.AddToken(packageSource.SourceUri, "TEST-TOKEN");
-            Func<string, string, string> tokenFactory = (endpoint, realm) =>
-            {
-                throw new InvalidOperationException("Should NOT mint new token.");
-            };
-
-            var requests = 0;
-            var handler = new StsAuthenticationHandler(packageSource, tokenStore, tokenFactory)
-            {
-                InnerHandler = new LambdaMessageHandler(
-                    request =>
-                    {
-                        Assert.Null(request.Headers.Authorization);
-                        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", "TEST");
-                        requests++;
-
-                        tokenStore.AddToken(packageSource.SourceUri, "TEST-TOKEN"); // update version for retry
-
-                        return new HttpResponseMessage(HttpStatusCode.Unauthorized);
-                    })
-            };
-
-            var response = await SendAsync(handler);
-
-            Assert.True(requests > 1, "No retries");
             Assert.NotNull(response);
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }


### PR DESCRIPTION
## Bug

Reverts: #3078
Regression: Yes 
* Last working version:  
* How are we preventing it in future:   

## Fix

Details: The PR was intended to fix NuGet/Home#8661, however, it uses reflection and did not get a unique method, causing failures on .NET Core 3. Talking to the team, we don't feel comfortable with using reflection, and want to investigate a better long term solution. The issues caused by reverting #3078 is less bad than the problems it introduced.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  Reverted regression
Validation:  
