### PR TITLE
Fix PackageSourceTelemetry exception when two sources have same url

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/PackageSourceTelemetry.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/PackageSourceTelemetry.cs
@@ -30,6 +30,7 @@ namespace NuGet.VisualStudio.Telemetry
             ProtocolDiagnostics.Event += ProtocolDiagnostics_Event;
             _parentId = parentId;
 
+            // Multiple sources can use the same feed url. We can't know which one protocol events come from, so choose any.
             _sources = new Dictionary<string, PackageSource>();
             foreach (var source in sources)
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/PackageSourceTelemetry.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/PackageSourceTelemetry.cs
@@ -28,8 +28,13 @@ namespace NuGet.VisualStudio.Telemetry
 
             _data = new ConcurrentDictionary<string, Data>();
             ProtocolDiagnostics.Event += ProtocolDiagnostics_Event;
-            _sources = sources.ToDictionary(s => s.Source);
             _parentId = parentId;
+
+            _sources = new Dictionary<string, PackageSource>();
+            foreach (var source in sources)
+            {
+                _sources[source.Source] = source;
+            }
         }
 
         private void ProtocolDiagnostics_Event(ProtocolDiagnosticEvent pdEvent)

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/PackageSourceTelemetryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/PackageSourceTelemetryTests.cs
@@ -17,14 +17,18 @@ namespace NuGet.VisualStudio.Common.Test.Telemetry
     public class PackageSourceTelemetryTests
     {
         [Fact]
-        public void Ctor_DuplicateSources_DoesNotThrow()
+        public void Ctor_DuplicateSourceUrls_DoesNotThrow()
         {
             // Arrange
-            var source = new PackageSource("https://source.test/v3/index.json");
-            PackageSource[] sources = new[] { source, source };
+            const string feedUrl = "https://source.test/v3/index.json";
+            PackageSource[] sources = new[]
+            {
+                new PackageSource(source: feedUrl, name: "Source1"),
+                new PackageSource(source: feedUrl, name: "Source2")
+            };
 
             // Act
-            var target = new PackageSourceTelemetry(sources, Guid.Empty);
+            _ = new PackageSourceTelemetry(sources, Guid.Empty);
 
             // Assert
             // no assert, just making sure ctor didn't throw.

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/PackageSourceTelemetryTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/Telemetry/PackageSourceTelemetryTests.cs
@@ -16,6 +16,20 @@ namespace NuGet.VisualStudio.Common.Test.Telemetry
 {
     public class PackageSourceTelemetryTests
     {
+        [Fact]
+        public void Ctor_DuplicateSources_DoesNotThrow()
+        {
+            // Arrange
+            var source = new PackageSource("https://source.test/v3/index.json");
+            PackageSource[] sources = new[] { source, source };
+
+            // Act
+            var target = new PackageSourceTelemetry(sources, Guid.Empty);
+
+            // Assert
+            // no assert, just making sure ctor didn't throw.
+        }
+
         [Theory]
         [InlineData("https://source.test/v3/flatcontainer/package/package.1.0.0.nupkg", true)]
         [InlineData("https://source.test/v3/flatcontainer/package/index.json", false)]


### PR DESCRIPTION
## Bug

Fixes: NuGet/Home#8847
Regression: No  
* Last working version:   
* How are we preventing it in future:   unit test

## Fix

Details: for a foreach loop to add to a new dictionary, rather than LINQ's ToDictionary method.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
