### PR TITLE
Don't make 2 threads busy by calling .Result

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Utility/DownloadTimeoutStream.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/DownloadTimeoutStream.cs
@@ -29,6 +29,10 @@ namespace NuGet.Protocol
             _downloadName = downloadName;
             _networkStream = networkStream;
             _timeout = timeout;
+            if (networkStream.CanTimeout)
+            {
+                networkStream.ReadTimeout = (int)timeout.TotalMilliseconds;
+            }
         }
 
         public override void Flush()
@@ -38,16 +42,9 @@ namespace NuGet.Protocol
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            try
-            {
-                return ReadAsync(buffer, offset, count, CancellationToken.None).Result;
-            }
-            catch (AggregateException e)
-            {
-                throw e.InnerException;
-            }
+            return _networkStream.Read(buffer, offset, count);
         }
-        
+
 #if !IS_CORECLR
         public override IAsyncResult BeginRead(
             byte[] buffer,

--- a/src/NuGet.Core/NuGet.Protocol/Utility/ProtocolDiagnosticsStream.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/ProtocolDiagnosticsStream.cs
@@ -63,10 +63,26 @@ namespace NuGet.Protocol.Utility
             }
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            // ReadAsync calls into Read, so don't double count.
-            return base.ReadAsync(buffer, offset, count, cancellationToken);
+            try
+            {
+                var read = await _baseStream.ReadAsync(buffer, offset, count, cancellationToken);
+                if (read > 0)
+                {
+                    _bytes += read;
+                }
+                else
+                {
+                    RaiseDiagnosticEvent(isSuccess: true);
+                }
+                return read;
+            }
+            catch
+            {
+                RaiseDiagnosticEvent(isSuccess: false);
+                throw;
+            }
         }
 
         public override long Seek(long offset, SeekOrigin origin)

--- a/test/TestUtilities/Test.Utility/ReadTimeoutHonoringSlowStream.cs
+++ b/test/TestUtilities/Test.Utility/ReadTimeoutHonoringSlowStream.cs
@@ -50,7 +50,7 @@ namespace Test.Utility
             return read;
         }
 
-        public override int ReadTimeout { get; set; } = int.MaxValue;
+        public override int ReadTimeout { get; set; } = Timeout.Infinite;
         public override bool CanTimeout => true;
     }
 }

--- a/test/TestUtilities/Test.Utility/ReadTimeoutHonoringSlowStream.cs
+++ b/test/TestUtilities/Test.Utility/ReadTimeoutHonoringSlowStream.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Test.Utility
+{
+    public class ReadTimeoutHonoringSlowStream : SlowStream
+    {
+        private readonly Stream _innerStream;
+        private readonly CancellationToken _cancellationToken;
+        private int _readTimeout = int.MaxValue;
+
+        public ReadTimeoutHonoringSlowStream(Stream innerStream)
+            : this(innerStream, CancellationToken.None)
+        {
+        }
+
+        public ReadTimeoutHonoringSlowStream(Stream innerStream, CancellationToken cancellationToken)
+            : base(innerStream, cancellationToken)
+        {
+            _innerStream = innerStream;
+            _cancellationToken = cancellationToken;
+        } 
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            OnRead?.Invoke(buffer, offset, count);
+            var read = _innerStream.Read(buffer, offset, count);
+
+            try
+            {
+                var expectedDelayInMs = DelayPerByte.TotalMilliseconds * read;
+                if (_readTimeout > expectedDelayInMs)
+                {
+                    Task.Delay(new TimeSpan(DelayPerByte.Ticks * read)).Wait(_cancellationToken);
+                }
+                else
+                {
+                    Task.Delay(_readTimeout).Wait(_cancellationToken);
+                    throw new IOException($"..timed out because no data was received for {_readTimeout}ms.", new TimeoutException());
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+
+            return read;
+        }
+
+        public override int ReadTimeout { get => _readTimeout; set => _readTimeout = value; }
+        public override bool CanTimeout => true;
+    }
+}

--- a/test/TestUtilities/Test.Utility/ReadTimeoutHonoringSlowStream.cs
+++ b/test/TestUtilities/Test.Utility/ReadTimeoutHonoringSlowStream.cs
@@ -12,7 +12,6 @@ namespace Test.Utility
     {
         private readonly Stream _innerStream;
         private readonly CancellationToken _cancellationToken;
-        private int _readTimeout = int.MaxValue;
 
         public ReadTimeoutHonoringSlowStream(Stream innerStream)
             : this(innerStream, CancellationToken.None)
@@ -34,14 +33,14 @@ namespace Test.Utility
             try
             {
                 var expectedDelayInMs = DelayPerByte.TotalMilliseconds * read;
-                if (_readTimeout > expectedDelayInMs)
+                if (ReadTimeout > expectedDelayInMs)
                 {
                     Task.Delay(new TimeSpan(DelayPerByte.Ticks * read)).Wait(_cancellationToken);
                 }
                 else
                 {
-                    Task.Delay(_readTimeout).Wait(_cancellationToken);
-                    throw new IOException($"..timed out because no data was received for {_readTimeout}ms.", new TimeoutException());
+                    Task.Delay(ReadTimeout).Wait(_cancellationToken);
+                    throw new IOException($"..timed out because no data was received for {ReadTimeout}ms.", new TimeoutException());
                 }
             }
             catch (OperationCanceledException)
@@ -51,7 +50,7 @@ namespace Test.Utility
             return read;
         }
 
-        public override int ReadTimeout { get => _readTimeout; set => _readTimeout = value; }
+        public override int ReadTimeout { get; set; } = int.MaxValue;
         public override bool CanTimeout => true;
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8853
Regression: Yes
* Last working version: 5.5 P1   
* How are we preventing it in future: Remove the .Result completely.

## Fix

Details: 
DownloadTimeoutStream is a custom implementation for a stream timeout. The reasoning behind that is that the timeout property is not observed for asynchronous operations.

https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.networkstream.readtimeout?view=netframework-4.8#remarks

This class is only used in one place in the HttpRetry handler.
https://github.com/NuGet/NuGet.Client/blob/1ce56a3cd779ec4ebae39a1b0ce3f7ccc3310584/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs#L141

We only really call the async APIs.
The sync api is implemented by calling .Result on the async call. This blocks the current thread.
https://github.com/NuGet/NuGet.Client/blob/1ce56a3cd779ec4ebae39a1b0ce3f7ccc3310584/src/NuGet.Core/NuGet.Protocol/Utility/DownloadTimeoutStream.cs#L43
Originally the intention was that this would never be called.

A bug in the ProtocolDiagnostics wrapper lead to the sync codepath being invoked. 
This fixes that and adds some more tests. 
We also remove any chance from ever using this blocking call. 
The ReadTimeout is observed by the sync calls so might as well set it :) 

## Testing/Validation

Tests Added: Yes  
Reason for not adding tests:  
Validation:  
