### PR TITLE
Refactor restore logic out of RestoreTask

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -152,17 +152,17 @@ namespace NuGet.Build.Tasks
                     // Pre-loaded request provider containing the graph file
                     var providers = new List<IPreLoadedRestoreRequestProvider>();
 
-                    // Add all child projects
-                    if (recursive)
-                    {
-                        AddAllProjectsForRestore(dependencyGraphSpec);
-                    }
-
                     if (dependencyGraphSpec.Restore.Count < 1)
                     {
                         // Restore will fail if given no inputs, but here we should skip it and provide a friendly message.
                         log.LogMinimal(Strings.NoProjectsToRestore);
                         return true;
+                    }
+
+                    // Add all child projects
+                    if (recursive)
+                    {
+                        BuildTasksUtility.AddAllProjectsForRestore(dependencyGraphSpec);
                     }
 
                     providers.Add(new DependencyGraphSpecRequestProvider(providerCache, dependencyGraphSpec));

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -1,10 +1,22 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+#if IS_CORECLR
+using System.Runtime.InteropServices;
+#endif
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Build.Framework;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Credentials;
 using NuGet.ProjectModel;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
 
 namespace NuGet.Build.Tasks
 {
@@ -97,5 +109,103 @@ namespace NuGet.Build.Tasks
             ProjectStyle.Standalone,
             ProjectStyle.ProjectJson
         };
