### PR TITLE
Fix self-issued certificate in signing/verification test

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SignCommandRunnerTests.cs
@@ -119,6 +119,8 @@ namespace NuGet.Commands.Test
             }
         }
 
+        //skip this test as the signing APIs are not yet implemented. We should enable this test when signing APIs are implemented. Tracking issue:https://github.com/NuGet/Home/issues/8807
+#if IS_DESKTOP
         [Fact]
         public async Task ExecuteCommandAsync_WithMultiplePackagesAndInvalidCertificate_RaisesErrorsOnceAsync()
         {
@@ -147,6 +149,7 @@ namespace NuGet.Commands.Test
                     message => message.Level == LogLevel.Warning && message.Code == NuGetLogCode.NU3018));
             }
         }
+#endif
 
         private static byte[] GetResource(string name)
         {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
@@ -109,22 +109,21 @@ namespace NuGet.Packaging.Test
                 Assert.Equal("Certificate chain validation failed.", exception.Message);
 
                 Assert.Equal(1, logger.Errors);
-                Assert.Equal(1, logger.Warnings);
 
-                if (RuntimeEnvironmentHelper.IsWindows)
+                if (!RuntimeEnvironmentHelper.IsMacOSX && RuntimeEnvironmentHelper.IsLinux)
                 {
-                    AssertNotTimeValid(logger.LogMessages, LogLevel.Error);
-                    SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Warning);
+                    Assert.Equal(2, logger.Warnings);
+                }else
+                {
+                    Assert.Equal(1, logger.Warnings);
                 }
-                else if (RuntimeEnvironmentHelper.IsMacOSX)
+
+                SigningTestUtility.AssertNotTimeValid(logger.LogMessages, LogLevel.Error);
+                SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Warning);
+
+                if (!RuntimeEnvironmentHelper.IsMacOSX && RuntimeEnvironmentHelper.IsLinux)
                 {
-                    AssertExpiredCertificate(logger.LogMessages, LogLevel.Error);
-                    SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Warning); 
-                }
-                else
-                {
-                    AssertPartialChain(logger.LogMessages, LogLevel.Error);
-                    SigningTestUtility.AssertOfflineRevocation(logger.LogMessages, LogLevel.Warning);
+                    SigningTestUtility.AssertRevocationStatusUnknown(logger.LogMessages, LogLevel.Warning);
                 }
             }
         }
@@ -686,13 +685,6 @@ namespace NuGet.Packaging.Test
         }
 #endif
 
-        private static void AssertNotTimeValid(IEnumerable<ILogMessage> issues, LogLevel logLevel)
-        {
-            Assert.Contains(issues, issue =>
-                issue.Code == NuGetLogCode.NU3018 &&
-                issue.Level == logLevel &&
-                issue.Message.Contains("A required certificate is not within its validity period when verifying against the current system clock or the timestamp in the signed file"));
-        }
 
         private static AuthorSignPackageRequest CreateRequest(X509Certificate2 certificate)
         {
@@ -700,22 +692,6 @@ namespace NuGet.Packaging.Test
                 certificate,
                 Common.HashAlgorithmName.SHA256,
                 Common.HashAlgorithmName.SHA256);
-        }
-
-        private static void AssertExpiredCertificate(IEnumerable<ILogMessage> issues, LogLevel logLevel)
-        {
-            Assert.Contains(issues, issue =>
-                issue.Code == NuGetLogCode.NU3018 &&
-                issue.Level == logLevel &&
-                issue.Message.Contains("An expired certificate was detected"));
-        }
-
-        private static void AssertPartialChain(IEnumerable<ILogMessage> issues, LogLevel logLevel)
-        {
-            Assert.Contains(issues, issue =>
-                issue.Code == NuGetLogCode.NU3018 &&
-                issue.Level == logLevel &&
-                issue.Message.Contains("unable to get local issuer certificate"));
         }
 
         private static RepositorySignPackageRequest CreateRequestRepository(

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
@@ -109,21 +109,18 @@ namespace NuGet.Packaging.Test
                 Assert.Equal("Certificate chain validation failed.", exception.Message);
 
                 Assert.Equal(1, logger.Errors);
+                SigningTestUtility.AssertNotTimeValid(logger.LogMessages, LogLevel.Error);
 
-                if (!RuntimeEnvironmentHelper.IsMacOSX && RuntimeEnvironmentHelper.IsLinux)
+                if (RuntimeEnvironmentHelper.IsLinux)
                 {
                     Assert.Equal(2, logger.Warnings);
-                }else
+                    SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Warning);
+                    SigningTestUtility.AssertRevocationStatusUnknown(logger.LogMessages, LogLevel.Warning);
+                }
+                else
                 {
                     Assert.Equal(1, logger.Warnings);
-                }
-
-                SigningTestUtility.AssertNotTimeValid(logger.LogMessages, LogLevel.Error);
-                SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Warning);
-
-                if (!RuntimeEnvironmentHelper.IsMacOSX && RuntimeEnvironmentHelper.IsLinux)
-                {
-                    SigningTestUtility.AssertRevocationStatusUnknown(logger.LogMessages, LogLevel.Warning);
+                    SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Warning);
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SigningUtilityTests.cs
@@ -109,19 +109,19 @@ namespace NuGet.Packaging.Test
                 Assert.Equal("Certificate chain validation failed.", exception.Message);
 
                 Assert.Equal(1, logger.Errors);
