### PR TITLE
Add overload to RestoreSettingsUtils.ReadSettings to use new SettingsLoadingContext

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreSettingsUtils.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreSettingsUtils.cs
@@ -18,7 +18,7 @@ namespace NuGet.Build.Tasks
 
         public static ISettings ReadSettings(string solutionDirectory, string restoreDirectory, string restoreConfigFile, Lazy<IMachineWideSettings> machineWideSettings)
         {
-            return ReadSettings(solutionDirectory, restoreDirectory, restoreConfigFile, machineWideSettings, null);
+            return ReadSettings(solutionDirectory, restoreDirectory, restoreConfigFile, machineWideSettings, settingsLoadContext: null);
         }
 
         public static ISettings ReadSettings(string solutionDirectory, string restoreDirectory, string restoreConfigFile, Lazy<IMachineWideSettings> machineWideSettings, SettingsLoadingContext settingsLoadContext)
@@ -58,7 +58,7 @@ namespace NuGet.Build.Tasks
                 return Configuration.Settings.LoadDefaultSettings(
                     directory,
                     configFileName,
-                    null,
+                    machineWideSettings: null,
                     settingsLoadContext);
             }
         }

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreSettingsUtils.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreSettingsUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Configuration;
@@ -18,6 +18,11 @@ namespace NuGet.Build.Tasks
 
         public static ISettings ReadSettings(string solutionDirectory, string restoreDirectory, string restoreConfigFile, Lazy<IMachineWideSettings> machineWideSettings)
         {
+            return ReadSettings(solutionDirectory, restoreDirectory, restoreConfigFile, machineWideSettings, null);
+        }
+
+        public static ISettings ReadSettings(string solutionDirectory, string restoreDirectory, string restoreConfigFile, Lazy<IMachineWideSettings> machineWideSettings, SettingsLoadingContext settingsLoadContext)
+        {
             if (!string.IsNullOrEmpty(solutionDirectory))
             {
                 // Read the solution-level settings
@@ -33,7 +38,8 @@ namespace NuGet.Build.Tasks
                 return Configuration.Settings.LoadDefaultSettings(
                     solutionSettingsFile,
                     configFileName: restoreConfigFile,
-                    machineWideSettings: machineWideSettings.Value);
+                    machineWideSettings: machineWideSettings.Value,
+                    settingsLoadingContext: settingsLoadContext);
             }
 
             if (string.IsNullOrEmpty(restoreConfigFile))
@@ -41,7 +47,8 @@ namespace NuGet.Build.Tasks
                 return Configuration.Settings.LoadDefaultSettings(
                     restoreDirectory,
                     configFileName: null,
-                    machineWideSettings: machineWideSettings.Value);
+                    machineWideSettings: machineWideSettings.Value,
+                    settingsLoadingContext: settingsLoadContext);
             }
             else
             {
@@ -51,7 +58,8 @@ namespace NuGet.Build.Tasks
                 return Configuration.Settings.LoadDefaultSettings(
                     directory,
                     configFileName,
-                    null);
+                    null,
+                    settingsLoadContext);
             }
         }
 

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsLoadingContext.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsLoadingContext.cs
@@ -21,7 +21,7 @@ namespace NuGet.Configuration
             _semaphore = new SemaphoreSlim(initialCount: 1, maxCount: 1);
         }
 
-        internal SettingsFile GetOrCreateSettingsFile(string filePath)
+        internal SettingsFile GetOrCreateSettingsFile(string filePath, bool isMachineWide = false)
         {
             if (_isDisposed)
             {
@@ -47,7 +47,7 @@ namespace NuGet.Configuration
                 }
 
                 var file = new FileInfo(filePath);
-                settingsFile = new Lazy<SettingsFile>(() => new SettingsFile(file.DirectoryName, file.Name));
+                settingsFile = new Lazy<SettingsFile>(() => new SettingsFile(file.DirectoryName, file.Name, isMachineWide));
                 _settingsFiles.Add(settingsFile);
             }
             finally


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8855
Regression: No
* Last working version:   
* How are we preventing it in future:   

## Fix

Details: Add overload to RestoreSettingsUtils.ReadSettings to use new SettingsLoadingContext.  This will allow me to consume the new functionality in a subsequent PR.

## Testing/Validation

Tests Added: Yes
Reason for not adding tests:  
Validation:  