+
+        public static async Task<bool> RestoreAsync(
+            DependencyGraphSpec dependencyGraphSpec,
+            bool interactive,
+            bool recursive,
+            bool noCache,
+            bool ignoreFailedSources,
+            bool disableParallel,
+            bool force,
+            bool forceEvaluate,
+            bool hideWarningsAndErrors,
+            Common.ILogger log,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                DefaultCredentialServiceUtility.SetupDefaultCredentialService(log, !interactive);
+
+                // Set connection limit
+                NetworkProtocolUtility.SetConnectionLimit();
+
+                // Set user agent string used for network calls
+#if IS_CORECLR
+                UserAgent.SetUserAgentString(new UserAgentStringBuilder("NuGet .NET Core MSBuild Task")
+                    .WithOSDescription(RuntimeInformation.OSDescription));
+#else
+                // OS description is set by default on Desktop
+                UserAgent.SetUserAgentString(new UserAgentStringBuilder("NuGet Desktop MSBuild Task"));
+#endif
+
+                // This method has no effect on .NET Core.
+                NetworkProtocolUtility.ConfigureSupportedSslProtocols();
+
+                var providerCache = new RestoreCommandProvidersCache();
+
+                using (var cacheContext = new SourceCacheContext())
+                {
+                    cacheContext.NoCache = noCache;
+                    cacheContext.IgnoreFailedSources = ignoreFailedSources;
+
+                    // Pre-loaded request provider containing the graph file
+                    var providers = new List<IPreLoadedRestoreRequestProvider>();
+
+                    // Add all child projects
+                    if (recursive)
+                    {
+                        AddAllProjectsForRestore(dependencyGraphSpec);
+                    }
+
+                    if (dependencyGraphSpec.Restore.Count < 1)
+                    {
+                        // Restore will fail if given no inputs, but here we should skip it and provide a friendly message.
+                        log.LogMinimal(Strings.NoProjectsToRestore);
+                        return true;
+                    }
+
+                    providers.Add(new DependencyGraphSpecRequestProvider(providerCache, dependencyGraphSpec));
+
+                    var restoreContext = new RestoreArgs()
+                    {
+                        CacheContext = cacheContext,
+                        LockFileVersion = LockFileFormat.Version,
+                        // 'dotnet restore' fails on slow machines (https://github.com/NuGet/Home/issues/6742)
+                        // The workaround is to pass the '--disable-parallel' option.
+                        // We apply the workaround by default when the system has 1 cpu.
+                        // This will fix restore failures on VMs with 1 CPU and containers with less or equal to 1 CPU assigned.
+                        DisableParallel = Environment.ProcessorCount == 1 ? true : disableParallel,
+                        Log = log,
+                        MachineWideSettings = new XPlatMachineWideSetting(),
+                        PreLoadedRequestProviders = providers,
+                        AllowNoOp = !force,
+                        HideWarningsAndErrors = hideWarningsAndErrors,
+                        RestoreForceEvaluate = forceEvaluate
+                    };
+
+                    if (restoreContext.DisableParallel)
+                    {
+                        HttpSourceResourceProvider.Throttle = SemaphoreSlimThrottle.CreateBinarySemaphore();
+                    }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var restoreSummaries = await RestoreRunner.RunAsync(restoreContext, cancellationToken);
+
+                    // Summary
+                    RestoreSummary.Log(log, restoreSummaries);
+
+                    return restoreSummaries.All(x => x.Success);
+                }
+            }
+            finally
+            {
+                // The CredentialService lifetime is for the duration of the process. We should not leave a potentially unavailable logger. 
+                // We need to update the delegating logger with a null instance
+                // because the tear downs of the plugins and similar rely on idleness and process exit.
+                DefaultCredentialServiceUtility.UpdateCredentialServiceDelegatingLogger(NullLogger.Instance);
+            }
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -123,6 +124,16 @@ namespace NuGet.Build.Tasks
             Common.ILogger log,
             CancellationToken cancellationToken)
         {
+            if(dependencyGraphSpec == null)
+            {
+                throw new ArgumentNullException(nameof(dependencyGraphSpec));
+            }
+
+            if (log == null)
+            {
+                throw new ArgumentNullException(nameof(log));
+            }
+
             try
             {
                 DefaultCredentialServiceUtility.SetupDefaultCredentialService(log, !interactive);

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -47,8 +47,7 @@ namespace NuGet.Build.Tasks
         public static void AddAllProjectsForRestore(DependencyGraphSpec spec)
         {
             // Add everything from projects except for packages.config and unknown project types
-            foreach (var project in spec.Projects
-                .Where(project => RestorableTypes.Contains(project.RestoreMetadata.ProjectStyle)))
+            foreach (var project in spec.Projects.Where(DoesProjectSupportRestore))
             {
                 spec.AddRestore(project.RestoreMetadata.ProjectUniqueName);
             }
@@ -70,6 +69,16 @@ namespace NuGet.Build.Tasks
             {
                 properties.Add(toKey, propertyValue);
             }
+        }
+
+        /// <summary>
+        /// Determines if the specified <see cref="PackageSpec" /> supports restore.
+        /// </summary>
+        /// <param name="packageSpec">A <see cref="PackageSpec" /> for a project.</param>
+        /// <returns><code>true</code> if the project supports restore, otherwise <code>false</code>.</returns>
+        internal static bool DoesProjectSupportRestore(PackageSpec packageSpec)
+        {
+            return RestorableTypes.Contains(packageSpec.RestoreMetadata.ProjectStyle);
         }
 
         public static string GetPropertyIfExists(ITaskItem item, string key)
@@ -111,7 +120,7 @@ namespace NuGet.Build.Tasks
             ProjectStyle.ProjectJson
         };
 
-        public static async Task<bool> RestoreAsync(
+        internal static async Task<bool> RestoreAsync(
             DependencyGraphSpec dependencyGraphSpec,
             bool interactive,
             bool recursive,

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -162,7 +162,7 @@ namespace NuGet.Build.Tasks
                     // Add all child projects
                     if (recursive)
                     {
-                        BuildTasksUtility.AddAllProjectsForRestore(dependencyGraphSpec);
+                        AddAllProjectsForRestore(dependencyGraphSpec);
                     }
 
                     providers.Add(new DependencyGraphSpecRequestProvider(providerCache, dependencyGraphSpec));

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -2,21 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Newtonsoft.Json;
 using NuGet.Commands;
 using NuGet.Common;
-using NuGet.Configuration;
-using NuGet.Credentials;
-using NuGet.ProjectModel;
-using NuGet.Protocol;
-using NuGet.Protocol.Core.Types;
 
 namespace NuGet.Build.Tasks
 {
@@ -25,12 +18,6 @@ namespace NuGet.Build.Tasks
     /// </summary>
     public class RestoreTask : Microsoft.Build.Utilities.Task, ICancelableTask, IDisposable
     {
-#if IS_DESKTOP
-        private const string HttpUserAgent = "NuGet Desktop MSBuild Task";
-#else
-        private const string HttpUserAgent = "NuGet .NET Core MSBuild Task";
-#endif
-
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
 
         /// <summary>
@@ -114,7 +101,6 @@ namespace NuGet.Build.Tasks
 
             try
             {
-                DefaultCredentialServiceUtility.SetupDefaultCredentialService(log, !Interactive);
                 return ExecuteAsync(log).Result;
             }
             catch (AggregateException ex) when (_cts.Token.IsCancellationRequested && ex.InnerException is TaskCanceledException)
@@ -128,13 +114,6 @@ namespace NuGet.Build.Tasks
                 ExceptionUtilities.LogException(e, log);
                 return false;
             }
-            finally
-            {
-                // The CredentialService lifetime is for the duration of the process. We should not leave a potentially unavailable logger. 
-                // We need to update the delegating logger with a null instance
-                // because the tear downs of the plugins and similar rely on idleness and process exit.
-                DefaultCredentialServiceUtility.UpdateCredentialServiceDelegatingLogger(NullLogger.Instance);
-            }
         }
  
         private async Task<bool> ExecuteAsync(Common.ILogger log)
@@ -145,99 +124,23 @@ namespace NuGet.Build.Tasks
                 return true;
             }
 
-            // Set user agent and connection settings.
-            ConfigureProtocol();
-
             // Convert to the internal wrapper
             var wrappedItems = RestoreGraphItems.Select(MSBuildUtility.WrapMSBuildItem);
 
-            //var graphLines = RestoreGraphItems;
-            var providerCache = new RestoreCommandProvidersCache();
+            var dgFile = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
 
-            using (var cacheContext = new SourceCacheContext())
-            {
-                cacheContext.NoCache = RestoreNoCache;
-                cacheContext.IgnoreFailedSources = RestoreIgnoreFailedSources;
-
-                // Pre-loaded request provider containing the graph file
-                var providers = new List<IPreLoadedRestoreRequestProvider>();
-
-                var dgFile = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
-
-                if (dgFile.Restore.Count < 1)
-                {
-                    // Restore will fail if given no inputs, but here we should skip it and provide a friendly message.
-                    log.LogMinimal(Strings.NoProjectsToRestore);
-                    return true;
-                }
-
-                // Add all child projects
-                if (RestoreRecursive)
-                {
-                    BuildTasksUtility.AddAllProjectsForRestore(dgFile);
-                }
-
-                providers.Add(new DependencyGraphSpecRequestProvider(providerCache, dgFile));
-
-                var restoreContext = new RestoreArgs()
-                {
-                    CacheContext = cacheContext,
-                    LockFileVersion = LockFileFormat.Version,
-                    DisableParallel = RestoreDisableParallel,
-                    Log = log,
-                    MachineWideSettings = new XPlatMachineWideSetting(),
-                    PreLoadedRequestProviders = providers,
-                    AllowNoOp = !RestoreForce,
-                    HideWarningsAndErrors = HideWarningsAndErrors,
-                    RestoreForceEvaluate = RestoreForceEvaluate
-                };
-
-                // 'dotnet restore' fails on slow machines (https://github.com/NuGet/Home/issues/6742)
-                // The workaround is to pass the '--disable-parallel' option.
-                // We apply the workaround by default when the system has 1 cpu.
-                // This will fix restore failures on VMs with 1 CPU and containers with less or equal to 1 CPU assigned.
-                if (Environment.ProcessorCount == 1)
-                {
-                    restoreContext.DisableParallel = true;
-                }
-
-                if (restoreContext.DisableParallel)
-                {
-                    HttpSourceResourceProvider.Throttle = SemaphoreSlimThrottle.CreateBinarySemaphore();
-                }
-
-                _cts.Token.ThrowIfCancellationRequested();
-
-                var restoreSummaries = await RestoreRunner.RunAsync(restoreContext, _cts.Token);
-
-                // Summary
-                RestoreSummary.Log(log, restoreSummaries);
-
-                return restoreSummaries.All(x => x.Success);
-            }
-        }
-
-        private static void ConfigureProtocol()
-        {
-            // Set connection limit
-            NetworkProtocolUtility.SetConnectionLimit();
-
-            // Set user agent string used for network calls
-            SetUserAgent();
-
-            // This method has no effect on .NET Core.
-            NetworkProtocolUtility.ConfigureSupportedSslProtocols();
-        }
-
-        private static void SetUserAgent()
-        {
-#if IS_CORECLR
-            UserAgent.SetUserAgentString(new UserAgentStringBuilder(HttpUserAgent)
-                .WithOSDescription(RuntimeInformation.OSDescription));
-#else
-            // OS description is set by default on Desktop
-            UserAgent.SetUserAgentString(new UserAgentStringBuilder(HttpUserAgent));
-#endif
+            return await BuildTasksUtility.RestoreAsync(
+                dependencyGraphSpec: dgFile,
+                interactive: Interactive,
+                recursive: RestoreRecursive,
+                noCache: RestoreNoCache,
+                ignoreFailedSources: RestoreIgnoreFailedSources,
+                disableParallel: RestoreDisableParallel,
+                force: RestoreForce,
+                forceEvaluate: RestoreForceEvaluate,
+                hideWarningsAndErrors: HideWarningsAndErrors,
+                log: log,
+                cancellationToken: _cts.Token);
         }
 
         public void Cancel()


### PR DESCRIPTION
This will allow me to reuse the logic in a later commit that uses a different mechanism for building the DependencyGraphSpec

## Bug

Fixes: https://github.com/NuGet/Home/issues/8829
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Moved logic to `BuildTasksUtility` so that my new prototype can call the same code as `RestoreTask`

## Testing/Validation

Tests Added: No
Reason for not adding tests:  Already covered by existing tests.
Validation:  
