### PR TITLE
Making Push for snupkgs consistent with Push nupkg behavior

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Utility/LocalFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/LocalFolderUtility.cs
@@ -989,26 +989,16 @@ namespace NuGet.Protocol
         /// <summary>
         /// If there isn't at least one Path specified, throw that no file paths were resolved for this Package.
         /// </summary>
-        /// <param name="packagePath">The package path the user originally provided for use while creating logs.</param>
+        /// <param name="packagePath">The package path the user originally provided.</param>
         /// <param name="matchingPackagePaths">A list of matching package paths that were previously resolved.</param>
         public static void EnsurePackageFileExists(string packagePath, IEnumerable<string> matchingPackagePaths)
         {
-            if (!ResolvedAnyPackagePath(matchingPackagePaths))
+            if (!(matchingPackagePaths != null && matchingPackagePaths.Any()))
             {
-                ErrorFileNotFound(packagePath);
-            }
-        }
-
-        public static void ErrorFileNotFound(string packagePath)
-        {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
                     Strings.UnableToFindFile,
                     packagePath));
-        }
-
-        public static bool ResolvedAnyPackagePath(IEnumerable<string> matchingPackagePaths)
-        {
-            return matchingPackagePaths != null && matchingPackagePaths.Any();
+            }
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/Utility/LocalFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/LocalFolderUtility.cs
@@ -987,18 +987,28 @@ namespace NuGet.Protocol
         }
 
         /// <summary>
-        /// This method checks of a given list of package paths exist on disk.
+        /// If there isn't at least one Path specified, throw that no file paths were resolved for this Package.
         /// </summary>
-        /// <param name="packagePath">A package path to be used while creating logs.</param>
-        /// <param name="matchingPackagePaths">A list of matching package paths that need to be checked.</param>
+        /// <param name="packagePath">The package path the user originally provided for use while creating logs.</param>
+        /// <param name="matchingPackagePaths">A list of matching package paths that were previously resolved.</param>
         public static void EnsurePackageFileExists(string packagePath, IEnumerable<string> matchingPackagePaths)
         {
-            if (!matchingPackagePaths.Any())
+            if (!ResolvedAnyPackagePath(matchingPackagePaths))
             {
+                ErrorFileNotFound(packagePath);
+            }
+        }
+
+        public static void ErrorFileNotFound(string packagePath)
+        {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
                     Strings.UnableToFindFile,
                     packagePath));
-            }
+        }
+
+        public static bool ResolvedAnyPackagePath(IEnumerable<string> matchingPackagePaths)
+        {
+            return matchingPackagePaths != null && matchingPackagePaths.Any();
         }
 
         /// <summary>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
@@ -151,6 +151,8 @@ namespace NuGet.Protocol.Tests
                     getApiKey: _ => apiKey,
                     getSymbolApiKey: _ => null,
                     noServiceEndpoint: false,
+                    skipDuplicate: false,
+                    symbolPackageUpdateResource: null,
                     log: NullLogger.Instance);
 
                 // Assert
@@ -203,6 +205,8 @@ namespace NuGet.Protocol.Tests
                     getApiKey: _ => apiKey,
                     getSymbolApiKey: _ => null,
                     noServiceEndpoint: false,
+                    skipDuplicate: false,
+                    symbolPackageUpdateResource: null,
                     log: NullLogger.Instance);
 
                 // Assert
@@ -290,6 +294,8 @@ namespace NuGet.Protocol.Tests
                     getApiKey: _ => apiKey,
                     getSymbolApiKey: _ => apiKey,
                     noServiceEndpoint: false,
+                    skipDuplicate: false,
+                    symbolPackageUpdateResource: null,
                     log: NullLogger.Instance);
 
                 // Assert
@@ -354,6 +360,8 @@ namespace NuGet.Protocol.Tests
                     getApiKey: _ => apiKey,
                     getSymbolApiKey: _ => apiKey,
                     noServiceEndpoint: false,
+                    skipDuplicate: false,
+                    symbolPackageUpdateResource: null,
                     log: NullLogger.Instance);
 
                 // Assert
@@ -426,6 +434,8 @@ namespace NuGet.Protocol.Tests
                     getApiKey: _ => apiKey,
                     getSymbolApiKey: _ => apiKey,
                     noServiceEndpoint: false,
+                    skipDuplicate: false,
+                    symbolPackageUpdateResource: null,
                     log: NullLogger.Instance);
 
                 // Assert
@@ -500,6 +510,8 @@ namespace NuGet.Protocol.Tests
                     getApiKey: _ => apiKey,
                     getSymbolApiKey: _ => null,
                     noServiceEndpoint: false,