-                SigningTestUtility.AssertNotTimeValid(logger.LogMessages, LogLevel.Error);
-
+                
                 if (RuntimeEnvironmentHelper.IsLinux)
                 {
                     Assert.Equal(2, logger.Warnings);
-                    SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Warning);
                     SigningTestUtility.AssertRevocationStatusUnknown(logger.LogMessages, LogLevel.Warning);
                 }
                 else
                 {
                     Assert.Equal(1, logger.Warnings);
-                    SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Warning);
                 }
+
+                SigningTestUtility.AssertNotTimeValid(logger.LogMessages, LogLevel.Error);
+                SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Warning);
             }
         }
 

--- a/test/TestUtilities/Test.Utility/Signing/ChainCertificateRequest.cs
+++ b/test/TestUtilities/Test.Utility/Signing/ChainCertificateRequest.cs
@@ -14,7 +14,7 @@ namespace Test.Utility.Signing
 
         public bool IsCA { get; set; }
 
-        public bool ConfigureCrl { get; set; } = true;
+        public bool ConfigureCrl { get; set; } = false;
 
         public X509Certificate2 Issuer { get; set; }
     }

--- a/test/TestUtilities/Test.Utility/Signing/ChainCertificateRequest.cs
+++ b/test/TestUtilities/Test.Utility/Signing/ChainCertificateRequest.cs
@@ -14,7 +14,7 @@ namespace Test.Utility.Signing
 
         public bool IsCA { get; set; }
 
