### PR TITLE
change a test using Enum.CompareTo, as it returns relative values according to the document

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/FrameworkDependencyTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/FrameworkDependencyTests.cs
@@ -48,7 +48,7 @@ namespace NuGet.LibraryModel
         [Fact]
         public void FrameworkDependecy_DifferentFlags_AffectCompare()
         {
-            Assert.Equal(1, new FrameworkDependency("AAA", FrameworkDependencyFlags.All).CompareTo(new FrameworkDependency("AAA", FrameworkDependencyFlags.None)));
+            Assert.True(new FrameworkDependency("AAA", FrameworkDependencyFlags.All).CompareTo(new FrameworkDependency("AAA", FrameworkDependencyFlags.None)) > 0);
         }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8830 
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Changed to check if the result is greater than 0, instead of checking if the result equals to 1. 

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
