### PR TITLE
Refactor logic in _GetRestoreProjectStyle target to a task (part 2)

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 #if IS_CORECLR
 using System.Runtime.InteropServices;
@@ -226,6 +227,91 @@ namespace NuGet.Build.Tasks
                 // because the tear downs of the plugins and similar rely on idleness and process exit.
                 DefaultCredentialServiceUtility.UpdateCredentialServiceDelegatingLogger(NullLogger.Instance);
             }
+        }
+
+        /// <summary>
+        /// Determines the restore style of a project.
+        /// </summary>
+        /// <param name="restoreProjectStyle">An optional user supplied restore style.</param>
+        /// <param name="hasPackageReferenceItems">A <see cref="bool"/> indicating whether or not the project has any PackageReference items.</param>
+        /// <param name="projectJsonPath">An optional path to the project's project.json file.</param>
+        /// <param name="projectDirectory">The full path to the project directory.</param>
+        /// <param name="projectName">The name of the project file.</param>
+        /// <param name="log">An <see cref="NuGet.Common.ILogger"/> object used to log messages.</param>
+        /// <returns>A <see cref="Tuple{ProjectStyle, Boolean}"/> containing the project style and a value indicating if the project is using a style that is compatible with PackageReference.
+        /// If the value of <paramref name="restoreProjectStyle"/> is not empty and could not be parsed, <code>null</code> is returned.</returns>
+        internal static (ProjectStyle ProjectStyle, bool IsPackageReferenceCompatibleProjectStyle) GetProjectRestoreStyle(string restoreProjectStyle, bool hasPackageReferenceItems, string projectJsonPath, string projectDirectory, string projectName, Common.ILogger log)
+        {
+            ProjectStyle projectStyle;
+
+            // Allow a user to override by setting RestoreProjectStyle in the project.
+            if (!string.IsNullOrWhiteSpace(restoreProjectStyle))
+            {
+                if (!Enum.TryParse(restoreProjectStyle, ignoreCase: true, out projectStyle))
+                {
+                    // Any value that is not recognized is treated as Unknown
+                    projectStyle = ProjectStyle.Unknown;
+                }
+            }
+            else if (hasPackageReferenceItems)
+            {
+                // If any PackageReferences exist treat it as PackageReference. This has priority over project.json.
+                projectStyle = ProjectStyle.PackageReference;
+            }
+            else if (!string.IsNullOrWhiteSpace(projectJsonPath))
+            {
+                // If this is not a PackageReference project check if project.json or projectName.project.json exists.
+                projectStyle = ProjectStyle.ProjectJson;
+            }
+            else if (ProjectHasPackagesConfigFile(projectDirectory, projectName))
+            {
+                // If this is not a PackageReference or ProjectJson project check if packages.config or packages.ProjectName.config exists
+                projectStyle = ProjectStyle.PackagesConfig;
+            }
+            else
+            {
+                // This project is either a packages.config project or one that does not use NuGet at all.
+                projectStyle = ProjectStyle.Unknown;
+            }
+
+            bool isPackageReferenceCompatibleProjectStyle = projectStyle == ProjectStyle.PackageReference || projectStyle == ProjectStyle.DotnetToolReference;
+
+            return (projectStyle, isPackageReferenceCompatibleProjectStyle);
+        }
+
+        /// <summary>
+        /// Determines if the project has a packages.config file.
+        /// </summary>
+        /// <param name="projectDirectory">The full path of the project directory.</param>
+        /// <param name="projectName">The name of the project file.</param>
+        /// <returns><code>true</code> if a packages.config exists next to the project, otherwise <code>false</code>.</returns>
+        private static bool ProjectHasPackagesConfigFile(string projectDirectory, string projectName)
+        {
+            if(string.IsNullOrWhiteSpace(projectDirectory))
+            {
+                throw new ArgumentNullException(nameof(projectDirectory));
+            }
+
+            if (string.IsNullOrWhiteSpace(projectName))
+            {
+                throw new ArgumentNullException(nameof(projectName));
+            }
+
+            string packagesConfigPath = Path.Combine(projectDirectory, NuGetConstants.PackageReferenceFile);
+
+            if (File.Exists(packagesConfigPath))
+            {
+                return true;
+            }
+
+            packagesConfigPath = Path.Combine(projectDirectory, $"packages.{projectName}.config");
+
+            if (File.Exists(packagesConfigPath))
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -134,7 +134,7 @@ namespace NuGet.Build.Tasks
             Common.ILogger log,
             CancellationToken cancellationToken)
         {
-            if(dependencyGraphSpec == null)
+            if (dependencyGraphSpec == null)
             {
                 throw new ArgumentNullException(nameof(dependencyGraphSpec));
             }
@@ -287,14 +287,14 @@ namespace NuGet.Build.Tasks
         /// <returns><code>true</code> if a packages.config exists next to the project, otherwise <code>false</code>.</returns>
         private static bool ProjectHasPackagesConfigFile(string projectDirectory, string projectName)
         {
-            if(string.IsNullOrWhiteSpace(projectDirectory))
+            if (string.IsNullOrWhiteSpace(projectDirectory))
             {
-                throw new ArgumentNullException(nameof(projectDirectory));
+                throw new ArgumentException(Strings.Argument_Cannot_Be_Null_Or_Empty, nameof(projectDirectory));
             }
 
             if (string.IsNullOrWhiteSpace(projectName))
             {
-                throw new ArgumentNullException(nameof(projectName));
+                throw new ArgumentException(Strings.Argument_Cannot_Be_Null_Or_Empty, nameof(projectName));
             }
 
             string packagesConfigPath = Path.Combine(projectDirectory, NuGetConstants.PackageReferenceFile);

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectStyleTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectStyleTask.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Build.Framework;
+using NuGet.ProjectModel;
+
+namespace NuGet.Build.Tasks
+{
+    /// <summary>
+    /// Gets the project style.
+    /// </summary>
+    public sealed class GetRestoreProjectStyleTask : Microsoft.Build.Utilities.Task
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether or not the project has any PackageReference items.
+        /// </summary>
+        public bool HasPackageReferenceItems { get; set; }
+
+        [Output]
+        public bool IsPackageReferenceCompatibleProjectStyle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the full path to the project directory.
+        /// </summary>
+        [Required]
+        public string MSBuildProjectDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the project file.
+        /// </summary>
+        [Required]
+        public string MSBuildProjectName { get; set; }
+
+        /// <summary>
+        /// The path to a project.json file.
+        /// </summary>
+        public string ProjectJsonPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ProjectModel.ProjectStyle"/> of the project.
+        /// </summary>
+        [Output]
+        public ProjectStyle ProjectStyle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user specified project style of the project.
+        /// </summary>
+        public string RestoreProjectStyle { get; set; }
+
+        public override bool Execute()
+        {
+            var log = new MSBuildLogger(Log);
+
+            // Log Inputs
+            BuildTasksUtility.LogInputParam(log, nameof(HasPackageReferenceItems), HasPackageReferenceItems.ToString());
+            BuildTasksUtility.LogInputParam(log, nameof(MSBuildProjectDirectory), MSBuildProjectDirectory);
+            BuildTasksUtility.LogInputParam(log, nameof(MSBuildProjectName), MSBuildProjectName);
+            BuildTasksUtility.LogInputParam(log, nameof(ProjectJsonPath), ProjectJsonPath);
+            BuildTasksUtility.LogInputParam(log, nameof(RestoreProjectStyle), RestoreProjectStyle);
+
+            var result = BuildTasksUtility.GetProjectRestoreStyle(RestoreProjectStyle, HasPackageReferenceItems, ProjectJsonPath, MSBuildProjectDirectory, MSBuildProjectName, log);
+
+            IsPackageReferenceCompatibleProjectStyle = result.IsPackageReferenceCompatibleProjectStyle;
+            ProjectStyle = result.ProjectStyle;
+
+            // Log Outputs
+            BuildTasksUtility.LogOutputParam(log, nameof(IsPackageReferenceCompatibleProjectStyle), IsPackageReferenceCompatibleProjectStyle.ToString());
+            BuildTasksUtility.LogOutputParam(log, nameof(ProjectStyle), ProjectStyle.ToString());
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -102,6 +102,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreSettingsTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.WarnForInvalidProjectsTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetReferenceNearestTargetFrameworkTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
+  <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreProjectStyleTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
 
   <!--
     ============================================================
@@ -167,7 +168,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <Target Name="CollectPackageReferences" Returns="@(PackageReference)" />
 
-    <!--
+  <!--
     ============================================================
     CollectPackageDownloads
     Gathers all PackageDownload items from the project.
@@ -177,7 +178,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <Target Name="CollectPackageDownloads" Returns="@(PackageDownload)" />
 
-   <!--
+  <!--
     ============================================================
     CollectFrameworkReferences
     ============================================================
@@ -429,19 +430,22 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_GetRestoreProjectStyle"
     DependsOnTargets="_GetProjectJsonPath;CollectPackageReferences"
     Returns="$(RestoreProjectStyle);$(PackageReferenceCompatibleProjectStyle)">
-    <!-- This may be overridden by setting RestoreProjectStyle in the project. -->
     <PropertyGroup>
-      <!-- If any PackageReferences exist treat it as PackageReference. This has priority over project.json. -->
-      <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND @(PackageReference) != '' ">PackageReference</RestoreProjectStyle>
-      <!-- If this is not a PackageReference project check if project.json or projectName.project.json exists. -->
-      <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND '$(_CurrentProjectJsonPath)' != '' ">ProjectJson</RestoreProjectStyle>
-      <!-- If this is not a PackageReference or ProjectJson project check if packages.config or packages.ProjectName.config exists -->
-      <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND (Exists('$(MSBuildProjectDirectory)\packages.config') Or Exists('$(MSBuildProjectDirectory)\packages.$(MSBuildProjectName).config'))">PackagesConfig</RestoreProjectStyle>
-      <!-- This project is either a packages.config project or one that does not use NuGet at all. -->
-      <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' ">Unknown</RestoreProjectStyle>
+      <_HasPackageReferenceItems Condition="@(PackageReference->Count()) > 0">true</_HasPackageReferenceItems>
     </PropertyGroup>
+
+    <GetRestoreProjectStyleTask
+      HasPackageReferenceItems="$(_HasPackageReferenceItems)"
+      MSBuildProjectDirectory="$(MSBuildProjectDirectory)"
+      MSBuildProjectName="$(MSBuildProjectName)"
+      ProjectJsonPath="$(_CurrentProjectJsonPath)"
+      RestoreProjectStyle="$(RestoreProjectStyle)">
+      <Output TaskParameter="ProjectStyle" PropertyName="RestoreProjectStyle" />
+      <Output TaskParameter="IsPackageReferenceCompatibleProjectStyle" PropertyName="PackageReferenceCompatibleProjectStyle" />
+    </GetRestoreProjectStyleTask>
+
     <PropertyGroup>
-      <PackageReferenceCompatibleProjectStyle Condition="  '$(RestoreProjectStyle)' == 'PackageReference' OR '$(RestoreProjectStyle)' == 'DotnetToolReference' ">true</PackageReferenceCompatibleProjectStyle>
+      <_HasPackageReferenceItems />
     </PropertyGroup>
   </Target>
 
@@ -457,13 +461,13 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="EnableIntermediateOutputPathMismatchWarning" DependsOnTargets="_GetRestoreProjectStyle"
           BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
           Condition="'$(RestoreProjectStyle)' == 'PackageReference'">
-    
+
     <PropertyGroup Condition="'$(EnableBaseIntermediateOutputPathMismatchWarning)' == ''">
       <EnableBaseIntermediateOutputPathMismatchWarning>true</EnableBaseIntermediateOutputPathMismatchWarning>
     </PropertyGroup>
-  
+
   </Target>
-  
+
   <!--
     ============================================================
     _GetRestoreTargetFrameworksOutput

--- a/src/NuGet.Core/NuGet.Build.Tasks/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Strings.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace NuGet.Build.Tasks {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace NuGet.Build.Tasks {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -40,7 +39,7 @@ namespace NuGet.Build.Tasks {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.Build.Tasks.Strings", typeof(Strings).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.Build.Tasks.Strings", typeof(Strings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -58,6 +57,15 @@ namespace NuGet.Build.Tasks {
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Argument cannot be null or empty.
+        /// </summary>
+        internal static string Argument_Cannot_Be_Null_Or_Empty {
+            get {
+                return ResourceManager.GetString("Argument_Cannot_Be_Null_Or_Empty", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Build.Tasks/Strings.resx
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Strings.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -140,5 +140,8 @@
   </data>
   <data name="UnsupportedTargetFramework" xml:space="preserve">
     <value>The project target framework '{0}' is not a supported target framework.</value>
+  </data>
+  <data name="Argument_Cannot_Be_Null_Or_Empty" xml:space="preserve">
+    <value>Argument cannot be null or empty</value>
   </data>
 </root>

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreProjectStyleTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreProjectStyleTaskTests.cs
@@ -1,0 +1,157 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using NuGet.Configuration;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Build.Tasks.Test
+{
+    public class GetRestoreProjectStyleTaskTests
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData("None")]
+        [InlineData("SomethingRandom")]
+        public void Execute_WhenNothingMatches_ReturnsUnknown(string restoreStyle)
+        {
+            var buildEngine = new TestBuildEngine();
+
+            var task = new GetRestoreProjectStyleTask
+            {
+                BuildEngine = buildEngine,
+                RestoreProjectStyle = restoreStyle,
+                ProjectJsonPath = string.Empty,
+                HasPackageReferenceItems = false,
+                MSBuildProjectName = "ProjectA",
+                MSBuildProjectDirectory = "SomeDirectory"
+            };
+
+            task.Execute().Should().BeTrue();
+
+            task.ProjectStyle.Should().Be(ProjectStyle.Unknown);
+            task.IsPackageReferenceCompatibleProjectStyle.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Execute_WhenProjectHasPackageReferenceItems_ReturnsPackageReference()
+        {
+            var buildEngine = new TestBuildEngine();
+
+            var task = new GetRestoreProjectStyleTask
+            {
+                BuildEngine = buildEngine,
+                HasPackageReferenceItems = true
+            };
+
+            task.Execute().Should().BeTrue();
+
+            task.ProjectStyle.Should().Be(ProjectStyle.PackageReference);
+            task.IsPackageReferenceCompatibleProjectStyle.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("packages.config")]
+        [InlineData("packages.ProjectA.config")]
+        public void Execute_WhenProjectHasPackagesConfigFile_ReturnsPackagesConfig(string packagesConfigFileName)
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                File.WriteAllText(Path.Combine(testDirectory, packagesConfigFileName), string.Empty);
+
+                var buildEngine = new TestBuildEngine();
+
+                var task = new GetRestoreProjectStyleTask
+                {
+                    BuildEngine = buildEngine,
+                    MSBuildProjectDirectory = testDirectory,
+                    MSBuildProjectName = "ProjectA"
+                };
+
+                task.Execute().Should().BeTrue();
+
+                task.ProjectStyle.Should().Be(ProjectStyle.PackagesConfig);
+                task.IsPackageReferenceCompatibleProjectStyle.Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public void Execute_WhenProjectJsonPathSpecified_ReturnsProjectJson()
+        {
+            var buildEngine = new TestBuildEngine();
+
+            var task = new GetRestoreProjectStyleTask
+            {
+                BuildEngine = buildEngine,
+                ProjectJsonPath = "SomePath"
+            };
+
+            task.Execute().Should().BeTrue();
+
+            task.ProjectStyle.Should().Be(ProjectStyle.ProjectJson);
+            task.IsPackageReferenceCompatibleProjectStyle.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Execute_WhenProjectStyleSupplied_ReturnsSuppliedProjectStyle(bool lowerCase)
+        {
+            foreach (var projectStyle in Enum.GetValues(typeof(ProjectStyle)).Cast<ProjectStyle>())
+            {
+                var buildEngine = new TestBuildEngine();
+
+                var task = new GetRestoreProjectStyleTask
+                {
+                    BuildEngine = buildEngine,
+                    RestoreProjectStyle = lowerCase ? projectStyle.ToString().ToLower() : projectStyle.ToString()
+                };
+
+                task.Execute().Should().BeTrue();
+
+                task.ProjectStyle.Should().Be(projectStyle);
+                if (projectStyle == ProjectStyle.PackageReference || projectStyle == ProjectStyle.DotnetToolReference)
+                {
+                    task.IsPackageReferenceCompatibleProjectStyle.Should().BeTrue();
+                }
+                else
+                {
+                    task.IsPackageReferenceCompatibleProjectStyle.Should().BeFalse();
+                }
+            }
+        }
+
+        [Fact]
+        public void Execute_WhenUserSuppliedValueOverridesDefault_ReturnsUserSuppliedProjectStyle()
+        {
+            var expected = ProjectStyle.Standalone;
+
+            using (var testDirectory = TestDirectory.Create())
+            {
+                File.WriteAllText(Path.Combine(testDirectory, NuGetConstants.PackageReferenceFile), string.Empty);
+
+                var buildEngine = new TestBuildEngine();
+
+                var task = new GetRestoreProjectStyleTask
+                {
+                    BuildEngine = buildEngine,
+                    RestoreProjectStyle = expected.ToString(),
+                    ProjectJsonPath = "Some value",
+                    HasPackageReferenceItems = true,
+                    MSBuildProjectName = "ProjectA",
+                    MSBuildProjectDirectory = "SomeDirectory"
+                };
+
+                task.Execute().Should().BeTrue();
+
+                task.ProjectStyle.Should().Be(expected);
+                task.IsPackageReferenceCompatibleProjectStyle.Should().BeFalse();
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/TestBuildEngine.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/TestBuildEngine.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections;
 using Microsoft.Build.Framework;
 using NuGet.Common;
@@ -40,9 +41,15 @@ namespace NuGet.Build.Tasks.Test
         {
             var message = new RestoreLogMessage(LogLevel.Error, e.Message)
             {
+
                 FilePath = e.File,
                 ProjectPath = e.ProjectFile
             };
+
+            if (!string.IsNullOrWhiteSpace(e.Code) && Enum.TryParse(e.Code, ignoreCase: true, out NuGetLogCode code))
+            {
+                message.Code = code;
+            }
 
             TestLogger.Log(message);
         }
@@ -77,6 +84,11 @@ namespace NuGet.Build.Tasks.Test
                 FilePath = e.File,
                 ProjectPath = e.ProjectFile
             };
+
+            if (!string.IsNullOrWhiteSpace(e.Code) && Enum.TryParse(e.Code, ignoreCase: true, out NuGetLogCode code))
+            {
+                message.Code = code;
+            }
 
             TestLogger.Log(message);
         }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8804
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

This is a reworking of my original change (https://github.com/NuGet/NuGet.Client/pull/3116) but this attempt should not break the Mono scenario.

This change only touches the task assembly and not any common assembly.  In the Mono scenario, an older version of NuGet.Commands.dll is loaded and when the newer logic would call into it we'd get MissingMethodExceptions.

This assembly is not loaded by anything but MSBuild so we know its always going to be the correct version.

Refactor logic in `_GetRestoreProjectStyle` target to a task.  This will allow the logic to be reused when I use MSBuild Static Graph instead of running the targets.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