-        public bool ConfigureCrl { get; set; } = false;
+        public bool ConfigureCrl { get; set; }
 
         public X509Certificate2 Issuer { get; set; }
     }

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -141,6 +141,7 @@ namespace Test.Utility.Signing
                 {
                     var chainCertificateRequest = new ChainCertificateRequest()
                     {
+                        ConfigureCrl = true,
                         CrlLocalBaseUri = crlLocalUri,
                         CrlServerBaseUri = crlServerUri,
                         IsCA = true
@@ -153,6 +154,7 @@ namespace Test.Utility.Signing
                 {
                     var chainCertificateRequest = new ChainCertificateRequest()
                     {
+                        ConfigureCrl = true,
                         CrlLocalBaseUri = crlLocalUri,
                         CrlServerBaseUri = crlServerUri,
                         IsCA = true,
@@ -207,11 +209,10 @@ namespace Test.Utility.Signing
             int publicKeyLength = 2048,
             ChainCertificateRequest chainCertificateRequest = null)
         {
-            if (chainCertificateRequest is null)
+            chainCertificateRequest = chainCertificateRequest ?? new ChainCertificateRequest()
             {
-                chainCertificateRequest = new ChainCertificateRequest();
-            }
-            chainCertificateRequest.IsCA = true;
+                IsCA = true
+            };
 
             using (var rsa = RSA.Create(publicKeyLength))
             {

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -679,10 +679,24 @@ namespace Test.Utility.Signing
 
         public static void AssertRevocationStatusUnknown(IEnumerable<ILogMessage> issues, LogLevel logLevel)
         {
+            string revocationStatusUnknown;
+
+            if (RuntimeEnvironmentHelper.IsWindows)
+            {
+                revocationStatusUnknown = "The revocation function was unable to check revocation for the certificate";
+            }
+            else if (RuntimeEnvironmentHelper.IsMacOSX)
+            {
+                revocationStatusUnknown = "An incomplete certificate revocation check occurred.";
+            }
+            else
+            {
+                revocationStatusUnknown = "unable to get certificate CRL";
+            }
             Assert.Contains(issues, issue =>
                 issue.Code == NuGetLogCode.NU3018 &&
                 issue.Level == logLevel &&
-                issue.Message.Contains("The revocation function was unable to check revocation for the certificate"));
+                issue.Message.Contains(revocationStatusUnknown));
         }
 
         public static void AssertUntrustedRoot(IEnumerable<ILogMessage> issues, LogLevel logLevel)

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -693,6 +693,7 @@ namespace Test.Utility.Signing
             {
                 revocationStatusUnknown = "unable to get certificate CRL";
             }
+
             Assert.Contains(issues, issue =>
                 issue.Code == NuGetLogCode.NU3018 &&
                 issue.Level == logLevel &&
@@ -738,12 +739,12 @@ namespace Test.Utility.Signing
             {
                 notTimeValid = "certificate has expired";
             }
+
             Assert.Contains(issues, issue =>
                 issue.Code == NuGetLogCode.NU3018 &&
                 issue.Level == logLevel &&
                 issue.Message.Contains(notTimeValid));
         }
-
 
         public static string AddSignatureLogPrefix(string log, PackageIdentity package, string source)
         {

--- a/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
@@ -207,6 +207,12 @@ namespace Test.Utility.Signing
             int publicKeyLength = 2048,
             ChainCertificateRequest chainCertificateRequest = null)
         {
+            if (chainCertificateRequest is null)
+            {
+                chainCertificateRequest = new ChainCertificateRequest();
+            }
+            chainCertificateRequest.IsCA = true;
+
             using (var rsa = RSA.Create(publicKeyLength))
             {
                 return GenerateCertificate(subjectName, modifyGenerator, rsa, hashAlgorithm, paddingMode, chainCertificateRequest);
@@ -700,6 +706,29 @@ namespace Test.Utility.Signing
                 issue.Level == logLevel &&
                 issue.Message.Contains(untrustedRoot));
         }
+
+        public static void AssertNotTimeValid(IEnumerable<ILogMessage> issues, LogLevel logLevel)
+        {
+            string notTimeValid;
+
+            if (RuntimeEnvironmentHelper.IsWindows)
+            {
+                notTimeValid = "A required certificate is not within its validity period when verifying against the current system clock or the timestamp in the signed file";
+            }
+            else if (RuntimeEnvironmentHelper.IsMacOSX)
+            {
+                notTimeValid = "An expired certificate was detected.";
+            }
+            else
+            {
+                notTimeValid = "certificate has expired";
+            }
+            Assert.Contains(issues, issue =>
+                issue.Code == NuGetLogCode.NU3018 &&
+                issue.Level == logLevel &&
+                issue.Message.Contains(notTimeValid));
+        }
+
 
         public static string AddSignatureLogPrefix(string log, PackageIdentity package, string source)
         {

--- a/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
@@ -62,7 +62,7 @@ namespace Test.Utility.Signing
             CertificateRevocationList crl = null;
 
             // create a crl only if the certificate is part of a chain and it is a CA
-            if (chainCertificateRequest != null && chainCertificateRequest.IsCA)
+            if (chainCertificateRequest != null && chainCertificateRequest.IsCA && chainCertificateRequest.ConfigureCrl)
             {
                 crl = CertificateRevocationList.CreateCrl(cert, chainCertificateRequest.CrlLocalBaseUri);
             }

--- a/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
+++ b/test/TestUtilities/Test.Utility/Signing/TestCertificate.cs
@@ -61,7 +61,7 @@ namespace Test.Utility.Signing
             var cert = SigningTestUtility.GenerateCertificateWithKeyInfo(certName, modifyGenerator, chainCertificateRequest: chainCertificateRequest);
             CertificateRevocationList crl = null;
 
-            // create a crl only if the certificate is part of a chain and it is a CA
+            // create a crl only if the certificate is part of a chain and it is a CA and ConfigureCrl is true
             if (chainCertificateRequest != null && chainCertificateRequest.IsCA && chainCertificateRequest.ConfigureCrl)
             {
                 crl = CertificateRevocationList.CreateCrl(cert, chainCertificateRequest.CrlLocalBaseUri);


### PR DESCRIPTION
## Bug

Fixes: [/NuGet/Home/issues/8841](https://github.com/NuGet/Home/issues/8841)
Regression: No  
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: 
1.Fix self-issued certificate for testing, setting X509KeyUsageFlags.CrlSign and X509KeyUsageFlags.KeyCertSign by setting IsCA=true
Change to set ConfigureCrl to false by default. Only set it to true when we need to configure a CRL. 
Fix broken tests. As chain build on self-issued certificate will have same status for Windows, Linux, Mac after this change(except Linux has an extra revocationStatusUnknown).

2.Disable a test ExecuteCommandAsync_WithMultiplePackagesAndInvalidCertificate_RaisesErrorsOnceAsync for netcore as Signing API is not yet enabled for netcore.

## Testing/Validation

Tests Added: No  
Reason for not adding tests:  
Validation:  