+                    skipDuplicate: false,
+                    symbolPackageUpdateResource: null,
                     log: NullLogger.Instance);
 
                 // Assert
@@ -551,6 +563,8 @@ namespace NuGet.Protocol.Tests
                     getApiKey: _ => apiKey,
                     getSymbolApiKey: _ => null,
                     noServiceEndpoint: true,
+                    skipDuplicate: false,
+                    symbolPackageUpdateResource: null,
                     log: NullLogger.Instance);
 
                 // Assert
@@ -599,6 +613,8 @@ namespace NuGet.Protocol.Tests
                     getApiKey: _ => apiKey,
                     getSymbolApiKey: _ => null,
                     noServiceEndpoint: false,
+                    skipDuplicate: false,
+                    symbolPackageUpdateResource: null,
                     log: NullLogger.Instance);
 
                 // Assert
@@ -660,6 +676,8 @@ namespace NuGet.Protocol.Tests
                     getApiKey: _ => apiKey,
                     getSymbolApiKey: _ => null,
                     noServiceEndpoint: false,
+                    skipDuplicate: false,
+                    symbolPackageUpdateResource: null,
                     log: NullLogger.Instance);
 
                 // Assert
@@ -730,6 +748,8 @@ namespace NuGet.Protocol.Tests
                         getApiKey: _ => apiKey,
                         getSymbolApiKey: _ => apiKey,
                         noServiceEndpoint: false,
+                        skipDuplicate: false,
+                        symbolPackageUpdateResource: null,
                         log: NullLogger.Instance));
 
                 // Assert
@@ -795,6 +815,8 @@ namespace NuGet.Protocol.Tests
                     getApiKey: _ => apiKey,
                     getSymbolApiKey: _ => null,
                     noServiceEndpoint: false,
+                    skipDuplicate: false,
+                    symbolPackageUpdateResource: null,
                     log: NullLogger.Instance);
 
                 // Assert


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/8148
Regression: No

## Fix

Snupkgs should now be consistent with Nupkg pushing, and the automatic pushing of Snupkgs should no longer break the push when no snupkgs exist in the directory.

I omitted in this PR my desired change of moving File Not Found logic earlier in the CLI Command logic. I documented that potential future work, and why I didn't do it now, in https://github.com/NuGet/Home/issues/8862.

### Wildcard doesn't find snupkgs

**Existing behavior:** We have always failed with "File does not exist" during a push to a symbol source where a * in the path was used, yet there were no snupkgs in the directory (having 1 or more snupkgs would succeed).

**Behavior change:**
- [x] Going forward, anytime we automatically push snupkgs when pushing nupkgs, we do not error if there are no snupkgs are found. (We are quiet about snupkgs).

Explicitly pushing snupkgs will continue to error if the directory contains no snupkgs.

### Push explicit snupkg where file doesn't exist

**Existing behavior:** Pushing "NotFound.snupkg" currently results in no CLI output (even with detailed verbosity), where the equivalent push using a "NotFound.nupkg " results in "File does not exist".

Pushing \*.snupkg correctly shows "File does not exist (…\*.snupkg)".

**Behavior change:** 
- [x] Pushing an explicit snupkg filename that does not exist will error.

### Duplicate snupkgs

**Existing behavior:** Snupkg duplicates can behave differently than nupkg duplicates (as is the case with nuget.org):

- If a snupkg already exists when pushed,  nuget.org will simply overwrite it, validation will be re-ran on this snupkg, and a success response (HTTP-201) is returned. 

- A special case is if server validation is currently executing on this snupkg (as it does immediately after a push), another push of the snupkg causes the server to return this duplicate error:

`Response status code does not indicate success: 409 (It looks like there is another copy of this symbols package pending validation(s). Please wait for the validation(s) to finish before trying to replace the symbols package.).`

**Behavior change:** We will split this error to be more consistent with how nupkg duplicate responses are handled:

Without SkipDuplicate (unchanged):

> Conflict https://www.nuget.org/api/v3/package/ (61ms)

- [x] With SkipDuplicate:
> Symbols Package 'C:\MyApp12.1.0.2.snupkg' already exists at feed 'https://dev.nugettest.org/api/v2/package'.

- [x] With `Verbosity: detailed` In either case above, show any message from the server accompanying the 409 
For example, nuget.org would show:

> It looks like there is another copy of this symbols package pending validation(s). Please wait for the validation(s) to finish before trying to replace the symbols package.

The above items evolved from a discussion with @rrelyea, @karann-msft, and @cristinamanum. 

## Testing/Validation

Tests Added: Yes  
Validation:  Functional tests were modified to Assert the new, desired Push snupkg behavior.
