### PR TITLE
Dev rrelyea enable debug dotnet exe in tests

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Program.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Program.cs
@@ -24,7 +24,7 @@ namespace NuGet.CommandLine
     {
         private const string Utf8Option = "-utf8";
         private const string ForceEnglishOutputOption = "-forceEnglishOutput";
-        private const string DebugOption = "--debug";
+        private const string DebugOption = "--debuglaunch";
         private const string OSVersionRegistryKey = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion";
         private const string FilesystemRegistryKey = @"SYSTEM\CurrentControlSet\Control\FileSystem";
         private const string DotNetSetupRegistryKey = @"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\";
@@ -53,9 +53,10 @@ namespace NuGet.CommandLine
             AppContext.SetSwitch("Switch.System.IO.BlockLongPaths", false);
 
 #if DEBUG
-            if (args.Contains(DebugOption, StringComparer.OrdinalIgnoreCase))
+            var debugNuGetExe = Environment.GetEnvironmentVariable("DEBUG_NUGET_EXE");
+            if (args.Contains(DebugOption) || string.Equals("launch", debugNuGetExe, StringComparison.OrdinalIgnoreCase))
             {
-                args = args.Where(arg => !string.Equals(arg, DebugOption, StringComparison.OrdinalIgnoreCase)).ToArray();
+                args = args.Where(arg => !StringComparer.OrdinalIgnoreCase.Equals(arg, DebugOption)).ToArray();
                 System.Diagnostics.Debugger.Launch();
             }
 #endif

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -18,6 +18,7 @@ namespace NuGet.CommandLine.XPlat
     public class Program
     {
         private const string DebugOption = "--debug";
+        private const string DebugLaunchOption = "--debuglaunch";
         private const string DotnetNuGetAppName = "dotnet nuget";
         private const string DotnetPackageAppName = "NuGet.CommandLine.XPlat.dll package";
 
@@ -49,7 +50,7 @@ namespace NuGet.CommandLine.XPlat
 
             var debugNuGetXPlat = Environment.GetEnvironmentVariable("DEBUG_NUGET_XPLAT");
 
-            if (args.Contains(DebugOption) || string.Equals(bool.TrueString, debugNuGetXPlat, StringComparison.OrdinalIgnoreCase))
+            if (args.Contains(DebugOption) || string.Equals("attach", debugNuGetXPlat, StringComparison.OrdinalIgnoreCase))
             {
                 args = args.Where(arg => !StringComparer.OrdinalIgnoreCase.Equals(arg, DebugOption)).ToArray();
 
@@ -62,6 +63,11 @@ namespace NuGet.CommandLine.XPlat
                 }
 
                 Debugger.Break();
+            }
+            else if (args.Contains(DebugLaunchOption) || string.Equals("launch", debugNuGetXPlat, StringComparison.OrdinalIgnoreCase))
+            {
+                args = args.Where(arg => !StringComparer.OrdinalIgnoreCase.Equals(arg, DebugLaunchOption)).ToArray();
+                Debugger.Launch();
             }
 #endif
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -86,7 +86,8 @@ namespace Dotnet.Integration.Test
             var restoreSolutionDirectory = workingDirectory;
             var msbuildProjectExtensionsPath = Path.Combine(workingDirectory);
             var packageReference = string.Empty;
-            foreach (var package in packages) {
+            foreach (var package in packages)
+            {
                 packageReference = string.Concat(packageReference, Environment.NewLine, $@"<PackageReference Include=""{ package.Id }"" Version=""{ package.Version.ToString()}""/>");
             }
 
@@ -156,13 +157,13 @@ namespace Dotnet.Integration.Test
         /// <summary>
         /// dotnet.exe args
         /// </summary>
-        internal CommandRunnerResult RunDotnet(string workingDirectory, string args, bool ignoreExitCode=false)
+        internal CommandRunnerResult RunDotnet(string workingDirectory, string args, bool ignoreExitCode = false)
         {
             // if test is being debugged, launch dotnet.exe with a --debuglaunch flag,
             // which will launch a new debugger, enabling debugging of nuget.commandline.xplat.dll
             // codepaths.
             string debugParam = string.Empty;
-            if (Debugger.IsAttached)
+            if (Debugger.IsAttached && args.StartsWith("nuget "))
             {
                 debugParam = " --debuglaunch";
             }
@@ -270,7 +271,8 @@ namespace Dotnet.Integration.Test
             }
 
 
-            foreach (var nupkgName in nupkgsToCopy) {
+            foreach (var nupkgName in nupkgsToCopy)
+            {
                 using (var nupkg = new PackageArchiveReader(FindMostRecentNupkg(nupkgsDirectory, nupkgName)))
                 {
                     var files = nupkg.GetFiles()

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuildIntegrationTestFixture.cs
@@ -158,10 +158,18 @@ namespace Dotnet.Integration.Test
         /// </summary>
         internal CommandRunnerResult RunDotnet(string workingDirectory, string args, bool ignoreExitCode=false)
         {
+            // if test is being debugged, launch dotnet.exe with a --debuglaunch flag,
+            // which will launch a new debugger, enabling debugging of nuget.commandline.xplat.dll
+            // codepaths.
+            string debugParam = string.Empty;
+            if (Debugger.IsAttached)
+            {
+                debugParam = " --debuglaunch";
+            }
 
             var result = CommandRunner.Run(TestDotnetCli,
                 workingDirectory,
-                args,
+                args + debugParam,
                 waitForExit: true,
                 environmentVariables: _processEnvVars);
 

--- a/test/TestUtilities/Test.Utility/CommandRunner.cs
+++ b/test/TestUtilities/Test.Utility/CommandRunner.cs
@@ -25,11 +25,20 @@ namespace NuGet.Test.Utility
             bool shareProcessObject = false,
             IDictionary<string, string> environmentVariables = null)
         {
-
             string debugParam = string.Empty;
-            if (Debugger.IsAttached)
+            if (
+                string.Compare(process, "nuget.exe", StringComparison.OrdinalIgnoreCase) == 0
+                || 
+                process.EndsWith("\\nuget.exe", StringComparison.OrdinalIgnoreCase)
+            )
             {
-                debugParam = " --debuglaunch";
+                // if test is being debugged, launch nuget.exe with a --debuglaunch flag,
+                // which will launch a new debugger, enabling debugging of nuget.commandline.xplat.dll
+                // codepaths.
+                if (Debugger.IsAttached)
+                {
+                    debugParam = " --debuglaunch";
+                }
             }
 
             var psi = new ProcessStartInfo(Path.GetFullPath(process), arguments + debugParam)

--- a/test/TestUtilities/Test.Utility/CommandRunner.cs
+++ b/test/TestUtilities/Test.Utility/CommandRunner.cs
@@ -25,7 +25,14 @@ namespace NuGet.Test.Utility
             bool shareProcessObject = false,
             IDictionary<string, string> environmentVariables = null)
         {
-            var psi = new ProcessStartInfo(Path.GetFullPath(process), arguments)
+
+            string debugParam = string.Empty;
+            if (Debugger.IsAttached)
+            {
+                debugParam = " --debuglaunch";
+            }
+
+            var psi = new ProcessStartInfo(Path.GetFullPath(process), arguments + debugParam)
             {
                 WorkingDirectory = Path.GetFullPath(workingDirectory),
                 UseShellExecute = false,


### PR DESCRIPTION
## Bug

Fixes: create one
Regression: Yes/No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: adding better support to debug nuget.exe functional tests or dotnet.exe function tests.
   - in both of these cases, the CommandRunner will launch another process. This change will make those processes launch a debugger.

## Testing/Validation

Tests Added: Yes/No  
Reason for not adding tests:  
Validation:  
