### PR TITLE
Add MethodImplOptions.NoInlining to MSBuild SDK resolver

### DIFF
--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/GlobalJsonReader.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.NuGetSdkResolver
@@ -61,6 +62,7 @@ namespace Microsoft.Build.NuGetSdkResolver
         /// <summary>
         /// Deserializes a global.json and returns the MSBuild SDK versions
         /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static Dictionary<string, string> Deserialize(string value)
         {
             return JsonConvert.DeserializeObject<GlobalJsonFile>(value).MSBuildSdks;

--- a/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
+++ b/src/NuGet.Core/Microsoft.Build.NuGetSdkResolver/NuGetSdkResolver.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using NuGet.Commands;
@@ -193,6 +194,7 @@ namespace Microsoft.Build.NuGetSdkResolver
             /// <summary>
             /// Attempts to parse a string as a NuGetVersion and returns an object containing the instance which can be cast later.
             /// </summary>
+            [MethodImpl(MethodImplOptions.NoInlining)]
             public static bool TryParseNuGetVersion(string version, out object parsed)
             {
                 if (NuGetVersion.TryParse(version, out var nuGetVersion))


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8848
Regression: No 
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: This ensures that `NuGet.Versioning.dll` and `Newtonsoft.Json.dll` aren't loaded.  We found that optimized builds are loading these two DLLs even if they aren't used which goes against the intent of the code.  This is because the methods are being inlined by the compiler so types are needed.

## Testing/Validation

Tests Added: No  
Reason for not adding tests: We don't have a good way to test that assemblies aren't loaded 
Validation:  Manual debugging to verify that assemblies aren't loaded
